### PR TITLE
[C02] Rewards pay out incorrectly when the service provider has a pending “decrease stake” request

### DIFF
--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -227,7 +227,7 @@ contract ClaimsManager is InitializableV2 {
     function processClaim(
         address _claimer,
         uint _totalLockedForSP
-    ) external
+    ) external returns (uint mintedRewards)
     {
         _requireIsInitialized();
         require(
@@ -262,7 +262,7 @@ contract ClaimsManager is InitializableV2 {
         // Total rewards can be zero if all stake is currently locked up
         if (!withinBounds || rewardsForClaimer == 0) {
             stakingContract.updateClaimHistory(0, _claimer);
-            return;
+            return 0;
         }
 
         // ERC20Mintable always returns true
@@ -286,6 +286,8 @@ contract ClaimsManager is InitializableV2 {
             totalStakedAtFundBlockForClaimer,
             newTotal
         );
+
+        return rewardsForClaimer;
     }
 
     /**

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -351,7 +351,6 @@ contract DelegateManager is InitializableV2 {
 
         // Total rewards
         // Equal to (balance in staking) - ((balance in sp factory) + (balance in delegate manager))
-        // uint totalRewards = totalBalanceInStaking.sub(totalBalanceOutsideStaking);
 
         // Emit claim event
         emit Claim(msg.sender, totalRewards, totalBalanceInStaking);

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -716,7 +716,6 @@ contract DelegateManager is InitializableV2 {
         uint totalRewards
     )
     {
-
         // Account for any pending locked up stake for the service provider
         (spLockedStake,) = spFactory.getPendingDecreaseStakeRequest(msg.sender);
         uint totalLockedUpStake = spDelegateInfo[msg.sender].totalLockedUpStake.add(spLockedStake);
@@ -729,28 +728,28 @@ contract DelegateManager is InitializableV2 {
         );
 
         // Amount stored in staking contract for owner
-        uint _totalBalanceInStaking = Staking(stakingAddress).totalStakedFor(msg.sender);
-        require(_totalBalanceInStaking > 0, "Stake required for claim");
+        totalBalanceInStaking = Staking(stakingAddress).totalStakedFor(msg.sender);
+        require(totalBalanceInStaking > 0, "Stake required for claim");
 
         // Amount in sp factory for claimer
-        (uint _totalBalanceInSPFactory,,,,,) = spFactory.getServiceProviderDetails(msg.sender);
+        (totalBalanceInSPFactory,,,,,) = spFactory.getServiceProviderDetails(msg.sender);
         // Require active stake to claim any rewards
-        require(_totalBalanceInSPFactory > 0, "Service Provider stake required");
+        require(totalBalanceInSPFactory.sub(spLockedStake) > 0, "Service Provider stake required");
 
         // Amount in delegate manager staked to service provider
-        uint _totalBalanceOutsideStaking = (
-            _totalBalanceInSPFactory.add(spDelegateInfo[msg.sender].totalDelegatedStake)
+        totalBalanceOutsideStaking = (
+            totalBalanceInSPFactory.add(spDelegateInfo[msg.sender].totalDelegatedStake)
         );
 
         require(
-            mintedRewards == _totalBalanceInStaking.sub(_totalBalanceOutsideStaking),
+            mintedRewards == totalBalanceInStaking.sub(totalBalanceOutsideStaking),
             "Reward amount mismatch"
         );
 
         return (
-            _totalBalanceInStaking,
-            _totalBalanceInSPFactory,
-            _totalBalanceOutsideStaking,
+            totalBalanceInStaking,
+            totalBalanceInSPFactory,
+            totalBalanceOutsideStaking,
             spLockedStake,
             mintedRewards
         );

--- a/eth-contracts/contracts/test/MockDelegateManager.sol
+++ b/eth-contracts/contracts/test/MockDelegateManager.sol
@@ -21,7 +21,7 @@ contract MockDelegateManager is InitializableV2 {
     function testProcessClaim(
         address _claimer,
         uint _totalLockedForSP
-    ) external {
+    ) external returns (uint) {
         ClaimsManager claimsManager = ClaimsManager(
             claimsManagerAddress
         );

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -270,9 +270,10 @@ contract('DelegateManager', async (accounts) => {
     let spDetails = await serviceProviderFactory.getServiceProviderDetails(account)
     spFactoryStake = spDetails.deployerStake
     totalInStakingContract = await staking.totalStakedFor(account)
+    let spDecreaseRequest = await serviceProviderFactory.getPendingDecreaseStakeRequest(account)
 
     let delegatedStake = await delegateManager.getTotalDelegatedToServiceProvider(account)
-    let lockedUpStake = await delegateManager.getTotalLockedDelegationForServiceProvider(account)
+    let lockedUpDelegatorStake = await delegateManager.getTotalLockedDelegationForServiceProvider(account)
     let delegatorInfo = {}
     let delegators = await delegateManager.getDelegatorsList(account)
     for (var i = 0; i < delegators.length; i++) {
@@ -286,7 +287,7 @@ contract('DelegateManager', async (accounts) => {
       }
     }
     let outsideStake = spFactoryStake.add(delegatedStake)
-    let totalActiveStake = outsideStake.sub(lockedUpStake)
+    let totalActiveStake = outsideStake.sub(lockedUpDelegatorStake)
     let stakeDiscrepancy = totalInStakingContract.sub(outsideStake)
     let accountSummary = {
       totalInStakingContract,
@@ -294,8 +295,9 @@ contract('DelegateManager', async (accounts) => {
       spFactoryStake,
       delegatorInfo,
       outsideStake,
-      lockedUpStake,
-      totalActiveStake
+      lockedUpDelegatorStake,
+      totalActiveStake,
+      spDecreaseRequest
     }
 
     if (print) {
@@ -914,7 +916,7 @@ contract('DelegateManager', async (accounts) => {
       )
 
       let preSlashInfo = await getAccountStakeInfo(stakerAccount, false)
-      let preSlashLockupStake = preSlashInfo.lockedUpStake
+      let preSlashLockupStake = preSlashInfo.lockedUpDelegatorStake
       assert.isTrue(
         preSlashLockupStake.eq(initialDelegateAmount),
         'Initial delegate amount not found')
@@ -924,7 +926,7 @@ contract('DelegateManager', async (accounts) => {
 
       let postRewardInfo = await getAccountStakeInfo(stakerAccount, false)
 
-      let postSlashLockupStake = postRewardInfo.lockedUpStake
+      let postSlashLockupStake = postRewardInfo.lockedUpDelegatorStake
       assert.equal(
         postSlashLockupStake,
         0,
@@ -1483,11 +1485,12 @@ contract('DelegateManager', async (accounts) => {
         let fundsPerRound = await claimsManager.getFundsPerRound()
         let expectedIncrease = fundsPerRound.div(_lib.toBN(4))
         // Request decrease in stake corresponding to 1/2 of DEFAULT_AMOUNT
-        await serviceProviderFactory.requestDecreaseStake(DEFAULT_AMOUNT.div(_lib.toBN(2)), { from: stakerAccount })
-        let info = await getAccountStakeInfo(stakerAccount)
+        let decreaseStakeAmount = DEFAULT_AMOUNT.div(_lib.toBN(2))
+        await serviceProviderFactory.requestDecreaseStake(decreaseStakeAmount, { from: stakerAccount })
+        let info = await getAccountStakeInfo(stakerAccount, true)
         await claimsManager.initiateRound({ from: stakerAccount })
         await delegateManager.claimRewards({ from: stakerAccount })
-        let info2 = await getAccountStakeInfo(stakerAccount)
+        let info2 = await getAccountStakeInfo(stakerAccount, true)
         let stakingDiff = (info2.totalInStakingContract).sub(info.totalInStakingContract)
         let spFactoryDiff = (info2.spFactoryStake).sub(info.spFactoryStake)
         assert.isTrue(stakingDiff.eq(expectedIncrease), 'Expected increase not found in Staking.sol')
@@ -1499,7 +1502,7 @@ contract('DelegateManager', async (accounts) => {
         let requestInfo = await serviceProviderFactory.getPendingDecreaseStakeRequest(stakerAccount)
         assert.isTrue((requestInfo.lockupExpiryBlock).gt(_lib.toBN(0)), 'Expected lockup expiry block to be set')
         assert.isTrue((requestInfo.amount).gt(_lib.toBN(0)), 'Expected amount to be set')
-        
+
         // Slash
         await _lib.slash(_lib.audToWei(5), slasherAccount, governance, delegateManagerKey, guardianAddress)
 
@@ -1512,7 +1515,7 @@ contract('DelegateManager', async (accounts) => {
         let duration = await serviceProviderFactory.getDecreaseStakeLockupDuration()
         // Double decrease stake duration
         let newDuration = duration.add(duration)
-        
+
         await _lib.assertRevert(
           serviceProviderFactory.updateDecreaseStakeLockupDuration(newDuration),
           "Only callable by Governance contract"


### PR DESCRIPTION
* Directly return rewards after mint operation occurs in ClaimsManager, eliminate potential for miscalculated totalRewards when decrease is pending