### PR TITLE
Fix Discovery Provider Indexing Plays

### DIFF
--- a/discovery-provider/alembic/versions/277bad300c09_clear_plays_with_index.py
+++ b/discovery-provider/alembic/versions/277bad300c09_clear_plays_with_index.py
@@ -1,0 +1,32 @@
+"""clear plays with index
+
+Revision ID: 277bad300c09
+Revises: f54b539b0527
+Create Date: 2020-08-21 15:08:54.613477
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '277bad300c09'
+down_revision = 'f54b539b0527'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    # Delete all rows from the plays table to force re-indexing from the beginning
+    connection.execute('''
+        DELETE FROM plays
+    ''')
+
+    # Create index on plays table with the play_item_id and user_id
+    op.create_index(op.f('ix_plays_user_play_item'), 'plays', ['play_item_id', 'user_id'], unique=False)
+    op.create_index(op.f('ix_plays_user_play_item_date'), 'plays', ['play_item_id', 'user_id', 'created_at'], unique=False)
+
+def downgrade():
+    op.drop_index(op.f('ix_plays_user_play_item'), table_name='plays')
+    op.drop_index(op.f('ix_plays_user_play_item_date'), table_name='plays')

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -276,7 +276,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "update_play_count": {
                 "task": "update_play_count",
-                "schedule": timedelta(seconds=5)
+                "schedule": timedelta(seconds=10)
             },
             "update_metrics": {
                 "task": "update_metrics",

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Text,
     Enum,
     PrimaryKeyConstraint,
+    Index,
     func,
 )
 from src.model_validator import ModelValidator
@@ -422,6 +423,9 @@ class Play(Base):
     play_item_id = Column(Integer, nullable=False, index=False)
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    Index('ix_plays_user_play_item', 'play_item_id', 'user_id', unique=False)
+    Index('ix_plays_user_play_item_date', 'play_item_id', 'user_id', 'created_at', unique=False)
 
     def __repr__(self):
         return f"<Play(\

--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -194,7 +194,7 @@ def get_track_plays(self, db):
             insert_refresh_time)
         job_extra_info['total_time'] = get_time_diff(start_time)
         logger.info("index_plays.py | update_play_count complete",
-                       extra=job_extra_info)
+                    extra=job_extra_info)
 
 ######## CELERY TASK ########
 @celery.task(name="update_play_count", bind=True)

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -1,7 +1,6 @@
 import logging
 import json
 import time
-import re
 from urllib.parse import urlparse, urljoin
 import requests
 from requests.exceptions import ReadTimeout
@@ -246,5 +245,5 @@ class IPFSClient:
         try:
             make_cid(cid)
             return True
-        except:
+        except Exception as e:
             return False

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -6,7 +6,7 @@ const { handleResponse, successResponse, errorResponseBadRequest } = require('..
 const { logger } = require('../logging')
 const authMiddleware = require('../authMiddleware')
 
-async function getListenHour() {
+async function getListenHour () {
   let listenDate = new Date()
   listenDate.setMinutes(0)
   listenDate.setSeconds(0)

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -6,7 +6,7 @@ const { handleResponse, successResponse, errorResponseBadRequest } = require('..
 const { logger } = require('../logging')
 const authMiddleware = require('../authMiddleware')
 
-async function getListenHour () {
+async function getListenHour() {
   let listenDate = new Date()
   listenDate.setMinutes(0)
   listenDate.setSeconds(0)
@@ -251,7 +251,7 @@ module.exports = function (app) {
 
     const trackListens = await models.UserTrackListen.findAll({
       where: { userId },
-      order: [[ 'updatedAt', 'DESC' ]],
+      order: [['updatedAt', 'DESC']],
       attributes: ['trackId', 'updatedAt'],
       limit,
       offset
@@ -385,7 +385,7 @@ module.exports = function (app) {
         }
       },
       order: [
-        [ 'count', 'DESC' ]
+        ['count', 'DESC']
       ],
       limit
     })
@@ -472,21 +472,25 @@ module.exports = function (app) {
       where: {
         updatedAt: { [models.Sequelize.Op.gt]: updatedAtMoment.toDate() }
       },
-      order: [['createdAt', 'ASC'], ['trackId', 'ASC']],
+      order: [['updatedAt', 'ASC'], ['trackId', 'ASC']],
       limit
     })
 
     const anonListens = await models.TrackListenCount.findAll({
-      attributes: ['trackId', ['listens', 'count'], 'createdAt', 'updatedAt'],
+      attributes: ['trackId', ['listens', 'count'], ['hour', 'createdAt'], 'updatedAt'],
       where: {
         updatedAt: { [models.Sequelize.Op.gt]: updatedAtMoment.toDate() }
       },
-      order: [['createdAt', 'ASC'], ['trackId', 'ASC']],
+      order: [['updatedAt', 'ASC'], ['trackId', 'ASC']],
       limit
     })
 
+    const listens = [...userListens, ...anonListens].sort((a, b) => {
+      return moment(a.updatedAt) - moment(b.updatedAt)
+    }).slice(0, limit)
+
     return successResponse({
-      listens: [...userListens, ...anonListens]
+      listens
     })
   }))
 }


### PR DESCRIPTION
### Trello Card Link
This trello issue is to use the plays table for trending, the DP plays table was inconsistent w/ what identity had stored for plays. So, this PR is to fix the inconsistency.
https://trello.com/c/c7DUIQB8/1438-api-update-the-trending-endpoint-to-use-the-plays-table

### Description
The plays recorded in DP are fetched from identity service using a time based offset to periodically fetch more plays. The current implementation used the wrong timestamp to fetch/store plays which is fixed in this PR.
**NOTES**: 
* The migration clears the plays table to reindex - deletes all rows to start the indexing from scratch to correct the missed track listen entries
* The migration adds a couple indexes on the plays table so that the dudupling logic is much faster - just a note on this is that it took upwards of 1-2 minutes for the query before and now around 2 seconds (can be up to 30 seconds - depends on re-indexing I believe)
* Added logging on timing during the index plays flow.
* Increased the indexing play interval time to 10 seconds b/c it took ~8 seconds on average on my machine/running the db locally per job. 


### Services
Discovery Provider
Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope - The plays in DP are not yet used in production. It does affect the v1 API trending and the play count returned, but again this is not used in our dapp at the moment.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

The production identity service tables `TrackListenCounts` and `UserTrackListens` were dumped into my local setup. 
The DP indexing flow was allowed run. I checked that plays table in DP has the same number of rows two tables in identity service. (There was a discrepancy of 2 track listens - I looked into this and it's b/c we use a time offset query pagination, so there were tracks that has the same timestamp on the edge of queries. I assume we can tolerate this error for now given that we will eventually switch to indexing from chain.)

Note: It took ~45 minutes for DP to catch up w/ identity's play counts when indexing. This is for ~1.7 million track listens.(1.3 mill anonymous & 300k user listens)

Logs should now look like: 
```
{"levelno": 30, "level": "INDO", "msg": "index_plays.py | update_play_count complete", "timestamp": "2020-08-24 17:04:34,130", "job": "index-plays", "identity_response_time": 0.843137264251709, "listens_query_building_time": 1.408
226490020752, "listens_query_time": 1.568885326385498, "build_insert_query_time": 1.1669285297393799, "number_rows_insert": 6139, "insert_time": 3.223522186279297, "total_time": 8.38098430633545}
```
