### PR TITLE
IPFS Peer ip override was never exposed in the /export route

### DIFF
--- a/creator-node/docker-compose/development.env
+++ b/creator-node/docker-compose/development.env
@@ -26,8 +26,8 @@ serviceCountry=
 
 # required when running with kubernetes, need to pass in the ip address of the instance that will run 
 # the ipfs node. should be done by default in audius manifests
-# ipfsClusterIP=
-# ipfsClusterPort=
+# ipfsClusterIP=127.0.0.1
+# ipfsClusterPort=4001
 
 # wallet information required on all environments
 delegateOwnerWallet=

--- a/creator-node/docker-compose/development.env
+++ b/creator-node/docker-compose/development.env
@@ -27,7 +27,7 @@ serviceCountry=
 # required when running with kubernetes, need to pass in the ip address of the instance that will run 
 # the ipfs node. should be done by default in audius manifests
 # ipfsClusterIP=127.0.0.1
-# ipfsClusterPort=4001
+# ipfsClusterPort=0
 
 # wallet information required on all environments
 delegateOwnerWallet=

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -16,6 +16,8 @@ const { logger } = require('../logging')
 const config = require('../config.js')
 const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
 const resizeImage = require('../resizeImage')
+const { getIPFSPeerId } = require('../utils')
+
 
 module.exports = function (app) {
   /** Store image in multiple-resolutions on disk + DB and make available via IPFS */
@@ -132,16 +134,8 @@ module.exports = function (app) {
 
   app.get('/ipfs_peer_info', handleResponse(async (req, res) => {
     const ipfs = req.app.get('ipfsAPI')
-    const ipfsClusterIP = config.get('ipfsClusterIP')
-    const ipfsClusterPort = config.get('ipfsClusterPort')
-    let ipfsIDObj = await ipfs.id()
-
-    // if it's a real host and port, generate a new ipfs id and override the addresses with this value
-    if (ipfsClusterIP && ipfsClusterPort !== null && ipfsClusterIP !== '127.0.0.1' && ipfsClusterPort !== 0) {
-      const addressStr = `/ip4/${ipfsClusterIP}/tcp/${ipfsClusterPort}/ipfs/${ipfsIDObj.id}`
-      ipfsIDObj.addresses = [addressStr]
-    }
-
+    const ipfsIDObj = await getIPFSPeerId(ipfs, config)
+  
     return successResponse(ipfsIDObj)
   }))
 

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -18,7 +18,6 @@ const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
 const resizeImage = require('../resizeImage')
 const { getIPFSPeerId } = require('../utils')
 
-
 module.exports = function (app) {
   /** Store image in multiple-resolutions on disk + DB and make available via IPFS */
   app.post('/image_upload', authMiddleware, nodeSyncMiddleware, upload.single('file'), handleResponse(async (req, res) => {
@@ -135,7 +134,7 @@ module.exports = function (app) {
   app.get('/ipfs_peer_info', handleResponse(async (req, res) => {
     const ipfs = req.app.get('ipfsAPI')
     const ipfsIDObj = await getIPFSPeerId(ipfs, config)
-  
+
     return successResponse(ipfsIDObj)
   }))
 

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -7,7 +7,6 @@ const { getNodeSyncRedisKey } = require('../redis')
 const config = require('../config.js')
 const { getIPFSPeerId } = require('../utils')
 
-
 module.exports = function (app) {
   /** Exports all db data (not files) associated with walletPublicKey[] as JSON.
    *  Returns IPFS node ID object, so importing nodes can peer manually for optimized file transfer.

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -4,6 +4,9 @@ const models = require('../models')
 const { saveFileForMultihash } = require('../fileManager')
 const { handleResponse, successResponse, errorResponse, errorResponseServerError, errorResponseBadRequest } = require('../apiHelpers')
 const { getNodeSyncRedisKey } = require('../redis')
+const config = require('../config.js')
+const { getIPFSPeerId } = require('../utils')
+
 
 module.exports = function (app) {
   /** Exports all db data (not files) associated with walletPublicKey[] as JSON.
@@ -60,7 +63,7 @@ module.exports = function (app) {
 
     // Expose ipfs node's peer ID.
     const ipfs = req.app.get('ipfsAPI')
-    let ipfsIDObj = await ipfs.id()
+    let ipfsIDObj = await getIPFSPeerId(ipfs, config)
 
     return successResponse({ cnodeUsers: cnodeUsersDict, ipfsIDObj: ipfsIDObj })
   }))

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -55,5 +55,23 @@ async function getFileUUIDForImageCID (req, imageCID) {
   } else return null
 }
 
+async function getIPFSPeerId (ipfs, config) {
+  const ipfsClusterIP = config.get('ipfsClusterIP')
+  const ipfsClusterPort = config.get('ipfsClusterPort')
+
+  if (!ipfsClusterIP || !ipfsClusterPort) throw new Error('ipfsCluster environment variable not set')
+
+  let ipfsIDObj = await ipfs.id()
+  
+  // if it's a real host and port, generate a new ipfs id and override the addresses with this value
+  if (ipfsClusterIP && ipfsClusterPort !== null && ipfsClusterIP !== '127.0.0.1' && ipfsClusterPort !== 0) {
+    const addressStr = `/ip4/${ipfsClusterIP}/tcp/${ipfsClusterPort}/ipfs/${ipfsIDObj.id}`
+    ipfsIDObj.addresses = [addressStr]
+  }
+
+  return ipfsIDObj
+}
+
 module.exports = Utils
 module.exports.getFileUUIDForImageCID = getFileUUIDForImageCID
+module.exports.getIPFSPeerId = getIPFSPeerId

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -59,11 +59,10 @@ async function getIPFSPeerId (ipfs, config) {
   const ipfsClusterIP = config.get('ipfsClusterIP')
   const ipfsClusterPort = config.get('ipfsClusterPort')
 
-  if (!ipfsClusterIP || !ipfsClusterPort) throw new Error('ipfsCluster environment variable not set')
-
   let ipfsIDObj = await ipfs.id()
   
   // if it's a real host and port, generate a new ipfs id and override the addresses with this value
+  // if it's local or these variables aren't passed in, just return the regular ipfs.id() result
   if (ipfsClusterIP && ipfsClusterPort !== null && ipfsClusterIP !== '127.0.0.1' && ipfsClusterPort !== 0) {
     const addressStr = `/ip4/${ipfsClusterIP}/tcp/${ipfsClusterPort}/ipfs/${ipfsIDObj.id}`
     ipfsIDObj.addresses = [addressStr]

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -60,7 +60,7 @@ async function getIPFSPeerId (ipfs, config) {
   const ipfsClusterPort = config.get('ipfsClusterPort')
 
   let ipfsIDObj = await ipfs.id()
-  
+
   // if it's a real host and port, generate a new ipfs id and override the addresses with this value
   // if it's local or these variables aren't passed in, just return the regular ipfs.id() result
   if (ipfsClusterIP && ipfsClusterPort !== null && ipfsClusterIP !== '127.0.0.1' && ipfsClusterPort !== 0) {


### PR DESCRIPTION
I changed /ipfs_peer_id but forgot to change the corresponding logic in /export so it was still returning the value from `ipfs.id()`. Refactored and fixed