### PR TITLE
Link by default on local

### DIFF
--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=false
+link_libs=true
 
 if [ "$link_libs" = true ]
 then

--- a/identity-service/scripts/dev-server.sh
+++ b/identity-service/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=false
+link_libs=true
 
 if [ "$link_libs" = true ]
 then


### PR DESCRIPTION
### Description
Link by default for creator node and identity service, removes additional step for local config. 

Why is this necessary?
While we roll out our updated contracts, the latest pinned version of libs for creator node does not match our local eth-contracts config

### Services

- [ ] Discovery Provider
- [x] Creator Node
- [x] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Set up locally