### PR TITLE
Add User Account Endpoint to discprov

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1452,7 +1452,7 @@ def get_users_account():
             Save.user_id == user_id,
             Save.is_current == True,
             Save.is_delete == False,
-            or_(Save.save_type == SaveType.playlist,Save.save_type == SaveType.album),
+            or_(Save.save_type == SaveType.playlist, Save.save_type == SaveType.album),
             Save.save_item_id.in_(
                 session.query(Playlist.playlist_id).filter(
                     Playlist.is_current == True,
@@ -1486,18 +1486,18 @@ def get_users_account():
         users = helpers.query_result_to_list(users)
         user_map = {}
 
-        collections = []
-        # Map the users to the collections
-        for collection_user in users:
-             user_map[collection_user['user_id']] = collection_user
+        stripped_playlists = []
+        # Map the users to the playlists/albums
+        for playlist_owner in users:
+             user_map[playlist_owner['user_id']] = playlist_owner
         for playlist in playlists:
-            collection_owner = user_map[playlist['playlist_owner_id']]
-            collections.append({
+            playlist_owner = user_map[playlist['playlist_owner_id']]
+            stripped_playlists.append({
                 'id': playlist['playlist_id'],
                 'name': playlist['playlist_name'],
                 'is_album': playlist['is_album'],
-                'user': { 'id': collection_owner['user_id'], 'handle': collection_owner['handle'] }
+                'user': { 'id': playlist_owner['user_id'], 'handle': playlist_owner['handle'] }
             })
-        user['collections'] = collections
+        user['playlists'] = stripped_playlists
 
     return api_helpers.success_response(user)

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1412,6 +1412,8 @@ def get_saves(save_type):
     return api_helpers.success_response(save_results)
 
 # Get the user saved collections & uploaded collections along with the collection user owners
+# NOTE: This is a one off endpoint for retrieving a user's collections/associated user and should
+# be consolidated later in the client
 @bp.route("/users/account", methods=("GET",))
 def get_users_account():
 
@@ -1422,55 +1424,41 @@ def get_users_account():
         # Don't return the user if they have no wallet or handle (user creation did not finish properly on chain)
         base_query = base_query.filter(User.is_current == True, User.wallet != None, User.handle != None)
 
-        if "wallet" in request.args:
-            wallet = request.args.get("wallet")
-            wallet = wallet.lower()
-            if len(wallet) == 42:
-                base_query = base_query.filter_by(wallet=wallet)
-                base_query = base_query.order_by(asc(User.created_at))
-            else:
-                logger.warning("Invalid wallet length")
-        if "handle" in request.args:
-            handle = request.args.get("handle").lower()
-            base_query = base_query.filter_by(handle_lc=handle)
-        if "id" in request.args:
-            id = int(request.args.get("id"))
-            base_query = base_query.filter_by(user_id=id)
+        if "wallet" not in request.args:
+            return api_helpers.error_response('Missing wallet param', 404)
 
-        users = base_query.all()
-        users = helpers.query_result_to_list(users)
+        wallet = request.args.get("wallet")
+        wallet = wallet.lower()
+        if len(wallet) == 42:
+            base_query = base_query.filter_by(wallet=wallet)
+            base_query = base_query.order_by(asc(User.created_at))
+        else:
+            return api_helpers.error_response('Invalid wallet length', 404)
 
-        user = users[0]
+        user = base_query.one()
+        user = helpers.model_to_dictionary(user)
         user_id = user['user_id']
 
         # bundle peripheral info into user results
-        users = populate_user_metadata(session, [user_id], users, user_id)
+        users = populate_user_metadata(session, [user_id], [user], user_id, True)
         user = users[0]
 
         # Get saved playlists / albums ids
-        saved_query = session.query(Save).filter(
+        saved_query = session.query(Save.save_item_id).filter(
             Save.user_id == user_id,
             Save.is_current == True,
             Save.is_delete == False,
-            or_(Save.save_type == SaveType.playlist, Save.save_type == SaveType.album),
-            Save.save_item_id.in_(
-                session.query(Playlist.playlist_id).filter(
-                    Playlist.is_current == True,
-                    Playlist.is_delete == False,
-                    Playlist.is_private == False
-                )
-            )
+            or_(Save.save_type == SaveType.playlist, Save.save_type == SaveType.album)
         )
  
         saved_query_results = saved_query.all()
-        save_collections = helpers.query_result_to_list(saved_query_results)
-        save_collection_ids = [item['save_item_id'] for item in save_collections]
+        save_collection_ids = [item[0] for item in saved_query_results]
 
         # Get Playlist/Albums saved or owned by the user
         playlist_query = session.query(Playlist).filter(
                 or_(
                     and_(Playlist.is_current == True, Playlist.is_delete == False, Playlist.playlist_owner_id == user_id),
-                    and_(Playlist.is_current == True, Playlist.playlist_id.in_(save_collection_ids))
+                    and_(Playlist.is_current == True, Playlist.is_delete == False, Playlist.playlist_id.in_(save_collection_ids))
                 )
             ).order_by(desc(Playlist.created_at))
         playlists = playlist_query.all()

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1433,7 +1433,7 @@ def get_users_account():
             base_query = base_query.filter_by(wallet=wallet)
             base_query = base_query.order_by(asc(User.created_at))
         else:
-            return api_helpers.error_response('Invalid wallet length', 404)
+            return api_helpers.error_response('Invalid wallet length', 400)
 
         user = base_query.one()
         user = helpers.model_to_dictionary(user)

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -195,7 +195,7 @@ def populate_user_metadata(session, user_ids, users, current_user_id):
     )
     repost_count_dict = {user_id: repost_count for (user_id, repost_count) in repost_counts}
 
-    # build dict of user id --> repost count
+    # build dict of user id --> track save count
     track_save_counts = (
         session.query(
             Save.user_id,

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -195,6 +195,23 @@ def populate_user_metadata(session, user_ids, users, current_user_id):
     )
     repost_count_dict = {user_id: repost_count for (user_id, repost_count) in repost_counts}
 
+    # build dict of user id --> repost count
+    track_save_counts = (
+        session.query(
+            Save.user_id,
+            func.count(Save.user_id)
+        )
+        .filter(
+            Save.is_current == True,
+            Save.is_delete == False,
+            Save.save_type == SaveType.track,
+            Save.user_id.in_(user_ids)
+        )
+        .group_by(Save.user_id)
+        .all()
+    )
+    track_save_count_dict = {user_id: user_track_save_count for (user_id, user_track_save_count) in track_save_counts}
+
     # build dict of user id --> track blocknumber
     track_blocknumbers = (
         session.query(
@@ -262,6 +279,7 @@ def populate_user_metadata(session, user_ids, users, current_user_id):
         user[response_name_constants.follower_count] = follower_count_dict.get(user_id, 0)
         user[response_name_constants.followee_count] = followee_count_dict.get(user_id, 0)
         user[response_name_constants.repost_count] = repost_count_dict.get(user_id, 0)
+        user[response_name_constants.track_save_count] = track_save_count_dict.get(user_id, 0)
         user[response_name_constants.track_blocknumber] = track_blocknumber_dict.get(user_id, -1)
         # current user specific
         user[response_name_constants.does_current_user_follow] = current_user_followed_user_ids.get(user_id, False)

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -93,7 +93,7 @@ def parse_sort_param(base_query, model, whitelist_sort_params):
 # given list of user ids and corresponding users, populates each user object with:
 #   track_count, playlist_count, album_count, follower_count, followee_count, repost_count
 #   if current_user_id available, populates does_current_user_follow, followee_follows
-def populate_user_metadata(session, user_ids, users, current_user_id):
+def populate_user_metadata(session, user_ids, users, current_user_id, with_track_save_count = False):
     # build dict of user id --> track count
     track_counts = (
         session.query(
@@ -194,23 +194,24 @@ def populate_user_metadata(session, user_ids, users, current_user_id):
         .all()
     )
     repost_count_dict = {user_id: repost_count for (user_id, repost_count) in repost_counts}
-
-    # build dict of user id --> track save count
-    track_save_counts = (
-        session.query(
-            Save.user_id,
-            func.count(Save.user_id)
+    track_save_count_dict = {}
+    if with_track_save_count : 
+        # build dict of user id --> track save count
+        track_save_counts = (
+            session.query(
+                Save.user_id,
+                func.count(Save.user_id)
+            )
+            .filter(
+                Save.is_current == True,
+                Save.is_delete == False,
+                Save.save_type == SaveType.track,
+                Save.user_id.in_(user_ids)
+            )
+            .group_by(Save.user_id)
+            .all()
         )
-        .filter(
-            Save.is_current == True,
-            Save.is_delete == False,
-            Save.save_type == SaveType.track,
-            Save.user_id.in_(user_ids)
-        )
-        .group_by(Save.user_id)
-        .all()
-    )
-    track_save_count_dict = {user_id: user_track_save_count for (user_id, user_track_save_count) in track_save_counts}
+        track_save_count_dict = {user_id: user_track_save_count for (user_id, user_track_save_count) in track_save_counts}
 
     # build dict of user id --> track blocknumber
     track_blocknumbers = (
@@ -279,8 +280,9 @@ def populate_user_metadata(session, user_ids, users, current_user_id):
         user[response_name_constants.follower_count] = follower_count_dict.get(user_id, 0)
         user[response_name_constants.followee_count] = followee_count_dict.get(user_id, 0)
         user[response_name_constants.repost_count] = repost_count_dict.get(user_id, 0)
-        user[response_name_constants.track_save_count] = track_save_count_dict.get(user_id, 0)
         user[response_name_constants.track_blocknumber] = track_blocknumber_dict.get(user_id, -1)
+        if with_track_save_count:
+            user[response_name_constants.track_save_count] = track_save_count_dict.get(user_id, 0)
         # current user specific
         user[response_name_constants.does_current_user_follow] = current_user_followed_user_ids.get(user_id, False)
         user[response_name_constants.current_user_followee_follow_count] = current_user_followee_follow_count_dict.get(user_id, 0)

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -14,6 +14,7 @@ followee_count = 'followee_count' # integer - total followee count of given user
 playlist_count = 'playlist_count' # integer - total count of playlists created by given user
 album_count = 'album_count' # integer - total count of albums created by given user (0 for all non-creators)
 track_count = 'track_count' # integer - total count of tracks created by given user
+track_save_count = 'track_save_count' # integer - total count of tracks saves created by given user
 created_at = 'created_at' # datetime - time track was created
 repost_count = 'repost_count' # integer - total count of reposts by given user
 track_blocknumber = 'track_blocknumber' # integer - blocknumber of latest track for user

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.67",
+  "version": "0.11.68",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.67",
+  "version": "0.11.68",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -565,7 +565,10 @@ class DiscoveryProvider {
   /**
    * Return user collections (saved & uploaded) along w/ users for those collections
    */
-  async getUserAccount (wallet = '') {
+  async getUserAccount (wallet) {
+    if (wallet === undefined) {
+      throw new Error('Expected wallet to get user account')
+    }
     let req = {
       endpoint: 'users/account',
       queryParams: { wallet }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -49,8 +49,8 @@ class DiscoveryProvider {
 
     if (endpoint && this.web3Manager && this.web3Manager.web3) {
       // Set current user if it exists
-      const users = await this.getUsers(1, 0, null, this.web3Manager.getWalletAddress())
-      if (users && users[0]) this.userStateManager.setCurrentUser(users[0])
+      const userAccount = await this.getUserAccount(this.web3Manager.getWalletAddress())
+      if (userAccount) this.userStateManager.setCurrentUser(userAccount)
     }
   }
 
@@ -558,6 +558,17 @@ class DiscoveryProvider {
     let req = {
       endpoint: 'saves/tracks',
       queryParams: { limit: limit, offset: offset, with_users: withUsers }
+    }
+    return this._makeRequest(req)
+  }
+
+  /**
+   * Return user collections (saved & uploaded) along w/ users for those collections
+   */
+  async getUserAccount (wallet = '') {
+    let req = {
+      endpoint: 'users/account',
+      queryParams: { wallet }
     }
     return this._makeRequest(req)
   }


### PR DESCRIPTION
## Summary
Adds a new route to discprov `/users/account` to return the populated user along w/ the collections the user has uploaded or saved & their users. This route is added b/c the init load of the dapp makes several  calls for this information and we want to reduce the init load time. Currently the dapp makes a call for the user, then for the user's playlists and saved playlists and then for the users for those playlists, which is reduced to a single api call in this case. 

also adds field `track_save_counts` to the populated users.  