### PR TITLE
Fixes DP v1 search api with no query parameter

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -4,7 +4,7 @@ from src.queries.get_playlists import get_playlists
 from flask_restx import Resource, Namespace, fields
 from src.queries.get_playlist_tracks import get_playlist_tracks
 from src.api.v1.helpers import abort_not_found, decode_with_abort, extend_playlist, extend_track,\
-    make_response, success_response, search_parser
+    make_response, success_response, search_parser, abort_bad_request_param
 from .models.tracks import track
 from src.queries.search_queries import SearchKind, search
 from src.utils.redis_cache import cache
@@ -86,6 +86,8 @@ class PlaylistSearchResult(Resource):
         """Search for a playlist."""
         args = search_parser.parse_args()
         query = args["query"]
+        if not query:
+            abort_bad_request_param('query', ns)
         search_args = {
             "query": query,
             "kind": SearchKind.playlists.name,

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -6,7 +6,7 @@ from src.queries.get_tracks import get_tracks
 from src.queries.get_track_user_creator_node import get_track_user_creator_node
 from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
     extend_track, make_response, search_parser, \
-    trending_parser, success_response
+    trending_parser, success_response, abort_bad_request_param
 from .models.tracks import track
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_trending_tracks import get_trending_tracks
@@ -109,6 +109,8 @@ class TrackSearchResult(Resource):
         """Search for a track."""
         args = search_parser.parse_args()
         query = args["query"]
+        if not query:
+            abort_bad_request_param('query', ns)
         search_args = {
             "query": query,
             "kind": SearchKind.tracks.name,

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -7,7 +7,7 @@ from src.queries.search_queries import SearchKind, search
 from flask_restx import Resource, Namespace, fields
 from src.queries.get_tracks import get_tracks
 from src.api.v1.helpers import abort_not_found, decode_with_abort, extend_favorite, extend_track, \
-     extend_user, make_response, search_parser, success_response
+     extend_user, make_response, search_parser, success_response, abort_bad_request_param
 from .models.tracks import track
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
@@ -107,6 +107,8 @@ class UserSearchResult(Resource):
         """Seach for a user."""
         args = search_parser.parse_args()
         query = args["query"]
+        if not query:
+            abort_bad_request_param('query', ns)
         search_args = {
             "query": query,
             "kind": SearchKind.users.name,


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/OSGIWLIv/1486-dp-v1-search-api-returning-500

### Description
The DP user/track/playlist search API returns a 500 response code when the query param equals nothing ie. `query=`.
This is b/c if the search function checks if the query evals to a "truthy" value which an empty string does not. 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran the system locally, made a query to each of the endpoints w/ and w/out a valid query parameter and got the 400 response.
