### PR TITLE
[L09] README file missing important information

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ instructions!
 We welcome contributions to Audius from anyone who opens a PR. Feel free to reach out to
 our team [on Discord](https://discord.com/invite/yNUg2e2) or via other channels for feedback and/or support!
 
+## Security
+
+Please report security issues to `security@audius.co` with a description of the
+vulenerability and any steps to reproduce. We have bounties available for issues reported
+via responsible disclosure!
+
 ## License
 
 Apache 2.0: [LICENSE file](https://github.com/AudiusProject/audius-protocol/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,13 +3,29 @@
 ---
 
 # audius-protocol
-Audius is working to create a fully decentralized community of artists, developers, and listeners collaborating to share and defend the world’s music.
-
-This repository encompasses all of the services, contracts and libs that comprise the Audius protocol.
 
 [![CircleCI](https://circleci.com/gh/AudiusProject/audius-protocol/tree/master.svg?style=svg&circle-token=e272a756b49e50a54dcc096af8fd8b0405f6bf41)](https://circleci.com/gh/AudiusProject/audius-protocol/tree/master)
 
+Audius is a decentralized, community-owned music-sharing protocol and app. It provides a
+censorship-resistant alternative to SoundCloud that helps artists distribute anything they
+want directly to fans, creating a unique and differentiated catalog. The mission of the
+project is to give everyone the freedom to share, monetize, and listen to any audio.
+
+This repository encompasses all of the services, contracts, and client-side libraries that
+comprise the Audius protocol.
+
+For a more detailed overview of how Audius works, how these components interact with one
+another, how to run an off-chain service, and more, see the [Audius protocol wiki](https://github.com/AudiusProject/audius-protocol/wiki) for more details.
+
+
+## Install
+
+The Audius protocol has many moving pieces, on-chain and off-chain. Refer to the
+installation and usage instructions for any of the sub-components of the Audius protocol:
+
 ### Audius Services
+
+These off-chain services are run by community members via the Audius staking system:
 
 | Service                                                        | Description                                                                                       
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------
@@ -18,10 +34,35 @@ This repository encompasses all of the services, contracts and libs that compris
 | [`identity-service`](identity-service)          | Stores encrypted auth ciphertexts, does Twitter oauth and relays transactions on behalf of users
 | [`content-service`](content-service)            | Monitors Audius activity and intelligently caches content to increase availability
 
-### Audius Smart Contracts & Libs
+### Audius Smart Contracts
 
-| Lib                                                        | Description                                                                                       
+The independent sets of smart contracts that underpin the Audius protocol:
+
+| Contracts                                                        | Description                                                                                       
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------
-| [`libs`](https://github.com/AudiusProject/audius-protocol/tree/master/libs)     | An easy interface to the distributed web and audius services: Identity Service, Discovery Provider, Creator Node
-| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/contracts)         | The smart contracts being developed for the audius streaming protocol
-| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/eth-contracts) | The ethereum smart contracts being developed for the audius streaming protocol
+| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/contracts)         | The POA network smart contracts for the Audius protocol, encompassing user account, content listing, and content interaction functionality
+| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/eth-contracts) | The ethereum smart contracts that run the Audius protocol, encompassing the Audius ERC20 token and functionality for staking, off-chain service registration / lookup, and governance
+
+
+### Audius Client Libraries
+
+Client-side libraries to provide a unified interface for interacting with the entire
+Audius protocol:
+
+| Library                                                        | Description                                                                                       
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------
+| [`libs`](https://github.com/AudiusProject/audius-protocol/tree/master/libs)     | A complete javascript interface to the Audius smart contracts and Audius services: Identity Service, Discovery Provider, Creator Node
+
+## Usage
+
+Refer to the READMEs of the various Audius components listed above for specific usage
+instructions!
+
+## Contributing
+
+We welcome contributions to Audius from anyone who opens a PR. Feel free to reach out to
+our team [on Discord](https://discord.com/invite/yNUg2e2) or via other channels for feedback and/or support!
+
+## License
+
+Apache 2.0: [LICENSE file](https://github.com/AudiusProject/audius-protocol/blob/master/LICENSE)

--- a/eth-contracts/README.md
+++ b/eth-contracts/README.md
@@ -1,5 +1,56 @@
-# eth-contracts
+# Audius Ethereum smart contracts
 
 [![Coverage Status](https://coveralls.io/repos/github/AudiusProject/audius-protocol/badge.svg)](https://coveralls.io/github/AudiusProject/audius-protocol)
 
-Contains contracts for ERC-20 token, staking functionality, service provider registration and version management
+Audius has two sets of contracts - the one in this directory, which runs on Ethereum mainnet in
+production, and the one
+[here](https://github.com/AudiusProject/audius-protocol/tree/master/contracts) which runs on POA
+mainnet in production.
+
+The smart contracts in this directory implement the Audius ERC-20 token, staking functionality, service
+provider registration, delegator support and off-chain service version management. For a
+more in depth look at the contracts and architecture, please see the
+[Audius Ethereum Contracts Wiki](https://github.com/AudiusProject/audius-protocol/wiki/Ethereum-Contracts-Overview)
+page.
+
+The two sets of smart contracts do not interact with one another, but both sets are used by end-user
+clients and the off-chain services that run Audius to make use of their respective
+functionality.
+
+## Installation
+
+To install and run the contracts locally, clone the `audius-protocol` repo and go into the
+`eth-contracts` folder. Assuming you have node.js, npm, and docker installed, run the
+following commands to run Ganache and migrate the contracts.
+
+*Note* - Ganache from the command below is exposed on port 8546, not 8545.
+
+```
+npm install
+npm run ganache
+npm run truffle-migrate
+```
+
+## Test
+
+To run tests, run the following command:
+
+```
+npm run test
+```
+
+To run tests with coverage calculation, run the following command:
+
+```
+npm run test-coverage
+```
+
+## Security
+
+Please report security issues to `security@audius.co` with a description of the
+vulenerability and any steps to reproduce. We have bounties available for issues reported
+via responsible disclosure!
+
+## License
+
+Apache 2.0


### PR DESCRIPTION
Supersedes the prior PR for this issue: https://github.com/AudiusProject/audius-protocol/pull/547/files

Updates both the eth-contracts directory README as well as the top-level project README to be compliant with the Standard Readme specification https://github.com/RichardLitt/standard-readme

Much of the suggested documentation to add here is already duplicated by the content of the Audius wiki, so rather than copy that here we linked out to it in the top section of the top-level README