### PR TITLE
API touchups

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -136,12 +136,18 @@ def extend_track(track):
     track = add_track_artwork(track)
     track["remix_of"] = extend_remix_of(track["remix_of"])
     track["favorite_count"] = track["save_count"]
+
     duration = 0.
     for segment in track["track_segments"]:
         # NOTE: Legacy track segments store the duration as a string
         duration += float(segment["duration"])
     track["duration"] = round(duration)
-    track["downloadable"] = track["download"] and track["download"]["is_downloadable"]
+
+    downloadable = "download" in track and \
+        track["download"] and \
+        track["download"]["is_downloadable"]
+    track["downloadable"] = bool(downloadable)
+
     return track
 
 def extend_playlist(playlist):

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -141,6 +141,7 @@ def extend_track(track):
         # NOTE: Legacy track segments store the duration as a string
         duration += float(segment["duration"])
     track["duration"] = round(duration)
+    track["downloadable"] = track["download"] and track["download"]["is_downloadable"]
     return track
 
 def extend_playlist(playlist):

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -54,7 +54,11 @@ track = ns.model('Track', {
     "tags": fields.String,
     "title": fields.String(required=True),
     "user": fields.Nested(user_model, required=True),
-    "duration": fields.Integer(required=True)
+    # Total track duration, rounded to the nearest second
+    "duration": fields.Integer(required=True),
+    # Whether or not the track is downloadable, see `download`
+    # on `track_full` for more details
+    "downloadable": fields.Boolean
 })
 
 track_full = ns.clone('track_full', track, {

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -131,6 +131,10 @@ class Trending(Resource):
     @record_metrics
     @ns.doc(
         id="""Trending Tracks""",
+        params={
+            'genre': 'Trending tracks for a specified genre',
+            'time': 'Trending tracks over a specified time range (week, month, allTime)'
+        },
         responses={
             200: 'Success',
             400: 'Bad request',

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -50,7 +50,7 @@ def get_trending_tracks(args):
     time = args.get('time')
     # Identity understands allTime as millennium.
     # TODO: Change this in https://github.com/AudiusProject/audius-protocol/pull/768/files
-    if (time == 'allTime'):
+    if time == 'allTime':
         time = 'millennium'
 
     with db.scoped_session() as session:

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -19,7 +19,7 @@ O = 1
 R = 0.25
 i = 0.01
 q = 5.0
-T = {'week':7, 'month':30, 'year':365}
+T = {'week':7, 'month':30, 'year':365, 'allTime': 100000}
 def z(time, track):
     # pylint: disable=W,C,R
     E=track['listens']
@@ -46,7 +46,13 @@ def get_trending_tracks(args):
     current_user_id = get_current_user_id(required=False)
 
     db = get_db_read_replica()
+
     time = args.get('time')
+    # Identity understands allTime as millennium.
+    # TODO: Change this in https://github.com/AudiusProject/audius-protocol/pull/768/files
+    if (time == 'allTime'):
+        time = 'millennium'
+
     with db.scoped_session() as session:
         trending_tracks = generate_trending(
             get_db_read_replica(), time, args.get('genre', None),

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -174,6 +174,9 @@ const getTrendingTracks = async (
       let oneYearBefore = new Date(currentHour.getTime() - oneYearInMs)
       dbQuery.where.hour = { [models.Sequelize.Op.gte]: oneYearBefore }
       break
+    case 'millennium':
+      dbQuery.where.hour = { [models.Sequelize.Op.gte]: new Date(0) }
+      break
     case undefined:
       break
     default:


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/lmBLqDxI/1508-api-add-download-field
https://trello.com/c/gg7KaBD4/1498-api-add-genre-filters-to-trending-subsections

### Description
- Adds a `downloadable` field to the track response (condensed version of the `download` metadata)
- Adds docs / support for timeRange queries on trending (inc. "millennium" for all time in identity). Note: https://github.com/AudiusProject/audius-protocol/pull/768/files will remove this explicit need.

### Services

- [x] Discovery Provider
- [x] Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Downloadable change
- upload track --> downloadable=false
- upload track & mark as downloadable during upload --> downloadable = true
- upload track & later mark as downloadable --> downloadable = false -> downloadable = true

2. Trending change
- queried http://localhost:7000/tracks/trending/millennium
- queried http://localhost:5000/v1/tracks/trending?time=allTime