### PR TITLE
[eth-contracts] Valid stake bounds indicator + direct deployer stake requirement

### DIFF
--- a/eth-contracts/contracts/service/ClaimFactory.sol
+++ b/eth-contracts/contracts/service/ClaimFactory.sol
@@ -96,7 +96,6 @@ contract ClaimFactory is RegistryContract {
         fundBlock = block.number;
         totalClaimedInRound = 0;
         roundNumber += 1;
-
         emit RoundInitiated(
             fundBlock,
             roundNumber,

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -305,6 +305,7 @@ contract DelegateManager is RegistryContract {
         );
         // Pass in locked amount for claimer
         uint totalLockedForClaimer = spDelegateInfo[msg.sender].totalLockedUpStake;
+
         // Process claim for msg.sender
         claimFactory.processClaim(msg.sender, totalLockedForClaimer);
 
@@ -322,6 +323,11 @@ contract DelegateManager is RegistryContract {
         // Amount in sp factory for claimer
         uint totalBalanceInSPFactory = spFactory.getServiceProviderStake(msg.sender);
         require(totalBalanceInSPFactory > 0, "Service Provider stake required");
+
+        // Confirm service provider is valid 
+        require(
+          spFactory.isServiceProviderWithinBounds(msg.sender),
+          'Service provider must be within bounds');
 
         // Amount in delegate manager staked to service provider
         uint totalBalanceInDelegateManager = spDelegateInfo[msg.sender].totalDelegatedStake;

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -293,6 +293,11 @@ contract DelegateManager is RegistryContract {
             serviceProvider: address(0)
         });
 
+        // Validate balance
+        ServiceProviderFactory(
+            registry.getContract(serviceProviderFactoryKey)
+        ).validateAccountStakeBalance(serviceProvider);
+
         // Return new total
         return delegateInfo[delegator][serviceProvider];
     }

--- a/eth-contracts/contracts/service/DelegateManager.sol
+++ b/eth-contracts/contracts/service/DelegateManager.sol
@@ -389,7 +389,6 @@ contract DelegateManager is RegistryContract {
         // Update total delegated to this SP
         spDelegateInfo[msg.sender].totalDelegatedStake += totalDelegatedStakeIncrease;
 
-        // TODO: Validate below with test cases
         uint spRewardShare = (
           totalBalanceInSPFactory.mul(totalRewards)
         ).div(totalActiveFunds);

--- a/eth-contracts/contracts/service/MockServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/MockServiceProviderFactory.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.5.0;
+
+import "./registry/RegistryContract.sol";
+
+
+// Test contract used in claim factory scenarios
+// Eliminates requirement for full SPFactory
+contract MockServiceProviderFactory is RegistryContract {
+    uint max;
+
+    constructor() public
+    {
+        // Configure test max
+        max = 100000000 * 10**uint256(18);
+    }
+
+    /// @notice Calculate the stake for an account based on total number of registered services
+    // TODO: Cache value
+    function getAccountStakeBounds(address sp)
+    external view returns (uint minStake, uint maxStake)
+    {
+        return (0, max);
+    }
+}

--- a/eth-contracts/contracts/service/MockServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/MockServiceProviderFactory.sol
@@ -15,7 +15,6 @@ contract MockServiceProviderFactory is RegistryContract {
     }
 
     /// @notice Calculate the stake for an account based on total number of registered services
-    // TODO: Cache value
     function getAccountStakeBounds(address sp)
     external view returns (uint minStake, uint maxStake)
     {

--- a/eth-contracts/contracts/service/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/ServiceProviderFactory.sol
@@ -22,7 +22,6 @@ contract ServiceProviderFactory is RegistryContract {
     }
 
     mapping(bytes32 => ServiceInstanceStakeRequirements) serviceTypeStakeRequirements;
-    // END Temporary data structures
 
     // Maps directly staked amount by SP, not including delegators
     mapping(address => uint) spDeployerStake;
@@ -32,6 +31,7 @@ contract ServiceProviderFactory is RegistryContract {
 
     // Bool indicating whether this SP has met the min/max stake requirements
     mapping(address => bool) spValidBounds;
+    // END Temporary data structures
 
     bytes empty;
 

--- a/eth-contracts/contracts/service/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/ServiceProviderFactory.sol
@@ -326,11 +326,18 @@ contract ServiceProviderFactory is RegistryContract {
     {
         // Update SP tracked total
         spDetails[_serviceProvider].deployerStake = _amount;
+        this.updateServiceProviderBoundStatus(_serviceProvider);
+    }
 
+  /**
+   * @notice Update service provider bound status
+   * TODO: Permission to only delegatemanager OR this
+   */
+    function updateServiceProviderBoundStatus(address _serviceProvider) external
+    {
         Staking stakingContract = Staking(
             registry.getContract(stakingProxyOwnerKey)
         );
-
         // Validate bounds for total stake
         uint totalSPStake = stakingContract.totalStakedFor(_serviceProvider);
         (uint minStake, uint maxStake) = this.getAccountStakeBounds(_serviceProvider);

--- a/eth-contracts/contracts/service/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/ServiceProviderFactory.sol
@@ -181,6 +181,7 @@ contract ServiceProviderFactory is RegistryContract {
 
         // Unstake on deregistration if and only if this is the last service endpoint
         uint unstakeAmount = 0;
+        bool unstaked = false;
         // owned by the user
         if (numberOfEndpoints == 1) {
             unstakeAmount = Staking(
@@ -194,8 +195,8 @@ contract ServiceProviderFactory is RegistryContract {
             );
 
             // Update deployer total
-            // spDeployerStake[owner] -= unstakeAmount;
             spDetails[owner].deployerStake -= unstakeAmount;
+            unstaked = true;
         }
 
         (uint deregisteredID) = ServiceProviderStorageInterface(
@@ -213,8 +214,11 @@ contract ServiceProviderFactory is RegistryContract {
             unstakeAmount);
 
         // Confirm both aggregate account balance and directly staked amount are valid
-        this.validateAccountStakeBalance(owner);
-        validateServiceProviderDirectStake(owner);
+        // Only if unstake operation has not occurred
+        if (!unstaked) {
+            this.validateAccountStakeBalance(owner);
+            validateServiceProviderDirectStake(owner);
+        }
 
         return deregisteredID;
     }

--- a/eth-contracts/contracts/service/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/service/ServiceProviderFactory.sol
@@ -550,9 +550,9 @@ contract ServiceProviderFactory is RegistryContract {
     function validateServiceProviderDirectStake(address sp)
     internal view returns (uint directStake)
     {
-      require(
-        spDetails[sp].deployerStake >= minDirectDeployerStake,
-        "Direct stake restriction violated for this service provider");
-      return spDetails[sp].deployerStake;
+        require(
+            spDetails[sp].deployerStake >= minDirectDeployerStake,
+            "Direct stake restriction violated for this service provider");
+        return spDetails[sp].deployerStake;
     }
 }

--- a/eth-contracts/migrations/6_claim_factory_migration.js
+++ b/eth-contracts/migrations/6_claim_factory_migration.js
@@ -4,6 +4,7 @@ const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
 const Registry = artifacts.require('Registry')
 const ownedUpgradeabilityProxyKey = web3.utils.utf8ToHex('OwnedUpgradeabilityProxy')
 const claimFactoryKey = web3.utils.utf8ToHex('ClaimFactory')
+const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
@@ -16,7 +17,8 @@ module.exports = (deployer, network, accounts) => {
       ClaimFactory,
       AudiusToken.address,
       registry.address,
-      ownedUpgradeabilityProxyKey)
+      ownedUpgradeabilityProxyKey,
+      serviceProviderFactoryKey)
 
     let claimFactory = await ClaimFactory.deployed()
 

--- a/eth-contracts/test/claimFactory.test.js
+++ b/eth-contracts/test/claimFactory.test.js
@@ -4,10 +4,12 @@ const AudiusToken = artifacts.require('AudiusToken')
 const Registry = artifacts.require('Registry')
 const ClaimFactory = artifacts.require('ClaimFactory')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
+const MockServiceProviderFactory = artifacts.require('MockServiceProviderFactory')
 const Staking = artifacts.require('Staking')
 const encodeCall = require('./encodeCall')
 
 const ownedUpgradeabilityProxyKey = web3.utils.utf8ToHex('OwnedUpgradeabilityProxy')
+const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
 
 const fromBn = n => parseInt(n.valueOf(), 10)
 
@@ -80,11 +82,16 @@ contract('ClaimFactory', async (accounts) => {
     staking = await Staking.at(proxy.address)
     staker = accounts[2]
 
+    // Mock SP for test
+    let mockSPFactory = await MockServiceProviderFactory.new({ from: accounts[0] })
+    await registry.addContract(serviceProviderFactoryKey, mockSPFactory.address)
+
     // Create new claim factory instance
     claimFactory = await ClaimFactory.new(
       token.address,
       registry.address,
       ownedUpgradeabilityProxyKey,
+      serviceProviderFactoryKey,
       { from: accounts[0] })
 
     // Register new contract as a minter, from the same address that deployed the contract

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -917,7 +917,6 @@ contract('DelegateManager', async (accounts) => {
       assert.isTrue(
         (web3.utils.toBN(currentBlockNum)).gte(undelegateRequestInfo.lockupExpiryBlock),
         'Confirm expired lockup period')
-
       // Try to execute undelegate stake, but fail due to min bound violation
       await _lib.assertRevert(
         delegateManager.undelegateStake({ from: delegatorAccount1 }),

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -827,7 +827,7 @@ contract('DelegateManager', async (accounts) => {
       )
     })
 
-    it.only('delegator increase/decrease + SP direct stake bound validation', async () => {
+    it('delegator increase/decrease + SP direct stake bound validation', async () => {
       let bounds = await serviceProviderFactory.getAccountStakeBounds(stakerAccount)
       let delegateAmount = bounds.min
       let info = await getAccountStakeInfo(stakerAccount, false)

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -705,6 +705,7 @@ contract('DelegateManager', async (accounts) => {
         increase,
         stakerAccount)
 
+      // Validate increase
       isWithinBounds = await serviceProviderFactory.isServiceProviderWithinBounds(slasherAccount)
       assert.isTrue(
         isWithinBounds,


### PR DESCRIPTION
* Prevent reward operations if SP dips below account configured bounds after slash