### PR TITLE
Add users to trending

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -90,7 +90,8 @@ class Trending(Resource):
         time = args.get("time") if args.get("time") is not None else 'week'
         args = {
             'time': time,
-            'genre': args.get("genre", None)
+            'genre': args.get("genre", None),
+            'with_users': True
         }
         tracks = get_trending_tracks(args)
         tracks = list(map(extend_track, tracks))


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/ubWANbVi/1450-api-bugs-issues

### Description
Fixes API trending results not having users, and artwork being empty.

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts


### How Has This Been Tested?

1. Test 1
- Hit /v1/tracks/trending
- Ensure that tracks returned have users, and artwork

