### PR TITLE
Hotfix for creator node /export 

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -81,7 +81,7 @@ module.exports = function (app) {
                 file.multihash,
                 file.storagePath)
             } else if (file.type === 'image') {
-              if (file.sourcePath === null) {
+              if (file.sourceFile === null) {
                 // Ensure pre-directory images are still exported appropriately
                 await rehydrateIpfsFromFsIfNecessary(
                   req,

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -75,20 +75,17 @@ module.exports = function (app) {
         // Ensure all relevant files are available through IPFS at export time
         await Promise.all(exportFilesSlice.map(async (file) => {
           try {
-            if (file.type === 'track' || file.type === 'metadata' || file.type === 'copy320') {
+            if (
+              (file.type === 'track' || file.type === 'metadata' || file.type === 'copy320') ||
+              // to address legacy single-res image rehydration where images are stored directly under its file CID
+              (file.type === 'image' && file.sourceFile === null)
+            ) {
               await rehydrateIpfsFromFsIfNecessary(
                 req,
                 file.multihash,
                 file.storagePath)
-            } else if (file.type === 'image') {
-              if (file.sourceFile === null) {
-                // Ensure pre-directory images are still exported appropriately
-                await rehydrateIpfsFromFsIfNecessary(
-                  req,
-                  file.multihash,
-                  file.storagePath)
-              }
             } else if (file.type === 'dir') {
+              // to address multi-res image rehydration where images are stored under a directory CID
               await rehydrateIpfsDirFromFsIfNecessary(req, file.multihash)
             }
           } catch (e) {


### PR DESCRIPTION
while making ipfs rehydration nonblocking is in progress, this quick refactor is to
- address the typo with `sourcePath` 
- remove duplicate code 