### PR TITLE
Add latest track, playlist, user endpoint

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1503,11 +1503,13 @@ def get_users_account():
 @bp.route("/latest/<type>", methods=("GET",))
 def get_max_id(type):
     if not type:
-        return api_helpers.error_response("Invalid type provided, must be one of 'track', 'playlist', 'user'", 400)
+        return api_helpers.error_response(
+            "Invalid type provided, must be one of 'track', 'playlist', 'user'", 400
+        )
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        if (type) == 'track':
+        if type == 'track':
             query_results = (
                 session
                 .query(Track)
@@ -1517,7 +1519,7 @@ def get_max_id(type):
             )
             res = helpers.query_result_to_list(query_results)
             return api_helpers.success_response(res[0])
-        elif (type) == 'playlist':
+        elif type == 'playlist':
             query_results = (
                 session
                 .query(Playlist)
@@ -1527,7 +1529,7 @@ def get_max_id(type):
             )
             res = helpers.query_result_to_list(query_results)
             return api_helpers.success_response(res[0])
-        elif (type) == 'user':
+        elif type == 'user':
             query_results = (
                 session
                 .query(User)

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1510,33 +1510,24 @@ def get_max_id(type):
     db = get_db_read_replica()
     with db.scoped_session() as session:
         if type == 'track':
-            query_results = (
+            latest = (
                 session
-                .query(Track)
-                .order_by(desc(Track.track_id))
-                .limit(1)
-                .all()
+                .query(func.max(Track.track_id))
+                .scalar()
             )
-            res = helpers.query_result_to_list(query_results)
-            return api_helpers.success_response(res[0])
+            return api_helpers.success_response(latest)
         elif type == 'playlist':
-            query_results = (
+            latest = (
                 session
-                .query(Playlist)
-                .order_by(desc(Playlist.playlist_id))
-                .limit(1)
-                .all()
+                .query(func.max(Playlist.playlist_id))
+                .scalar()
             )
-            res = helpers.query_result_to_list(query_results)
-            return api_helpers.success_response(res[0])
+            return api_helpers.success_response(latest)
         elif type == 'user':
-            query_results = (
+            latest = (
                 session
-                .query(User)
-                .order_by(desc(User.user_id))
-                .limit(1)
-                .all()
+                .query(func.max(User.user_id))
+                .scalar()
             )
-            res = helpers.query_result_to_list(query_results)
-            return api_helpers.success_response(res[0])
+            return api_helpers.success_response(latest)
     return api_helpers.error_response("Unable to compute latest", 400)

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1498,3 +1498,43 @@ def get_users_account():
         user['playlists'] = stripped_playlists
 
     return api_helpers.success_response(user)
+
+# Gets the max id for tracks, playlists, or users.
+@bp.route("/latest/<type>", methods=("GET",))
+def get_max_id(type):
+    if not type:
+        return api_helpers.error_response("Invalid type provided, must be one of 'track', 'playlist', 'user'", 400)
+
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        if (type) == 'track':
+            query_results = (
+                session
+                .query(Track)
+                .order_by(desc(Track.track_id))
+                .limit(1)
+                .all()
+            )
+            res = helpers.query_result_to_list(query_results)
+            return api_helpers.success_response(res[0])
+        elif (type) == 'playlist':
+            query_results = (
+                session
+                .query(Playlist)
+                .order_by(desc(Playlist.playlist_id))
+                .limit(1)
+                .all()
+            )
+            res = helpers.query_result_to_list(query_results)
+            return api_helpers.success_response(res[0])
+        elif (type) == 'user':
+            query_results = (
+                session
+                .query(User)
+                .order_by(desc(User.user_id))
+                .limit(1)
+                .all()
+            )
+            res = helpers.query_result_to_list(query_results)
+            return api_helpers.success_response(res[0])
+    return api_helpers.error_response("Unable to compute latest", 400)


### PR DESCRIPTION
Not only will this be nice to have -- it's *really* useful for the sitemap crawler which needs to have better stopping criteria (so it knows when it has indexed everything into the discprov into the sitemap)

more on that here

https://github.com/AudiusProject/cartographer


I tested this against staging