### PR TITLE
upgrading libs in creator node

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -17,9 +17,9 @@
       }
     },
     "@audius/libs": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-0.12.2.tgz",
-      "integrity": "sha512-oCzTQXoEmSFsfRZjhE/deC7ysy9iX4mVexB5dTJ+XE78Y6xc5Y6sMInDwE4/VZ36Tf0Ipj5SIjhWTRRT1LeJ8Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-0.13.1.tgz",
+      "integrity": "sha512-FEi0dx3s+qwLWBhL/VxkNwCkvDdrSGpEPI7F7EZaHnGJxt5ycRHkbCUBJqNqKgwBDdYSWXWQVi2oihrWYSz2qA==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
         "abi-decoder": "^1.2.0",
@@ -241,62 +241,62 @@
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.135.tgz",
-      "integrity": "sha512-y9r/ajYBCDVM1ZD6kKgTRHBOxgURcQ24qTolw3oGyK373XHNrcY9ufDgZ5KR8h0OvLvczb4SGzYhahYvBnyZwA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
+      "integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
       "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.138",
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
-        "@ethersproject/keccak256": ">=5.0.0-beta.131",
-        "@ethersproject/logger": ">=5.0.0-beta.137",
-        "@ethersproject/rlp": ">=5.0.0-beta.132",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
         "bn.js": "^4.4.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.0-beta.139",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.139.tgz",
-      "integrity": "sha512-h1C1okCmPK3UVWwMGUbuCZykplJmD/TdknPQQHJWL/chK5MqBhyQ5o1Cay7mHXKCBnjWrR9BtwjfkAh76pYtFA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.2.tgz",
+      "integrity": "sha512-fy27wYrrgXCHSG1Y8WMrcZQC8L28X2+yRHvSMr/dXAS0BDqIjcT+QdiVAynbIzShALklZdMkKHBe0qA45nLNEQ==",
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
-        "@ethersproject/logger": ">=5.0.0-beta.137",
-        "@ethersproject/properties": ">=5.0.0-beta.140",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
         "bn.js": "^4.4.0"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.0-beta.138",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.138.tgz",
-      "integrity": "sha512-q4vaIthv89RJQ0V6gdzh1xuluJE1uYbnfzBUYTegicaXX6jRTCjDDhyiQhyEnNi7pKrGtuOrR3v3+7WtAR8Imw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
+      "integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
       "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.137"
+        "@ethersproject/logger": "^5.0.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.134.tgz",
-      "integrity": "sha512-tKKL7F3ozL+XgZ4+McNmp12rnPxKf+InKr36asVVAiVLa0WxnNsO9m/+0LkW5dMFbqn2i2VJtBwKfl1OE6GInA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
+      "integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
       "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.138"
+        "@ethersproject/bignumber": "^5.0.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.0-beta.134.tgz",
-      "integrity": "sha512-yvHyu+9Mgi4jn41DakA8tgHwngsSlTEyLBavP08GN3oS6fTiqflEMa4AXUFndztpcvk7UdGlowCOp6UupbmRVQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
+      "integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
-        "@ethersproject/keccak256": ">=5.0.0-beta.131",
-        "@ethersproject/logger": ">=5.0.0-beta.137",
-        "@ethersproject/strings": ">=5.0.0-beta.136"
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.132.tgz",
-      "integrity": "sha512-YpkwYGV4nu1QM7Q+mhYKO1bCk/sbiV7AAU/HnHwZhDiwJZSDRwfjiFkAJQpvTbsAR02Ek9LhFEBg4OfLTEhJLg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
+      "integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
+        "@ethersproject/bytes": "^5.0.0",
         "js-sha3": "0.5.7"
       },
       "dependencies": {
@@ -308,35 +308,78 @@
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.0-beta.137",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.137.tgz",
-      "integrity": "sha512-H36iMhWOY+tco1+o2NZUdQT8Gc6Y9795RSPgvluatvjvyt3X6mHtWXes4F8Rc5N/95px++a/ODYVSkSmlr68+A=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g=="
     },
     "@ethersproject/properties": {
-      "version": "5.0.0-beta.142",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.142.tgz",
-      "integrity": "sha512-Xd9pZHlUACNAfw7mp0hx0s6t7pjw+yv3xcc9VdHjrEXH45UpcUt80TxLIY7hc+1aEEgQXzewRr1TifuUTTjUnA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
+      "integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
       "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.137"
+        "@ethersproject/logger": "^5.0.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.133.tgz",
-      "integrity": "sha512-4zwGZov221uYuz6oXqAf2i5dk3ven7mSNkPRYvS2xdAlUn1Qy8GFUswyRuLaGzpWUGNlKIWCEnvomP5L/CtMPQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
+      "integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
-        "@ethersproject/logger": ">=5.0.0-beta.137"
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.2.tgz",
+      "integrity": "sha512-kgpCdtgoLoKXJTwJPw3ggRW7EO93YCQ98zY8hBpIb4OK3FxFCR3UUjlrGEwjMnLHDjFrxpKCeJagGWf477RyMQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "elliptic": "6.5.3"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.0-beta.137",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.137.tgz",
-      "integrity": "sha512-Z1xKXjoBWM5DOlc8HvjpOKO1zZ8kf4nLpf4C8zZjz+GNhaH03z74tXNNpdLf4UV6otMcHcJtO+X5ATE4TCn9Iw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
+      "integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.137",
-        "@ethersproject/constants": ">=5.0.0-beta.133",
-        "@ethersproject/logger": ">=5.0.0-beta.137"
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
+      "integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -757,44 +800,6 @@
       "version": "12.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
-    },
-    "@web3-js/scrypt-shim": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
-      "integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
-      "requires": {
-        "scryptsy": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "scryptsy": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-          "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
-        }
-      }
-    },
-    "@web3-js/websocket": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
-      "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
-      "requires": {
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "nan": "^2.14.0",
-        "typedarray-to-buffer": "^3.1.5",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -1572,9 +1577,9 @@
           "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
         },
         "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -1994,11 +1999,11 @@
           }
         },
         "multicodec": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
-          "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.3.tgz",
+          "integrity": "sha512-8G4JKbHWSe/39Xx2uiI+/b/S6mGgimzwEN4TOCokFUIfofg1T8eHny88ht9eWImD2dng+EEQRsApXxA5ubhU4g==",
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "varint": "^5.0.0"
           }
         }
@@ -3447,17 +3452,17 @@
       }
     },
     "ethereumjs-wallet": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
-      "integrity": "sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.4.tgz",
+      "integrity": "sha512-xAYLWVH/MA9Ds1+BiDTfdRrCBQIz7r70EJSjuBnvw/x40qJ1jBoBBAp8/l+I9VPGAsUXvHTfcnp2OZ9LbcTs/g==",
       "requires": {
         "aes-js": "^3.1.1",
         "bs58check": "^2.1.2",
         "ethereumjs-util": "^6.0.0",
-        "hdkey": "^1.1.0",
+        "hdkey": "^1.1.1",
         "randombytes": "^2.0.6",
         "safe-buffer": "^5.1.2",
-        "scrypt.js": "^0.3.0",
+        "scryptsy": "^1.2.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
       }
@@ -8606,9 +8611,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -9659,23 +9664,10 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.0.8"
-      }
-    },
-    "scrypt.js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
-      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
-      "requires": {
-        "scrypt": "^6.0.2",
-        "scryptsy": "^1.2.1"
-      }
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "scryptsy": {
       "version": "1.2.1",
@@ -11216,23 +11208,23 @@
       }
     },
     "web3": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.8.tgz",
-      "integrity": "sha512-rXUn16VKxn2aIe9v0KX+bSm2JXdq/Vnj3lZ0Rub2Q5YUSycHdCBaDtJRukl/jB5ygAdyr5/cUwvJzhNDJSYsGw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.9.tgz",
+      "integrity": "sha512-Mo5aBRm0JrcNpN/g4VOrDzudymfOnHRC3s2VarhYxRA8aWgF5rnhQ0ziySaugpic1gksbXPe105pUWyRqw8HUA==",
       "requires": {
-        "web3-bzz": "1.2.8",
-        "web3-core": "1.2.8",
-        "web3-eth": "1.2.8",
-        "web3-eth-personal": "1.2.8",
-        "web3-net": "1.2.8",
-        "web3-shh": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-bzz": "1.2.9",
+        "web3-core": "1.2.9",
+        "web3-eth": "1.2.9",
+        "web3-eth-personal": "1.2.9",
+        "web3-net": "1.2.9",
+        "web3-shh": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-bzz": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.8.tgz",
-      "integrity": "sha512-jbi24/s2tT7FYuN+ktRvTa5em0GxhqcIYQ8FnD3Zb/ZoEPi+/7rH0Hh+WDol0pSZL+wdz/iM+Z2C9NE42z6EmQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.9.tgz",
+      "integrity": "sha512-ogVQr9jHodu9HobARtvUSmWG22cv2EUQzlPeejGWZ7j5h20HX40EDuWyomGY5VclIj5DdLY76Tmq88RTf/6nxA==",
       "requires": {
         "@types/node": "^10.12.18",
         "got": "9.6.0",
@@ -11241,24 +11233,24 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-          "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         }
       }
     },
     "web3-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.8.tgz",
-      "integrity": "sha512-hvlYWyE1UcLoGa6qF1GoxGgi1quFsZOdwIUIVsAp+sp0plXp/Nqva2lAjJ+FFyWtVKbC7Zq+qwTJ4iP1aN0vTg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.9.tgz",
+      "integrity": "sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==",
       "requires": {
         "@types/bn.js": "^4.11.4",
         "@types/node": "^12.6.1",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-core-requestmanager": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core-helpers": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-core-requestmanager": "1.2.9",
+        "web3-utils": "1.2.9"
       },
       "dependencies": {
         "bignumber.js": {
@@ -11269,103 +11261,104 @@
       }
     },
     "web3-core-helpers": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.8.tgz",
-      "integrity": "sha512-Wrl7ZPKn3Xyg0Hl5+shDnJcLP+EtTfThmQ1eCJLcg/BZqvLUR1SkOslNlhEojcYeBwhhymAKs8dfQbtYi+HMnw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz",
+      "integrity": "sha512-t0WAG3orLCE3lqi77ZoSRNFok3VQWZXTniZigDQjyOJYMAX7BU3F3js8HKbjVnAxlX3tiKoDxI0KBk9F3AxYuw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-eth-iban": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-core-method": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.8.tgz",
-      "integrity": "sha512-69qbvOgx0Frw46dXvEKzYgtaPXpUaQAlQmczgb0ZUBHsEU2K7jTtFgBy6kVBgAwsXDvoZ99AX4SjpY2dTMwPkw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.9.tgz",
+      "integrity": "sha512-bjsIoqP3gs7A/gP8+QeLUCyOKJ8bopteCSNbCX36Pxk6TYfYWNuC6hP+2GzUuqdP3xaZNe+XEElQFUNpR3oyAg==",
       "requires": {
+        "@ethersproject/transactions": "^5.0.0-beta.135",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-promievent": "1.2.8",
-        "web3-core-subscriptions": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core-helpers": "1.2.9",
+        "web3-core-promievent": "1.2.9",
+        "web3-core-subscriptions": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-core-promievent": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.8.tgz",
-      "integrity": "sha512-3EdRieaHpBVVhfGjoREQfdoCM3xC0WwWjXXzT6oTldotfYC38kwk/GW8c8txYiLP/KxhslAN1cJSlXNOJjKSog==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz",
+      "integrity": "sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==",
       "requires": {
         "eventemitter3": "3.1.2"
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.8.tgz",
-      "integrity": "sha512-bwc2ABG6yzgTy28fv4t59g+tf6+UmTRMoF8HqTeiNDffoMKP2akyKFZeu1oD2gE7j/7GA75TAUjwJ7pH9ek1MA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.9.tgz",
+      "integrity": "sha512-1PwKV2m46ALUnIN5VPPgjOj8yMLJhhqZYvYJE34hTN5SErOkwhzx5zScvo5MN7v7KyQGFnpVCZKKGCiEnDmtFA==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.8",
-        "web3-providers-http": "1.2.8",
-        "web3-providers-ipc": "1.2.8",
-        "web3-providers-ws": "1.2.8"
+        "web3-core-helpers": "1.2.9",
+        "web3-providers-http": "1.2.9",
+        "web3-providers-ipc": "1.2.9",
+        "web3-providers-ws": "1.2.9"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.8.tgz",
-      "integrity": "sha512-wmsRJ4ipwoF1mlOR+Oo8JdKigpkoVNQtqiRUuyQrTVhJx7GBuSaAIenpBYlkucC+RgByoGybR7Q3tTNJ6z/2tQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz",
+      "integrity": "sha512-Y48TvXPSPxEM33OmXjGVDMzTd0j8X0t2+sDw66haeBS8eYnrEzasWuBZZXDq0zNUsqyxItgBGDn+cszkgEnFqg==",
       "requires": {
         "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.8"
+        "web3-core-helpers": "1.2.9"
       }
     },
     "web3-eth": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.8.tgz",
-      "integrity": "sha512-CEnVIIR1zZQ9vQh/kPFAUbvbbHYkC84y15jdhRUDDGR6bs4FxO2NNWR2YDtNe038lrz747tZahsC9kEiGkJFZQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.9.tgz",
+      "integrity": "sha512-sIKO4iE9FEBa/CYUd6GdPd7GXt/wISqxUd8PlIld6+hvMJj02lgO7Z7p5T9mZIJcIZJGvZX81ogx8oJ9yif+Ag==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.2.8",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-core-subscriptions": "1.2.8",
-        "web3-eth-abi": "1.2.8",
-        "web3-eth-accounts": "1.2.8",
-        "web3-eth-contract": "1.2.8",
-        "web3-eth-ens": "1.2.8",
-        "web3-eth-iban": "1.2.8",
-        "web3-eth-personal": "1.2.8",
-        "web3-net": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-core-subscriptions": "1.2.9",
+        "web3-eth-abi": "1.2.9",
+        "web3-eth-accounts": "1.2.9",
+        "web3-eth-contract": "1.2.9",
+        "web3-eth-ens": "1.2.9",
+        "web3-eth-iban": "1.2.9",
+        "web3-eth-personal": "1.2.9",
+        "web3-net": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-eth-abi": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.8.tgz",
-      "integrity": "sha512-OKp/maLdKHPpQxZhEd0HgnCJFQajsGe42WOG6SVftlgzyR8Jjv4KNm46TKvb3hv5OJTKZWU7nZIxkEG+fyI58w==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz",
+      "integrity": "sha512-3YwUYbh/DMfDbhMWEebAdjSd5bj3ZQieOjLzWFHU23CaLEqT34sUix1lba+hgUH/EN6A7bKAuKOhR3p0OvTn7Q==",
       "requires": {
         "@ethersproject/abi": "5.0.0-beta.153",
         "underscore": "1.9.1",
-        "web3-utils": "1.2.8"
+        "web3-utils": "1.2.9"
       }
     },
     "web3-eth-accounts": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.8.tgz",
-      "integrity": "sha512-QODqSD4SZN/1oWfvlvsuum6Ud9+2FUTW4VTPJh245YTewCpa0M5+Fzug3UTeUZNv88STwC//dV72zReITNh4ZQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.9.tgz",
+      "integrity": "sha512-jkbDCZoA1qv53mFcRHCinoCsgg8WH+M0YUO1awxmqWXRmCRws1wW0TsuSQ14UThih5Dxolgl+e+aGWxG58LMwg==",
       "requires": {
-        "@web3-js/scrypt-shim": "^0.1.0",
         "crypto-browserify": "3.12.0",
         "eth-lib": "^0.2.8",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
+        "scrypt-js": "^3.0.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.2.8",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-utils": "1.2.9"
       },
       "dependencies": {
         "eth-lib": {
@@ -11390,44 +11383,44 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.8.tgz",
-      "integrity": "sha512-EWRLVhZksbzGAyHd7RaOsakjCJBA2BREWiJmBDlrxDBqw8HltXFzKdkRug/mwVNa5ZYMabKSRF/MMh0Sx06CFw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz",
+      "integrity": "sha512-PYMvJf7EG/HyssUZa+pXrc8IB06K/YFfWYyW4R7ed3sab+9wWUys1TlWxBCBuiBXOokSAyM6H6P6/cKEx8FT8Q==",
       "requires": {
         "@types/bn.js": "^4.11.4",
         "underscore": "1.9.1",
-        "web3-core": "1.2.8",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-core-promievent": "1.2.8",
-        "web3-core-subscriptions": "1.2.8",
-        "web3-eth-abi": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-core-promievent": "1.2.9",
+        "web3-core-subscriptions": "1.2.9",
+        "web3-eth-abi": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-eth-ens": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.8.tgz",
-      "integrity": "sha512-zsFXY26BMGkihPkEO5qj9AEqyxPH4mclbzYs1dyrw7sHFmrUvhZc+jLGT9WyQGoujq37RN2l/tlOpCaFVVR8ng==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.9.tgz",
+      "integrity": "sha512-kG4+ZRgZ8I1WYyOBGI8QVRHfUSbbJjvJAGA1AF/NOW7JXQ+x7gBGeJw6taDWJhSshMoEKWcsgvsiuoG4870YxQ==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.2.8",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-promievent": "1.2.8",
-        "web3-eth-abi": "1.2.8",
-        "web3-eth-contract": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-promievent": "1.2.9",
+        "web3-eth-abi": "1.2.9",
+        "web3-eth-contract": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-eth-iban": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.8.tgz",
-      "integrity": "sha512-xgPUOuDOQJYloUS334/wot6jvp6K8JBz8UvQ1tAxU9LO2v2DW+IDTJ5gQ6TdutTmzdDi97KdwhwnQwhQh5Z1PA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz",
+      "integrity": "sha512-RtdVvJE0pyg9dHLy0GzDiqgnLnssSzfz/JYguhC1wsj9+Gnq1M6Diy3NixACWUAp6ty/zafyOaZnNQ+JuH9TjQ==",
       "requires": {
         "bn.js": "4.11.8",
-        "web3-utils": "1.2.8"
+        "web3-utils": "1.2.9"
       },
       "dependencies": {
         "bn.js": {
@@ -11438,56 +11431,56 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.8.tgz",
-      "integrity": "sha512-sWhxF1cpF9pB1wMISrOSy/i8IB1NWtvoXT9dfkWtvByGf3JfC2DlnllLaA1f9ohyvxnR+QTgPKgOQDknmqDstw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.9.tgz",
+      "integrity": "sha512-cFiNrktxZ1C/rIdJFzQTvFn3/0zcsR3a+Jf8Y3KxeQDHszQtosjLWptP7bsUmDwEh4hzh0Cy3KpOxlYBWB8bJQ==",
       "requires": {
         "@types/node": "^12.6.1",
-        "web3-core": "1.2.8",
-        "web3-core-helpers": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-net": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-net": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-net": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.8.tgz",
-      "integrity": "sha512-Nsq6qgncvvThOjC+sQ+NfDH8L7jclQCFzLFYa9wsd5J6HJ6f5gJl/mv6rsZQX9iDEYDPKkDfyqHktynOBgKWMQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.9.tgz",
+      "integrity": "sha512-d2mTn8jPlg+SI2hTj2b32Qan6DmtU9ap/IUlJTeQbZQSkTLf0u9suW8Vjwyr4poJYXTurdSshE7OZsPNn30/ZA==",
       "requires": {
-        "web3-core": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-utils": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-utils": "1.2.9"
       }
     },
     "web3-providers-http": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.8.tgz",
-      "integrity": "sha512-Esj4SpgabmBDOR4QD3qYapzwFYWHigcdgdjvt/VWT5/7TD10o52hr+Nsvp3/XV5AFrcCMdY+lzKFLVH24u0sww==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.9.tgz",
+      "integrity": "sha512-F956tCIj60Ttr0UvEHWFIhx+be3He8msoPzyA44/kfzzYoMAsCFRn5cf0zQG6al0znE75g6HlWVSN6s3yAh51A==",
       "requires": {
-        "web3-core-helpers": "1.2.8",
+        "web3-core-helpers": "1.2.9",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.8.tgz",
-      "integrity": "sha512-ts3/UXCTRADPASdJ27vBVmcfM+lfG9QVBxGedY6+oNIo5EPxBUtsz94R32sfvFd6ofPsz6gOhK/M/ZKiJoi1sg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz",
+      "integrity": "sha512-NQ8QnBleoHA2qTJlqoWu7EJAD/FR5uimf7Ielzk4Z2z+m+6UAuJdJMSuQNj+Umhz9L/Ys6vpS1vHx9NizFl+aQ==",
       "requires": {
         "oboe": "2.1.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.8"
+        "web3-core-helpers": "1.2.9"
       }
     },
     "web3-providers-ws": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.8.tgz",
-      "integrity": "sha512-Gcm0n82wd/XVeGFGTx+v56UqyrV9EyB2r1QFaBx4mS+VHbW2MCOdiRbNDfoZQslflnCWl8oHsivJ8Tya9kqlTQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.9.tgz",
+      "integrity": "sha512-6+UpvINeI//dglZoAKStUXqxDOXJy6Iitv2z3dbgInG4zb8tkYl/VBDL80UjUg3ZvzWG0g7EKY2nRPEpON2TFA==",
       "requires": {
-        "@web3-js/websocket": "^1.0.29",
         "eventemitter3": "^4.0.0",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.8"
+        "web3-core-helpers": "1.2.9",
+        "websocket": "^1.0.31"
       },
       "dependencies": {
         "eventemitter3": {
@@ -11498,20 +11491,20 @@
       }
     },
     "web3-shh": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.8.tgz",
-      "integrity": "sha512-e29qKSfuZWDmxCG/uB48Nth6DCFFr2h2U+uI/fHEuhEjAEkBHopPNLc3ixrCTc6pqMocfJRPHJq/yET9PYN3oQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.9.tgz",
+      "integrity": "sha512-PWa8b/EaxaMinFaxy6cV0i0EOi2M7a/ST+9k9nhyhCjVa2vzXuNoBNo2IUOmeZ0WP2UQB8ByJ2+p4htlJaDOjA==",
       "requires": {
-        "web3-core": "1.2.8",
-        "web3-core-method": "1.2.8",
-        "web3-core-subscriptions": "1.2.8",
-        "web3-net": "1.2.8"
+        "web3-core": "1.2.9",
+        "web3-core-method": "1.2.9",
+        "web3-core-subscriptions": "1.2.9",
+        "web3-net": "1.2.9"
       }
     },
     "web3-utils": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
-      "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+      "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
@@ -11536,6 +11529,28 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
+          }
+        }
+      }
+    },
+    "websocket": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
+      "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@audius/libs": "0.12.2",
+    "@audius/libs": "^0.13.1",
     "JSONStream": "^1.3.5",
     "axios": "^0.19.0",
     "base64-url": "^2.2.0",

--- a/creator-node/src/index.js
+++ b/creator-node/src/index.js
@@ -48,7 +48,7 @@ const initAudiusLibs = async () => {
         ownerWallet: config.get('delegateOwnerWallet')
       }
     },
-    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(true, discoveryProviderWhitelist)
+    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(discoveryProviderWhitelist)
   })
   await audiusLibs.init()
   return audiusLibs


### PR DESCRIPTION
creator node local startup fails with the older version of libs and this error occurs when selecting an endpoint for the disc provs using the disc prov route /version:
```
Error: Invalid semver version found - [object Object]
```

the libs upgrade includes replacing the axios request from /version to /health_check, as /health_check includes the version now.