### PR TITLE
Discprov remix parent/children and populate metadata

### DIFF
--- a/discovery-provider/alembic/versions/7b3f27e78b84_add_remixes_table.py
+++ b/discovery-provider/alembic/versions/7b3f27e78b84_add_remixes_table.py
@@ -1,4 +1,4 @@
-"""add-credits-table
+"""add-remixes-table
 
 Revision ID: 7b3f27e78b84
 Revises: c64edfb319a3
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table('credits',
-        # A child track "credits" parent track (and can credit many)
+    op.create_table('remixes',
+        # A child track "remixes" parent track (and can remixes many)
         sa.Column('parent_track_id', sa.Integer(), nullable=False, index=True),
         sa.Column('child_track_id', sa.Integer(), nullable=False, index=True),
         # TODO: Consider a way to make this possible. It's not right now because
@@ -30,4 +30,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('credits')
+    op.drop_table('remixes')

--- a/discovery-provider/alembic/versions/c64edfb319a3_remixes_jsonb.py
+++ b/discovery-provider/alembic/versions/c64edfb319a3_remixes_jsonb.py
@@ -1,4 +1,4 @@
-"""credits-splits-jsonb
+"""remixes-jsonb
 
 Revision ID: c64edfb319a3
 Revises: b3084b7bc025
@@ -17,10 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.drop_column('tracks', 'credits_splits')
-    op.add_column('tracks', sa.Column('credits_splits', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('tracks', sa.Column('remix_of', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
 
 
 def downgrade():
-    op.drop_column('tracks', 'credits_splits')
-    op.add_column('tracks', sa.Column('credits_splits', postgresql.VARCHAR(), nullable=True))
+    op.drop_column('tracks', 'remix_of')

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -315,7 +315,7 @@ is_delete={self.is_delete}>"
 class Remix(Base):
     __tablename__ = "remixes"
 
-    parent_track_id = Column(Integer, nullable=Falsem, index=True)
+    parent_track_id = Column(Integer, nullable=False, index=True)
     child_track_id = Column(Integer, nullable=False, index=True)
     PrimaryKeyConstraint(parent_track_id, child_track_id)
 

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -132,7 +132,8 @@ class Track(Base):
     tags = Column(String)
     genre = Column(String)
     mood = Column(String)
-    credits_splits = Column(postgresql.JSONB, nullable=True)
+    credits_splits = Column(String)
+    remix_of = Column(postgresql.JSONB, nullable=True)
     create_date = Column(String)
     release_date = Column(String)
     file_type = Column(String)
@@ -169,6 +170,7 @@ class Track(Base):
             f"genre={self.genre},"
             f"mood={self.mood},"
             f"credits_splits={self.credits_splits},"
+            f"remix_of={self.remix_of},"
             f"create_date={self.create_date},"
             f"release_date={self.release_date},"
             f"file_type={self.file_type},"
@@ -310,13 +312,13 @@ save_type={self.save_type},\
 is_current={self.is_current},\
 is_delete={self.is_delete}>"
 
-class Credit(Base):
-    __tablename__ = "credits"
+class Remix(Base):
+    __tablename__ = "remixes"
 
     parent_track_id = Column(Integer, nullable=Falsem, index=True)
     child_track_id = Column(Integer, nullable=False, index=True)
     PrimaryKeyConstraint(parent_track_id, child_track_id)
 
     def __repr__(self):
-        return f"<Credit(parent_track_id={self.parent_track_id},\
+        return f"<Remix(parent_track_id={self.parent_track_id},\
 child_track_id={self.child_track_id}>"

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -329,84 +329,7 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
     )
     save_count_dict = {track_id: save_count for (track_id, save_count) in save_counts}
 
-    # Fetch the remix parent track's user and if that user has saved/favorited the child track 
-    remix_query = session.query(
-        Track.owner_id.label('track_owner_id'),
-        Remix.parent_track_id.label('parent_track_id'),
-        Remix.child_track_id.label('child_track_id'),
-        Save.is_current.label('has_remix_author_favorited'),
-        Repost.is_current.label('has_remix_author_reposted'),
-        User
-    ).join(
-        Remix,
-        and_(
-            Remix.parent_track_id == Track.track_id,
-            Remix.child_track_id.in_(track_ids)
-        )
-    ).join(
-        User,
-        and_(
-            User.user_id == Track.owner_id,
-            User.is_current == True
-        )
-    ).outerjoin(
-        Save,
-        and_(
-            Save.save_item_id == Remix.child_track_id,
-            Save.save_type == SaveType.track,
-            Save.is_current == True,
-            Save.is_delete == False,
-            Save.user_id == Track.owner_id
-        )
-    ).outerjoin(
-        Repost,
-        and_(
-            Repost.repost_item_id == Remix.child_track_id,
-            Repost.user_id == Track.owner_id,
-            Repost.repost_type == RepostType.track,
-            Repost.is_current == True,
-            Repost.is_delete == False
-        )
-    ).filter(
-        Track.is_current == True
-    )
-
-    remixes = {}
-    remix_parent_owners = {}
-    populated_users = {}
-
-    # Build a dict of user id -> user model obj of the remixed track's parent owner to dedupe users
-    for remix_relationship in remix_query:
-        [track_owner_id, _, _, _, _, user] = remix_relationship
-        if not track_owner_id in remix_parent_owners:
-            remix_parent_owners[track_owner_id] = user
-
-    # populate the user's metadata for the remixed track's parent owner
-    # build `populated_users` as a map of userId -> json user
-    if len(remix_parent_owners) > 0:
-        [remix_parent_owner_ids, remix_parent_owners] = list(zip(*[[k, remix_parent_owners[k]] for k in remix_parent_owners]))
-        remix_parent_owners = helpers.query_result_to_list(list(remix_parent_owners))
-        populated_remix_parent_users = populate_user_metadata(session, list(remix_parent_owner_ids), remix_parent_owners, current_user_id)
-        for user in populated_remix_parent_users:
-            populated_users[user['user_id']] = user
-
-    # Build a dict of child track id => parent track id => { user, has_remix_author_favorited, has_remix_author_reposted }
-    for remix_relationship in remix_query:
-        [track_owner_id, parent_track_id, child_track_id, has_remix_author_favorited, has_remix_author_reposted, _] = remix_relationship
-        if not child_track_id in remixes:
-            remixes[child_track_id] = {
-                parent_track_id: {
-                    'has_remix_author_favorited': bool(has_remix_author_favorited),
-                    'has_remix_author_reposted': bool(has_remix_author_reposted),
-                    'user': populated_users[track_owner_id]
-                } 
-            }
-        else: 
-            remixes[child_track_id][parent_track_id] = {
-                'has_remix_author_favorited': bool(has_remix_author_favorited),
-                'has_remix_author_reposted': bool(has_remix_author_reposted),
-                'user': populated_users[track_owner_id]
-            }
+    remixes = get_track_remix_metadata(session, tracks, current_user_id)
 
     user_reposted_track_dict = {}
     user_saved_track_dict = {}
@@ -498,8 +421,8 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
         track[response_name_constants.has_current_user_saved] = user_saved_track_dict.get(track['track_id'], False)
 
         # Populate the remix_of tracks w/ the parent track's user and if that user saved/reposted the child
-        if "remix_of" in track and type(track["remix_of"]) is dict and track["track_id"] in remixes:
-            remix_tracks = track["remix_of"].get("tracks")
+        if response_name_constants.remix_of in track and type(track[response_name_constants.remix_of]) is dict and track["track_id"] in remixes:
+            remix_tracks = track[response_name_constants.remix_of].get("tracks")
             if remix_tracks and type(remix_tracks) is list:
                 for remix_track in remix_tracks:
                     parent_track_id = remix_track.get("parent_track_id")
@@ -510,6 +433,124 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
 
     return tracks
 
+
+def get_track_remix_metadata(session, tracks, current_user_id):
+    """
+    Fetches tracks' remix parent owners and if they have saved/reposted the tracks
+
+    Args:
+        session: (DB) The scoped db session for running db queries
+        tracks: (List<Track>) The tracks table objects to fetch remix parent user's information for
+        current_user_id?: (int) Requesting user's id for adding additional metadata to the fetched users
+
+    Returns:
+        remixes: (dict) Mapping of child track ids to parent track ids to parent track user's metadata
+        {
+            [childTrackId] : {
+                [parentTrackId]: {
+                    has_remix_author_favorited: boolean,
+                    has_remix_author_reposted: boolean,
+                    user: populated user metadata
+                }
+            }
+        }
+    """
+    track_ids_with_remix = []
+    remix_query = []
+    for track in tracks:
+        if response_name_constants.remix_of in track:
+            track_ids_with_remix.append(track['track_id'])
+
+    if len(track_ids_with_remix) > 0:
+        # Fetch the remix parent track's user and if that user has saved/favorited the child track 
+        remix_query = (
+            session.query(
+                Track.owner_id.label('track_owner_id'),
+                Remix.parent_track_id.label('parent_track_id'),
+                Remix.child_track_id.label('child_track_id'),
+                Save.is_current.label('has_remix_author_favorited'),
+                Repost.is_current.label('has_remix_author_reposted'),
+                User
+            )
+            .join(
+                Remix,
+                and_(
+                    Remix.parent_track_id == Track.track_id,
+                    Remix.child_track_id.in_(track_ids_with_remix)
+                )
+            )
+            .join(
+                User,
+                and_(
+                    User.user_id == Track.owner_id,
+                    User.is_current == True
+                )
+            )
+            .outerjoin(
+                Save,
+                and_(
+                    Save.save_item_id == Remix.child_track_id,
+                    Save.save_type == SaveType.track,
+                    Save.is_current == True,
+                    Save.is_delete == False,
+                    Save.user_id == Track.owner_id
+                )
+            )
+            .outerjoin(
+                Repost,
+                and_(
+                    Repost.repost_item_id == Remix.child_track_id,
+                    Repost.user_id == Track.owner_id,
+                    Repost.repost_type == RepostType.track,
+                    Repost.is_current == True,
+                    Repost.is_delete == False
+                )
+            )
+            .filter(
+                Track.is_current == True,
+                Track.is_unlisted == False
+            )
+            .all()
+        ) 
+
+    remixes = {}
+    remix_parent_owners = {}
+    populated_users = {}
+
+    # Build a dict of user id -> user model obj of the remixed track's parent owner to dedupe users
+    for remix_relationship in remix_query:
+        [track_owner_id, _, _, _, _, user] = remix_relationship
+        if not track_owner_id in remix_parent_owners:
+            remix_parent_owners[track_owner_id] = user
+
+    # populate the user's metadata for the remixed track's parent owner
+    # build `populated_users` as a map of userId -> json user
+    if len(remix_parent_owners) > 0:
+        [remix_parent_owner_ids, remix_parent_owners] = list(zip(*[[k, remix_parent_owners[k]] for k in remix_parent_owners]))
+        remix_parent_owners = helpers.query_result_to_list(list(remix_parent_owners))
+        populated_remix_parent_users = populate_user_metadata(session, list(remix_parent_owner_ids), remix_parent_owners, current_user_id)
+        for user in populated_remix_parent_users:
+            populated_users[user['user_id']] = user
+
+    # Build a dict of child track id => parent track id => { user, has_remix_author_favorited, has_remix_author_reposted }
+    for remix_relationship in remix_query:
+        [track_owner_id, parent_track_id, child_track_id, has_remix_author_favorited, has_remix_author_reposted, _] = remix_relationship
+        if not child_track_id in remixes:
+            remixes[child_track_id] = {
+                parent_track_id: {
+                    response_name_constants.has_remix_author_favorited: bool(has_remix_author_favorited),
+                    response_name_constants.has_remix_author_reposted : bool(has_remix_author_reposted),
+                    'user': populated_users[track_owner_id]
+                } 
+            }
+        else: 
+            remixes[child_track_id][parent_track_id] = {
+                response_name_constants.has_remix_author_favorited: bool(has_remix_author_favorited),
+                response_name_constants.has_remix_author_reposted: bool(has_remix_author_reposted),
+                'user': populated_users[track_owner_id]
+            }
+
+    return remixes
 
 # given list of playlist ids and corresponding playlists, populates each playlist object with:
 #   repost_count, save_count
@@ -1045,3 +1086,23 @@ def filter_to_playlist_mood(session, mood, query, correlation):
     return query.filter(
         mood_exists_query.exists()
     )
+
+def add_users_to_tracks(session, tracks):
+    """
+    Fetches the owners for the tracks and adds them to the track dict under the key 'user'
+
+    Args:
+        session: (DB) sqlalchemy scoped db session
+        tracks: (Array<track dict>) Array of tracks dict
+
+    Side Effects:
+        Modifies the track dictionaries to add a nested owner user
+
+    Returns: None
+    """
+    user_id_list = get_users_ids(tracks)
+    users = get_users_by_id(session, user_id_list)
+    for track in tracks:
+        user = users[track['owner_id']]
+        if user:
+            track['user'] = user

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -7,6 +7,14 @@ followee_reposts = 'followee_reposts' # array - followees of current user that h
 followee_saves = 'followee_saves' # array - followees of current user that have saved given track/playlist
 play_count = 'play_count' # integer - total number of plays for a given track/playlist
 
+# remix track specific
+remix_of = 'remix_of' # dictionary - contains an array of parent track ids
+has_remix_author_reposted = 'has_remix_author_reposted' # boolean - does the remix track author repost the track
+has_remix_author_favorited = 'has_remix_author_favorited' # boolean - does the remix track author favorite the track
+
+does_current_user_follow = 'does_current_user_follow' # boolean - does current user follow given user
+current_user_followee_follow_count = 'current_user_followee_follow_count' # integer - number of followees of current user that also follow given user
+
 # user metadata
 user_id = 'user_id' # integer - unique id of a user
 follower_count = 'follower_count' # integer - total follower count of given user

--- a/discovery-provider/src/tasks/celery_app.py
+++ b/discovery-provider/src/tasks/celery_app.py
@@ -6,7 +6,7 @@ from celery import Celery
 celery = Celery(__name__)
 
 # Celery removes all configured loggers. This setting prevents
-# Celery from overriding the configured logger set in create_celery() 
+# Celery from overriding the configured logger set in create_celery()
 celery.conf.update({
     'worker_hijack_root_logger': False
 })

--- a/discovery-provider/src/tasks/metadata.py
+++ b/discovery-provider/src/tasks/metadata.py
@@ -19,6 +19,7 @@ track_metadata_format = {
     "iswc": None,
     "track_segments": [],
     "download": {},
+    "remix_of": None,
     "is_unlisted": False,
     "field_visibility": None
 }

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -117,7 +117,7 @@ def invalidate_old_track(session, track_id):
     ), "Update operation requires a current track to be invalidated"
 
 
-def update_rexmixes_table(session, track_record, track_metadata):
+def update_remixes_table(session, track_record, track_metadata):
     child_track_id = track_record.track_id
 
     # Delete existing remix parents
@@ -125,7 +125,6 @@ def update_rexmixes_table(session, track_record, track_metadata):
 
     # Add all remixes
     if "remix_of" in track_metadata and isinstance(track_metadata["remix_of"], dict):
-        logger.info("here ins")
         tracks = track_metadata["remix_of"].get("tracks")
         if tracks and isinstance(tracks, list):
             for track in tracks:
@@ -194,7 +193,7 @@ def parse_track_event(
                 track_record.cover_art_sizes = track_record.cover_art
                 track_record.cover_art = None
 
-        update_rexmixes_table(session, track_record, track_metadata)
+        update_remixes_table(session, track_record, track_metadata)
 
     if event_type == track_event_types_lookup["update_track"]:
         upd_track_metadata_digest = event_args._multihashDigest.hex()
@@ -242,7 +241,7 @@ def parse_track_event(
                 track_record.cover_art_sizes = track_record.cover_art
                 track_record.cover_art = None
 
-        update_rexmixes_table(session, track_record, track_metadata)
+        update_remixes_table(session, track_record, track_metadata)
 
     if event_type == track_event_types_lookup["delete_track"]:
         track_record.is_delete = True

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from sqlalchemy.orm.session import make_transient
 from src import contract_addresses
 from src.utils import multihash, helpers
-from src.models import Track, User, BlacklistedIPLD, Credit
+from src.models import Track, User, BlacklistedIPLD, Remix
 from src.tasks.metadata import track_metadata_format
 
 logger = logging.getLogger(__name__)
@@ -117,24 +117,25 @@ def invalidate_old_track(session, track_id):
     ), "Update operation requires a current track to be invalidated"
 
 
-def update_credit_splits(session, track_record, track_metadata):
+def update_rexmixes_table(session, track_record, track_metadata):
     child_track_id = track_record.track_id
 
-    # Delete existing credits
-    session.query(Credit).filter_by(child_track_id=child_track_id).delete()
+    # Delete existing remix parents
+    session.query(Remix).filter_by(child_track_id=child_track_id).delete()
 
-    # Add all credits
-    if "credits_splits" in track_metadata:
-        splits = track_metadata["credits_splits"].get("splits")
-        if splits:
-            for split in splits:
-                parent_track_id = split.get("track_id")
-                if parent_track_id:
-                    credit = Credit(
+    # Add all remixes
+    if "remix_of" in track_metadata and type(track_metadata["remix_of"]) is dict:
+        logger.info("here ins")
+        tracks = track_metadata["remix_of"].get("tracks")
+        if tracks and type(tracks) is list:
+            for track in tracks:
+                parent_track_id = track.get("parent_track_id")
+                if parent_track_id and type(parent_track_id) is int:
+                    remix = Remix(
                         parent_track_id=parent_track_id,
                         child_track_id=child_track_id
                     )
-                    session.add(credit)
+                    session.add(remix)
 
 
 def parse_track_event(
@@ -193,7 +194,7 @@ def parse_track_event(
                 track_record.cover_art_sizes = track_record.cover_art
                 track_record.cover_art = None
 
-        update_credit_splits(session, track_record, track_metadata)
+        update_rexmixes_table(session, track_record, track_metadata)
 
     if event_type == track_event_types_lookup["update_track"]:
         upd_track_metadata_digest = event_args._multihashDigest.hex()
@@ -241,7 +242,7 @@ def parse_track_event(
                 track_record.cover_art_sizes = track_record.cover_art
                 track_record.cover_art = None
 
-        update_credit_splits(session, track_record, track_metadata)
+        update_rexmixes_table(session, track_record, track_metadata)
 
     if event_type == track_event_types_lookup["delete_track"]:
         track_record.is_delete = True
@@ -277,6 +278,7 @@ def populate_track_record_metadata(track_record, track_metadata, handle):
     track_record.track_segments = track_metadata["track_segments"]
     track_record.is_unlisted = track_metadata["is_unlisted"]
     track_record.field_visibility = track_metadata["field_visibility"]
+    track_record.remix_of = track_metadata["remix_of"]
 
     if "download" in track_metadata:
         track_record.download = {

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -124,13 +124,13 @@ def update_rexmixes_table(session, track_record, track_metadata):
     session.query(Remix).filter_by(child_track_id=child_track_id).delete()
 
     # Add all remixes
-    if "remix_of" in track_metadata and type(track_metadata["remix_of"]) is dict:
+    if "remix_of" in track_metadata and isinstance(track_metadata["remix_of"], dict):
         logger.info("here ins")
         tracks = track_metadata["remix_of"].get("tracks")
-        if tracks and type(tracks) is list:
+        if tracks and isinstance(tracks, list):
             for track in tracks:
                 parent_track_id = track.get("parent_track_id")
-                if parent_track_id and type(parent_track_id) is int:
+                if parent_track_id and isinstance(parent_track_id, int):
                     remix = Remix(
                         parent_track_id=parent_track_id,
                         child_track_id=child_track_id


### PR DESCRIPTION
# Summary
Added Discprov Endpoint: `/remixes/<int:track_id>/parents`  - fetches the tracks that are the parent of the request trackID. 
Added Discprov Endpoint: `/remixes/<int:track_id>/children`  - fetches the tracks that are the children of the request trackID. 
Update the `credit_splits` table to match the updated spec: Changed the table name to `remixes`. 
Update the indexing flow to leave the current `credit_splits` column in the `tracks` table the same and add a `remixes_of` column. It also resets/inserts into the remixes table.  
Updated the populate track metadata function in the query_helpers to add the remix track data from the spec. 
