### PR TITLE
Correctly set API search offset

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -93,7 +93,7 @@ class PlaylistSearchResult(Resource):
             "current_user_id": None,
             "with_users": True,
             "limit": 10,
-            "offset": 1
+            "offset": 0
         }
         response = search(search_args)
         playlists = list(map(extend_playlist, response["playlists"]))

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -116,7 +116,7 @@ class TrackSearchResult(Resource):
             "current_user_id": None,
             "with_users": True,
             "limit": 10,
-            "offset": 1
+            "offset": 0
         }
         response = search(search_args)
         tracks = response["tracks"]

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -114,7 +114,7 @@ class UserSearchResult(Resource):
             "current_user_id": None,
             "with_users": True,
             "limit": 10,
-            "offset": 1,
+            "offset": 0,
         }
         response = search(search_args)
         users = response["users"]


### PR DESCRIPTION
### Description
Fix incorrect offset of 1 rather than 0 for searches from V1 API

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts


### How Has This Been Tested?

1. Compare search results from V1 API and regular /search/full endpoint.
