### PR TITLE
add configurable values for pg pool options

### DIFF
--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -326,6 +326,32 @@ const config = convict({
     format: String,
     default: 'development',
     env: 'environment'
+  },
+  pgConnectionPoolMin: {
+    doc: 'The max count for the pool of connections',
+    format: 'nat',
+    default: 50,
+    env: 'pgConnectionPoolMin'
+  },
+  pgConnectionPoolMax: {
+    doc: 'The minimum count for the pool of connections',
+    format: 'nat',
+    default: 5,
+    env: 'pgConnectionPoolMax'
+  },
+  pgConnectionPoolAcquireTimeout: {
+    doc:
+      'The maximum time (ms) the pool will try to get the connection before throwing an error',
+    format: 'nat',
+    default: 60000,
+    env: 'pgConnectionPoolAcquireTimeout'
+  },
+  pgConnectionPoolIdleTimeout: {
+    doc:
+      'The maximum time (ms) that a connection can be idle before being released',
+    format: 'nat',
+    default: 10000,
+    env: 'pgConnectionPoolIdleTimeout'
   }
 })
 
@@ -340,10 +366,10 @@ if (defaultConfigExists) config.loadFile('default-config.json')
 if (fs.existsSync('eth-contract-config.json')) {
   let ethContractConfig = require('../eth-contract-config.json')
   config.load({
-    'ethTokenAddress': ethContractConfig.audiusTokenAddress,
-    'ethRegistryAddress': ethContractConfig.registryAddress,
-    'ethOwnerWallet': ethContractConfig.ownerWallet,
-    'ethWallets': ethContractConfig.allWallets
+    ethTokenAddress: ethContractConfig.audiusTokenAddress,
+    ethRegistryAddress: ethContractConfig.registryAddress,
+    ethOwnerWallet: ethContractConfig.ownerWallet,
+    ethWallets: ethContractConfig.allWallets
   })
 }
 

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -330,13 +330,13 @@ const config = convict({
   pgConnectionPoolMin: {
     doc: 'The max count for the pool of connections',
     format: 'nat',
-    default: 50,
+    default: 5,
     env: 'pgConnectionPoolMin'
   },
   pgConnectionPoolMax: {
     doc: 'The minimum count for the pool of connections',
     format: 'nat',
-    default: 5,
+    default: 50,
     env: 'pgConnectionPoolMax'
   },
   pgConnectionPoolAcquireTimeout: {

--- a/identity-service/src/models/index.js
+++ b/identity-service/src/models/index.js
@@ -13,10 +13,10 @@ const sequelize = new Sequelize(globalConfig.get('dbUrl'), {
   logging: false,
   operatorsAliases: false,
   pool: {
-    max: 50,
-    min: 5,
-    acquire: 60000,
-    idle: 10000
+    max: globalConfig.get('pgConnectionPoolMax'),
+    min: globalConfig.get('pgConnectionPoolMin'),
+    acquire: globalConfig.get('pgConnectionPoolAcquireTimeout'),
+    idle: globalConfig.get('pgConnectionPoolIdleTimeout')
   }
 })
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/F6wLyoCV/1522-api-identity-pg-pool-max-connections-env-var-dbcheck-route-like-creator-node
(Identity pg pool max connections env var) 

### Description
Make the Postgres pool options configurable via our config file. This will make updating values straight forward and not need to touch the actual Sequelize `index.js` file.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [x] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅  Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Console logged out the Sequelize object after its creation. The Sequelize object looks like this (note the `pool` keys):
```
Sequelize {
  options:
   { dialect: 'postgres',
     dialectModulePath: null,
     host: 'identity-db',
     protocol: 'tcp',
     define: {},
     query: {},
     sync: {},
     timezone: '+00:00',
     standardConformingStrings: true,
     logging: false,
     omitNull: false,
     native: false,
     replication: false,
     ssl: undefined,
     pool: { max: 50, min: 5, acquire: 60000, idle: 10000 },
     quoteIdentifiers: true,
     hooks: {},
     retry: { max: 5, match: [Array] },
     transactionType: 'DEFERRED',
     isolationLevel: null,
     databaseVersion: 0,
     typeValidation: false,
     benchmark: false,
     operatorsAliases: false,
     port: '5432' },
  config:
   { database: 'audius_identity_service',
     username: 'postgres',
     password: 'postgres',
     host: 'identity-db',
     port: '5432',
     pool: { max: 50, min: 5, acquire: 60000, idle: 10000 },
     protocol: 'tcp',
     native: false,
     ssl: undefined,
     replication: false,
     dialectModulePath: null,
     keepDefaultTimezone: undefined,
     dialectOptions: undefined },
```

Also hit `/health_check` to check identity service health:
```
{
  "healthy": true,
  "git": ""
}
```

Please list the unit test(s) you added to verify your changes.

None
