### PR TITLE
Accept empty end in Range requests and return Content-Range in response

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -59,7 +59,7 @@ const streamFromFileSystem = async (req, res, path) => {
         return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
       }
 
-      fileStream = fs.createReadStream(path, { start, end: end || stat.size })
+      fileStream = fs.createReadStream(path, { start, end: end || (stat.size - 1) })
 
       // Add a content range header to the response
       res.set('Content-Range', formatContentRange(start, end, stat.size))
@@ -148,8 +148,9 @@ const getCID = async (req, res) => {
         }
 
         // Set length to be end - start + 1 so it matches behavior of fs.createReadStream
+        const length = end ? end - start + 1 : stat.size - start
         stream = req.app.get('ipfsAPI').catReadableStream(
-          CID, { offset: start, length: (end || stat.size) - start + 1 }
+          CID, { offset: start, length }
         )
         // Add a content range header to the response
         res.set('Content-Range', formatContentRange(start, end, stat.size))

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -2,7 +2,7 @@ const Redis = require('ioredis')
 const fs = require('fs')
 var contentDisposition = require('content-disposition')
 
-const { getRequestRange } = require('../utils/requestRange')
+const { getRequestRange, formatContentRange } = require('../utils/requestRange')
 const { uploadTempDiskStorage } = require('../fileManager')
 const {
   handleResponse,
@@ -62,7 +62,7 @@ const streamFromFileSystem = async (req, res, path) => {
       fileStream = fs.createReadStream(path, { start, end: end || stat.size })
 
       // Add a content range header to the response
-      res.set('Content-Range', `${start}-${end || stat.size}/${stat.size}`)
+      res.set('Content-Range', formatContentRange(start, end, stat.size))
       // set 206 "Partial Content" success status response code
       res.status(206)
     } else {
@@ -140,7 +140,6 @@ const getCID = async (req, res) => {
       const range = getRequestRange(req)
 
       if (req.params.streamable && range) {
-        req.logger.info('should not be here\n\n\n\n', range)
         const { start, end } = range
         if (end >= stat.size) {
           // Set "Requested Range Not Satisfiable" header and exit
@@ -153,7 +152,7 @@ const getCID = async (req, res) => {
           CID, { offset: start, length: (end || stat.size) - start + 1 }
         )
         // Add a content range header to the response
-        res.set('Content-Range', `${start}-${end || stat.size}/${stat.size}`)
+        res.set('Content-Range', formatContentRange(start, end, stat.size))
         // set 206 "Partial Content" success status response code
         res.status(206)
       } else {

--- a/creator-node/src/utils/requestRange.js
+++ b/creator-node/src/utils/requestRange.js
@@ -42,7 +42,7 @@ const getRequestRange = (req) => {
  * @returns {string} Content-Range header value
  */
 const formatContentRange = (start, end, size) => {
-  return `bytes ${start}-${end || size}/${size}`
+  return `bytes ${start}-${end || (size - 1)}/${size}`
 }
 
 module.exports = {

--- a/creator-node/src/utils/requestRange.js
+++ b/creator-node/src/utils/requestRange.js
@@ -5,6 +5,8 @@
  *
  * This is a widely supported pattern, e.g.
  * https://musicpartners.sonos.com/node/465
+ * or
+ * https://github.com/tumtumtum/StreamingKit/blob/eb9268e83ea0c0cea6a1c7af16559de455d4326e/StreamingKit/StreamingKit/STKHTTPDataSource.m#L605
  *
  * @param {Request} req express request object
  *
@@ -35,6 +37,15 @@ const getRequestRange = (req) => {
   }
 }
 
+/**
+ * Formats a Content-Range header response
+ * @returns {string} Content-Range header value
+ */
+const formatContentRange = (start, end, size) => {
+  return `bytes ${start}-${end || size}/${size}`
+}
+
 module.exports = {
-  getRequestRange
+  getRequestRange,
+  formatContentRange
 }

--- a/creator-node/src/utils/requestRange.js
+++ b/creator-node/src/utils/requestRange.js
@@ -1,0 +1,40 @@
+/**
+ * Gets range request headers off of a request object
+ * Drop in replacement for `req.range()` which does not
+ * support ranges without a specified `end`.
+ *
+ * This is a widely supported pattern, e.g.
+ * https://musicpartners.sonos.com/node/465
+ *
+ * @param {Request} req express request object
+ *
+ * @returns
+ *  { start, end } where start and end are integer byte values
+ *  or
+ *  null if the request could not be parsed
+ */
+const getRequestRange = (req) => {
+  const header = req.header('range')
+  if (!header) return null
+
+  // Format: bytes=start-end
+  // e.g. bytes=1024-2048
+  const matches = header.match(/(.*)=(\d*)-(\d*)/)
+  // Only `start` is required
+  if (!matches || !matches[2]) return null
+
+  try {
+    const start = parseInt(matches[2], 10)
+    const end = matches[3]
+      ? parseInt(matches[3], 10)
+      : undefined
+
+    return { start, end }
+  } catch (e) {
+    return null
+  }
+}
+
+module.exports = {
+  getRequestRange
+}

--- a/creator-node/src/utils/requestRange.test.js
+++ b/creator-node/src/utils/requestRange.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { getRequestRange } = require('./requestRange')
+const { getRequestRange, formatContentRange } = require('./requestRange')
 
 describe('Test getRequestRange', () => {
   it('Should calculate start and end', () => {
@@ -34,5 +34,17 @@ describe('Test getRequestRange', () => {
     }
     const range = getRequestRange(req)
     assert.strictEqual(range, null)
+  })
+})
+
+describe('Test formatContentRange', () => {
+  it('Should format correctly', () => {
+    const header = formatContentRange(1024, 2048, 4096)
+    assert.strictEqual(header, 'bytes 1024-2048/4096')
+  })
+
+  it('Should use size when end is unset', () => {
+    const header = formatContentRange(1024, undefined, 4096)
+    assert.strictEqual(header, 'bytes 1024-4096/4096')
   })
 })

--- a/creator-node/src/utils/requestRange.test.js
+++ b/creator-node/src/utils/requestRange.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert')
+const { getRequestRange } = require('./requestRange')
+
+describe('Test getRequestRange', () => {
+  it ('Should calculate start and end', () => {
+    const req = {
+      header: () => 'bytes=1024-2048'
+    }
+    const { start, end } = getRequestRange(req)
+    assert.equal(start, 1024)
+    assert.equal(end, 2048)
+  })
+
+  it ('Should calculate start with no end', () => {
+    const req = {
+      header: () => 'bytes=1024-'
+    }
+    const { start, end } = getRequestRange(req)
+    assert.equal(start, 1024)
+    assert.equal(end, undefined)
+  })
+
+  it ('Should error at malformatted range', () => {
+    const req = {
+      header: () => ''
+    }
+    const range = getRequestRange(req)
+    assert.equal(range, -1)
+  })
+
+  it ('Should error at non integer ranges', () => {
+    const req = {
+      header: () => 'bytes=abc-def'
+    }
+    const range = getRequestRange(req)
+    assert.equal(range, -1)
+  })
+})

--- a/creator-node/src/utils/requestRange.test.js
+++ b/creator-node/src/utils/requestRange.test.js
@@ -2,37 +2,37 @@ const assert = require('assert')
 const { getRequestRange } = require('./requestRange')
 
 describe('Test getRequestRange', () => {
-  it ('Should calculate start and end', () => {
+  it('Should calculate start and end', () => {
     const req = {
       header: () => 'bytes=1024-2048'
     }
     const { start, end } = getRequestRange(req)
-    assert.equal(start, 1024)
-    assert.equal(end, 2048)
+    assert.strictEqual(start, 1024)
+    assert.strictEqual(end, 2048)
   })
 
-  it ('Should calculate start with no end', () => {
+  it('Should calculate start with no end', () => {
     const req = {
       header: () => 'bytes=1024-'
     }
     const { start, end } = getRequestRange(req)
-    assert.equal(start, 1024)
-    assert.equal(end, undefined)
+    assert.strictEqual(start, 1024)
+    assert.strictEqual(end, undefined)
   })
 
-  it ('Should error at malformatted range', () => {
+  it('Should error at malformatted range', () => {
     const req = {
       header: () => ''
     }
     const range = getRequestRange(req)
-    assert.equal(range, -1)
+    assert.strictEqual(range, null)
   })
 
-  it ('Should error at non integer ranges', () => {
+  it('Should error at non integer ranges', () => {
     const req = {
       header: () => 'bytes=abc-def'
     }
     const range = getRequestRange(req)
-    assert.equal(range, -1)
+    assert.strictEqual(range, null)
   })
 })


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/ydolq9p3/1496-look-into-issues-w-streaming-mp3s-w-o-providing-total-bytes-as-a-part-of-the-header

### Description
Supports two new features on the /stream endpoint

* Content Range header now autofills content-length if `end` is not present on the header. Note comment in PR explaining the need.
* Partial Content Responses (206) get an attached Content-Range response header according to
https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests


### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches Creator node files

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. New Unit tests for getRequestRange

2. Postman tests. Ran against streamFromFilesystem *and* fetching directly from IPFS
```
localhost:5000/v1/tracks/7eP5n/stream
Range: bytes=2048-

Response: Content-Range: 2048-12098925/12098925
```

```
localhost:5000/v1/tracks/7eP5n/stream
Range: bytes=1024-2048

Response: Content-Range: 1024-2048/12098925
```

```
localhost:5000/v1/tracks/7eP5n/stream
No range header

Accept-Ranges: bytes
Content-Length: 12098925
```