### PR TITLE
[L03] Duplicated staker check

### DIFF
--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -227,9 +227,8 @@ contract ClaimsManager is InitializableV2 {
     function initiateRound() external {
         _requireIsInitialized();
 
-        bool senderStaked = Staking(stakingAddress).totalStakedFor(msg.sender) > 0;
         require(
-            senderStaked || (msg.sender == governanceAddress),
+            Staking(stakingAddress).isStaker(msg.sender) || (msg.sender == governanceAddress),
             "Only callable by staked account or Governance contract"
         );
 

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -200,8 +200,10 @@ contract Governance is InitializableV2 {
         );
 
         // Require proposer is active Staker
-        Staking stakingContract = Staking(stakingAddress);
-        require(stakingContract.isCurrentStaker(proposer), "Proposer must be active staker with non-zero stake.");
+        require(
+            Staking(stakingAddress).isStaker(proposer),
+            "Proposer must be active staker with non-zero stake."
+        );
 
         // Require _targetContractRegistryKey points to a valid registered contract
         address targetContractAddress = registry.getContract(_targetContractRegistryKey);
@@ -267,13 +269,13 @@ contract Governance is InitializableV2 {
         );
 
         // Require voter is active Staker + get voterStake.
-        Staking stakingContract = Staking(stakingAddress);
 
         // Check that msg.sender had a valid stake at proposal start
-        uint256 voterStake = stakingContract.wasStakerAt(
+        uint256 voterStake = Staking(stakingAddress).totalStakedForAt(
             voter,
             proposals[_proposalId].startBlockNumber
         );
+        require(voterStake > 0, "Voter must be active staker with non-zero stake.");
 
         // Require proposal is still active
         require(

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -201,7 +201,7 @@ contract Governance is InitializableV2 {
 
         // Require proposer is active Staker
         Staking stakingContract = Staking(stakingAddress);
-        stakingContract.isCurrentStaker(proposer);
+        require(stakingContract.isCurrentStaker(proposer), "Proposer must be active staker with non-zero stake.");
 
         // Require _targetContractRegistryKey points to a valid registered contract
         address targetContractAddress = registry.getContract(_targetContractRegistryKey);

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -165,10 +165,7 @@ contract Governance is InitializableV2 {
 
         // Require proposer is active Staker
         Staking stakingContract = Staking(stakingAddress);
-        require(
-            stakingContract.totalStakedFor(proposer) > 0,
-            "Proposer must be active staker with non-zero stake."
-        );
+        stakingContract.isCurrentStaker(proposer);
 
         // Require _targetContractRegistryKey points to a valid registered contract
         address targetContractAddress = registry.getContract(_targetContractRegistryKey);
@@ -233,11 +230,11 @@ contract Governance is InitializableV2 {
         // Require voter is active Staker + get voterStake.
         Staking stakingContract = Staking(stakingAddress);
 
-        uint256 voterStake = stakingContract.totalStakedForAt(
+        // Check that msg.sender had a valid stake at proposal start
+        uint256 voterStake = stakingContract.wasStakerAt(
             voter,
             proposals[_proposalId].startBlockNumber
         );
-        require(voterStake > 0, "Voter must be active staker with non-zero stake.");
 
         // Require proposal is still active
         require(
@@ -336,12 +333,8 @@ contract Governance is InitializableV2 {
         // Require msg.sender is active Staker.
         Staking stakingContract = Staking(stakingAddress);
 
-        require(
-            stakingContract.totalStakedForAt(
-                msg.sender, proposals[_proposalId].startBlockNumber
-            ) > 0,
-            "Governance::evaluateProposalOutcome: Caller must be active staker with non-zero stake."
-        );
+        // Check that msg.sender had a valid stake at proposal start
+        stakingContract.wasStakerAt(msg.sender, proposals[_proposalId].startBlockNumber);
 
         // Require proposal votingPeriod has ended.
         uint256 startBlockNumber = proposals[_proposalId].startBlockNumber;

--- a/eth-contracts/contracts/ServiceTypeManager.sol
+++ b/eth-contracts/contracts/ServiceTypeManager.sol
@@ -225,7 +225,7 @@ contract ServiceTypeManager is InitializableV2 {
     external view returns (bytes32 currentVersion)
     {
         _requireIsInitialized();
-    
+
         require(
             serviceTypeVersions[_serviceType].length >= 1,
             "No registered version of serviceType"

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -323,7 +323,7 @@ contract Staking is InitializableV2 {
     function totalStakedForAt(
         address _accountAddress,
         uint256 _blockNumber
-    ) public view returns (uint256) {
+    ) external view returns (uint256) {
         return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
     }
 

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -292,19 +292,6 @@ contract Staking is InitializableV2 {
     }
 
     /**
-     * @notice Get the total amount of tokens staked by `_accountAddress` at block number `_blockNumber`
-     * @param _accountAddress - Account requesting for
-     * @param _blockNumber - Block number at which we are requesting
-     * @return The amount of tokens staked by the account at the given block number
-     */
-    function totalStakedForAt(
-        address _accountAddress,
-        uint256 _blockNumber
-    ) public view returns (uint256) {
-        return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
-    }
-
-    /**
      * @notice Get the total amount of tokens staked by all users at block number `_blockNumber`
      * @param _blockNumber - Block number at which we are requesting
      * @return The amount of tokens staked at the given block number
@@ -333,6 +320,40 @@ contract Staking is InitializableV2 {
         return delegateManagerAddress;
     }
 
+    /* External helper functions */
+
+    /**
+     * @notice Helper function wrapped around totalStakedForAt. Checks whether _accountAddress
+            was valid staker at _blockNumber
+     * @param _accountAddress - Account requesting for
+     * @param _blockNumber - Block number at which we are requesting
+     * @return The amount of tokens staked by the account at the given block number
+     */
+    function wasStakerAt(
+        address _accountAddress,
+        uint256 _blockNumber
+    ) external view returns (uint256) {
+        uint256 voterStake = totalStakedForAt(_accountAddress, _blockNumber);
+        require(
+            voterStake > 0,
+            "Caller was not an active staker with non-zero stake at _blockNumber."
+        );
+
+        return voterStake;
+    }
+
+    /**
+     * @notice Helper function wrapped around totalStakedFor. Checks whether _accountAddress
+            is currently a valid staker with a non-zero stake
+     * @param _accountAddress - Account requesting for
+     */
+    function isCurrentStaker(address _accountAddress) external view {
+        require(
+            totalStakedFor(_accountAddress) > 0,
+            "Caller is not an active staker with non-zero stake."
+        );
+    }
+
     /* Public functions */
 
     /**
@@ -354,38 +375,17 @@ contract Staking is InitializableV2 {
         return totalStakedHistory.getLast();
     }
 
-    /* External helper functions */
-
     /**
-     * @notice Helper function wrapped around totalStakedForAt. Checks whether _accountAddress
-            was valid staker at _blockNumber
+     * @notice Get the total amount of tokens staked by `_accountAddress` at block number `_blockNumber`
      * @param _accountAddress - Account requesting for
      * @param _blockNumber - Block number at which we are requesting
      * @return The amount of tokens staked by the account at the given block number
      */
-    function wasStakerAt(
+    function totalStakedForAt(
         address _accountAddress,
         uint256 _blockNumber
-    ) external view returns (uint256) {
-        uint256 voterStake = totalStakedForAt(_accountAddress, _blockNumber);
-        require(
-            voterStake > 0,
-            "Caller was not an active staker with non-zero stake at _blockNumber"
-        );
-
-        return voterStake;
-    }
-
-    /**
-     * @notice Helper function wrapped around totalStakedFor. Checks whether _accountAddress
-            is currently a valid staker with a non-zero stake
-     * @param _accountAddress - Account requesting for
-     */
-    function isCurrentStaker(address _accountAddress) external view {
-        require(
-            totalStakedFor(_accountAddress) > 0,
-            "Caller is not an active staker with non-zero stake."
-        );
+    ) public view returns (uint256) {
+        return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
     }
 
     /* Internal functions */

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -292,6 +292,19 @@ contract Staking is InitializableV2 {
     }
 
     /**
+     * @notice Get the total amount of tokens staked by `_accountAddress` at block number `_blockNumber`
+     * @param _accountAddress - Account requesting for
+     * @param _blockNumber - Block number at which we are requesting
+     * @return The amount of tokens staked by the account at the given block number
+     */
+    function totalStakedForAt(
+        address _accountAddress,
+        uint256 _blockNumber
+    ) public view returns (uint256) {
+        return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
+    }
+
+    /**
      * @notice Get the total amount of tokens staked by all users at block number `_blockNumber`
      * @param _blockNumber - Block number at which we are requesting
      * @return The amount of tokens staked at the given block number
@@ -333,7 +346,7 @@ contract Staking is InitializableV2 {
         address _accountAddress,
         uint256 _blockNumber
     ) external view returns (uint256) {
-        uint256 voterStake = totalStakedForAt(_accountAddress, _blockNumber);
+        uint256 voterStake = this.totalStakedForAt(_accountAddress, _blockNumber);
         require(
             voterStake > 0,
             "Caller was not an active staker with non-zero stake at _blockNumber."
@@ -373,19 +386,6 @@ contract Staking is InitializableV2 {
     function totalStaked() public view returns (uint256) {
         // we assume it's not possible to stake in the future
         return totalStakedHistory.getLast();
-    }
-
-    /**
-     * @notice Get the total amount of tokens staked by `_accountAddress` at block number `_blockNumber`
-     * @param _accountAddress - Account requesting for
-     * @param _blockNumber - Block number at which we are requesting
-     * @return The amount of tokens staked by the account at the given block number
-     */
-    function totalStakedForAt(
-        address _accountAddress,
-        uint256 _blockNumber
-    ) public view returns (uint256) {
-        return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
     }
 
     /* Internal functions */

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -324,6 +324,8 @@ contract Staking is InitializableV2 {
         address _accountAddress,
         uint256 _blockNumber
     ) external view returns (uint256) {
+        _requireIsInitialized();
+
         return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
     }
 
@@ -373,6 +375,8 @@ contract Staking is InitializableV2 {
      * @return Boolean indicating whether account is a staker
      */
     function isStaker(address _accountAddress) external view returns (bool) {
+        _requireIsInitialized();
+
         return totalStakedFor(_accountAddress) > 0;
     }
 

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -184,7 +184,7 @@ contract Staking is InitializableV2 {
     ) external
     {
         _requireIsInitialized();
-    
+
         require(
             msg.sender == serviceProviderFactoryAddress,
             "Only callable from ServiceProviderFactory"
@@ -206,7 +206,7 @@ contract Staking is InitializableV2 {
     ) external
     {
         _requireIsInitialized();
-    
+
         require(
             msg.sender == serviceProviderFactoryAddress,
             "Only callable from ServiceProviderFactory"
@@ -230,7 +230,7 @@ contract Staking is InitializableV2 {
         uint256 _amount
     ) external {
         _requireIsInitialized();
-    
+
         require(
             msg.sender == delegateManagerAddress,
             "delegateStakeFor - Only callable from DelegateManager"
@@ -366,38 +366,14 @@ contract Staking is InitializableV2 {
         return delegateManagerAddress;
     }
 
-    /* External helper functions */
-
-    /**
-     * @notice Helper function wrapped around totalStakedForAt. Checks whether _accountAddress
-            was valid staker at _blockNumber
-     * @param _accountAddress - Account requesting for
-     * @param _blockNumber - Block number at which we are requesting
-     * @return The amount of tokens staked by the account at the given block number
-     */
-    function wasStakerAt(
-        address _accountAddress,
-        uint256 _blockNumber
-    ) external view returns (uint256) {
-        uint256 voterStake = this.totalStakedForAt(_accountAddress, _blockNumber);
-        require(
-            voterStake > 0,
-            "Caller was not an active staker with non-zero stake at _blockNumber."
-        );
-
-        return voterStake;
-    }
-
     /**
      * @notice Helper function wrapped around totalStakedFor. Checks whether _accountAddress
             is currently a valid staker with a non-zero stake
      * @param _accountAddress - Account requesting for
+     * @return Boolean indicating whether account is a staker
      */
-    function isCurrentStaker(address _accountAddress) external view {
-        require(
-            totalStakedFor(_accountAddress) > 0,
-            "Caller is not an active staker with non-zero stake."
-        );
+    function isStaker(address _accountAddress) external view returns (bool) {
+        return totalStakedFor(_accountAddress) > 0;
     }
 
     /* Public functions */

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -300,7 +300,7 @@ contract Staking is InitializableV2 {
     function totalStakedForAt(
         address _accountAddress,
         uint256 _blockNumber
-    ) external view returns (uint256) {
+    ) public view returns (uint256) {
         return accounts[_accountAddress].stakedHistory.get(_blockNumber.toUint64());
     }
 
@@ -352,6 +352,40 @@ contract Staking is InitializableV2 {
     function totalStaked() public view returns (uint256) {
         // we assume it's not possible to stake in the future
         return totalStakedHistory.getLast();
+    }
+
+    /* External helper functions */
+
+    /**
+     * @notice Helper function wrapped around totalStakedForAt. Checks whether _accountAddress
+            was valid staker at _blockNumber
+     * @param _accountAddress - Account requesting for
+     * @param _blockNumber - Block number at which we are requesting
+     * @return The amount of tokens staked by the account at the given block number
+     */
+    function wasStakerAt(
+        address _accountAddress,
+        uint256 _blockNumber
+    ) external view returns (uint256) {
+        uint256 voterStake = totalStakedForAt(_accountAddress, _blockNumber);
+        require(
+            voterStake > 0,
+            "Caller was not an active staker with non-zero stake at _blockNumber"
+        );
+
+        return voterStake;
+    }
+
+    /**
+     * @notice Helper function wrapped around totalStakedFor. Checks whether _accountAddress
+            is currently a valid staker with a non-zero stake
+     * @param _accountAddress - Account requesting for
+     */
+    function isCurrentStaker(address _accountAddress) external view {
+        require(
+            totalStakedFor(_accountAddress) > 0,
+            "Caller is not an active staker with non-zero stake."
+        );
     }
 
     /* Internal functions */

--- a/eth-contracts/contracts/registry/Registry.sol
+++ b/eth-contracts/contracts/registry/Registry.sol
@@ -100,7 +100,7 @@ contract Registry is InitializableV2, Ownable {
      */
     function getContract(bytes32 _name) external view returns (address contractAddr) {
         _requireIsInitialized();
-        
+
         return addressStorage[_name];
     }
 
@@ -125,7 +125,7 @@ contract Registry is InitializableV2, Ownable {
      */
     function getContractVersionCount(bytes32 _name) external view returns (uint) {
         _requireIsInitialized();
-        
+
         return addressStorageHistory[_name].length;
     }
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -585,7 +585,7 @@ contract('Governance.sol', async (accounts) => {
           proposalDescription,
           { from: proposerAddress }
         ),
-        "Caller is not an active staker with non-zero stake."
+        "Proposer must be active staker with non-zero stake"
       )
     })
 
@@ -681,7 +681,7 @@ contract('Governance.sol', async (accounts) => {
       it('Fail to vote with invalid voter', async () => {
         await _lib.assertRevert(
           governance.submitProposalVote(proposalId, Vote.Yes, { from: accounts[15] }),
-          "Caller was not an active staker with non-zero stake at _blockNumber"
+          "Voter must be active staker with non-zero stake."
         )
       })
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -576,7 +576,7 @@ contract('Governance.sol', async (accounts) => {
           proposalDescription,
           { from: proposerAddress }
         ),
-        "Proposer must be active staker with non-zero stake."
+        "Caller is not an active staker with non-zero stake."
       )
     })
 
@@ -673,7 +673,7 @@ contract('Governance.sol', async (accounts) => {
       it('Fail to vote with invalid voter', async () => {
         await _lib.assertRevert(
           governance.submitProposalVote(proposalId, Vote.Yes, { from: accounts[15] }),
-          "Voter must be active staker with non-zero stake."
+          "Caller was not an active staker with non-zero stake at _blockNumber"
         )
       })
 
@@ -842,7 +842,7 @@ contract('Governance.sol', async (accounts) => {
       it('Fail to call evaluate proposal from non-staker', async () => {
         await _lib.assertRevert(
           governance.evaluateProposalOutcome(proposalId, { from: accounts[15] }),
-          "Governance::evaluateProposalOutcome: Caller must be active staker with non-zero stake."
+          "Caller was not an active staker with non-zero stake at _blockNumber."
         )
       })
 


### PR DESCRIPTION
"
_In lines 236 and 340 of Governance.sol, the same check for active stake at a particular block number is executed._

_To avoid duplication, and to improve encapsulation and readability, consider implementing a function wasStakerAt in the Staking contract, and calling this function in the Governance contract instead of reimplementing the check._

_In the same Governance contract there is another check to see if the account currently has some stake. For readability and consistency with the previous suggestion, consider adding also a function isCurrentStaker the Staking contract._
"
