### PR TITLE
Vulnerability in proposal execution, which allows circumvention of guardian veto

### DIFF
--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -523,6 +523,9 @@ contract Governance is InitializableV2 {
 
         proposals[_proposalId].outcome = Outcome.Vetoed;
 
+        // Remove from inProgressProposals array
+        _removeFromInProgressProposals(_proposalId);
+
         emit ProposalVetoed(_proposalId);
     }
 

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -438,7 +438,7 @@ contract Governance is InitializableV2 {
             block.number > endBlockNumber,
             "Governance: Proposal votingPeriod & executionDelay must end before evaluation."
         );
-        
+
         address targetContractAddress = registry.getContract(
             proposals[_proposalId].targetContractRegistryKey
         );
@@ -517,7 +517,7 @@ contract Governance is InitializableV2 {
         );
 
         require(
-            proposals[_proposalId].outcome == Outcome.InProgress,   
+            proposals[_proposalId].outcome == Outcome.InProgress,
             "Governance: Cannot veto inactive proposal."
         );
 

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -20,7 +20,8 @@ const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
 
-const ExecutionDelayBlocks = 10
+// 5hr * 60min/hr * 60sec/min / ~15 sec/block = 1200 blocks
+const ExecutionDelayBlocks = 1200
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -20,8 +20,8 @@ const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
 
-// 5hr * 60min/hr * 60sec/min / ~15 sec/block = 1200 blocks
-const ExecutionDelayBlocks = 1200
+// 24hr * 60min/hr * 60sec/min / ~15 sec/block = 5760 blocks
+const ExecutionDelayBlocks = 5760
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
@@ -37,8 +37,8 @@ module.exports = (deployer, network, accounts) => {
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint16', 'uint16', 'uint16', 'address'],
-      [registryAddress, VotingPeriod, VotingQuorumPercent, MaxInProgressProposals, MaxDescriptionLengthBytes, ExecutionDelayBlocks, guardianAddress]
+      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
+      [registryAddress, VotingPeriod, ExecutionDelayBlocks, VotingQuorumPercent, MaxInProgressProposals, MaxDescriptionLengthBytes, guardianAddress]
     )
     const governanceProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -20,8 +20,8 @@ const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
 
-// 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646.153846153846154 blocks
-const ExecutionDelayBlocks = 5760
+// 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646 blocks
+const ExecutionDelayBlocks = 6646
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -9,8 +9,8 @@ const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabil
 
 const governanceRegKey = web3.utils.utf8ToHex('Governance')
 
-// 48hr * 60 min/hr * 60 sec/min / ~15 sec/block = 11520 blocks
-const VotingPeriod = 11520
+// 48hr * 60 min/hr * 60 sec/min / ~13 sec/block = 13292 blocks
+const VotingPeriod = 13292
 // Required percent of total stake to have been voted with on proposal
 const VotingQuorumPercent = 10
 
@@ -20,7 +20,7 @@ const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
 
-// 24hr * 60min/hr * 60sec/min / ~15 sec/block = 5760 blocks
+// 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646.153846153846154 blocks
 const ExecutionDelayBlocks = 5760
 
 module.exports = (deployer, network, accounts) => {

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -20,6 +20,8 @@ const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
 
+const ExecutionDelayBlocks = 10
+
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
     const config = contractConfig[network]
@@ -34,8 +36,8 @@ module.exports = (deployer, network, accounts) => {
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registryAddress, VotingPeriod, VotingQuorumPercent, MaxInProgressProposals, MaxDescriptionLengthBytes, guardianAddress]
+      ['address', 'uint256', 'uint256', 'uint16', 'uint16', 'uint16', 'address'],
+      [registryAddress, VotingPeriod, VotingQuorumPercent, MaxInProgressProposals, MaxDescriptionLengthBytes, ExecutionDelayBlocks, guardianAddress]
     )
     const governanceProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/test/audiusToken.test.js
+++ b/eth-contracts/test/audiusToken.test.js
@@ -17,6 +17,7 @@ contract('AudiusToken', async (accounts) => {
   const guardianAddress = proxyDeployerAddress
 
   const votingPeriod = 10
+  const executionDelay = votingPeriod
   const votingQuorumPercent = 10
   
   const callValue0 = _lib.toBN(0)
@@ -29,6 +30,7 @@ contract('AudiusToken', async (accounts) => {
       proxyDeployerAddress,
       registry,
       votingPeriod,
+      executionDelay,
       votingQuorumPercent,
       guardianAddress
     )

--- a/eth-contracts/test/claimsManager.test.js
+++ b/eth-contracts/test/claimsManager.test.js
@@ -16,6 +16,7 @@ const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
 
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
 const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 
 const callValue0 = _lib.toBN(0)
@@ -52,6 +53,7 @@ contract('ClaimsManager', async (accounts) => {
       proxyDeployerAddress,
       registry,
       VOTING_PERIOD,
+      EXECUTION_DELAY,
       VOTING_QUORUM_PERCENT,
       guardianAddress
     )

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -27,6 +27,7 @@ const INITIAL_BAL = _lib.audToWeiBN(1000)
 const DEFAULT_AMOUNT_VAL = _lib.audToWei(120)
 const DEFAULT_AMOUNT = _lib.toBN(DEFAULT_AMOUNT_VAL)
 const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 const DECREASE_STAKE_LOCKUP_DURATION = 10
 
@@ -60,6 +61,7 @@ contract('DelegateManager', async (accounts) => {
       proxyDeployerAddress,
       registry,
       VOTING_PERIOD,
+      EXECUTION_DELAY,
       VOTING_QUORUM_PERCENT,
       guardianAddress
     )

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -1426,6 +1426,19 @@ contract('Governance.sol', async (accounts) => {
             "Cannot evaluate inactive proposal."
           )
         })
+
+        it('Ensure veto does not prevent future governance actions', async () => {
+          await governance.vetoProposal(proposalId, { from: guardianAddress })
+
+          submitProposalTxReceipt = await governance.submitProposal(
+            targetContractRegistryKey,
+            callValue,
+            functionSignature,
+            callData,
+            proposalDescription,
+            { from: proposerAddress }
+          )
+        })
       })
     })
   })
@@ -1513,7 +1526,7 @@ contract('Governance.sol', async (accounts) => {
     )
   })
 
-  it('Test max value of maxInProgressProposals via submit & evaluate', async () => {
+  it('Test max value of maxInProgressProposals', async () => {
     /**
      * TODO - finish fleshing out this test
      * currently confirms ~170 inprogress proposals takes about 1mm gas for submit and ~300k gas for evaluate

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -1523,19 +1523,6 @@ contract('Governance.sol', async (accounts) => {
             { from: proposerAddress }
           )
         })
-
-        it('Ensure veto does not prevent future governance actions', async () => {
-          await governance.vetoProposal(proposalId, { from: guardianAddress })
-
-          submitProposalTxReceipt = await governance.submitProposal(
-            targetContractRegistryKey,
-            callValue,
-            functionSignature,
-            callData,
-            proposalDescription,
-            { from: proposerAddress }
-          )
-        })
       })
     })
   })

--- a/eth-contracts/test/serviceProvider.test.js
+++ b/eth-contracts/test/serviceProvider.test.js
@@ -26,6 +26,7 @@ const testEndpoint2 = 'https://localhost:5002'
 
 const MIN_STAKE_AMOUNT = 10
 const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 const DECREASE_STAKE_LOCKUP_DURATION = 10
 
@@ -118,6 +119,7 @@ contract('ServiceProvider test', async (accounts) => {
       proxyDeployerAddress,
       registry,
       VOTING_PERIOD,
+      EXECUTION_DELAY,
       VOTING_QUORUM_PERCENT,
       guardianAddress
     )
@@ -1264,8 +1266,9 @@ contract('ServiceProvider test', async (accounts) => {
         proxyAdminAddress,
         proxyDeployerAddress,
         registry2,
-        10, /*votingPeriod*/
-        1, /*votingQuorum*/
+        VOTING_PERIOD,
+        EXECUTION_DELAY,
+        VOTING_QUORUM_PERCENT,
         guardianAddress
       )
       // setGovernanceAddress in ServiceTypeManager.sol

--- a/eth-contracts/test/staking.test.js
+++ b/eth-contracts/test/staking.test.js
@@ -14,6 +14,7 @@ const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
 
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
 const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 
 
@@ -61,6 +62,7 @@ contract('Staking test', async (accounts) => {
       proxyDeployerAddress,
       registry,
       VOTING_PERIOD,
+      EXECUTION_DELAY,
       VOTING_QUORUM_PERCENT,
       guardianAddress
     )

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -3,7 +3,6 @@ import * as _lib from '../utils/lib.js'
 const Registry = artifacts.require('Registry')
 const Staking = artifacts.require('Staking')
 const StakingUpgraded = artifacts.require('StakingUpgraded')
-const AudiusToken = artifacts.require('AudiusToken')
 const MockStakingCaller = artifacts.require('MockStakingCaller')
 const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
 
@@ -11,11 +10,11 @@ const claimsManagerProxyKey = web3.utils.utf8ToHex('ClaimsManagerProxy')
 const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
 const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
 const governanceKey = web3.utils.utf8ToHex('Governance')
-const serviceTypeManagerProxyKey = web3.utils.utf8ToHex('ServiceTypeManagerProxy')
 const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
 
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
 const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 
 const { expectEvent } = require('@openzeppelin/test-helpers')
@@ -57,6 +56,7 @@ contract('Upgrade proxy test', async (accounts) => {
       proxyDeployerAddress,
       registry,
       VOTING_PERIOD,
+      EXECUTION_DELAY,
       VOTING_QUORUM_PERCENT,
       guardianAddress
     )

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -224,6 +224,7 @@ export const deployGovernance = async (
   proxyDeployerAddress,
   registry,
   votingPeriod,
+  executionDelay,
   votingQuorum,
   guardianAddress,
   maxInProgressProposals = 20,
@@ -235,8 +236,8 @@ export const deployGovernance = async (
   const governance0 = await Governance.new({ from: proxyDeployerAddress })
   const governanceInitializeData = encodeCall(
     'initialize',
-    ['address', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-    [registry.address, votingPeriod, votingQuorum, maxInProgressProposals, maxDescriptionLength, guardianAddress]
+    ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
+    [registry.address, votingPeriod, executionDelay, votingQuorum, maxInProgressProposals, maxDescriptionLength, guardianAddress]
   )
   // Initialize proxy with zero address
   const governanceProxy = await AudiusAdminUpgradeabilityProxy.new(


### PR DESCRIPTION
Currently, a malicious actor can wait to vote to pass a proposal until right before the votingPeriod expires, and then immediately call execute it by calling `evaluateProposalOutcome()`. If the proposal was set to fail until the final vote came in, this creates a vulnerability, without giving sufficient time to veto. We have added an `executionDelay` to mitigate this, ensuring that there is sufficient time to veto a proposal after its votingPeriod has ended, before it can be executed.