### PR TITLE
Downgrade web3 to 5.8.0

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -1,3 +1,4 @@
+# web3 used to be 5.11.0 but due to a build issue in docker, downgraded to 5.8.0
 web3==5.8.0
 Flask==1.0.2
 psycopg2==2.7.7

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -1,4 +1,4 @@
-web3==5.11.0
+web3==5.8.0
 Flask==1.0.2
 psycopg2==2.7.7
 SQLAlchemy==1.2.5


### PR DESCRIPTION
We're seeing an error building docker containers. The root cause is web3==5.11.0. If we downgrade web3 to 5.8.0 it starts to work again. Also interesting because when we pip install in the command line it works. This likely has something to do with the dependency graph being built inside docker.
```
Collecting base58 (from multiaddr>=0.0.7->ipfshttpclient<1,>=0.4.12->web3==5.11.0->-r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/3c/03/58572025c77b9e6027155b272a1b96298e711cd4f95c24967f7137ab0c4b/base58-2.0.1-py3-none-any.whl
Collecting rusty-rlp<0.2,>=0.1.15 (from rlp<=2.0.0.alpha-1,>=1.0.0->eth-account<0.6.0,>=0.5.2->web3==5.11.0->-r requirements.txt (line 1))
  Could not find a version that satisfies the requirement rusty-rlp<0.2,>=0.1.15 (from rlp<=2.0.0.alpha-1,>=1.0.0->eth-account<0.6.0,>=0.5.2->web3==5.11.0->-r requirements.txt (line 1)) (from versions: )
No matching distribution found for rusty-rlp<0.2,>=0.1.15 (from rlp<=2.0.0.alpha-1,>=1.0.0->eth-account<0.6.0,>=0.5.2->web3==5.11.0->-r requirements.txt (line 1))
You are using pip version 18.1, however version 20.2.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c apk update &&  apk add alpine-sdk &&  apk add linux-headers &&  apk add bash &&  apk add postgresql-libs &&  apk add --virtual .build-deps gcc musl-dev postgresql-dev &&  python3 -m pip install -r requirements.txt --no-cache-dir &&  apk --purge del .build-deps' returned a non-zero code: 1
```

Tested on DP3 on staging to verify API signature and indexing still works