### PR TITLE
Update DP response codes and metrics route

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -3,6 +3,7 @@ from src.utils.config import shared_config
 from hashids import Hashids
 from flask_restx import fields, reqparse
 from src.queries.search_queries import SearchKind
+from datetime import datetime
 
 HASH_MIN_LENGTH = 5
 HASH_SALT = "azowernasdfoia"
@@ -108,6 +109,21 @@ def extend_remix_of(remix_of):
     remix_of["tracks"] = list(map(extend_track_element, remix_of["tracks"]))
     return remix_of
 
+def parse_bool_param(param):
+    if not isinstance(params, str):
+        return None
+    param = param.lower()
+    if param == 'true':
+        return True
+    elif param == 'false':
+        return False
+    return None
+
+def parse_unix_epoch_param(time, default=0):
+    if time is None:
+        return datetime.utcfromtimestamp(default)
+    return datetime.utcfromtimestamp(time)
+
 def extend_track(track):
     track_id = encode_int_id(track["track_id"])
     owner_id = encode_int_id(track["owner_id"])
@@ -137,6 +153,9 @@ def extend_playlist(playlist):
     playlist = add_playlist_artwork(playlist)
     playlist["favorite_count"] = playlist["save_count"]
     return playlist
+
+def abort_bad_request_param(param, namespace):
+    namespace.abort(400, "Oh no! Bad request parameter {}.".format(param))
 
 def abort_not_found(identifier, namespace):
     namespace.abort(404, "Oh no! Resource for ID {} not found.".format(identifier))

--- a/discovery-provider/src/api/v1/metrics.py
+++ b/discovery-provider/src/api/v1/metrics.py
@@ -2,8 +2,8 @@ import logging # pylint: disable=C0302
 from datetime import datetime
 from flask import Flask, Blueprint
 from flask_restx import Resource, Namespace, fields, reqparse
-from src import api_helpers
-from src.api.v1.helpers import make_response, success_response, to_dict
+from src.api.v1.helpers import make_response, success_response, to_dict, \
+    parse_bool_param, parse_unix_epoch_param, abort_bad_request_param
 from .models.metrics import route_metric, app_name_metric, app_name
 from src.queries.get_route_metrics import get_route_metrics
 from src.queries.get_app_name_metrics import get_app_name_metrics
@@ -18,15 +18,32 @@ app_name_response = make_response("app_name_response", ns, fields.List(fields.Ne
 app_name_metrics_response = make_response("app_name_metrics_response", ns, fields.List(fields.Nested(app_name_metric)))
 
 metrics_route_parser = reqparse.RequestParser()
-metrics_route_parser.add_argument('path', required=True)
+metrics_route_parser.add_argument('path', required=False)
 metrics_route_parser.add_argument('query_string', required=False)
-metrics_route_parser.add_argument('start_time', required=True, type=int)
+metrics_route_parser.add_argument('start_time', required=False, type=int)
+metrics_route_parser.add_argument('exact', required=False)
 metrics_route_parser.add_argument('limit', required=False, type=int)
 metrics_route_parser.add_argument('version', required=False, action='append')
 
 @ns.route("/routes", doc=False)
 class RouteMetrics(Resource):
     @ns.expect(metrics_route_parser)
+    @ns.doc(
+        id="""Route Metrics""",
+        params={
+            'path': 'Request Path',
+            'query_string': 'Query String',
+            'start_time': 'Start Time in Unix Epoch',
+            'exact': 'Exact Path Query Match',
+            'limit': 'Limit',
+            'version': 'API Version Query Filter'
+        },
+        responses={
+            200: 'Success',
+            400: 'Bad request',
+            500: 'Server error'
+        }
+    )
     @ns.marshal_with(route_metrics_response)
     def get(self):
         """Get the route metrics"""
@@ -36,10 +53,18 @@ class RouteMetrics(Resource):
         else:
             args['limit'] = min(args.get('limit'), 48)
         try:
-            args['start_time'] = datetime.utcfromtimestamp(args['start_time'])
+            args['start_time'] = parse_unix_epoch_param(args.get('start_time'), 0)
         except:
-            return api_helpers.error_response('Poorly formated start_time parameter', 400)
+            abort_bad_request_param('start_time', ns)
 
+        if args.get('exact') is not None:
+            args['exact'] = parse_bool_param(args.get('exact'))
+            if args.get('exact') is None:
+                abort_bad_request_param('exact', ns)
+        else:
+            args['exact'] = False
+
+        args['path'] = args.get('path') if args.get('path') is not None else ''
         route_metrics = get_route_metrics(args)
         response = success_response(route_metrics)
         return response
@@ -51,6 +76,18 @@ metrics_app_name_list_parser.add_argument('offset', required=False, type=int)
 
 @ns.route("/app_name", doc=False)
 class AppNameListMetrics(Resource):
+    @ns.doc(
+        id="""Get App Names""",
+        params={
+            'Offset': 'Offset',
+            'limit': 'Limit'
+        },
+        responses={
+            200: 'Success',
+            400: 'Bad request',
+            500: 'Server error'
+        }
+    )
     @ns.expect(metrics_app_name_list_parser)
     @ns.marshal_with(app_name_response)
     def get(self):
@@ -69,11 +106,23 @@ class AppNameListMetrics(Resource):
 
 
 metrics_app_name_parser = reqparse.RequestParser()
-metrics_app_name_parser.add_argument('start_time', required=True, type=int)
+metrics_app_name_parser.add_argument('start_time', required=False, type=int)
 metrics_app_name_parser.add_argument('limit', required=False, type=int)
 
 @ns.route("/app_name/<string:app_name>", doc=False)
 class AppNameMetrics(Resource):
+    @ns.doc(
+        id="""Get Metrics by App Name""",
+        params={
+            'start_time': 'Start Time in Unix Epoch',
+            'limit': 'Limit'
+        },
+        responses={
+            200: 'Success',
+            400: 'Bad request',
+            500: 'Server error'
+        }
+    )
     @ns.expect(metrics_app_name_parser)
     @ns.marshal_with(app_name_metrics_response)
     def get(self, app_name):
@@ -84,9 +133,9 @@ class AppNameMetrics(Resource):
         else:
             args['limit'] = min(args.get('limit'), 48)
         try:
-            args['start_time'] = datetime.utcfromtimestamp(args['start_time'])
+            args['start_time'] = parse_unix_epoch_param(args.get('start_time'), 0)
         except:
-            return api_helpers.error_response('Poorly formated start_time parameter', 400)
+            abort_bad_request_param('start_time', ns)
         app_name_metrics = get_app_name_metrics(app_name, args)
         response = success_response(app_name_metrics)
         return response

--- a/discovery-provider/src/api/v1/models/metrics.py
+++ b/discovery-provider/src/api/v1/models/metrics.py
@@ -2,7 +2,6 @@ from flask_restx import fields
 from .common import ns
 
 route_metric = ns.model('route_metric', {
-    "route": fields.String,
     "timestamp": fields.String,
     "count": fields.Integer
 })

--- a/discovery-provider/src/queries/get_route_metrics_test.py
+++ b/discovery-provider/src/queries/get_route_metrics_test.py
@@ -39,7 +39,7 @@ def populate_mock_db(db, date):
         session.bulk_save_objects(route_metric_obj)
 
 
-def test_get_route_metrics(db_mock):
+def test_get_route_metrics_exact(db_mock):
     """Tests that the route metrics can queried by exact path match"""
 
     date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
@@ -59,7 +59,7 @@ def test_get_route_metrics(db_mock):
     assert metrics[0]['count'] == 5
 
 
-def test_get_route_metrics(db_mock):
+def test_get_route_metrics_non_exact(db_mock):
     """Tests that the route metrics can be queried by non-exact path match"""
 
     date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
@@ -79,7 +79,7 @@ def test_get_route_metrics(db_mock):
     assert metrics[0]['count'] == 9
 
 
-def test_get_route_metrics(db_mock):
+def test_get_route_metrics_query_string(db_mock):
     """Tests that the route metrics are queried with query_string parameter"""
 
     date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
@@ -100,7 +100,7 @@ def test_get_route_metrics(db_mock):
     assert metrics[0]['count'] == 2
 
 
-def test_get_route_metrics(db_mock):
+def test_get_route_metrics_no_matches(db_mock):
     """Tests that route metrics returns nothing if no matching query_string"""
 
     date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)

--- a/discovery-provider/src/queries/get_route_metrics_test.py
+++ b/discovery-provider/src/queries/get_route_metrics_test.py
@@ -3,88 +3,118 @@ from src.models import RouteMetrics
 from src.queries.get_route_metrics import get_route_metrics
 
 
-def test_get_route_metrics(db_mock):
-    """Tests that the route metrics are queried correctly from db data"""
-
-    date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
-    before_all_date = (date + timedelta(hours=-2))
-    before_date = (date + timedelta(hours=-1))
-
-    route_metrics = [{
+def populate_mock_db(db, date):
+    """Helper function to populate the mock DB with route metrics"""
+    mock_route_metrics = [{
         'version': '1',
         'route_path': 'tracks/some_hash',
         'query_string': '',
         'count': 3,
-        'timestamp': before_date
+        'timestamp': date
     }, {
         'version': '1',
         'route_path': 'tracks/some_hash',
         'query_string': 'with_users=true',
         'count': 2,
-        'timestamp': before_date
+        'timestamp': date
     }, {
         'version': '1',
         'route_path': 'tracks/some_hash/stream',
         'query_string': '',
         'count': 4,
-        'timestamp': before_date
+        'timestamp': date
     }]
 
-    RouteMetrics.__table__.create(db_mock._engine)
+    RouteMetrics.__table__.create(db._engine)
 
-    # Set up db state
-    with db_mock.scoped_session() as session:
+    with db.scoped_session() as session:
         route_metric_obj = [RouteMetrics(
             version=metric['version'],
             route_path=metric['route_path'],
             query_string=metric['query_string'],
             count=metric['count'],
             timestamp=metric['timestamp']
-        ) for metric in route_metrics]
+        ) for metric in mock_route_metrics]
 
         session.bulk_save_objects(route_metric_obj)
 
-    args_1 = {
+
+def test_get_route_metrics(db_mock):
+    """Tests that the route metrics can queried by exact path match"""
+
+    date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    before_date = (date + timedelta(hours=-1))
+
+    populate_mock_db(db_mock, date)
+
+    args = {
         'limit': 10,
-        'start_time': before_all_date,
+        'start_time': before_date,
         'path': 'tracks/some_hash',
         'exact': True
     }
-    metrics_1 = get_route_metrics(args_1)
+    metrics = get_route_metrics(args)
 
-    assert len(metrics_1) == 1
-    assert metrics_1[0]['count'] == 5
+    assert len(metrics) == 1
+    assert metrics[0]['count'] == 5
 
-    args_2 = {
+
+def test_get_route_metrics(db_mock):
+    """Tests that the route metrics can be queried by non-exact path match"""
+
+    date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    before_date = (date + timedelta(hours=-1))
+
+    populate_mock_db(db_mock, date)
+
+    args = {
         'limit': 10,
-        'start_time': before_all_date,
+        'start_time': before_date,
         'path': 'tracks/some_hash',
         'exact': False
     }
-    metrics_2 = get_route_metrics(args_2)
+    metrics = get_route_metrics(args)
 
-    assert len(metrics_2) == 1
-    assert metrics_2[0]['count'] == 9
+    assert len(metrics) == 1
+    assert metrics[0]['count'] == 9
 
-    args_3 = {
+
+def test_get_route_metrics(db_mock):
+    """Tests that the route metrics are queried with query_string parameter"""
+
+    date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    before_date = (date + timedelta(hours=-1))
+
+    populate_mock_db(db_mock, date)
+
+    args = {
         'limit': 10,
-        'start_time': before_all_date,
+        'start_time': before_date,
         'path': 'tracks/some_hash',
         'query_string': 'with_users=true',
         'exact': False
     }
-    metrics_3 = get_route_metrics(args_3)
+    metrics = get_route_metrics(args)
 
-    assert len(metrics_3) == 1
-    assert metrics_3[0]['count'] == 2
+    assert len(metrics) == 1
+    assert metrics[0]['count'] == 2
 
-    args_4 = {
+
+def test_get_route_metrics(db_mock):
+    """Tests that route metrics returns nothing if no matching query_string"""
+
+    date = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    before_date = (date + timedelta(hours=-1))
+
+    populate_mock_db(db_mock, date)
+
+    args = {
         'limit': 10,
-        'start_time': before_all_date,
+        'start_time': before_date,
         'path': 'tracks/some_hash',
         'query_string': 'with_users=WRONG',
         'exact': False
     }
-    metrics_4 = get_route_metrics(args_4)
+    metrics = get_route_metrics(args)
 
-    assert not metrics_4
+    assert not metrics

--- a/discovery-provider/src/queries/get_route_metrics_test.py
+++ b/discovery-provider/src/queries/get_route_metrics_test.py
@@ -22,6 +22,12 @@ def test_get_route_metrics(db_mock):
         'query_string': 'with_users=true',
         'count': 2,
         'timestamp': before_date
+    }, {
+        'version': '1',
+        'route_path': 'tracks/some_hash/stream',
+        'query_string': '',
+        'count': 4,
+        'timestamp': before_date
     }]
 
     RouteMetrics.__table__.create(db_mock._engine)
@@ -41,7 +47,8 @@ def test_get_route_metrics(db_mock):
     args_1 = {
         'limit': 10,
         'start_time': before_all_date,
-        'path': 'tracks/some_hash'
+        'path': 'tracks/some_hash',
+        'exact': True
     }
     metrics_1 = get_route_metrics(args_1)
 
@@ -52,19 +59,32 @@ def test_get_route_metrics(db_mock):
         'limit': 10,
         'start_time': before_all_date,
         'path': 'tracks/some_hash',
-        'query_string': 'with_users=true'
+        'exact': False
     }
     metrics_2 = get_route_metrics(args_2)
 
     assert len(metrics_2) == 1
-    assert metrics_2[0]['count'] == 2
+    assert metrics_2[0]['count'] == 9
 
     args_3 = {
         'limit': 10,
         'start_time': before_all_date,
         'path': 'tracks/some_hash',
-        'query_string': 'with_users=WRONG'
+        'query_string': 'with_users=true',
+        'exact': False
     }
     metrics_3 = get_route_metrics(args_3)
 
-    assert not metrics_3
+    assert len(metrics_3) == 1
+    assert metrics_3[0]['count'] == 2
+
+    args_4 = {
+        'limit': 10,
+        'start_time': before_all_date,
+        'path': 'tracks/some_hash',
+        'query_string': 'with_users=WRONG',
+        'exact': False
+    }
+    metrics_4 = get_route_metrics(args_4)
+
+    assert not metrics_4

--- a/discovery-provider/src/queries/search.py
+++ b/discovery-provider/src/queries/search.py
@@ -9,13 +9,14 @@ bp = Blueprint("search_queries", __name__)
 def validate_search_args(args):
     searchStr = args.get("query")
     if not searchStr:
-        return api_helpers.error_response("Invalid value for parameter 'query'")
+        return api_helpers.error_response("Invalid value for parameter 'query'", 400)
 
     kind = args.get("kind", "all")
     if kind not in SearchKind.__members__:
         return api_helpers.error_response(
             "Invalid value for parameter 'kind' must be in %s" % [
-                k.name for k in SearchKind]
+                k.name for k in SearchKind],
+            400
         )
     return None
 

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -56,7 +56,8 @@ def search_tags():
     except Exception:
         return api_helpers.error_response(
             "Invalid value for parameter 'kind' must be in %s" % [
-                k.name for k in validSearchKinds]
+                k.name for k in validSearchKinds],
+            400
         )
 
     results = {}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/56GUdPFE/1478-route-checks-should-match-sub-routes-in-discprov-metrics

### Description
Updated `v1/metrics/routes` so that the path parameter is now optional and is a LIKE query by default, added an exact param for exact matching, and the start_time defaults to the beginning of time. 
Updated `v1/metrics/app_name` so that the start_time param defaults to the beginning of time.
Updated unit test for get route metrics exact vs substring matching
Also, the search query args parsing now returns 400 on failure to parse args instead of 500. 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Ran the system locally, queried the v1 API and made queries to the `v1/metrics/routes`, `v1/metrics/app_name` and `v1/metrics/app_name/<app_name>` routes w/ the `exact` param and w/ and w/out the `start_time` param. 

Please list the unit test(s) you added to verify your changes.

1. Updated the `get_route_metrics_test.py` unit tests to add a check for the route path LIKE query - with the exact param being passed in.
