### PR TITLE
Bump contracts/eth-contracts truffle version(s)

### DIFF
--- a/contracts/contracts/SigningLogic.sol
+++ b/contracts/contracts/SigningLogic.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
 
@@ -15,11 +15,11 @@ contract SigningLogic {
     );
 
     bytes32 domainSeparator;
-    
+
     // Signatures contain a nonce to make them unique. usedSignatures tracks which signatures
     //  have been used so they can't be replayed
     mapping (bytes32 => bool) public usedSignatures;
-    
+
     struct EIP712Domain {
         string  name;
         string  version;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -33,7 +33,7 @@
     "ethlint": "^1.2.3",
     "fs-extra": "^7.0.0",
     "openzeppelin-solidity": "^2.1.0",
-    "truffle": "5.0.1"
+    "truffle": "5.0.42"
   },
   "devDependencies": {
     "async": "^2.6.1",

--- a/eth-contracts/package.json
+++ b/eth-contracts/package.json
@@ -26,7 +26,7 @@
     "ethlint": "^1.2.3",
     "fs-extra": "^7.0.0",
     "openzeppelin-solidity": "^2.3.0",
-    "truffle": "5.0.1",
+    "truffle": "5.0.42",
     "truffle-hdwallet-provider": "^1.0.13",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
Fixes bug where contracts were being replaced on every call to truffle migrate.

Now the expected behavior is resumed.

**BEFORE**

On any run after the first (with no new migrations)
```
...

3_registry_migration.js
=======================

   Replacing 'Registry'   <----------
   --------------------
   > transaction hash:    0xe59569a5e41b204a4e54f9f2186bf804d08456476d3affb34d2bc9fbad5b2590

...
```

**AFTER**

On any run after the first (with no new migrations)
```
Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.

Network up to date.
```