### PR TITLE
Fix fetch metadata for create remix notif in email

### DIFF
--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -151,6 +151,7 @@ async function fetchNotificationMetadata (audius, userId, notifications) {
         break
       }
       case NotificationType.RemixCreate: {
+        trackIdsToFetch.push(notification.entityId)
         for (const action of notification.actions) {
           if (action.actionEntityType === Entity.Track) {
             trackIdsToFetch.push(action.actionEntityId)


### PR DESCRIPTION
Forgot to fetch original track id from fetch notification metadata for the create remix notification in the email. 