### PR TITLE
[mainnet] Consume UpgradeabilityProxy in AudiusAdminUpgradeabilityProxy

### DIFF
--- a/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
+++ b/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/upgrades/contracts/upgradeability/UpgradeabilityProxy.sol"
 /**
  * Wrapper around OpenZeppelin's UpgradeabilityProxy contract.
  * Permissions proxy upgrade logic to Audius Governance contract.
- * https://github.com/OpenZeppelin/openzeppelin-sdk/blob/release/2.8/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+ * https://github.com/OpenZeppelin/openzeppelin-sdk/blob/release/2.8/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
  */
 contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
     address private governanceAddress;

--- a/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
+++ b/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
@@ -4,9 +4,11 @@ import "@openzeppelin/upgrades/contracts/upgradeability/UpgradeabilityProxy.sol"
 
 
 /**
- * Wrapper around OpenZeppelin's UpgradeabilityProxy contract.
+ * @notice Wrapper around OpenZeppelin's UpgradeabilityProxy contract.
  * Permissions proxy upgrade logic to Audius Governance contract.
  * https://github.com/OpenZeppelin/openzeppelin-sdk/blob/release/2.8/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
+ * @dev Any logic contract that has a signature clash with this proxy contract will be unable to call those functions
+ *      Please ensure logic contract functions do not share a signature with any functions defined in this file
  */
 contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
     address private proxyAdmin;

--- a/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
+++ b/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
@@ -9,8 +9,10 @@ import "@openzeppelin/upgrades/contracts/upgradeability/UpgradeabilityProxy.sol"
  * https://github.com/OpenZeppelin/openzeppelin-sdk/blob/release/2.8/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
  */
 contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
-    address private governanceAddress;
     address private proxyAdmin;
+    string private constant ERROR_ONLY_ADMIN = (
+        "AudiusAdminUpgradeabilityProxy: Caller must be current proxy admin"
+    );
 
     /**
      * @notice Sets admin address for future upgrades
@@ -39,21 +41,20 @@ contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
      * @param _newImplementation - new address of logic contract that the proxy will point to
      */
     function upgradeTo(address _newImplementation) external {
-        require(
-            msg.sender == proxyAdmin,
-            "Caller must be current proxy admin"
-        );
+        require(msg.sender == proxyAdmin, ERROR_ONLY_ADMIN);
         _upgradeTo(_newImplementation);
     }
 
-    /// @notice Returns the Audius governance address
+    /**
+     * @return Current proxy admin address
+     */
     function getAudiusProxyAdminAddress() external view returns (address) {
         return proxyAdmin;
     }
 
     /**
-    * @return The address of the implementation.
-    */
+     * @return The address of the implementation.
+     */
     function implementation() external view returns (address) {
         return _implementation();
     }
@@ -64,10 +65,7 @@ contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
      * @param _adminAddress - new admin address
      */
     function setAudiusProxyAdminAddress(address _adminAddress) external {
-        require(
-            msg.sender == proxyAdmin,
-            "Caller must be proxy admin or proxy upgrader"
-        );
+        require(msg.sender == proxyAdmin, ERROR_ONLY_ADMIN);
         proxyAdmin = _adminAddress;
     }
 }

--- a/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
+++ b/eth-contracts/contracts/AudiusAdminUpgradeabilityProxy.sol
@@ -1,67 +1,73 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/upgrades/contracts/upgradeability/AdminUpgradeabilityProxy.sol";
+import "@openzeppelin/upgrades/contracts/upgradeability/UpgradeabilityProxy.sol";
 
 
 /**
- * Wrapper around OpenZeppelin's AdminUpgradeabilityProxy contract.
+ * Wrapper around OpenZeppelin's UpgradeabilityProxy contract.
  * Permissions proxy upgrade logic to Audius Governance contract.
  * https://github.com/OpenZeppelin/openzeppelin-sdk/blob/release/2.8/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
  */
-contract AudiusAdminUpgradeabilityProxy is AdminUpgradeabilityProxy {
+contract AudiusAdminUpgradeabilityProxy is UpgradeabilityProxy {
     address private governanceAddress;
+    address private proxyAdmin;
 
     /**
-     * @notice Sets governance address for future upgrades
+     * @notice Sets admin address for future upgrades
      * @param _logic - address of underlying logic contract.
-     *      Passed to AdminUpgradeabilityProxy constructor.
-     * @param _proxyAdmin - address of proxy admin, but cedes upgrade control to _governanceAddress.
-     *      Passed to AdminUpgradeabilityProxy constructor.
+     *      Passed to UpgradeabilityProxy constructor.
+     * @param _proxyAdmin - address of proxy admin
+     *      Set to governance contract address for all non-governance contracts
+     *      Governance is deployed and upgraded to have own address as admin
      * @param _data - data of function to be called on logic contract.
-     *      Passed to AdminUpgradeabilityProxy constructor.
-     * @param _governanceAddress - address of Audius governance contract, which has proxy upgrade control.
+     *      Passed to UpgradeabilityProxy constructor.
      */
     constructor(
       address _logic,
       address _proxyAdmin,
-      bytes memory _data,
-      address _governanceAddress
+      bytes memory _data
     )
-    AdminUpgradeabilityProxy(_logic, _proxyAdmin, _data) public payable
+    UpgradeabilityProxy(_logic, _data) public payable
     {
-        governanceAddress = _governanceAddress;
+        proxyAdmin = _proxyAdmin;
     }
 
     /**
      * @notice Upgrade the address of the logic contract for this proxy
-     * @dev Wrapper on AdminUpgradeabilityProxy._upgradeTo.
-     *      Adds a check to ensure msg.sender is the Audius Governance contract.
+     * @dev Recreation of AdminUpgradeabilityProxy._upgradeTo.
+     *      Adds a check to ensure msg.sender is the Audius Proxy Admin
      * @param _newImplementation - new address of logic contract that the proxy will point to
      */
     function upgradeTo(address _newImplementation) external {
         require(
-            msg.sender == governanceAddress,
-            "Caller must be current proxy governance address"
+            msg.sender == proxyAdmin,
+            "Caller must be current proxy admin"
         );
         _upgradeTo(_newImplementation);
     }
 
     /// @notice Returns the Audius governance address
-    function getAudiusGovernanceAddress() external view returns (address) {
-        return governanceAddress;
+    function getAudiusProxyAdminAddress() external view returns (address) {
+        return proxyAdmin;
     }
 
     /**
-     * @notice Set the Audius Governance address
-     * @dev Callable by admin if governance address not yet set, else by Governance
-     * @param _governanceAddress - address of Governance contract
+    * @return The address of the implementation.
+    */
+    function implementation() external view returns (address) {
+        return _implementation();
+    }
+
+    /**
+     * @notice Set the Audius Proxy Admin
+     * @dev Only callable by current proxy admin address
+     * @param _adminAddress - new admin address
      */
-    function setAudiusGovernanceAddress(address _governanceAddress) external {
+    function setAudiusProxyAdminAddress(address _adminAddress) external {
         require(
-            msg.sender == governanceAddress ||
-            (governanceAddress == address(0x0) && msg.sender == _admin()),
+            msg.sender == proxyAdmin,
             "Caller must be proxy admin or proxy upgrader"
         );
-        governanceAddress = _governanceAddress;
+        proxyAdmin = _adminAddress;
     }
 }

--- a/eth-contracts/contracts/test/MockStakingCaller.sol
+++ b/eth-contracts/contracts/test/MockStakingCaller.sol
@@ -119,12 +119,12 @@ contract MockStakingCaller is InitializableV2 {
         return AudiusAdminUpgradeabilityProxy(stakingAddress).upgradeTo(_newImplementation);
     }
 
-    function setAudiusGovernanceAddress(address _governanceAddress) external {
+    function setAudiusProxyAdminAddress(address _governanceAddress) external {
         _requireIsInitialized();
 
         return AudiusAdminUpgradeabilityProxy(
             stakingAddress
-        ).setAudiusGovernanceAddress(_governanceAddress);
+        ).setAudiusProxyAdminAddress(_governanceAddress);
     }
 
     /// @notice Used to check if is governance contract before setting governance address in other contracts

--- a/eth-contracts/contracts/test/MockStakingCaller.sol
+++ b/eth-contracts/contracts/test/MockStakingCaller.sol
@@ -113,7 +113,7 @@ contract MockStakingCaller is InitializableV2 {
     }
 
     /// Governance mock functions
-    function upgradeTo(address _newImplementation) external {
+    function upgradeStakingTo(address _newImplementation) external {
         _requireIsInitialized();
 
         return AudiusAdminUpgradeabilityProxy(stakingAddress).upgradeTo(_newImplementation);

--- a/eth-contracts/contracts/test/MockStakingCaller.sol
+++ b/eth-contracts/contracts/test/MockStakingCaller.sol
@@ -119,7 +119,7 @@ contract MockStakingCaller is InitializableV2 {
         return AudiusAdminUpgradeabilityProxy(stakingAddress).upgradeTo(_newImplementation);
     }
 
-    function setAudiusProxyAdminAddress(address _governanceAddress) external {
+    function setStakingAudiusProxyAdminAddress(address _governanceAddress) external {
         _requireIsInitialized();
 
         return AudiusAdminUpgradeabilityProxy(

--- a/eth-contracts/contracts/test/MockStakingCaller.sol
+++ b/eth-contracts/contracts/test/MockStakingCaller.sol
@@ -131,5 +131,11 @@ contract MockStakingCaller is InitializableV2 {
     function isGovernanceAddress() external pure returns (bool) {
         return true;
     }
+
+    /// @notice Used to intentionally generate a function signature clash with AudiusAdminUpgradeabilityProxy
+    ///         Returns current address instead of proxy admin address
+    function getAudiusProxyAdminAddress() external view returns (address) {
+        return address(this);
+    }
 }
 

--- a/eth-contracts/migrations/2_registry_migration.js
+++ b/eth-contracts/migrations/2_registry_migration.js
@@ -22,13 +22,12 @@ module.exports = (deployer, network, accounts) => {
       registry0.address,
       proxyAdminAddress,
       initializeCallData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
     const registry = await Registry.at(registryProxy.address)
 
     assert.equal(await registry.owner.call(), proxyDeployerAddress)
-    assert.equal(await registryProxy.getAudiusGovernanceAddress.call(), _lib.addressZero)
+    assert.equal(await registryProxy.getAudiusProxyAdminAddress.call(), proxyAdminAddress)
 
     // Register Registry in self to enable governance by key
     await registry.addContract(registryRegKey, registry.address, { from: proxyDeployerAddress })

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -32,6 +32,7 @@ module.exports = (deployer, network, accounts) => {
 
     const registryAddress = process.env.registryAddress
     const registry = await Registry.at(registryAddress)
+    const registryProxy = await AudiusAdminUpgradeabilityProxy.at(registryAddress)
 
     // Deploy + register Governance
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
@@ -55,6 +56,11 @@ module.exports = (deployer, network, accounts) => {
     await governanceProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
     govAddrFromProxy = await governanceProxy.getAudiusProxyAdminAddress.call()
     assert.equal(govAddrFromProxy, governanceProxy.address)
+
+    // Set governance address on Registry proxy contract to enable upgrades
+    await registryProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
+    let govAddrFromRegProxy = await registryProxy.getAudiusProxyAdminAddress()
+    assert.equal(govAddrFromRegProxy, governanceProxy.address)
 
     // Transfer registry ownership to Governance
     await registry.transferOwnership(governance.address, { from: proxyDeployerAddress })

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -45,16 +45,15 @@ module.exports = (deployer, network, accounts) => {
       governance0.address,
       proxyAdminAddress,
       initializeCallData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
     const governance = await Governance.at(governanceProxy.address)
 
     // Set governance Address on Governance proxy contract to enable self-upgradeability
-    let govAddrFromProxy = await governanceProxy.getAudiusGovernanceAddress.call()
-    assert.equal(govAddrFromProxy, _lib.addressZero)
-    await governanceProxy.setAudiusGovernanceAddress(governanceProxy.address, { from: proxyAdminAddress })
-    govAddrFromProxy = await governanceProxy.getAudiusGovernanceAddress.call()
+    let govAddrFromProxy = await governanceProxy.getAudiusProxyAdminAddress.call()
+    assert.equal(govAddrFromProxy, proxyAdminAddress)
+    await governanceProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
+    govAddrFromProxy = await governanceProxy.getAudiusProxyAdminAddress.call()
     assert.equal(govAddrFromProxy, governanceProxy.address)
 
     // Transfer registry ownership to Governance

--- a/eth-contracts/migrations/4_token_migration.js
+++ b/eth-contracts/migrations/4_token_migration.js
@@ -31,9 +31,8 @@ module.exports = (deployer, network, accounts) => {
     const tokenProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       token0.address,
-      proxyAdminAddress,
-      initializeCallData,
       governanceAddress,
+      initializeCallData,
       { from: proxyDeployerAddress }
     )
     const token = await AudiusToken.at(tokenProxy.address)

--- a/eth-contracts/migrations/5_staking_migration.js
+++ b/eth-contracts/migrations/5_staking_migration.js
@@ -34,9 +34,8 @@ module.exports = (deployer, network, accounts) => {
     const stakingProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       staking0.address,
-      proxyAdminAddress,
-      initializeCallData,
       process.env.governanceAddress,
+      initializeCallData,
       { from: proxyDeployerAddress }
     )
     _lib.registerContract(governance, stakingProxyKey, stakingProxy.address, guardianAddress)

--- a/eth-contracts/migrations/6_claims_manager_migration.js
+++ b/eth-contracts/migrations/6_claims_manager_migration.js
@@ -41,9 +41,8 @@ module.exports = (deployer, network, accounts) => {
     const claimsManagerProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       claimsManager0.address,
-      proxyAdminAddress,
-      initializeCallData,
       governanceAddress,
+      initializeCallData,
       { from: proxyDeployerAddress }
     )
 

--- a/eth-contracts/migrations/7_versioning_service_migration.js
+++ b/eth-contracts/migrations/7_versioning_service_migration.js
@@ -60,9 +60,8 @@ module.exports = (deployer, network, accounts) => {
     const serviceTypeManagerProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       serviceTypeManager0.address,
-      proxyAdminAddress,
-      serviceTypeCalldata,
       process.env.governanceAddress,
+      serviceTypeCalldata,
       { from: proxyDeployerAddress }
     )
     const serviceTypeManager = await ServiceTypeManager.at(serviceTypeManagerProxy.address)
@@ -113,9 +112,8 @@ module.exports = (deployer, network, accounts) => {
     const serviceProviderFactoryProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       serviceProviderFactory0.address,
-      proxyAdminAddress,
-      serviceProviderFactoryCalldata,
       process.env.governanceAddress,
+      serviceProviderFactoryCalldata,
       { from: proxyDeployerAddress }
     )
     await _lib.registerContract(governance, serviceProviderFactoryKey, serviceProviderFactoryProxy.address, guardianAddress)

--- a/eth-contracts/migrations/8_delegate_manager_migration.js
+++ b/eth-contracts/migrations/8_delegate_manager_migration.js
@@ -48,9 +48,8 @@ module.exports = (deployer, network, accounts) => {
     const delegateManagerProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,
       delegateManager0.address,
-      proxyAdminAddress,
-      initializeCallData,
       governanceAddress,
+      initializeCallData,
       { from: proxyDeployerAddress }
     )
 

--- a/eth-contracts/test/claimsManager.test.js
+++ b/eth-contracts/test/claimsManager.test.js
@@ -78,9 +78,8 @@ contract('ClaimsManager', async (accounts) => {
     )
     stakingProxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       governance.address,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
     await registry.addContract(stakingProxyKey, stakingProxy.address, { from: proxyDeployerAddress })
@@ -100,9 +99,8 @@ contract('ClaimsManager', async (accounts) => {
     )
     claimsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       claimsManager0.address,
-      proxyAdminAddress,
-      claimsInitializeCallData,
       governance.address,
+      claimsInitializeCallData,
       { from: proxyDeployerAddress }
     )
     claimsManager = await ClaimsManager.at(claimsManagerProxy.address)

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -86,9 +86,8 @@ contract('DelegateManager', async (accounts) => {
     )
     const stakingProxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       governance.address,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
     staking = await Staking.at(stakingProxy.address)
@@ -102,9 +101,8 @@ contract('DelegateManager', async (accounts) => {
     let serviceTypeManager0 = await ServiceTypeManager.new({ from: proxyDeployerAddress })
     let serviceTypeManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceTypeManager0.address,
-      proxyAdminAddress,
-      serviceTypeInitializeData,
       governance.address,
+      serviceTypeInitializeData,
       { from: proxyDeployerAddress }
     )
     await registry.addContract(serviceTypeManagerProxyKey, serviceTypeManagerProxy.address, { from: proxyDeployerAddress })
@@ -122,9 +120,8 @@ contract('DelegateManager', async (accounts) => {
     )
     let serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,
-      proxyAdminAddress,
-      serviceProviderFactoryCalldata,
       governance.address,
+      serviceProviderFactoryCalldata,
       { from: proxyDeployerAddress }
     )
     serviceProviderFactory = await ServiceProviderFactory.at(serviceProviderFactoryProxy.address)
@@ -139,9 +136,8 @@ contract('DelegateManager', async (accounts) => {
     )
     claimsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       claimsManager0.address,
-      proxyAdminAddress,
-      claimsInitializeCallData,
       governance.address,
+      claimsInitializeCallData,
       { from: proxyDeployerAddress }
     )
     claimsManager = await ClaimsManager.at(claimsManagerProxy.address)
@@ -170,9 +166,8 @@ contract('DelegateManager', async (accounts) => {
     let delegateManager0 = await DelegateManager.new({ from: proxyDeployerAddress })
     let delegateManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       delegateManager0.address,
-      proxyAdminAddress,
-      delegateManagerInitializeData,
       governance.address,
+      delegateManagerInitializeData,
       { from: proxyDeployerAddress }
     )
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -2067,6 +2067,26 @@ contract('Governance.sol', async (accounts) => {
       )
     })
 
+    it('Update proxy admin address', async () => {
+      let stakingProxy = await AudiusAdminUpgradeabilityProxy.at(staking.address)
+      let currentAdmin = await stakingProxy.getAudiusProxyAdminAddress()
+      assert.equal(currentAdmin, governance.address, 'Expect governance to be admin')
+      let newAdmin = accounts[9]
+
+      // Execute tx to change admin
+      // NOTE - In reality, this function should rarely if ever be invoked from governance
+      //        After migrations, all contract admins are ALREADY governance
+      await governance.guardianExecuteTransaction(
+        stakingProxyKey,
+        callValue0,
+        'setAudiusProxyAdminAddress(address)',
+        _lib.abiEncode(['address'], [newAdmin]),
+        { from: guardianAddress }
+      )
+      currentAdmin = await stakingProxy.getAudiusProxyAdminAddress()
+      assert.equal(currentAdmin, newAdmin, 'Expect updated admin')
+    })
+
     it('Upgrade governance contract', async () => {
       // Confirm governance.newFunction() not callable before upgrade
       const governanceCopy = await GovernanceUpgraded.at(governance.address)

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -83,7 +83,6 @@ contract('Governance.sol', async (accounts) => {
       registry0.address,
       proxyAdminAddress,
       registryInitData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
     registry = await Registry.at(registryProxy.address)
@@ -112,9 +111,8 @@ contract('Governance.sol', async (accounts) => {
     )
     tokenProxy = await AudiusAdminUpgradeabilityProxy.new(
       token0.address,
-      proxyAdminAddress,
-      tokenInitData,
       governance.address,
+      tokenInitData,
       { from: proxyDeployerAddress }
     )
     token = await AudiusToken.at(tokenProxy.address)
@@ -132,9 +130,8 @@ contract('Governance.sol', async (accounts) => {
     )
     stakingProxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       governance.address,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
     staking = await Staking.at(stakingProxy.address)
@@ -149,9 +146,8 @@ contract('Governance.sol', async (accounts) => {
     )
     const serviceTypeManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceTypeManager0.address,
-      proxyAdminAddress,
-      serviceTypeInitializeData,
       governance.address,
+      serviceTypeInitializeData,
       { from: proxyAdminAddress }
     )
     await registry.addContract(serviceTypeManagerProxyKey, serviceTypeManagerProxy.address, { from: proxyDeployerAddress })
@@ -169,9 +165,8 @@ contract('Governance.sol', async (accounts) => {
     )
     const serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,
-      proxyAdminAddress,
-      serviceProviderFactoryCalldata,
       governance.address,
+      serviceProviderFactoryCalldata,
       { from: proxyAdminAddress }
     )
     serviceProviderFactory = await ServiceProviderFactory.at(serviceProviderFactoryProxy.address)
@@ -186,9 +181,8 @@ contract('Governance.sol', async (accounts) => {
     )
     const claimsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       claimsManager0.address,
-      proxyAdminAddress,
-      claimsInitializeCallData,
       governance.address,
+      claimsInitializeCallData,
       { from: proxyDeployerAddress }
     )
     claimsManager = await ClaimsManager.at(claimsManagerProxy.address)
@@ -216,9 +210,8 @@ contract('Governance.sol', async (accounts) => {
     let delegateManager0 = await DelegateManager.new({ from: proxyDeployerAddress })
     let delegateManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       delegateManager0.address,
-      proxyAdminAddress,
-      delegateManagerInitializeData,
       governance.address,
+      delegateManagerInitializeData,
       { from: proxyDeployerAddress }
     )
     delegateManager = await DelegateManager.at(delegateManagerProxy.address)
@@ -337,7 +330,6 @@ contract('Governance.sol', async (accounts) => {
         governance0.address,
         proxyAdminAddress,
         governanceCallData,
-        _lib.addressZero,
         { from: proxyDeployerAddress }
       ),
       'revert'
@@ -352,9 +344,8 @@ contract('Governance.sol', async (accounts) => {
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
         governance0.address,
-        proxyAdminAddress,
-        governanceCallData,
         governance.address,
+        governanceCallData,
         { from: proxyDeployerAddress }
       ),
       "revert"
@@ -369,9 +360,8 @@ contract('Governance.sol', async (accounts) => {
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
         governance0.address,
-        proxyAdminAddress,
-        governanceCallData,
         governance.address,
+        governanceCallData,
         { from: proxyDeployerAddress }
       ),
       "revert"
@@ -386,9 +376,8 @@ contract('Governance.sol', async (accounts) => {
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
         governance0.address,
-        proxyAdminAddress,
-        governanceCallData,
         governance.address,
+        governanceCallData,
         { from: proxyDeployerAddress }
       ),
       "revert"
@@ -403,9 +392,8 @@ contract('Governance.sol', async (accounts) => {
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
         governance0.address,
-        proxyAdminAddress,
-        governanceCallData,
         governance.address,
+        governanceCallData,
         { from: proxyDeployerAddress }
       ),
       "revert"
@@ -420,9 +408,8 @@ contract('Governance.sol', async (accounts) => {
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
         governance0.address,
-        proxyAdminAddress,
-        governanceCallData,
         governance.address,
+        governanceCallData,
         { from: proxyDeployerAddress }
       ),
       "revert"
@@ -468,9 +455,8 @@ contract('Governance.sol', async (accounts) => {
     )
     const stakingProxy2 = await AudiusAdminUpgradeabilityProxy.new(
       staking2_0.address,
-      proxyAdminAddress,
-      stakingInitializeData2,
       governance2.address,
+      stakingInitializeData2,
       { from: proxyDeployerAddress }
     )
     const staking2 = await Staking.at(stakingProxy2.address)
@@ -2468,9 +2454,8 @@ contract('Governance.sol', async (accounts) => {
       const initData = _lib.encodeCall('initialize', [], [])
       const contractProxy = await AudiusAdminUpgradeabilityProxy.new(
         contract0.address,
-        proxyAdminAddress,
-        initData,
         governance.address,
+        initData,
         { from: proxyDeployerAddress }
       )
       const contract = await TestContract.at(contractProxy.address)
@@ -2526,7 +2511,7 @@ contract('Governance.sol', async (accounts) => {
       )
 
       // Update registry's governance address
-      await registryProxy.setAudiusGovernanceAddress(governance.address, { from: proxyAdminAddress })
+      await registryProxy.setAudiusProxyAdminAddress(governance.address, { from: proxyAdminAddress })
 
       // Upgrade registry proxy to new logic address
       await governance.guardianExecuteTransaction(

--- a/eth-contracts/test/registry.test.js
+++ b/eth-contracts/test/registry.test.js
@@ -18,14 +18,13 @@ contract('Registry', async (accounts) => {
       registry0.address,
       proxyAdminAddress,
       initializeCallData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
 
     registry = await Registry.at(registryProxy.address)
 
     assert.equal(await registry.owner.call(), proxyDeployerAddress)
-    assert.equal(await registryProxy.getAudiusGovernanceAddress.call(), _lib.addressZero)
+    assert.equal(await registryProxy.getAudiusProxyAdminAddress.call(), proxyAdminAddress)
   })
 
   it('Confirm unregistered contract request returns 0 address', async () => {
@@ -238,7 +237,6 @@ contract('Registry', async (accounts) => {
       registry2_0.address,
       proxyAdminAddress,
       initializeCallData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
     const registry2 = await Registry.at(registry2Proxy.address)

--- a/eth-contracts/test/serviceProvider.test.js
+++ b/eth-contracts/test/serviceProvider.test.js
@@ -147,9 +147,8 @@ contract('ServiceProvider test', async (accounts) => {
     )
     proxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       governance.address,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
     staking = await Staking.at(proxy.address)
@@ -162,9 +161,8 @@ contract('ServiceProvider test', async (accounts) => {
     let serviceTypeManager0 = await ServiceTypeManager.new({ from: proxyDeployerAddress })
     let serviceTypeManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceTypeManager0.address,
-      proxyAdminAddress,
-      serviceTypeInitializeData,
       governance.address,
+      serviceTypeInitializeData,
       { from: proxyAdminAddress }
     )
     serviceTypeManager = await ServiceTypeManager.at(serviceTypeManagerProxy.address)
@@ -179,9 +177,8 @@ contract('ServiceProvider test', async (accounts) => {
     )
     claimsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       claimsManager0.address,
-      proxyAdminAddress,
-      claimsInitializeCallData,
       governance.address,
+      claimsInitializeCallData,
       { from: proxyDeployerAddress }
     )
     claimsManager = await ClaimsManager.at(claimsManagerProxy.address)
@@ -227,9 +224,8 @@ contract('ServiceProvider test', async (accounts) => {
     )
     let serviceProviderFactoryProxy = await AudiusAdminUpgradeabilityProxy.new(
       serviceProviderFactory0.address,
-      proxyAdminAddress,
-      serviceProviderFactoryCalldata,
       governance.address,
+      serviceProviderFactoryCalldata,
       { from: proxyAdminAddress }
     )
     serviceProviderFactory = await ServiceProviderFactory.at(serviceProviderFactoryProxy.address)

--- a/eth-contracts/test/staking.test.js
+++ b/eth-contracts/test/staking.test.js
@@ -1,7 +1,5 @@
 import * as _lib from '../utils/lib.js'
 
-const Registry = artifacts.require('Registry')
-const AudiusToken = artifacts.require('AudiusToken')
 const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
 const Staking = artifacts.require('Staking')
 const MockStakingCaller = artifacts.require('MockStakingCaller')
@@ -9,7 +7,6 @@ const MockStakingCaller = artifacts.require('MockStakingCaller')
 const claimsManagerProxyKey = web3.utils.utf8ToHex('ClaimsManagerProxy')
 const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
 const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
-const governanceKey = web3.utils.utf8ToHex('Governance')
 const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
 
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
@@ -95,9 +92,8 @@ contract('Staking test', async (accounts) => {
 
     proxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       mockGovAddress,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
 
@@ -418,9 +414,8 @@ contract('Staking test', async (accounts) => {
       await _lib.assertRevert(
         AudiusAdminUpgradeabilityProxy.new(
           staking1.address,
-          proxyAdminAddress,
-          invalidStakingInitializeData,
           mockStakingCaller.address,
+          invalidStakingInitializeData,
           { from: proxyDeployerAddress }
         ),
       )
@@ -473,9 +468,8 @@ contract('Staking test', async (accounts) => {
       await _lib.assertRevert(
         AudiusAdminUpgradeabilityProxy.new(
           testStaking.address,
-          proxyAdminAddress,
-          invalidStakingInitializeData,
           mockStakingCaller.address,
+          invalidStakingInitializeData,
           { from: proxyDeployerAddress }
         )
       )

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -225,8 +225,6 @@ contract('Upgrade proxy test', async (accounts) => {
     proxyGovAddr = await proxy.getAudiusProxyAdminAddress.call({ from: proxyAdminAddress })
     assert.equal(proxyGovAddr, mockGovAddr2)
 
-    // TODO: Test that old admin cannot call proxy functions
-  
     // Attempt to set the admin address from the OLD admin, expect failure
     await _lib.assertRevert(
       mockStakingCaller.setStakingAudiusProxyAdminAddress(mockGovAddr2, { from: proxyAdminAddress }),

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -88,9 +88,8 @@ contract('Upgrade proxy test', async (accounts) => {
 
     proxy = await AudiusAdminUpgradeabilityProxy.new(
       staking0.address,
-      proxyAdminAddress,
-      stakingInitializeData,
       mockGovAddr,
+      stakingInitializeData,
       { from: proxyDeployerAddress }
     )
 
@@ -137,7 +136,7 @@ contract('Upgrade proxy test', async (accounts) => {
 
     await _lib.assertRevert(
       proxy.upgradeTo(stakingUpgraded.address),
-      "Caller must be current proxy governance address"
+      "Caller must be current proxy admin"
     )
   })
 
@@ -170,18 +169,17 @@ contract('Upgrade proxy test', async (accounts) => {
       staking0.address,
       proxyAdminAddress,
       stakingInitializeData,
-      _lib.addressZero,
       { from: proxyDeployerAddress }
     )
 
-    let govAddress = await noGovProxy.getAudiusGovernanceAddress()
-    assert.equal(govAddress, _lib.addressZero, 'Expect zero governance addr')
+    let govAddress = await noGovProxy.getAudiusProxyAdminAddress()
+    assert.equal(govAddress,proxyAdminAddress, 'Expect zero governance addr')
 
     await _lib.assertRevert(
-      noGovProxy.setAudiusGovernanceAddress(mockStakingCaller.address, { from: accounts[7] }),
+      noGovProxy.setAudiusProxyAdminAddress(mockStakingCaller.address, { from: accounts[7] }),
       'Caller must be proxy admin or proxy upgrade')
-    await noGovProxy.setAudiusGovernanceAddress(mockStakingCaller.address, { from: proxyAdminAddress })
-    govAddress = await noGovProxy.getAudiusGovernanceAddress()
+    await noGovProxy.setAudiusProxyAdminAddress(mockStakingCaller.address, { from: proxyAdminAddress })
+    govAddress = await noGovProxy.getAudiusProxyAdminAddress()
     assert.equal(govAddress, mockStakingCaller.address, 'Expect updated governance addr')
   })
 
@@ -189,19 +187,19 @@ contract('Upgrade proxy test', async (accounts) => {
     const registry2 = await Registry.new()
     await registry2.initialize()
 
-    let proxyGovAddr = await proxy.getAudiusGovernanceAddress.call({ from: proxyAdminAddress })
+    let proxyGovAddr = await proxy.getAudiusProxyAdminAddress.call({ from: proxyAdminAddress })
     assert.equal(proxyGovAddr, mockGovAddr)
 
     let mockStakingCaller2 = await MockStakingCaller.new()
     let mockGovAddr2 = mockStakingCaller2.address
 
     await _lib.assertRevert(
-      proxy.setAudiusGovernanceAddress(mockGovAddr2, { from: proxyAdminAddress }),
+      proxy.setAudiusProxyAdminAddress(mockGovAddr2, { from: proxyAdminAddress }),
       'Caller must be proxy admin or proxy upgrader')
 
-    await mockStakingCaller.setAudiusGovernanceAddress(mockGovAddr2, { from: proxyAdminAddress })
+    await mockStakingCaller.setAudiusProxyAdminAddress(mockGovAddr2, { from: proxyAdminAddress })
 
-    proxyGovAddr = await proxy.getAudiusGovernanceAddress.call({ from: proxyAdminAddress })
+    proxyGovAddr = await proxy.getAudiusProxyAdminAddress.call({ from: proxyAdminAddress })
     assert.equal(proxyGovAddr, mockGovAddr2)
   })
 

--- a/eth-contracts/test/upgradeability.test.js
+++ b/eth-contracts/test/upgradeability.test.js
@@ -152,7 +152,7 @@ contract('Upgrade proxy test', async (accounts) => {
     staking = await StakingUpgraded.at(proxy.address)
     await _lib.assertRevert(staking.newFunction.call({ from: proxyDeployerAddress }), 'revert')
 
-    const upgradeTxReceipt = await mockStakingCaller.upgradeTo(stakingUpgraded.address, { from: proxyAdminAddress })
+    const upgradeTxReceipt = await mockStakingCaller.upgradeStakingTo(stakingUpgraded.address, { from: proxyAdminAddress })
     await expectEvent.inTransaction(upgradeTxReceipt.tx, AudiusAdminUpgradeabilityProxy, 'Upgraded', { implementation: stakingUpgraded.address })
 
     // Confirm proxy implementation's address has updated to new logic contract
@@ -228,7 +228,7 @@ contract('Upgrade proxy test', async (accounts) => {
       const otherAccount = accounts[4]
 
       await approveAndStake(DEFAULT_AMOUNT, staker, staking)
-      await mockStakingCaller.upgradeTo(stakingUpgraded.address, { from: proxyAdminAddress })
+      await mockStakingCaller.upgradeStakingTo(stakingUpgraded.address, { from: proxyAdminAddress })
 
       staking = await StakingUpgraded.at(proxy.address)
 

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -190,9 +190,8 @@ export const deployToken = async (
   )
   const tokenProxy = await AudiusAdminUpgradeabilityProxy.new(
     token0.address,
-    proxyAdminAddress,
-    tokenInitData,
     governanceAddress,
+    tokenInitData,
     { from: proxyDeployerAddress }
   )
   const token = await AudiusToken.at(tokenProxy.address)
@@ -210,7 +209,6 @@ export const deployRegistry = async (artifacts, proxyAdminAddress, proxyDeployer
     registry0.address,
     proxyAdminAddress,
     registryInitData,
-    addressZero,
     { from: proxyDeployerAddress }
   )
   const registry = await Registry.at(registryProxy.address)
@@ -244,10 +242,9 @@ export const deployGovernance = async (
     governance0.address,
     proxyAdminAddress,
     governanceInitializeData,
-    addressZero,
     { from: proxyDeployerAddress }
   )
-  await governanceProxy.setAudiusGovernanceAddress(governanceProxy.address, { from: proxyAdminAddress })
+  await governanceProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
 
   const governance = await Governance.at(governanceProxy.address)
   return governance


### PR DESCRIPTION
* Eliminate consumption of OZ AdminUpgradeabilityProxy in favor of UpgradeabilityProxy
* Reduces unused API surface in AdminUpgradeabilityProxy (changeAdmin, upgradeToAndCall were unsued) in favor of explicit management of lower level contract
* Eliminates unnecessary storage of admin + governance address in each proxy contract, and makes governance the administrator

Tests needed:
---
- [x] ensure current tests all pass
- [x] test for governance executing each exposed proxy contract function
       (only function here is setAudiusProxyAdminAddress)
- [x] admin is changed after deploy - confirm old admin cannot call functions after relinquishing
       (upgradeability.test.js for this)
- [x] clashing function signature behavior