### PR TITLE
add /db_check for identity service

### DIFF
--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -220,7 +220,7 @@ module.exports = function (app) {
     let idleConnections = null
 
     // Get number of open DB connections
-    let numConnectionsQuery = await sequelize.query("SELECT numbackends from pg_stat_database where datname = 'audius_identity_service'")
+    const numConnectionsQuery = await sequelize.query("SELECT numbackends from pg_stat_database where datname = 'audius_identity_service'")
     if (numConnectionsQuery && numConnectionsQuery[0] && numConnectionsQuery[0][0] && numConnectionsQuery[0][0].numbackends) {
       numConnections = numConnectionsQuery[0][0].numbackends
     }


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/F6wLyoCV/1522-api-identity-pg-pool-max-connections-env-var-dbcheck-route-like-creator-node
(/db_check route like creator node)

### Description
This PR adds the route `/db_check` to identity service to display the number of connections to its database.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [x] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅   Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Hit the route `/db_check` and got reasonable results:
```
{
  "git": "",
  "connectionStatus": {
    "total": 7,
    "active": 1,
    "idle": 6
  },
  "maxConnections": 50
}
```

Please list the unit test(s) you added to verify your changes.

None