### PR TITLE
Added with remixes url param to notifications

### DIFF
--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -274,6 +274,7 @@ module.exports = function (app) {
    * Fetches the notifications for the specified userId
    * urlQueryParam: {number} limit        Max number of notifications to return, Cannot exceed 100
    * urlQueryParam: {number?} timeOffset  A timestamp reference offset for fetch notification before this date
+   * urlQueryParam: {boolean?} withRemix  A boolean to fetch notifications with remixes
    *
    * TODO: Validate userId
    * NOTE: The `createdDate` param can/should be changed to the user sending their wallet &
@@ -288,6 +289,10 @@ module.exports = function (app) {
       return errorResponseBadRequest(`Invalid Date params`)
     }
 
+    const withRemixQuery = req.query.withRemix === 'true' ? {} : {
+      type: { [models.Sequelize.Op.notIn]:[NotificationType.RemixCreate, NotificationType.RemixCosign] }
+    }
+
     if (isNaN(limit) || limit > 100) {
       return errorResponseBadRequest(
         `Limit and offset number be integers with a max limit of 100`
@@ -298,6 +303,7 @@ module.exports = function (app) {
         where: {
           userId,
           isHidden: false,
+          ...withRemixQuery,
           timestamp: {
             [models.Sequelize.Op.lt]: timeOffset.toDate()
           }
@@ -314,7 +320,13 @@ module.exports = function (app) {
         limit
       })
       let unViewedCount = await models.Notification.findAll({
-        where: { userId, isViewed: false, isRead: false, isHidden: false },
+        where: {
+          userId,
+          isViewed: false,
+          isRead: false,
+          isHidden: false,
+          ...withRemixQuery
+        },
         include: [{ model: models.NotificationAction, as: 'actions', required: true, attributes: [] }],
         attributes: [[models.Sequelize.fn('COUNT', models.Sequelize.col('Notification.id')), 'total']],
         group: ['Notification.id']

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -290,7 +290,7 @@ module.exports = function (app) {
     }
 
     const withRemixQuery = req.query.withRemix === 'true' ? {} : {
-      type: { [models.Sequelize.Op.notIn]:[NotificationType.RemixCreate, NotificationType.RemixCosign] }
+      type: { [models.Sequelize.Op.notIn]: [NotificationType.RemixCreate, NotificationType.RemixCosign] }
     }
 
     if (isNaN(limit) || limit > 100) {


### PR DESCRIPTION
We need to withRemixes url param to be backwards compatible because the ui does not filter out notifications that it does not recognize and results in a messed up ui. 