### PR TITLE
Hotfix: Return earlier in non-dir cnode gateway if the file type is dir

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -103,6 +103,8 @@ const getCID = async (req, res) => {
     return sendResponse(req, res, errorResponseNotFound(`No valid file found for provided CID: ${CID}`))
   }
 
+  if (queryResults.type === 'dir') return sendResponse(req, res, errorResponseBadRequest('this dag node is a directory'))
+
   redisClient.incr('ipfsStandaloneReqs')
   const totalStandaloneIpfsReqs = parseInt(await redisClient.get('ipfsStandaloneReqs'))
   req.logger.info(`IPFS Standalone Request - ${CID}`)


### PR DESCRIPTION
The problem is in our creator node gateway, we primarily use IPFS to check if a file is a directory or not. The way that works is by doing a single byte cat. If the cat times out, it tries to rehydrate the file into IPFS. However, if someone calls /ipfs with a directory cid, the Files table contains that cid so it passes the db check and if IPFS doesn't have that dir cid, it will attempt to rehydrate the dir through the file codepath.

Stacktrace of original issue
```
[2020-08-03T08:52:15.943Z] ERROR: audius_creator_node/1 on creator-2-backend-66b9bc969c-dwgh9: rehydrateIpfsFromFsIfNecessary - failed to addFromFs Error: Can only add directories using --recursive, Re-adding file - QmPHufo2f8yTm5NbBxuoiMoP7Zj4nxQUD4TP3bAQvKfC6A, stg path: /file_storage/QmPHufo2f8yTm5NbBxuoiMoP7Zj4nxQUD4TP3bAQvKfC6A (requestMethod=GET, requestHostname=creatornode2.audius.co)

      throw er; // Unhandled 'error' event
      ^

Error: expected a file argument
    at parseError (/usr/src/app/node_modules/ipfs-http-client/src/utils/send-request.js:22:17)
    at ClientRequest.<anonymous> (/usr/src/app/node_modules/ipfs-http-client/src/utils/send-request.js:64:14)
    at Object.onceWrapper (events.js:286:20)
    at ClientRequest.emit (events.js:198:13)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:556:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
    at Socket.socketOnData (_http_client.js:442:20)
    at Socket.emit (events.js:198:13)
    at addChunk (_stream_readable.js:288:12)
    at readableAddChunk (_stream_readable.js:269:11)
    at Socket.Readable.push (_stream_readable.js:224:10)
    at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
Emitted 'error' event at:
    at send (/usr/src/app/node_modules/ipfs-http-client/src/utils/send-files-stream.js:105:26)
    at f (/usr/src/app/node_modules/once/once.js:25:25)
    at streamToJsonValue (/usr/src/app/node_modules/ipfs-http-client/src/utils/send-request.js:47:5)
    at streamToValue (/usr/src/app/node_modules/ipfs-http-client/src/utils/stream-to-json-value.js:30:5)
    at pump (/usr/src/app/node_modules/ipfs-http-client/src/utils/stream-to-value.js:14:14)
    at /usr/src/app/node_modules/pump/index.js:75:7
    at f (/usr/src/app/node_modules/once/once.js:25:25)
    at ConcatStream.<anonymous> (/usr/src/app/node_modules/pump/index.js:33:5)
    at ConcatStream.f (/usr/src/app/node_modules/once/once.js:25:25)
    at ConcatStream.onfinish (/usr/src/app/node_modules/end-of-stream/index.js:30:27)
    at ConcatStream.emit (events.js:203:15)
    at finishMaybe (/usr/src/app/node_modules/ipfs-http-client/node_modules/readable-stream/lib/_stream_writable.js:620:14)
    at afterWrite (/usr/src/app/node_modules/ipfs-http-client/node_modules/readable-stream/lib/_stream_writable.js:466:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

This change short circuits all of that by checking the type of the file in the Files table. If it's of type dir, reject.