### PR TITLE
[H04] No incentive for evaluating proposals with outcome other than Yes

### DIFF
--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -26,7 +26,8 @@ contract Governance is InitializableV2 {
     uint256 private votingQuorum;
 
     /// @notice Max number of InProgress proposals possible at once
-    uint8 private maxInProgressProposals;
+    /// @dev uint16 gives max possible value of 65,535
+    uint16 private maxInProgressProposals;
 
     /**
      * @notice Address of account that has special Governance permissions. Can veto proposals
@@ -135,7 +136,7 @@ contract Governance is InitializableV2 {
         uint256 _votingPeriod,
         uint256 _votingQuorum,
         // TODO - order vars for optimal memory data packing
-        uint8 _maxInProgressProposals,
+        uint16 _maxInProgressProposals,
         address _guardianAddress
     ) public initializer {
         require(_registryAddress != address(0x00), "Requires non-zero _registryAddress");
@@ -512,7 +513,7 @@ contract Governance is InitializableV2 {
      * @dev Only callable by self via _executeTransaction
      * @param _newMaxInProgressProposals - new value for maxInProgressProposals
      */
-    function setMaxInProgressProposals(uint8 _newMaxInProgressProposals) external {
+    function setMaxInProgressProposals(uint16 _newMaxInProgressProposals) external {
         require(msg.sender == address(this), "Only callable by self");
         require(_newMaxInProgressProposals > 0, "Requires non-zero _newMaxInProgressProposals");
         maxInProgressProposals = _newMaxInProgressProposals;
@@ -681,7 +682,7 @@ contract Governance is InitializableV2 {
     }
 
     /// @notice Get the max number of concurrent InProgress proposals
-    function getMaxInProgressProposals() external view returns (uint8) {
+    function getMaxInProgressProposals() external view returns (uint16) {
         return maxInProgressProposals;
     }
 

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -25,6 +25,9 @@ contract Governance is InitializableV2 {
     /// @notice Required miniumum number of votes to consider a proposal valid
     uint256 private votingQuorum;
 
+    /// @notice Max number of InProgress proposals possible at once
+    uint8 private maxInProgressProposals;
+
     /**
      * @notice Address of account that has special Governance permissions. Can veto proposals
      *      and execute transactions directly on contracts.
@@ -72,8 +75,16 @@ contract Governance is InitializableV2 {
     }
 
     /***** Proposal storage *****/
+
+    /// @notice ID of most recently created proposal. Ids are monotonically increasing and 1-indexed.
     uint256 lastProposalId = 0;
+
+    /// @notice mapping of proposalId to Proposal struct with all proposal state
     mapping(uint256 => Proposal) proposals;
+
+    /// @notice array of proposals with InProgress state
+    uint256[] inProgressProposals;
+
 
     /***** Events *****/
     event ProposalSubmitted(
@@ -116,13 +127,15 @@ contract Governance is InitializableV2 {
      * @param _registryAddress - address of the registry proxy contract
      * @param _votingPeriod - period in blocks for which a governance proposal is open for voting
      * @param _votingQuorum - required minimum number of votes to consider a proposal valid
+     * @param _maxInProgressProposals - max number of InProgress proposals possible at once
      * @param _guardianAddress - address of account that has special Governance permissions
-
      */
     function initialize(
         address _registryAddress,
         uint256 _votingPeriod,
         uint256 _votingQuorum,
+        // TODO - order vars for optimal memory data packing
+        uint8 _maxInProgressProposals,
         address _guardianAddress
     ) public initializer {
         require(_registryAddress != address(0x00), "Requires non-zero _registryAddress");
@@ -131,6 +144,9 @@ contract Governance is InitializableV2 {
 
         require(_votingPeriod > 0, "Requires non-zero _votingPeriod");
         votingPeriod = _votingPeriod;
+
+        require(_maxInProgressProposals > 0, "Requires non-zero _maxInProgressProposals");
+        maxInProgressProposals = _maxInProgressProposals;
 
         require(_votingQuorum > 0, "Requires non-zero _votingQuorum");
         votingQuorum = _votingQuorum;
@@ -162,6 +178,18 @@ contract Governance is InitializableV2 {
         _requireIsInitialized();
 
         address proposer = msg.sender;
+
+        // Require all InProgress proposals that can be evaluated have been evaluated before new proposal submission
+        require(
+            _proposalsAreUpToDate(),
+            "Governance::submitProposal: Cannot submit new proposal until all evaluatable InProgress proposals are evaluated."
+        );
+
+        // Require new proposal submission would not push number of InProgress proposals over max number
+        require(
+            inProgressProposals.length <= maxInProgressProposals,
+            "Governance::submitProposal: Number of InProgress proposals already at max. Please evaluate if possible, or wait for current proposals' votingPeriods to expire."
+        );
 
         // Require proposer is active Staker
         Staking stakingContract = Staking(stakingAddress);
@@ -202,6 +230,9 @@ contract Governance is InitializableV2 {
             numVotes: 0
             /* votes: mappings are auto-initialized to default state */
         });
+
+        // Append new proposalId to inProgressProposals array
+        inProgressProposals.push(newProposalId);
 
         emit ProposalSubmitted(
             newProposalId,
@@ -321,8 +352,8 @@ contract Governance is InitializableV2 {
             "Governance::evaluateProposalOutcome: Cannot evaluate inactive proposal."
         );
 
-        /// Re-entrancy should not be possible here since this switches the status of the
-        /// proposal to 'Evaluating' so it should fail the status is 'InProgress' check
+        // Re-entrancy should not be possible here since this switches the status of the
+        // proposal to 'Evaluating' so it should fail the status is 'InProgress' check
         proposals[_proposalId].outcome = Outcome.Evaluating;
 
         // Require msg.sender is active Staker.
@@ -387,8 +418,11 @@ contract Governance is InitializableV2 {
             outcome = Outcome.No;
         }
 
-        /// This records the final outcome in the proposals mapping
+        // This records the final outcome in the proposals mapping
         proposals[_proposalId].outcome = outcome;
+
+        // Remove from inProgressProposals array
+        _removeFromInProgressProposals(_proposalId);
 
         emit ProposalOutcomeEvaluated(
             _proposalId,
@@ -471,6 +505,17 @@ contract Governance is InitializableV2 {
         require(_registryAddress != address(0x00), "Requires non-zero _registryAddress");
         registryAddress = _registryAddress;
         registry = Registry(_registryAddress);
+    }
+
+    /**
+     * @notice Set the max number of concurrent InProgress proposals
+     * @dev Only callable by self via _executeTransaction
+     * @param _newMaxInProgressProposals - new value for maxInProgressProposals
+     */
+    function setMaxInProgressProposals(uint8 _newMaxInProgressProposals) external {
+        require(msg.sender == address(this), "Only callable by self");
+        require(_newMaxInProgressProposals > 0, "Requires non-zero _newMaxInProgressProposals");
+        maxInProgressProposals = _newMaxInProgressProposals;
     }
 
     // ========================================= Guardian Actions =========================================
@@ -635,6 +680,16 @@ contract Governance is InitializableV2 {
         return registryAddress;
     }
 
+    /// @notice Get the max number of concurrent InProgress proposals
+    function getMaxInProgressProposals() external view returns (uint8) {
+        return maxInProgressProposals;
+    }
+
+    /// @notice Get the array of all InProgress proposal Ids
+    function getInProgressProposals() external view returns (uint256[] memory) {
+        return inProgressProposals;
+    }
+
     // ========================================= Internal Functions =========================================
 
     /**
@@ -690,5 +745,48 @@ contract Governance is InitializableV2 {
         proposals[_proposalId].voteMagnitudeNo = (
             proposals[_proposalId].voteMagnitudeNo.sub(_voterStake)
         );
+    }
+
+    /**
+     * @dev Can make O(1) by storing index pointer in proposals mapping.
+     *      Requires inProgressProposals to be 1-indexed, since all proposals that are not present
+     *          will have pointer set to 0.
+     */
+    function _removeFromInProgressProposals(uint256 _proposalId) internal {
+        uint256 index = 0;
+        bool found = false;
+        for (uint i = 0; i < inProgressProposals.length; i++) {
+            if (inProgressProposals[i] == _proposalId) {
+                index = i;
+                found = true;
+                break;
+            }
+        }
+        require(
+            found == true,
+            "Governance::_removeFromInProgressProposals: Could not find InProgress proposal."
+        );
+
+        // Swap proposalId to end of array + pop (deletes last elem + decrements array length)
+        inProgressProposals[index] = inProgressProposals[inProgressProposals.length - 1];
+        inProgressProposals.pop();
+    }
+
+    /**
+     * @notice Returns false if any proposals in inProgressProposals array are evaluatable
+     *          Evaluatable = proposals with closed votingPeriod
+     */
+    function _proposalsAreUpToDate() internal view returns (bool) {
+        // compare current block number against endBlockNumber of each proposal
+        for (uint i = 0; i < inProgressProposals.length; i++) {
+            if (
+                block.number >
+                (proposals[inProgressProposals[i]].startBlockNumber).add(votingPeriod)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -135,7 +135,6 @@ contract Governance is InitializableV2 {
         address _registryAddress,
         uint256 _votingPeriod,
         uint256 _votingQuorum,
-        // TODO - order vars for optimal memory data packing
         uint16 _maxInProgressProposals,
         address _guardianAddress
     ) public initializer {

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -814,7 +814,7 @@ contract Governance is InitializableV2 {
      *      log(2^256/(10^27*100))/log(1.07) ~= 1635
      */
     function _quorumMet(Proposal memory proposal, Staking stakingContract)
-    internal returns (bool)
+    internal view returns (bool)
     {
         uint256 participation = (
             (proposal.voteMagnitudeYes + proposal.voteMagnitudeNo)

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -13,8 +13,10 @@ const governanceRegKey = web3.utils.utf8ToHex('Governance')
 const VotingPeriod = 11520
 // Required number of votes on proposal
 const VotingQuorum = 1
+
 // Max number of concurrent InProgress proposals
-const MaxInProgressProposals = 20
+// - Setting to 100 by default as that is a sufficiently large value that is not at gas limit risk
+const MaxInProgressProposals = 100
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -32,7 +32,7 @@ module.exports = (deployer, network, accounts) => {
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint8', 'address'],
+      ['address', 'uint256', 'uint256', 'uint16', 'address'],
       [registryAddress, VotingPeriod, VotingQuorum, MaxInProgressProposals, guardianAddress]
     )
     const governanceProxy = await deployer.deploy(

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -13,6 +13,8 @@ const governanceRegKey = web3.utils.utf8ToHex('Governance')
 const VotingPeriod = 11520
 // Required number of votes on proposal
 const VotingQuorum = 1
+// Max number of concurrent InProgress proposals
+const MaxInProgressProposals = 20
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
@@ -28,8 +30,8 @@ module.exports = (deployer, network, accounts) => {
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'address'],
-      [registryAddress, VotingPeriod, VotingQuorum, guardianAddress]
+      ['address', 'uint256', 'uint256', 'uint8', 'address'],
+      [registryAddress, VotingPeriod, VotingQuorum, MaxInProgressProposals, guardianAddress]
     )
     const governanceProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -43,6 +43,7 @@ contract('Governance.sol', async (accounts) => {
 
   const votingPeriod = 10
   const votingQuorum = 1
+  const maxInProgressProposals = 20
 
   // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress, newUpdateAddress] = accounts
@@ -86,7 +87,8 @@ contract('Governance.sol', async (accounts) => {
       registry,
       votingPeriod,
       votingQuorum,
-      guardianAddress
+      guardianAddress,
+      maxInProgressProposals
     )
     await registry.addContract(governanceKey, governance.address, { from: proxyDeployerAddress })
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -1064,7 +1064,7 @@ contract('Governance.sol', async (accounts) => {
         assert.isAtLeast(participationPercent2, latestVotingQuorumPercent, 'Quorum would be met')
 
         // Increase quorum to failure amount
-        const newVotingQuorumPercent = 60
+        const newVotingQuorumPercent = 75
         await governance.guardianExecuteTransaction(
           governanceKey,
           callValue0,
@@ -1379,7 +1379,7 @@ contract('Governance.sol', async (accounts) => {
         { from: proposerAddress }
       )
       const submitProposalTx = _lib.parseTx(submitProposalTxR)
-      console.log(`Successfully submitted proposalId ${submitProposalTx.event.args.proposalId} with gas usage of ${submitProposalTxR.receipt.gasUsed}`)
+      // console.log(`Successfully submitted proposalId ${submitProposalTx.event.args.proposalId} with gas usage of ${submitProposalTxR.receipt.gasUsed}`)
     }
 
     // Confirm all InProgress proposals are uptodate bc votingPeriod is still active
@@ -1400,7 +1400,7 @@ contract('Governance.sol', async (accounts) => {
     for (let i = 1; i <= newMaxInProgressProposals; i++) {
       const evaluateTxR = await governance.evaluateProposalOutcome(i, { from: proposerAddress })
       const evaluateTx = _lib.parseTx(evaluateTxR)
-      console.log(`Successfully evaluated proposalId ${evaluateTx.event.args.proposalId} with gas usage of ${evaluateTxR.receipt.gasUsed}`)
+      // console.log(`Successfully evaluated proposalId ${evaluateTx.event.args.proposalId} with gas usage of ${evaluateTxR.receipt.gasUsed}`)
     }
 
     // Confirm all InProgress proposals are uptodate bc all have been evaluated
@@ -1426,7 +1426,7 @@ contract('Governance.sol', async (accounts) => {
         { from: proposerAddress }
       )
       const submitProposalTx = _lib.parseTx(submitProposalTxR)
-      console.log(`Successfully submitted proposalId ${submitProposalTx.event.args.proposalId} with gas usage of ${submitProposalTxR.receipt.gasUsed}`)
+      // console.log(`Successfully submitted proposalId ${submitProposalTx.event.args.proposalId} with gas usage of ${submitProposalTxR.receipt.gasUsed}`)
     }
 
     // Confirm all InProgress proposals are uptodate as votingPeriod is active

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -1289,8 +1289,8 @@ contract('Governance.sol', async (accounts) => {
     await governance.guardianExecuteTransaction(
       governanceKey,
       callValue0,
-      'setMaxInProgressProposals(uint8)',
-      _lib.abiEncode(['uint8'], [newMaxInProgressProposals]),
+      'setMaxInProgressProposals(uint16)',
+      _lib.abiEncode(['uint16'], [newMaxInProgressProposals]),
       { from: guardianAddress }
     )
 
@@ -1675,8 +1675,8 @@ contract('Governance.sol', async (accounts) => {
       await governance.guardianExecuteTransaction(
         governanceKey,
         callValue0,
-        'setMaxInProgressProposals(uint8)',
-        _lib.abiEncode(['uint8'], [newMaxInProgressProposals]),
+        'setMaxInProgressProposals(uint16)',
+        _lib.abiEncode(['uint16'], [newMaxInProgressProposals]),
         { from: guardianAddress }
       )
 

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -225,7 +225,8 @@ export const deployGovernance = async (
   registry,
   votingPeriod,
   votingQuorum,
-  guardianAddress
+  guardianAddress,
+  maxInProgressProposals = 20
 ) => {
   const Governance = artifacts.require('Governance')
   const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
@@ -233,8 +234,8 @@ export const deployGovernance = async (
   const governance0 = await Governance.new({ from: proxyDeployerAddress })
   const governanceInitializeData = encodeCall(
     'initialize',
-    ['address', 'uint256', 'uint256', 'address'],
-    [registry.address, votingPeriod, votingQuorum, guardianAddress]
+    ['address', 'uint256', 'uint256', 'uint8', 'address'],
+    [registry.address, votingPeriod, votingQuorum, maxInProgressProposals, guardianAddress]
   )
   // Initialize proxy with zero address
   const governanceProxy = await AudiusAdminUpgradeabilityProxy.new(

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -234,7 +234,7 @@ export const deployGovernance = async (
   const governance0 = await Governance.new({ from: proxyDeployerAddress })
   const governanceInitializeData = encodeCall(
     'initialize',
-    ['address', 'uint256', 'uint256', 'uint8', 'address'],
+    ['address', 'uint256', 'uint256', 'uint16', 'address'],
     [registry.address, votingPeriod, votingQuorum, maxInProgressProposals, guardianAddress]
   )
   // Initialize proxy with zero address


### PR DESCRIPTION
**Proposed Solution:** prevent new proposal submission if any currently InProgress proposals are evaluatable. Anyone who wants to submit new proposal must first separately evaluate any evaluatable proposals.

Work Items
---
- [x] add InProgress proposals tracking
    - [x] add `uint256[] inProgressProposals` - array of proposalIds
    - [x] at end of `submitProposal()`, add `newProposalId` to end of `inProgressProposals` array
    - [x] in `evaluateProposalOutcome()`, remove evaluated proposalId from `inProgressProposals` array
        - [x] O(n) implementation - loop through arr, swap elem to end + remove
    - [x] expose getter for array
- [x] block `submitProposal()` if any evaluatable proposals remain
    - [x] check this by checking if any proposal in `inProgressProposals` array has an expired votingPeriod
- [x] hard cap size of `inProgressProposals` to avoid gas limit issue
    - [x] store `maxInProgressProposals` value in contract storage
    - [x] check this value at beginning of `submitProposal` and revert if bound met
    - [x] make this value modifiable by governance
    - [x] default to 100
    - [x] find better value for this var via test that submits proposals in loop while increasing value until breaks
        - [x] 100 works with ~1m gas used, > 500 should work. setting to 100 for now
- [x] make `_proposalsAreUpToDate()` function external for UI access
    - [x] make external, update contract, add unit test, ensure other tests work
    - [x] benchmark new gas usage
- [x] fix existing tests + add new tests to cover new behavior
    - [x] get / set maxInProgressProposals
- [x] code cleanup