### PR TITLE
[H02] Delegators can prevent service providers from deregistering endpoints

### DIFF
--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -833,14 +833,14 @@ contract DelegateManager is InitializableV2 {
 
     function _removeFromDelegatorsList(address _serviceProvider, address _delegator) internal
     {
-      for (uint i = 0; i < spDelegateInfo[_serviceProvider].delegators.length; i++) {
-          if (spDelegateInfo[_serviceProvider].delegators[i] == _delegator) {
-              // Overwrite and shrink delegators list
-              spDelegateInfo[_serviceProvider].delegators[i] = spDelegateInfo[_serviceProvider].delegators[spDelegateInfo[_serviceProvider].delegators.length - 1];
-              spDelegateInfo[_serviceProvider].delegators.length--;
-              break;
-          }
-      }
+        for (uint i = 0; i < spDelegateInfo[_serviceProvider].delegators.length; i++) {
+            if (spDelegateInfo[_serviceProvider].delegators[i] == _delegator) {
+                // Overwrite and shrink delegators list
+                spDelegateInfo[_serviceProvider].delegators[i] = spDelegateInfo[_serviceProvider].delegators[spDelegateInfo[_serviceProvider].delegators.length - 1];
+                spDelegateInfo[_serviceProvider].delegators.length--;
+                break;
+            }
+        }
     }
 
     /**

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -535,8 +535,6 @@ contract DelegateManager is InitializableV2 {
 
         // Remove from list of delegators
         _removeFromDelegatorsList(_serviceProvider, _delegator);
-
-        return;
     }
 
     /**

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -283,14 +283,7 @@ contract DelegateManager is InitializableV2 {
 
         // Remove from delegators list if no delegated stake remaining
         if (delegateInfo[delegator][serviceProvider] == 0) {
-            for (uint i = 0; i < spDelegateInfo[serviceProvider].delegators.length; i++) {
-                if (spDelegateInfo[serviceProvider].delegators[i] == delegator) {
-                    // Overwrite and shrink delegators list
-                    spDelegateInfo[serviceProvider].delegators[i] = spDelegateInfo[serviceProvider].delegators[spDelegateInfo[serviceProvider].delegators.length - 1];
-                    spDelegateInfo[serviceProvider].delegators.length--;
-                    break;
-                }
-            }
+            _removeFromDelegatorsList(serviceProvider, delegator);
         }
 
         // Update total locked for this service provider, decreasing by unstake amount
@@ -539,6 +532,9 @@ contract DelegateManager is InitializableV2 {
             );
             _resetUndelegateStakeRequest(_delegator);
         }
+
+        // Remove from list of delegators
+        _removeFromDelegatorsList(_serviceProvider, _delegator);
 
         return;
     }
@@ -835,6 +831,18 @@ contract DelegateManager is InitializableV2 {
     ) internal
     {
         spDelegateInfo[_serviceProvider].totalLockedUpStake = _updatedLockupAmount;
+    }
+
+    function _removeFromDelegatorsList(address _serviceProvider, address _delegator) internal
+    {
+      for (uint i = 0; i < spDelegateInfo[_serviceProvider].delegators.length; i++) {
+          if (spDelegateInfo[_serviceProvider].delegators[i] == _delegator) {
+              // Overwrite and shrink delegators list
+              spDelegateInfo[_serviceProvider].delegators[i] = spDelegateInfo[_serviceProvider].delegators[spDelegateInfo[_serviceProvider].delegators.length - 1];
+              spDelegateInfo[_serviceProvider].delegators.length--;
+              break;
+          }
+      }
     }
 
     /**

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1554,11 +1554,28 @@ contract('DelegateManager', async (accounts) => {
 
       // Attempt to deregister an endpoint
       // TODO: Make this work
+      await _lib.assertRevert(
+        _lib.deregisterServiceProvider(
+          serviceProviderFactory,
+          testDiscProvType,
+          testEndpoint,
+          stakerAccount),
+        'Maximum stake amount exceeded'
+      )
+
+      // Forcibly remove the delegator from service provider account
+      await delegateManager.removeDelegator(stakerAccount, delegatorAccount1, { from: stakerAccount })
+
+      // TODO: Verify delegator removal
+
+      // Again try to deregister
       await _lib.deregisterServiceProvider(
         serviceProviderFactory,
         testDiscProvType,
         testEndpoint,
         stakerAccount)
+
+      // TODO: Verify sp removal
     })
 
     describe('Service provider decrease stake behavior', async () => {

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1591,6 +1591,16 @@ contract('DelegateManager', async (accounts) => {
         'Expect pending request cancellation'
       )
 
+      // Cache current spID
+      let spID = await serviceProviderFactory.getServiceProviderIdFromEndpoint(testEndpoint)
+      let info = await serviceProviderFactory.getServiceEndpointInfo(testDiscProvType, spID)
+      assert.isTrue(
+        info.owner === stakerAccount &&
+        info.delegateOwnerWallet === stakerAccount &&
+        info.endpoint === testEndpoint,
+        'Expect sp state removal'
+      )
+
       // Again try to deregister
       await _lib.deregisterServiceProvider(
         serviceProviderFactory,
@@ -1598,7 +1608,18 @@ contract('DelegateManager', async (accounts) => {
         testEndpoint,
         stakerAccount)
 
-      // TODO: Verify sp removal
+      // Confirm endpoint has no ID associated
+      let spID2 = await serviceProviderFactory.getServiceProviderIdFromEndpoint(testEndpoint)
+      assert.isTrue(spID2.eq(_lib.toBN(0)), 'Expect reset of endpoint')
+      // Confirm removal of all sp state
+      info = await serviceProviderFactory.getServiceEndpointInfo(testDiscProvType, spID)
+      assert.isTrue(
+        info.owner === (_lib.addressZero) &&
+        info.delegateOwnerWallet === (_lib.addressZero) &&
+        info.endpoint === '' &&
+        info.blockNumber.eq(_lib.toBN(0)),
+        'Expect sp state removal'
+      )
     })
 
     describe('Service provider decrease stake behavior', async () => {

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -34,7 +34,7 @@ const callValue0 = _lib.toBN(0)
 
 contract('DelegateManager', async (accounts) => {
   let staking, stakingAddress, token, registry, governance, claimsManager0, claimsManagerProxy
-  let serviceProviderFactory, claimsManager, delegateManager, serviceTypeManager
+  let serviceProviderFactory, serviceTypeManager, claimsManager, delegateManager
 
   // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress] = accounts
@@ -1510,7 +1510,7 @@ contract('DelegateManager', async (accounts) => {
       )
     })
 
-    it.only('Deregister max stake violation', async () => {
+    it('Deregister max stake violation', async () => {
       let serviceTypeInfo = await serviceTypeManager.getServiceTypeInfo(testDiscProvType)
       // Register 2nd endpoint from SP1, with minimum additional stake
       await _lib.registerServiceProvider(

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -35,7 +35,7 @@ const callValue0 = _lib.toBN(0)
 contract('DelegateManager', async (accounts) => {
   let staking, stakingAddress, token, registry, governance, claimsManager0, claimsManagerProxy
   let serviceProviderFactory, claimsManager, delegateManager, serviceTypeManager
-  
+
   // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress] = accounts
   const tokenOwnerAddress = proxyDeployerAddress
@@ -1441,7 +1441,7 @@ contract('DelegateManager', async (accounts) => {
     })
 
     it.only('Deregister max stake violation', async () => {
-      let serviceTypeInfo = await serviceTypeManager.getServiceTypeStakeInfo(testDiscProvType)
+      let serviceTypeInfo = await serviceTypeManager.getServiceTypeInfo(testDiscProvType)
       console.log(serviceTypeInfo)
       // Register 2nd endpoint from SP1, with minimum additional stake
       await _lib.registerServiceProvider(
@@ -1450,7 +1450,7 @@ contract('DelegateManager', async (accounts) => {
         serviceProviderFactory,
         testDiscProvType,
         testEndpoint3,
-        serviceTypeInfo.min,
+        serviceTypeInfo.minStake,
         stakerAccount)
 
       let ids = await serviceProviderFactory.getServiceProviderIdsFromAddress(stakerAccount, testDiscProvType)


### PR DESCRIPTION
* Enabling service providers to forcibly remove a delegator  
* If maximum bounds are violated due to a delegator stake, SP can forcibly remove their stake and return funds, enabling deregistration
* Test case to confirm functionality