### PR TITLE
Fix generate_trending millennium arg

### DIFF
--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -50,12 +50,13 @@ def get_trending_tracks(args):
     time = args.get('time')
     # Identity understands allTime as millennium.
     # TODO: Change this in https://github.com/AudiusProject/audius-protocol/pull/768/files
+    query_time = time
     if time == 'allTime':
-        time = 'millennium'
+        query_time = 'millennium'
 
     with db.scoped_session() as session:
         trending_tracks = generate_trending(
-            get_db_read_replica(), time, args.get('genre', None),
+            get_db_read_replica(), query_time, args.get('genre', None),
             limit, offset)
 
         track_scores = [z(time, track) for track in trending_tracks['listen_counts']]


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/gg7KaBD4/1498-api-add-genre-filters-to-trending-subsections

### Description
Bugfix. Not sure why this didn't throw when testing locally, probably for lack of data. `time` is used later on in the function and we only need `millennium` for the call to `generate_trending`

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Cut a custom tag and verified behavior on staging
https://discoveryprovider3.staging.audius.co/v1/tracks/trending?time=allTime

Used to throw internal server error, now does not
