### PR TITLE
Expose searchTags on account API

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -206,6 +206,19 @@ class Account extends Base {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
     return this.discoveryProvider.searchAutocomplete(text, limit, offset)
   }
+
+  /**
+   * Perform a tags-only search. Returns tracks with required tag and users
+   * that have used a tag greater than a specified number of times
+   * @param {string} text search query
+   * @param {number} user_tag_count min # of times a user must have used a tag to be returned
+   * @param {number} limit max # of items to return per list (for pagination)
+   * @param {number} offset offset into list to return from (for pagination)
+   */
+  async searchTags (text, user_tag_count = 2, limit = 100, offset = 0) {
+    this.REQUIRES(Services.DISCOVERY_PROVIDER)
+    return this.discoveryProvider.searchTags(text, user_tag_count, limit, offset)
+  }
 }
 
 module.exports = Account

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -324,7 +324,7 @@ class DiscoveryProvider {
    * Perform a tags-only search. Returns tracks with required tag and users
    * that have used a tag greater than a specified number of times
    * @param {string} text search query
-   * @param {number} user_tag_count # of times a user must have used a tag to be returned
+   * @param {number} user_tag_count min # of times a user must have used a tag to be returned
    * @param {number} limit max # of items to return per list (for pagination)
    * @param {number} offset offset into list to return from (for pagination)
    */


### PR DESCRIPTION
Also added the word 'min' to the user_tag_count doc b/c VSCode interprets a line starting with `#` as markdown, and renders that doc as a large header in intellisense. 