### PR TITLE
Fix DP v1 API track duration by casting type

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -122,7 +122,8 @@ def extend_track(track):
     track["favorite_count"] = track["save_count"]
     duration = 0.
     for segment in track["track_segments"]:
-        duration += segment["duration"]
+        # NOTE: Legacy track segments store the duration as a string
+        duration += float(segment["duration"])
     track["duration"] = round(duration)
     return track
 

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -54,7 +54,7 @@ track = ns.model('Track', {
     "tags": fields.String,
     "title": fields.String(required=True),
     "user": fields.Nested(user_model, required=True),
-    "duration": fields.Float(required=True)
+    "duration": fields.Integer(required=True)
 })
 
 track_full = ns.clone('track_full', track, {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Z6K7uuFz/1474-tracks-api-query-for-rain-broken

### Description
Old tracks w/ id 390 and lower have track segment duration stored as a string while tracks w/ id after 390 have it as a float. 
ie. https://discoveryprovider.audius.co/tracks?id=390
Because the new api calculates the duration server side and adds up each segment it errors because it expects a number instead of a string. The fix was to cast all segment durations to float. 
Note, this PR also updates the track model to change the duration type from float to int. 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

I downloaded the latest Production DB dump, started a local instance of postgres & pg_restored the dump. I then made queries to the discovery provider api for `/v1/tracks/search?query=rain` which was the reported error breaking route and returned a track w/ id < 390. It returned fine w/out erroring.
