### PR TITLE
Link libs in cnode dev-server.sh

### DIFF
--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=false
+link_libs=true
 
 if [ "$link_libs" = true ]
 then


### PR DESCRIPTION
PR #779 depends on this. This PR just sets local cnodes to link local libs by default.