### PR TITLE
Fix regressed mode in the case that all providers are behind (and not registered)

### DIFF
--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -7,7 +7,6 @@ const {
   REGRESSED_MODE_TIMEOUT
 } = require('./constants')
 const semver = require('semver')
-const { isActive } = require('nock')
 
 const PREVIOUS_VERSIONS_TO_CHECK = 5
 
@@ -191,7 +190,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
     // { blockdiff => [provider] }
     Object.keys(this.backups).forEach(backup => {
       const { block_difference: blockDiff, version } = this.backups[backup]
-      
+
       let isVersionOk = false
       for (let i = 0; i < this.validVersions.length; ++i) {
         if (this.ethContracts.hasSameMajorAndMinorVersion(this.validVersions[i], version)) {

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -234,7 +234,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
     }
 
     // Select the best block diff provider
-    const bestBlockDiff = blockDiffs.sort().reverse()[0]
+    const bestBlockDiff = blockDiffs.sort()[0]
 
     selected = blockDiffMap[bestBlockDiff][0]
     this.enterRegressedMode()

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -189,7 +189,7 @@ describe('DiscoveryProviderSelection', () => {
       mockEthContracts([behind20, behind40], '1.2.3')
     )
     const service = await s.select()
-    assert.strictEqual(service, behind40)
+    assert.strictEqual(service, behind20)
     assert.deepStrictEqual(s.backups, {
       [behind20]: {
         service: 'discovery-provider',
@@ -233,7 +233,7 @@ describe('DiscoveryProviderSelection', () => {
       )
     )
     const service = await s.select()
-    assert.strictEqual(service, behind200)
+    assert.strictEqual(service, behind100)
     assert.deepStrictEqual(s.backups, {
       [behind100]: {
         service: 'discovery-provider',

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -27,6 +27,9 @@ describe('DiscoveryProviderSelection', () => {
     const localStorage = new LocalStorage('./local-storage')
     localStorage.removeItem('@audius/libs:discovery-provider-timestamp')
   })
+  afterEach(() => {
+    nock.cleanAll()
+  })
 
   it('selects a healthy service', async () => {
     const healthy = 'https://healthy.audius.co'
@@ -127,7 +130,6 @@ describe('DiscoveryProviderSelection', () => {
   it('can select an old version', async () => {
     const healthyButBehind = 'https://healthyButBehind.audius.co'
     nock(healthyButBehind)
-      .log(console.log)
       .get('/health_check')
       .reply(200, { data: {
         service: 'discovery-provider',
@@ -136,7 +138,6 @@ describe('DiscoveryProviderSelection', () => {
       } })
     const pastVersionNotBehind = 'https://pastVersionNotBehind.audius.co'
     nock(pastVersionNotBehind)
-      .log(console.log)
       .get('/health_check')
       .reply(200, { data: {
         service: 'discovery-provider',


### PR DESCRIPTION
This fixes the issue we saw last weekend where all service providers were behind, but clients refused to select one and enter regressed mode.

The reason for this was that the exact version of the SP wasn't registered on chain and this logic needed the same correction that was added here:

https://github.com/AudiusProject/audius-protocol/commit/22c90d784d8f384e8fea132dc843cd1402e93f5e

Tested:
- added new unit test to exercise this edge case
- ran dapp & confirmed normal behavior against staging discprovs