### PR TITLE
Order populated users by previous order

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1955,22 +1955,25 @@ def get_top_genre_users():
         if with_genres:
             user_genre_followers_query = user_genre_followers_query.filter(user_genre_query.c.genre.in_(genres))
 
+        # If the with_users flag is not set, respond with the user_ids
+        users = paginate_query(user_genre_followers_query).all()
+        user_ids = list(map(lambda user: user[0], users))
+
         # If the with_users flag is used, retrieve the user metadata
         if with_users:
-            user_genre_followers_query = paginate_query(user_genre_followers_query).subquery('user_genre_followers_query')
             user_query = session.query(User).filter(
-                User.user_id.in_(user_genre_followers_query),
+                User.user_id.in_(user_ids),
                 User.is_current == True
             )
             users = user_query.all()
             users = helpers.query_result_to_list(users)
-            user_ids = list(map(lambda user: user["user_id"], users))
-            users = populate_user_metadata(session, user_ids, users, None)
+            queried_user_ids = list(map(lambda user: user["user_id"], users))
+            users = populate_user_metadata(session, queried_user_ids, users, None)
+
+            # Sort the users so that it's in the same order as the previous query
+            user_map = {user['user_id']:user for user in users}
+            users = [user_map[user_id] for user_id in user_ids]
             return api_helpers.success_response({ 'users': users })
 
-
-        # If the with_users flag is not set, respond with the user_ids
-        users = paginate_query(user_genre_followers_query).all()
-        user_ids = list(map(lambda user: user[0], users))
 
         return api_helpers.success_response({ 'user_ids': user_ids })


### PR DESCRIPTION
The populated users were not sorted b/c to query for the user metadata w/ the filter in userIds returns the users out of the sorted order. This just resorts it before sending it back to the client. 