### PR TITLE
Special case images to accomodate for legacy non-dir images

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -308,9 +308,12 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
               // The files inside the directory are synced separately
               if (nonTrackFile.type !== 'dir') {
                 // if it's an image file, we need to pass in the actual filename because the gateway request is /ipfs/Qm123/<filename>
-                if (nonTrackFile.type === 'image') {
+                // need to also check sourceFile is not null to make sure it's a dir-style image
+                if (nonTrackFile.type === 'image' && nonTrackFile.sourceFile !== null) {
                   return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet, nonTrackFile.fileName)
-                } else return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
+                } else {
+                  return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)
+                }
               }
             }
           ))

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -308,8 +308,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
               // The files inside the directory are synced separately
               if (nonTrackFile.type !== 'dir') {
                 // if it's an image file, we need to pass in the actual filename because the gateway request is /ipfs/Qm123/<filename>
-                // need to also check sourceFile is not null to make sure it's a dir-style image
-                if (nonTrackFile.type === 'image' && nonTrackFile.sourceFile !== null) {
+                // need to also check fileName is not null to make sure it's a dir-style image. non-dir images won't have a 'fileName' db column
+                if (nonTrackFile.type === 'image' && nonTrackFile.fileName !== null) {
                   return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet, nonTrackFile.fileName)
                 } else {
                   return saveFileForMultihash(req, nonTrackFile.multihash, nonTrackFile.storagePath, userReplicaSet)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/nRfD3oJu/1459-bugfix-in-nodesync-doesnt-sync-non-dir-images-correctly-through-gateways

### Description
Bug introduced in https://github.com/AudiusProject/audius-protocol/pull/718/files#diff-6296aeaad2e77b78d513911233301094R311. Bug is that the code only checks if image, but it doesn't take into account non-dir images

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts


### How Has This Been Tested?
I created an account and uploaded a track locally. I then manually copied over a non-dir image file from my local machine to inside the docker container and also added it to the Files table of the primary. I then kicked off the sync to the secondary and verified that the secondary had the non-dir image file. 

The CID I added was QmbL34ZqDaT4kMsSZziLE9H9S7eFTRvHz4FrsNqJ2LPi19


Files on the primary
<img width="1116" alt="docker_exec_-it_935d17d02ef0__bin_sh_—_docker_exec_-it_935d17d02ef0__bin_sh_—_158×54" src="https://user-images.githubusercontent.com/295938/89845801-53447880-db34-11ea-813e-eda04c97dcd7.png">

Files on the secondary
<img width="1116" alt="docker_exec_-it_449ffd4a66c1__bin_sh_—_docker_exec_-it_449ffd4a66c1__bin_sh_—_158×54" src="https://user-images.githubusercontent.com/295938/89845821-5e97a400-db34-11ea-845c-548c2d5f1404.png">

No diff between the two files
<img width="1116" alt="Downloads_—_dheeraj_Dheerajs-MacBook-Pro-2_—_-zsh_—_158×54" src="https://user-images.githubusercontent.com/295938/89845746-2f813280-db34-11ea-8de8-04a02a4b8f74.png">



