### PR TITLE
Fix rehydrate queue instability round 2

### DIFF
--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -8,6 +8,8 @@ const PROCESS_NAMES = Object.freeze({
   rehydrate_file: 'rehydrate_file'
 })
 
+const MAX_COUNT = 50000
+
 class RehydrateIpfsQueue {
   constructor () {
     this.queue = new Bull(
@@ -73,6 +75,8 @@ class RehydrateIpfsQueue {
    */
   async addRehydrateIpfsFromFsIfNecessaryTask (multihash, storagePath, { logContext }, filename = null) {
     this.logStatus(logContext, 'Adding a rehydrateIpfsFromFsIfNecessary task to the queue!')
+    const count = await this.queue.count()
+    if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_file,
       { multihash, storagePath, filename, logContext }
@@ -89,6 +93,8 @@ class RehydrateIpfsQueue {
    */
   async addRehydrateIpfsDirFromFsIfNecessaryTask (multihash, { logContext }) {
     this.logStatus(logContext, 'Adding a rehydrateIpfsDirFromFsIfNecessary task to the queue!')
+    const count = await this.queue.count()
+    if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_dir,
       { multihash, logContext }

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -83,9 +83,9 @@ module.exports = function (app) {
               // to address legacy single-res image rehydration where images are stored directly under its file CID
               (file.type === 'image' && file.sourceFile === null)
             ) {
-              RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(file.multihash, file.storagePath, { logContext: req.logContext })
+              await RehydrateIpfsQueue.addRehydrateIpfsFromFsIfNecessaryTask(file.multihash, file.storagePath, { logContext: req.logContext })
             } else if (file.type === 'dir') {
-              RehydrateIpfsQueue.addRehydrateIpfsDirFromFsIfNecessaryTask(file.multihash, { logContext: req.logContext })
+              await RehydrateIpfsQueue.addRehydrateIpfsDirFromFsIfNecessaryTask(file.multihash, { logContext: req.logContext })
             }
           } catch (e) {
             req.logger.info(`Export rehydrateIpfs processing files ${i} to ${i + RehydrateIPFSConcurrencyLimit}, ${e}`)


### PR DESCRIPTION
### Trello Card Link


### Description


### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Test 1
- Step 1
- Step 2
- Step 3

Please list the unit test(s) you added to verify your changes.

1. Unit test 1
