### PR TITLE
Disable rejection based on timestamp

### DIFF
--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -46,8 +46,8 @@ module.exports = function (app) {
     const theirTimestamp = parseInt(data.split(':')[1])
     const ourTimestamp = Math.round((new Date()).getTime() / 1000)
 
-    if (Math.abs(theirTimestamp - ourTimestamp) > 300) {
-      return errorResponseBadRequest('Timestamp too old')
+    if (Math.abs(theirTimestamp - ourTimestamp) > 3600) {
+      console.error(`Timestamp too old. User timestamp ${theirTimestamp}, Server timestamp ${ourTimestamp}`)
     }
 
     // all checks have passed! generate a new session token for the user

--- a/creator-node/test/users.js
+++ b/creator-node/test/users.js
@@ -89,6 +89,7 @@ describe('test Users', function () {
       .expect(400)
   })
 
+  /*
   it('login fails on old timestamp', async function () {
     await createStarterCNodeUser()
     const ts = Math.round((new Date()).getTime() / 1000) - 305
@@ -99,6 +100,7 @@ describe('test Users', function () {
       .send({ data, signature })
       .expect(400)
   })
+  */
 
   it('logout works', async function () {
     const session = await createStarterCNodeUser()


### PR DESCRIPTION
* Simply log if timestamp is outdated and issue token
* Interim fix for creator node