### PR TITLE
Add fix for older postgres <11

### DIFF
--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -911,7 +911,7 @@ def filter_to_playlist_mood(session, mood, query, correlation):
         session.query(
             func.jsonb_array_elements(
                 correlation.c.playlist_contents['track_ids']
-            ).op('->')('track').cast(Integer)
+            ).op('->>')('track').cast(Integer)
         )
     )
 


### PR DESCRIPTION
this converts the json to text and then to integer, which works in older postgres versions