### PR TITLE
Unlisted: fix handle casing issues

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -148,7 +148,7 @@ def get_tracks_including_unlisted():
 
         # Create filter conditions as a list of `and` clauses
         for i in identifiers:
-            route_id = f"""{i["handle"]}/{i["url_title"]}"""
+            route_id = helpers.create_track_route_id(i["url_title"], i["handle"])
             filter_cond.append(and_(Track.is_current == True, Track.route_id == route_id, Track.track_id == i["id"]))
 
         # Pass array of `and` clauses into an `or` clause as destrucutred *args

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -195,7 +195,10 @@ def create_track_route_id(title, handle):
     # Lowercase it
     sanitized_title = sanitized_title.lower()
 
-    return f"{handle}/{sanitized_title}"
+    # Lowercase the handle
+    sanitized_handle = handle.lower()
+
+    return f"{sanitized_handle}/{sanitized_title}"
 
 # Validates the existance of arguments within a request.
 # req_args is a map, expected_args is a list of string arguments expected to be present in the map.


### PR DESCRIPTION
In our migration, we preserved capitalization of handles when constructing the route ID. However, the dapp always passes us a lowercased handle, so we must treat all handles as lowercase when constructing the route ID to successfully match.