### PR TITLE
Fix duplicate notification and halting condition

### DIFF
--- a/identity-service/src/awsSNS.js
+++ b/identity-service/src/awsSNS.js
@@ -142,6 +142,13 @@ async function addNotificationToBuffer (message, userId, tx, buffer, playSound, 
     userId: userId,
     notificationParams: { message, title, playSound }
   }
+  let existingEntriesCheck = buffer.filter(
+    entry => (
+      (entry.userId === userId) && (entry.notificationParams.message === message)
+    )
+  )
+  // Ensure no dups are added
+  if (existingEntriesCheck.length > 0) return
   buffer.push(bufferObj)
 }
 

--- a/identity-service/src/notifications/milestoneProcessing.js
+++ b/identity-service/src/notifications/milestoneProcessing.js
@@ -392,7 +392,7 @@ async function _processMilestone (milestoneType, userId, entityId, entityType, m
       await publish(msg, userId, tx, true, title)
     } catch (e) {
       // Log on error instead of failing
-      logger.info(`Error sending push notification ${e}. notifStub ${notifStub}`)
+      logger.info(`Error adding push notification to buffer: ${e}. notifStub ${notifStub}`)
     }
   }
 }

--- a/identity-service/src/notifications/milestoneProcessing.js
+++ b/identity-service/src/notifications/milestoneProcessing.js
@@ -380,15 +380,20 @@ async function _processMilestone (milestoneType, userId, entityId, entityType, m
 
     const metadata = await fetchNotificationMetadata(audiusLibs, milestoneValue, [notifStub])
     const mapNotification = notificationResponseMap[milestoneType]
-    let msgGenNotif = {
-      ...notifStub,
-      ...(mapNotification(notifStub, metadata))
+    try {
+      let msgGenNotif = {
+        ...notifStub,
+        ...(mapNotification(notifStub, metadata))
+      }
+      logger.debug('processMilestone - About to generate message for milestones push notification', msgGenNotif, metadata)
+      const msg = pushNotificationMessagesMap[notificationTypes.Milestone](msgGenNotif)
+      logger.debug(`processMilestone - message: ${msg}`)
+      const title = notificationResponseTitleMap[notificationTypes.Milestone]
+      await publish(msg, userId, tx, true, title)
+    } catch (e) {
+      // Log on error instead of failing
+      logger.info(`Error sending push notification ${e}. notifStub ${notifStub}`)
     }
-    logger.debug('processMilestone - About to generate message for milestones push notification', msgGenNotif, metadata)
-    const msg = pushNotificationMessagesMap[notificationTypes.Milestone](msgGenNotif)
-    logger.debug(`processMilestone - message: ${msg}`)
-    const title = notificationResponseTitleMap[notificationTypes.Milestone]
-    await publish(msg, userId, tx, true, title)
   }
 }
 


### PR DESCRIPTION
* Title parsing for a notification entity failed during processing of a given notif window block, a window in which a previous notif had added a push notification to the buffer. due to this failure, the buffer was repeatedly added to until resolution - once the title was formatted correctly, the entire buffer was drained.
* This can be prevented with a duplicate check during buffer add as well as improved error handling and logging
