### PR TITLE
[eth-contracts] Lockup for undelegate operations

### DIFF
--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -103,6 +103,7 @@ contract ClaimFactory is RegistryContract {
 
     // TODO: Name this function better
     // TODO: Permission caller
+    // TODO: Add parameter for locked funds, this will be subtracted in reards calculation
     function processClaim(address _claimer) external returns (uint newAccountTotal) {
         address stakingAddress = registry.getContract(stakingProxyOwnerKey);
         Staking stakingContract = Staking(stakingAddress);

--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -56,7 +56,6 @@ contract ClaimFactory is RegistryContract {
         stakingProxyOwnerKey = _stakingProxyOwnerKey;
         audiusToken = ERC20Mintable(tokenAddress);
         registry = RegistryInterface(_registryAddress);
-        // Allow a claim to be funded initially by subtracting the configured difference
         fundBlock = 0;
     }
 

--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -104,9 +104,10 @@ contract ClaimFactory is RegistryContract {
     // TODO: Name this function better
     // TODO: Permission caller
     function processClaim(
-      address _claimer,
-      uint _totalLockedForSP
-    ) external returns (uint newAccountTotal) {
+        address _claimer,
+        uint _totalLockedForSP
+    ) external returns (uint newAccountTotal)
+    {
         address stakingAddress = registry.getContract(stakingProxyOwnerKey);
         Staking stakingContract = Staking(stakingAddress);
         // Prevent duplicate claim

--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -57,7 +57,7 @@ contract ClaimFactory is RegistryContract {
         audiusToken = ERC20Mintable(tokenAddress);
         registry = RegistryInterface(_registryAddress);
         // Allow a claim to be funded initially by subtracting the configured difference
-        fundBlock = block.number - fundRoundBlockDiff;
+        fundBlock = 0;
     }
 
     function getFundingRoundBlockDiff()
@@ -156,6 +156,6 @@ contract ClaimFactory is RegistryContract {
         address stakingAddress = registry.getContract(stakingProxyOwnerKey);
         Staking stakingContract = Staking(stakingAddress);
         uint lastClaimedForSP = stakingContract.lastClaimedFor(_sp);
-        return (lastClaimedForSP >= fundBlock);
+        return (lastClaimedForSP < fundBlock);
     }
 }

--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -103,7 +103,6 @@ contract ClaimFactory is RegistryContract {
 
     // TODO: Name this function better
     // TODO: Permission caller
-    // TODO: Add parameter for locked funds, this will be subtracted in reards calculation
     function processClaim(
       address _claimer,
       uint _totalLockedForSP
@@ -122,7 +121,6 @@ contract ClaimFactory is RegistryContract {
         uint totalStakedAtFundBlock = stakingContract.totalStakedAt(fundBlock);
 
         // Calculate claimer rewards
-        // TODO: Determine whether claimerTotalStake has to be adjusted by locked amount
         uint rewardsForClaimer = (
           claimerTotalStake.mul(fundingAmount)
         ).div(totalStakedAtFundBlock);

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -162,7 +162,7 @@ contract DelegateManager is RegistryContract {
     {
         require(
           claimPending(_target) == false,
-          'Undelegate not permitted for SP pending claim'
+          'Undelegate request not permitted for SP pending claim'
         );
         address delegator = msg.sender;
         bool exists = delegatorExistsForSP(delegator, _target);
@@ -204,13 +204,14 @@ contract DelegateManager is RegistryContract {
         require(undelegateRequests[delegator].amount != 0, "Pending lockup amount expected");
         require(undelegateRequests[delegator].serviceProvider != address(0), "Pending lockup SP expected");
 
+        // Confirm lockup expiry has expired
+        require(undelegateRequests[delegator].lockupExpiryBlock <= block.number, "Lockup must be expired");
+
+        // Confirm no pending claim for this service provider
         require(
           claimPending(undelegateRequests[delegator].serviceProvider) == false,
           'Undelegate not permitted for SP pending claim'
         );
-
-        // Confirm lockup expiry has expired
-        require(undelegateRequests[delegator].lockupExpiryBlock <= block.number, "Lockup must be expired");
 
         address serviceProvider = undelegateRequests[delegator].serviceProvider;  
         uint unstakeAmount = undelegateRequests[delegator].amount; 

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -8,8 +8,6 @@ import "./interface/registry/RegistryInterface.sol";
 import "../staking/Staking.sol";
 import "./ServiceProviderFactory.sol";
 import "./ClaimFactory.sol";
-// import "../staking/Checkpointing.sol";
-
 
 // WORKING CONTRACT
 // Designed to manage delegation to staking contract
@@ -26,7 +24,7 @@ contract DelegateManager is RegistryContract {
 
     // Number of blocks an undelegate operation has to wait
     // TODO: Expose CRUD
-    // TODO: Consider moving this value to Staking.sol as SPFactory may need as well 
+    // TODO: Move this value to Staking.sol as SPFactory may need as well 
     uint undelegateLockupDuration = 10;
 
     // Staking contract ref

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -194,9 +194,24 @@ contract DelegateManager is RegistryContract {
         return delegatorStakeTotal[delegator] - _amount;
     }
 
-    // TODO: Cancel undelegation request from delegator
+    // Cancel undelegation request
+    function cancelUndelegateStake() external {
+        address delegator = msg.sender;
+        // Confirm pending delegation request
+        require(
+            undelegateRequests[delegator].lockupExpiryBlock != 0, "Pending lockup expiry expected");
+        require(undelegateRequests[delegator].amount != 0, "Pending lockup amount expected");
+        require(
+            undelegateRequests[delegator].serviceProvider != address(0), "Pending lockup SP expected");
+        // Remove pending request
+        undelegateRequests[delegator] = UndelegateStakeRequest({
+            lockupExpiryBlock: 0,
+            amount: 0,
+            serviceProvider: address(0)
+        });
+    }
 
-    // Finalize undelegation request
+    // Finalize undelegation request and withdraw stake
     function undelegateStake() external returns (uint newTotal) {
         address delegator = msg.sender;
 

--- a/eth-contracts/test/_lib/lib.js
+++ b/eth-contracts/test/_lib/lib.js
@@ -79,3 +79,13 @@ export const advanceBlock = (web3) => {
     })
   })
 }
+
+export const advanceToTargetBlock = async (targetBlockNumber, web3) => {
+  let currentBlock = await web3.eth.getBlock('latest')
+  let currentBlockNum = currentBlock.number
+  while (currentBlockNum < targetBlockNumber) {
+    await advanceBlock(web3)
+    currentBlock = await web3.eth.getBlock('latest')
+    currentBlockNum = currentBlock.number
+  }
+}

--- a/eth-contracts/test/claimFactory.test.js
+++ b/eth-contracts/test/claimFactory.test.js
@@ -108,7 +108,7 @@ contract('ClaimFactory', async (accounts) => {
     let fundsPerRound = await claimFactory.getFundsPerRound()
 
     await claimFactory.initiateRound()
-    await claimFactory.processClaim(staker)
+    await claimFactory.processClaim(staker, 0)
 
     totalStaked = await staking.totalStaked()
 
@@ -137,7 +137,7 @@ contract('ClaimFactory', async (accounts) => {
 
     // Initiate round
     await claimFactory.initiateRound()
-    await claimFactory.processClaim(staker)
+    await claimFactory.processClaim(staker, 0)
     totalStaked = await staking.totalStaked()
 
     assert.isTrue(
@@ -172,7 +172,7 @@ contract('ClaimFactory', async (accounts) => {
 
     // Initiate another round
     await claimFactory.initiateRound()
-    await claimFactory.processClaim(staker)
+    await claimFactory.processClaim(staker, 0)
     totalStaked = await staking.totalStaked()
     let finalAcctStake = await staking.totalStakedFor(staker)
     let expectedFinalValue = accountStakeBeforeSecondClaim.add(fundsPerClaim)
@@ -212,7 +212,7 @@ contract('ClaimFactory', async (accounts) => {
 
     // Initiate claim
     await claimFactory.initiateRound()
-    await claimFactory.processClaim(staker)
+    await claimFactory.processClaim(staker, 0)
     totalStaked = await staking.totalStaked()
 
     assert.isTrue(

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -228,7 +228,7 @@ contract('DelegateManager', async (accounts) => {
         'Stake value in SPFactory and Staking.sol must be equal')
     })
 
-    it.only('single delegator basic operations', async () => {
+    it('single delegator basic operations', async () => {
       // TODO: Validate all
       // Transfer 1000 tokens to delegator
       await token.transfer(delegatorAccount1, INITIAL_BAL, { from: treasuryAddress })

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -645,7 +645,7 @@ contract('DelegateManager', async (accounts) => {
         'Expect no lockup funds to carry over')
     })
 
-    it.only('3 delegators + pending claim + undelegate restrictions', async () => {
+    it('3 delegators + pending claim + undelegate restrictions', async () => {
       const delegatorAccount2 = accounts[5]
       const delegatorAccount3 = accounts[6]
       // Transfer 1000 tokens to delegator2, delegator3
@@ -740,8 +740,5 @@ contract('DelegateManager', async (accounts) => {
 
       await delegateManager.claimRewards({ from: stakerAccount })
     })
-    // TODO: What happens when someone delegates after a funding round has started...?
-    //        Do they still get rewards or not?
-    //        Potential idea - just lockup delegation for some inteval
   })
 })

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -179,7 +179,7 @@ contract('DelegateManager', async (accounts) => {
     }
   }
 
-  describe('Delegation flow', () => {
+  describe('Delegation tests', () => {
     let regTx
     beforeEach(async () => {
       // Transfer 1000 tokens to stakers
@@ -602,7 +602,7 @@ contract('DelegateManager', async (accounts) => {
     })
 
     // Confirm a pending undelegate operation negates any claimed value
-    it.only('single delegator + undelegate + slash', async () => {
+    it('single delegator + undelegate + slash', async () => {
       let initialDelegateAmount = toWei(60)
       let slashAmount = toWei(100)
 

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -366,12 +366,15 @@ contract('DelegateManager', async (accounts) => {
 
       totalStakedForSP = await staking.totalStakedFor(stakerAccount)
       let delegatedStake = await delegateManager.getTotalDelegatorStake(delegatorAccount1)
-
       let deployerCut = await serviceProviderFactory.getServiceProviderDeployerCut(stakerAccount)
       let deployerCutBase = await serviceProviderFactory.getServiceProviderDeployerCutBase()
 
       // Initiate round
       await claimFactory.initiateRound()
+
+      // Confirm claim is pending
+      let pendingClaim = await claimFactory.claimPending(stakerAccount)
+      assert.isTrue(pendingClaim, 'ClaimFactory expected to consider claim pending')
 
       let spStake = await serviceProviderFactory.getServiceProviderStake(stakerAccount)
       let totalStake = await staking.totalStaked()

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -244,7 +244,7 @@ contract('DelegateManager', async (accounts) => {
         { from: delegatorAccount1 })
 
       let delegators = await delegateManager.getDelegatorsList(stakerAccount)
-      await delegateManager.increaseDelegatedStake(
+      await delegateManager.delegateStake(
         stakerAccount,
         initialDelegateAmount,
         { from: delegatorAccount1 })
@@ -339,7 +339,7 @@ contract('DelegateManager', async (accounts) => {
         initialDelegateAmount,
         { from: delegatorAccount1 })
 
-      await delegateManager.increaseDelegatedStake(
+      await delegateManager.delegateStake(
         stakerAccount,
         initialDelegateAmount,
         { from: delegatorAccount1 })
@@ -394,7 +394,7 @@ contract('DelegateManager', async (accounts) => {
         initialDelegateAmount,
         { from: delegatorAccount1 })
 
-      await delegateManager.increaseDelegatedStake(
+      await delegateManager.delegateStake(
         stakerAccount,
         initialDelegateAmount,
         { from: delegatorAccount1 })
@@ -455,7 +455,7 @@ contract('DelegateManager', async (accounts) => {
           singleDelegateAmount,
           { from: delegator })
 
-        await delegateManager.increaseDelegatedStake(
+        await delegateManager.delegateStake(
           stakerAccount,
           singleDelegateAmount,
           { from: delegator })

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -288,6 +288,15 @@ contract('DelegateManager', async (accounts) => {
         delegateManager.undelegateStake({ from: delegatorAccount1 }),
         'Lockup must be expired'
       )
+      // Try to submit another request, expect revert
+      await _lib.assertRevert(
+        delegateManager.requestUndelegateStake(
+          stakerAccount,
+          initialDelegateAmount,
+          { from: delegatorAccount1 }),
+          'No pending lockup expiry allowed'
+      )
+
       // Advance to valid block
       await _lib.advanceToTargetBlock(
         fromBn(undelegateRequestInfo.lockupExpiryBlock),


### PR DESCRIPTION
* Enforces a block difference for undelegate operations, locking funds
* Handles reward negation for locked up funds
* Slash operations reset undelegate requests
* Disabled delegate operations while claim is pending