### PR TITLE
Identity email add remix template

### DIFF
--- a/identity-service/src/notifications/components/Body.jsx
+++ b/identity-service/src/notifications/components/Body.jsx
@@ -74,6 +74,31 @@ const snippetMap = {
       return `${user.name} released ${notification.entity.count} new ${notification.entity.type}`
     }
     return `${user.name} released a new ${notification.entity.type}  ${notification.entity.name}`
+  },
+  [NotificationType.RemixCreate] (notification) {
+    const { parentTrack } = notification
+    return `New remix of your track ${parentTrack.title}`
+  },
+  [NotificationType.RemixCosign] (notification) {
+    const { parentTrackUser, parentTracks } = notification
+    const parentTrack = parentTracks.find(t => t.ownerId === parentTrackUser.userId)
+    return `${parentTrackUser.name} Co-signed your Remix of ${parentTrack.title}`
+  }
+}
+
+const mapNotification = (notification) => {
+  switch (notification.type) {
+    case NotificationType.RemixCreate: {
+      notification.users = [notification.remixUser]
+      return notification
+    }
+    case NotificationType.RemixCosign: {
+      notification.track = notification.remixTrack
+      return notification
+    }
+    default: {
+      return notification
+    }
   }
 }
 
@@ -146,7 +171,7 @@ const Body = (props) => {
               }}
             >
               {props.notifications.map((notification, ind) => (
-                <Notification key={ind} {...notification} />
+                <Notification key={ind} {...mapNotification(notification)} />
               ))}
             </td>
           </tr>
@@ -160,7 +185,7 @@ const Body = (props) => {
                 <tr>
                   <td style={{ borderRadius: '17px', margin: '0px auto' }} bgcolor='#7E1BCC'>
                     <a
-                      href='https://audius.co'
+                      href='https://audius.co/feed?openNotifications=true'
                       target='_blank'
                       style={{
                         padding: '8px 24px',

--- a/identity-service/src/notifications/components/notifications/Notification.jsx
+++ b/identity-service/src/notifications/components/notifications/Notification.jsx
@@ -10,7 +10,9 @@ export const NotificationType = Object.freeze({
   Favorite: 'Favorite',
   Milestone: 'Milestone',
   UserSubscription: 'UserSubscription',
-  Announcement: 'Announcement'
+  Announcement: 'Announcement',
+  RemixCreate: 'RemixCreate',
+  RemixCosign: 'RemixCosign'
 })
 
 const EntityType = Object.freeze({
@@ -139,7 +141,29 @@ const notificationMap = {
         <BodyText text={` released a new ${notification.entity.type} ${notification.entity.name}`} />
       </span>
     )
+  },
+  [NotificationType.RemixCreate] (notification) {
+    const { remixUser, remixTrack, parentTrackUser, parentTrack } = notification
+    return (
+      <span className={'notificationText'}>
+        <HighlightText text={remixTrack.title} />
+        <BodyText text={` by `} />
+        <HighlightText text={remixUser.name} />
+      </span>
+    )
+  },
+  [NotificationType.RemixCosign] (notification) {
+    const { parentTrackUser, parentTracks } = notification
+    const parentTrack = parentTracks.find(t => t.owner_id === parentTrackUser.user_id)
+    return (
+      <span className={'notificationText'}>
+        <HighlightText text={parentTrackUser.name} />
+        <BodyText text={` Co-signed your Remix of `} />
+        <HighlightText text={parentTrack.title} />
+      </span>
+    )
   }
+
 }
 
 const getMessage = (notification) => {
@@ -148,10 +172,88 @@ const getMessage = (notification) => {
   return getNotificationMessage(notification)
 }
 
+const getTitle = (notification) => {
+  switch (notification.type) {
+    case NotificationType.RemixCreate: {
+      const { parentTrack } = notification
+      return (
+        <span className={'notificationText'}>
+          <BodyText text={`New remix of your track `} />
+          <HighlightText text={parentTrack.title} />
+        </span>
+      )
+    }
+    default: 
+      return null
+  }
+}
+
+const getTrackMessage = (notification) => {
+  switch (notification.type) {
+    case NotificationType.RemixCosign: {
+      const { remixTrack } = notification
+      return (
+        <span className={'notificationText'}>
+          <HighlightText text={remixTrack.title} />
+        </span>
+      )
+    }
+    default: 
+      return null
+  }
+}
+
+export const getTrackLink = (track) => {
+  return `https://audius.co/${track.route_id}`
+}
+
+const getTwitter = (notification) => {
+  switch (notification.type) {
+    case NotificationType.RemixCreate: {
+      const { parentTrack, parentTrackUser, remixUser, remixTrack } = notification
+      const twitterHandle = parentTrackUser.twitterHandle 
+        ? `@${parentTrackUser.twitterHandle}`
+        : parentTrackUser.name
+      const text = `New remix of ${parentTrack.title} by ${twitterHandle} on @AudiusProject #Audius`
+      const url = getTrackLink(remixTrack)
+      return {
+        message: 'Share With Your Friends',
+        href: `http://twitter.com/share?url=${encodeURIComponent(url)
+          }&text=${encodeURIComponent(text)}`
+      }
+    }
+    case NotificationType.RemixCosign: {
+      const { parentTracks, parentTrackUser, remixTrack } = notification
+      const parentTrack = parentTracks.find(t => t.owner_id === parentTrackUser.user_id)
+      const url = getTrackLink(remixTrack)
+      const twitterHandle = parentTrackUser.twitterHandle 
+        ? `@${parentTrackUser.twitterHandle}`
+        : parentTrackUser.name
+      const text = `My remix of ${parentTrack.title} was Co-Signed by ${twitterHandle} on @AudiusProject #Audius`
+      return {
+        message: 'Share With Your Friends',
+        href: `http://twitter.com/share?url=${encodeURIComponent(url)
+          }&text=${encodeURIComponent(text)}`
+      }
+    }
+    default: 
+      return null
+  }
+}
+
 const Notification = (props) => {
   const message = getMessage(props)
+  const title = getTitle(props)
+  const trackMessage = getTrackMessage(props)
+  const twitter = getTwitter(props)
   return (
-    <NotificationBody {...props} message={message} />
+    <NotificationBody
+      {...props}
+      title={title}
+      message={message}
+      trackMessage={trackMessage}
+      twitter={twitter}
+    />
   )
 }
 

--- a/identity-service/src/notifications/components/notifications/Notification.jsx
+++ b/identity-service/src/notifications/components/notifications/Notification.jsx
@@ -204,7 +204,7 @@ const getTrackMessage = (notification) => {
 }
 
 export const getTrackLink = (track) => {
-  return `https://audius.co/${track.route_id}`
+  return `https://audius.co/${track.route_id}-${track.track_id}`
 }
 
 const getTwitter = (notification) => {

--- a/identity-service/src/notifications/components/notifications/NotificationBody.jsx
+++ b/identity-service/src/notifications/components/notifications/NotificationBody.jsx
@@ -4,11 +4,22 @@ import MultiUserHeader from './MultiUserHeader'
 
 const UserImage = ({ user }) => (
   <img
-    src={user.image}
+    src={user.image || user.thumbnail}
     style={{
       height: '32px',
       width: '32px',
       borderRadius: '50%'
+    }}
+  />
+)
+
+const TrackImage = ({ track }) => (
+  <img
+    src={track.image || track.thumbnail}
+    style={{
+      height: '42px',
+      width: '42px',
+      borderRadius: '3px'
     }}
   />
 )
@@ -85,7 +96,7 @@ const OpenAudiusLink = () => (
 const WrapLink = (props) => {
   return (
     <a
-      href='https://audius.co'
+      href='https://audius.co/feed?openNotifications=true' 
       style={{ textDecoration: 'none' }}>
       {props.children}
     </a>
@@ -93,10 +104,9 @@ const WrapLink = (props) => {
   )
 }
 
-const Favorite = (props) => {
+const Body = (props) => {
   const hasUsers = Array.isArray(props.users)
   const hasMultiUser = hasUsers && props.users.length > 1
-
   return (
     <table
       border='0'
@@ -131,6 +141,21 @@ const Favorite = (props) => {
                   <AnnouncementHeader />
                 </tr>
               )}
+              {props.title && (
+                <tr>
+                  <td
+                    colspan={'12'}
+                    valign='center'
+                    style={{
+                      padding: '16px 16px 0px',
+                      paddingTop: '16px',
+                      borderRadius: '4px'
+                    }}
+                  >
+                    {props.title}
+                  </td>
+                </tr>
+              )}
               {hasMultiUser && (
                 <tr>
                   <td
@@ -138,7 +163,7 @@ const Favorite = (props) => {
                     valign='center'
                     style={{
                       padding: '16px 16px 0px',
-                      paddingTop: props.type === 'Announcement' ? '8px' : '16px',
+                      paddingTop: (props.type === 'Announcement' || props.title) ? '8px' : '16px',
                       borderRadius: '4px'
                     }}
                   >
@@ -165,12 +190,100 @@ const Favorite = (props) => {
                   style={{
                     padding: '12px 16px 8px',
                     paddingLeft: (hasUsers && !hasMultiUser) ? '12px' : '16px',
+                    paddingTop: props.title ? '8px': ((hasUsers && !hasMultiUser) ? '12px' : '16px'),
                     width: '100%'
                   }}
                 >
                   {props.message}
                 </td>
               </tr>
+              {props.trackMessage && (
+                <tr>
+                  <td
+                    colspan={'1'}
+                    valign='center'
+                    style={{
+                      padding: '6px 0px 8px 16px',
+                      width: '60px'
+                    }}
+                  >
+                    <TrackImage track={props.track} />
+                  </td>
+                  <td
+                    colspan={11}
+                    valign='center'
+                    style={{
+                      padding: '6px 16px 8px',
+                      paddingLeft: '12px',
+                      width: '100%'
+                    }}
+                  >
+                    {props.trackMessage}
+                  </td>
+                </tr>
+              )}
+              {props.twitter && (
+                <tr>
+                  <td colspan={'12'} style={{ padding: '4px 0px 16px 16px', borderRadius: '4px' }}>
+                  <a
+                    href={props.twitter.href}
+                    target='_blank'
+                    style={{
+                      textDecoration: 'none'
+                    }}
+                  >
+                    <table
+                      cellspacing='0'
+                      cellpadding='0'
+                      style={{ margin: '0px' }}
+                    >
+                      <tr>
+                          <td style={{ borderRadius: '4px', padding: '4px 8px', margin: '0px' }} bgcolor='#1BA1F1'>
+                            <table
+                              cellspacing='0'
+                              cellpadding='0'
+                              style={{ margin: '0px' }}
+                            >
+                              <tr>
+                                <td 
+                                  valign='center'
+                                  style={{
+                                    margin: '0px'
+                                  }}
+                                >
+                                  <img
+                                    src='https://download.audius.co/static-resources/email/iconTwitterWhite.png'
+                                    alt='twitter'
+                                    style={{
+                                      height: '18px',
+                                      width: '18px',
+                                      padding: '0px',
+                                      marginRight: '8px',
+                                      verticalAlign: 'text-bottom'
+                                    }}
+                                  />
+                                </td>
+                                <td 
+                                  valign='center'
+                                  style={{
+                                    margin: '0px',
+                                    fontSize: '14px',
+                                    fontWeight: '500',
+                                    color: '#ffffff',
+                                    textDecoration: 'none'
+                                  }}
+                                >
+                                {props.twitter.message}
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </a>
+                  </td>
+                </tr>
+              )}
               {props.hasReadMore && (
                 <tr>
                   <td
@@ -201,4 +314,4 @@ const Favorite = (props) => {
   )
 }
 
-export default Favorite
+export default Body

--- a/identity-service/src/notifications/formatNotificationMetadata.js
+++ b/identity-service/src/notifications/formatNotificationMetadata.js
@@ -10,7 +10,7 @@ const formatFavorite = (notification, metadata, entity) => {
       const userId = action.actionEntityId
       const user = metadata.users[userId]
       if (!user) return null
-      return { name: user.name, image: user.thumbnail }
+      return { id: user.id, handle: user.handle, name: user.name, image: user.thumbnail }
     }),
     entity
   }
@@ -23,7 +23,7 @@ const formatRepost = (notification, metadata, entity) => {
       const userId = action.actionEntityId
       const user = metadata.users[userId]
       if (!user) return null
-      return { name: user.name, image: user.thumbnail }
+      return { id: user.user_id, handle: user.handle, name: user.name, image: user.thumbnail }
     }),
     entity
   }
@@ -64,7 +64,7 @@ function formatFollow (notification, metadata) {
       const userId = action.actionEntityId
       const user = metadata.users[userId]
       if (!user) return null
-      return { name: user.name, image: user.thumbnail }
+      return { id: userId, handle: user.handle, name: user.name, image: user.thumbnail }
     })
   }
 }
@@ -78,31 +78,32 @@ function formatAnnouncement (notification) {
 }
 
 function formatRemixCreate (notification, metadata) {
-  const {
-    'entity_id': trackId,
-    'entity_owner_id': userId,
-    'remix_parent_track_user_id': parentTrackUserId,
-    'remix_parent_track_id': parentTrackId
-  } = notification.metadata
+  const trackId = notification.entityId
+  const parentTrackId = notification.actions[0].actionEntityId
+  const remixTrack = metadata.tracks[trackId]
+  const parentTrack = metadata.tracks[parentTrackId]
+  const userId = remixTrack.owner_id
+  const parentTrackUserId = parentTrack.owner_id
 
   return {
     type: NotificationType.RemixCreate,
     remixUser: metadata.users[userId],
-    remixTrack: metadata.tracks[trackId],
+    remixTrack,
     parentTrackUser: metadata.users[parentTrackUserId],
-    parentTrack: metadata.tracks[parentTrackId]
+    parentTrack
   }
 }
 
 function formatRemixCosign (notification, metadata) {
-  const {
-    'entity_id': trackId
-  } = notification.metadata
-  const parentTrackUserId = notification.initiator
+  const trackId = notification.entityId
+  const parentTrackUserId = notification.actions[0].actionEntityId
+  const remixTrack = metadata.tracks[trackId]
+  const parentTracks = remixTrack.remix_of.tracks.map(t => metadata.tracks[t.parent_track_id])
   return {
     type: NotificationType.RemixCosign,
     parentTrackUser: metadata.users[parentTrackUserId],
-    remixTrack: metadata.tracks[trackId]
+    parentTracks,
+    remixTrack
   }
 }
 

--- a/identity-service/src/notifications/renderEmail/Body.js
+++ b/identity-service/src/notifications/renderEmail/Body.js
@@ -103,8 +103,40 @@ var snippetMap = (_snippetMap = {}, _defineProperty(_snippetMap, _Notification.N
   }
 
   return "".concat(user.name, " released a new ").concat(notification.entity.type, "  ").concat(notification.entity.name);
-}), _snippetMap); // Generate snippet for email composed of the first three notification texts,
+}), _defineProperty(_snippetMap, _Notification.NotificationType.RemixCreate, function (notification) {
+  var parentTrack = notification.parentTrack;
+  return "New remix of your track ".concat(parentTrack.title);
+}), _defineProperty(_snippetMap, _Notification.NotificationType.RemixCosign, function (notification) {
+  var parentTrackUser = notification.parentTrackUser,
+      parentTracks = notification.parentTracks;
+  var parentTrack = parentTracks.find(function (t) {
+    return t.ownerId === parentTrackUser.userId;
+  });
+  return "".concat(parentTrackUser.name, " Co-signed your Remix of ").concat(parentTrack.title);
+}), _snippetMap);
+
+var mapNotification = function mapNotification(notification) {
+  switch (notification.type) {
+    case _Notification.NotificationType.RemixCreate:
+      {
+        notification.users = [notification.remixUser];
+        return notification;
+      }
+
+    case _Notification.NotificationType.RemixCosign:
+      {
+        notification.track = notification.remixTrack;
+        return notification;
+      }
+
+    default:
+      {
+        return notification;
+      }
+  }
+}; // Generate snippet for email composed of the first three notification texts,
 // but limited to 90 characters w/ an ellipsis
+
 
 var SNIPPET_ELLIPSIS_LENGTH = 90;
 
@@ -174,7 +206,7 @@ var Body = function Body(props) {
   }, props.notifications.map(function (notification, ind) {
     return _react["default"].createElement(_Notification["default"], _extends({
       key: ind
-    }, notification));
+    }, mapNotification(notification)));
   }))), _react["default"].createElement("tr", null, _react["default"].createElement("td", {
     align: "center",
     valign: "top",
@@ -196,7 +228,7 @@ var Body = function Body(props) {
     },
     bgcolor: "#7E1BCC"
   }, _react["default"].createElement("a", {
-    href: "https://audius.co",
+    href: "https://audius.co/feed?openNotifications=true",
     target: "_blank",
     style: {
       padding: '8px 24px',

--- a/identity-service/src/notifications/renderEmail/notifications/Notification.js
+++ b/identity-service/src/notifications/renderEmail/notifications/Notification.js
@@ -255,7 +255,7 @@ var getTrackMessage = function getTrackMessage(notification) {
 };
 
 var getTrackLink = function getTrackLink(track) {
-  return "https://audius.co/".concat(track.route_id);
+  return "https://audius.co/".concat(track.route_id, "-").concat(track.track_id);
 };
 
 exports.getTrackLink = getTrackLink;

--- a/identity-service/src/notifications/renderEmail/notifications/Notification.js
+++ b/identity-service/src/notifications/renderEmail/notifications/Notification.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = exports.getEntity = exports.getUsers = exports.NotificationType = void 0;
+exports["default"] = exports.getTrackLink = exports.getEntity = exports.getUsers = exports.NotificationType = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -33,7 +33,9 @@ var NotificationType = Object.freeze({
   Favorite: 'Favorite',
   Milestone: 'Milestone',
   UserSubscription: 'UserSubscription',
-  Announcement: 'Announcement'
+  Announcement: 'Announcement',
+  RemixCreate: 'RemixCreate',
+  RemixCosign: 'RemixCosign'
 });
 exports.NotificationType = NotificationType;
 var EntityType = Object.freeze({
@@ -177,7 +179,36 @@ var notificationMap = (_notificationMap = {}, _defineProperty(_notificationMap, 
   }, _react["default"].createElement(HighlightText, {
     text: user.name
   }), _react["default"].createElement(BodyText, {
-    text: " released a new ".concat(notification.entity.type, "  ").concat(notification.entity.name)
+    text: " released a new ".concat(notification.entity.type, " ").concat(notification.entity.name)
+  }));
+}), _defineProperty(_notificationMap, NotificationType.RemixCreate, function (notification) {
+  var remixUser = notification.remixUser,
+      remixTrack = notification.remixTrack,
+      parentTrackUser = notification.parentTrackUser,
+      parentTrack = notification.parentTrack;
+  return _react["default"].createElement("span", {
+    className: 'notificationText'
+  }, _react["default"].createElement(HighlightText, {
+    text: remixTrack.title
+  }), _react["default"].createElement(BodyText, {
+    text: " by "
+  }), _react["default"].createElement(HighlightText, {
+    text: remixUser.name
+  }));
+}), _defineProperty(_notificationMap, NotificationType.RemixCosign, function (notification) {
+  var parentTrackUser = notification.parentTrackUser,
+      parentTracks = notification.parentTracks;
+  var parentTrack = parentTracks.find(function (t) {
+    return t.owner_id === parentTrackUser.user_id;
+  });
+  return _react["default"].createElement("span", {
+    className: 'notificationText'
+  }, _react["default"].createElement(HighlightText, {
+    text: parentTrackUser.name
+  }), _react["default"].createElement(BodyText, {
+    text: " Co-signed your Remix of "
+  }), _react["default"].createElement(HighlightText, {
+    text: parentTrack.title
   }));
 }), _notificationMap);
 
@@ -187,10 +218,102 @@ var getMessage = function getMessage(notification) {
   return getNotificationMessage(notification);
 };
 
+var getTitle = function getTitle(notification) {
+  switch (notification.type) {
+    case NotificationType.RemixCreate:
+      {
+        var parentTrack = notification.parentTrack;
+        return _react["default"].createElement("span", {
+          className: 'notificationText'
+        }, _react["default"].createElement(BodyText, {
+          text: "New remix of your track "
+        }), _react["default"].createElement(HighlightText, {
+          text: parentTrack.title
+        }));
+      }
+
+    default:
+      return null;
+  }
+};
+
+var getTrackMessage = function getTrackMessage(notification) {
+  switch (notification.type) {
+    case NotificationType.RemixCosign:
+      {
+        var remixTrack = notification.remixTrack;
+        return _react["default"].createElement("span", {
+          className: 'notificationText'
+        }, _react["default"].createElement(HighlightText, {
+          text: remixTrack.title
+        }));
+      }
+
+    default:
+      return null;
+  }
+};
+
+var getTrackLink = function getTrackLink(track) {
+  return "https://audius.co/".concat(track.route_id);
+};
+
+exports.getTrackLink = getTrackLink;
+
+var getTwitter = function getTwitter(notification) {
+  switch (notification.type) {
+    case NotificationType.RemixCreate:
+      {
+        var parentTrack = notification.parentTrack,
+            parentTrackUser = notification.parentTrackUser,
+            remixUser = notification.remixUser,
+            remixTrack = notification.remixTrack;
+        var twitterHandle = parentTrackUser.twitterHandle ? "@".concat(parentTrackUser.twitterHandle) : parentTrackUser.name;
+        var text = "New remix of ".concat(parentTrack.title, " by ").concat(twitterHandle, " on @AudiusProject #Audius");
+        var url = getTrackLink(remixTrack);
+        return {
+          message: 'Share With Your Friends',
+          href: "http://twitter.com/share?url=".concat(encodeURIComponent(url), "&text=").concat(encodeURIComponent(text))
+        };
+      }
+
+    case NotificationType.RemixCosign:
+      {
+        var parentTracks = notification.parentTracks,
+            _parentTrackUser = notification.parentTrackUser,
+            _remixTrack = notification.remixTrack;
+
+        var _parentTrack = parentTracks.find(function (t) {
+          return t.owner_id === _parentTrackUser.user_id;
+        });
+
+        var _url = getTrackLink(_remixTrack);
+
+        var _twitterHandle = _parentTrackUser.twitterHandle ? "@".concat(_parentTrackUser.twitterHandle) : _parentTrackUser.name;
+
+        var _text = "My remix of ".concat(_parentTrack.title, " was Co-Signed by ").concat(_twitterHandle, " on @AudiusProject #Audius");
+
+        return {
+          message: 'Share With Your Friends',
+          href: "http://twitter.com/share?url=".concat(encodeURIComponent(_url), "&text=").concat(encodeURIComponent(_text))
+        };
+      }
+
+    default:
+      return null;
+  }
+};
+
 var Notification = function Notification(props) {
   var message = getMessage(props);
+  var title = getTitle(props);
+  var trackMessage = getTrackMessage(props);
+  var twitter = getTwitter(props);
   return _react["default"].createElement(_NotificationBody["default"], _extends({}, props, {
-    message: message
+    title: title,
+    message: message,
+    trackMessage: trackMessage,
+    twitter: twitter
   }));
 };
 

--- a/identity-service/src/notifications/renderEmail/notifications/NotificationBody.js
+++ b/identity-service/src/notifications/renderEmail/notifications/NotificationBody.js
@@ -14,11 +14,23 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 var UserImage = function UserImage(_ref) {
   var user = _ref.user;
   return _react["default"].createElement("img", {
-    src: user.image,
+    src: user.image || user.thumbnail,
     style: {
       height: '32px',
       width: '32px',
       borderRadius: '50%'
+    }
+  });
+};
+
+var TrackImage = function TrackImage(_ref2) {
+  var track = _ref2.track;
+  return _react["default"].createElement("img", {
+    src: track.image || track.thumbnail,
+    style: {
+      height: '42px',
+      width: '42px',
+      borderRadius: '3px'
     }
   });
 };
@@ -82,14 +94,14 @@ var OpenAudiusLink = function OpenAudiusLink() {
 
 var WrapLink = function WrapLink(props) {
   return _react["default"].createElement("a", {
-    href: "https://audius.co",
+    href: "https://audius.co/feed?openNotifications=true",
     style: {
       textDecoration: 'none'
     }
   }, props.children);
 };
 
-var Favorite = function Favorite(props) {
+var Body = function Body(props) {
   var hasUsers = Array.isArray(props.users);
   var hasMultiUser = hasUsers && props.users.length > 1;
   return _react["default"].createElement("table", {
@@ -115,12 +127,20 @@ var Favorite = function Favorite(props) {
       height: 'auto',
       width: '100%'
     }
-  }, props.type === 'Announcement' && _react["default"].createElement("tr", null, _react["default"].createElement(AnnouncementHeader, null)), hasMultiUser && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+  }, props.type === 'Announcement' && _react["default"].createElement("tr", null, _react["default"].createElement(AnnouncementHeader, null)), props.title && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
     colspan: '12',
     valign: "center",
     style: {
       padding: '16px 16px 0px',
-      paddingTop: props.type === 'Announcement' ? '8px' : '16px',
+      paddingTop: '16px',
+      borderRadius: '4px'
+    }
+  }, props.title)), hasMultiUser && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+    colspan: '12',
+    valign: "center",
+    style: {
+      padding: '16px 16px 0px',
+      paddingTop: props.type === 'Announcement' || props.title ? '8px' : '16px',
       borderRadius: '4px'
     }
   }, _react["default"].createElement(_MultiUserHeader["default"], {
@@ -140,9 +160,82 @@ var Favorite = function Favorite(props) {
     style: {
       padding: '12px 16px 8px',
       paddingLeft: hasUsers && !hasMultiUser ? '12px' : '16px',
+      paddingTop: props.title ? '8px' : hasUsers && !hasMultiUser ? '12px' : '16px',
       width: '100%'
     }
-  }, props.message)), props.hasReadMore && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+  }, props.message)), props.trackMessage && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+    colspan: '1',
+    valign: "center",
+    style: {
+      padding: '6px 0px 8px 16px',
+      width: '60px'
+    }
+  }, _react["default"].createElement(TrackImage, {
+    track: props.track
+  })), _react["default"].createElement("td", {
+    colspan: 11,
+    valign: "center",
+    style: {
+      padding: '6px 16px 8px',
+      paddingLeft: '12px',
+      width: '100%'
+    }
+  }, props.trackMessage)), props.twitter && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+    colspan: '12',
+    style: {
+      padding: '4px 0px 16px 16px',
+      borderRadius: '4px'
+    }
+  }, _react["default"].createElement("a", {
+    href: props.twitter.href,
+    target: "_blank",
+    style: {
+      textDecoration: 'none'
+    }
+  }, _react["default"].createElement("table", {
+    cellspacing: "0",
+    cellpadding: "0",
+    style: {
+      margin: '0px'
+    }
+  }, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+    style: {
+      borderRadius: '4px',
+      padding: '4px 8px',
+      margin: '0px'
+    },
+    bgcolor: "#1BA1F1"
+  }, _react["default"].createElement("table", {
+    cellspacing: "0",
+    cellpadding: "0",
+    style: {
+      margin: '0px'
+    }
+  }, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
+    valign: "center",
+    style: {
+      margin: '0px'
+    }
+  }, _react["default"].createElement("img", {
+    src: "https://download.audius.co/static-resources/email/iconTwitterWhite.png",
+    alt: "twitter",
+    style: {
+      height: '18px',
+      width: '18px',
+      padding: '0px',
+      marginRight: '8px',
+      verticalAlign: 'text-bottom'
+    }
+  })), _react["default"].createElement("td", {
+    valign: "center",
+    style: {
+      margin: '0px',
+      fontSize: '14px',
+      fontWeight: '500',
+      color: '#ffffff',
+      textDecoration: 'none'
+    }
+  }, props.twitter.message))))))))), props.hasReadMore && _react["default"].createElement("tr", null, _react["default"].createElement("td", {
     colspan: '12',
     valign: "center",
     className: 'avenir',
@@ -161,5 +254,5 @@ var Favorite = function Favorite(props) {
   }, _react["default"].createElement(OpenAudiusLink, null))))))));
 };
 
-var _default = Favorite;
+var _default = Body;
 exports["default"] = _default;


### PR DESCRIPTION
Add remix create and remix cosign notifications to the identity email template.
Also added additional logic to fetch information needed to display the new notification types. 
NOTE: Only review the first commit, the second is the transpiled email template