### PR TITLE
Remove unnecessary db calls in search query

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -23,7 +23,7 @@ from src import exceptions
 from src.queries import queries, search, search_queries, health_check, trending, notifications
 from src.api.v1 import api as api_v1
 from src.utils import helpers, config
-from src.utils.db_session import SessionManager
+from src.utils.db_session import SessionManager, on_init_db
 from src.utils.config import config_files, shared_config, ConfigIni
 from src.utils.ipfs_lib import IPFSClient
 from src.tasks import celery_app
@@ -232,6 +232,19 @@ def configure_flask(test_config, app, mode="app"):
     if test_config is not None:
         # load the test config if passed in
         app.config.update(test_config)
+
+    app.db_session_manager = SessionManager(
+        app.config["db"]["url"],
+        ast.literal_eval(app.config["db"]["engine_args_literal"]),
+    )
+    on_init_db(app.db_session_manager)
+
+    app.db_read_replica_session_manager = SessionManager(
+        app.config["db"]["url_read_replica"],
+        ast.literal_eval(app.config["db"]["engine_args_literal"]),
+    )
+    on_init_db(app.db_read_replica_session_manager)
+
 
     exceptions.register_exception_handlers(app)
     app.register_blueprint(queries.bp)

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -23,7 +23,7 @@ from src import exceptions
 from src.queries import queries, search, search_queries, health_check, trending, notifications
 from src.api.v1 import api as api_v1
 from src.utils import helpers, config
-from src.utils.db_session import SessionManager, on_init_db
+from src.utils.session_manager import SessionManager
 from src.utils.config import config_files, shared_config, ConfigIni
 from src.utils.ipfs_lib import IPFSClient
 from src.tasks import celery_app
@@ -237,13 +237,11 @@ def configure_flask(test_config, app, mode="app"):
         app.config["db"]["url"],
         ast.literal_eval(app.config["db"]["engine_args_literal"]),
     )
-    on_init_db(app.db_session_manager)
 
     app.db_read_replica_session_manager = SessionManager(
         app.config["db"]["url_read_replica"],
         ast.literal_eval(app.config["db"]["engine_args_literal"]),
     )
-    on_init_db(app.db_read_replica_session_manager)
 
 
     exceptions.register_exception_handlers(app)

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -15,7 +15,6 @@ from flask.json import dumps
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
-import time
 
 logger = logging.getLogger(__name__)
 ns = Namespace('tracks', description='Track related operations')

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -15,6 +15,8 @@ from flask.json import dumps
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
+import time
+
 logger = logging.getLogger(__name__)
 ns = Namespace('tracks', description='Track related operations')
 

--- a/discovery-provider/src/conftest.py
+++ b/discovery-provider/src/conftest.py
@@ -13,7 +13,7 @@ import src.utils.db_session
 # Test fixture to mock a postgres database using an in-memory alternative
 @pytest.fixture()
 def db_mock(monkeypatch):
-    db = src.utils.db_session.SessionManager(
+    db = src.utils.session_manager.SessionManager(
         'sqlite://',
         {}
     )

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -9,6 +9,10 @@ minSearchSimilarity = 0.1
 def set_search_similarity(session):
     """
     Sets the search similarity threshold to be used by % operator in queries.
+    https://www.postgresql.org/docs/9.6/pgtrgm.html
+
+    Note: set_limit was replaced by pg_trgm.similarity_threshold in PG 9.6.
+    https://stackoverflow.com/a/11250001/11435157
     """
     session.execute(sqlalchemy.text(
         f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -1,9 +1,13 @@
+import logging
 import sqlalchemy
 
 trackTitleWeight = 0.7
 userNameWeight = 0.7
 playlistNameWeight = 0.7
 minSearchSimilarity = 0.1
+
+
+logger = logging.getLogger(__name__)
 
 
 def set_search_similarity(session):
@@ -14,6 +18,9 @@ def set_search_similarity(session):
     Note: set_limit was replaced by pg_trgm.similarity_threshold in PG 9.6.
     https://stackoverflow.com/a/11250001/11435157
     """
-    session.execute(sqlalchemy.text(
-        f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"
-    ))
+    try:
+        session.execute(sqlalchemy.text(
+            f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"
+        ))
+    except Exception as e:
+        logger.error(f"Unable to set similarity_threshold, {0}".format(e))

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -1,0 +1,15 @@
+import sqlalchemy
+
+trackTitleWeight = 0.7
+userNameWeight = 0.7
+playlistNameWeight = 0.7
+minSearchSimilarity = 0.1
+
+
+def set_search_similarity(session):
+    """
+    Sets the search similarity threshold to be used by % operator in queries.
+    """
+    session.execute(sqlalchemy.text(
+        f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"
+    ))

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -4,6 +4,7 @@ from flask import Blueprint, request
 import sqlalchemy
 
 from src import api_helpers, exceptions
+from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight
 from src.models import User, Track, RepostType, Playlist, Save, SaveType, Follow
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
@@ -18,13 +19,6 @@ bp = Blueprint("search_tags", __name__)
 
 
 ######## VARS ########
-
-
-trackTitleWeight = 0.7
-userNameWeight = 0.7
-playlistNameWeight = 0.7
-minSearchSimilarity = 0.1
-
 
 class SearchKind(Enum):
     all = 1
@@ -356,20 +350,19 @@ def search(args):
                     return results
                 return add_users(session, results)
 
-            # Set similarity threshold to be used by % operator in queries.
-            session.execute(sqlalchemy.text(
-                f"select set_limit({minSearchSimilarity});"))
 
             if (searchKind in [SearchKind.all, SearchKind.tracks]):
                 results['tracks'] = with_users_added(track_search_query(
                     session, searchStr, limit, offset, False, is_auto_complete, current_user_id))
-                results['saved_tracks'] = with_users_added(track_search_query(
-                    session, searchStr, limit, offset, True, is_auto_complete, current_user_id))
+                if current_user_id:
+                    results['saved_tracks'] = with_users_added(track_search_query(
+                        session, searchStr, limit, offset, True, is_auto_complete, current_user_id))
             if (searchKind in [SearchKind.all, SearchKind.users]):
                 results['users'] = user_search_query(
                     session, searchStr, limit, offset, False, is_auto_complete, current_user_id)
-                results['followed_users'] = user_search_query(
-                    session, searchStr, limit, offset, True, is_auto_complete, current_user_id)
+                if current_user_id:
+                    results['followed_users'] = user_search_query(
+                        session, searchStr, limit, offset, True, is_auto_complete, current_user_id)
             if (searchKind in [SearchKind.all, SearchKind.playlists]):
                 results['playlists'] = with_users_added(playlist_search_query(
                     session,
@@ -381,29 +374,31 @@ def search(args):
                     is_auto_complete,
                     current_user_id
                 ))
-                results['saved_playlists'] = with_users_added(playlist_search_query(
-                    session,
-                    searchStr,
-                    limit,
-                    offset,
-                    False,
-                    True,
-                    is_auto_complete,
-                    current_user_id
-                ))
+                if current_user_id:
+                    results['saved_playlists'] = with_users_added(playlist_search_query(
+                        session,
+                        searchStr,
+                        limit,
+                        offset,
+                        False,
+                        True,
+                        is_auto_complete,
+                        current_user_id
+                    ))
             if (searchKind in [SearchKind.all, SearchKind.albums]):
                 results['albums'] = with_users_added(playlist_search_query(
                     session, searchStr, limit, offset, True, False, is_auto_complete, current_user_id))
-                results['saved_albums'] = with_users_added(playlist_search_query(
-                    session,
-                    searchStr,
-                    limit,
-                    offset,
-                    True,
-                    True,
-                    is_auto_complete,
-                    current_user_id
-                ))
+                if current_user_id:
+                    results['saved_albums'] = with_users_added(playlist_search_query(
+                        session,
+                        searchStr,
+                        limit,
+                        offset,
+                        True,
+                        True,
+                        is_auto_complete,
+                        current_user_id
+                    ))
 
     return results
 

--- a/discovery-provider/src/utils/db_session.py
+++ b/discovery-provider/src/utils/db_session.py
@@ -1,9 +1,9 @@
 import ast
 from contextlib import contextmanager
-from src.queries.search_config import set_search_similarity
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from flask import current_app, g
+from src.queries.search_config import set_search_similarity
 
 
 session_manager = None

--- a/discovery-provider/src/utils/db_session.py
+++ b/discovery-provider/src/utils/db_session.py
@@ -1,13 +1,8 @@
-import ast
 from contextlib import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from flask import current_app, g
+from flask import current_app
 from src.queries.search_config import set_search_similarity
-
-
-session_manager = None
-
 
 def on_init_db(db):
     """
@@ -17,20 +12,12 @@ def on_init_db(db):
         set_search_similarity(session)
 
 
-
 def get_db():
     """Connect to the configured database. The connection
     is unique for each request and will be reused if this is called
     again.
     """
-    if "db" not in g:
-        g.db = SessionManager(
-            current_app.config["db"]["url"],
-            ast.literal_eval(current_app.config["db"]["engine_args_literal"]),
-        )
-        on_init_db(g.db)
-
-    return g.db
+    return current_app.db_session_manager
 
 
 def get_db_read_replica():
@@ -38,14 +25,7 @@ def get_db_read_replica():
     is unique for each request and will be reused if this is called
     again.
     """
-    if "db_read_replica" not in g:
-        g.db_read_replica = SessionManager(
-            current_app.config["db"]["url_read_replica"],
-            ast.literal_eval(current_app.config["db"]["engine_args_literal"]),
-        )
-        on_init_db(g.db_read_replica)
-
-    return g.db_read_replica
+    return current_app.db_read_replica_session_manager
 
 
 class SessionManager:

--- a/discovery-provider/src/utils/db_session.py
+++ b/discovery-provider/src/utils/db_session.py
@@ -1,11 +1,21 @@
 import ast
 from contextlib import contextmanager
+from src.queries.search_config import set_search_similarity
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from flask import current_app, g
 
 
 session_manager = None
+
+
+def on_init_db(db):
+    """
+    Queries to run on web server startup.
+    """
+    with db.scoped_session() as session:
+        set_search_similarity(session)
+
 
 
 def get_db():
@@ -18,6 +28,7 @@ def get_db():
             current_app.config["db"]["url"],
             ast.literal_eval(current_app.config["db"]["engine_args_literal"]),
         )
+        on_init_db(g.db)
 
     return g.db
 
@@ -32,6 +43,7 @@ def get_db_read_replica():
             current_app.config["db"]["url_read_replica"],
             ast.literal_eval(current_app.config["db"]["engine_args_literal"]),
         )
+        on_init_db(g.db_read_replica)
 
     return g.db_read_replica
 

--- a/discovery-provider/src/utils/db_session.py
+++ b/discovery-provider/src/utils/db_session.py
@@ -1,16 +1,4 @@
-from contextlib import contextmanager
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 from flask import current_app
-from src.queries.search_config import set_search_similarity
-
-def on_init_db(db):
-    """
-    Queries to run on web server startup.
-    """
-    with db.scoped_session() as session:
-        set_search_similarity(session)
-
 
 def get_db():
     """Connect to the configured database. The connection
@@ -26,37 +14,3 @@ def get_db_read_replica():
     again.
     """
     return current_app.db_read_replica_session_manager
-
-
-class SessionManager:
-    def __init__(self, db_url, db_engine_args):
-        self._engine = create_engine(db_url, **db_engine_args)
-        self._session_factory = sessionmaker(bind=self._engine)
-
-    def session(self):
-        """ Get a session for direct management/use. Use not recommended unless absolutely
-            necessary.
-        """
-        return self._session_factory()
-
-    @contextmanager
-    def scoped_session(self, expire_on_commit=True):
-        """ Usage:
-                with scoped_session() as session:
-                    use the session ...
-
-            Session commits when leaving the block normally, or rolls back if an exception
-            is thrown.
-
-            Taken from: http://docs.sqlalchemy.org/en/latest/orm/session_basics.html
-        """
-        session = self._session_factory()
-        session.expire_on_commit = expire_on_commit
-        try:
-            yield session
-            session.commit()
-        except:
-            session.rollback()
-            raise
-        finally:
-            session.close()

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -245,5 +245,5 @@ class IPFSClient:
         try:
             make_cid(cid)
             return True
-        except Exception as e:
+        except Exception:
             return False

--- a/discovery-provider/src/utils/session_manager.py
+++ b/discovery-provider/src/utils/session_manager.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from src.queries.search_config import set_search_similarity
+
+
+def on_init_db(db):
+    """
+    Queries to run on web server startup.
+    """
+    with db.scoped_session() as session:
+        set_search_similarity(session)
+
+
+class SessionManager:
+    def __init__(self, db_url, db_engine_args):
+        self._engine = create_engine(db_url, **db_engine_args)
+        self._session_factory = sessionmaker(bind=self._engine)
+
+        on_init_db(self)
+
+    def session(self):
+        """ Get a session for direct management/use. Use not recommended unless absolutely
+            necessary.
+        """
+        return self._session_factory()
+
+    @contextmanager
+    def scoped_session(self, expire_on_commit=True):
+        """ Usage:
+                with scoped_session() as session:
+                    use the session ...
+
+            Session commits when leaving the block normally, or rolls back if an exception
+            is thrown.
+
+            Taken from: http://docs.sqlalchemy.org/en/latest/orm/session_basics.html
+        """
+        session = self._session_factory()
+        session.expire_on_commit = expire_on_commit
+        try:
+            yield session
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            session.close()


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/AXXBob6a/1519-api-optimize-tracks-search

### Description
Improves search speed a bit by removing unnecessary queries.

My system isn't a perfect example of what happens on prod (esp. since there's way more network latency to rds), but generally this is a ~ 2.2s => 1.6s reduction end to end for my system. Lowest hanging fruit.

Second set of changes here bring 1.6s down to 1.2s.

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran against prod database clone.
http://localhost:5000/v1/tracks/search?query=c

2. Pushed a custom tag to staging & verified the dapp behaved as expected for an authenticated and unauthenticated user.

3. Verified manually that similarity threshold is persisted correctly (0.1) on each request given the setup here.