### PR TITLE
Fix discprov image dirCID indexing

### DIFF
--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -168,41 +168,57 @@ class IPFSClient:
             raise  # error is of type ipfshttpclient.exceptions.TimeoutError
 
     def multihash_is_directory(self, multihash):
+        # First attempt to cat multihash locally.
         try:
-            # attempt to cat single byte from CID to determine if dir or file
+            # If cat successful, multihash is not directory.
             self._api.cat(multihash, 0, 1)
             return False
         except Exception as e:  # pylint: disable=W0703
             if "this dag node is a directory" in str(e):
-                logger.warning(f'IPFSCLIENT | Found directory {multihash}')
+                logger.warning(f"IPFSCLIENT | Found directory {multihash}")
                 return True
 
-        # Attempt to retrieve from cnode gateway endpoints
+        # Attempt to retrieve from cnode gateway endpoints.
         gateway_endpoints = self._cnode_endpoints
         for address in gateway_endpoints:
-            gateway_query_address = "%s/ipfs/%s" % (address, multihash)
+            # First, query as dir.
+            gateway_query_address = "%s/ipfs/%s/150x150.jpg" % (address, multihash)
             r = None
             try:
-                logger.warning(f"IPFSCLIENT | Querying directory {gateway_query_address}")
+                logger.warning(f"IPFSCLIENT | Querying {gateway_query_address}")
                 r = requests.get(gateway_query_address, timeout=20)
             except Exception as e:
-                logger.warning(f'Failed to query {gateway_query_address}, {e}')
+                logger.warning(f"Failed to query {gateway_query_address} with error {e}")
 
             if r is not None:
                 try:
                     json_resp = r.json()
-                    if 'error' in json_resp and "this dag node is a directory" in json_resp['error']:
-                        logger.warning(f'IPFSCLIENT | Found directory {multihash}')
+                    if 'error' in json_resp and 'no link named' in json_resp['error']:
+                        logger.warning(f"IPFSCLIENT | Found directory {gateway_query_address}")
                         return True
                 except Exception as e:
-                    logger.warning(f'IPFSCLIENT | Failed to deserialize json for {multihash}, {e}')
+                    logger.warning(f"IPFSCLIENT | Failed to deserialize json for {multihash} for error {e}")
 
-                # Successful non-json response indicates image, not directory
+                # Success non-json response indicates image in dir
                 if r.status_code == 200:
                     logger.warning(f"IPFSCLIENT | Returned image at {gateway_query_address}")
-                    return False
+                    return True
 
-        raise Exception(f'Failed to determine multihash status, {multihash}')
+            # Else, query as non-dir image
+            gateway_query_address = "%s/ipfs/%s" % (address, multihash)
+            r = None
+            try:
+                logger.warning(f"IPFSCLIENT | Querying {gateway_query_address}")
+                r = requests.get(gateway_query_address, timeout=20)
+            except Exception as e:
+                logger.warning(f"Failed to query {gateway_query_address}, {e}")
+
+            # Successful non-json response indicates image, not directory
+            if r is not None and r.status_code == 200:
+                logger.warning(f"IPFSCLIENT | Returned image at {gateway_query_address}")
+                return False
+
+        raise Exception(f"Failed to determine multihash status, {multihash}")
 
     def connect_peer(self, peer):
         try:

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -193,6 +193,7 @@ class IPFSClient:
             if r is not None:
                 try:
                     json_resp = r.json()
+                    # Gateway will return "no link named" error if dir  but no file named 150x150.jpg exists in dir.
                     if 'error' in json_resp and 'no link named' in json_resp['error']:
                         logger.warning(f"IPFSCLIENT | Found directory {gateway_query_address}")
                         return True

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 import requests
 from requests.exceptions import ReadTimeout
 import ipfshttpclient
@@ -182,11 +182,11 @@ class IPFSClient:
         gateway_endpoints = self._cnode_endpoints
         for address in gateway_endpoints:
             # First, query as dir.
-            gateway_query_address = "%s/ipfs/%s/150x150.jpg" % (address, multihash)
+            gateway_query_address = urljoin(address, f"/ipfs/{multihash}/150x150.jpg")
             r = None
             try:
                 logger.warning(f"IPFSCLIENT | Querying {gateway_query_address}")
-                r = requests.get(gateway_query_address, timeout=20)
+                r = requests.get(gateway_query_address, timeout=10)
             except Exception as e:
                 logger.warning(f"Failed to query {gateway_query_address} with error {e}")
 
@@ -205,11 +205,11 @@ class IPFSClient:
                     return True
 
             # Else, query as non-dir image
-            gateway_query_address = "%s/ipfs/%s" % (address, multihash)
+            gateway_query_address = urljoin(address, f"/ipfs/{multihash}")
             r = None
             try:
                 logger.warning(f"IPFSCLIENT | Querying {gateway_query_address}")
-                r = requests.get(gateway_query_address, timeout=20)
+                r = requests.get(gateway_query_address, timeout=10)
             except Exception as e:
                 logger.warning(f"Failed to query {gateway_query_address}, {e}")
 


### PR DESCRIPTION
Fixes discprov image indexing when local cat fails. Regression occurred after we added multi-res images and changed the cnode ipfs gateway route API. The indexing code was still pinging the non-dir image gateway route on cnode, which no longer returns error msg indicating CID is a directory. Logic now first checks the dir image gateway route.

Tested fallback logic by removing the local cat logic at beginning of function so it has to ping the gateways.
Tested non-dir image fallback logic by running local discprov against staging chain from scratch.