### PR TITLE
Celery worker restart

### DIFF
--- a/discovery-provider/compose/docker-compose.dev.override.yml
+++ b/discovery-provider/compose/docker-compose.dev.override.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - discovery-provider-db
       - redis-server
+    volumes:
+      - '../.:/audius-discovery-provider'
     networks:
       - audius_dev
   celery-beat:
@@ -21,6 +23,8 @@ services:
       - .env
     depends_on:
       - celery-worker
+    volumes:
+      - '../.:/audius-discovery-provider'
     networks:
       - audius_dev
   web-server:


### PR DESCRIPTION
Problem:
Celery workers don't have auto reloading and getting latest changes for a worker tends to be a tricky and painstaking process. Current methods of development include running the worker locally in venv or calling down/up on the compose file for every code change.

Solution:
By mounting the code volume into the discovery container, we can propagate the latest code changes into the container. Then we can call `docker restart <container-id>` to trigger the new code to be run on restart.

Testing:
I tested this locally by adding a log in the index.py flow
```python3
try:
  # Attempt to acquire lock - do not block if unable to acquire
  have_lock = update_lock.acquire(blocking=False)
  if have_lock:
    logger.warning('dheeraj here ')
```

I then ran discovery worker and made sure it printed out in the logs. I then changed the log message and called the docker restart command and verified the new message showed up in the logs. 

