### PR TITLE
Enforce transcoded uuid is passed in

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -335,7 +335,7 @@ module.exports = function (app) {
           throw new Error('Failed to associate files for every track segment CID.')
         }
 
-        // Associate created trackUUID the transcoded copy
+        // Associate created trackUUID to the transcoded copy
 
         // Using the correct source file, find a transcoded 320kbps copy and associate that
         const { sourceFile } = trackFiles[0]
@@ -358,19 +358,22 @@ module.exports = function (app) {
             cnodeUserUUID,
             trackUUID: null,
             type: 'copy320'
-          }
+          },
+          transaction: t
         })
 
         const numTranscodeAffectedRows = await models.File.update(
           { trackUUID: track.trackUUID },
-          { where: {
-            fileUUID: transcodedCopy.fileUUID,
-            cnodeUserUUID,
-            trackUUID: null,
-            type: 'copy320'
-          },
-          transaction: t
-          })
+          {
+            where: {
+              fileUUID: transcodedCopy.fileUUID,
+              cnodeUserUUID,
+              trackUUID: null,
+              type: 'copy320'
+            },
+            transaction: t
+          }
+        )
 
         if (numTranscodeAffectedRows === 0) {
           throw new Error('Failed to associate the transcoded file for the provided track UUID.')

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -339,6 +339,11 @@ module.exports = function (app) {
 
         // Using the correct source file, find a transcoded 320kbps copy and associate that
         const { sourceFile } = trackFiles[0]
+        // Check that each segment file found matches the same source file.
+        // In the case a user uploaded two of the same track twice and failed both times
+        // to associate, this will be exercised. We may want to remove this check here and
+        // let the user recover, but in practice, this may not really happen, so we invariant here
+        // so it's logged.
         for (let i = 1; i < trackFiles.length; ++i) {
           if (trackFiles[i].sourceFile !== sourceFile) {
             throw new Error(

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -370,7 +370,7 @@ module.exports = function (app) {
             type: 'copy320'
           },
           transaction: t
-        })
+          })
 
         if (numTranscodeAffectedRows === 0) {
           throw new Error('Failed to associate the transcoded file for the provided track UUID.')

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -239,7 +239,7 @@ module.exports = function (app) {
    * and associates segment & image file entries with track. Ends track creation/update process.
    */
   app.post('/tracks', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, handleResponse(async (req, res) => {
-    const { blockchainTrackId, blockNumber, metadataFileUUID, transcodedTrackUUID } = req.body
+    const { blockchainTrackId, blockNumber, metadataFileUUID } = req.body
 
     if (!blockchainTrackId || !blockNumber || !metadataFileUUID) {
       return errorResponseBadRequest('Must include blockchainTrackId, blockNumber, and metadataFileUUID.')
@@ -300,37 +300,7 @@ module.exports = function (app) {
 
       // if track created, ensure files exist with trackuuid = null and update them.
       if (trackCreated) {
-        // Update the transcoded 320kbps copy
-        if (transcodedTrackUUID) {
-          const transcodedFile = await models.File.findOne({
-            where: {
-              fileUUID: transcodedTrackUUID,
-              cnodeUserUUID,
-              trackUUID: null,
-              type: 'copy320'
-            },
-            transaction: t
-          })
-          if (!transcodedFile) {
-            throw new Error('Did not find a transcoded file for the provided CID.')
-          }
-          const numAffectedRows = await models.File.update(
-            { trackUUID: track.trackUUID },
-            { where: {
-              fileUUID: transcodedTrackUUID,
-              cnodeUserUUID,
-              trackUUID: null,
-              type: 'copy320'
-            },
-            transaction: t
-            }
-          )
-          if (numAffectedRows === 0) {
-            throw new Error('Failed to associate the transcoded file for the provided track UUID.')
-          }
-        }
-
-        // Update the corresponding segment files
+        // Associate created trackUUID to each segment file
         const trackFiles = await models.File.findAll({
           where: {
             multihash: trackSegmentCIDs,
@@ -340,9 +310,15 @@ module.exports = function (app) {
           },
           transaction: t
         })
+
+        if (trackFiles.length === 0) {
+          throw new Error('Did not find any track files for track segments CIDs.')
+        }
+
         if (trackFiles.length < trackSegmentCIDs.length) {
           throw new Error('Did not find files for every track segment CID.')
         }
+
         const numAffectedRows = await models.File.update(
           { trackUUID: track.trackUUID },
           { where: {
@@ -354,38 +330,45 @@ module.exports = function (app) {
           transaction: t
           }
         )
+
         if (numAffectedRows < trackSegmentCIDs.length) {
           throw new Error('Failed to associate files for every track segment CID.')
         }
-      } else { /** If track updated, ensure files exist with trackuuid. */
-        // Check the transcoded copy if present
-        if (transcodedTrackUUID) {
-          const transcodedFile = await models.File.findOne({
-            where: {
-              fileUUID: transcodedTrackUUID,
-              cnodeUserUUID,
-              trackUUID: track.trackUUID,
-              type: 'copy320'
-            },
-            transaction: t
-          })
-          if (!transcodedFile) {
-            throw new Error('Did not find the corresponding transcoded file for the provided track UUID.')
+
+        // Associate created trackUUID the transcoded copy
+
+        // Using the correct source file, find a transcoded 320kbps copy and associate that
+        const { sourceFile } = trackFiles[0]
+        for (let i = 1; i < trackFiles.length; ++i) {
+          if (trackFiles[i].sourceFile !== sourceFile) {
+            throw new Error(
+              `Found non-matching sourcefile ${trackFiles[i].sourceFile} for sourceFile ${sourceFile}`
+            )
           }
         }
 
-        // Check the segment files
-        const trackFiles = await models.File.findAll({
+        const transcodedCopy = await models.File.findOne({
           where: {
-            multihash: trackSegmentCIDs,
+            sourceFile,
             cnodeUserUUID,
-            trackUUID: track.trackUUID,
-            type: 'track'
+            trackUUID: null,
+            type: 'copy320'
+          }
+        })
+
+        const numTranscodeAffectedRows = await models.File.update(
+          { trackUUID: track.trackUUID },
+          { where: {
+            fileUUID: transcodedCopy.fileUUID,
+            cnodeUserUUID,
+            trackUUID: null,
+            type: 'copy320'
           },
           transaction: t
         })
-        if (trackFiles.length < trackSegmentCIDs.length) {
-          throw new Error('Did not find files for every track segment CID with trackUUID.')
+
+        if (numTranscodeAffectedRows === 0) {
+          throw new Error('Failed to associate the transcoded file for the provided track UUID.')
         }
       }
 


### PR DESCRIPTION
Tested (everything locally):

- upload track, checked db state
- upload track & quit before POST /tracks check db state, edit track, checked db state
- confirmed secondary node has the correct state along the way
- confirmed uploading the same track twice (and failing during upload) causes the "Found non-matching" error to be thrown
- uploaded a track via the playlist creation path
- uploaded a track, quit before POST /tracks, verified that updating own profile led to a sync of the files. switched creator nodes and the finished the associate step successfully on the new primary