### PR TITLE
adding logic to call autoSelectEndpoint() if dp initialized with is down

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -612,7 +612,7 @@ class DiscoveryProvider {
       endpoint: 'users/account',
       queryParams: { wallet }
     }
-    return this._makeRequest(req, 0, true)
+    return this._makeRequest(req)
   }
 
   async getTopPlaylists (type, limit, mood, filter, withUsers = false) {
@@ -671,8 +671,8 @@ class DiscoveryProvider {
   // requestObj consists of multiple properties
   // endpoint - base route
   // urlParams - string of url params to be appended after base route
-  // queryParams - object of query params to be appended to url
-  async _makeRequest (requestObj, retries = MAKE_REQUEST_RETRY_COUNT, silent = false) {
+  // queryParams - object of query params to be appended to ur
+  async _makeRequest (requestObj, retries = MAKE_REQUEST_RETRY_COUNT) {
     if (!this.discoveryProviderEndpoint) {
       await this.autoSelectEndpoint()
     }
@@ -740,9 +740,7 @@ class DiscoveryProvider {
 
       return parsedResponse.data
     } catch (e) {
-      if (!silent) {
-        console.error(e)
-      }
+      console.error(e)
 
       if (retries > 0) {
         return this._makeRequest(requestObj, retries - 1)

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -671,7 +671,7 @@ class DiscoveryProvider {
   // requestObj consists of multiple properties
   // endpoint - base route
   // urlParams - string of url params to be appended after base route
-  // queryParams - object of query params to be appended to ur
+  // queryParams - object of query params to be appended to url
   async _makeRequest (requestObj, retries = MAKE_REQUEST_RETRY_COUNT) {
     if (!this.discoveryProviderEndpoint) {
       await this.autoSelectEndpoint()

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -740,6 +740,7 @@ class DiscoveryProvider {
           console.info(`${this.discoveryProviderEndpoint} is too far behind, reselecting discovery provider`)
           const endpoint = await this.autoSelectEndpoint(AUTOSELECT_DISCOVERY_PROVIDER_RETRY_COUNT, true)
           this.setEndpoint(endpoint)
+          retries = MAKE_REQUEST_RETRY_COUNT // reset retry count when setting a new endpoint
           throw new Error(`Selected endpoint was too far behind. Indexed: ${indexedBlock} Chain: ${chainBlock}`)
         }
       }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -672,7 +672,7 @@ class DiscoveryProvider {
   // urlParams - string of url params to be appended after base route
   // queryParams - object of query params to be appended to url
   async _makeRequest (requestObj, retries = 10, silent = false) {
-    if (!this.discoveryProviderEndpoint) {
+    if (!this.discoveryProviderEndpoint || retries === 0) {
       await this.autoSelectEndpoint()
     }
 

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -321,16 +321,10 @@ class EthContracts {
    * @return {Promise<{healthy: boolean, blockDiff: number}>} If the discovery provider is valid
    */
   async validateDiscoveryProviderHealth (endpoint) {
-    // TEMP: forcing dp1 healthcheck to fail
-    let path = 'health_check'
-    if (endpoint === 'https://discoveryprovider.staging.audius.co') {
-      path = 'fail'
-    }
-
     try {
       const healthResp = await axios(
         {
-          url: urlJoin(endpoint, path),
+          url: urlJoin(endpoint, 'health_check'),
           method: 'get',
           timeout: 5000
         }
@@ -351,10 +345,10 @@ class EthContracts {
    * @param {Set<string>?} whitelist optional whitelist to autoselect from
    * @return {Promise<string>} The selected discovery provider url
    */
-  async autoselectDiscoveryProvider (whitelist = null, clearDPLocalStorageEntryAndClearInterval = false) {
+  async autoselectDiscoveryProvider (whitelist = null, clearCachedDiscoveryProvider = false) {
     // If under the context of selecting a new DP because of prior failure, do not use the old DP endpoint
     // in local storage by clearing the entry and clearing the interval
-    if (clearDPLocalStorageEntryAndClearInterval) {
+    if (clearCachedDiscoveryProvider) {
       localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
       clearInterval(this.discProvInterval)
     }

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -197,7 +197,7 @@ class EthContracts {
       this.expectedServiceVersions = await this.getExpectedServiceVersions()
     }
 
-    console.info(`Looking latest for service provider in ${serviceProviders} with version ${this.expectedServiceVersions}`)
+    console.info(`Looking latest for service provider in ${JSON.stringify(serviceProviders)} with version ${JSON.stringify(this.expectedServiceVersions)}`)
 
     if (!this.expectedServiceVersions.hasOwnProperty(spType)) {
       throw new Error(`Invalid service name: ${spType}`)
@@ -259,7 +259,7 @@ class EthContracts {
           }
         } catch (e) {
           // Swallow errors for a single sp endpoint to ensure others can proceed
-          console.error(`Failed to retrieve information for ${sp}`)
+          console.error(`Failed to retrieve information for ${JSON.stringify(sp)}:\n\t${e}`)
         }
       }))
 


### PR DESCRIPTION
**Context:**
DP was down and the logic to select a different DP was not working. 

**Problem:**
The `autoSelectEndpoint()` in `_makeRequest()` was only being called if the DP response did not contain block information, or the block diff was greater than the set healthy amount. 

**The fix:**
added:
- retry logic in `_makeRequest()` where if max retries have been attempted that autoSelectEndpoint() is called
- `JSON.strinigifiy()` to objects in logs
- local storage clearing
- global retry count of 50