### PR TITLE
Enable crytic (Slither only)

### DIFF
--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "ClaimsManager"
+    "contract": "Governance"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "Registry"
+    "contract": "ClaimsManager"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,8 +1,5 @@
 {
   "cwd": "eth-contracts",
-  "truffle": {
-    "enabled": true
-  },
   "echidna": {
     "contract": "DelegateManager"
   }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "Registry"
+    "contract": "RegistryContract"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "Migrations"
+    "contract": "InitializableV2"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "DelegateManager"
+    "contract": "AudiusToken"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "Governance"
+    "contract": "InitializableV2"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "RegistryContract"
+    "contract": "AudiusAdminUpgradeabilityProxy"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,0 +1,3 @@
+{
+  "cwd": "./eth-contracts"
+}

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "ServiceProviderFactory"
+    "contract": "ServiceTypeManager"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "AudiusAdminUpgradeabilityProxy"
+    "contract": "Registry"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "ServiceTypeManager"
+    "contract": "Staking"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,3 +1,3 @@
 {
-  "cwd": "./eth-contracts"
+  "cwd": "eth-contracts"
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "AudiusToken"
+    "contract": "Registry"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,3 +1,9 @@
 {
-  "cwd": "eth-contracts"
+  "cwd": "eth-contracts",
+  "truffle": {
+    "enabled": true
+  },
+  "echidna": {
+    "contract": "DelegateManager"
+  }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "InitializableV2"
+    "contract": "Migrations"
   }
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,3 @@
 {
-  "cwd": "eth-contracts",
-  "echidna": {
-    "contract": "Staking"
-  }
+  "cwd": "eth-contracts"
 }

--- a/crytic-config.json
+++ b/crytic-config.json
@@ -1,6 +1,6 @@
 {
   "cwd": "eth-contracts",
   "echidna": {
-    "contract": "InitializableV2"
+    "contract": "ServiceProviderFactory"
   }
 }

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -1,5 +1,3 @@
-// TEST COMMENT
-
 pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Mintable.sol";

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -1,3 +1,5 @@
+// TEST COMMENT
+
 pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Mintable.sol";


### PR DESCRIPTION
Commit history + code diff is confusing.

Echidna runs on one contract at a time, so in commits in this PR you can see each commit maps to a single contract, triggering an echidna run on that contract.

Adding `crytic-config.json` with `cwd` is all we need to get crytic running correctly with slither (security).