### PR TITLE
Add live email setting

### DIFF
--- a/identity-service/sequelize/migrations/20200723161647-add-live-emails.js
+++ b/identity-service/sequelize/migrations/20200723161647-add-live-emails.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 const models = require('../../src/models')
 
 module.exports = {
@@ -8,31 +8,31 @@ module.exports = {
       "ALTER TYPE \"enum_NotificationEmails_emailFrequency\" ADD VALUE 'live'"
     )
     // Change the default to 'live'
-    .then(() => {
-      return queryInterface.sequelize.query(
-        "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'live'::\"enum_NotificationEmails_emailFrequency\""
-      )
-    })
-    // Add 'live' to "UserNotificationSettings" "emailFrequency"
-    .then(() => {
-      queryInterface.sequelize.query(
-        "ALTER TYPE \"enum_UserNotificationSettings_emailFrequency\" ADD VALUE 'live'"
-      )
-    })
-    // Change the default ot 'live'
-    .then(() => {
-      return queryInterface.sequelize.query(
-        "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'live'::\"enum_UserNotificationSettings_emailFrequency\""
-      )
-    })
-    // Set all the users who have the default (daily) to live
-    .then(() => {
-      return models.UserNotificationSettings.update({
-        emailFrequency: 'live'
-      }, {
-        where: { emailFrequency: 'daily' }
+      .then(() => {
+        return queryInterface.sequelize.query(
+          "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'live'::\"enum_NotificationEmails_emailFrequency\""
+        )
       })
-    })
+    // Add 'live' to "UserNotificationSettings" "emailFrequency"
+      .then(() => {
+        queryInterface.sequelize.query(
+          "ALTER TYPE \"enum_UserNotificationSettings_emailFrequency\" ADD VALUE 'live'"
+        )
+      })
+    // Change the default ot 'live'
+      .then(() => {
+        return queryInterface.sequelize.query(
+          "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'live'::\"enum_UserNotificationSettings_emailFrequency\""
+        )
+      })
+    // Set all the users who have the default (daily) to live
+      .then(() => {
+        return models.UserNotificationSettings.update({
+          emailFrequency: 'live'
+        }, {
+          where: { emailFrequency: 'daily' }
+        })
+      })
   },
 
   down: (queryInterface, Sequelize) => {
@@ -43,30 +43,30 @@ module.exports = {
       where: { emailFrequency: 'live' }
     })
     // Change the default back to 'daily'
-    .then(() => {
-      queryInterface.sequelize.query(
-        "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'daily'::\"enum_NotificationEmails_emailFrequency\""
-      )
-    })
+      .then(() => {
+        queryInterface.sequelize.query(
+          "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'daily'::\"enum_NotificationEmails_emailFrequency\""
+        )
+      })
     // Delete 'live' from "NotificationEmails" "emailFrequency"
-    .then(() => {
-      const query = 'DELETE FROM pg_enum ' +
+      .then(() => {
+        const query = 'DELETE FROM pg_enum ' +
         'WHERE enumlabel = \'live\' ' +
         'AND enumtypid = ( SELECT oid FROM pg_type WHERE typname = \'enum_NotificationEmails_emailFrequency\')'
-      return queryInterface.sequelize.query(query)
-    })
+        return queryInterface.sequelize.query(query)
+      })
     // Change the default back to 'daily'
-    .then(() => {
-      return queryInterface.sequelize.query(
-        "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'daily'::\"enum_UserNotificationSettings_emailFrequency\""
-      )
-    })
+      .then(() => {
+        return queryInterface.sequelize.query(
+          "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'daily'::\"enum_UserNotificationSettings_emailFrequency\""
+        )
+      })
     // Delete 'live' from "NotificationEmails" "emailFrequency"
-    .then(() => {
-      const query = 'DELETE FROM pg_enum ' +
+      .then(() => {
+        const query = 'DELETE FROM pg_enum ' +
         'WHERE enumlabel = \'live\' ' +
         'AND enumtypid = ( SELECT oid FROM pg_type WHERE typname = \'enum_UserNotificationSettings_emailFrequency\')'
-      return queryInterface.sequelize.query(query)
-    })
+        return queryInterface.sequelize.query(query)
+      })
   }
-};
+}

--- a/identity-service/sequelize/migrations/20200723161647-add-live-emails.js
+++ b/identity-service/sequelize/migrations/20200723161647-add-live-emails.js
@@ -1,0 +1,72 @@
+'use strict';
+const models = require('../../src/models')
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    // Add 'live' to "NotificatiionEmails" "emailFrequency"
+    return queryInterface.sequelize.query(
+      "ALTER TYPE \"enum_NotificationEmails_emailFrequency\" ADD VALUE 'live'"
+    )
+    // Change the default to 'live'
+    .then(() => {
+      return queryInterface.sequelize.query(
+        "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'live'::\"enum_NotificationEmails_emailFrequency\""
+      )
+    })
+    // Add 'live' to "UserNotificationSettings" "emailFrequency"
+    .then(() => {
+      queryInterface.sequelize.query(
+        "ALTER TYPE \"enum_UserNotificationSettings_emailFrequency\" ADD VALUE 'live'"
+      )
+    })
+    // Change the default ot 'live'
+    .then(() => {
+      return queryInterface.sequelize.query(
+        "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'live'::\"enum_UserNotificationSettings_emailFrequency\""
+      )
+    })
+    // Set all the users who have the default (daily) to live
+    .then(() => {
+      return models.UserNotificationSettings.update({
+        emailFrequency: 'live'
+      }, {
+        where: { emailFrequency: 'daily' }
+      })
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    // Set all the users who have the default (live) to daily
+    return models.UserNotificationSettings.update({
+      emailFrequency: 'daily'
+    }, {
+      where: { emailFrequency: 'live' }
+    })
+    // Change the default back to 'daily'
+    .then(() => {
+      queryInterface.sequelize.query(
+        "ALTER TABLE \"NotificationEmails\" ALTER \"emailFrequency\" set default 'daily'::\"enum_NotificationEmails_emailFrequency\""
+      )
+    })
+    // Delete 'live' from "NotificationEmails" "emailFrequency"
+    .then(() => {
+      const query = 'DELETE FROM pg_enum ' +
+        'WHERE enumlabel = \'live\' ' +
+        'AND enumtypid = ( SELECT oid FROM pg_type WHERE typname = \'enum_NotificationEmails_emailFrequency\')'
+      return queryInterface.sequelize.query(query)
+    })
+    // Change the default back to 'daily'
+    .then(() => {
+      return queryInterface.sequelize.query(
+        "ALTER TABLE \"UserNotificationSettings\" ALTER \"emailFrequency\" set default 'daily'::\"enum_UserNotificationSettings_emailFrequency\""
+      )
+    })
+    // Delete 'live' from "NotificationEmails" "emailFrequency"
+    .then(() => {
+      const query = 'DELETE FROM pg_enum ' +
+        'WHERE enumlabel = \'live\' ' +
+        'AND enumtypid = ( SELECT oid FROM pg_type WHERE typname = \'enum_UserNotificationSettings_emailFrequency\')'
+      return queryInterface.sequelize.query(query)
+    })
+  }
+};

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -74,7 +74,6 @@ class App {
   configureMailgun () {
     // Configure mailgun instance
     let mg = null
-    logger.info(`MG processEmailNotifications`, config.get('mailgunApiKey'), "<---")
     if (config.get('mailgunApiKey')) {
       mg = mailgun({ apiKey: config.get('mailgunApiKey'), domain: DOMAIN })
     }

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -74,6 +74,7 @@ class App {
   configureMailgun () {
     // Configure mailgun instance
     let mg = null
+    logger.info(`MG processEmailNotifications`, config.get('mailgunApiKey'), "<---")
     if (config.get('mailgunApiKey')) {
       mg = mailgun({ apiKey: config.get('mailgunApiKey'), domain: DOMAIN })
     }

--- a/identity-service/src/models/notificationemail.js
+++ b/identity-service/src/models/notificationemail.js
@@ -13,8 +13,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     emailFrequency: {
       allowNull: false,
-      type: DataTypes.ENUM('daily', 'weekly', 'off'),
-      defaultValue: 'daily'
+      type: DataTypes.ENUM('live', 'daily', 'weekly', 'off'),
+      defaultValue: 'live'
     }
   }, {})
   NotificationEmail.associate = function (models) {

--- a/identity-service/src/models/userNotificationSettings.js
+++ b/identity-service/src/models/userNotificationSettings.js
@@ -38,8 +38,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     emailFrequency: {
       allowNull: false,
-      type: DataTypes.ENUM('daily', 'weekly', 'off'),
-      defaultValue: 'daily'
+      type: DataTypes.ENUM('live', 'daily', 'weekly', 'off'),
+      defaultValue: 'live'
     }
 
   }, {})

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -124,10 +124,10 @@ class NotificationProcessor {
       fs.mkdirSync(emailCachePath)
     }
 
-    // Every hour cron: '0 * * * *'
+    // Every minute cron: '* * * * *'
     this.emailQueue.add(
       { type: 'unreadEmailJob' },
-      { repeat: { cron: '0 * * * *' } }
+      { repeat: { cron: '* * * * *' } }
     )
 
     let startBlock = await getHighestBlockNumber()

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -124,10 +124,10 @@ class NotificationProcessor {
       fs.mkdirSync(emailCachePath)
     }
 
-    // Every minute cron: '* * * * *'
+    // Every 10 minutes cron: '*/10 * * * *'
     this.emailQueue.add(
       { type: 'unreadEmailJob' },
-      { repeat: { cron: '* * * * *' } }
+      { repeat: { cron: '*/10 * * * *' } }
     )
 
     let startBlock = await getHighestBlockNumber()

--- a/identity-service/src/notifications/milestoneProcessing.js
+++ b/identity-service/src/notifications/milestoneProcessing.js
@@ -17,7 +17,7 @@ const {
 
 // Base milestone list shared across all types
 // Each type can be configured as needed
-const baseMilestoneList = [10, 25, 50, 100, 250, 500, 1000]
+const baseMilestoneList = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000]
 const followerMilestoneList = baseMilestoneList
 // Repost milestone list shared across tracks/albums/playlists
 const repostMilestoneList = baseMilestoneList

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -19,14 +19,20 @@ const {
 let mg
 
 async function processEmailNotifications (expressApp, audiusLibs) {
+  console.log
   try {
     logger.info(`${new Date()} - processEmailNotifications`)
 
     mg = expressApp.get('mailgun')
     if (mg === null) {
-      logger.error('Mailgun not configured')
+      logger.error('processEmailNotifications - Mailgun not configured')
       return
     }
+
+    let liveEmailUsers = await models.UserNotificationSettings.findAll({
+      attributes: ['userId'],
+      where: { emailFrequency: 'live' }
+    }).map(x => x.userId)
 
     let dailyEmailUsers = await models.UserNotificationSettings.findAll({
       attributes: ['userId'],
@@ -38,7 +44,9 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       where: { emailFrequency: 'weekly' }
     }).map(x => x.userId)
 
-    logger.info(`processEmailNotifications - ${dailyEmailUsers.length} daily users, ${weeklyEmailUsers.length}`)
+    logger.info(`processEmailNotifications - ${liveEmailUsers.length} live users`)
+    logger.info(`processEmailNotifications - ${dailyEmailUsers.length} daily users`)
+    logger.info(`processEmailNotifications - ${weeklyEmailUsers.length} weekly users`)
     let now = moment()
     let dayAgo = now.clone().subtract(1, 'days')
     let weekAgo = now.clone().subtract(7, 'days')
@@ -46,6 +54,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
     let appAnnouncements = expressApp.get('announcements')
     // For each announcement, we generate a list of valid users
     // Based on the user's email frequency
+    let liveUsersWithPendingAnnouncements = []
     let dailyUsersWithPendingAnnouncements = []
     let weeklyUsersWithPendingAnnouncements = []
     let currentTime = moment.utc()
@@ -73,7 +82,10 @@ async function processEmailNotifications (expressApp, audiusLibs) {
         if (userNotificationQuery) {
           continue
         }
-        if (dailyEmailUsers.includes(user)) {
+        if (liveEmailUsers.includes(user)) {
+          logger.info(`Announcements - ${id} | Live user ${user}`)
+          liveUsersWithPendingAnnouncements.append(user)
+        } else if (dailyEmailUsers.includes(user)) {
           if (timeSinceAnnouncement < (dayInHours * 1.5)) {
             logger.info(`Announcements - ${id} | Daily user ${user}, <1 day`)
             dailyUsersWithPendingAnnouncements.append(user)
@@ -88,12 +100,30 @@ async function processEmailNotifications (expressApp, audiusLibs) {
     }
     let pendingNotificationUsers = new Set()
     // Add users with pending announcement notifications
+    liveUsersWithPendingAnnouncements.forEach(
+      item => pendingNotificationUsers.add(item))
     dailyUsersWithPendingAnnouncements.forEach(
       item => pendingNotificationUsers.add(item))
     weeklyUsersWithPendingAnnouncements.forEach(
       item => pendingNotificationUsers.add(item))
 
     // Query users with pending notifications grouped by frequency
+    let liveEmailUsersWithUnseenNotifications = await models.Notification.findAll({
+      attributes: ['userId'],
+      where: {
+        isViewed: false,
+        userId: { [ models.Sequelize.Op.in]: liveEmailUsers },
+        // Over fetch users here, they will get dropped later on if they have 0 notifications
+        // to process.
+        // We could be more precise here by looking at the last sent email for each user
+        // but that query would be more expensive than just finding extra users here and then
+        // dropping them.
+        timestamp: { [models.Sequelize.Op.gt]: dayAgo }
+      },
+      group: ['userId']
+    }).map(x => x.userId)
+    liveEmailUsersWithUnseenNotifications.forEach(item => pendingNotificationUsers.add(item))
+
     let dailyEmailUsersWithUnseeenNotifications = await models.Notification.findAll({
       attributes: ['userId'],
       where: {
@@ -115,8 +145,10 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       group: ['userId']
     }).map(x => x.userId)
     weeklyEmailUsersWithUnseeenNotifications.forEach(item => pendingNotificationUsers.add(item))
-    logger.info(`Daily Email Users: ${dailyEmailUsersWithUnseeenNotifications}`)
-    logger.info(`Weekly Email Users: ${weeklyEmailUsersWithUnseeenNotifications}`)
+
+    logger.info(`processEmailNotifications - Live Email Users: ${liveEmailUsersWithUnseenNotifications}`)
+    logger.info(`processEmailNotifications - Daily Email Users: ${dailyEmailUsersWithUnseeenNotifications}`)
+    logger.info(`processEmailNotifications - Weekly Email Users: ${weeklyEmailUsersWithUnseeenNotifications}`)
 
     // All users with notifications, including announcements
     let allUsersWithUnseenNotifications = [...pendingNotificationUsers]
@@ -151,18 +183,45 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       let startOfUserDay = userTime.clone().startOf('day')
       let difference = moment.duration(userTime.diff(startOfUserDay)).asHours()
 
+      let latestUserEmail = await models.NotificationEmail.findOne({
+        where: {
+          userId
+        },
+        order: [['timestamp', 'DESC']]
+      })
+      let lastSentTimestamp
+      if (latestUserEmail) {
+        lastSentTimestamp = moment(latestUserEmail.timestamp)
+      } else {
+        lastSentTimestamp = moment(0) // EPOCH
+      }
+
+      // If the user is in live email mode, just send them right away
+      if (frequency === 'live') {
+        let sent = await renderAndSendEmail(
+          userId,
+          userEmail,
+          appAnnouncements,
+          frequency,
+          lastSentTimestamp, // use lastSentTimestamp to get all new notifs
+          audiusLibs
+        )
+        if (!sent) { continue }
+        logger.info(`Live email to ${userId}, last email from ${lastSentTimestamp}`)
+        await models.NotificationEmail.create({
+          userId,
+          emailFrequency: frequency,
+          timestamp: currentUtcTime
+        })
+        continue
+      }
+
       // Based on this difference, schedule email for users
       // In prod, this difference must be <1 hour or between midnight - 1am
       let maxHourDifference = 2 // 1.5
       // Valid time found
       if (difference < maxHourDifference) {
         logger.info(`Valid email period for user ${userId}, ${timezone}, ${difference} hrs since startOfDay`)
-        let latestUserEmail = await models.NotificationEmail.findOne({
-          where: {
-            userId
-          },
-          order: [['timestamp', 'DESC']]
-        })
         if (!latestUserEmail) {
           let sent = await renderAndSendEmail(
             userId,
@@ -180,7 +239,6 @@ async function processEmailNotifications (expressApp, audiusLibs) {
             timestamp: currentUtcTime
           })
         } else {
-          let lastSentTimestamp = moment(latestUserEmail.timestamp)
           let timeSinceEmail = moment.duration(currentUtcTime.diff(lastSentTimestamp)).asHours()
           if (frequency === 'daily') {
             // If 1 day has passed, send email
@@ -258,7 +316,9 @@ async function renderAndSendEmail (
 
     let renderProps = {}
     renderProps['notifications'] = notificationProps
-    if (frequency === 'daily') {
+    if (frequency === 'live') {
+      renderProps['title'] = `Email - ${userEmail}`
+    } else if (frequency === 'daily') {
       renderProps['title'] = `Daily Email - ${userEmail}`
     } else if (frequency === 'weekly') {
       renderProps['title'] = `Weekly Email - ${userEmail}`
@@ -269,10 +329,19 @@ async function renderAndSendEmail (
     let weekAgo = now.clone().subtract(7, 'days')
     let formattedDayAgo = dayAgo.format('MMMM Do YYYY')
     let shortWeekAgoFormat = weekAgo.format('MMMM Do')
+    let liveSubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''}`
     let weeklySubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''} from ${shortWeekAgoFormat} - ${formattedDayAgo}`
     let dailySubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''} from ${formattedDayAgo}`
 
-    const subject = frequency === 'daily' ? dailySubjectFormat : weeklySubjectFormat
+    let subject
+    if (frequency === 'live') {
+      subject = liveSubjectFormat
+    } else if (frequency === 'daily') {
+      subject = dailySubjectFormat
+    } else {
+      subject = weeklySubjectFormat
+    }
+
     renderProps['subject'] = subject
     const notifHtml = renderEmail(renderProps)
 

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -19,7 +19,6 @@ const {
 let mg
 
 async function processEmailNotifications (expressApp, audiusLibs) {
-  console.log
   try {
     logger.info(`${new Date()} - processEmailNotifications`)
 
@@ -112,7 +111,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       attributes: ['userId'],
       where: {
         isViewed: false,
-        userId: { [ models.Sequelize.Op.in]: liveEmailUsers },
+        userId: { [ models.Sequelize.Op.in ]: liveEmailUsers },
         // Over fetch users here, they will get dropped later on if they have 0 notifications
         // to process.
         // We could be more precise here by looking at the last sent email for each user


### PR DESCRIPTION
Testing:

- Created two users with 'daily' email settings, ray1 and ray2
- Ran the migration so that they both had 'live' setting
- Created tracks as ray1 and triggered notifications with ray2
- Received emails for ray1
- Repeated above for multiple notifications at once (that get combined in the same email)
- Set ray1 back to 'daily', confirmed live emails were not sent
- Undid migration and confirmed that table state was reset