### PR TITLE
Fix DP request args

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -36,7 +36,7 @@ class PlaylistTracks(Resource):
         """Fetch tracks within a playlist"""
         playlist_id = decode_with_abort(playlist_id, ns)
         current_user_id = get_current_user_id(required=False)
-        args = {"playlist_id": playlist_id, "with_users": 'true', "current_user_id": current_user_id}
+        args = {"playlist_id": playlist_id, "with_users": True, "current_user_id": current_user_id}
         playlist_tracks = get_playlist_tracks(args)
         if not playlist_tracks:
             abort_not_found(playlist_id, ns)

--- a/discovery-provider/src/queries/get_feed.py
+++ b/discovery-provider/src/queries/get_feed.py
@@ -17,18 +17,9 @@ def get_feed(args):
     feed_results = []
     db = get_db_read_replica()
 
-    # filter should be one of ["all", "reposts", "original"]
-    # empty filter value results in "all"
-    if "filter" in args and args.get("filter") in ["all", "repost", "original"]:
-        feed_filter = args.get("filter")
-    else:
-        feed_filter = "all"
-
+    feed_filter = args.get("filter")
     # Allow for fetching only tracks
-    if 'tracks_only' in args and args.get('tracks_only') != 'false':
-        tracks_only = True
-    else:
-        tracks_only = False
+    tracks_only = args.get('tracks_only', False)
 
     # Current user - user for whom feed is being generated
     current_user_id = get_current_user_id()

--- a/discovery-provider/src/queries/get_playlist_tracks.py
+++ b/discovery-provider/src/queries/get_playlist_tracks.py
@@ -48,7 +48,7 @@ def get_playlist_tracks(args):
             tracks = populate_track_metadata(
                 session, playlist_track_ids, tracks, current_user_id)
 
-            if "with_users" in args and args.get("with_users") != 'false':
+            if args.get("with_users", False):
                 add_users_to_tracks(session, tracks)
 
             tracks_dict = {track['track_id']: track for track in tracks}

--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -26,10 +26,8 @@ def get_playlists(args):
 
             # playlist ids filter if the optional query param is passed in
             if "playlist_id" in args:
-                playlist_id_str_list = args.get("playlist_id")
-                playlist_id_list = []
+                playlist_id_list = args.get("playlist_id")
                 try:
-                    playlist_id_list = [int(y) for y in playlist_id_str_list]
                     playlist_query = playlist_query.filter(Playlist.playlist_id.in_(playlist_id_list))
                 except ValueError as e:
                     raise exceptions.ArgumentError("Invalid value found in playlist id list", e)
@@ -77,7 +75,7 @@ def get_playlists(args):
                 current_user_id
             )
 
-            if "with_users" in args and args.get("with_users") != 'false':
+            if args.get("with_users", False):
                 user_id_list = get_users_ids(playlists)
                 users = get_users_by_id(session, user_id_list)
                 for playlist in playlists:

--- a/discovery-provider/src/queries/get_remix_track_parents.py
+++ b/discovery-provider/src/queries/get_remix_track_parents.py
@@ -35,7 +35,7 @@ def get_remix_track_parents(track_id, args):
         current_user_id = get_current_user_id(required=False)
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             add_users_to_tracks(session, tracks)
 
     return tracks

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -108,7 +108,7 @@ def get_remixes_of(track_id, args):
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             add_users_to_tracks(session, tracks)
 
     return {'tracks': tracks, 'count': count}

--- a/discovery-provider/src/queries/get_repost_feed_for_user.py
+++ b/discovery-provider/src/queries/get_repost_feed_for_user.py
@@ -257,7 +257,7 @@ def get_repost_feed_for_user(user_id, args):
         feed_results = sorted(
             unsorted_feed, key=lambda entry: entry[response_name_constants.activity_timestamp], reverse=True)
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             user_id_list = get_users_ids(feed_results)
             users = get_users_by_id(session, user_id_list)
             for result in feed_results:

--- a/discovery-provider/src/queries/get_top_followee_saves.py
+++ b/discovery-provider/src/queries/get_top_followee_saves.py
@@ -15,10 +15,7 @@ def get_top_followee_saves(saveType, args):
             "Invalid type provided, must be one of 'track'"
         )
 
-    if 'limit' in args:
-        limit = min(int(args.get('limit')), 100)
-    else:
-        limit = 25
+    limit = args.get('limit', 25)
 
     current_user_id = get_current_user_id()
     db = get_db_read_replica()
@@ -85,7 +82,7 @@ def get_top_followee_saves(saveType, args):
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)
 
-        if 'with_users' in args and args.get('with_users') != 'false':
+        if args.get('with_users', False):
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:

--- a/discovery-provider/src/queries/get_top_followee_windowed.py
+++ b/discovery-provider/src/queries/get_top_followee_windowed.py
@@ -21,10 +21,7 @@ def get_top_followee_windowed(type, window, args):
             "Invalid window provided, must be one of {}".format(valid_windows)
         )
 
-    if 'limit' in args:
-        limit = min(int(args.get('limit')), 100)
-    else:
-        limit = 25
+    limit = args.get('limit', 25)
 
     current_user_id = get_current_user_id()
     db = get_db_read_replica()
@@ -79,7 +76,7 @@ def get_top_followee_windowed(type, window, args):
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)
 
-        if 'with_users' in args and args.get('with_users') != 'false':
+        if args.get('with_users', False):
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:

--- a/discovery-provider/src/queries/get_top_genre_users.py
+++ b/discovery-provider/src/queries/get_top_genre_users.py
@@ -12,7 +12,7 @@ def get_top_genre_users(args):
         genres = args.get("genre")
 
     # If the with_users url arg is provided, then populate the user metadata else return user ids
-    with_users = "with_users" in args and args.get("with_users") != 'false'
+    with_users = args.get("with_users", False)
 
     db = get_db_read_replica()
     with db.scoped_session() as session:

--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -19,15 +19,8 @@ def get_top_playlists(kind, args):
             "Invalid kind provided, must be one of 'playlist', 'album'"
         )
 
-    if 'limit' in args:
-        limit = min(int(args.get('limit')), 100)
-    else:
-        limit = 16
-
-    if 'mood' in args:
-        mood = args.get('mood')
-    else:
-        mood = None
+    limit = args.get('limit', 16)
+    mood = args.get('mood', None)
 
     if 'filter' in args:
         query_filter = args.get('filter')
@@ -127,7 +120,7 @@ def get_top_playlists(kind, args):
         for playlist in playlists:
             playlist['score'] = score_map[playlist['playlist_id']]
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             user_id_list = get_users_ids(playlists)
             users = get_users_by_id(session, user_id_list)
             for playlist in playlists:

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -18,12 +18,8 @@ def get_tracks(args):
 
         # Conditionally process an array of tracks
         if "id" in args:
-            # Retrieve argument from flask request object
-            # Ensures empty parameters are not processed
-            track_id_str_list = args.get("id")
-            track_id_list = []
+            track_id_list = args.get("id")
             try:
-                track_id_list = [int(y) for y in track_id_str_list]
                 # Update query with track_id list
                 base_query = base_query.filter(Track.track_id.in_(track_id_list))
             except ValueError as e:
@@ -42,13 +38,13 @@ def get_tracks(args):
         # will be evaluated as true, so an explicit check is made for true
         if "filter_deleted" in args:
             filter_deleted = args.get("filter_deleted")
-            if filter_deleted.lower() == 'true':
+            if filter_deleted:
                 base_query = base_query.filter(
                     Track.is_delete == False
                 )
 
         if "min_block_number" in args:
-            min_block_number = args.get("min_block_number", type=int)
+            min_block_number = args.get("min_block_number")
             base_query = base_query.filter(
                 Track.blocknumber >= min_block_number
             )
@@ -65,7 +61,7 @@ def get_tracks(args):
         # bundle peripheral info into track results
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:

--- a/discovery-provider/src/queries/get_tracks_including_unlisted.py
+++ b/discovery-provider/src/queries/get_tracks_including_unlisted.py
@@ -37,7 +37,7 @@ def get_tracks_including_unlisted(args, body):
         # will be evaluated as true, so an explicit check is made for true
         if "filter_deleted" in args:
             filter_deleted = args.get("filter_deleted")
-            if filter_deleted.lower() == 'true':
+            if filter_deleted:
                 base_query = base_query.filter(
                     Track.is_delete == False
                 )
@@ -62,7 +62,7 @@ def get_tracks_including_unlisted(args, body):
 
         tracks = list(filter(filter_fn, tracks))
 
-        if "with_users" in args and args.get("with_users") != 'false':
+        if args.get("with_users", False):
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:

--- a/discovery-provider/src/queries/get_users.py
+++ b/discovery-provider/src/queries/get_users.py
@@ -21,8 +21,7 @@ def get_users(args):
 
         # Process filters
         if "is_creator" in args:
-            is_creator_flag = args.get("is_creator") == "true"
-            base_query = base_query.filter(User.is_creator == is_creator_flag)
+            base_query = base_query.filter(User.is_creator == args.get("is_creator"))
         if "wallet" in args:
             wallet = args.get("wallet")
             wallet = wallet.lower()
@@ -37,18 +36,15 @@ def get_users(args):
 
         # Conditionally process an array of users
         if "id" in args:
-            user_id_str_list = args.get("id")
-            user_id_list = []
+            user_id_list = args.get("id")
             try:
-                user_id_list = [int(y) for y in user_id_str_list]
                 base_query = base_query.filter(User.user_id.in_(user_id_list))
             except ValueError as e:
                 raise exceptions.ArgumentError(
                     "Invalid value found in user id list", e)
         if "min_block_number" in args:
-            min_block_number = args.get("min_block_number", type=int)
             base_query = base_query.filter(
-                User.blocknumber >= min_block_number
+                User.blocknumber >= args.get("min_block_number")
             )
         users = paginate_query(base_query).all()
         users = helpers.query_result_to_list(users)


### PR DESCRIPTION
## Summary
Updated the Discovery Provider API params to be parsed in queries.py instead of of each function
This standardizes the input into the route functions to be shared across versions
* Changes all booleans to check is equal to false in queries.py
* Parse params of array of ids in queries.py 
* parse int url params in queries.py

## Testing
For every endpoint changed, use the staging dapp and find a request that matches. Run the discprov locally against the staging DB and check that the response is the same (NOTE for signed in requests, make sure header x-user-id is set). Then modify each url params to ensure it's parsed correctly and behaves well. 