### PR TITLE
env var to optionally turn optimizer off

### DIFF
--- a/eth-contracts/package.json
+++ b/eth-contracts/package.json
@@ -16,7 +16,7 @@
     "truffle-console": "./node_modules/.bin/truffle console --network development",
     "truffle-console-test": "./node_modules/.bin/truffle console --network test_local",
     "test": "npm run truffle-test",
-    "test-coverage": "./node_modules/.bin/truffle run coverage",
+    "test-coverage": "ENABLE_OPTIMIZER=false ./node_modules/.bin/truffle run coverage",
     "test-only": "./node_modules/.bin/truffle test --network=test_local",
     "truffle-test": "./scripts/truffle-test.sh",
     "truffle-test-v": "./scripts/truffle-test.sh --verbose-rpc",

--- a/eth-contracts/truffle-config.js
+++ b/eth-contracts/truffle-config.js
@@ -19,6 +19,8 @@ const getEnv = env => {
   }
   return value
 }
+let ENABLE_OPTIMIZER = true
+if (getEnv('ENABLE_OPTIMIZER') === 'false') ENABLE_OPTIMIZER = false
 
 // Values must be set in calling environment
 // Consult @hareeshnagaraj for details
@@ -61,7 +63,7 @@ module.exports = {
       settings: {
         evmVersion: 'istanbul', // istanbul is latest stable, and default setting
         optimizer: {
-          enabled: true,
+          enabled: ENABLE_OPTIMIZER,
           runs: 200, // 200 is default value
           details: {
             orderLiterals: true,

--- a/eth-contracts/truffle-config.js
+++ b/eth-contracts/truffle-config.js
@@ -28,6 +28,29 @@ const privateKey = getEnv('ETH_WALLET_PRIVATE_KEY')
 const liveNetwork = getEnv('ETH_LIVE_NETWORK')
 const liveNetworkId = getEnv('ETH_LIVE_NETWORK_ID')
 
+const solc = {
+  // 0.5.16 is latest 0.5.x version
+  // cannot use 0.6.x due to openzeppelin dependency, which are only 0.5.x compatible
+  version: '0.5.16',
+  parser: 'solcjs', // Leverages solc-js purely for speedy parsing
+  settings: {
+    evmVersion: 'istanbul', // istanbul is latest stable, and default setting
+  }
+}
+
+if (ENABLE_OPTIMIZER) {
+  solc.settings.optimizer = {
+    enabled: true,
+    runs: 200, // 200 is default value
+    details: {
+      orderLiterals: true,
+      deduplicate: true,
+      cse: true,
+      constantOptimizer: true,
+      yul: false // disabled as Yul optimizer is still experimental in 0.5.x
+    }
+  }
+}
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
@@ -55,26 +78,7 @@ module.exports = {
   },
   // https://solidity.readthedocs.io/en/develop/using-the-compiler.html#input-description
   compilers: {
-    solc: {
-      // 0.5.16 is latest 0.5.x version
-      // cannot use 0.6.x due to openzeppelin dependency, which are only 0.5.x compatible
-      version: '0.5.16',
-      parser: 'solcjs', // Leverages solc-js purely for speedy parsing
-      settings: {
-        evmVersion: 'istanbul', // istanbul is latest stable, and default setting
-        optimizer: {
-          enabled: ENABLE_OPTIMIZER,
-          runs: 200, // 200 is default value
-          details: {
-            orderLiterals: true,
-            deduplicate: true,
-            cse: true,
-            constantOptimizer: true,
-            yul: false // disabled as Yul optimizer is still experimental in 0.5.x
-          }
-        }
-      }
-    }
+    solc: solc
   },
   mocha: {
     enableTimeouts: false


### PR DESCRIPTION
The 'cse' flag in the optimizer causes code coverage to break. So added an env var which optionally disables the compiler during coverage tests. Interestingly the README for the code coverage says it doesn't use the optimized builds(https://github.com/sc-forks/solidity-coverage/blob/master/README.md#usage-notes), but for some reason it's still fails when we have our optimizer enabled. 