### PR TITLE
Enable @audius/libs npm link for local dev

### DIFF
--- a/creator-node/compose/docker-compose.yml
+++ b/creator-node/compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - audius_dev
   creator-node:
     build: ../.
-    command: sh -c '/usr/bin/wait && exec ./node_modules/.bin/nodemon src/index.js | ./node_modules/.bin/bunyan'
+    command: sh -c '/usr/bin/wait && exec ./scripts/dev-server.sh'
     depends_on:
       - creator-node-db
       - creator-node-redis
@@ -35,6 +35,8 @@ services:
       # Prevent hiding node_modules on container with host volume
       # From https://github.com/barrysteyn/node-scrypt/issues/148
       - /usr/src/app/node_modules
+      # Mount audius libs as a directory
+      - ../../libs:/usr/src/audius-libs
     networks:
       - audius_dev
   creator-node-redis:

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=true
+link_libs=false
 
 if [ "$link_libs" = true ]
 then

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,8 +2,13 @@
 set -o xtrace
 set -e
 
-cd ../audius-libs
-npm link
-cd ../app
-npm link @audius/libs
+link_libs=false
+
+if [ "$link_libs" = true ] ; then
+    cd ../audius-libs
+    npm link
+    cd ../app
+    npm link @audius/libs
+fi
+
 exec ./node_modules/.bin/nodemon src/index.js | ./node_modules/.bin/bunyan

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -o xtrace
+set -e
+
+cd ../audius-libs
+npm link
+cd ../app
+npm link @audius/libs
+exec ./node_modules/.bin/nodemon src/index.js | ./node_modules/.bin/bunyan

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,13 +2,15 @@
 set -o xtrace
 set -e
 
-link_libs=false
+link_libs=true
 
-if [ "$link_libs" = true ] ; then
+if [ "$link_libs" = true ]
+then
     cd ../audius-libs
     npm link
     cd ../app
     npm link @audius/libs
+    exec ./node_modules/.bin/nodemon --watch src --watch ../audius-libs/ src/index.js | ./node_modules/.bin/bunyan
+else
+    exec ./node_modules/.bin/nodemon src/index.js | ./node_modules/.bin/bunyan
 fi
-
-exec ./node_modules/.bin/nodemon src/index.js | ./node_modules/.bin/bunyan

--- a/identity-service/compose/docker-compose.full.yml
+++ b/identity-service/compose/docker-compose.full.yml
@@ -19,7 +19,7 @@ services:
       - audius_dev
   identity-service:
     build: ../.
-    command: sh -c '/usr/bin/wait && exec ./node_modules/.bin/nodemon --ignore "./emailCache" src/index.js'
+    command: sh -c '/usr/bin/wait && exec ./scripts/dev-server.sh'
     env_file:
       - .env
     depends_on:
@@ -30,6 +30,7 @@ services:
       # Prevent hiding node_modules on container with host volume
       # From https://github.com/barrysteyn/node-scrypt/issues/148
       - /usr/src/app/node_modules
+      - ../../libs:/usr/src/audius-libs
     ports:
       - '7000:7000'
     networks:

--- a/identity-service/scripts/dev-server.sh
+++ b/identity-service/scripts/dev-server.sh
@@ -2,13 +2,15 @@
 set -o xtrace
 set -e
 
-link_libs=true
+link_libs=false
 
-if [ "$link_libs" = true ] ; then
+if [ "$link_libs" = true ]
+then
     cd ../audius-libs
     npm link
     cd ../app
     npm link @audius/libs
+    exec ./node_modules/.bin/nodemon --ignore "./emailCache" --watch src --watch ../audius-libs/ src/index.js
+else
+    exec ./node_modules/.bin/nodemon --ignore "./emailCache" src/index.js
 fi
-
-exec ./node_modules/.bin/nodemon --ignore "./emailCache" src/index.js

--- a/identity-service/scripts/dev-server.sh
+++ b/identity-service/scripts/dev-server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -o xtrace
+set -e
+
+cd ../audius-libs
+npm link
+cd ../app
+npm link @audius/libs
+exec ./node_modules/.bin/nodemon --ignore "./emailCache" src/index.js

--- a/identity-service/scripts/dev-server.sh
+++ b/identity-service/scripts/dev-server.sh
@@ -2,8 +2,13 @@
 set -o xtrace
 set -e
 
-cd ../audius-libs
-npm link
-cd ../app
-npm link @audius/libs
+link_libs=true
+
+if [ "$link_libs" = true ] ; then
+    cd ../audius-libs
+    npm link
+    cd ../app
+    npm link @audius/libs
+fi
+
 exec ./node_modules/.bin/nodemon --ignore "./emailCache" src/index.js


### PR DESCRIPTION
* Explicitly mount libs and link for local development in identity and creator nodes
* Toggled by setting `link_libs=true` in `identity-service/scripts/dev-server.sh` and `creator-node/scripts/dev-server.sh`

Tested by:
- Modifying local libs with test output on init
- Bringing up the entire audius system with 2 cnodes
- Inspect cn1, cn2, identity logs to confirm test output and libs link
- Modify host libs with additional changes
- `cat` modified file from each containers `/app/node_modules/@audius/libs/` to confirm changes are picked up 