### PR TITLE
Reduced creator node logging for ipfs rehydrate and single byte cat

### DIFF
--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -54,15 +54,13 @@ class RehydrateIpfsQueue {
   async logStatus (logContext, message) {
     const logger = genericLogger.child(logContext)
     const count = await this.queue.count()
-    logger.info(`RehydrateIpfsQueue: ${message}`)
-    logger.info(`RehydrateIpfsQueue: count: ${count}`)
+    logger.debug(`RehydrateIpfsQueue: ${message}, count: ${count}`)
   }
 
   async logError (logContext, message) {
     const logger = genericLogger.child(logContext)
     const count = await this.queue.count()
     logger.error(`RehydrateIpfsQueue error: ${message}`)
-    logger.info(`RehydrateIpfsQueue: count: ${count}`)
   }
 
   /**

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -95,7 +95,11 @@ const ipfsSingleByteCat = (path, logContext, timeout = 1000) => {
       logger.info(`ipfsSingleByteCat - Retrieved ${path} in ${Date.now() - start}ms`)
       resolve()
     } catch (e) {
-      logger.error(`ipfsSingleByteCat - Error: ${e}`)
+      // Expected message for e is `TimeoutError: Request timed out`
+      // if it's not that message, log out the error
+      if (!e.message.includes('Request timed out')) {
+        logger.error(`ipfsSingleByteCat - Error: ${e}`)
+      }
       reject(e)
     }
   })


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/VU79WSj9/1471-cnode-error-logging-cleanup

### Description
Creator node logs are extremely verbose. The usefulness of logs is overshadowed by the sheer volume. According to an aggregation of our most common logs on production over the last week, the most common logs were:

```
RehydrateIpfsQueue: count: 0
9,244,789

RehydrateIpfsQueue: Adding a rehydrateIpfsFromFsIfNecessary task to the queue!
4,194,961

RehydrateIpfsQueue: Successfully added a rehydrateIpfsFromFsIfNecessary task!
3,997,661

ipfsSingleByteCat - Error: TimeoutError: Request timed out
834,008

rehydrateIpfsFromFsIfNecessary - addResp {}
396,037

Success
273,005

Error processing request: Request timed out || Request Body: {}
262,794
```

There's a huge long tail of errors, but the top few errors seem to be coming from RehydrateIpfsQueue and ipfsSingleByteCat.
### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Tested locally by verifying RehydrateIpfsQueue logs are of level DEBUG.
```
[2020-08-19T05:34:54.939Z] DEBUG: audius_creator_node/28 on b756f93b5c10: RehydrateIpfsQueue: Adding a rehydrateIpfsFromFsIfNecessary task to the queue!, count: 0 (requestID=e4_c5hTJzp, requestMethod=GET, requestHostname=localhost)
```

Also added a log statement in ipfsSingleByteCat
```
if (!e.message.includes('Request timed out')) {
  logger.error(`ipfsSingleByteCat - Error: ${e}`)
}
else logger.info('expected error rto')
```
And i saw the expected log
```
[2020-08-19T05:34:55.029Z]  INFO: audius_creator_node/28 on b756f93b5c10: expected error rto (requestID=e4_c5hTJzp, requestMethod=GET, requestHostname=localhost)
```