### PR TITLE
Fix creator node lint

### DIFF
--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -59,7 +59,6 @@ class RehydrateIpfsQueue {
 
   async logError (logContext, message) {
     const logger = genericLogger.child(logContext)
-    const count = await this.queue.count()
     logger.error(`RehydrateIpfsQueue error: ${message}`)
   }
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/VU79WSj9/1471-cnode-error-logging-cleanup

### Description
Lint issue introduced in https://github.com/AudiusProject/audius-protocol/pull/757. Somehow, CircleCI didn't run the workflow for the other PR and just marked it as passing

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Ran lint and it passed