### PR TITLE
Fix ipfs gateway url to fetch dir images from other creator nodes

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -307,7 +307,10 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
               // Skip over directories since there's no actual content to sync
               // The files inside the directory are synced separately
               if (nonTrackFile.type !== 'dir') {
-                return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
+                // if it's an image file, we need to pass in the actual filename because the gateway request is /ipfs/Qm123/<filename>
+                if (nonTrackFile.type === 'image') {
+                  return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet, nonTrackFile.fileName)
+                } else return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
               }
             }
           ))


### PR DESCRIPTION
What's the problem?
IPFS gateway calls for images inside directories takes the form `/ipfs/Qm123/Qmabc` instead of `/ipfs/Qm123/<filename>.jpg`

What's the solution?
Pass in the file name from the files table (original.jpg, 150x150.jpg etc...) into the saveFileForMultihash function so requests to other cnode can be in the form `/ipfs/Qm123/<filename>.jpg`

How is this tested?
1. Setup a fresh audius instance locally and created a user and uploaded a track
2. Set ipfs operation timeouts to 1ms so they'll timeout and it will always to go to fetch from other cnode gateways. 
3. Triggered a sync
4. Verified that the number of items in both `/file_storage` volumes match the number of files in the files table in the db. The saveFileForMultihash function also runs ipfs add with the only has option to make sure the CID and the actual contents of the file match.
5. Clear the secondary's `/file_storage` volume. Do an `ipfs repo gc` on all ipfs nodes and make sure you can't cat the files on any node. Run steps 3&4 again
6. Add new cover art to my user profile. This should trigger a sync.  Verify according to step 4 again.