### PR TITLE
Check for valid array before indexing matched segment list

### DIFF
--- a/creator-node/src/ffprobe-exec.js
+++ b/creator-node/src/ffprobe-exec.js
@@ -21,7 +21,12 @@ async function getSegmentsDuration (req, segmentPath) {
         const segmentDurations = {}
         const resultsArr = stdout.split('\n')
         for (let i = 0; i < resultsArr.length - 2; i += 2) {
-          const segmentName = (resultsArr[i].match(SEGMENT_REGEXP)[0])
+          let matchedResults = resultsArr[i].match(SEGMENT_REGEXP)
+          if (matchedResults === null) {
+            req.logger.error(`matched results for ${resultsArr[i]} - NULL`)
+            continue
+          }
+          const segmentName = (matchedResults[0])
           const duration = Number(resultsArr[i + 1])
           segmentDurations[segmentName] = duration
         }


### PR DESCRIPTION
Addresses following error, throwing 502 at /track_content staging routes:
```
const segmentName = (resultsArr[i].match(SEGMENT_REGEXP)[0])\n",
TypeError: Cannot read property '0' of null\n
at exec (/usr/src/app/src/ffprobe-exec.js:24:67)\n",
```

Confirmed by behavior by comparing staging cn1 (master) vs. cn2 (patched) behavior with identical sets of tracks. User with cn2 primary did not hit this error, user with cn1 did.