### PR TITLE
Add user track listen history, identity & libs

### DIFF
--- a/identity-service/sequelize/migrations/20191209222218-create-user-track-listen.js
+++ b/identity-service/sequelize/migrations/20191209222218-create-user-track-listen.js
@@ -1,0 +1,33 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('UserTrackListens', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      trackId: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    }).then(() => queryInterface.addIndex('UserTrackListens', ['userId']))
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('UserTrackListens', ['userId'])
+      .then(() => queryInterface.dropTable('UserTrackListens'))
+  }
+}

--- a/identity-service/sequelize/migrations/20191209222218-create-user-track-listen.js
+++ b/identity-service/sequelize/migrations/20191209222218-create-user-track-listen.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('UserTrackListens', {

--- a/identity-service/src/models/usertracklisten.js
+++ b/identity-service/src/models/usertracklisten.js
@@ -1,0 +1,28 @@
+'use strict'
+module.exports = (sequelize, DataTypes) => {
+  const UserTrackListen = sequelize.define('UserTrackListen', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    trackId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    }
+  }, {})
+  return UserTrackListen
+}

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.55",
+  "version": "0.11.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.55",
+  "version": "0.11.56",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/track.js
+++ b/libs/src/api/track.js
@@ -119,6 +119,18 @@ class Tracks extends Base {
   }
 
   /**
+   * Return saved tracks for current user
+   * NOTE in returned JSON, SaveType string one of track, playlist, album
+   * @param {number} userId
+   * @param {number} limit - max # of items to return
+   * @param {number} offset - offset into list to return from (for pagination)
+   */
+  async getListenHistoryTracks (userId, limit = 100, offset = 0) {
+    this.REQUIRES(Services.IDENTITY_SERVICE)
+    return this.identityService.getListenHistoryTracks(userId, limit, offset)
+  }
+
+  /**
    * Checks if a download is available from provided creator node endpoints
    * @param {string} creatorNodeEndpoints creator node endpoints
    * @param {number} trackId

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -114,6 +114,21 @@ class IdentityService {
   }
 
   /**
+   * Return listen history tracks for a given user id.
+   * @param {number} userID - User ID
+   * @param {number} limit - max # of items to return
+   * @param {number} offset - offset into list to return from (for pagination)
+   */
+  async getListenHistoryTracks (userId, limit = 100, offset = 0) {
+    let req = {
+      method: 'get',
+      url: '/tracks/history',
+      params: { userId, limit, offset }
+    }
+    return this._makeRequest(req)
+  }
+
+  /**
    * Looks up a Twitter account by handle.
    * @returns {Object} twitter API response.
    */


### PR DESCRIPTION
## Changes

#### Identity Service
* Add DB table to store user track listens
* Updated `/track/:id/listen` route to store user track listen w/ limit
* Added `/tracks/history` route to get tracks for a user's history 

#### Libs 
* Added method to get a user's track listen history - call to identity service