### PR TITLE
Updated DP logger to be JSON for easier parsing

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -19,3 +19,4 @@ jsonschema==3.2.0
 flask-restx==0.2.0
 hashids==1.2.0
 fakeredis==1.4.2
+jsonformatter==0.3.0

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -167,7 +167,7 @@ def create(test_config=None, mode="app"):
     configure_flask(test_config, app, mode)
 
     if mode == "app":
-        helpers.configure_logging(shared_config["discprov"]["loglevel_flask"])
+        helpers.configure_flask_app_logging(app, shared_config["discprov"]["loglevel_flask"])
         return app
 
     if mode == "celery":

--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -37,5 +37,5 @@ def register_exception_handlers(flask_app):
 
     @flask_app.errorhandler(404)
     def handle_404(_error): # pylint: disable=W0612
-        logger.error('404 - %s', request.url)
+        logger.info('404 - %s', request.url)
         return api_helpers.error_response(["Route does not exist"], 404)

--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -37,5 +37,4 @@ def register_exception_handlers(flask_app):
 
     @flask_app.errorhandler(404)
     def handle_404(_error): # pylint: disable=W0612
-        logger.info('404 - %s', request.url)
         return api_helpers.error_response(["Route does not exist"], 404)

--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -1,7 +1,4 @@
 import logging
-
-from flask import request
-
 from src import api_helpers
 
 

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -295,7 +295,6 @@ def search_tags():
 
 def add_users(session, results):
     user_id_list = get_users_ids(results)
-    logger.warning(user_id_list)
     users = get_users_by_id(session, user_id_list)
     for result in results:
         user_id = None

--- a/discovery-provider/src/queries/trending.py
+++ b/discovery-provider/src/queries/trending.py
@@ -34,11 +34,11 @@ def trending(time):
             json_cache = json.loads(redis_cache_value.decode('utf-8'))
             if json_cache is not None:
                 num_cached_entries = len(json_cache['listen_counts'])
-                logger.error(
+                logger.info(
                     f'Cache for {redis_key}, {num_cached_entries} entries, request limit {limit}')
                 if offset + limit <= num_cached_entries:
                     json_cache['listen_counts'] = json_cache['listen_counts'][offset:offset + limit]
-                    logger.error(f'Returning cache for {redis_key}')
+                    logger.info(f'Returning cache for {redis_key}')
                     # Increment cache hit count
                     REDIS.incr(trending_cache_hits_key, 1)
                     return api_helpers.success_response(json_cache)

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -81,7 +81,8 @@ def tuple_to_model_dictionary(t, model):
 log_format = {
     "levelno": "levelno",
     "level": "levelname",
-    "msg": "message"
+    "msg": "message",
+    "timestamp": "asctime",
 }
 
 formatter = JsonFormatter(
@@ -132,14 +133,11 @@ def configure_flask_app_logging(app, loglevel_str):
         ip = request.headers.get('X-Forwarded-For', request.remote_addr)
         host = request.host.split(':', 1)[0]
         args = request.query_string.decode("utf-8")
-        now = datetime.now()
-        timestamp = now.strftime("%Y/%m/%d %H:%M:%S")
 
         log_params = {
             'method': request.method,
             'path': request.path,
             'status': response.status_code,
-            'timestamp': timestamp,
             'duration': duration,
             'ip': ip,
             'host': host,

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -4,7 +4,6 @@ import json
 import re
 import time
 import contextlib
-from datetime import datetime
 from urllib.parse import urljoin
 from functools import reduce
 import requests
@@ -153,7 +152,6 @@ def configure_flask_app_logging(app, loglevel_str):
             part = "{}={}".format(name, value)
             parts.append(part)
 
-        line = " ".join(parts)
         logger.info('handle flask request', extra=log_params)
         return response
 

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -4,6 +4,7 @@ import json
 import re
 import time
 import contextlib
+from datetime import datetime
 from urllib.parse import urljoin
 from functools import reduce
 import requests
@@ -131,11 +132,14 @@ def configure_flask_app_logging(app, loglevel_str):
         ip = request.headers.get('X-Forwarded-For', request.remote_addr)
         host = request.host.split(':', 1)[0]
         args = request.query_string.decode("utf-8")
+        now = datetime.now()
+        timestamp = now.strftime("%Y/%m/%d %H:%M:%S")
 
         log_params = {
             'method': request.method,
             'path': request.path,
             'status': response.status_code,
+            'timestamp': timestamp,
             'duration': duration,
             'ip': ip,
             'host': host,
@@ -152,8 +156,7 @@ def configure_flask_app_logging(app, loglevel_str):
             parts.append(part)
 
         line = " ".join(parts)
-        logger.info(line, extra=log_params)
-
+        logger.info('handle flask request', extra=log_params)
         return response
 
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/8qfduiZ4/1464-better-error-detection-on-prod

### Description
Update the Discovery Provider logs to be in JSON format. This is so that it's easily parsed and more extensible (If we want to add more fields and have them propagate, it could be done w/out modifying regex in fluentd and updating the k8s config) 
This also adds a [python dependency of `jsonformatter`](https://pypi.org/project/jsonformatter/) to Discovery Provider.

The default flask logger is disabled and a new log per request is made with the method, path, status, duration, ip, host, params, and optionally "x-user-id" fields. 

Relies on audius-k8s change: https://github.com/AudiusProject/audius-k8s/pull/133

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope

### How Has This Been Tested?
This was tested by looking at the logs to verify that they are in JSON format in the server and in the celery worker. 
A DP image was build and pushed to staging's k8s cluster to verify that this was working with the fluentd parser changes and that the logs were seen in the loggly search tool.
images of the logs in loggy are shown below for the worker and server
![Screen Shot 2020-08-13 at 6 37 39 PM](https://user-images.githubusercontent.com/7064122/90193963-1b3b7080-dd94-11ea-8d81-c0f734bd2e27.png)
![Screen Shot 2020-08-13 at 6 37 28 PM](https://user-images.githubusercontent.com/7064122/90193964-1bd40700-dd94-11ea-870c-6479d7371b5f.png)
