### PR TITLE
Default to user metadata for images from non-creators

### DIFF
--- a/discovery-provider/compose/.env
+++ b/discovery-provider/compose/.env
@@ -10,3 +10,4 @@ WAIT_HOSTS=discovery-provider-db:5432,redis-server:6379, ipfs-node:5001
 audius_delegate_owner_wallet=0x1D9c77BcfBfa66D37390BF2335f0140979a6122B
 audius_delegate_private_key=0x3873ed01bfb13621f9301487cc61326580614a5b99f3c33cf39c6f9da3a19cad
 audius_discprov_identity_service_url=http://audius-identity-service_identity-service_1:7000
+audius_discprov_user_metadata_service_url=http://cn1_creator-node_1:4000

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -3,12 +3,12 @@ start_block = 0x0
 loglevel_flask = DEBUG
 ; do not configure the log level here as this gets overridden by celery lib during setup
 ; set log level via command line in docker yml files instead
-; loglevel_celery = INFO 
+; loglevel_celery = INFO
 block_processing_window = 20
 blacklist_block_processing_window = 600
 peer_refresh_interval = 3000
 identity_service_url = https://identityservice.test
-user_metadata_service_url = '' 
+user_metadata_service_url = http://cn1_creator-node_1:4000
 healthy_block_diff = 100
 
 [flask]

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -8,7 +8,7 @@ block_processing_window = 20
 blacklist_block_processing_window = 600
 peer_refresh_interval = 3000
 identity_service_url = https://identityservice.test
-user_metadata_service_url = http://cn1_creator-node_1:4000
+user_metadata_service_url = ''
 healthy_block_diff = 100
 
 [flask]

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -1,4 +1,5 @@
 from src import api_helpers
+from src.utils.config import shared_config
 from hashids import Hashids
 from flask_restx import fields, reqparse
 from src.queries.search_queries import SearchKind
@@ -24,7 +25,7 @@ def make_image(endpoint, cid, width="", height=""):
 def get_primary_endpoint(user):
     raw_endpoint = user["creator_node_endpoint"]
     if not raw_endpoint:
-        return None
+        return shared_config["discprov"]["user_metadata_service_url"]
     return raw_endpoint.split(",")[0]
 
 def add_track_artwork(track):


### PR DESCRIPTION
Testing:
- Ran all services locally, created a user from the dapp, created a playlist with artwork, checked the artwork properly resolved in the V1 API.

This envvar already exists in Kube (checked with @dmanjunath), so we don't have to update it there. 
