### PR TITLE
fix export ipfsPath using filename column value in files table

### DIFF
--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -173,8 +173,8 @@ async function rehydrateIpfsDirFromFsIfNecessary (req, dirHash) {
 
   let rehydrateNecessary = false
   for (let entry of findOriginalFileQuery) {
-    let sourcePath = entry.sourceFile
-    let ipfsPath = `${dirHash}/${sourcePath}`
+    let filename = entry.fileName
+    let ipfsPath = `${dirHash}/${filename}`
     req.logger.info(`rehydrateIpfsDirFromFsIfNecessary, ipfsPath: ${ipfsPath}`)
     try {
       ipfsSingleByteCat(ipfsPath, req)

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -177,7 +177,7 @@ async function rehydrateIpfsDirFromFsIfNecessary (req, dirHash) {
     let ipfsPath = `${dirHash}/${filename}`
     req.logger.info(`rehydrateIpfsDirFromFsIfNecessary, ipfsPath: ${ipfsPath}`)
     try {
-      ipfsSingleByteCat(ipfsPath, req)
+      await ipfsSingleByteCat(ipfsPath, req)
     } catch (e) {
       rehydrateNecessary = true
       req.logger.info(`rehydrateIpfsDirFromFsIfNecessary - error condition met ${ipfsPath}, ${e}`)


### PR DESCRIPTION
Testing process:
1. Bring up entire local system
2. Upload a song to dapp
3. Write a test route to directly call `rehydrateIpfsDirFromFsIfNecessary` with a dirCID listed in the Files table
```
app.get('/test', handleResponse(async (req, res) => {
    try {
      await rehydrateIpfsDirFromFsIfNecessary(req, 'QmbXxYtfXVHtmWvPC8i9Kzxu2uXQRUqXZHNdQc4UzoFkZM')
    } catch (e) {
      req.logger.error(`something went wrong: ${e}`)
    }

    return successResponse({ hash: 'QmbXxYtfXVHtmWvPC8i9Kzxu2uXQRUqXZHNdQc4UzoFkZM' })
  })
```

-- for files existing in ipfs -- 
4. hit localhost:4000/test and checked docker logs to ensure that 
- the file is present in ipfs 
- no error regarding  'no link found' error shows up

-- for files not existing in ipfs --
5. ran `ipfs repo gc` on both local ipfs containers
6. hit localhost:4000/test and checked docker logs to ensure that
- the file is not present in ipfs
- ipfs gets rehydrated with file from fs
- no error regarding  'no link found' error shows up


7. hit localhost:4000/ipfs/:dirCID/:filename to ensure image is served