### PR TITLE
Update CN and DP request logs with duration and query string

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -8555,11 +8555,6 @@
         "ee-first": "1.1.1"
       }
     },
-    "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9735,15 +9730,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "response-time": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
-      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
-      "requires": {
-        "depd": "~1.1.0",
-        "on-headers": "~1.0.1"
-      }
     },
     "responselike": {
       "version": "1.0.2",

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -47,7 +47,6 @@
     "multer": "^1.4.0",
     "pg": "^7.6.1",
     "rate-limit-redis": "^1.6.0",
-    "response-time": "^2.3.2",
     "sequelize": "^4.41.2",
     "shortid": "^2.2.14",
     "umzug": "^2.2.0",

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -24,8 +24,11 @@ module.exports.handleResponse = (func) => {
 }
 
 const sendResponse = module.exports.sendResponse = (req, res, resp) => {
+  const endTime = process.hrtime(req.startTime)
+  const duration = Math.round(endTime[0] * 1e3 + endTime[1] * 1e-6)
   let logger = req.logger.child({
-    statusCode: resp.statusCode
+    statusCode: resp.statusCode,
+    duration
   })
   if (resp.statusCode === 200) {
     if (requestNotExcludedFromLogging(req.originalUrl)) {

--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-const responseTime = require('response-time')
 
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { logger, loggingMiddleware } = require('./logging')
@@ -13,7 +12,6 @@ const config = require('./config')
 const app = express()
 // middleware functions will be run in order they are added to the app below
 //  - loggingMiddleware must be first to ensure proper error handling
-app.use(responseTime())
 app.use(loggingMiddleware)
 app.use(bodyParser.json({ limit: '1mb' }))
 app.use(userNodeMiddleware)

--- a/identity-service/src/apiHelpers.js
+++ b/identity-service/src/apiHelpers.js
@@ -18,8 +18,11 @@ module.exports.handleResponse = (func) => {
 }
 
 const sendResponse = module.exports.sendResponse = (req, res, resp) => {
+  const endTime = process.hrtime(req.startTime)
+  const duration = Math.round(endTime[0] * 1e3 + endTime[1] * 1e-6)
   let logger = req.logger.child({
-    statusCode: resp.statusCode
+    statusCode: resp.statusCode,
+    duration
   })
   if (resp.statusCode === 200) {
     if (requestNotExcludedFromLogging(req.originalUrl)) {

--- a/identity-service/src/logging.js
+++ b/identity-service/src/logging.js
@@ -22,11 +22,14 @@ function requestNotExcludedFromLogging (url) {
 
 function loggingMiddleware (req, res, next) {
   const requestID = shortid.generate()
+  const urlParts = req.url.split('?')
+  req.startTime = process.hrtime()
   req.logger = logger.child({
     requestID: requestID,
     requestMethod: req.method,
     requestHostname: req.hostname,
-    requestUrl: req.url.split('?')[0], // remove query params from request before logging
+    requestUrl: urlParts[0],
+    requestQueryParams: urlParts.length > 1 ? urlParts[1] : undefined,
     requestIP: req.ip
   })
   if (requestNotExcludedFromLogging(req.originalUrl)) {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/MI1Q0n93/1479-query-params-should-also-get-logged-to-loggly-right-now-i-think-just-the-route-path-gets-logged-and-send-alerts-to-slack-if-fata

### Description
Update the CN and DP logs per request to include the duration of the request and url query string. 

CN: A separate log was being output per request w/ response time using the `response-time` npm package, but I added a start time and calculated the difference manually so that it could be a part of the response log instead of a separate log. Note that when comparing the difference in time, it was ~1-2 ms of a difference. This also puts it in the JSON format which makes it nicer to run analytics on in loggly. The query string was also separated from the url being printed out which should make analytics nicer as well for url grouping.

DP: The duration and query string were added to the request logs

### Services
- Discovery Provider
- Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I looked at the logs.

Please list the unit test(s) you added to verify your changes.

