### PR TITLE
[H06] Endpoint registration can be frontrun

### DIFF
--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -117,16 +117,17 @@ contract ServiceProviderFactory is InitializableV2 {
      * @notice Function to initialize the contract
      * @param _governanceAddress - Governance proxy address
      */
-    function initialize (address _governanceAddress) public initializer
+    function initialize (
+        address _governanceAddress,
+        uint _decreaseStakeLockupDuration
+    ) public initializer
     {
         governanceAddress = _governanceAddress;
 
         // Configure direct minimum stake for deployer
         minDeployerStake = 5 * 10**uint256(DECIMALS);
 
-        // stake lockup duration = 1 wk in blocks
-        // 1/13 block/s * 604800 s/wk ~= 46523 block/wk
-        decreaseStakeLockupDuration = 46523;
+        decreaseStakeLockupDuration = _decreaseStakeLockupDuration;
 
         InitializableV2.initialize();
     }

--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -124,8 +124,9 @@ contract ServiceProviderFactory is InitializableV2 {
         // Configure direct minimum stake for deployer
         minDeployerStake = 5 * 10**uint256(DECIMALS);
 
-        // 10 blocks for lockup duration
-        decreaseStakeLockupDuration = 10;
+        // stake lockup duration = 1 wk in blocks
+        // 1/13 block/s * 604800 s/wk ~= 46523 block/wk
+        decreaseStakeLockupDuration = 46523;
 
         InitializableV2.initialize();
     }

--- a/eth-contracts/migrations/7_versioning_service_migration.js
+++ b/eth-contracts/migrations/7_versioning_service_migration.js
@@ -31,7 +31,9 @@ const cnTypeMax = _lib.audToWei(3000000)
 const serviceTypeDP = web3.utils.utf8ToHex('discovery-provider')
 const dpTypeMin = _lib.audToWei(200000)
 const dpTypeMax = _lib.audToWei(2000000)
-
+// stake lockup duration = 1 wk in blocks
+// - 1/13 block/s * 604800 s/wk ~= 46523 block/wk
+const decreaseStakeLockupDuration = 46523
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
@@ -105,8 +107,8 @@ module.exports = (deployer, network, accounts) => {
     const serviceProviderFactory0 = await deployer.deploy(ServiceProviderFactory, { from: proxyDeployerAddress })
     const serviceProviderFactoryCalldata = _lib.encodeCall(
       'initialize',
-      ['address'],
-      [process.env.governanceAddress]
+      ['address', 'uint'],
+      [process.env.governanceAddress, decreaseStakeLockupDuration]
     )
     const serviceProviderFactoryProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -28,6 +28,7 @@ const DEFAULT_AMOUNT_VAL = _lib.audToWei(120)
 const DEFAULT_AMOUNT = _lib.toBN(DEFAULT_AMOUNT_VAL)
 const VOTING_PERIOD = 10
 const VOTING_QUORUM = 1
+const DECREASE_STAKE_LOCKUP_DURATION = 10
 
 const callValue0 = _lib.toBN(0)
 
@@ -114,8 +115,8 @@ contract('DelegateManager', async (accounts) => {
     let serviceProviderFactory0 = await ServiceProviderFactory.new({ from: proxyDeployerAddress })
     const serviceProviderFactoryCalldata = _lib.encodeCall(
       'initialize',
-      ['address'],
-      [governance.address]
+      ['address', 'uint'],
+      [governance.address, DECREASE_STAKE_LOCKUP_DURATION]
     )
     let serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,
@@ -1622,8 +1623,10 @@ contract('DelegateManager', async (accounts) => {
         assert.isTrue((requestInfo.amount).eq(_lib.toBN(0)), 'Expected amount reset')
       })
 
-      it('Update lockup duration', async () => {
+      it('Update decreaseStakeLockupDuration', async () => {
         let duration = await serviceProviderFactory.getDecreaseStakeLockupDuration()
+        assert.equal(_lib.fromBN(duration), DECREASE_STAKE_LOCKUP_DURATION, 'Expected same decreaseStakeLockupDuration')
+
         // Double decrease stake duration
         let newDuration = duration.add(duration)
 
@@ -1642,6 +1645,7 @@ contract('DelegateManager', async (accounts) => {
 
         let updatedDuration = await serviceProviderFactory.getDecreaseStakeLockupDuration()
         assert.isTrue(updatedDuration.eq(newDuration), 'Update not reflected')
+
         let tx = await serviceProviderFactory.requestDecreaseStake(DEFAULT_AMOUNT.div(_lib.toBN(2)), { from: stakerAccount })
         let blocknumber = _lib.toBN(tx.receipt.blockNumber)
         let requestInfo = await serviceProviderFactory.getPendingDecreaseStakeRequest(stakerAccount)

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -43,6 +43,7 @@ contract('Governance.sol', async (accounts) => {
 
   const votingPeriod = 10
   const votingQuorum = 1
+  const decreaseStakeLockupDuration = 10
 
   // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress, newUpdateAddress] = accounts
@@ -151,8 +152,8 @@ contract('Governance.sol', async (accounts) => {
     const serviceProviderFactory0 = await ServiceProviderFactory.new({ from: proxyDeployerAddress })
     const serviceProviderFactoryCalldata = _lib.encodeCall(
       'initialize',
-      ['address'],
-      [governance.address]
+      ['address', 'uint'],
+      [governance.address, decreaseStakeLockupDuration]
     )
     const serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,

--- a/eth-contracts/test/serviceProvider.test.js
+++ b/eth-contracts/test/serviceProvider.test.js
@@ -26,6 +26,7 @@ const testEndpoint2 = 'https://localhost:5002'
 const MIN_STAKE_AMOUNT = 10
 const VOTING_PERIOD = 10
 const VOTING_QUORUM = 1
+const DECREASE_STAKE_LOCKUP_DURATION = 10
 
 const INITIAL_BAL = _lib.audToWeiBN(1000)
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
@@ -205,8 +206,8 @@ contract('ServiceProvider test', async (accounts) => {
     let serviceProviderFactory0 = await ServiceProviderFactory.new({ from: proxyDeployerAddress })
     const serviceProviderFactoryCalldata = _lib.encodeCall(
       'initialize',
-      ['address'],
-      [governance.address]
+      ['address', 'uint'],
+      [governance.address, DECREASE_STAKE_LOCKUP_DURATION]
     )
     let serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,
@@ -331,6 +332,15 @@ contract('ServiceProvider test', async (accounts) => {
       const serviceTypeDPInfo = await serviceTypeManager.getServiceTypeInfo(testDiscProvType)
       assert.isTrue(serviceTypeDPInfo.minStake.eq(spDetails.minAccountStake), 'Expected serviceTypeDP minStake == sp 1 minAccountStake')
       assert.isTrue(serviceTypeDPInfo.maxStake.eq(spDetails.maxAccountStake), 'Expected serviceTypeDP maxStake == sp 1 maxAccountStake')
+    })
+
+    it('Confirm initial decreaseStakeLockupDuration', async () => {
+      const decreaseStakeLockupDuration = await serviceProviderFactory.getDecreaseStakeLockupDuration.call()
+      assert.equal(
+        _lib.fromBN(decreaseStakeLockupDuration),
+        DECREASE_STAKE_LOCKUP_DURATION,
+        'Expected same decreaseStakeLockupDuration'
+      )
     })
 
     it('Confirm correct stake for account', async () => {


### PR DESCRIPTION
Increases `ServiceProviderFactory.decreaseStakeLockupDuration` from 10 blocks to 1 week. This makes endpoint registration front-running attack sufficiently improbable by giving the network enough time to slash malicious actor.

Option - Instead of making `decreaseStakeLockupDuration` an init param, we could leave it as is (hard-coded) and in tests, just call `updateDecreaseStakeLockupDuration` with a lower val