### PR TITLE
Fix API images edge case

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -31,9 +31,9 @@ def add_track_artwork(track):
     if not "user" in track:
         return track
     endpoint = get_primary_endpoint(track["user"])
-    if not endpoint:
-        return track
     cid = track["cover_art_sizes"]
+    if not endpoint or not cid:
+        return track
     artwork = {
         "150x150": make_image(endpoint, cid, 150, 150),
         "480x480": make_image(endpoint, cid, 480, 480),
@@ -46,9 +46,9 @@ def add_playlist_artwork(playlist):
     if not "user" in playlist:
         return playlist
     endpoint = get_primary_endpoint(playlist["user"])
-    if not endpoint:
-        return playlist
     cid = playlist["playlist_image_sizes_multihash"]
+    if not endpoint or not cid:
+        return playlist
     artwork = {
         "150x150": make_image(endpoint, cid, 150, 150),
         "480x480": make_image(endpoint, cid, 480, 480),

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -18,7 +18,7 @@ class Track(Resource):
     def get(self, track_id):
         """Fetch a track"""
         encoded_id = decode_with_abort(track_id, ns)
-        args = {"id": [encoded_id]}
+        args = {"id": [encoded_id], "with_users": True}
         tracks = get_tracks(args)
         if not tracks:
             abort_not_found(encoded_id, ns)

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -301,15 +301,10 @@ def add_users(session, results):
         user_id = None
         if 'playlist_owner_id' in result:
             user_id = result['playlist_owner_id']
-            logger.warning(1)
-            logger.warning(user_id)
         elif 'owner_id' in result:
             user_id = result['owner_id']
 
-        # pylint: disable=W1202
-        logger.warning("User id is {}".format(user_id))
         if user_id is not None:
-            logger.warning(3)
             user = users[user_id]
             result["user"] = user
     return results


### PR DESCRIPTION
- Some tracks didn't have the "cover_art_sizes" field, and we needed to handle this.
- Removed some extra logs
- Ensure tracks endpoint returns users with tracks