### PR TITLE
[DO NOT MERGE] Allow upload of file segments

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -65,6 +65,12 @@ const config = convict({
       'ts', 'tsv', 'tsa'
     ]
   },
+  allowedUploadFileSegmentExtensions: {
+    doc: 'Override the default list of file segment extension allowed',
+    format: Array,
+    env: 'allowedUploadFileSegmentExtensions',
+    default: ['m3u8', 'ts']
+  },
   redisPort: {
     doc: 'Redis port',
     format: 'port',

--- a/creator-node/src/ffmpeg.js
+++ b/creator-node/src/ffmpeg.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn
 /** Segments file into equal size chunks without re-encoding
  *  Try to segment as mp3 and error on failure
  */
-function segmentFile (req, fileDir, fileName) {
+function segmentFile (req, fileDir, fileName, trackName) {
   return new Promise((resolve, reject) => {
     const absolutePath = path.resolve(fileDir, fileName)
 
@@ -24,7 +24,7 @@ function segmentFile (req, fileDir, fileName) {
       // "-vn" flag required to allow track uploading with album art
       // https://stackoverflow.com/questions/20193065/how-to-remove-id3-audio-tag-image-or-metadata-from-mp3-with-ffmpeg
       '-vn',
-      path.resolve(fileDir, fileName.split('.')[0] + '.m3u8')
+      path.resolve(fileDir, trackName.split('.')[0] + '.m3u8')
     ]
     const proc = spawn(ffmpeg, args)
 

--- a/creator-node/src/segmentDuration.js
+++ b/creator-node/src/segmentDuration.js
@@ -1,18 +1,13 @@
-const path = require('path')
 const fs = require('fs')
 
 const SEGMENT_REGEXP = /(segment[0-9]*.ts)/
 
 // Parse m3u8 file from HLS output and return mapped segment durations
-async function getSegmentsDuration (req, segmentPath, filename, filedir) {
+async function getSegmentsDuration (manifestPath) {
   return new Promise((resolve, reject) => {
     try {
-      let splitResults = filename.split('.')
-      let fileRandomName = splitResults[0]
-      let manifestPath = path.join(filedir, `${fileRandomName}.m3u8`)
       let manifestContents = fs.readFileSync(manifestPath)
       let splitManifest = manifestContents.toString().split('\n')
-
       let segmentDurations = {}
       for (let i = 0; i < splitManifest.length; i += 1) {
         let matchedResults = splitManifest[i].match(SEGMENT_REGEXP)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -356,8 +356,14 @@ class CreatorNode {
     await this.ensureConnected()
 
     // form data is from browser, not imported npm module
-    let formData = new FormData()
-    formData.append('file', file)
+    let formData
+    if (file instanceof FormData) {
+      formData = file
+    } else {
+      formData = new FormData()
+      formData.append('file', file)
+    }
+
     Object.keys(extraFormDataOptions).forEach(key => {
       formData.append(key, extraFormDataOptions[key])
     })


### PR DESCRIPTION
## Summary
Modifies the `/track_content` endpoint in the creator node to allow upload of a pre-segmented track. The endpoint currently parses the `file` fieldname in the formdata of the request. The multer middleware was modified to also accept a `fileSegments` fieldname. If the file segments are uploaded, the original file is not segmented w/ ffmpeg and, instead the uploaded fileSegments are used. 

The audius libs was also modified to accept a custom formData field on track upload instead of a file.