### PR TITLE
[N03] Named return variables

### DIFF
--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -108,7 +108,7 @@ contract ClaimsManager is InitializableV2 {
     }
 
     /// @notice Get the duration of a funding round in blocks
-    function getFundingRoundBlockDiff() external view returns (uint256 blockDiff)
+    function getFundingRoundBlockDiff() external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -116,7 +116,7 @@ contract ClaimsManager is InitializableV2 {
     }
 
     /// @notice Get the last block where a funding round was initiated
-    function getLastFundBlock() external view returns (uint256 lastFundBlock)
+    function getLastFundBlock() external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -124,7 +124,7 @@ contract ClaimsManager is InitializableV2 {
     }
 
     /// @notice Get the amount funded per round in wei
-    function getFundsPerRound() external view returns (uint256 amount)
+    function getFundsPerRound() external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -132,7 +132,7 @@ contract ClaimsManager is InitializableV2 {
     }
 
     /// @notice Get the total amount claimed in the current round
-    function getTotalClaimedInRound() external view returns (uint256 claimedAmount)
+    function getTotalClaimedInRound() external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -140,21 +140,21 @@ contract ClaimsManager is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getGovernanceAddress() external view returns (address addr) {
+    function getGovernanceAddress() external view returns (address) {
         _requireIsInitialized();
 
         return governanceAddress;
     }
 
     /// @notice Get the ServiceProviderFactory address
-    function getServiceProviderFactoryAddress() external view returns (address addr) {
+    function getServiceProviderFactoryAddress() external view returns (address) {
         _requireIsInitialized();
 
         return serviceProviderFactoryAddress;
     }
 
     /// @notice Get the DelegateManager address
-    function getDelegateManagerAddress() external view returns (address addr) {
+    function getDelegateManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return delegateManagerAddress;
@@ -163,7 +163,7 @@ contract ClaimsManager is InitializableV2 {
     /**
      * @notice Get the Staking address
      */
-    function getStakingAddress() external view returns (address addr)
+    function getStakingAddress() external view returns (address)
     {
         _requireIsInitialized();
 
@@ -260,11 +260,12 @@ contract ClaimsManager is InitializableV2 {
      * @dev Callable through DelegateManager by Service Provider
      * @param _claimer  - service provider address
      * @param _totalLockedForSP - amount of tokens locked up across DelegateManager + ServiceProvider
+     * @return minted rewards for this claimer
      */
     function processClaim(
         address _claimer,
         uint256 _totalLockedForSP
-    ) external returns (uint256 mintedRewards)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -344,8 +345,7 @@ contract ClaimsManager is InitializableV2 {
      * @notice Modify funding amount per round
      * @param _newAmount - new amount to fund per round in wei
      */
-    function updateFundingAmount(uint256 _newAmount)
-    external returns (uint256 newAmount)
+    function updateFundingAmount(uint256 _newAmount) external
     {
         _requireIsInitialized();
 
@@ -355,16 +355,15 @@ contract ClaimsManager is InitializableV2 {
         );
         fundingAmount = _newAmount;
         emit FundingAmountUpdated(_newAmount);
-        return _newAmount;
     }
 
     /**
      * @notice Returns boolean indicating whether a claim is considered pending
      * @dev Note that an address with no endpoints can never have a pending claim
      * @param _sp - address of the service provider to check
-     * @return boolean - true if eligible for claim, false if not
+     * @return true if eligible for claim, false if not
      */
-    function claimPending(address _sp) external view returns (bool pending) {
+    function claimPending(address _sp) external view returns (bool) {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
         _requireServiceProviderFactoryAddressIsSet();

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -123,7 +123,7 @@ contract DelegateManager is InitializableV2 {
     function delegateStake(
         address _targetSP,
         uint256 _amount
-    ) external returns (uint256 delegatedAmount)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -194,7 +194,7 @@ contract DelegateManager is InitializableV2 {
     function requestUndelegateStake(
         address _target,
         uint256 _amount
-    ) external returns (uint256 newDelegateAmount)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireClaimsManagerAddressIsSet();
@@ -259,7 +259,7 @@ contract DelegateManager is InitializableV2 {
      * @notice Finalize undelegation request and withdraw stake
      * @return New total amount currently staked after stake has been undelegated
      */
-    function undelegateStake() external returns (uint256 newTotal) {
+    function undelegateStake() external returns (uint256) {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
         _requireServiceProviderFactoryAddressIsSet();
@@ -644,7 +644,7 @@ contract DelegateManager is InitializableV2 {
      * @param _sp - service provider address
      */
     function getDelegatorsList(address _sp)
-    external view returns (address[] memory dels)
+    external view returns (address[] memory)
     {
         _requireIsInitialized();
 
@@ -653,7 +653,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Get total amount delegated to a service provider
     function getTotalDelegatedToServiceProvider(address _sp)
-    external view returns (uint256 total)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -662,7 +662,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Get total delegated stake locked up for a service provider
     function getTotalLockedDelegationForServiceProvider(address _sp)
-    external view returns (uint256 total)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -671,7 +671,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Get total currently staked for a delegator, for a given service provider
     function getDelegatorStakeForServiceProvider(address _delegator, address _serviceProvider)
-    external view returns (uint256 amount)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -693,7 +693,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Get current undelegate lockup duration
     function getUndelegateLockupDuration()
-    external view returns (uint256 duration)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -702,7 +702,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Current maximum delegators
     function getMaxDelegators()
-    external view returns (uint256 numDelegators)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -711,7 +711,7 @@ contract DelegateManager is InitializableV2 {
 
     /// @notice Get minimum delegation amount
     function getMinDelegationAmount()
-    external view returns (uint256 minDelegation)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -719,28 +719,28 @@ contract DelegateManager is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getGovernanceAddress() external view returns (address addr) {
+    function getGovernanceAddress() external view returns (address) {
         _requireIsInitialized();
 
         return governanceAddress;
     }
 
     /// @notice Get the ServiceProviderFactory address
-    function getServiceProviderFactoryAddress() external view returns (address addr) {
+    function getServiceProviderFactoryAddress() external view returns (address) {
         _requireIsInitialized();
 
         return serviceProviderFactoryAddress;
     }
 
     /// @notice Get the ClaimsManager address
-    function getClaimsManagerAddress() external view returns (address addr) {
+    function getClaimsManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return claimsManagerAddress;
     }
 
     /// @notice Get the Staking address
-    function getStakingAddress() external view returns (address addr)
+    function getStakingAddress() external view returns (address)
     {
         _requireIsInitialized();
 
@@ -961,11 +961,12 @@ contract DelegateManager is InitializableV2 {
      * @notice Returns if delegator has delegated to a service provider
      * @param _delegator - address of delegator
      * @param _serviceProvider - address of service provider
+     * @return boolean indicating whether delegator exists for service provider
      */
     function _delegatorExistsForSP(
         address _delegator,
         address _serviceProvider
-    ) internal view returns (bool exists)
+    ) internal view returns (bool)
     {
         for (uint256 i = 0; i < spDelegateInfo[_serviceProvider].delegators.length; i++) {
             if (spDelegateInfo[_serviceProvider].delegators[i] == _delegator) {
@@ -977,19 +978,21 @@ contract DelegateManager is InitializableV2 {
     }
 
     /**
-     * @notice Boolean indicating whether a claim is pending for this service provider
+     * @notice Determine if a claim is pending for this service provider
      * @param _sp - address of service provider
+     * @return boolean indicating whether a claim is pending
      */
-    function _claimPending(address _sp) internal view returns (bool pending) {
+    function _claimPending(address _sp) internal view returns (bool) {
         ClaimsManager claimsManager = ClaimsManager(claimsManagerAddress);
         return claimsManager.claimPending(_sp);
     }
 
     /**
-     * @notice Boolean indicating whether a decrease request has been initiated
+     * @notice Determine if a decrease request has been initiated
      * @param _delegator - address of delegator
+     * @return boolean indicating whether a decrease request is pending 
      */
-    function _undelegateRequestIsPending(address _delegator) internal view returns (bool pending)
+    function _undelegateRequestIsPending(address _delegator) internal view returns (bool)
     {
         return (
             (undelegateRequests[_delegator].lockupExpiryBlock != 0) &&

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -990,7 +990,7 @@ contract DelegateManager is InitializableV2 {
     /**
      * @notice Determine if a decrease request has been initiated
      * @param _delegator - address of delegator
-     * @return boolean indicating whether a decrease request is pending 
+     * @return boolean indicating whether a decrease request is pending
      */
     function _undelegateRequestIsPending(address _delegator) internal view returns (bool)
     {

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -186,6 +186,7 @@ contract Governance is InitializableV2 {
      * @param _functionSignature - function signature of the function to be executed if proposal is successful
      * @param _callData - encoded value(s) to call function with if proposal is successful
      * @param _description - Text description of proposal to be emitted in event
+     * @return - ID of new proposal
      */
     function submitProposal(
         bytes32 _targetContractRegistryKey,
@@ -193,7 +194,7 @@ contract Governance is InitializableV2 {
         string calldata _functionSignature,
         bytes calldata _callData,
         string calldata _description
-    ) external returns (uint256 proposalId)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -360,9 +361,10 @@ contract Governance is InitializableV2 {
      *      To pass, stake-weighted vote must be > 50% Yes.
      * @dev Requires that caller is an active staker at the time the proposal is created
      * @param _proposalId - id of the proposal
+     * @return Outcome of proposal evaluation
      */
     function evaluateProposalOutcome(uint256 _proposalId)
-    external returns (Outcome proposalOutcome)
+    external returns (Outcome)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -678,7 +680,7 @@ contract Governance is InitializableV2 {
      * @return returns a value from the Vote enum if a valid vote, otherwise returns no value
      */
     function getVoteByProposalAndVoter(uint256 _proposalId, address _voter)
-    external view returns (Vote vote)
+    external view returns (Vote)
     {
         _requireIsInitialized();
 
@@ -783,13 +785,13 @@ contract Governance is InitializableV2 {
         uint256 _callValue,
         string memory _functionSignature,
         bytes memory _callData
-    ) internal returns (bool /** success */, bytes memory /** returnData */)
+    ) internal returns (bool success, bytes memory returnData)
     {
         bytes memory encodedCallData = abi.encodePacked(
             bytes4(keccak256(bytes(_functionSignature))),
             _callData
         );
-        (bool success, bytes memory returnData) = (
+        (success, returnData) = (
             // solium-disable-next-line security/no-call-value
             _targetContractAddress.call.value(_callValue)(encodedCallData)
         );
@@ -873,9 +875,9 @@ contract Governance is InitializableV2 {
     }
 
     /**
-     * Helper function to perform validation for submitVote() and updateVote() functions
-     * Validates new _vote, _proposalId, proposal state, and voter state
-     * Returns stake of voter at proposal submission time
+     * @notice Helper function to perform validation for submitVote() and updateVote() functions
+     * @dev Validates new _vote, _proposalId, proposal state, and voter state
+     * @return stake of voter at proposal submission time
      */
     function _validateVoteAndGetVoterStake(address _voter, uint256 _proposalId, Vote _vote)
     private view returns (uint256) {

--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -151,13 +151,14 @@ contract ServiceProviderFactory is InitializableV2 {
      * @param _endpoint - url of the service to register - url of the service to register
      * @param _stakeAmount - amount to stake, must be within bounds in ServiceTypeManager
      * @param _delegateOwnerWallet - wallet to delegate some permissions for some basic management properties
+     * @return New service provider ID for this endpoint
      */
     function register(
         bytes32 _serviceType,
         string calldata _endpoint,
         uint256 _stakeAmount,
         address _delegateOwnerWallet
-    ) external returns (uint256 spID)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -239,7 +240,7 @@ contract ServiceProviderFactory is InitializableV2 {
     function deregister(
         bytes32 _serviceType,
         string calldata _endpoint
-    ) external returns (uint256 deregisteredSpID)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -329,7 +330,7 @@ contract ServiceProviderFactory is InitializableV2 {
      */
     function increaseStake(
         uint256 _increaseStakeAmount
-    ) external returns (uint256 newTotalStake)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -381,7 +382,7 @@ contract ServiceProviderFactory is InitializableV2 {
      * @return New total stake amount after the lockup
      */
     function requestDecreaseStake(uint256 _decreaseStakeAmount)
-    external returns (uint256 newStakeAmount)
+    external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -441,7 +442,7 @@ contract ServiceProviderFactory is InitializableV2 {
      * @notice Called by user to decrease a stake after waiting the appropriate lockup period.
      * @return New total stake after decrease
      */
-    function decreaseStake() external returns (uint256 newTotalStake)
+    function decreaseStake() external returns (uint256)
     {
         _requireIsInitialized();
         _requireStakingAddressIsSet();
@@ -521,12 +522,13 @@ contract ServiceProviderFactory is InitializableV2 {
      * @param _serviceType - type of service to register, must be valid in ServiceTypeManager
      * @param _oldEndpoint - old endpoint currently registered
      * @param _newEndpoint - new endpoint to replace old endpoint
+     * @return ID of updated service provider
      */
     function updateEndpoint(
         bytes32 _serviceType,
         string calldata _oldEndpoint,
         string calldata _newEndpoint
-    ) external returns (uint256 spID)
+    ) external returns (uint256)
     {
         _requireIsInitialized();
 
@@ -622,7 +624,7 @@ contract ServiceProviderFactory is InitializableV2 {
 
     /// @notice Get denominator for deployer cut calculations
     function getServiceProviderDeployerCutBase()
-    external view returns (uint256 base)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -631,7 +633,7 @@ contract ServiceProviderFactory is InitializableV2 {
 
     /// @notice Get total number of service providers for a given serviceType
     function getTotalServiceTypeProviders(bytes32 _serviceType)
-    external view returns (uint256 numberOfProviders)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -640,7 +642,7 @@ contract ServiceProviderFactory is InitializableV2 {
 
     /// @notice Get service provider id for an endpoint
     function getServiceProviderIdFromEndpoint(string calldata _endpoint)
-    external view returns (uint256 spID)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -652,7 +654,7 @@ contract ServiceProviderFactory is InitializableV2 {
      * @return List of service ids of that type for a service provider
      */
     function getServiceProviderIdsFromAddress(address _ownerAddress, bytes32 _serviceType)
-    external view returns (uint256[] memory spIds)
+    external view returns (uint256[] memory)
     {
         _requireIsInitialized();
 
@@ -720,7 +722,7 @@ contract ServiceProviderFactory is InitializableV2 {
 
     /// @notice Get current unstake lockup duration
     function getDecreaseStakeLockupDuration()
-    external view returns (uint256 duration)
+    external view returns (uint256)
     {
         _requireIsInitialized();
 
@@ -745,35 +747,35 @@ contract ServiceProviderFactory is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getGovernanceAddress() external view returns (address addr) {
+    function getGovernanceAddress() external view returns (address) {
         _requireIsInitialized();
 
         return governanceAddress;
     }
 
     /// @notice Get the Staking address
-    function getStakingAddress() external view returns (address addr) {
+    function getStakingAddress() external view returns (address) {
         _requireIsInitialized();
 
         return stakingAddress;
     }
 
     /// @notice Get the DelegateManager address
-    function getDelegateManagerAddress() external view returns (address addr) {
+    function getDelegateManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return delegateManagerAddress;
     }
 
     /// @notice Get the ServiceTypeManager address
-    function getServiceTypeManagerAddress() external view returns (address addr) {
+    function getServiceTypeManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return serviceTypeManagerAddress;
     }
 
     /// @notice Get the ClaimsManager address
-    function getClaimsManagerAddress() external view returns (address addr) {
+    function getClaimsManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return claimsManagerAddress;
@@ -898,7 +900,7 @@ contract ServiceProviderFactory is InitializableV2 {
      * return Boolean of whether decrease request has been initiated
      */
     function _decreaseRequestIsPending(address _serviceProvider)
-    internal view returns (bool pending)
+    internal view returns (bool)
     {
         return (
             (decreaseStakeRequests[_serviceProvider].lockupExpiryBlock > 0) &&
@@ -914,7 +916,7 @@ contract ServiceProviderFactory is InitializableV2 {
      * @param _serviceProvider - address of service provider
      * return Boolean of whether claim is pending
      */
-    function _claimPending(address _serviceProvider) internal view returns (bool pending) {
+    function _claimPending(address _serviceProvider) internal view returns (bool) {
         return ClaimsManager(claimsManagerAddress).claimPending(_serviceProvider);
     }
 

--- a/eth-contracts/contracts/ServiceTypeManager.sol
+++ b/eth-contracts/contracts/ServiceTypeManager.sol
@@ -47,7 +47,7 @@ contract ServiceTypeManager is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getGovernanceAddress() external view returns (address addr) {
+    function getGovernanceAddress() external view returns (address) {
         _requireIsInitialized();
 
         return governanceAddress;
@@ -156,7 +156,7 @@ contract ServiceTypeManager is InitializableV2 {
      * @notice Get list of valid service types
      */
     function getValidServiceTypes()
-    external view returns (bytes32[] memory types)
+    external view returns (bytes32[] memory)
     {
         _requireIsInitialized();
 
@@ -167,7 +167,7 @@ contract ServiceTypeManager is InitializableV2 {
      * @notice Return indicating whether this is a valid service type
      */
     function serviceTypeIsValid(bytes32 _serviceType)
-    external view returns (bool isValid)
+    external view returns (bool)
     {
         _requireIsInitialized();
 
@@ -208,9 +208,10 @@ contract ServiceTypeManager is InitializableV2 {
      * @notice Get a version for a service type given it's index
      * @param _serviceType - type of service
      * @param _versionIndex - index in list of service versions
+     * @return bytes32 value for serviceVersion
      */
     function getVersion(bytes32 _serviceType, uint256 _versionIndex)
-    external view returns (bytes32 version)
+    external view returns (bytes32)
     {
         _requireIsInitialized();
 
@@ -227,7 +228,7 @@ contract ServiceTypeManager is InitializableV2 {
      * @return Returns current version of service
      */
     function getCurrentVersion(bytes32 _serviceType)
-    external view returns (bytes32 currentVersion)
+    external view returns (bytes32)
     {
         _requireIsInitialized();
 
@@ -257,7 +258,7 @@ contract ServiceTypeManager is InitializableV2 {
      * @param _serviceVersion - version of service to check
      */
     function serviceVersionIsValid(bytes32 _serviceType, bytes32 _serviceVersion)
-    external view returns (bool isValidServiceVersion)
+    external view returns (bool)
     {
         _requireIsInitialized();
 

--- a/eth-contracts/contracts/Staking.sol
+++ b/eth-contracts/contracts/Staking.sol
@@ -355,28 +355,28 @@ contract Staking is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getGovernanceAddress() external view returns (address addr) {
+    function getGovernanceAddress() external view returns (address) {
         _requireIsInitialized();
 
         return governanceAddress;
     }
 
     /// @notice Get the ClaimsManager address
-    function getClaimsManagerAddress() external view returns (address addr) {
+    function getClaimsManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return claimsManagerAddress;
     }
 
     /// @notice Get the ServiceProviderFactory address
-    function getServiceProviderFactoryAddress() external view returns (address addr) {
+    function getServiceProviderFactoryAddress() external view returns (address) {
         _requireIsInitialized();
 
         return serviceProviderFactoryAddress;
     }
 
     /// @notice Get the DelegateManager address
-    function getDelegateManagerAddress() external view returns (address addr) {
+    function getDelegateManagerAddress() external view returns (address) {
         _requireIsInitialized();
 
         return delegateManagerAddress;


### PR DESCRIPTION
* All functions with a single return value no longer use a named return variable
* Functions returning a tuple explicitly use named return variables

Why this distinction? We chose to continue returning named variables for tuples so that non-contract clients can easily access the returned values - for example, in the function 'getServiceProviderDetails' a client can simply access 'object.numberOfEndpoints' instead of having to call "object['3']". While there may be a (very) slight decrease in contract readability, the other benefits that named values provide compelled us to use them.