### PR TITLE
Fix requirements.txt and add index for documentation sake in models.py

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -15,4 +15,3 @@ base58==1.0.0
 flask-cors==3.0.6
 gunicorn==19.9.0
 jsonschema==3.2.0
-eth_account==0.5.2

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -117,7 +117,7 @@ class BlacklistedIPLD(Base):
     blocknumber = Column(Integer, ForeignKey("ipld_blacklist_blocks.number"), nullable=False)
     ipld = Column(String, nullable=False)
     is_blacklisted = Column(Boolean, nullable=False)
-    is_current = Column(Boolean, nullable=False)
+    is_current = Column(Boolean, nullable=False, index=True)
 
     PrimaryKeyConstraint(blockhash, ipld, is_blacklisted, is_current)
 


### PR DESCRIPTION
Forgot to add the index to the file in models.py from b208928079eaa9d87570f118d59fe7b2ab228832

Also, chatted with @vicky-g  eth_account is a dep of web3 (ty vicky). Perhaps what was happening here was I was pip installing with python not 3.x which didn't have web3 5.11.x available, so eth_account wasn't being pulled in and since it's a newer dep of the alembic flow (since api_helpers needs it), this was breaking.