### PR TITLE
Increase creator node serve timeouts

### DIFF
--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -8,6 +8,7 @@ const { logger, loggingMiddleware } = require('./logging')
 const { userNodeMiddleware } = require('./userNodeMiddleware')
 const { userReqLimiter, trackReqLimiter, audiusUserReqLimiter, metadataReqLimiter, imageReqLimiter } = require('./reqLimiter')
 const redisClient = require('./redis')
+const config = require('./config')
 
 const TWENTY_MINUTES = 1000 * 60 * 20 // 1,200,000ms = 20min
 
@@ -52,6 +53,9 @@ const initializeApp = (port, storageDir, ipfsAPI, audiusLibs, blacklistManager) 
 
   // Increase from 2min default to accommodate long-lived requests.
   server.setTimeout(TWENTY_MINUTES)
+  server.keepAliveTimeout = config.get('keepAliveTimeout')
+  server.headersTimeout = config.get('headersTimeout')
+  console.log(server)
 
   return { app: app, server: server }
 }

--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -55,7 +55,6 @@ const initializeApp = (port, storageDir, ipfsAPI, audiusLibs, blacklistManager) 
   server.setTimeout(TWENTY_MINUTES)
   server.keepAliveTimeout = config.get('keepAliveTimeout')
   server.headersTimeout = config.get('headersTimeout')
-  console.log(server)
 
   return { app: app, server: server }
 }

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -77,6 +77,18 @@ const config = convict({
     env: 'port',
     default: null
   },
+  keepAliveTimeout: {
+    doc: 'Server keep alive timeout',
+    format: 'nat',
+    env: 'keepAliveTimeout',
+    default: 5000 //node.js default value
+  },
+  headersTimeout: {
+    doc: 'Server headers timeout',
+    format: 'nat',
+    env: 'headersTimeout',
+    default: 60000 //node.js default value
+  },
   logLevel: {
     doc: 'Log level',
     format: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -81,13 +81,13 @@ const config = convict({
     doc: 'Server keep alive timeout',
     format: 'nat',
     env: 'keepAliveTimeout',
-    default: 5000 //node.js default value
+    default: 5000 // node.js default value
   },
   headersTimeout: {
     doc: 'Server headers timeout',
     format: 'nat',
     env: 'headersTimeout',
-    default: 60000 //node.js default value
+    default: 60000 // node.js default value
   },
   logLevel: {
     doc: 'Log level',


### PR DESCRIPTION
In some cases the ELB has a timing issue that causes some long running commands like uploads to fail (https://medium.com/@ngchiwang/aws-alb-express-502-ramdom-daaabaafb7cf)