### PR TITLE
DP Listens

### DIFF
--- a/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
+++ b/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
@@ -37,7 +37,7 @@ def upgrade():
         count(*) as count
       FROM
           plays
-      GROUP BY plays.play_item_id
+      GROUP BY plays.play_item_id;
 
       -- add index on above materialized view
       CREATE INDEX play_item_id_idx ON aggregate_plays (play_item_id);

--- a/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
+++ b/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
@@ -1,0 +1,59 @@
+"""Add play counts
+
+Revision ID: 776ca72b16db
+Revises: 626aa04489af
+Create Date: 2020-07-20 18:35:47.571403
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '776ca72b16db'
+down_revision = '626aa04489af'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('plays',
+        sa.Column('id', sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('source', sa.String(), nullable=True),
+        sa.Column('play_item_id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        # sa.ForeignKeyConstraint(['user_id'], ['users.user_id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    connection = op.get_bind()
+
+    # playlist search index
+    connection.execute('''
+      CREATE MATERIALIZED VIEW aggregate_plays as
+      SELECT * FROM (
+        SELECT
+          plays.play_item_id as play_item_id,
+          count(*) as count
+        FROM
+            plays
+        GROUP BY plays.play_item_id
+      ) AS words;
+
+      -- add index on above materialized view
+      CREATE INDEX play_item_id_idx ON aggregate_plays (play_item_id);
+    ''')
+
+def downgrade():
+
+    connection = op.get_bind()
+    # playlist search index
+    connection.execute('''
+      -- Drop
+      DROP INDEX IF EXISTS play_item_id_idx;
+      DROP MATERIALIZED VIEW IF EXISTS aggregate_plays;
+    ''')
+
+    op.drop_table('plays')

--- a/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
+++ b/discovery-provider/alembic/versions/776ca72b16db_add_play_counts.py
@@ -24,32 +24,28 @@ def upgrade():
         sa.Column('play_item_id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
-        # sa.ForeignKeyConstraint(['user_id'], ['users.user_id']),
         sa.PrimaryKeyConstraint('id')
     )
 
     connection = op.get_bind()
 
-    # playlist search index
+    # aggreagate plays mat view
     connection.execute('''
       CREATE MATERIALIZED VIEW aggregate_plays as
-      SELECT * FROM (
-        SELECT
-          plays.play_item_id as play_item_id,
-          count(*) as count
-        FROM
-            plays
-        GROUP BY plays.play_item_id
-      ) AS words;
+      SELECT
+        plays.play_item_id as play_item_id,
+        count(*) as count
+      FROM
+          plays
+      GROUP BY plays.play_item_id
 
       -- add index on above materialized view
       CREATE INDEX play_item_id_idx ON aggregate_plays (play_item_id);
     ''')
 
 def downgrade():
-
     connection = op.get_bind()
-    # playlist search index
+    # aggreagate plays mat view
     connection.execute('''
       -- Drop
       DROP INDEX IF EXISTS play_item_id_idx;

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -258,7 +258,7 @@ def configure_celery(flask_app, celery, test_config=None):
 
     # Update celery configuration
     celery.conf.update(
-        imports=["src.tasks.index", "src.tasks.index_blacklist", "src.tasks.index_cache"],
+        imports=["src.tasks.index", "src.tasks.index_blacklist", "src.tasks.index_cache", "src.tasks.index_plays"],
         beat_schedule={
             "update_discovery_provider": {
                 "task": "update_discovery_provider",
@@ -271,6 +271,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "update_cache": {
                 "task": "update_discovery_cache",
                 "schedule": timedelta(seconds=60)
+            },
+            "update_play_count": {
+                "task": "update_play_count",
+                "schedule": timedelta(seconds=10)
             }
         },
         task_serializer="json",

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -274,7 +274,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "update_play_count": {
                 "task": "update_play_count",
-                "schedule": timedelta(seconds=10)
+                "schedule": timedelta(seconds=5)
             }
         },
         task_serializer="json",

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -417,7 +417,7 @@ class Play(Base):
     __tablename__ = "plays"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.user_id"), nullable=True, index=False)
+    user_id = Column(Integer, nullable=True, index=False)
     source = Column(String, nullable=True, index=False)
     play_item_id = Column(Integer, nullable=False, index=False)
     created_at = Column(DateTime, nullable=False, default=func.now())

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Text,
     Enum,
     PrimaryKeyConstraint,
+    func,
 )
 from src.model_validator import ModelValidator
 
@@ -398,8 +399,8 @@ class Stem(Base):
     PrimaryKeyConstraint(parent_track_id, child_track_id)
 
     def __repr__(self):
-        return f"<Remix(parent_track_id={self.parent_track_id},\
-            child_track_id={self.child_track_id})"
+        return f"<Stem(parent_track_id={self.parent_track_id},\
+child_track_id={self.child_track_id})>"
 
 class Remix(Base):
     __tablename__ = "remixes"
@@ -410,4 +411,23 @@ class Remix(Base):
 
     def __repr__(self):
         return f"<Remix(parent_track_id={self.parent_track_id},\
-            child_track_id={self.child_track_id}>"
+child_track_id={self.child_track_id}>"
+
+class Play(Base):
+    __tablename__ = "plays"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.user_id"), nullable=True, index=False)
+    source = Column(String, nullable=True, index=False)
+    play_item_id = Column(Integer, nullable=False, index=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<Play(\
+id={self.id},\
+user_id={self.user_id},\
+source={self.source},\
+play_item_id={self.play_item_id}\
+updated_at={self.updated_at}\
+created_at={self.created_at}>"

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -313,6 +313,8 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
 
 
 def get_track_play_count_dict(session, track_ids):
+    if not track_ids:
+        return {}
     query = text(
         f"""
         select play_item_id, count

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -976,7 +976,7 @@ def get_track_play_counts(track_ids):
         for listen_info in listen_count_json['listenCounts']:
             current_id = listen_info['trackId']
             track_listen_counts[current_id] = listen_info['listens']
-    return track_listen_count
+    return track_listen_counts
 
 
 def get_pagination_vars():

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -1,7 +1,7 @@
 import logging  # pylint: disable=C0302
 from urllib.parse import urljoin
 import requests
-from sqlalchemy import func, desc, text, Integer, and_
+from sqlalchemy import func, desc, text, Integer, and_, bindparam
 
 from flask import request
 
@@ -312,6 +312,21 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
     return users
 
 
+def get_track_play_counts(session, track_ids):
+    query = text(
+        f"""
+        select play_item_id, count
+        from aggregate_plays
+        where play_item_id in :ids
+        """
+    )
+    query = query.bindparams(bindparam('ids', expanding=True))
+
+    track_play_counts = session.execute(query, { "ids": track_ids }).fetchall()
+    track_play_dict = dict(track_play_counts)
+    return track_play_dict
+
+
 # given list of track ids and corresponding tracks, populates each track object with:
 #   repost_count, save_count
 #   if remix: remix users, has_remix_author_reposted, has_remix_author_saved
@@ -352,6 +367,8 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
     )
     save_count_dict = {track_id: save_count for (
         track_id, save_count) in save_counts}
+
+    play_count_dict = get_track_play_counts(session, track_ids)
 
     remixes = get_track_remix_metadata(session, tracks, current_user_id)
 
@@ -445,6 +462,8 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
         track[response_name_constants.repost_count] = repost_count_dict.get(
             track_id, 0)
         track[response_name_constants.save_count] = save_count_dict.get(
+            track_id, 0)
+        track[response_name_constants.play_count] = play_count_dict.get(
             track_id, 0)
         # current user specific
         track[response_name_constants.followee_reposts] = followee_track_repost_dict.get(
@@ -919,43 +938,6 @@ def get_follower_count_dict(session, user_ids, max_block_number=None):
     return follower_count_dict
 
 
-def get_track_play_counts(track_ids):
-    track_listen_counts = {}
-
-    if not track_ids:
-        return track_listen_counts
-
-    identity_url = shared_config['discprov']['identity_service_url']
-    # Create and query identity service endpoint
-    identity_tracks_endpoint = urljoin(identity_url, 'tracks/listens')
-
-    post_body = {}
-    post_body['track_ids'] = track_ids
-    try:
-        resp = requests.post(identity_tracks_endpoint, json=post_body)
-    except Exception as e:
-        logger.error(
-            f'Error retrieving play count - {identity_tracks_endpoint}, {e}'
-        )
-        return track_listen_counts
-
-    json_resp = resp.json()
-    keys = list(resp.json().keys())
-    if not keys:
-        return track_listen_counts
-
-    # Scenario should never arise, since we don't impose date parameter on initial query
-    if len(keys) != 1:
-        raise Exception('Invalid number of keys')
-
-    # Parse listen query results into track listen count dictionary
-    date_key = keys[0]
-    listen_count_json = json_resp[date_key]
-    if 'listenCounts' in listen_count_json:
-        for listen_info in listen_count_json['listenCounts']:
-            current_id = listen_info['trackId']
-            track_listen_counts[current_id] = listen_info['listens']
-    return track_listen_counts
 
 
 def get_pagination_vars():

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -1,6 +1,7 @@
 # track/playlist metadata
 repost_count = 'repost_count'  # integer - total repost count of given track/playlist
 save_count = 'save_count'  # integer - total save count of given track/playlist
+play_count = 'play_count' # integer - total play count of given track
 # boolean - has current user reposted given track/playlist
 has_current_user_reposted = 'has_current_user_reposted'
 # boolean - has current user saved given track/playlist

--- a/discovery-provider/src/queries/search.py
+++ b/discovery-provider/src/queries/search.py
@@ -128,7 +128,7 @@ def search_tags():
             )
 
             tracks = helpers.query_result_to_list(tracks)
-            track_play_counts = get_track_play_counts(session, track_ids)
+            track_play_counts = get_track_play_counts(track_ids)
 
             tracks = populate_track_metadata(
                 session, track_ids, tracks, current_user_id)

--- a/discovery-provider/src/queries/search.py
+++ b/discovery-provider/src/queries/search.py
@@ -128,7 +128,7 @@ def search_tags():
             )
 
             tracks = helpers.query_result_to_list(tracks)
-            track_play_counts = get_track_play_counts(track_ids)
+            track_play_counts = get_track_play_counts(session, track_ids)
 
             tracks = populate_track_metadata(
                 session, track_ids, tracks, current_user_id)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,9 +1,5 @@
 import logging
-from urllib.parse import urljoin
-import requests
-import dateutil.parser
-import datetime
-from sqlalchemy import func, desc
+from sqlalchemy import desc
 from src import contract_addresses
 from src.models import Block, User, Track, Repost, Follow, Playlist, Save, Play
 from src.tasks.celery_app import celery
@@ -248,100 +244,6 @@ def index_blocks(self, db, blocks_list):
     if num_blocks > 0:
         logger.warning(f"index.py | index_blocks | Indexed {num_blocks} blocks")
 
-
-def get_user_track_play_counts(session, user_id, track_id):
-    query = text(
-        f"""
-        select play_item_id, count
-        from aggregate_plays
-        where play_item_id in :ids
-        """
-    )
-    query = query.bindparams(bindparam('ids', expanding=True))
-
-    track_play_counts = session.execute(query, { "ids": track_ids }).fetchall()
-    track_play_dict = dict(track_play_counts)
-    return track_play_dict
-
-# Retrieve the play counts from the identity service
-# NOTE: indexing the plays will eventually be a part of `index_blocks`
-def get_track_plays(self, db):
-    with db.scoped_session() as session:
-        # Get the most retrieved play date in the db to use as an offet for fetching
-        # more play counts from identity
-        most_recent_play_date = session.query(
-                Play.updated_at
-            ).order_by(
-                desc(Play.updated_at),
-                desc(Play.id)
-            ).first()
-        if most_recent_play_date == None:
-            # Make the date way back in the past to get the first play count onwards
-            most_recent_play_date = datetime.datetime(2000,1,1,0,0).timestamp()
-        else:
-            most_recent_play_date = most_recent_play_date[0].timestamp()
-
-        # Create and query identity service endpoint for track play counts
-        identity_url = update_task.shared_config['discprov']['identity_service_url']
-        params = { 'startTime': most_recent_play_date, 'limit': 1000 }
-        identity_tracks_endpoint = urljoin(identity_url, 'listens/bulk')
-
-        track_listens = {}
-        try:
-            resp = requests.get(identity_tracks_endpoint, params=params)
-            track_listens = resp.json()
-        except Exception as e:
-            logger.error(
-                f'Error retrieving track play counts - {identity_tracks_endpoint}, {e}'
-            )
-
-        # Insert a new row for each count instance in the plays table
-        plays = []
-        if 'listens' in track_listens:
-            for listen in track_listens['listens']:
-                if 'userId' in listen and listen['userId'] != None:
-                    # If the userId is present, query for exist plays and only
-                    # insert new plays for the difference
-                    user_track_play_count = session.query(
-                        func.count(Play.play_item_id)
-                    ).filter(
-                        Play.play_item_id == listen['trackId'],
-                        Play.user_id == listen['userId']
-                    ).scalar()
-                    new_play_count = listen['count'] - user_track_play_count
-                    if new_play_count > 0:
-                        plays.extend([
-                            Play(
-                                user_id=listen['userId'],
-                                play_item_id=listen['trackId'],
-                                created_at=listen['createdAt'],
-                            ) for _ in range(new_play_count)
-                        ])
-                else:
-                    # For anon track plays, check the current hour play counts
-                    # and only insert new plays for the difference
-                    current_hour_query = dateutil.parser.parse(
-                            listen['createdAt']
-                        ).replace(microsecond=0, second=0, minute=0)
-                    anon_hr_track_play_count = session.query(
-                        func.count(Play.play_item_id)
-                    ).filter(
-                        Play.play_item_id == listen['trackId'],
-                        Play.user_id == None,
-                        Play.created_at >= current_hour_query
-                    ).scalar()
-                    new_play_count = listen['count'] - anon_hr_track_play_count
-                    if new_play_count > 0:
-                        plays.extend([
-                            Play(
-                                play_item_id=listen['trackId'],
-                                created_at=listen['createdAt'],
-                            ) for _ in range(new_play_count)
-                        ])
-
-        if len(plays) > 0:
-            session.bulk_save_objects(plays)
-            session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
 
 # transactions are reverted in reverse dependency order (social features --> playlists --> tracks --> users)
 def revert_blocks(self, db, revert_blocks_list):
@@ -720,7 +622,6 @@ def update_task(self):
             # Perform indexing operations
             index_blocks(self, db, index_blocks_list)
             logger.info(f"index.py | update_task | {self.request.id} | Processing complete within session")
-            get_track_plays(self, db)
         else:
             logger.error(f"index.py | update_task | {self.request.id} | Failed to acquire disc_prov_lock")
     except Exception as e:

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,7 +1,7 @@
 import logging
-from sqlalchemy import desc
+
 from src import contract_addresses
-from src.models import Block, User, Track, Repost, Follow, Playlist, Save, Play
+from src.models import Block, User, Track, Repost, Follow, Playlist, Save
 from src.tasks.celery_app import celery
 from src.tasks.tracks import track_state_update
 from src.tasks.users import user_state_update  # pylint: disable=E0611,E0001
@@ -243,7 +243,6 @@ def index_blocks(self, db, blocks_list):
 
     if num_blocks > 0:
         logger.warning(f"index.py | index_blocks | Indexed {num_blocks} blocks")
-
 
 # transactions are reverted in reverse dependency order (social features --> playlists --> tracks --> users)
 def revert_blocks(self, db, revert_blocks_list):

--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -1,0 +1,136 @@
+import logging
+from urllib.parse import urljoin
+import requests
+import dateutil.parser
+import datetime
+from sqlalchemy import func, desc
+from src.models import Play
+from src.tasks.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+
+######## HELPER FUNCTIONS ########
+def get_user_track_play_counts(session, user_id, track_id):
+    query = text(
+        f"""
+        select play_item_id, count
+        from aggregate_plays
+        where play_item_id in :ids
+        """
+    )
+    query = query.bindparams(bindparam('ids', expanding=True))
+
+    track_play_counts = session.execute(query, { "ids": track_ids }).fetchall()
+    track_play_dict = dict(track_play_counts)
+    return track_play_dict
+
+# Retrieve the play counts from the identity service
+# NOTE: indexing the plays will eventually be a part of `index_blocks`
+def get_track_plays(self, db):
+    with db.scoped_session() as session:
+        # Get the most retrieved play date in the db to use as an offet for fetching
+        # more play counts from identity
+        most_recent_play_date = session.query(
+                Play.updated_at
+            ).order_by(
+                desc(Play.updated_at),
+                desc(Play.id)
+            ).first()
+        if most_recent_play_date == None:
+            # Make the date way back in the past to get the first play count onwards
+            most_recent_play_date = datetime.datetime(2000,1,1,0,0).timestamp()
+        else:
+            most_recent_play_date = most_recent_play_date[0].timestamp()
+
+        # Create and query identity service endpoint for track play counts
+        identity_url = update_play_count.shared_config['discprov']['identity_service_url']
+        params = { 'startTime': most_recent_play_date, 'limit': 1000 }
+        identity_tracks_endpoint = urljoin(identity_url, 'listens/bulk')
+
+        track_listens = {}
+        try:
+            resp = requests.get(identity_tracks_endpoint, params=params)
+            track_listens = resp.json()
+        except Exception as e:
+            logger.error(
+                f'Error retrieving track play counts - {identity_tracks_endpoint}, {e}'
+            )
+
+        # Insert a new row for each count instance in the plays table
+        plays = []
+        if 'listens' in track_listens:
+            for listen in track_listens['listens']:
+                if 'userId' in listen and listen['userId'] != None:
+                    # If the userId is present, query for exist plays and only
+                    # insert new plays for the difference
+                    user_track_play_count = session.query(
+                        func.count(Play.play_item_id)
+                    ).filter(
+                        Play.play_item_id == listen['trackId'],
+                        Play.user_id == listen['userId']
+                    ).scalar()
+                    new_play_count = listen['count'] - user_track_play_count
+                    if new_play_count > 0:
+                        plays.extend([
+                            Play(
+                                user_id=listen['userId'],
+                                play_item_id=listen['trackId'],
+                                created_at=listen['createdAt'],
+                            ) for _ in range(new_play_count)
+                        ])
+                else:
+                    # For anon track plays, check the current hour play counts
+                    # and only insert new plays for the difference
+                    current_hour_query = dateutil.parser.parse(
+                            listen['createdAt']
+                        ).replace(microsecond=0, second=0, minute=0)
+                    anon_hr_track_play_count = session.query(
+                        func.count(Play.play_item_id)
+                    ).filter(
+                        Play.play_item_id == listen['trackId'],
+                        Play.user_id == None,
+                        Play.created_at >= current_hour_query
+                    ).scalar()
+                    new_play_count = listen['count'] - anon_hr_track_play_count
+                    if new_play_count > 0:
+                        plays.extend([
+                            Play(
+                                play_item_id=listen['trackId'],
+                                created_at=listen['createdAt'],
+                            ) for _ in range(new_play_count)
+                        ])
+
+        if len(plays) > 0:
+            session.bulk_save_objects(plays)
+            session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+
+######## CELERY TASK ########
+@celery.task(name="update_play_count", bind=True)
+def update_play_count(self):
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/__init__.py
+    db = update_play_count.db
+    redis = update_play_count.redis
+
+    # Define lock acquired boolean
+    have_lock = False
+
+    # Define redis lock object
+    update_lock = redis.lock("update_play_count_lock", blocking_timeout=25)
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info(f"index_plays.py | update_play_count | {self.request.id} | Acquired update_play_count_lock")
+            get_track_plays(self, db)
+            logger.info(f"index_plaus.py | update_play_count | {self.request.id} | Processing complete within session")
+        else:
+            logger.error(f"index_plaus.py | update_play_count | {self.request.id} | Failed to acquire update_play_count_lock")
+    except Exception as e:
+        logger.error("Fatal error in main loop of update_play_count", exc_info=True)
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -477,6 +477,7 @@ module.exports = function (app) {
     })
 
     const anonListens = await models.TrackListenCount.findAll({
+      attributes: ['trackId', ['listens', 'count'], 'createdAt', 'updatedAt'],
       where: {
         createdAt: { [models.Sequelize.Op.gt]: createdAtMoment.toDate() }
       },

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -459,10 +459,10 @@ module.exports = function (app) {
       return errorResponseBadRequest(`Provided limit ${limit} too large (must be <= 5000)`)
     }
 
-    let createdAtMoment
+    let updatedAtMoment
     try {
-      createdAtMoment = moment.unix(startTime)
-      if (!createdAtMoment.isValid()) throw new Error()
+      updatedAtMoment = moment.unix(startTime)
+      if (!updatedAtMoment.isValid()) throw new Error()
     } catch (e) {
       return errorResponseBadRequest(`Provided startTime ${startTime} not parseable`)
     }
@@ -470,7 +470,7 @@ module.exports = function (app) {
     const userListens = await models.UserTrackListen.findAll({
       attributes: { exclude: ['id'] },
       where: {
-        createdAt: { [models.Sequelize.Op.gt]: createdAtMoment.toDate() }
+        updatedAt: { [models.Sequelize.Op.gt]: updatedAtMoment.toDate() }
       },
       order: [['createdAt', 'ASC'], ['trackId', 'ASC']],
       limit
@@ -479,7 +479,7 @@ module.exports = function (app) {
     const anonListens = await models.TrackListenCount.findAll({
       attributes: ['trackId', ['listens', 'count'], 'createdAt', 'updatedAt'],
       where: {
-        createdAt: { [models.Sequelize.Op.gt]: createdAtMoment.toDate() }
+        updatedAt: { [models.Sequelize.Op.gt]: updatedAtMoment.toDate() }
       },
       order: [['createdAt', 'ASC'], ['trackId', 'ASC']],
       limit


### PR DESCRIPTION
Notion Spec: https://www.notion.so/audiusproject/Play-counts-in-Discovery-Provider-4489acc63eff4b9994c865323982efa9

Major Note: 
B/c the identity service has a rolling time range for holding anon listens, if the listens are fetched for a track in the current time range and it then that count increases, we wouldn't re-fetch it b/c it's fetched using created at and we would pass that timestamp (Same goes for user listens to track). So, there needs to be a delay somehow to fetching or a way to dedupe plays. Duduping would be too hard, but not sure what's the best way to go about w/ dealing the the time range. lmk if this doesn't make sense. 

Minor Notes: 
* The plays table in dp needs an index w/ sqlAlchemy, so I added an id b/c there isn't anything unique I could think of to create a unique key from. Is this ok, thoughts? 
* The foreign key constraint from the plays table to users w/ user_id isn't possible b/c the users table has multiple users w/ that id, so it can't map to a single row. I removed the constraint
* I wasn't sure if I should copy over the createdAt, updatedAt from the identity bulk listens response into the dp plays table or not. Thoughts on that?
* Updated the identity response to conform to the spec - anonListens has the field `listens` instead of `count`. Another thing about this though is should I follow the spec to update it to return key `user: null` b/c it's not attached to the response rn for anon listens. 

------ 
Edit:
After talking w/ ray we are going to dedupe the plays on the discovery provider side. The changes for this would be for identity to send listens startTIme querying for UserTrackListens and TrackListenCounts w/ updatedAt timestamp after the startTIme instead of the createdAt. On the dp side of things, for anon users, it's query for the track play count in the last hour, insert plays for the difference. For user track listens it's the same deal w/out the timerange. 

We are keeping the id in the plays table as the primary key
There will be no foreign key constraint on user_id


### Testing
What I did to test was set up the system locally, created a couple account and uploaded 3 tracks. Then I listened to those tracks on both account and from an anonymous user. I compared the identity tables `UserTrackListens` and `TrackListenCount` with the 'plays' table in DP and also checked that the dp /tracks endpoint was returning the correct track play_count