### PR TITLE
changing if to check literal '', not empty string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,10 @@ jobs:
           name: discovery provider tests
           command: |
             cd discovery-provider
+            export audius_ipfs_port=5001
+            export audius_redis_url=redis://localhost:6379/0
+            export audius_delegate_owner_wallet=0x1D9c77BcfBfa66D37390BF2335f0140979a6122B
+            export audius_delegate_private_key=0x3873ed01bfb13621f9301487cc61326580614a5b99f3c33cf39c6f9da3a19ca
             ./scripts/circle-ci.sh
 
   test-identity-service:

--- a/discovery-provider/scripts/circle-ci.sh
+++ b/discovery-provider/scripts/circle-ci.sh
@@ -3,10 +3,6 @@ source ./scripts/utilities.sh
 
 function main {
   set -e
-  export audius_ipfs_port=5001
-  export audius_redis_url=redis://localhost:6379/0
-  export audius_delegate_owner_wallet=0x1D9c77BcfBfa66D37390BF2335f0140979a6122B
-  export audius_delegate_private_key=0x3873ed01bfb13621f9301487cc61326580614a5b99f3c33cf39c6f9da3a19cad
   source venv/bin/activate
   cd_contracts_repo
   echo 'Migrating contracts'

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -443,7 +443,7 @@ def refresh_peer_connections(task_context):
             for cnode_user_set in entry:
                 cnode_entries = cnode_user_set.split(',')
                 for cnode_url in cnode_entries:
-                    if cnode_url == '':
+                    if cnode_url == "''":
                         continue
                     cnode_endpoints[cnode_url] = True
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -460,7 +460,7 @@ def refresh_peer_connections(task_context):
             stored_in_redis = redis.get(cnode_url)
             if stored_in_redis is not None:
                 continue
-            if cnode_url == '':
+            if cnode_url == "''":
                 continue
 
             try:


### PR DESCRIPTION
### Trello Card Link
no link

### Description
Was checking celery worker logs for ipld blacklist indexing, and noticed an error in the logs. In `refresh_peer_connections()`. The `if cnode_url == '':` checks an empty string. However, the key is actual the literal `''` string. This fix changes the if condition to check the literal `''` string.

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Added the following two lines of code 
```
is_equal = cnode_url == ''
logger.warning(f"i am equal {cnode_url} to \'\': {is_equal}")
```

Captured the logs pre-fix by logging the CN endpoints and error. Also added a log to the creator node to check the equality to an empty string `''`:
```
[2020-08-06 03:47:00,156] {src.tasks.index:457} (WARNING) - all creator node endpoints
[2020-08-06 03:47:00,156] {src.tasks.index:458} (WARNING) - {'http://cn2_creator-node_1:4001': True, 'http://cn1_creator-node_1:4000': True, "''": True}
[2020-08-06 03:47:00,156] {src.tasks.index:460} (WARNING) - i am equal http://cn2_creator-node_1:4001 to '': False
[2020-08-06 03:47:00,157] {src.tasks.index:460} (WARNING) - i am equal http://cn1_creator-node_1:4000 to '': False
[2020-08-06 03:47:00,158] {src.tasks.index:460} (WARNING) - i am equal '' to '': False
[2020-08-06 03:47:00,158] {src.tasks.index:469} (WARNING) - index.py | Retrieving connection info for ''
[2020-08-06 03:47:00,160] {src.tasks.index:476} (WARNING) - index.py | Error retrieving info for '', Invalid URL 'ipfs_peer_info': No schema supplied. Perhaps you meant http://ipfs_peer_info?
```

Added the following two lines of code 
```
is_equal = cnode_url == "''"
logger.warning(f"i am equal {cnode_url} to \'\': {is_equal}")
```

Captured the logs post-fix by logging the CN endpoints. Also added a log to the creator node to check the equality to two literal single quotes `"''"`:
```
[2020-08-06 03:56:00,337] {src.tasks.index:457} (WARNING) - all creator node endpoints
[2020-08-06 03:56:00,338] {src.tasks.index:458} (WARNING) - {'http://cn2_creator-node_1:4001': True, 'http://cn1_creator-node_1:4000': True, "''": True}
[2020-08-06 03:56:00,338] {src.tasks.index:461} (WARNING) - i am equal http://cn2_creator-node_1:4001 to '': False
[2020-08-06 03:56:00,339] {src.tasks.index:461} (WARNING) - i am equal http://cn1_creator-node_1:4000 to '': False
[2020-08-06 03:56:00,341] {src.tasks.index:461} (WARNING) - i am equal '' to '': True
```

Please list the unit test(s) you added to verify your changes.

no unit tests 