### PR TITLE
[C01] A malicious delegator can permanently lock all stake and rewards for a victim service provider and all of its honest delegators

### DIFF
--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -224,6 +224,13 @@ contract DelegateManager is InitializableV2 {
         address delegator = msg.sender;
         // Confirm pending delegation request
         require(_undelegateRequestIsPending(delegator), "Pending lockup expected");
+
+        // Reset locked up stake
+        address unlockFundsSP = undelegateRequests[delegator].serviceProvider;
+        spDelegateInfo[unlockFundsSP].totalLockedUpStake = ( 
+            spDelegateInfo[unlockFundsSP].totalLockedUpStake.sub(undelegateRequests[delegator].amount)
+         );
+
         // Remove pending request
         undelegateRequests[delegator] = UndelegateStakeRequest({
             lockupExpiryBlock: 0,

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -227,9 +227,9 @@ contract DelegateManager is InitializableV2 {
 
         // Reset locked up stake
         address unlockFundsSP = undelegateRequests[delegator].serviceProvider;
-        spDelegateInfo[unlockFundsSP].totalLockedUpStake = ( 
+        spDelegateInfo[unlockFundsSP].totalLockedUpStake = (
             spDelegateInfo[unlockFundsSP].totalLockedUpStake.sub(undelegateRequests[delegator].amount)
-         );
+        );
 
         // Remove pending request
         undelegateRequests[delegator] = UndelegateStakeRequest({


### PR DESCRIPTION
* Code fix to reset total locked stake on cancel of undelegate request + corresponding test case