### PR TITLE
filtering out any deleted tracks in dp endpoints

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -103,6 +103,10 @@ def get_tracks():
             except ValueError as e:
                 logger.error("Invalid value found in track id list", exc_info=True)
                 raise e
+        else:
+            base_query = base_query.filter(
+                Track.is_delete == False
+            )
 
         # Allow filtering of tracks by a certain creator
         if "user_id" in request.args:
@@ -320,6 +324,7 @@ def get_feed():
             playlist_tracks = (
                 session.query(Track)
                 .filter(
+                    # Track.is_delete == False, # ? do we want to show the tombstone
                     Track.is_current == True,
                     Track.track_id.in_(playlist_track_ids)
                 )
@@ -347,6 +352,7 @@ def get_feed():
             created_tracks_query = (
                 session.query(Track)
                 .filter(
+                    Track.is_delete == False,
                     Track.is_current == True,
                     Track.is_delete == False,
                     Track.is_unlisted == False,
@@ -418,6 +424,7 @@ def get_feed():
 
             # Query tracks reposted by followees
             reposted_tracks = session.query(Track).filter(
+                Track.is_delete == False,
                 Track.is_current == True,
                 Track.is_delete == False,
                 Track.is_unlisted == False,
@@ -555,6 +562,7 @@ def get_repost_feed_for_user(user_id):
         track_query = (
             session.query(Track)
             .filter(
+                Track.is_delete == False,
                 Track.is_current == True,
                 Track.is_delete == False,
                 Track.is_unlisted == False,
@@ -808,6 +816,7 @@ def get_track_repost_intersection_users(repost_track_id, follower_user_id):
     with db.scoped_session() as session:
         # ensure track_id exists
         track_entry = session.query(Track).filter(
+            Track.is_delete == False,
             Track.track_id == repost_track_id,
             Track.is_current == True
         ).first()
@@ -1036,6 +1045,7 @@ def get_reposters_for_track(repost_track_id):
     with db.scoped_session() as session:
         # Ensure Track exists for provided repost_track_id.
         track_entry = session.query(Track).filter(
+            Track.is_delete == False,
             Track.track_id == repost_track_id,
             Track.is_current == True
         ).first()
@@ -1165,6 +1175,7 @@ def get_savers_for_track(save_track_id):
     with db.scoped_session() as session:
         # Ensure Track exists for provided save_track_id.
         track_entry = session.query(Track).filter(
+            Track.is_delete == False,
             Track.track_id == save_track_id,
             Track.is_current == True
         ).first()
@@ -1335,6 +1346,7 @@ def get_saves(save_type):
             query = query.filter(
                 Save.save_item_id.in_(
                     session.query(Track.track_id).filter(
+                        Track.is_delete == False,
                         Track.is_current == True
                     )
                 )

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1338,7 +1338,6 @@ def get_saves(save_type):
             query = query.filter(
                 Save.save_item_id.in_(
                     session.query(Track.track_id).filter(
-                        Track.is_delete == False,
                         Track.is_current == True
                     )
                 )

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -347,7 +347,6 @@ def get_feed():
             created_tracks_query = (
                 session.query(Track)
                 .filter(
-                    Track.is_delete == False,
                     Track.is_current == True,
                     Track.is_delete == False,
                     Track.is_unlisted == False,
@@ -419,7 +418,6 @@ def get_feed():
 
             # Query tracks reposted by followees
             reposted_tracks = session.query(Track).filter(
-                Track.is_delete == False,
                 Track.is_current == True,
                 Track.is_delete == False,
                 Track.is_unlisted == False,
@@ -557,7 +555,6 @@ def get_repost_feed_for_user(user_id):
         track_query = (
             session.query(Track)
             .filter(
-                Track.is_delete == False,
                 Track.is_current == True,
                 Track.is_delete == False,
                 Track.is_unlisted == False,

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -103,10 +103,6 @@ def get_tracks():
             except ValueError as e:
                 logger.error("Invalid value found in track id list", exc_info=True)
                 raise e
-        else:
-            base_query = base_query.filter(
-                Track.is_delete == False
-            )
 
         # Allow filtering of tracks by a certain creator
         if "user_id" in request.args:
@@ -324,7 +320,6 @@ def get_feed():
             playlist_tracks = (
                 session.query(Track)
                 .filter(
-                    # Track.is_delete == False, # ? do we want to show the tombstone
                     Track.is_current == True,
                     Track.track_id.in_(playlist_track_ids)
                 )
@@ -816,7 +811,6 @@ def get_track_repost_intersection_users(repost_track_id, follower_user_id):
     with db.scoped_session() as session:
         # ensure track_id exists
         track_entry = session.query(Track).filter(
-            Track.is_delete == False,
             Track.track_id == repost_track_id,
             Track.is_current == True
         ).first()
@@ -1045,7 +1039,6 @@ def get_reposters_for_track(repost_track_id):
     with db.scoped_session() as session:
         # Ensure Track exists for provided repost_track_id.
         track_entry = session.query(Track).filter(
-            Track.is_delete == False,
             Track.track_id == repost_track_id,
             Track.is_current == True
         ).first()
@@ -1175,7 +1168,6 @@ def get_savers_for_track(save_track_id):
     with db.scoped_session() as session:
         # Ensure Track exists for provided save_track_id.
         track_entry = session.query(Track).filter(
-            Track.is_delete == False,
             Track.track_id == save_track_id,
             Track.is_current == True
         ).first()

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -111,10 +111,10 @@ def get_tracks():
                 Track.owner_id == user_id
             )
 
-        # Filter deleted tracks if we are not querying by track ids or we've explicitly said to filter deletes
+        # Allow filtering of deletes
         # Note: There is no standard for boolean url parameters, and any value (including 'false')
         # will be evaluated as true, so an explicit check is made for true
-        if ("id" not in request.args) or ("filter_deleted" in request.args):
+        if ("filter_deleted" in request.args):
             filter_deleted = request.args.get("filter_deleted")
             if (filter_deleted.lower() == 'true'):
                 base_query = base_query.filter(
@@ -162,13 +162,22 @@ def get_tracks_including_unlisted():
             route_id = helpers.create_track_route_id(i["url_title"], i["handle"])
             filter_cond.append(and_(
                 Track.is_current == True,
-                Track.is_delete == False,
                 Track.route_id == route_id,
                 Track.track_id == i["id"]
             ))
 
-        # Pass array of `and` clauses into an `or` clause as destrucutred *args
+        # Pass array of `and` clauses into an `or` clause as destructured *args
         base_query = base_query.filter(or_(*filter_cond))
+
+        # Allow filtering of deletes
+        # Note: There is no standard for boolean url parameters, and any value (including 'false')
+        # will be evaluated as true, so an explicit check is made for true
+        if ("filter_deleted" in request.args):
+            filter_deleted = request.args.get("filter_deleted")
+            if (filter_deleted.lower() == 'true'):
+                base_query = base_query.filter(
+                    Track.is_delete == False
+                )
 
         # Perform the query
         query_results = paginate_query(base_query).all()

--- a/discovery-provider/src/queries/search.py
+++ b/discovery-provider/src/queries/search.py
@@ -426,6 +426,7 @@ def track_search_query(session, searchStr, limit, offset, personalized, isAutoco
     tracks = (
         session.query(Track)
         .filter(
+            Track.is_delete == False,
             Track.is_current == True,
             Track.is_unlisted == False,
             Track.track_id.in_(track_ids),

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -71,7 +71,7 @@ def track_state_update(self, update_task, session, track_factory_txs, block_numb
 def lookup_track_record(update_task, session, entry, event_track_id, block_number, block_hash):
     # Check if track record exists
     track_exists = (
-        session.query(Track).filter_by(Track.is_delete == False, track_id=event_track_id).count() > 0
+        session.query(Track).filter_by(track_id=event_track_id).count() > 0
     )
 
     track_record = None
@@ -101,7 +101,7 @@ def lookup_track_record(update_task, session, entry, event_track_id, block_numbe
 
 def invalidate_old_track(session, track_id):
     track_exists = (
-        session.query(Track).filter_by(Track.is_delete == False, track_id=track_id).count() > 0
+        session.query(Track).filter_by(track_id=track_id).count() > 0
     )
 
     if not track_exists:

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -71,7 +71,7 @@ def track_state_update(self, update_task, session, track_factory_txs, block_numb
 def lookup_track_record(update_task, session, entry, event_track_id, block_number, block_hash):
     # Check if track record exists
     track_exists = (
-        session.query(Track).filter_by(track_id=event_track_id).count() > 0
+        session.query(Track).filter_by(Track.is_delete == False, track_id=event_track_id).count() > 0
     )
 
     track_record = None
@@ -101,7 +101,7 @@ def lookup_track_record(update_task, session, entry, event_track_id, block_numbe
 
 def invalidate_old_track(session, track_id):
     track_exists = (
-        session.query(Track).filter_by(track_id=track_id).count() > 0
+        session.query(Track).filter_by(Track.is_delete == False, track_id=track_id).count() > 0
     )
 
     if not track_exists:


### PR DESCRIPTION
So the original task was to filter out all deleted tracks in dp endpts, but upon further discussion, that shouldn't be the case.

Tombstones should show up for deleted tracks on/in:
- playlists
- favorites
- dashboard 

Tracks that are deleted should not be shown in/on:
- trending
- feed/repost feed
- search results

With this in mind, the queries have been modified to filter out deleted tracks in only the relevant methods. 