### PR TITLE
Fix eth-contracts migrations bug

### DIFF
--- a/eth-contracts/migrations/1_initial_migration.js
+++ b/eth-contracts/migrations/1_initial_migration.js
@@ -1,5 +1,7 @@
-const Migrations = artifacts.require("Migrations");
+const Migrations = artifacts.require('./Migrations.sol')
 
-module.exports = function(deployer) {
-  deployer.deploy(Migrations);
-};
+module.exports = (deployer) => {
+  deployer.then(async () => {
+    await deployer.deploy(Migrations)
+  })
+}


### PR DESCRIPTION
Found an interesting bug whereby `truffle migrate` would consistently replace migrations, even though no changes were made.

Upon inspecting the differences between our `contracts` migrations, and our `eth-contracts` migrations, I found this discrepancy (in the diff).

Our other contracts also exhibit the same small differences (from the data contracts). I am unsure if we need to update those also. Would like to get some thoughts on this.

Nonetheless, it now appears we get the correct message:
```
$ k logs eth-contracts-1-migrations-job-bxk2w
Network up to date.
```

Rather than re-migrating, and hence "replacing" contracts each time.