### PR TITLE
Add discprov fallback and regressed mode

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.61",
+  "version": "0.11.63",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.62",
+  "version": "0.11.63",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/services/discoveryProvider/constants.js
+++ b/libs/src/services/discoveryProvider/constants.js
@@ -1,5 +1,5 @@
 module.exports.DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-provider-timestamp'
-module.exports.UNHEALTHY_BLOCK_DIFF = -1
+module.exports.UNHEALTHY_BLOCK_DIFF = 15
 
 // When to time out the cached discovery provider
 module.exports.DISCOVERY_PROVIDER_RESELECT_TIMEOUT = 1 /* min */ * 60 /* seconds */ * 1000 /* millisec */

--- a/libs/src/services/discoveryProvider/constants.js
+++ b/libs/src/services/discoveryProvider/constants.js
@@ -1,5 +1,5 @@
 module.exports.DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-provider-timestamp'
-module.exports.UNHEALTHY_BLOCK_DIFF = 15
+module.exports.UNHEALTHY_BLOCK_DIFF = -1
 
 // When to time out the cached discovery provider
 module.exports.DISCOVERY_PROVIDER_RESELECT_TIMEOUT = 1 /* min */ * 60 /* seconds */ * 1000 /* millisec */

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -36,10 +36,12 @@ class DiscoveryProvider {
       }
 
       const pick = _.sample([...this.whitelist]) // selects random element from list.
-      const isValid = await this.ethContracts.validateDiscoveryProvider(pick)
+      const isValid = false// await this.ethContracts.validateDiscoveryProvider(pick)
       if (isValid) {
+        console.info('Initial discovery provider was valid')
         endpoint = pick
       } else {
+        console.info('Initial discovery provider was invalid, searching for a new one')
         endpoint = await this.ethContracts.selectDiscoveryProvider(this.whitelist)
       }
     }
@@ -561,6 +563,7 @@ class DiscoveryProvider {
   // urlParams - string of url params to be appended after base route
   // queryParams - object of query params to be appended to url
   async _makeRequest (requestObj, retries = 4) {
+    console.log(requestObj.endpoint)
     if (!this.discoveryProviderEndpoint) {
       await this.autoSelectEndpoint()
     }
@@ -596,6 +599,7 @@ class DiscoveryProvider {
       const parsedResponse = Utils.parseDataFromResponse(response)
 
       if (
+        !this.ethContracts.isInRegressedMode() &&
         'latest_indexed_block' in parsedResponse &&
         'latest_chain_block' in parsedResponse
       ) {
@@ -612,6 +616,7 @@ class DiscoveryProvider {
           // Clear any cached discprov
           localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
           // Select a new one
+          console.info(`${this.discoveryProviderEndpoint} is too far behind, reselecting discovery provider`)
           const endpoint = await this.autoSelectEndpoint()
           this.setEndpoint(endpoint)
           throw new Error(`Selected endpoint was too far behind. Indexed: ${indexedBlock} Chain: ${chainBlock}`)

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -563,7 +563,6 @@ class DiscoveryProvider {
   // urlParams - string of url params to be appended after base route
   // queryParams - object of query params to be appended to url
   async _makeRequest (requestObj, retries = 4) {
-    console.log(requestObj.endpoint)
     if (!this.discoveryProviderEndpoint) {
       await this.autoSelectEndpoint()
     }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -36,7 +36,7 @@ class DiscoveryProvider {
       }
 
       const pick = _.sample([...this.whitelist]) // selects random element from list.
-      const isValid = false// await this.ethContracts.validateDiscoveryProvider(pick)
+      const isValid = await this.ethContracts.validateDiscoveryProvider(pick)
       if (isValid) {
         console.info('Initial discovery provider was valid')
         endpoint = pick

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -186,7 +186,6 @@ class EthContracts {
     if (whitelist) {
       serviceProviders = serviceProviders.filter(d => whitelist.has(d.endpoint))
     }
-    console.info('Looking latest for service provider in', serviceProviders)
 
     // No discovery providers found.
     if (serviceProviders.length === 0) {
@@ -197,6 +196,9 @@ class EthContracts {
     if (!this.expectedServiceVersions) {
       this.expectedServiceVersions = await this.getExpectedServiceVersions()
     }
+
+    console.info(`Looking latest for service provider in ${serviceProviders} with version ${this.expectedServiceVersions}`)
+
     if (!this.expectedServiceVersions.hasOwnProperty(spType)) {
       throw new Error(`Invalid service name: ${spType}`)
     }
@@ -240,11 +242,11 @@ class EthContracts {
           if (spType === 'discovery-provider') {
             const { healthy, blockDiff } = await this.validateDiscoveryProviderHealth(sp.endpoint)
             if (!healthy) {
-              throw new Error('Discovery provider is not healthy')
+              throw new Error(`Discovery provider ${sp.endpoint} is not healthy`)
             }
             if (blockDiff > UNHEALTHY_BLOCK_DIFF) {
               fallbackServiceProviders[sp.endpoint] = blockDiff
-              throw new Error('Discovery provider is too far behind, adding as a fallback')
+              throw new Error(`Discovery provider ${sp.endpoint} is too far behind, adding as a fallback`)
             }
           }
 
@@ -275,7 +277,7 @@ class EthContracts {
       selectedServiceProvider = randomValidSPEndpoint
     } catch (err) {
       console.error(err)
-      console.warn(`All discovery providers failed for latest ${this.expectedServiceVersions[spType]} with healthy block numbers`)
+      console.warn(`All ${spType} failed for latest ${this.expectedServiceVersions[spType]} with healthy block numbers`)
       console.info('Trying to choose most up-to-date discovery provider from', fallbackServiceProviders)
 
       // Pick a fallback that has the smallest block difference and signal that we are running

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -269,10 +269,8 @@ class EthContracts {
 
       // Sort found endpoints array by semantic version
       var highestFoundSPVersion = foundVersionsList.sort(semver.rcompare)[0]
-      console.log(spVersionToEndpoint, highestFoundSPVersion)
       // Randomly select from highest found endpoints
       let highestFoundSPVersionEndpoints = spVersionToEndpoint[highestFoundSPVersion]
-      console.log(highestFoundSPVersionEndpoints)
       var randomValidSPEndpoint = highestFoundSPVersionEndpoints[Math.floor(Math.random() * highestFoundSPVersionEndpoints.length)]
       selectedServiceProvider = randomValidSPEndpoint
     } catch (err) {
@@ -280,12 +278,13 @@ class EthContracts {
       console.warn(`All discovery providers failed for latest ${this.expectedServiceVersions[spType]} with healthy block numbers`)
       console.info('Trying to choose most up-to-date discovery provider from', fallbackServiceProviders)
 
+      // Pick a fallback that has the smallest block difference and signal that we are running
+      // in regressed mode.
       if (Object.keys(fallbackServiceProviders).length > 0) {
         const sortedByBlockDiff = Object.keys(fallbackServiceProviders).sort(
           (a, b) => fallbackServiceProviders[a] - fallbackServiceProviders[b]
         )
         this.enterRegressedMode()
-        console.log(sortedByBlockDiff)
         return sortedByBlockDiff[0]
       } else {
         selectedServiceProvider = null
@@ -471,7 +470,7 @@ class EthContracts {
    * Gets a discovery provider in the following precedence:
    *  - Latest version and block diff < `UNHEALTHY_BLOCK_DIFF`
    *  - Latest version with the smallest block diff
-   *  - Prior version with a healthy block diff
+   *  - Prior version and block diff < `UNHEALTHY_BLOCK_DIFF`
    *  - null
    * @param {Set<string>?} whitelist optional whitelist to autoselect from
    */


### PR DESCRIPTION
TL;DR here is in the comment of selectDiscoveryProvider

```
* Gets a discovery provider in the following precedence:
   *  - Latest version and block diff < `UNHEALTHY_BLOCK_DIFF`
   *  - Latest version with the smallest block diff
   *  - Prior version and block diff < `UNHEALTHY_BLOCK_DIFF`
   *  - null
```

If case #2 (latest version w/ smaller block diff) is picked, the eth contracts wrapper enters "regressed mode" which the discprov wrapper uses to make sure it doesn't enforce block diff checks on each make_request.

This whole thing could definitely use a refactor, but I think this sets us up decently enough.