### PR TITLE
Sync non-track files in nodesync

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -118,19 +118,18 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
   // eg. `/QmABC` splits into ['', 'QmABC'] so it's exactly two parts so it's a non-dir file
   const splitPath = filePath.split('/')
   if (splitPath.length > 2) {
+    // this is a directory
     const dir = path.dirname(expectedStoragePath)
 
-    if (dir) {
-      // override gateway urls to make it compatible with directory
-      urls = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${splitPath[1]}/`)
+    // override gateway urls to make it compatible with directory
+    urls = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${splitPath[1]}/`)
 
-      try {
-        // calling this on an existing directory doesn't overwrite the existing data or throw an error
-        // the mkdir recursive is equivalent to `mkdir -p`
-        await mkdir(dir, { recursive: true })
-      } catch (e) {
-        throw e
-      }
+    try {
+      // calling this on an existing directory doesn't overwrite the existing data or throw an error
+      // the mkdir recursive is equivalent to `mkdir -p`
+      await mkdir(dir, { recursive: true })
+    } catch (e) {
+      throw e
     }
   }
   return _saveFileForMultihashHelper(req, multihash, expectedStoragePath, urls)

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -133,8 +133,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
       // the mkdir recursive is equivalent to `mkdir -p`
       await mkdir(dir, { recursive: true })
     } catch (e) {
-      req.logger.error(`saveFileForMultihash - Error making directory at ${dir}`, e)
-      throw e
+      throw new Error(`saveFileForMultihash - Error making directory at ${dir} - ${e.message}`)
     }
   }
 

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -113,6 +113,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
   const filePath = expectedStoragePath.replace(storagePath, '') // should be `/Qm1/Qm2` for dir and `/Qm1` for non-dir
 
   // will be modified to directory compatible route later if directory
+  // TODO - don't concat url's by hand like this, use module like urljoin
   let gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/`)
 
   // Check if the file we are trying to copy is in a directory and if so, create the directory first

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -100,13 +100,13 @@ async function saveFileToIPFSFromFS (req, srcPath, fileType, sourceFile, transac
  * creating directories, changeing IPFS gateway urls before calling _saveFileForMultihash
  * @param {Object} req request object
  * @param {String} multihash IPFS cid
- * @param {String} expectedStoragePath file system path similar to `/file_storage/Qm1` 
+ * @param {String} expectedStoragePath file system path similar to `/file_storage/Qm1`
  *                  for non dir files and `/file_storage/Qmdir/Qm2` for dir files
  * @param {Array} gatewaysToTry List of gateway endpoints to try
  */
 async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewaysToTry) {
   const storagePath = req.app.get('storagePath') // should be like `/file_storage'
-  const filePath = expectedStoragePath.replace(storagePath, '') //should be `/Qm1/Qm2` for dir and `/Qm1` for non-dir
+  const filePath = expectedStoragePath.replace(storagePath, '') // should be `/Qm1/Qm2` for dir and `/Qm1` for non-dir
 
   // will be modified to directory compatible route later if directory
   let urls = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/`)
@@ -148,7 +148,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
  *  - If file is not available via IPFS try other cnode gateways for user's replica set.
  *  - Add file to local ipfs node if not already there.
  */
-async function _saveFileForMultihashHelper (req, multihash, expectedStoragePath, gatewaysToTry=[]) {
+async function _saveFileForMultihashHelper (req, multihash, expectedStoragePath, gatewaysToTry = []) {
   // If file already stored on disk, return immediately.
   if (fs.existsSync(expectedStoragePath)) {
     req.logger.info(`File already stored at ${expectedStoragePath} for ${multihash}`)

--- a/creator-node/src/models/file.js
+++ b/creator-node/src/models/file.js
@@ -46,6 +46,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING(16),
       allowNull: true,
       validate: {
+        // track and non types broken down below and attached to Track model
         isIn: [['track', 'metadata', 'image', 'dir', 'copy320']]
       }
     }
@@ -75,6 +76,9 @@ module.exports = (sequelize, DataTypes) => {
       onDelete: 'RESTRICT'
     })
   }
+
+  File.TrackTypes = ['track', 'copy320']
+  File.NonTrackTypes = ['dir', 'image', 'metadata']
 
   return File
 }

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -12,8 +12,6 @@ const syncQueue = {}
 const TrackSaveConcurrencyLimit = 10
 const NonTrackFileSaveConcurrencyLimit = 10
 const RehydrateIPFSConcurrencyLimit = 10
-const TrackTypes = ['track', 'copy320']
-const NonTrackTypes = ['dir', 'image', 'metadata']
 
 module.exports = function (app) {
   /**
@@ -292,8 +290,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
 
         // Files with trackUUIDs cannot be created until tracks have been created,
         // but tracks cannot be created until metadata and cover art files have been created.
-        const trackFiles = fetchedCNodeUser.files.filter(file => TrackTypes.includes(file.type))
-        const nonTrackFiles = fetchedCNodeUser.files.filter(file => NonTrackTypes.includes(file.type))
+        const trackFiles = fetchedCNodeUser.files.filter(file => models.File.TrackTypes.includes(file.type))
+        const nonTrackFiles = fetchedCNodeUser.files.filter(file => models.File.NonTrackTypes.includes(file.type))
 
         // Save all track files to disk in batches (to limit concurrent load)
         for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -302,6 +302,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
           ))
         }
 
+        req.logger.info('Saved all track files to disk.')
+
         // Save all non-track files to disk in batches (to limit concurrent load)
         for (let i = 0; i < nonTrackFiles.length; i += NonTrackFileSaveConcurrencyLimit) {
           const nonTrackFilesSlice = nonTrackFiles.slice(i, i + NonTrackFileSaveConcurrencyLimit)
@@ -316,7 +318,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
             }
           ))
         }
-        req.logger.info('Saved all track files to disk and ipfs.')
+        req.logger.info('Saved all non-track files to disk.')
 
         await models.File.bulkCreate(nonTrackFiles.map(file => ({
           fileUUID: file.fileUUID,

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -292,8 +292,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
 
         // Files with trackUUIDs cannot be created until tracks have been created,
         // but tracks cannot be created until metadata and cover art files have been created.
-        const trackFiles = fetchedCNodeUser.files.filter(file => TrackTypes.includes(file))
-        const nonTrackFiles = fetchedCNodeUser.files.filter(file => NonTrackTypes.includes(file))
+        const trackFiles = fetchedCNodeUser.files.filter(file => TrackTypes.includes(file.type))
+        const nonTrackFiles = fetchedCNodeUser.files.filter(file => NonTrackTypes.includes(file.type))
 
         // Save all track files to disk in batches (to limit concurrent load)
         for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -10,6 +10,7 @@ const middlewares = require('../middlewares')
 // Dictionary tracking currently queued up syncs with debounce
 const syncQueue = {}
 const TrackSaveConcurrencyLimit = 10
+const NonTrackFileSaveConcurrencyLimit = 10
 const RehydrateIPFSConcurrencyLimit = 10
 
 module.exports = function (app) {
@@ -291,6 +292,32 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
         // but tracks cannot be created until metadata and cover art files have been created.
         const trackFiles = fetchedCNodeUser.files.filter(file => file.trackUUID != null)
         const nonTrackFiles = fetchedCNodeUser.files.filter(file => file.trackUUID == null)
+
+        // Save all track files to disk in batches (to limit concurrent load)
+        for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {
+          const trackFilesSlice = trackFiles.slice(i, i + TrackSaveConcurrencyLimit)
+          req.logger.info(`TrackFiles saveFileForMultihash - processing trackFiles ${i} to ${i + TrackSaveConcurrencyLimit}...`)
+          await Promise.all(trackFilesSlice.map(
+            trackFile => saveFileForMultihash(req, trackFile.multihash, trackFile.storagePath, userReplicaSet)
+          ))
+        }
+
+        // Save all non-track files to disk in batches (to limit concurrent load)
+        for (let i = 0; i < nonTrackFiles.length; i += NonTrackFileSaveConcurrencyLimit) {
+          const nonTrackFilesSlice = nonTrackFiles.slice(i, i + NonTrackFileSaveConcurrencyLimit)
+          req.logger.info(`NonTrackFiles saveFileForMultihash - processing files ${i} to ${i + NonTrackFileSaveConcurrencyLimit}...`)
+          await Promise.all(nonTrackFilesSlice.map(
+            nonTrackFile => {
+              // Skip over directories since there's no actual content to sync
+              // The files inside the directory are synced separately
+              if (nonTrackFile.type !== 'dir') {
+                saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
+              }
+            }
+          ))
+        }
+        req.logger.info('Saved all track files to disk and ipfs.')
+
         await models.File.bulkCreate(nonTrackFiles.map(file => ({
           fileUUID: file.fileUUID,
           trackUUID: null,
@@ -313,16 +340,6 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
           coverArtFileUUID: track.coverArtFileUUID
         })), { transaction: t })
         req.logger.info(redisKey, 'created all tracks')
-
-        // Save all track files to disk in batches (to limit concurrent load)
-        for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {
-          const trackFilesSlice = trackFiles.slice(i, i + TrackSaveConcurrencyLimit)
-          req.logger.info(`TrackFiles saveFileForMultihash - processing trackFiles ${i} to ${i + TrackSaveConcurrencyLimit}...`)
-          await Promise.all(trackFilesSlice.map(
-            trackFile => saveFileForMultihash(req, trackFile.multihash, trackFile.storagePath, userReplicaSet)
-          ))
-        }
-        req.logger.info('Saved all track files to disk and ipfs.')
 
         // Save all track files to db
         await models.File.bulkCreate(trackFiles.map(trackFile => ({

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -313,7 +313,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
               // Skip over directories since there's no actual content to sync
               // The files inside the directory are synced separately
               if (nonTrackFile.type !== 'dir') {
-                saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
+                return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
               }
             }
           ))

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -12,6 +12,8 @@ const syncQueue = {}
 const TrackSaveConcurrencyLimit = 10
 const NonTrackFileSaveConcurrencyLimit = 10
 const RehydrateIPFSConcurrencyLimit = 10
+const TrackTypes = ['track', 'copy320']
+const NonTrackTypes = ['dir', 'image', 'metadata']
 
 module.exports = function (app) {
   /**
@@ -290,8 +292,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
 
         // Files with trackUUIDs cannot be created until tracks have been created,
         // but tracks cannot be created until metadata and cover art files have been created.
-        const trackFiles = fetchedCNodeUser.files.filter(file => file.trackUUID != null)
-        const nonTrackFiles = fetchedCNodeUser.files.filter(file => file.trackUUID == null)
+        const trackFiles = fetchedCNodeUser.files.filter(file => TrackTypes.includes(file))
+        const nonTrackFiles = fetchedCNodeUser.files.filter(file => NonTrackTypes.includes(file))
 
         // Save all track files to disk in batches (to limit concurrent load)
         for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -89,7 +89,7 @@ const ipfsSingleByteCat = (path, req, timeout = 1000) => new Promise(async (reso
     for await (const chunk of ipfs.cat(path, { length: 1, timeout })) {
       continue
     }
-    req.logger.info(`ipfsSingleByteCat - Retrieved ${path} in ${Date.now() - start}ms`)
+    req.logger.debug(`ipfsSingleByteCat - Retrieved ${path} in ${Date.now() - start}ms`)
     resolve()
   } catch (e) {
     req.logger.error(`ipfsSingleByteCat - Error: ${e}`)
@@ -119,7 +119,7 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
     for await (const chunk of ipfs.cat(path, options)) {
       chunks.push(chunk)
     }
-    req.logger.info(`ipfsCat - Retrieved ${path} in ${Date.now() - start}ms`)
+    req.logger.debug(`ipfsCat - Retrieved ${path} in ${Date.now() - start}ms`)
     resolve(Buffer.concat(chunks))
   } catch (e) {
     req.logger.error(`ipfsCat - Error: ${e}`)


### PR DESCRIPTION
Based off @raymondjacobson's earlier PR (https://github.com/AudiusProject/audius-protocol/pull/617/files). This applies those changes on top of the most recent gateway fetch changes on master. 

Scope of PR: Previously we only synced track segments + the 320kpbs transcoded copy of the file as part of nodesync. This PR expands that to include both dir and non-dir images as well as user and track metadata. As a result of this, our saveFileForMultihash code also needs to be updated to support downloading directory images. saveFileForMultihash now checks the directory structure and creates any child directories if necessary before calling a new saveFileForMultihash helper function that actually syncs the file and stores it to the location on disk.

Local testing: I tested this locally with two creator nodes and verified that if i started with an empty volume for the secondary creator node, all images, metadata and track files are synced to the secondary and are accessible via the respective creator node gateways. I would manually clear the volumes, call sync on the secondary against the primary, and check that all files in the Files db table also exist in the file system. 