### PR TITLE
adding early exit if user cannot be found

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1466,7 +1466,7 @@ def get_users_account():
         try:
             user = base_query.one()
         except NoResultFound:
-            return api_helpers.success_response([])
+            return api_helpers.success_response(None)
 
         user = helpers.model_to_dictionary(user)
         user_id = user['user_id']

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1461,7 +1461,12 @@ def get_users_account():
         else:
             return api_helpers.error_response('Invalid wallet length', 400)
 
-        user = base_query.one()
+        # If user cannot be found, exit early and return empty response
+        try:
+            user = base_query.one()
+        except:
+            return api_helpers.success_response([])
+
         user = helpers.model_to_dictionary(user)
         user_id = user['user_id']
 

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -3,6 +3,7 @@ import datetime
 import sqlalchemy
 from sqlalchemy import func, asc, desc, text, or_, and_, Integer, Float, Date
 from sqlalchemy.orm import aliased
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.dialects import postgresql
 
 from flask import Blueprint, request
@@ -1464,7 +1465,7 @@ def get_users_account():
         # If user cannot be found, exit early and return empty response
         try:
             user = base_query.one()
-        except:
+        except NoResultFound:
             return api_helpers.success_response([])
 
         user = helpers.model_to_dictionary(user)


### PR DESCRIPTION
- adding similar behavior to hitting route `/users?wallet=doesntexist` where the response body will contain an empty arr VS the current 'Something caused the server to crash' response
- new error response will dictate specific handling in dp autoselect logic addressed in the [dp autoselect pr](https://github.com/AudiusProject/audius-protocol/pull/375)