### PR TITLE
Filter out old announcements

### DIFF
--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -76,8 +76,18 @@ async function getEmailNotifications (audius, userId, announcements = [], fromTi
     const announcementIds = new Set(announcements.map(({ entityId }) => entityId))
     const filteredNotifications = notifications.filter(({ id }) => !announcementIds.has(id))
 
+    let tenDaysAgo = moment().subtract(10, 'days')
+
+    // An announcement is valid if it's
+    // 1.) created after the user
+    // 2.) created after "fromTime" which represent the time the last email was sent
+    // 3.) created within the last 10 days
     const validUserAnnouncements = announcements
-      .filter(a => moment(a.datePublished).isAfter(user.createdAt) && moment(a.datePublished).isAfter(fromTime))
+      .filter(a => (
+        moment(a.datePublished).isAfter(user.createdAt)
+        && moment(a.datePublished).isAfter(fromTime)
+        && moment(a.datePublished).isAfter(tenDaysAgo)
+      ))
 
     const userNotifications = mergeAudiusAnnoucements(validUserAnnouncements, filteredNotifications)
     let unreadAnnouncementCount = 0

--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -84,9 +84,9 @@ async function getEmailNotifications (audius, userId, announcements = [], fromTi
     // 3.) created within the last 10 days
     const validUserAnnouncements = announcements
       .filter(a => (
-        moment(a.datePublished).isAfter(user.createdAt)
-        && moment(a.datePublished).isAfter(fromTime)
-        && moment(a.datePublished).isAfter(tenDaysAgo)
+        moment(a.datePublished).isAfter(user.createdAt) &&
+        moment(a.datePublished).isAfter(fromTime) &&
+        moment(a.datePublished).isAfter(tenDaysAgo)
       ))
 
     const userNotifications = mergeAudiusAnnoucements(validUserAnnouncements, filteredNotifications)

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -11,7 +11,7 @@ const {
   calculateTrackListenMilestones,
   getHighestBlockNumber
 } = require('./utils')
-// const { processEmailNotifications } = require('./sendNotificationEmails')
+const { processEmailNotifications } = require('./sendNotificationEmails')
 const { processDownloadAppEmail } = require('./sendDownloadAppEmails')
 const { pushAnnouncementNotifications } = require('./pushAnnouncementNotifications')
 const { notificationJobType, announcementJobType } = require('./constants')
@@ -106,7 +106,7 @@ class NotificationProcessor {
     // Email notification queue
     this.emailQueue.process(async (job, done) => {
       logger.info('processEmailNotifications')
-      // await processEmailNotifications(expressApp, audiusLibs)
+      await processEmailNotifications(expressApp, audiusLibs)
       await processDownloadAppEmail(expressApp, audiusLibs)
       done()
     })

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -57,7 +57,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       // If the announcement is too old filter it out, it's not necessary to process.
       return timeSinceAnnouncement < (weekInHours * 1.5)
     })
-    logger.info({ appAnnouncements })
+
     // For each announcement, we generate a list of valid users
     // Based on the user's email frequency
     let liveUsersWithPendingAnnouncements = []

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -46,24 +46,26 @@ async function processEmailNotifications (expressApp, audiusLibs) {
     logger.info(`processEmailNotifications - ${liveEmailUsers.length} live users`)
     logger.info(`processEmailNotifications - ${dailyEmailUsers.length} daily users`)
     logger.info(`processEmailNotifications - ${weeklyEmailUsers.length} weekly users`)
+    let currentTime = moment.utc()
     let now = moment()
     let dayAgo = now.clone().subtract(1, 'days')
     let weekAgo = now.clone().subtract(7, 'days')
 
-    let appAnnouncements = expressApp.get('announcements')
+    let appAnnouncements = expressApp.get('announcements').filter(a => {
+      let announcementDate = moment(a['datePublished'])
+      let timeSinceAnnouncement = moment.duration(currentTime.diff(announcementDate)).asHours()
+      // If the announcement is too old filter it out, it's not necessary to process.
+      return timeSinceAnnouncement < (weekInHours * 1.5)
+    })
+    logger.info({ appAnnouncements })
     // For each announcement, we generate a list of valid users
     // Based on the user's email frequency
     let liveUsersWithPendingAnnouncements = []
     let dailyUsersWithPendingAnnouncements = []
     let weeklyUsersWithPendingAnnouncements = []
-    let currentTime = moment.utc()
     for (var announcement of appAnnouncements) {
       let announcementDate = moment(announcement['datePublished'])
       let timeSinceAnnouncement = moment.duration(currentTime.diff(announcementDate)).asHours()
-      // If the announcement is too old skip it, it's not necessary to process.
-      if (timeSinceAnnouncement > (weekInHours * 1.5)) {
-        continue
-      }
       let announcementEntityId = announcement['entityId']
       let id = announcement['id']
       let usersCreatedAfterAnnouncement = await models.User.findAll({
@@ -86,7 +88,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
           continue
         }
         if (liveEmailUsers.includes(user)) {
-          // As an added safety check, check only process if the announcement was made in the last hour
+          // As an added safety check, only process if the announcement was made in the last hour
           if (timeSinceAnnouncement < 1) {
             logger.info(`Announcements - ${id} | Live user ${user}`)
             liveUsersWithPendingAnnouncements.push(user)


### PR DESCRIPTION
Filters out old announcements in 3 places. 
When processing the users to send notifications to in the `sendNotificationEmails.js`: if it's over a week and a half old don't even bother, and if it's a live user, only add it if the notification was made in the last hour. 
It also filters out old announcements in `fetchNotificationMetadata.js` which selects the notification to be put in the email. If the announcement is over 10 days old don't add it to the email. 

Testing:
Use an prod identity DB replica and ran only the identity service's email job against it. Made sure that at each step it was filtering out the notification based on its date. 