### PR TITLE
[mainnet-audit] upgradeToAndCall permissions restriction

### DIFF
--- a/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
+++ b/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
@@ -43,7 +43,26 @@ contract AudiusAdminUpgradeabilityProxy is AdminUpgradeabilityProxy {
             msg.sender == governanceAddress,
             "Caller must be current proxy governance address"
         );
-        _upgradeTo(_newImplementation);
+        super._upgradeTo(_newImplementation); //_upgradeTo(_newImplementation);
+    }
+
+    /**
+     * @notice Upgrade the address of the logic contract for this proxy and invoke a function
+     * @dev Wrapper on AdminUpgradeabilityProxy.upgradeToAndCall.
+     *      Adds a check to ensure msg.sender is the Audius Governance contract.
+     * @param _newImplementation - new address of logic contract that the proxy will point to
+     * @param _data - data for the initial function
+     */
+    // solium-disable security/no-low-level-calls
+    function upgradeToAndCall(address _newImplementation, bytes calldata _data) external payable {
+        require(
+            msg.sender == governanceAddress,
+            "Caller must be current proxy governance address"
+        );
+        // this.upgradeToAndCall(_newImplementation, _callData);
+        super._upgradeTo(_newImplementation);
+        (bool success,) = _newImplementation.delegatecall(_data);
+        require(success == true, "Failed to invoke provided function");
     }
 
     /// @notice Returns the Audius governance address

--- a/eth-contracts/contracts/test/MockStakingCaller.sol
+++ b/eth-contracts/contracts/test/MockStakingCaller.sol
@@ -113,10 +113,21 @@ contract MockStakingCaller is InitializableV2 {
     }
 
     /// Governance mock functions
-    function upgradeTo(address _newImplementation) external {
+    function upgradeStakingTo(address _newImplementation) external {
         _requireIsInitialized();
 
         return AudiusAdminUpgradeabilityProxy(stakingAddress).upgradeTo(_newImplementation);
+    }
+
+    function upgradeStakingToAndCall(
+        address _newImplementation,
+        bytes calldata _data
+    ) external payable {
+        _requireIsInitialized();
+        return AudiusAdminUpgradeabilityProxy(stakingAddress).upgradeToAndCall(
+            _newImplementation,
+            _data
+        );
     }
 
     function setAudiusGovernanceAddress(address _governanceAddress) external {

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -165,6 +165,21 @@ contract('Upgrade proxy test', async (accounts) => {
     assert.equal(newFunctionResp, 5)
   })
 
+  it.only('upgradeToAndCall - stakingUpgraded', async () => {
+    staking = await StakingUpgraded.at(proxy.address)
+
+    await _lib.assertRevert(
+      proxy.upgradeTo(stakingUpgraded.address, { from: proxyAdminAddress }),
+      "Caller must be current proxy governance address"
+    )
+    const initializeCallData = _lib.encodeCall('newFunction', [], [])
+
+    // This should NOT be possible from the proxyAdminAddress
+    await proxy.upgradeToAndCall(stakingUpgraded.address, initializeCallData, { from: proxyAdminAddress })
+    let r = await staking.newFunction()
+    assert.isTrue(r.eq(_lib.toBN(5)), 'Test function returned, should never have reached here')
+  })
+
   it('Initialize with no governance address and set value from admin', async () => {
     let noGovProxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,


### PR DESCRIPTION
* Example of how we can restrict upgradeToAndCall, including corresponding test case
* Does not account for orphaned admin address in proxy contract, or any issues deriving from said address