### PR TITLE
[H02] Delegators can prevent service providers from deregistering endpoints

### DIFF
--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -36,6 +36,8 @@ contract DelegateManager is InitializableV2 {
 
     /**
      * Number of blocks an undelegate operation has to wait
+     * The undelegate operation speed bump is to prevent a delegator from
+     *      attempting to remove their delegation in anticipation of a slash.
      * @notice must be >= Governance.votingPeriod
      */
     uint256 private undelegateLockupDuration;
@@ -47,7 +49,9 @@ contract DelegateManager is InitializableV2 {
     uint256 private minDelegationAmount;
 
     /**
-     * Lockup duration for a remove delegator request
+     * Lockup duration for a remove delegator request.
+     * The remove delegator speed bump is to prevent a service provider from maliciously
+     *     removing a delegator prior to the evaluation of a proposal.
      * @notice must be >= Governance.votingPeriod
      */
     uint256 private removeDelegatorLockupDuration;

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -149,11 +149,12 @@ contract DelegateManager is InitializableV2 {
     {
         _updateGovernanceAddress(_governanceAddress);
         audiusToken = ERC20Mintable(_tokenAddress);
-        undelegateLockupDuration = _undelegateLockupDuration;
         maxDelegators = 175;
         // Default minimum delegation amount set to 100AUD
         minDelegationAmount = 100 * 10**uint256(18);
         InitializableV2.initialize();
+
+        _updateUndelegateLockupDuration(_undelegateLockupDuration);
 
         // 1 week = 168hrs * 60 min/hr * 60 sec/min / ~13 sec/block = 46523 blocks
         _updateRemoveDelegatorLockupDuration(46523);
@@ -679,7 +680,7 @@ contract DelegateManager is InitializableV2 {
 
         require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
 
-        undelegateLockupDuration = _duration;
+        _updateUndelegateLockupDuration(_duration);
         emit UndelegateLockupDurationUpdated(_duration);
     }
 
@@ -1148,7 +1149,7 @@ contract DelegateManager is InitializableV2 {
 
     /**
      * @notice Set the remove delegator lockup duration after validating against governance
-     * @param _duration - Incoming duration value
+     * @param _duration - Incoming remove delegator duration value
      */
     function _updateRemoveDelegatorLockupDuration(uint256 _duration) internal {
         Governance governance = Governance(governanceAddress);
@@ -1157,6 +1158,19 @@ contract DelegateManager is InitializableV2 {
             "DelegateManager: removeDelegatorLockupDuration duration must be greater than governance votingPeriod + executionDelay"
         );
         removeDelegatorLockupDuration = _duration;
+    }
+
+    /**
+     * @notice Set the undelegate lockup duration after validating against governance
+     * @param _duration - Incoming undelegate lockup duration value
+     */
+    function _updateUndelegateLockupDuration(uint256 _duration) internal {
+        Governance governance = Governance(governanceAddress);
+        require(
+            _duration > governance.getVotingPeriod() + governance.getExecutionDelay(),
+            "DelegateManager: undelegateLockupDuration duration must be greater than governance votingPeriod + executionDelay"
+        );
+        undelegateLockupDuration = _duration;
     }
 
     /**

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -151,8 +151,8 @@ contract DelegateManager is InitializableV2 {
         minDelegationAmount = 100 * 10**uint256(18);
         InitializableV2.initialize();
 
-        // 72hr * 60 min/hr * 60 sec/min / ~13 sec/block = 199938 blocks
-        _updateRemoveDelegatorLockupDuration(199938);
+        // 1 week = 168hrs * 60 min/hr * 60 sec/min / ~13 sec/block = 46523 blocks
+        _updateRemoveDelegatorLockupDuration(46523);
 
         // 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646 blocks
         removeDelegatorEvalDuration = 6646;

--- a/eth-contracts/migrations/8_delegate_manager_migration.js
+++ b/eth-contracts/migrations/8_delegate_manager_migration.js
@@ -16,9 +16,9 @@ const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
 const governanceKey = web3.utils.utf8ToHex('Governance')
 const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
 
-// stake lockup duration = 1 wk in blocks
+// undelegate lockup duration = 1 wk in blocks
 // - 1/13 block/s * 604800 s/wk ~= 46523 block/wk
-const decreaseStakeLockupDuration = 46523
+const undelegateLockupDuration = 46523
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
@@ -43,7 +43,7 @@ module.exports = (deployer, network, accounts) => {
     const initializeCallData = _lib.encodeCall(
       'initialize',
       ['address', 'address', 'uint256'],
-      [token.address, governanceAddress, decreaseStakeLockupDuration]
+      [token.address, governanceAddress, undelegateLockupDuration]
     )
     const delegateManagerProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1877,7 +1877,7 @@ contract('DelegateManager', async (accounts) => {
         tx.tx,
         DelegateManager,
         'DelegatorRemoved',
-        { _serviceProvider: stakerAccount, _delegator: delegatorAccount1 }
+        { _serviceProvider: stakerAccount, _delegator: delegatorAccount1, _unstakedAmount: delegationAmount }
       )
 
       requestTargetBlock = await delegateManager.getPendingRemoveDelegatorRequest(stakerAccount, delegatorAccount1)

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -30,6 +30,7 @@ const VOTING_PERIOD = 10
 const EXECUTION_DELAY = VOTING_PERIOD
 const VOTING_QUORUM_PERCENT = 10
 const DECREASE_STAKE_LOCKUP_DURATION = 10
+const UNDELEGATE_LOCKUP_DURATION = 21
 
 const callValue0 = _lib.toBN(0)
 
@@ -161,7 +162,7 @@ contract('DelegateManager', async (accounts) => {
     const delegateManagerInitializeData = _lib.encodeCall(
       'initialize',
       ['address', 'address', 'uint256'],
-      [token.address, governance.address, 10]
+      [token.address, governance.address, UNDELEGATE_LOCKUP_DURATION]
     )
     let delegateManager0 = await DelegateManager.new({ from: proxyDeployerAddress })
     let delegateManagerProxy = await AudiusAdminUpgradeabilityProxy.new(

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -53,6 +53,7 @@ contract('Governance.sol', async (accounts) => {
   const maxInProgressProposals = 20
   const maxDescriptionLength = 250
   const executionDelay = votingPeriod
+  const undelegateLockupDuration = 21
 
   // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress, newUpdateAddress] = accounts
@@ -205,7 +206,7 @@ contract('Governance.sol', async (accounts) => {
     const delegateManagerInitializeData = _lib.encodeCall(
       'initialize',
       ['address', 'address', 'uint256'],
-      [token.address, governance.address, 10]
+      [token.address, governance.address, undelegateLockupDuration]
     )
     let delegateManager0 = await DelegateManager.new({ from: proxyDeployerAddress })
     let delegateManagerProxy = await AudiusAdminUpgradeabilityProxy.new(


### PR DESCRIPTION
* Old PR - https://github.com/AudiusProject/audius-protocol/pull/570
* Adds a time lock mechanism to removeDelegator, ensuring that a service provider cannot maliciously remove delegators to get around slash actions or other protocol enforcement
* Enforce relationship between undelegate lockup duration and voting period + execution delay
* Enforce relationship between removeDelegator lockup duration and voting period + execution delay
* Tests added 