### PR TITLE
Fix lint error, CI

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -7,7 +7,7 @@ const {
   DISCOVERY_PROVIDER_TIMESTAMP,
   UNHEALTHY_BLOCK_DIFF,
   DISCOVERY_PROVIDER_SELECTION_TIMEOUT_MS
- } = require('./constants')
+} = require('./constants')
 
 // TODO - webpack workaround. find a way to do this without checkout for .default property
 let urlJoin = require('proper-url-join')


### PR DESCRIPTION
* Libs failing lint on discovery provider service code
* Major bug in libs CI found where test failures do NOT fail CI, will be addressed separately