### PR TITLE
Allow single discprov (seo)

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.70",
+  "version": "0.11.71",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "0.11.70",
+  "version": "0.11.71",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
This allows the dapp to run against the discprov without initializing any contracts and used a fixed discprov whitelist of just a single-string.