### PR TITLE
Adds identity endpoint for clearing badge count

### DIFF
--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -493,18 +493,18 @@ module.exports = function (app) {
   /*
    * Clears a user's notification badge count to 0
   */
- app.post('/notifications/clear_badges', authMiddleware, handleResponse(async (req, res, next) => {
-  const { blockchainUserId: userId } = req.user
+  app.post('/notifications/clear_badges', authMiddleware, handleResponse(async (req, res, next) => {
+    const { blockchainUserId: userId } = req.user
 
-  try {
-    await clearBadgeCounts(userId, req.logger)
-    return successResponse({ message: 'success' })
-  } catch (err) {
-    return errorResponseBadRequest({
-      message: `[Error] Unable to clear user badges for userID: ${userID}`
-    })
-  }
-}))
+    try {
+      await clearBadgeCounts(userId, req.logger)
+      return successResponse({ message: 'success' })
+    } catch (err) {
+      return errorResponseBadRequest({
+        message: `[Error] Unable to clear user badges for userID: ${userId}`
+      })
+    }
+  }))
 
   /**
    * @deprecated

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -490,6 +490,22 @@ module.exports = function (app) {
     }
   }))
 
+  /*
+   * Clears a user's notification badge count to 0
+  */
+ app.post('/notifications/clear_badges', authMiddleware, handleResponse(async (req, res, next) => {
+  const { blockchainUserId: userId } = req.user
+
+  try {
+    await clearBadgeCounts(userId, req.logger)
+    return successResponse({ message: 'success' })
+  } catch (err) {
+    return errorResponseBadRequest({
+      message: `[Error] Unable to clear user badges for userID: ${userID}`
+    })
+  }
+}))
+
   /**
    * @deprecated
    * Updates fields for a user's settings (or creates the settings w/ db defaults if not created)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/hy9V9hZ3/1489-notification-badge-regression-no-longer-clears-on-app-opening-if-theres-nothing-see-attached-video

### Description
The native app currently clears the notification badge for the app icon when you go to the notifications page in the app. 
It should be changed to clear the notifications badge on app open. Since the clearing is currently part of the `POST /notifications/all` route which marks all the notification as `seen`, a new route was made so that setting the notification badge count can be done separately from marking notifications as seen. 

### Services
Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

The system was run locally, a user account was created via the ui. I manually inserted a row for PushNotificationBadgeCounts for the created user with iosBadgeCount set to 1. I opened the app and checked that the request to the new endpoint was returning successful. I then checked the DB to see the iosBadgeCount column for the user set to 0
