### PR TITLE
[eth-contracts] Current round logic

### DIFF
--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -41,6 +41,15 @@ contract ClaimsManager is RegistryContract {
     // Staking contract ref
     ERC20Mintable private audiusToken;
 
+    // Struct representing round state
+    struct Round {
+        uint fundBlock;
+        uint fundingAmount;
+    }
+
+    // Current round information
+    Round currentRound;
+
     event RoundInitiated(
       uint _blockNumber,
       uint _roundNumber,

--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -28,6 +28,8 @@ contract ClaimsManager is RegistryContract {
     // Claim related configurations
     uint private fundingRoundBlockDiff;
 
+    uint private fundingAmount;
+
     // Denotes current round
     uint private roundNumber;
 

--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -27,21 +27,17 @@ contract ClaimsManager is RegistryContract {
 
     // Claim related configurations
     uint private fundingRoundBlockDiff;
-    // uint private fundBlock;
-
-    // TODO: Make this modifiable based on total staking pool?
-    uint private fundingAmount;
 
     // Denotes current round
     uint private roundNumber;
-
-    // Total claimed so far in round
-    // uint private totalClaimedInRound;
 
     // Staking contract ref
     ERC20Mintable private audiusToken;
 
     // Struct representing round state
+    // 1) Block at which round was funded
+    // 2) Total funded for this round
+    // 3) Total claimed in round
     struct Round {
         uint fundBlock;
         uint fundingAmount;

--- a/eth-contracts/test/claimsManager.test.js
+++ b/eth-contracts/test/claimsManager.test.js
@@ -250,7 +250,7 @@ contract('ClaimsManager', async (accounts) => {
       'Required block difference not met')
   })
 
-  it('updates funding amount', async () => {
+  it('Updates funding amount', async () => {
     let currentFunding = await claimsManager.getFundsPerRound()
     let newAmount = _lib.audToWeiBN(1000)
     assert.isTrue(!newAmount.eq(currentFunding), 'Expect change in funding value')
@@ -263,7 +263,7 @@ contract('ClaimsManager', async (accounts) => {
     assert.isTrue(newAmount.eq(updatedFundingAmount), 'Expect updated funding amount')
   })
 
-  it('updates fundRoundBlockDiff', async () => {
+  it('Updates fundRoundBlockDiff', async () => {
     const curBlockDiff = await claimsManager.getFundingRoundBlockDiff.call()
     const proposedBlockDiff = curBlockDiff.mul(_lib.toBN(2))
     await _lib.assertRevert(
@@ -278,7 +278,7 @@ contract('ClaimsManager', async (accounts) => {
     )
   })
 
-  it('minimum bound violation during claim processing,', async () => {
+  it('Minimum bound violation during claim processing,', async () => {
     let invalidAmount = _lib.audToWeiBN(5)
     // Stake default amount
     await approveTransferAndStake(invalidAmount, staker)
@@ -288,7 +288,7 @@ contract('ClaimsManager', async (accounts) => {
       'Minimum stake bounds violated at fund block')
   })
 
-  it('maximum bound violation during claim processing,', async () => {
+  it('Maximum bound violation during claim processing,', async () => {
     // Exactly 1 AUD over max bound
     let invalidAmount = _lib.audToWeiBN(1000001)
     // Stake default amount

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1004,7 +1004,7 @@ contract('DelegateManager', async (accounts) => {
       )
     })
 
-    it('Delegator increase/decrease + SP direct stake bound validation', async () => {
+    it.only('Delegator increase/decrease + SP direct stake bound validation', async () => {
       let spDetails = await serviceProviderFactory.getServiceProviderDetails(stakerAccount)
       let delegateAmount = spDetails.minAccountStake
       let info = await getAccountStakeInfo(stakerAccount, false)

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1004,7 +1004,7 @@ contract('DelegateManager', async (accounts) => {
       )
     })
 
-    it.only('Delegator increase/decrease + SP direct stake bound validation', async () => {
+    it('Delegator increase/decrease + SP direct stake bound validation', async () => {
       let spDetails = await serviceProviderFactory.getServiceProviderDetails(stakerAccount)
       let delegateAmount = spDetails.minAccountStake
       let info = await getAccountStakeInfo(stakerAccount, false)


### PR DESCRIPTION
* Separate 'current round' state from configuration variables, enabling fundingAmount modification during ongoing round