### PR TITLE
Fix user event migration

### DIFF
--- a/identity-service/sequelize/migrations/20200706140854-download-email.js
+++ b/identity-service/sequelize/migrations/20200706140854-download-email.js
@@ -35,7 +35,6 @@ module.exports = {
       }))
 
       await models.UserEvents.bulkCreate(toInsert, { transaction, ignoreDuplicates: true })
-      console.log('finished')
       await models.UserEvents.update({
         needsRecoveryEmail: false,
         hasSignedInNativeMobile: true,

--- a/identity-service/sequelize/migrations/20200706140854-download-email.js
+++ b/identity-service/sequelize/migrations/20200706140854-download-email.js
@@ -34,7 +34,14 @@ module.exports = {
         hasSentDownloadAppEmail: false
       }))
 
-      return models.UserEvents.bulkCreate(toInsert, { transaction })
+      await models.UserEvents.bulkCreate(toInsert, { transaction, ignoreDuplicates: true })
+      console.log('finished')
+      await models.UserEvents.update({
+        needsRecoveryEmail: false,
+        hasSignedInNativeMobile: true,
+        hasSentDownloadAppEmail: false
+      }, { where: {}, transaction }
+      )
     })
   },
 


### PR DESCRIPTION
Fix user event migration. 
It is currently erroring on insert rows w/ duplicate key.
Solution is to bulkCreate w/ the ignoreOnDuplicate and then update all rows. 