### PR TITLE
[H07] A service provider can prevent their delegators from undelegating their stake

### DIFF
--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -21,7 +21,7 @@ contract ServiceProviderFactory is InitializableV2 {
     ///        2) % Cut of delegator tokens taken during reward
     ///        3) Bool indicating whether this SP has met min/max requirements
     ///        4) Number of endpoints registered by SP
-    ///        5) Minimum total stake for this account
+    ///        5) Minimum deployer stake for this service provider
     ///        6) Maximum total stake for this account
     struct ServiceProviderDetails {
         uint deployerStake;
@@ -40,10 +40,6 @@ contract ServiceProviderFactory is InitializableV2 {
 
     /// @dev - Mapping of service provider address to details
     mapping(address => ServiceProviderDetails) spDetails;
-
-    /// @dev - Minimum staked by service provider account deployer
-    /// @dev - Static regardless of total number of endpoints for a given account
-    uint minDeployerStake;
 
     /// @dev - standard - imitates relationship between Ether and Wei
     uint8 private constant DECIMALS = 18;
@@ -120,9 +116,6 @@ contract ServiceProviderFactory is InitializableV2 {
     function initialize (address _governanceAddress) public initializer
     {
         governanceAddress = _governanceAddress;
-
-        // Configure direct minimum stake for deployer
-        minDeployerStake = 5 * 10**uint256(DECIMALS);
 
         // 10 blocks for lockup duration
         decreaseStakeLockupDuration = 10;
@@ -591,13 +584,6 @@ contract ServiceProviderFactory is InitializableV2 {
         return serviceProviderEndpointToId[keccak256(bytes(_endpoint))];
     }
 
-    /// @notice Get minDeployerStake
-    function getMinDeployerStake()
-    external view returns (uint min)
-    {
-        return minDeployerStake;
-    }
-
     /**
      * @notice Get service provider ids for a given service provider and service type
      * @return List of service ids of that type for a service provider
@@ -773,16 +759,15 @@ contract ServiceProviderFactory is InitializableV2 {
     function _validateBalanceInternal(address _sp, uint _amount) internal view
     {
         require(
-            _amount >= spDetails[_sp].minAccountStake,
-            "Minimum stake requirement not met");
-
-        require(
             _amount <= spDetails[_sp].maxAccountStake,
-            "Maximum stake amount exceeded");
+            "Maximum stake amount exceeded"
+        );
 
         require(
-            spDetails[_sp].deployerStake == 0 || spDetails[_sp].deployerStake >= minDeployerStake,
-            "Direct stake restriction violated for this service provider");
+            spDetails[_sp].deployerStake == 0 ||
+            spDetails[_sp].deployerStake >= spDetails[_sp].minAccountStake,
+            "Minimum stake requirement not met"
+        );
     }
 
     /**

--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -766,7 +766,6 @@ contract ServiceProviderFactory is InitializableV2 {
         );
 
         require(
-            spDetails[_sp].deployerStake == 0 ||
             spDetails[_sp].deployerStake >= spDetails[_sp].minAccountStake,
             "Minimum stake requirement not met"
         );

--- a/eth-contracts/test/serviceProvider.test.js
+++ b/eth-contracts/test/serviceProvider.test.js
@@ -433,15 +433,11 @@ contract('ServiceProvider test', async (accounts) => {
       )
     })
 
-    it('Min direct deployer stake violation', async () => {
-      const minDirectStake = await serviceProviderFactory.getMinDeployerStake()
-
-      // Calculate an invalid direct stake amount
-      const invalidDirectStake = minDirectStake.sub(_lib.toBN(1))
-      await token.transfer(stakerAccount2, invalidDirectStake, { from: proxyDeployerAddress })
-
+    it('Min deployer stake violation', async () => {
       const dpTypeInfo = await serviceTypeManager.getServiceTypeInfo(testDiscProvType)
-      assert.isTrue(invalidDirectStake.gt(dpTypeInfo.minStake), 'Invalid direct stake above dp type min')
+      // Calculate an invalid direct stake amount
+      let invalidStakeAmount = dpTypeInfo.minStake.sub(_lib.toBN(1))
+      await token.transfer(stakerAccount2, invalidStakeAmount, { from: proxyDeployerAddress })
 
       // Validate that this value won't violate service type minimum
       await _lib.assertRevert(
@@ -451,9 +447,9 @@ contract('ServiceProvider test', async (accounts) => {
           serviceProviderFactory,
           testDiscProvType,
           testEndpoint1,
-          invalidDirectStake,
+          invalidStakeAmount,
           stakerAccount2),
-        'Direct stake restriction violated'
+        'Minimum stake requirement not met'
       )
     })
 


### PR DESCRIPTION
* Enforce minimum account balance for service provider only, excluding delegator balance (per audit suggestion)
* Ensures delegate operations can never force a service provider below the minimum stake value as they are forced to maintain the minimum in direct stake
* Corresponding test fixes 