### PR TITLE
Clean up creator node logging a bit

### DIFF
--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -46,23 +46,20 @@ class RehydrateIpfsQueue {
         done(e)
       }
     })
-
-    this.addRehydrateIpfsFromFsTask = this.addRehydrateIpfsFromFsIfNecessaryTask.bind(this)
-    this.addRehydrateIpfsDirFromFsIfNecessaryTask = this.addRehydrateIpfsDirFromFsIfNecessaryTask.bind(this)
   }
 
   async logStatus (logContext, message) {
     const logger = genericLogger.child(logContext)
     const count = await this.queue.count()
-    logger.info(`RehydrateIpfsQueue: ${message}`)
-    logger.info(`RehydrateIpfsQueue: count: ${count}`)
+    logger.debug(`RehydrateIpfsQueue: ${message}`)
+    logger.debug(`RehydrateIpfsQueue: count: ${count}`)
   }
 
   async logError (logContext, message) {
     const logger = genericLogger.child(logContext)
     const count = await this.queue.count()
     logger.error(`RehydrateIpfsQueue error: ${message}`)
-    logger.info(`RehydrateIpfsQueue: count: ${count}`)
+    logger.debug(`RehydrateIpfsQueue: count: ${count}`)
   }
 
   /**

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -115,7 +115,7 @@ const getCID = async (req, res) => {
 
   try {
     // Add a rehydration task to the queue to be processed in the background
-    RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(CID, queryResults.storagePath, { logContext: req.logContext })
+    await RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(CID, queryResults.storagePath, { logContext: req.logContext })
     // Attempt to stream file to client.
     req.logger.info(`Retrieving ${queryResults.storagePath} directly from filesystem`)
     return await streamFromFileSystem(req, res, queryResults.storagePath)
@@ -200,7 +200,7 @@ const getDirCID = async (req, res) => {
 
   try {
     // Add rehydrate task to queue to be processed in background
-    RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(dirCID, parentStoragePath, { logContext: req.logContext }, filename)
+    await RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(dirCID, parentStoragePath, { logContext: req.logContext }, filename)
     // Attempt to stream file to client.
     req.logger.info(`Retrieving ${queryResults.storagePath} directly from filesystem`)
     return await streamFromFileSystem(req, res, queryResults.storagePath)

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -83,9 +83,9 @@ module.exports = function (app) {
               // to address legacy single-res image rehydration where images are stored directly under its file CID
               (file.type === 'image' && file.sourceFile === null)
             ) {
-              RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(file.multihash, file.storagePath, { logContext: req.logContext })
+              await RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(file.multihash, file.storagePath, { logContext: req.logContext })
             } else if (file.type === 'dir') {
-              RehydrateIpfsQueue.addRehydrateIpfsDirFromFsIfNecessaryTask(file.multihash, { logContext: req.logContext })
+              await RehydrateIpfsQueue.addRehydrateIpfsDirFromFsIfNecessaryTask(file.multihash, { logContext: req.logContext })
             }
           } catch (e) {
             req.logger.info(`Export rehydrateIpfs processing files ${i} to ${i + RehydrateIPFSConcurrencyLimit}, ${e}`)

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -451,7 +451,7 @@ module.exports = function (app) {
     // Asynchronously rehydrate and return CID. If file is not in ipfs, serve from FS
     try {
       // Rehydrate master copy if necessary
-      RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(copyFile.multihash, copyFile.storagePath, { logContext: req.logContext })
+      await RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(copyFile.multihash, copyFile.storagePath, { logContext: req.logContext })
 
       return successResponse({ isDownloadable: true, cid: copyFile.multihash })
     } catch (e) {


### PR DESCRIPTION
Tons of rehydratea logs are being printed out, 4 for each rehydrated file every single time. Trying to cut that down.