### PR TITLE
Fixes the search tag endpoint

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -20,7 +20,7 @@ import alembic
 import alembic.config  # pylint: disable=E0611
 
 from src import exceptions
-from src.queries import queries, search, health_check, trending, notifications
+from src.queries import queries, search, search_queries, health_check, trending, notifications
 from src.api.v1 import api as api_v1
 from src.utils import helpers, config
 from src.utils.db_session import SessionManager
@@ -237,6 +237,7 @@ def configure_flask(test_config, app, mode="app"):
     app.register_blueprint(queries.bp)
     app.register_blueprint(trending.bp)
     app.register_blueprint(search.bp)
+    app.register_blueprint(search_queries.bp)
     app.register_blueprint(notifications.bp)
     app.register_blueprint(health_check.bp)
 

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -14,7 +14,7 @@ from src.queries.query_helpers import get_current_user_id, get_users_by_id, get_
     get_track_play_counts
 
 logger = logging.getLogger(__name__)
-bp = Blueprint("search_queries", __name__)
+bp = Blueprint("search_tags", __name__)
 
 
 ######## VARS ########


### PR DESCRIPTION
### Trello Card Link
n/a

### Description
Search tags was not a registered route

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches register routes


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Ran it locally an hit the `search/tags` endpoint and it did NOT return a 404. 
