### PR TITLE
Fix isNaN check in trackListens cleaning up error log

### DIFF
--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -26,7 +26,7 @@
   "rateLimitingListensPerIPPerDay": 60,
   "rateLimitingListensPerTrackPerWeek": 120,
   "rateLimitingListensPerIPPerWeek": 180,
-  "rateLimitingListensIPWhitelist": "(.*192.168.*|ffff:172.19.0.14.*)",
+  "rateLimitingListensIPWhitelist": "(.*192.168.*|ffff:172.*)",
   "minimumBalance": 10,
   "ethProviderUrl": "http://audius_ganache_cli_eth_contracts:8545",
   "notificationDiscoveryProvider": "http://audius-disc-prov_web-server_1:5000",

--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -26,7 +26,7 @@
   "rateLimitingListensPerIPPerDay": 60,
   "rateLimitingListensPerTrackPerWeek": 120,
   "rateLimitingListensPerIPPerWeek": 180,
-  "rateLimitingListensIPWhitelist": "(.*192.168.*)",
+  "rateLimitingListensIPWhitelist": "(.*192.168.*|ffff:172.19.0.14.*)",
   "minimumBalance": 10,
   "ethProviderUrl": "http://audius_ganache_cli_eth_contracts:8545",
   "notificationDiscoveryProvider": "http://audius-disc-prov_web-server_1:5000",


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/uzRtP7S6/1499-make-sure-creator-node-ips-are-whitelisted-in-identity-service

### Description
No material change in this PR, just removes log spam. Since creator nodes send a hex string as a userId, it shouldn't record a UserTrackListen, but turns out isNaN(hex-string) is not falsey. It tries to insert the hex value in the table and fails, creating an error log.

### Services

- [x] Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Tested a track listen from the dapp as a logged in user
2. Tested a track listen from the dapp as a logged out user
3. Tested a track listen from the /stream endpoint
