### PR TITLE
unit tests for creator-node/src/routes/track.js

### DIFF
--- a/creator-node/.gitignore
+++ b/creator-node/.gitignore
@@ -11,3 +11,4 @@ eth-contract-config.json
 local-storage/
 test_file_storage/
 coverage/
+.nyc_output/

--- a/creator-node/.gitignore
+++ b/creator-node/.gitignore
@@ -10,3 +10,4 @@ local-test/
 eth-contract-config.json
 local-storage/
 test_file_storage/
+coverage/

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "nodemon src/index.js | ./node_modules/.bin/bunyan || exit 0",
     "test": "./scripts/run-tests.sh",
+    "coverage": "nyc npm run test",
+    "report": "nyc report --reporter=html",
     "lint": "./node_modules/.bin/standard",
     "lint-fix": "./node_modules/.bin/standard --fix",
     "psql": "psql -U postgres -h localhost -p 4432 -d audius_creator_node"
@@ -49,6 +51,7 @@
   "devDependencies": {
     "mocha": "^5.2.0",
     "nodemon": "^1.18.6",
+    "nyc": "^15.0.0",
     "sequelize-cli": "^5.3.0",
     "sinon": "^7.0.0",
     "standard": "^12.0.1",

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -6,7 +6,7 @@
     "start": "nodemon src/index.js | ./node_modules/.bin/bunyan || exit 0",
     "test": "./scripts/run-tests.sh",
     "coverage": "nyc npm run test",
-    "report": "nyc report --reporter=html",
+    "report": "nyc report --reporter=html", 
     "lint": "./node_modules/.bin/standard",
     "lint-fix": "./node_modules/.bin/standard --fix",
     "psql": "psql -U postgres -h localhost -p 4432 -d audius_creator_node"
@@ -60,6 +60,10 @@
   "//": {
     "dependenciesComments": {
       "lodash": "Vuln in < 4.17.13, fixed by https://github.com/lodash/lodash/pull/4336"
+    },
+    "scriptsComments": {
+      "coverage": "Runs nyc on tests/ dir and outputs results in ./nyc_output. Can be used for vscode extensions.",
+      "report": "Generates static html files representing code coverage per test file and outputs them into /coverage."
     }
   },
   "standard": {

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -142,7 +142,8 @@ module.exports = function (app) {
   }))
 
   /**
-   * Serve IPFS data hosted by creator node.
+   * Serve IPFS data hosted by creator node and create download route using query string pattern
+   * `...?filename=<file_name.mp3>`.
    * @dev This route does not handle responses by design, so we can pipe the response to client.
    */
   app.get('/ipfs/:CID', async (req, res) => {

--- a/creator-node/test/tracks.js
+++ b/creator-node/test/tracks.js
@@ -320,7 +320,6 @@ describe('test Tracks', function () {
 
     expect(resp1.body.track_segments[0].multihash).to.equal('testCIDLink')
     expect(resp1.body.track_segments.length).to.equal(32)
-    // expect(resp1.body.source_file).to.contain('.mp3')
 
     // creates a downloadable Audius track with no track_id and no source_file
     const metadata = {


### PR DESCRIPTION
Added 2 unit tests to `creator_node/test/track.js`:
- if `track_id` and `source_id` is not present, service should throw and error
- when passing in `download.is_downloadable: true, download.cid: <cid>` into metadata obj., a downloadable track should be created and return 200