### PR TITLE
index cache fix

### DIFF
--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -201,7 +201,7 @@ def generate_trending(db, time, genre, limit, offset):
             # Populate created at timestamps
             if track_entry[response_name_constants.track_id] in track_created_at_dict:
                 track_entry[response_name_constants.created_at] = \
-                        track_created_at_dict[track_entry[response_name_constants.track_id]]
+                        track_created_at_dict[track_entry[response_name_constants.track_id]].isoformat(timespec='seconds')
             else:
                 track_entry[response_name_constants.created_at] = None
 

--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -202,7 +202,6 @@ def generate_trending(db, time, genre, limit, offset):
             if track_entry[response_name_constants.track_id] in track_created_at_dict:
                 # datetime needs to be in isoformat for json.dumps() in `update_trending_cache()` to
                 # properly process the dp response and add to redis cache
-
                 # timespec = specifies additional components of the time to include
                 track_entry[response_name_constants.created_at] = \
                         track_created_at_dict[track_entry[response_name_constants.track_id]] \

--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -200,8 +200,13 @@ def generate_trending(db, time, genre, limit, offset):
 
             # Populate created at timestamps
             if track_entry[response_name_constants.track_id] in track_created_at_dict:
+                # datetime needs to be in isoformat for json.dumps() in `update_trending_cache()` to
+                # properly process the dp response and add to redis cache
+
+                # timespec = specifies additional components of the time to include
                 track_entry[response_name_constants.created_at] = \
-                        track_created_at_dict[track_entry[response_name_constants.track_id]].isoformat(timespec='seconds')
+                        track_created_at_dict[track_entry[response_name_constants.track_id]] \
+                            .isoformat(timespec='seconds')
             else:
                 track_entry[response_name_constants.created_at] = None
 


### PR DESCRIPTION
redis was not caching generate_trending results because the `json.dumps()` call in `update_trending_cache()` was throwing an error because the `created_at` field was returned as a `datetime` object. 

this fix is to convert the datetime into an isoformat that `json.dumps()` can handle