### PR TITLE
Enable new discovery provider selection

### DIFF
--- a/libs/examples/initAudiusLibs.js
+++ b/libs/examples/initAudiusLibs.js
@@ -29,7 +29,7 @@ async function initAudiusLibs (useExternalWeb3, ownerWalletOverride = null, ethO
         ethWeb3ProviderEndpoint,
         ethWallet
       ),
-      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(false, new Set(['http://docker.for.mac.localhost:5000'])),
+      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(new Set(['http://docker.for.mac.localhost:5000'])),
       isServer
     }
   } else {
@@ -41,7 +41,7 @@ async function initAudiusLibs (useExternalWeb3, ownerWalletOverride = null, ethO
         ethWeb3ProviderEndpoint,
         ethContractsConfig.ownerWallet),
       creatorNodeConfig: AudiusLibs.configCreatorNode(creatorNodeEndpoint),
-      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(true),
+      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(),
       identityServiceConfig: AudiusLibs.configIdentityService(identityServiceEndpoint),
       isServer
     }

--- a/libs/examples/initializeVersions.js
+++ b/libs/examples/initializeVersions.js
@@ -55,7 +55,7 @@ async function initializeVersionServiceProviderContracts () {
       ethWeb3,
       ownerWallet
     ),
-    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(true),
+    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(),
     isServer: isServer
   }
   let audiusLibs = new AudiusLibs(audiusLibsConfig)

--- a/libs/initScripts/mainnet.js
+++ b/libs/initScripts/mainnet.js
@@ -91,7 +91,7 @@ function getLibsConfig (config, privateKey, ownerWallet) {
       ethWeb3,
       ownerWallet
     ),
-    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(true),
+    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(),
     isServer: isServer
   }
   return audiusLibsConfig

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -25,7 +25,7 @@ class AudiusLibs {
    * Configures a discovery provider wrapper
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whitelist)
    * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
-   * @param {(selection: sring) => void?} selectionCallback invoked with the select discovery provider
+   * @param {(selection: string) => void?} selectionCallback invoked with the select discovery provider
    */
   static configDiscoveryProvider (whitelist = null, reselectTimeout = null, selectionCallback = null) {
     return { whitelist, reselectTimeout, selectionCallback }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -24,11 +24,11 @@ class AudiusLibs {
   /**
    * Configures a discovery provider wrapper
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whitelist)
-   * - if `autoselect=true`, autoselections are validated against the whitelist
-   * - if `autoselect=false`, selection is performed at random from the whitelist
+   * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
+   * @param {(selection: sring) => void?} selectionCallback invoked with the select discovery provider
    */
-  static configDiscoveryProvider (whitelist = null, reselectTimeout = null) {
-    return { whitelist, reselectTimeout }
+  static configDiscoveryProvider (whitelist = null, reselectTimeout = null, selectionCallback = null) {
+    return { whitelist, reselectTimeout, selectionCallback }
   }
 
   /**
@@ -207,7 +207,8 @@ class AudiusLibs {
         this.userStateManager,
         this.ethContracts,
         this.web3Manager,
-        this.discoveryProviderConfig.reselectTimeout
+        this.discoveryProviderConfig.reselectTimeout,
+        this.discoveryProviderConfig.selectionCallback
       )
       await this.discoveryProvider.init()
     }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -23,13 +23,12 @@ const ServiceProvider = require('./api/serviceProvider')
 class AudiusLibs {
   /**
    * Configures a discovery provider wrapper
-   * @param {boolean} autoselect whether or not to autoselect a discovery provider endpoint
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whitelist)
    * - if `autoselect=true`, autoselections are validated against the whitelist
    * - if `autoselect=false`, selection is performed at random from the whitelist
    */
-  static configDiscoveryProvider (autoselect = true, whitelist = null) {
-    return { autoselect, whitelist }
+  static configDiscoveryProvider (whitelist = null, reselectTimeout = null) {
+    return { whitelist, reselectTimeout }
   }
 
   /**
@@ -204,11 +203,11 @@ class AudiusLibs {
     /** Discovery Provider */
     if (this.discoveryProviderConfig) {
       this.discoveryProvider = new DiscoveryProvider(
-        this.discoveryProviderConfig.autoselect,
         this.discoveryProviderConfig.whitelist,
         this.userStateManager,
         this.ethContracts,
-        this.web3Manager
+        this.web3Manager,
+        this.discoveryProviderConfig.reselectTimeout
       )
       await this.discoveryProvider.init()
     }

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -65,39 +65,57 @@ class ServiceSelection {
 
     // Total number of services attempted
     this.totalAttempts = 0
+
+    // The decision tree path that was taken. Reset on each new selection.
+    this.decisionTree = []
   }
 
-  async select () {
+  /**
+   * Selects a service
+   * @param {boolean} reset if reset is true, clear the decision tree
+   */
+  async select (reset = true) {
+    if (reset) { this.decisionTree = [] }
+
     // If a short circuit is provided, take it. Don't check it, just use it.
     const shortcircuit = this.shortcircuit()
+    this.decisionTree.push({stage: 'Check Short Circuit', val: shortcircuit })
     if (shortcircuit) return shortcircuit
 
     // Get all the services
     let services = await this.getServices()
+    this.decisionTree.push({stage: 'Get All Services', val: services })
 
     // If a whitelist is provided, filter down to it
     if (this.whitelist) {
       services = this.filterToWhitelist(services)
+      this.decisionTree.push({ stage: 'Filter To Whitelist', val: services })
     }
 
     // Filter out anything we know is already unhealthy
     const filteredServices = this.filterOutKnownUnhealthy(services)
+    this.decisionTree.push({ stage: 'Filter Out Known Unhealthy', val: filteredServices })
 
     // Randomly sample a "round" to test
     const round = this.getSelectionRound(filteredServices)
+    this.decisionTree.push({ stage: 'Get Selection Round', val: round })
 
     this.totalAttempts += round.length
 
     // If there are no services left to try, either pick a backup or return null
     if (filteredServices.length === 0) {
+      this.decisionTree.push({ stage: 'No Services Left To Try' })
       if (Object.keys(this.backups).length > 0) {
         // Some backup exists
-        return this.selectFromBackups()
+        const backup = this.selectFromBackups()
+        this.decisionTree.push({ stage: 'Selected From Backup', val: backup })
+        return backup
       } else {
         // Nothing could be found that was healthy.
         // Reset everything we know so that we might try again.
         this.unhealthy = []
         this.backups = {}
+        this.decisionTree.push({ stage: 'Failed Everything. Resetting.' })
         return null
       }
     }
@@ -116,9 +134,11 @@ class ServiceSelection {
 
     // Recursively try this selection function if we didn't find something
     if (!best) {
-      return this.select()
+      this.decisionTree.push({ stage: 'Round Failed Retry' })
+      return this.select(/* reset */ false)
     }
 
+    this.decisionTree.push({ stage: 'Made A Selection', val: best })
     // If we made it this far, we found the best service! (of the rounds we tried)
     return best
   }
@@ -198,6 +218,7 @@ class ServiceSelection {
         /* timeBetweenRequests */ 0,
         /* validationCheck */ (resp) => this.isHealthy(resp, map)
       )
+      this.decisionTree.push({ stage: 'Raced And Found Best', val: best })
       return { best, errored: errored.map(e => map[e.config.url]) }
     } catch (e) {
       return { best: null, errored: [] }

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -79,12 +79,12 @@ class ServiceSelection {
 
     // If a short circuit is provided, take it. Don't check it, just use it.
     const shortcircuit = this.shortcircuit()
-    this.decisionTree.push({stage: 'Check Short Circuit', val: shortcircuit })
+    this.decisionTree.push({ stage: 'Check Short Circuit', val: shortcircuit })
     if (shortcircuit) return shortcircuit
 
     // Get all the services
     let services = await this.getServices()
-    this.decisionTree.push({stage: 'Get All Services', val: services })
+    this.decisionTree.push({ stage: 'Get All Services', val: services })
 
     // If a whitelist is provided, filter down to it
     if (this.whitelist) {

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -93,7 +93,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
     }
     console.info(`Selected discprov ${endpoint}`, this.decisionTree)
     if (this.selectionCallback) {
-      this.selectionCallback(endpoint)
+      this.selectionCallback(endpoint, this.decisionTree)
     }
     return endpoint
   }

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -35,6 +35,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
     this.ethContracts = ethContracts
     this.currentVersion = null
     this.reselectTimeout = config.reselectTimeout
+    this.selectionCallback = config.selectionCallback
 
     // Whether or not we are running in `regressed` mode, meaning we were
     // unable to select a discovery provider that was up-to-date. Clients may
@@ -91,6 +92,9 @@ class DiscoveryProviderSelection extends ServiceSelection {
       this.setCached(endpoint)
     }
     console.info(`Selected discprov ${endpoint}`, this.decisionTree)
+    if (this.selectionCallback) {
+      this.selectionCallback(endpoint)
+    }
     return endpoint
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -10,7 +10,7 @@ const mockEthContracts = (urls, currrentVersion) => ({
   getVersion: async (spType, queryIndex) => {
     return ['1.2.2', '1.2.3'][queryIndex]
   },
-  getServiceProviderList: async () => urls,
+  getServiceProviderList: async () => urls.map(u => ({ endpoint: u })),
   isValidSPVersion: (version1, version2) => {
     return (
       semver.major(version1) === semver.major(version2) &&

--- a/libs/src/services/discoveryProvider/constants.js
+++ b/libs/src/services/discoveryProvider/constants.js
@@ -4,7 +4,7 @@ module.exports.UNHEALTHY_BLOCK_DIFF = 15
 module.exports.REGRESSED_MODE_TIMEOUT = 2 * 60 * 1000 // two minutes
 
 // When to time out the cached discovery provider
-module.exports.DISCOVERY_PROVIDER_RESELECT_TIMEOUT = 1 /* min */ * 60 /* seconds */ * 1000 /* millisec */
+module.exports.DISCOVERY_PROVIDER_RESELECT_TIMEOUT = 10 /* min */ * 60 /* seconds */ * 1000 /* millisec */
 // How often to make sure the cached discovery provider is fresh
 module.exports.DISCOVERY_PROVIDER_TIMESTAMP_INTERVAL = 5000
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -1,8 +1,6 @@
 const axios = require('axios')
 
 const Utils = require('../../utils')
-const { raceRequests } = require('../../utils/network')
-const { serviceType } = require('../ethContracts/index')
 
 const {
   UNHEALTHY_BLOCK_DIFF,

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -18,7 +18,7 @@ const MAKE_REQUEST_RETRY_COUNT = 3
 const MAX_MAKE_REQUEST_RETRY_COUNT = 50
 
 class DiscoveryProvider {
-  constructor (whitelist, userStateManager, ethContracts, web3Manager, reselectTimeout) {
+  constructor (whitelist, userStateManager, ethContracts, web3Manager, reselectTimeout, selectionCallback) {
     this.whitelist = whitelist
     this.userStateManager = userStateManager
     this.ethContracts = ethContracts
@@ -26,7 +26,8 @@ class DiscoveryProvider {
 
     this.serviceSelector = new DiscoveryProviderSelection({
       whitelist: this.whitelist,
-      reselectTimeout
+      reselectTimeout,
+      selectionCallback
     }, this.ethContracts)
   }
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -13,60 +13,27 @@ const Requests = require('./requests')
 
 // TODO - webpack workaround. find a way to do this without checkout for .default property
 let urlJoin = require('proper-url-join')
+const DiscoveryProviderSelection = require('./DiscoveryProviderSelection')
 if (urlJoin && urlJoin.default) urlJoin = urlJoin.default
 
 const MAKE_REQUEST_RETRY_COUNT = 3
 const MAX_MAKE_REQUEST_RETRY_COUNT = 50
-const AUTOSELECT_DISCOVERY_PROVIDER_RETRY_COUNT = 3
 
 class DiscoveryProvider {
-  constructor (autoselect, whitelist, userStateManager, ethContracts, web3Manager) {
-    this.autoselect = autoselect
+  constructor (whitelist, userStateManager, ethContracts, web3Manager, reselectTimeout) {
     this.whitelist = whitelist
     this.userStateManager = userStateManager
     this.ethContracts = ethContracts
     this.web3Manager = web3Manager
+
+    this.serviceSelector = new DiscoveryProviderSelection({
+      whitelist: this.whitelist,
+      reselectTimeout
+    }, this.ethContracts)
   }
 
   async init () {
-    let endpoint
-    let pick
-    let isValid = null
-
-    if (this.autoselect) {
-      endpoint = await this.autoSelectEndpoint()
-    } else {
-      if (typeof this.whitelist === 'string') {
-        endpoint = this.whitelist
-      } else {
-        if (!this.whitelist || this.whitelist.size === 0) {
-          throw new Error('Must pass autoselect true or provide whitelist.')
-        }
-
-        // use this as a lookup between version endpoint and base url
-        const whitelistMap = {}
-        this.whitelist.forEach((url) => {
-          whitelistMap[urlJoin(url, '/version')] = url
-        })
-
-        try {
-          const { response } = await raceRequests(Object.keys(whitelistMap), (url) => {
-            pick = whitelistMap[url]
-          }, {}, REQUEST_TIMEOUT_MS)
-
-          isValid = pick && response.data.service && (response.data.service === serviceType.DISCOVERY_PROVIDER)
-          if (isValid) {
-            console.info('Initial discovery provider was valid')
-            endpoint = pick
-          } else {
-            console.info('Initial discovery provider was invalid, searching for a new one')
-            endpoint = await this.ethContracts.selectDiscoveryProvider(this.whitelist)
-          }
-        } catch (e) {
-          throw new Error('Could not select a discprov from the whitelist', e)
-        }
-      }
-    }
+    const endpoint = await this.serviceSelector.select()
     this.setEndpoint(endpoint)
 
     if (endpoint && this.web3Manager && this.web3Manager.web3) {
@@ -78,25 +45,6 @@ class DiscoveryProvider {
 
   setEndpoint (endpoint) {
     this.discoveryProviderEndpoint = endpoint
-  }
-
-  /**
-   * Wrapper method to auto select a valid discovery provider.
-   * @param {*} retries max retries before throwing an error
-   * @param {*} clearCachedDiscoveryProvider if set to true, implies that the previously
-   * selected discovery provider has been failing to serve requests. The prior recurring interval of
-   * checking local storage for DP and old DP local storage entry need to be cleared.
-   */
-  async autoSelectEndpoint (retries = 3, clearCachedDiscoveryProvider = false) {
-    if (retries > 0) {
-      const endpoint = await this.ethContracts.autoselectDiscoveryProvider(this.whitelist, clearCachedDiscoveryProvider)
-      if (endpoint) {
-        this.setEndpoint(endpoint)
-        return endpoint
-      }
-      return this.autoSelectEndpoint(retries - 1)
-    }
-    throw new Error('Failed to autoselect discovery provider')
   }
 
   /**
@@ -533,14 +481,16 @@ class DiscoveryProvider {
     }
 
     if (!this.discoveryProviderEndpoint) {
-      await this.autoSelectEndpoint()
+      const endpoint = await this.serviceSelector.select()
+      this.setEndpoint(endpoint)
     }
 
     if (retries === 0) {
       // Reset the retries count in the case that the newly selected disc prov fails, we can
       // allow it to try MAKE_REQUEST_RETRIES_COUNT number of times before trying another
       retries = MAKE_REQUEST_RETRY_COUNT
-      await this.autoSelectEndpoint(AUTOSELECT_DISCOVERY_PROVIDER_RETRY_COUNT, true)
+      const endpoint = await this.serviceSelector.select()
+      this.setEndpoint(endpoint)
     }
 
     let requestUrl
@@ -591,8 +541,12 @@ class DiscoveryProvider {
         ) {
           // Select a new one
           console.info(`${this.discoveryProviderEndpoint} is too far behind, reselecting discovery provider`)
-          const endpoint = await this.autoSelectEndpoint(AUTOSELECT_DISCOVERY_PROVIDER_RETRY_COUNT, true)
+          // Mark the current selection as a backup
+          this.serviceSelector.addBackup(this.discoveryProviderEndpoint, response)
+          // Select a new one
+          const endpoint = await this.serviceSelector.select()
           this.setEndpoint(endpoint)
+
           retries = MAKE_REQUEST_RETRY_COUNT // reset retry count when setting a new endpoint
           throw new Error(`Selected endpoint was too far behind. Indexed: ${indexedBlock} Chain: ${chainBlock}`)
         }


### PR DESCRIPTION
Was thinking of making this a minor release of libs

Reasons why this works now
1. On the DApp we choose a discprov eagerly before this and then call this logic after libs loads in
2. We will pass in reselect timeout with remote config so we can modify those vals at will