### PR TITLE
Fix staging setup alongside local setup in creator node

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -134,7 +134,7 @@ async function getOwnEndpoint (req) {
   }
 
   const spId = await libs.ethContracts.ServiceProviderFactoryClient.getServiceProviderIdFromAddress(spOwnerWallet, 'creator-node')
-  const spInfo = [await libs.ethContracts.ServiceProviderFactoryClient.getServiceEndpointInfo('creator-node', spId)]
+  const spInfo = [await libs.ethContracts.ServiceProviderFactoryClient.getServiceProviderInfo('creator-node', spId)]
 
   // confirm on-chain endpoint exists and is valid FQDN
   if (!spInfo ||

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -5,7 +5,7 @@ function getLibsMock () {
     ethContracts: {
       ServiceProviderFactoryClient: {
         getServiceProviderIdFromAddress: sinon.mock().atLeast(1),
-        getServiceEndpointInfo: sinon.mock().atLeast(1)
+        getServiceProviderInfo: sinon.mock().atLeast(1)
       }
     },
     User: {
@@ -16,7 +16,7 @@ function getLibsMock () {
     }
   }
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderIdFromAddress.returns('1')
-  libsMock.ethContracts.ServiceProviderFactoryClient.getServiceEndpointInfo.returns({ 'endpoint': 'http://localhost:5000' })
+  libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderInfo.returns({ 'endpoint': 'http://localhost:5000' })
   libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://localhost:5000', 'blocknumber': 10, 'track_blocknumber': 10 }])
 
   return libsMock

--- a/libs/src/services/ethContracts/serviceProviderFactoryClient.js
+++ b/libs/src/services/ethContracts/serviceProviderFactoryClient.js
@@ -180,6 +180,12 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
     return info
   }
 
+  // TODO: Remove this method after all consumers are using
+  // `getServiceEndpointInfo` directly
+  async getServiceProviderInfo (serviceType, serviceId) {
+    return this.getServiceEndpointInfo(serviceType, serviceId)
+  }
+
   async getServiceEndpointInfo (serviceType, serviceId) {
     const method = await this.getMethod('getServiceEndpointInfo',
       Utils.utf8ToHex(serviceType),


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/nRGLsSX2/1475-update-libs-to-work-with-new-eth-contracts

### Description
Fixes the issue on staging caused by https://github.com/AudiusProject/audius-protocol/pull/761#issuecomment-679311203
There’s a method on libs `getServiceProviderInfo` that was renamed to `getServiceEndpointInfo` (to reflect the changes in contracts). This PR exposes both temporarily to support both staging & local dev.

### Services

- [x] Creator Node
- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran services locally
