### PR TITLE
Remove IPFS pin ops

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -119,14 +119,10 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath) {
   // If multihash already pinned by local INode, cat file from local ipfs node
   req.logger.info(`checking if ${multihash} already pinned by local ipfs node`)
   try {
-    const pinset = await ipfs.pin.ls(multihash)
-    if (pinset.includes(multihash)) {
-      req.logger.info(`File for ${multihash} already pinned by local ipfs node`)
-      fileBuffer = await ipfs.cat(multihash)
-      req.logger.info(`Retrieved file for ${multihash} from local ipfs node`)
-    }
+    fileBuffer = await ipfs.cat(multihash)
+    req.logger.info(`Retrieved file for ${multihash} from local ipfs node`)
   } catch (e) {
-    req.logger.info(`Multihash ${multihash} is not pinned by local ipfs node`)
+    req.logger.info(`Multihash ${multihash} is not available on local ipfs node`)
   }
 
   // If file not already pinned by local INode, fetch from IPFS.

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -29,7 +29,7 @@ async function saveFileFromBuffer (req, buffer, fileType) {
 
   const ipfs = req.app.get('ipfsAPI')
 
-  const multihash = (await ipfs.add(buffer))[0].hash
+  const multihash = (await ipfs.add(buffer, { pin: false }))[0].hash
 
   const dstPath = path.join(req.app.get('storagePath'), multihash)
 
@@ -68,7 +68,7 @@ async function saveFileToIPFSFromFS (req, srcPath, fileType, sourceFile, transac
 
   // Adding a file through js-ipfs-api pins by default
   // Ensuring this multihash is available through garbage collection
-  const multihash = (await ipfs.addFromFs(srcPath, { pin: true }))[0].hash
+  const multihash = (await ipfs.addFromFs(srcPath, { pin: false }))[0].hash
   req.logger.info(`Time taken in saveFileToIpfsFromFS to add: ${Date.now() - codeBlockTimeStart}`)
   codeBlockTimeStart = Date.now()
   const dstPath = path.join(req.app.get('storagePath'), multihash)
@@ -145,11 +145,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath) {
   await writeFile(storagePath, fileBuffer)
   req.logger.info(`wrote file to ${storagePath}`)
 
-  // Pin file to local INode.
-  req.logger.info(`pinning file ${multihash}...`)
-  await ipfs.pin.add(multihash)
   req.logger.info(`\nAdded file: ${multihash} at ${storagePath}`)
-
   return storagePath
 }
 

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -47,7 +47,7 @@ module.exports = function (app) {
           { path: path.join(req.file.originalname, '480x480.jpg'), content: imageBuffer480x480 },
           { path: path.join(req.file.originalname, '150x150.jpg'), content: imageBuffer150x150 },
           { path: path.join(req.file.originalname, 'original.jpg'), content: imageBufferOriginal }
-        ], { pin: true })
+        ], { pin: false })
       } else /** req.body.square == 'false' */ {
         // Resize image to desired resolutions
         const [imageBuffer2000x, imageBuffer640x] = await Promise.all([
@@ -61,7 +61,7 @@ module.exports = function (app) {
           { path: path.join(req.file.originalname, '2000x.jpg'), content: imageBuffer2000x },
           { path: path.join(req.file.originalname, '640x.jpg'), content: imageBuffer640x },
           { path: path.join(req.file.originalname, 'original.jpg'), content: imageBufferOriginal }
-        ], { pin: true })
+        ], { pin: false })
       }
       req.logger.info('ipfs add resp', ipfsAddResp)
 


### PR DESCRIPTION
Simply removes ipfs pin ops until rehydrate PR can be checked in https://github.com/AudiusProject/audius-protocol/pull/197. Will also allow us to remove pin rm cron job and minimize ipfs load