### PR TITLE
Fix for local setup scripts

### DIFF
--- a/libs/examples/initAudiusLibs.js
+++ b/libs/examples/initAudiusLibs.js
@@ -48,7 +48,13 @@ async function initAudiusLibs (useExternalWeb3, ownerWalletOverride = null, ethO
   }
   let audiusLibs = new AudiusLibs(audiusLibsConfig)
 
-  await audiusLibs.init()
+  // we need this try/catch because sometimes we call init before a discprov has been brought up
+  // in that case, handle that error and continue so we're unblocking scripts that depend on this libs instance for other functionality
+  try {
+    await audiusLibs.init()
+  } catch(e) {
+    console.error(`Couldn't init libs`, e)
+  }
   return audiusLibs
 }
 

--- a/libs/examples/initAudiusLibs.js
+++ b/libs/examples/initAudiusLibs.js
@@ -52,7 +52,7 @@ async function initAudiusLibs (useExternalWeb3, ownerWalletOverride = null, ethO
   // in that case, handle that error and continue so we're unblocking scripts that depend on this libs instance for other functionality
   try {
     await audiusLibs.init()
-  } catch(e) {
+  } catch (e) {
     console.error(`Couldn't init libs`, e)
   }
   return audiusLibs

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -29,6 +29,7 @@ class DiscoveryProvider {
   async init () {
     let endpoint
     let pick
+    let isValid = null
 
     if (this.autoselect) {
       endpoint = await this.autoSelectEndpoint()
@@ -46,17 +47,21 @@ class DiscoveryProvider {
           whitelistMap[urlJoin(url, '/version')] = url
         })
 
-        let resp = await Utils.raceRequests(Object.keys(whitelistMap), (url) => {
-          pick = whitelistMap[url]
-        }, {})
-
-        const isValid = pick && resp.data.service && (resp.data.service === serviceType.DISCOVERY_PROVIDER)
-        if (isValid) {
-          console.info('Initial discovery provider was valid')
-          endpoint = pick
-        } else {
-          console.info('Initial discovery provider was invalid, searching for a new one')
-          endpoint = await this.ethContracts.selectDiscoveryProvider(this.whitelist)
+        try {
+          let resp = await Utils.raceRequests(Object.keys(whitelistMap), (url) => {
+            pick = whitelistMap[url]
+          }, {})
+  
+          isValid = pick && resp.data.service && (resp.data.service === serviceType.DISCOVERY_PROVIDER)
+          if (isValid) {
+            console.info('Initial discovery provider was valid')
+            endpoint = pick
+          } else {
+            console.info('Initial discovery provider was invalid, searching for a new one')
+            endpoint = await this.ethContracts.selectDiscoveryProvider(this.whitelist)
+          }
+        } catch (e) {
+          console.error('Could not select a discprov from the whitelist', e)
         }
       }
     }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -51,7 +51,7 @@ class DiscoveryProvider {
           let resp = await Utils.raceRequests(Object.keys(whitelistMap), (url) => {
             pick = whitelistMap[url]
           }, {})
-  
+
           isValid = pick && resp.data.service && (resp.data.service === serviceType.DISCOVERY_PROVIDER)
           if (isValid) {
             console.info('Initial discovery provider was valid')

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -61,7 +61,7 @@ class DiscoveryProvider {
             endpoint = await this.ethContracts.selectDiscoveryProvider(this.whitelist)
           }
         } catch (e) {
-          console.error('Could not select a discprov from the whitelist', e)
+          throw new Error('Could not select a discprov from the whitelist', e)
         }
       }
     }


### PR DESCRIPTION
This is causing local setup scripts to fail. Anywhere the libs.init() is called, it will try to select a discprov if autoselect is false. If there's no discprov available to select, it throws an error. This adds a try/catch to handle that case and log out an error