### PR TITLE
Fix init case for local dev

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -48,7 +48,6 @@ def initialize_blocks_table_if_necessary(db):
                 parenthash=target_blockhash,
                 is_current=True,
             )
-
             if target_block.number == 0:
                 block_model.number = None
 
@@ -61,8 +60,10 @@ def initialize_blocks_table_if_necessary(db):
 
             # set the last indexed block in redis
             current_block_result = current_block_query_result.first()
-            redis.set(most_recent_indexed_block_redis_key, current_block_result.number)
-            redis.set(most_recent_indexed_block_hash_redis_key, current_block_result.blockhash)
+            if current_block_result.number:
+                redis.set(most_recent_indexed_block_redis_key, current_block_result.number)
+            if current_block_result.blockhash:
+                redis.set(most_recent_indexed_block_hash_redis_key, current_block_result.blockhash)
 
     return target_blockhash
 


### PR DESCRIPTION
### Description
Discovery provider initialization on startup is broken for local development after a recent commit.
```
    initialize_blocks_table_if_necessary(db)
  File "/audius-discovery-provider/src/tasks/index.py", line 65, in initialize_blocks_table_if_necessary
    redis.set(most_recent_indexed_block_redis_key, current_block_result.number)
  File "/usr/local/lib/python3.7/site-packages/redis/client.py", line 1451, in set
```

Caused by an invalid null access in the new redis `set` operations in the init case introduced here  https://github.com/AudiusProject/audius-protocol/commit/4a8744c732cff23bcc4d8398c653ef0d7511d18e. 

There is a unique init behavior involving setting block.number = None but that is _not what broke here_. We can discuss that fix independently once local setup is unblocked

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts


### How Has This Been Tested?

Brought up all services locally after failing to do so on master

 