### PR TITLE
Clean up streaming track listens

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -37,8 +37,9 @@ const streamFromFileSystem = async (req, res, path) => {
     let fileStream
 
     let stat
-    if (req.params.streammable) {
+    if (req.params.streamable) {
       // Add content length headers
+      // Stats a file from FS and returns fs stat info, like size in bytes
       stat = fs.statSync(path)
       res.set('Accept-Ranges', 'bytes')
       res.set('Content-Length', stat.size)
@@ -54,7 +55,7 @@ const streamFromFileSystem = async (req, res, path) => {
     // TODO - route doesn't support multipart ranges (see spec above),
     if (stat && range && range[0]) {
       const { start, end } = range[0]
-      if (end > stat.size) {
+      if (end >= stat.size) {
         // Set "Requested Range Not Satisfiable" header and exit
         res.status(416)
         return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
@@ -135,9 +136,9 @@ const getCID = async (req, res) => {
       let stream
       // If a range header is present, use that to create the ipfs stream
       const range = req.range()
-      if (req.params.streammable && range && range[0]) {
+      if (req.params.streamable && range && range[0]) {
         const { start, end } = range[0]
-        if (end > stat.size) {
+        if (end >= stat.size) {
           // Set "Requested Range Not Satisfiable" header and exit
           res.status(416)
           return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -487,11 +487,12 @@ module.exports = function (app) {
     if (libs.identityService) {
       req.logger.info(`Logging listen for track ${blockchainId} by ${delegateOwnerWallet}`)
       // Fire and forget listen recording
+      // TODO: Consider queueing these requests
       libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet)
     }
 
     req.params.CID = multihash
-    req.params.streammable = true
+    req.params.streamable = true
 
     return getCID(req, res)
   })


### PR DESCRIPTION
Addresses some post-merge comments in
https://github.com/AudiusProject/audius-protocol/pull/683

Re: using spId, might be better. We can easily swap it out. Don't expect to be activating this quite yet anyway (and per dheeraj's comment in the last PR, we're not quite ready
https://trello.com/c/W6Xhh5bx/1415-api-track-creator-node-delegate-owner-wallet-in-identity-service-in-discovery-provider