### PR TITLE
Added discprov endpoint for previously unlisted track

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -2205,7 +2205,7 @@ def get_previously_unlisted_tracks():
 
         track_ids = [result[0] for result in previously_unlisted_results]
 
-    return api_helpers.success_response({ 'track_ids': track_ids })
+    return api_helpers.success_response({ 'ids': track_ids })
 
 # Get the playlists that were previously private and became public after the date provided
 @bp.route("/previously_private/playlist", methods=("GET",))
@@ -2252,4 +2252,4 @@ def get_previously_private_playlist():
 
         playlist_ids = [result[0] for result in previously_private_results]
 
-    return api_helpers.success_response({ 'playlist_ids': playlist_ids })
+    return api_helpers.success_response({ 'ids': playlist_ids })

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -2167,7 +2167,7 @@ def get_previously_unlisted_tracks():
     with db.scoped_session() as session:
         if "date" not in request.args:
             return api_helpers.error_response(
-                "'date' required to query for retrieveing previously unlisted tracks", 400
+                "'date' required to query for retrieving previously unlisted tracks", 400
             )
 
         date = request.args.get("date")
@@ -2214,7 +2214,7 @@ def get_previously_private_playlist():
     with db.scoped_session() as session:
         if "date" not in request.args:
             return api_helpers.error_response(
-                "'date' required to query for retrieveing previously private playlists", 400
+                "'date' required to query for retrieving previously private playlists", 400
             )
 
         date = request.args.get("date")

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -1566,6 +1566,7 @@ def get_max_id(type):
             latest = (
                 session
                 .query(func.max(Track.track_id))
+                .filter(Track.is_unlisted == False)
                 .scalar()
             )
             return api_helpers.success_response(latest)
@@ -1573,6 +1574,7 @@ def get_max_id(type):
             latest = (
                 session
                 .query(func.max(Playlist.playlist_id))
+                .filter(Playlist.is_private == False)
                 .scalar()
             )
             return api_helpers.success_response(latest)
@@ -2158,19 +2160,19 @@ def get_remix_track_parents(track_id):
 
     return api_helpers.success_response(tracks)
 
-# Get the tracks that were previously unlisted and became public after the date provide
-@bp.route("/previously_unlisted_tracks", methods=("GET",))
+# Get the tracks that were previously unlisted and became public after the date provided
+@bp.route("/previously_unlisted/track", methods=("GET",))
 def get_previously_unlisted_tracks():
     db = get_db_read_replica()
     with db.scoped_session() as session:
         if "date" not in request.args:
             return api_helpers.error_response(
-                "Date required to query for retrieveing previously unlisted tracks", 400
+                "'date' required to query for retrieveing previously unlisted tracks", 400
             )
 
         date = request.args.get("date")
 
-        tracks_before_date = (
+        tracks_after_date = (
             session.query(
                 Track.track_id,
                 Track.updated_at
@@ -2178,11 +2180,11 @@ def get_previously_unlisted_tracks():
                 Track.track_id
             ).filter(
                 Track.is_unlisted == False,
-                Track.updated_at > date
+                Track.updated_at >= date
             ).subquery()
         )
 
-        tracks_after_date = (
+        tracks_before_date = (
             session.query(
                 Track.track_id,
                 Track.updated_at
@@ -2204,3 +2206,50 @@ def get_previously_unlisted_tracks():
         track_ids = [result[0] for result in previously_unlisted_results]
 
     return api_helpers.success_response({ 'track_ids': track_ids })
+
+# Get the playlists that were previously private and became public after the date provided
+@bp.route("/previously_private/playlist", methods=("GET",))
+def get_previously_private_playlist():
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        if "date" not in request.args:
+            return api_helpers.error_response(
+                "'date' required to query for retrieveing previously private playlists", 400
+            )
+
+        date = request.args.get("date")
+
+        playlist_after_date = (
+            session.query(
+                Playlist.playlist_id,
+                Playlist.updated_at
+            ).distinct(
+                Playlist.playlist_id
+            ).filter(
+                Playlist.is_private == False,
+                Playlist.updated_at >= date
+            ).subquery()
+        )
+
+        playlist_before_date = (
+            session.query(
+                Playlist.playlist_id,
+                Playlist.updated_at
+            ).distinct(
+                Playlist.playlist_id
+            ).filter(
+                Playlist.is_private == True,
+                Playlist.updated_at < date
+            ).subquery()
+        )
+
+        previously_private_results = session.query(
+            playlist_before_date.c['playlist_id']
+        ).join(
+            playlist_after_date,
+            playlist_after_date.c['playlist_id'] == playlist_before_date.c['playlist_id'],
+        ).all()
+
+        playlist_ids = [result[0] for result in previously_private_results]
+
+    return api_helpers.success_response({ 'playlist_ids': playlist_ids })


### PR DESCRIPTION
Added a discprov endpoint that gets the previously unlisted tracks.
Given a timestamp, it returns tracks that were unlisted before the timestamp and public after. 

ie. 
t0: track A is created as unlisted
t1: cartographer indexes track A and decides not to add to sitemap
t2: track B is created as listed
t3: cartographer adds track B to sitemap
t4: track A become public
t5: cartographer uses the last indexed track's udpated_at timestamp to request track ids that were previously unlisted