### PR TITLE
Fetch account on login

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.68",
+  "version": "0.11.69",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.68",
+  "version": "0.11.69",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -41,14 +41,14 @@ class Account extends Base {
     }
 
     phase = phases.FIND_USER
-    const users = await this.discoveryProvider.getUsers(1, 0, null, this.web3Manager.getWalletAddress())
-    if (users && users[0]) {
-      this.userStateManager.setCurrentUser(users[0])
-      const creatorNodeEndpoint = users[0].creator_node_endpoint
+    const userAccount = await this.discoveryProvider.getUserAccount(this.web3Manager.getWalletAddress())
+    if (userAccount) {
+      this.userStateManager.setCurrentUser(userAccount)
+      const creatorNodeEndpoint = userAccount.creator_node_endpoint
       if (creatorNodeEndpoint) {
         this.creatorNode.setEndpoint(CreatorNodeService.getPrimary(creatorNodeEndpoint))
       }
-      return { user: users[0], error: false, phase }
+      return { user: userAccount, error: false, phase }
     }
     return { error: 'No user found', phase }
   }


### PR DESCRIPTION
On login, update fetch user to fetch account so that the playlists are fetched too
Note, on signup only the user object is returned. An update to the dapp should be made to catch the case that the playlists may be undefined 