### PR TITLE
add 404 handling for deleted tracks via api streaming

### DIFF
--- a/discovery-provider/src/queries/get_track_user_creator_node.py
+++ b/discovery-provider/src/queries/get_track_user_creator_node.py
@@ -24,5 +24,8 @@ def get_track_user_creator_node(args):
         ).filter(
             User.is_current
         ).first()
+
+        if not user:
+            return None
         creator_nodes = user[0]
         return creator_nodes


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/4yWqP3nn/1524-api-errors-on-track-streaming-look-in-loggly-dashboard

### Description
The track that is causing this error is https://discoveryprovider.audius.co/tracks?id=17915. It is deleted and is attempted to be streamed. Not _quite_ sure if this is the fix for the streaming error, however, if any requests attempt to stream a deleted track, the stream route will throw a 404.

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?
1. bring up local services
2. upload a track
3. delete the track 
4. set `decoded_id = 1` in the api route `"/<string:track_id>/stream"` (to bypass the hashids decoding)
5. hit route `http://localhost:5000/v1/tracks/dfsfdsaf/stream` 

Old error in attempting to stream a deleted track:
```
{
  "error": [
    "Something caused the server to crash."
  ],
  "success": false
}
```

New error:
```
{
  "message": "Oh no! Resource for ID dfsfdsaf not found. You have requested this URI [/v1/tracks/dfsfdsaf/stream] but did you mean /v1/tracks/<string:track_id>/stream or /v1/tracks/search or /v1/tracks/trending ?"
}
```

Please list the unit test(s) you added to verify your changes.

none