### PR TITLE
[N01] Inconsistent style for error messages

### DIFF
--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -16,6 +16,13 @@ import "./ClaimsManager.sol";
 contract DelegateManager is InitializableV2 {
     using SafeMath for uint256;
 
+    string private constant ERROR_ONLY_GOVERNANCE = (
+        "DelegateManager: Only callable by Governance contract"
+    );
+    string private constant ERROR_MINIMUM_DELEGATION = (
+        "DelegateManager: Minimum delegation amount required"
+    );
+
     address private governanceAddress;
     address private stakingAddress;
     address private serviceProviderFactoryAddress;
@@ -132,7 +139,7 @@ contract DelegateManager is InitializableV2 {
 
         require(
             !_claimPending(_targetSP),
-            "Delegation not permitted for SP pending claim"
+            "DelegateManager: Delegation not permitted for SP pending claim"
         );
         address delegator = msg.sender;
         Staking stakingContract = Staking(stakingAddress);
@@ -150,7 +157,7 @@ contract DelegateManager is InitializableV2 {
             spDelegateInfo[_targetSP].delegators.push(delegator);
             require(
                 spDelegateInfo[_targetSP].delegators.length <= maxDelegators,
-                "Maximum delegators exceeded"
+                "DelegateManager: Maximum delegators exceeded"
             );
         }
 
@@ -167,7 +174,7 @@ contract DelegateManager is InitializableV2 {
 
         require(
             delegateInfo[delegator][_targetSP] >= minDelegationAmount,
-            "Minimum delegation amount"
+            ERROR_MINIMUM_DELEGATION
         );
 
         // Validate balance
@@ -201,23 +208,30 @@ contract DelegateManager is InitializableV2 {
 
         require(
             _amount > 0,
-            "Requested undelegate stake amount must be greater than zero"
+            "DelegateManager: Requested undelegate stake amount must be greater than zero"
         );
         require(
             !_claimPending(_target),
-            "Undelegate request not permitted for SP pending claim"
+            "DelegateManager: Undelegate request not permitted for SP pending claim"
         );
         address delegator = msg.sender;
-        require(_delegatorExistsForSP(delegator, _target), "Delegator must be staked for SP");
+        require(
+            _delegatorExistsForSP(delegator, _target),
+            "DelegateManager: Delegator must be staked for SP"
+        );
 
         // Confirm no pending delegation request
-        require(!_undelegateRequestIsPending(delegator), "No pending lockup expected");
+        require(
+            !_undelegateRequestIsPending(delegator),
+            "DelegateManager: No pending lockup expected"
+        );
 
         // Ensure valid bounds
         uint256 currentlyDelegatedToSP = delegateInfo[delegator][_target];
         require(
             _amount <= currentlyDelegatedToSP,
-            "Cannot decrease greater than currently staked for this ServiceProvider");
+            "DelegateManager: Cannot decrease greater than currently staked for this ServiceProvider"
+        );
 
         // Submit updated request for sender, with target sp, undelegate amount, target expiry block
         _updateUndelegateStakeRequest(
@@ -243,7 +257,10 @@ contract DelegateManager is InitializableV2 {
 
         address delegator = msg.sender;
         // Confirm pending delegation request
-        require(_undelegateRequestIsPending(delegator), "Pending lockup expected");
+        require(
+            _undelegateRequestIsPending(delegator),
+            "DelegateManager: Pending lockup expected"
+        );
         uint256 unstakeAmount = undelegateRequests[delegator].amount;
         address unlockFundsSP = undelegateRequests[delegator].serviceProvider;
         // Update total locked for this service provider, decreasing by unstake amount
@@ -268,16 +285,21 @@ contract DelegateManager is InitializableV2 {
         address delegator = msg.sender;
 
         // Confirm pending delegation request
-        require(_undelegateRequestIsPending(delegator), "Pending lockup expected");
+        require(
+            _undelegateRequestIsPending(delegator),
+            "DelegateManager: Pending lockup expected"
+        );
 
         // Confirm lockup expiry has expired
         require(
-            undelegateRequests[delegator].lockupExpiryBlock <= block.number, "Lockup must be expired");
+            undelegateRequests[delegator].lockupExpiryBlock <= block.number,
+            "DelegateManager: Lockup must be expired"
+        );
 
         // Confirm no pending claim for this service provider
         require(
             !_claimPending(undelegateRequests[delegator].serviceProvider),
-            "Undelegate not permitted for SP pending claim"
+            "DelegateManager: Undelegate not permitted for SP pending claim"
         );
 
         address serviceProvider = undelegateRequests[delegator].serviceProvider;
@@ -303,7 +325,7 @@ contract DelegateManager is InitializableV2 {
         require(
             (delegateInfo[delegator][serviceProvider] >= minDelegationAmount ||
              delegateInfo[delegator][serviceProvider] == 0),
-            "Minimum delegation amount"
+            ERROR_MINIMUM_DELEGATION
         );
 
         // Remove from delegators list if no delegated stake remaining
@@ -412,10 +434,7 @@ contract DelegateManager is InitializableV2 {
         _requireStakingAddressIsSet();
         _requireServiceProviderFactoryAddressIsSet();
 
-        require(
-            msg.sender == governanceAddress,
-            "Only callable by Governance contract"
-        );
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
         Staking stakingContract = Staking(stakingAddress);
         ServiceProviderFactory spFactory = ServiceProviderFactory(serviceProviderFactoryAddress);
@@ -424,7 +443,8 @@ contract DelegateManager is InitializableV2 {
         uint256 totalBalanceInStakingPreSlash = stakingContract.totalStakedFor(_slashAddress);
         require(
             (totalBalanceInStakingPreSlash >= _amount),
-            "Cannot slash more than total currently staked");
+            "DelegateManager: Cannot slash more than total currently staked"
+        );
 
         // Cancel any withdrawal request for this service provider
         (uint256 spLockedStake,) = spFactory.getPendingDecreaseStakeRequest(_slashAddress);
@@ -436,7 +456,10 @@ contract DelegateManager is InitializableV2 {
         (uint256 totalBalanceInSPFactory,,,,,) = (
             spFactory.getServiceProviderDetails(_slashAddress)
         );
-        require(totalBalanceInSPFactory > 0, "Service Provider stake required");
+        require(
+            totalBalanceInSPFactory > 0,
+            "DelegateManager: Service Provider stake required"
+        );
 
         // Decrease value in Staking contract
         // A value of zero slash will fail in staking, reverting this transaction
@@ -501,7 +524,7 @@ contract DelegateManager is InitializableV2 {
 
         require(
             msg.sender == _serviceProvider || msg.sender == governanceAddress,
-            "Only callable by target SP or governance"
+            "DelegateManager: Only callable by target SP or governance"
         );
         uint256 unstakeAmount = delegateInfo[_delegator][_serviceProvider];
         // Unstake on behalf of target service provider
@@ -543,10 +566,7 @@ contract DelegateManager is InitializableV2 {
     function updateUndelegateLockupDuration(uint256 _duration) external {
         _requireIsInitialized();
 
-        require(
-            msg.sender == governanceAddress,
-            "Only callable by Governance contract"
-        );
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
         undelegateLockupDuration = _duration;
         emit UndelegateLockupDurationUpdated(_duration);
@@ -559,10 +579,7 @@ contract DelegateManager is InitializableV2 {
     function updateMaxDelegators(uint256 _maxDelegators) external {
         _requireIsInitialized();
 
-        require(
-            msg.sender == governanceAddress,
-            "Only callable by Governance contract"
-        );
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
         maxDelegators = _maxDelegators;
         emit MaxDelegatorsUpdated(_maxDelegators);
@@ -575,10 +592,7 @@ contract DelegateManager is InitializableV2 {
     function updateMinDelegationAmount(uint256 _minDelegationAmount) external {
         _requireIsInitialized();
 
-        require(
-            msg.sender == governanceAddress,
-            "Only callable by Governance contract"
-        );
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
         minDelegationAmount = _minDelegationAmount;
         emit MinDelegationUpdated(_minDelegationAmount);
@@ -592,7 +606,7 @@ contract DelegateManager is InitializableV2 {
     function setGovernanceAddress(address _governanceAddress) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         _updateGovernanceAddress(_governanceAddress);
         governanceAddress = _governanceAddress;
         emit GovernanceAddressUpdated(_governanceAddress);
@@ -606,7 +620,7 @@ contract DelegateManager is InitializableV2 {
     function setStakingAddress(address _stakingAddress) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         stakingAddress = _stakingAddress;
         emit StakingAddressUpdated(_stakingAddress);
     }
@@ -619,7 +633,7 @@ contract DelegateManager is InitializableV2 {
     function setServiceProviderFactoryAddress(address _spFactory) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         serviceProviderFactoryAddress = _spFactory;
         emit ServiceProviderFactoryAddressUpdated(_spFactory);
     }
@@ -632,7 +646,7 @@ contract DelegateManager is InitializableV2 {
     function setClaimsManagerAddress(address _claimsManagerAddress) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         claimsManagerAddress = _claimsManagerAddress;
         emit ClaimsManagerAddressUpdated(_claimsManagerAddress);
     }
@@ -780,12 +794,15 @@ contract DelegateManager is InitializableV2 {
 
         // Amount stored in staking contract for owner
         totalBalanceInStaking = Staking(stakingAddress).totalStakedFor(_serviceProvider);
-        require(totalBalanceInStaking > 0, "Stake required for claim");
+        require(totalBalanceInStaking > 0, "DelegateManager: Stake required for claim");
 
         // Amount in sp factory for claimer
         (totalBalanceInSPFactory,,,,,) = spFactory.getServiceProviderDetails(_serviceProvider);
         // Require active stake to claim any rewards
-        require(totalBalanceInSPFactory.sub(spLockedStake) > 0, "Service Provider stake required");
+        require(
+            totalBalanceInSPFactory.sub(spLockedStake) > 0,
+            "DelegateManager: Service Provider stake required"
+        );
 
         // Amount in delegate manager staked to service provider
         uint256 totalBalanceOutsideStaking = (
@@ -796,7 +813,7 @@ contract DelegateManager is InitializableV2 {
 
         require(
             mintedRewards == totalBalanceInStaking.sub(totalBalanceOutsideStaking),
-            "Reward amount mismatch"
+            "DelegateManager: Reward amount mismatch"
         );
 
         return (
@@ -952,7 +969,7 @@ contract DelegateManager is InitializableV2 {
     function _updateGovernanceAddress(address _governanceAddress) internal {
         require(
             Governance(_governanceAddress).isGovernanceAddress() == true,
-            "_governanceAddress is not a valid governance contract"
+            "DelegateManager: _governanceAddress is not a valid governance contract"
         );
         governanceAddress = _governanceAddress;
     }
@@ -1001,17 +1018,23 @@ contract DelegateManager is InitializableV2 {
     // ========================================= Private Functions =========================================
 
     function _requireStakingAddressIsSet() private view {
-        require(stakingAddress != address(0x00), "stakingAddress is not set");
+        require(
+            stakingAddress != address(0x00),
+            "DelegateManager: stakingAddress is not set"
+        );
     }
 
     function _requireServiceProviderFactoryAddressIsSet() private view {
         require(
             serviceProviderFactoryAddress != address(0x00),
-            "serviceProviderFactoryAddress is not set"
+            "DelegateManager: serviceProviderFactoryAddress is not set"
         );
     }
 
     function _requireClaimsManagerAddressIsSet() private view {
-        require(claimsManagerAddress != address(0x00), "claimsManagerAddress is not set");
+        require(
+            claimsManagerAddress != address(0x00),
+            "DelegateManager: claimsManagerAddress is not set"
+        );
     }
 }

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -9,10 +9,18 @@ import "./InitializableV2.sol";
 contract Governance is InitializableV2 {
     using SafeMath for uint256;
 
-    string private constant ERROR_INVALID_PROPOSAL = "Governance: Must provide valid non-zero _proposalId";
-    string private constant ERROR_ONLY_GOVERNANCE = "Governance: Only callable by self";
-    string private constant ERROR_INVALID_VOTING_PERIOD = "Governance: Requires non-zero _votingPeriod";
-    string private constant ERROR_INVALID_REGISTRY = "Governance: Requires non-zero _registryAddress";
+    string private constant ERROR_INVALID_PROPOSAL = (
+        "Governance: Must provide valid non-zero _proposalId"
+    );
+    string private constant ERROR_ONLY_GOVERNANCE = (
+        "Governance: Only callable by self"
+    );
+    string private constant ERROR_INVALID_VOTING_PERIOD = (
+        "Governance: Requires non-zero _votingPeriod"
+    );
+    string private constant ERROR_INVALID_REGISTRY = (
+        "Governance: Requires non-zero _registryAddress"
+    );
     string private constant ERROR_INVALID_VOTING_QUORUM = (
         "Governance: Requires _votingQuorumPercent between 1 & 100"
     );

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -9,11 +9,11 @@ import "./InitializableV2.sol";
 contract Governance is InitializableV2 {
     using SafeMath for uint256;
 
-    string private ERROR_INVALID_PROPOSAL = "Governance: Must provide valid non-zero _proposalId";
-    string private ERROR_ONLY_GOVERNANCE = "Governance: Only callable by self";
-    string private ERROR_INVALID_VOTING_PERIOD = "Governance: Requires non-zero _votingPeriod";
-    string private ERROR_INVALID_REGISTRY = "Governance: Requires non-zero _registryAddress";
-    string private ERROR_INVALID_VOTING_QUORUM = (
+    string private constant ERROR_INVALID_PROPOSAL = "Governance: Must provide valid non-zero _proposalId";
+    string private constant ERROR_ONLY_GOVERNANCE = "Governance: Only callable by self";
+    string private constant ERROR_INVALID_VOTING_PERIOD = "Governance: Requires non-zero _votingPeriod";
+    string private constant ERROR_INVALID_REGISTRY = "Governance: Requires non-zero _registryAddress";
+    string private constant ERROR_INVALID_VOTING_QUORUM = (
         "Governance: Requires _votingQuorumPercent between 1 & 100"
     );
 

--- a/eth-contracts/contracts/InitializableV2.sol
+++ b/eth-contracts/contracts/InitializableV2.sol
@@ -16,6 +16,7 @@ contract InitializableV2 is Initializable {
     string private constant ERROR_ALREADY_INITIALIZED = "InitializableV2: Already initialized";
 
     function initialize() public initializer {
+        require(isInitialized == false, ERROR_ALREADY_INITIALIZED);
         isInitialized = true;
     }
 

--- a/eth-contracts/contracts/InitializableV2.sol
+++ b/eth-contracts/contracts/InitializableV2.sol
@@ -12,8 +12,8 @@ import "@openzeppelin/upgrades/contracts/Initializable.sol";
 contract InitializableV2 is Initializable {
     bool private isInitialized;
 
-    string private constant ERROR_NOT_INITIALIZED = "INIT_NOT_INITIALIZED";
-    string private constant ERROR_ALREADY_INITIALIZED = "ERROR_ALREADY_INITIALIZED";
+    string private constant ERROR_NOT_INITIALIZED = "InitializableV2: Not initialized";
+    string private constant ERROR_ALREADY_INITIALIZED = "InitializableV2: Already initialized";
 
     function initialize() public initializer {
         isInitialized = true;

--- a/eth-contracts/contracts/InitializableV2.sol
+++ b/eth-contracts/contracts/InitializableV2.sol
@@ -16,7 +16,6 @@ contract InitializableV2 is Initializable {
     string private constant ERROR_ALREADY_INITIALIZED = "InitializableV2: Already initialized";
 
     function initialize() public initializer {
-        require(isInitialized == false, ERROR_ALREADY_INITIALIZED);
         isInitialized = true;
     }
 

--- a/eth-contracts/contracts/ServiceTypeManager.sol
+++ b/eth-contracts/contracts/ServiceTypeManager.sol
@@ -7,6 +7,10 @@ import "./Governance.sol";
 contract ServiceTypeManager is InitializableV2 {
     address governanceAddress;
 
+    string private constant ERROR_ONLY_GOVERNANCE = (
+        "ServiceTypeManager: Only callable by Governance contract"
+    );
+
     /**
      * @dev - mapping of serviceType - serviceTypeVersion
      * Example - "discovery-provider" - ["0.0.1", "0.0.2", ..., "currentVersion"]
@@ -81,18 +85,21 @@ contract ServiceTypeManager is InitializableV2 {
     {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only callable by Governance contract");
-        require(!this.serviceTypeIsValid(_serviceType), "Already known service type");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+        require(
+            !this.serviceTypeIsValid(_serviceType),
+            "ServiceTypeManager: Already known service type"
+        );
         require(
             _serviceTypeMax > _serviceTypeMin,
-            "Max stake must be non-zero and greater than min stake"
+            "ServiceTypeManager: Max stake must be non-zero and greater than min stake"
         );
 
         // Ensure serviceType cannot be re-added if it previously existed and was removed
         // stored maxStake > 0 means it was previously added and removed
         require(
             serviceTypeInfo[_serviceType].maxStake == 0,
-            "Cannot re-add serviceType after it was removed."
+            "ServiceTypeManager: Cannot re-add serviceType after it was removed."
         );
 
         validServiceTypes.push(_serviceType);
@@ -112,7 +119,7 @@ contract ServiceTypeManager is InitializableV2 {
     function removeServiceType(bytes32 _serviceType) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only callable by Governance contract");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
         uint256 serviceIndex = 0;
         bool foundService = false;
@@ -123,7 +130,7 @@ contract ServiceTypeManager is InitializableV2 {
                 break;
             }
         }
-        require(foundService == true, "Invalid service type, not found");
+        require(foundService == true, "ServiceTypeManager: Invalid service type, not found");
         // Overwrite service index
         uint256 lastIndex = validServiceTypes.length - 1;
         validServiceTypes[serviceIndex] = validServiceTypes[lastIndex];
@@ -188,11 +195,11 @@ contract ServiceTypeManager is InitializableV2 {
     {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only callable by Governance contract");
-        require(this.serviceTypeIsValid(_serviceType), "Invalid service type");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+        require(this.serviceTypeIsValid(_serviceType), "ServiceTypeManager: Invalid service type");
         require(
             serviceTypeVersionInfo[_serviceType][_serviceVersion] == false,
-            "Already registered"
+            "ServiceTypeManager: Already registered"
         );
 
          // Update array of known versions for type
@@ -216,7 +223,7 @@ contract ServiceTypeManager is InitializableV2 {
 
         require(
             serviceTypeVersions[_serviceType].length > _versionIndex,
-            "No registered version of serviceType"
+            "ServiceTypeManager: No registered version of serviceType"
         );
         return (serviceTypeVersions[_serviceType][_versionIndex]);
     }
@@ -233,7 +240,7 @@ contract ServiceTypeManager is InitializableV2 {
 
         require(
             serviceTypeVersions[_serviceType].length >= 1,
-            "No registered version of serviceType"
+            "ServiceTypeManager: No registered version of serviceType"
         );
         uint256 latestVersionIndex = serviceTypeVersions[_serviceType].length - 1;
         return (serviceTypeVersions[_serviceType][latestVersionIndex]);
@@ -271,7 +278,7 @@ contract ServiceTypeManager is InitializableV2 {
     function _updateGovernanceAddress(address _governanceAddress) internal {
         require(
             Governance(_governanceAddress).isGovernanceAddress() == true,
-            "_governanceAddress is not a valid governance contract"
+            "ServiceTypeManager: _governanceAddress is not a valid governance contract"
         );
         governanceAddress = _governanceAddress;
     }

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -17,10 +17,11 @@ contract Staking is InitializableV2 {
     using Checkpointing for Checkpointing.History;
     using SafeERC20 for ERC20;
 
-    string private constant ERROR_TOKEN_NOT_CONTRACT = "STAKING_TOKEN_NOT_CONTRACT";
-    string private constant ERROR_AMOUNT_ZERO = "STAKING_AMOUNT_ZERO";
-    string private constant ERROR_TOKEN_TRANSFER = "STAKING_TOKEN_TRANSFER";
-    string private constant ERROR_NOT_ENOUGH_BALANCE = "STAKING_NOT_ENOUGH_BALANCE";
+    string private constant ERROR_TOKEN_NOT_CONTRACT = "Staking: Staking token is not a contract";
+    string private constant ERROR_AMOUNT_ZERO = "Staking: Zero amount not allowed";
+    string private constant ERROR_ONLY_GOVERNANCE = "Staking: Only governance";
+    string private constant ERROR_ONLY_DELEGATE_MANAGER = "Staking: Only callable from DelegateManager";
+    string private constant ERROR_ONLY_SERVICE_PROVIDER_FACTORY = "Staking: Only callable from ServiceProviderFactory";
 
     address private governanceAddress;
     address private claimsManagerAddress;
@@ -73,7 +74,7 @@ contract Staking is InitializableV2 {
     function setGovernanceAddress(address _governanceAddress) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         _updateGovernanceAddress(_governanceAddress);
     }
 
@@ -85,7 +86,7 @@ contract Staking is InitializableV2 {
     function setClaimsManagerAddress(address _claimsManager) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         claimsManagerAddress = _claimsManager;
     }
 
@@ -97,7 +98,7 @@ contract Staking is InitializableV2 {
     function setServiceProviderFactoryAddress(address _spFactory) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         serviceProviderFactoryAddress = _spFactory;
     }
 
@@ -109,7 +110,7 @@ contract Staking is InitializableV2 {
     function setDelegateManagerAddress(address _delegateManager) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, "Only governance");
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         delegateManagerAddress = _delegateManager;
     }
 
@@ -126,7 +127,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == claimsManagerAddress,
-            "Only callable from ClaimsManager"
+            "Staking: Only callable from ClaimsManager"
         );
         _stakeFor(_stakerAccount, msg.sender, _amount);
 
@@ -144,7 +145,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == claimsManagerAddress || msg.sender == address(this),
-            "Only callable from ClaimsManager or Staking.sol"
+            "Staking: Only callable from ClaimsManager or Staking.sol"
         );
 
         // Update claim history even if no value claimed
@@ -167,7 +168,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == delegateManagerAddress,
-            "Only callable from DelegateManager"
+            ERROR_ONLY_DELEGATE_MANAGER
         );
 
         // Burn slashed tokens from account
@@ -195,7 +196,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == serviceProviderFactoryAddress,
-            "Only callable from ServiceProviderFactory"
+            ERROR_ONLY_SERVICE_PROVIDER_FACTORY
         );
         _stakeFor(
             _accountAddress,
@@ -219,7 +220,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == serviceProviderFactoryAddress,
-            "Only callable from ServiceProviderFactory"
+            ERROR_ONLY_SERVICE_PROVIDER_FACTORY
         );
         _unstakeFor(
             _accountAddress,
@@ -245,7 +246,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == delegateManagerAddress,
-            "delegateStakeFor - Only callable from DelegateManager"
+            ERROR_ONLY_DELEGATE_MANAGER
         );
         _stakeFor(
             _accountAddress,
@@ -270,7 +271,7 @@ contract Staking is InitializableV2 {
 
         require(
             msg.sender == delegateManagerAddress,
-            "undelegateStakeFor - Only callable from DelegateManager"
+            ERROR_ONLY_DELEGATE_MANAGER
         );
         _unstakeFor(
             _accountAddress,
@@ -518,7 +519,7 @@ contract Staking is InitializableV2 {
         } else {
             require(
                 currentInternalStake >= _by,
-                "Cannot decrease greater than current balance");
+                "Staking: Cannot decrease greater than current balance");
             newStake = currentInternalStake.sub(_by);
         }
 
@@ -552,7 +553,7 @@ contract Staking is InitializableV2 {
     function _updateGovernanceAddress(address _governanceAddress) internal {
         require(
             Governance(_governanceAddress).isGovernanceAddress() == true,
-            "_governanceAddress is not a valid governance contract"
+            "Staking: _governanceAddress is not a valid governance contract"
         );
         governanceAddress = _governanceAddress;
     }
@@ -560,17 +561,17 @@ contract Staking is InitializableV2 {
     // ========================================= Private Functions =========================================
 
     function _requireClaimsManagerAddressIsSet() private view {
-        require(claimsManagerAddress != address(0x00), "claimsManagerAddress is not set");
+        require(claimsManagerAddress != address(0x00), "Staking: claimsManagerAddress is not set");
     }
 
     function _requireDelegateManagerAddressIsSet() private view {
-        require(delegateManagerAddress != address(0x00), "delegateManagerAddress is not set");
+        require(delegateManagerAddress != address(0x00), "Staking: delegateManagerAddress is not set");
     }
 
     function _requireServiceProviderFactoryAddressIsSet() private view {
         require(
             serviceProviderFactoryAddress != address(0x00),
-            "serviceProviderFactoryAddress is not set"
+            "Staking: serviceProviderFactoryAddress is not set"
         );
     }
 

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -20,8 +20,12 @@ contract Staking is InitializableV2 {
     string private constant ERROR_TOKEN_NOT_CONTRACT = "Staking: Staking token is not a contract";
     string private constant ERROR_AMOUNT_ZERO = "Staking: Zero amount not allowed";
     string private constant ERROR_ONLY_GOVERNANCE = "Staking: Only governance";
-    string private constant ERROR_ONLY_DELEGATE_MANAGER = "Staking: Only callable from DelegateManager";
-    string private constant ERROR_ONLY_SERVICE_PROVIDER_FACTORY = "Staking: Only callable from ServiceProviderFactory";
+    string private constant ERROR_ONLY_DELEGATE_MANAGER = (
+      "Staking: Only callable from DelegateManager"
+    );
+    string private constant ERROR_ONLY_SERVICE_PROVIDER_FACTORY = (
+      "Staking: Only callable from ServiceProviderFactory"
+    );
 
     address private governanceAddress;
     address private claimsManagerAddress;
@@ -565,7 +569,10 @@ contract Staking is InitializableV2 {
     }
 
     function _requireDelegateManagerAddressIsSet() private view {
-        require(delegateManagerAddress != address(0x00), "Staking: delegateManagerAddress is not set");
+        require(
+            delegateManagerAddress != address(0x00),
+            "Staking: delegateManagerAddress is not set"
+        );
     }
 
     function _requireServiceProviderFactoryAddressIsSet() private view {

--- a/eth-contracts/contracts/registry/Registry.sol
+++ b/eth-contracts/contracts/registry/Registry.sol
@@ -20,10 +20,6 @@ contract Registry is InitializableV2, Ownable {
     mapping(bytes32 => address) private addressStorage;
     mapping(bytes32 => address[]) private addressStorageHistory;
 
-    string private constant ERROR_NO_CONTRACT = (
-        "Registry: Cannot remove - no contract registered with given _name."
-    );
-
     event ContractAdded(bytes32 _name, address _address);
     event ContractRemoved(bytes32 _name, address _address);
     event ContractUpgraded(bytes32 _name, address _oldAddress, address _newAddress);
@@ -66,7 +62,7 @@ contract Registry is InitializableV2, Ownable {
         _requireIsInitialized();
 
         address contractAddress = addressStorage[_name];
-        require(contractAddress != address(0x00), ERROR_NO_CONTRACT);
+        require(contractAddress != address(0x00), "Registry: Cannot remove - no contract registered with given _name.");
 
         setAddress(_name, address(0x00));
 
@@ -82,7 +78,10 @@ contract Registry is InitializableV2, Ownable {
         _requireIsInitialized();
 
         address oldAddress = addressStorage[_name];
-        require(oldAddress != address(0x00), ERROR_NO_CONTRACT);
+        require(
+            oldAddress != address(0x00),
+            "Registry: Cannot upgrade - no contract registered with given _name."
+        );
         require(
             _newAddress != address(0x00),
             "Registry: Cannot upgrade - cannot register zero address."

--- a/eth-contracts/contracts/registry/Registry.sol
+++ b/eth-contracts/contracts/registry/Registry.sol
@@ -62,7 +62,10 @@ contract Registry is InitializableV2, Ownable {
         _requireIsInitialized();
 
         address contractAddress = addressStorage[_name];
-        require(contractAddress != address(0x00), "Registry: Cannot remove - no contract registered with given _name.");
+        require(
+            contractAddress != address(0x00),
+            "Registry: Cannot remove - no contract registered with given _name."
+        );
 
         setAddress(_name, address(0x00));
 

--- a/eth-contracts/contracts/registry/Registry.sol
+++ b/eth-contracts/contracts/registry/Registry.sol
@@ -20,6 +20,10 @@ contract Registry is InitializableV2, Ownable {
     mapping(bytes32 => address) private addressStorage;
     mapping(bytes32 => address[]) private addressStorageHistory;
 
+    string private constant ERROR_NO_CONTRACT = (
+        "Registry: Cannot remove - no contract registered with given _name."
+    );
+
     event ContractAdded(bytes32 _name, address _address);
     event ContractRemoved(bytes32 _name, address _address);
     event ContractUpgraded(bytes32 _name, address _oldAddress, address _newAddress);
@@ -62,10 +66,7 @@ contract Registry is InitializableV2, Ownable {
         _requireIsInitialized();
 
         address contractAddress = addressStorage[_name];
-        require(
-            contractAddress != address(0x00),
-            "Registry: Cannot remove - no contract registered with given _name."
-        );
+        require(contractAddress != address(0x00), ERROR_NO_CONTRACT);
 
         setAddress(_name, address(0x00));
 
@@ -81,10 +82,7 @@ contract Registry is InitializableV2, Ownable {
         _requireIsInitialized();
 
         address oldAddress = addressStorage[_name];
-        require(
-            oldAddress != address(0x00),
-            "Registry: Cannot upgrade - no contract registered with given _name."
-        );
+        require(oldAddress != address(0x00), ERROR_NO_CONTRACT);
         require(
             _newAddress != address(0x00),
             "Registry: Cannot upgrade - cannot register zero address."

--- a/eth-contracts/contracts/registry/Registry.sol
+++ b/eth-contracts/contracts/registry/Registry.sol
@@ -42,11 +42,11 @@ contract Registry is InitializableV2, Ownable {
 
         require(
             addressStorage[_name] == address(0x00),
-            "Registry::addContract: Contract already registered with given name."
+            "Registry: Contract already registered with given name."
         );
         require(
             _address != address(0x00),
-            "Registry::addContract: Cannot register zero address."
+            "Registry: Cannot register zero address."
         );
 
         setAddress(_name, _address);
@@ -64,7 +64,7 @@ contract Registry is InitializableV2, Ownable {
         address contractAddress = addressStorage[_name];
         require(
             contractAddress != address(0x00),
-            "Registry::removeContract: Cannot remove - no contract registered with given _name."
+            "Registry: Cannot remove - no contract registered with given _name."
         );
 
         setAddress(_name, address(0x00));
@@ -83,11 +83,11 @@ contract Registry is InitializableV2, Ownable {
         address oldAddress = addressStorage[_name];
         require(
             oldAddress != address(0x00),
-            "Registry::upgradeContract: Cannot upgrade - no contract registered with given _name."
+            "Registry: Cannot upgrade - no contract registered with given _name."
         );
         require(
             _newAddress != address(0x00),
-            "Registry::upgradeContract: Cannot upgrade - cannot register zero address."
+            "Registry: Cannot upgrade - cannot register zero address."
         );
 
         setAddress(_name, _newAddress);
@@ -117,7 +117,7 @@ contract Registry is InitializableV2, Ownable {
         // array length for key implies version number
         require(
             _version <= addressStorageHistory[_name].length,
-            "Registry::getContract: Index out of range _version."
+            "Registry: Index out of range _version."
         );
         return addressStorageHistory[_name][_version.sub(1)];
     }

--- a/eth-contracts/test/claimsManager.test.js
+++ b/eth-contracts/test/claimsManager.test.js
@@ -205,7 +205,7 @@ contract('ClaimsManager', async (accounts) => {
     // Confirm another claim cannot be immediately funded
     await _lib.assertRevert(
       _lib.initiateFundingRound(governance, claimsManagerProxyKey, guardianAddress),
-      "Governance::guardianExecuteTransaction: Transaction failed."
+      "Governance: Transaction failed."
     )
 
     await _lib.assertRevert(
@@ -246,7 +246,7 @@ contract('ClaimsManager', async (accounts) => {
     // Confirm another round cannot be immediately funded
     await _lib.assertRevert(
       _lib.initiateFundingRound(governance, claimsManagerProxyKey, guardianAddress),
-      "Governance::guardianExecuteTransaction: Transaction failed."
+      "Governance: Transaction failed."
     )
 
     let lastClaimBlock = await claimsManager.getLastFundBlock()
@@ -315,7 +315,7 @@ contract('ClaimsManager', async (accounts) => {
     // Confirm another round cannot be immediately funded, despite 2x block diff
     await _lib.assertRevert(
       _lib.initiateFundingRound(governance, claimsManagerProxyKey, guardianAddress),
-      "Governance::guardianExecuteTransaction: Transaction failed."
+      "Governance: Transaction failed."
     )
   })
 

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -787,13 +787,13 @@ contract('DelegateManager', async (accounts) => {
       // Fail to slash more than currently staked
       await _lib.assertRevert(
         _lib.slash(DEFAULT_AMOUNT_VAL, slasherAccount, governance, delegateManagerKey, guardianAddress),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // Fail to slash more than currently staked
       await _lib.assertRevert(
         _lib.slash(DEFAULT_AMOUNT_VAL + 4, stakerAccount2, governance, delegateManagerKey, guardianAddress),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // Transfer 1000 tokens to delegator
@@ -825,7 +825,7 @@ contract('DelegateManager', async (accounts) => {
       // Fail to slash account with zero stake
       _lib.assertRevert(
         _lib.slash(DEFAULT_AMOUNT_VAL, stakerAccount2, governance, delegateManagerKey, guardianAddress),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
     })
 
@@ -1579,19 +1579,19 @@ contract('DelegateManager', async (accounts) => {
     it('Fail to set service addresses from non-governance contract', async () => {
       await _lib.assertRevert(
         delegateManager.setGovernanceAddress(_lib.addressZero),
-        'Only governance'
+        'Only callable by Governance contract'
       )
       await _lib.assertRevert(
         delegateManager.setClaimsManagerAddress(_lib.addressZero),
-        'Only governance'
+        'Only callable by Governance contract'
       )
       await _lib.assertRevert(
         delegateManager.setServiceProviderFactoryAddress(_lib.addressZero),
-        'Only governance'
+        'Only callable by Governance contract'
       )
       await _lib.assertRevert(
         delegateManager.setStakingAddress(_lib.addressZero),
-        'Only governance'
+        'Only callable by Governance contract'
       )
     })
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -563,7 +563,7 @@ contract('Governance.sol', async (accounts) => {
           proposalDescription,
           { from: proposerAddress }
         ),
-        "Governance::submitProposal: _signature cannot be empty."
+        "Governance: _signature cannot be empty."
       )
     })
 
@@ -692,14 +692,14 @@ contract('Governance.sol', async (accounts) => {
 
         await _lib.assertRevert(
           governance.submitProposalVote(proposalId, Vote.Yes, { from: stakerAccount1 }),
-          "Governance::submitProposalVote: Proposal votingPeriod has ended"
+          "Governance: Proposal votingPeriod has ended"
         )
       })
 
       it('Fail to submit invalid vote', async () => {
         await _lib.assertRevert(
           governance.submitProposalVote(proposalId, Vote.None, { from: stakerAccount1 }),
-          "Governance::submitProposalVote: Can only submit a Yes or No vote"
+          "Governance: Can only submit a Yes or No vote"
         )
       })
 
@@ -869,7 +869,7 @@ contract('Governance.sol', async (accounts) => {
       it('Fail to evaluate proposal with invalid proposalId', async () => {
         await _lib.assertRevert(
           governance.evaluateProposalOutcome(5, { from: proposerAddress }),
-          "Governance::evaluateProposalOutcome: Must provide valid non-zero _proposalId."
+          "Governance: Must provide valid non-zero _proposalId."
         )
       })
 
@@ -895,7 +895,7 @@ contract('Governance.sol', async (accounts) => {
             _lib.parseTx(submitProposalTxReceipt).event.args.proposalId,
             { from: proposerAddress }
           ),
-          "Governance::evaluateProposalOutcome: Proposal votingPeriod must end before evaluation."
+          "Governance: Proposal votingPeriod must end before evaluation."
         )
       })
 
@@ -1124,7 +1124,7 @@ contract('Governance.sol', async (accounts) => {
         
         await _lib.assertRevert(
           governance.evaluateProposalOutcome(proposalId, { from: proposerAddress }),
-          "Governance::evaluateProposalOutcome: Cannot evaluate inactive proposal."
+          "Governance: Cannot evaluate inactive proposal."
         )
       })
 
@@ -1215,7 +1215,7 @@ contract('Governance.sol', async (accounts) => {
           // Fail to veto from non-guardian address
           await _lib.assertRevert(
             governance.vetoProposal(proposalId, { from: stakerAccount1 }),
-            'Governance::vetoProposal: Only guardian can veto proposals'
+            'Governance: Only guardian can veto proposals'
           )
         })
 
@@ -1223,7 +1223,7 @@ contract('Governance.sol', async (accounts) => {
           const invalidProposalId = 5
           await _lib.assertRevert(
             governance.vetoProposal(invalidProposalId, { from: guardianAddress }),
-            "Governance::vetoProposal: Must provide valid non-zero _proposalId."
+            "Governance: Must provide valid non-zero _proposalId."
           )
         })
 
@@ -1240,7 +1240,7 @@ contract('Governance.sol', async (accounts) => {
           // Fail to veto due to inactive proposal
           await _lib.assertRevert(
             governance.vetoProposal(proposalId, { from: guardianAddress }),
-            'Governance::vetoProposal: Cannot veto inactive proposal.'
+            'Governance: Cannot veto inactive proposal.'
           )
         })
 
@@ -1263,12 +1263,12 @@ contract('Governance.sol', async (accounts) => {
           // Confirm that further actions are blocked
           await _lib.assertRevert(
             governance.submitProposalVote(proposalId, voter1Vote, { from: voter1Address }),
-            "Governance::submitProposalVote: Cannot vote on inactive proposal."
+            "Governance: Cannot vote on inactive proposal."
           )
           
           await _lib.assertRevert(
             governance.evaluateProposalOutcome(proposalId, { from: proposerAddress }),
-            "Governance::evaluateProposalOutcome: Cannot evaluate inactive proposal."
+            "Governance: Cannot evaluate inactive proposal."
           )
         })
       })
@@ -1483,7 +1483,7 @@ contract('Governance.sol', async (accounts) => {
           callData,
           { from: stakerAccount1 }
         ),
-        "Governance::guardianExecuteTransaction: Only guardian."
+        "Governance: Only guardian."
       )
     })
 
@@ -1547,7 +1547,7 @@ contract('Governance.sol', async (accounts) => {
           callData,
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: _targetContractRegistryKey must point to valid registered contract"
+        "Governance: _targetContractRegistryKey must point to valid registered contract"
       )
     })
 
@@ -1560,7 +1560,7 @@ contract('Governance.sol', async (accounts) => {
           callData,
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: _signature cannot be empty."
+        "Governance: _signature cannot be empty."
       )
     })
 
@@ -1651,13 +1651,13 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['bytes32', 'bytes32'], [testDiscProvType, serviceVersion2]),
           { from: newGuardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Only guardian."
+        "Governance: Only guardian."
       )
       
       // Confirm only current guardianAddress can transfer guardianship
       await _lib.assertRevert(
         governance.transferGuardianship(newGuardianAddress, { from: accounts[18] }),
-        "Governance::guardianExecuteTransaction: Only guardian."
+        "Governance: Only guardian."
       )
       
       // Update guardianAddress
@@ -1679,7 +1679,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['bytes32', 'bytes32'], [testDiscProvType, serviceVersion2]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Only guardian."
+        "Governance: Only guardian."
       )
 
       // Confirm new guardianAddress is now active
@@ -1714,7 +1714,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['uint256'], [0]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
       
       await governance.guardianExecuteTransaction(
@@ -1763,7 +1763,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['uint256'], [0]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
       // should revert if attempting to set voting quorum % > 100
       await _lib.assertRevert(
@@ -1774,7 +1774,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['uint256'], [120]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       await governance.guardianExecuteTransaction(
@@ -1915,7 +1915,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['bytes32', 'address'], [contractRegKey, contract.address]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // Transfer registry ownership to Governance
@@ -1953,7 +1953,7 @@ contract('Governance.sol', async (accounts) => {
           _lib.abiEncode(['address'], [registryUpgraded0.address]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // Update registry's governance address

--- a/eth-contracts/test/registry.test.js
+++ b/eth-contracts/test/registry.test.js
@@ -89,28 +89,28 @@ contract('Registry', async (accounts) => {
 
     await _lib.assertRevert(
       registry.addContract(contractName, testContract2.address, { from: proxyDeployerAddress }),
-      "Registry::addContract: Contract already registered with given name."
+      "Registry: Contract already registered with given name."
     )
   })
 
   it('Fail to add register 0 address', async () => {
     await _lib.assertRevert(
       registry.addContract(contractName, _lib.addressZero, { from: proxyDeployerAddress }),
-      "Registry::addContract: Cannot register zero address."
+      "Registry: Cannot register zero address."
     )
   })
 
   it('Fail to fetch contract with invalid version', async () => {
     await _lib.assertRevert(
       registry.getContract.call(contractName, 2),
-      "Registry::getContract: Index out of range _version."
+      "Registry: Index out of range _version."
     )
   })
 
   it('Fail to remove unregistered contract', async () => {
     await _lib.assertRevert(
       registry.removeContract(contractName, { from: proxyDeployerAddress }),
-      "Registry::removeContract: Cannot remove - no contract registered with given _name."
+      "Registry: Cannot remove - no contract registered with given _name."
     )
   })
 
@@ -119,7 +119,7 @@ contract('Registry', async (accounts) => {
 
     await _lib.assertRevert(
       registry.upgradeContract(contractName, testContract.address, { from: proxyDeployerAddress }),
-      "Registry::upgradeContract: Cannot upgrade - no contract registered with given _name."
+      "Registry: Cannot upgrade - no contract registered with given _name."
     )
   })
 

--- a/eth-contracts/test/serviceProvider.test.js
+++ b/eth-contracts/test/serviceProvider.test.js
@@ -1037,7 +1037,7 @@ contract('ServiceProvider test', async (accounts) => {
           DEFAULT_AMOUNT,
           stakerAccount
         ),
-        'No claim expected to be pending prior to stake transfer'
+        'No pending claim expected'
       )
 
       await _lib.assertRevert(
@@ -1060,7 +1060,7 @@ contract('ServiceProvider test', async (accounts) => {
 
       await _lib.assertRevert(
         serviceProviderFactory.cancelDecreaseStakeRequest(stakerAccount),
-        'Only callable from owner or DelegateManager'
+        'Only owner or DelegateManager'
       )
       await _lib.assertRevert(
         serviceProviderFactory.cancelDecreaseStakeRequest(stakerAccount, { from: stakerAccount }),
@@ -1104,7 +1104,7 @@ contract('ServiceProvider test', async (accounts) => {
           callDataDP,
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // Add new serviceType
@@ -1167,7 +1167,7 @@ contract('ServiceProvider test', async (accounts) => {
           _lib.abiEncode(['bytes32', 'bytes32'], [testType, testVersion]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       let chainVersion = await serviceTypeManager.getCurrentVersion(testType)
@@ -1238,7 +1238,7 @@ contract('ServiceProvider test', async (accounts) => {
           _lib.abiEncode(['bytes32'], [unregisteredType]),
           { from: guardianAddress }
         ),
-        "Governance::guardianExecuteTransaction: Transaction failed."
+        "Governance: Transaction failed."
       )
 
       // removeServiceType successfully

--- a/eth-contracts/test/staking.test.js
+++ b/eth-contracts/test/staking.test.js
@@ -126,7 +126,7 @@ contract('Staking test', async (accounts) => {
         staker,
         0
       ),
-      'STAKING_AMOUNT_ZERO'
+      'Zero amount not allowed'
     )
   })
 
@@ -255,7 +255,7 @@ contract('Staking test', async (accounts) => {
     // Fail to slash zero
     await _lib.assertRevert(
       slashAccount(0, account, proxyDeployerAddress),
-      'STAKING_AMOUNT_ZERO'
+      'Zero amount not allowed'
     )
 
     // Slash account's stake

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -109,7 +109,7 @@ contract('Upgrade proxy test', async (accounts) => {
     const mock = await MockStakingCaller.new({ from: proxyAdminAddress })
     await _lib.assertRevert(
       mock.stakeRewards(10, accounts[5], { from: proxyDeployerAddress }),
-      "INIT_NOT_INITIALIZED"
+      "Not initialized"
     )
 
     const isInitialized = await mock.isInitialized.call()


### PR DESCRIPTION
* Consistent format for error messages with "ContractName: errorMessage"
* Any message used >1x within a contract is declared as a private string const to avoid duplication