### PR TITLE
Add better logging to milestone notifs

### DIFF
--- a/identity-service/src/awsSNS.js
+++ b/identity-service/src/awsSNS.js
@@ -23,7 +23,7 @@ function _promisifySNS (functionName) {
       }
       sns[functionName](...args, function (err, data) {
         if (err) {
-          logger.debug(`${err}`)
+          logger.debug(`Error sending to SNS: ${err}`)
           reject(err)
         } else resolve(data)
       })
@@ -161,6 +161,7 @@ async function drainMessageObject (bufferObj) {
       }
 
       if (formattedMessage) {
+        logger.debug(`Publishing SNS message: ${JSON.stringify(formattedMessage)}`)
         await publishPromisified(formattedMessage)
       }
     } catch (e) {

--- a/identity-service/src/notifications/milestoneProcessing.js
+++ b/identity-service/src/notifications/milestoneProcessing.js
@@ -390,7 +390,7 @@ async function _processMilestone (milestoneType, userId, entityId, entityType, m
       await publish(msg, userId, tx, true, title, types)
     } catch (e) {
       // Log on error instead of failing
-      logger.info(`Error adding push notification to buffer: ${e}. notifStub ${notifStub}`)
+      logger.info(`Error adding push notification to buffer: ${e}. notifStub ${JSON.stringify(notifStub)}`)
     }
   }
 }


### PR DESCRIPTION
Add more verbose logs to try and track notification failures.

@hareeshnagaraj  Looks like the notifications were actually received by SNS and SNS says they were delivered (and they were not).

Hopefully this logging might make things a bit more clear.