### PR TITLE
API resolve route

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -1,6 +1,6 @@
 # web3 used to be 5.11.0 but due to a build issue in docker, downgraded to 5.8.0
 web3==5.8.0
-Flask==1.0.2
+Flask==1.0.4
 psycopg2==2.7.7
 SQLAlchemy==1.2.5
 alembic==1.0.0

--- a/discovery-provider/src/api/v1/api.py
+++ b/discovery-provider/src/api/v1/api.py
@@ -6,6 +6,7 @@ from src.api.v1.playlists import ns as playlists_ns
 from src.api.v1.tracks import ns as tracks_ns
 from src.api.v1.metrics import ns as metrics_ns
 from src.api.v1.models.users import ns as models_ns
+from src.api.v1.resolve import ns as resolve_ns
 
 class ApiWithHTTPS(Api):
     @property
@@ -25,3 +26,4 @@ api_v1.add_namespace(users_ns)
 api_v1.add_namespace(playlists_ns)
 api_v1.add_namespace(tracks_ns)
 api_v1.add_namespace(metrics_ns)
+api_v1.add_namespace(resolve_ns)

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -110,7 +110,7 @@ def extend_remix_of(remix_of):
     return remix_of
 
 def parse_bool_param(param):
-    if not isinstance(params, str):
+    if not isinstance(param, str):
         return None
     param = param.lower()
     if param == 'true':

--- a/discovery-provider/src/api/v1/resolve.py
+++ b/discovery-provider/src/api/v1/resolve.py
@@ -1,0 +1,45 @@
+import logging
+from flask import redirect
+from flask_restx import Resource, Namespace, reqparse
+from src.api.v1.helpers import abort_bad_request_param, abort_not_found
+from src.api.v1.utils.resolve_url import resolve_url
+from src.utils import db_session
+
+
+logger = logging.getLogger(__name__)
+
+ns = Namespace('resolve', description='Audius Cannonical URL resolver')
+
+resolve_route_parser = reqparse.RequestParser()
+resolve_route_parser.add_argument('url', required=True)
+
+
+@ns.route("")  # Root, no "/"
+class Resolve(Resource):
+    @ns.expect(resolve_route_parser)
+    @ns.doc(
+        id="""Resolve""",
+        params={
+            'url': 'Url to resolve. Either fully formed with protocol and domain or the absolute path'
+        },
+        responses={
+            307: 'Internal redirect'
+        }
+    )
+    def get(self):
+        """
+        Resolves a provided url to the canonical api object.
+        Follow the redirect (302) returned by this endpoint.
+        """
+        args = resolve_route_parser.parse_args()
+        url = args.get("url")
+        if not url:
+            abort_bad_request_param('url', ns)
+        try:
+            db = db_session.get_db_read_replica()
+            with db.scoped_session() as session:
+                resolved_url = resolve_url(session, url)
+            return redirect(resolved_url, code=307)
+        except Exception as e:
+            logger.warning(e)
+            abort_not_found(url, ns)

--- a/discovery-provider/src/api/v1/resolve.py
+++ b/discovery-provider/src/api/v1/resolve.py
@@ -20,18 +20,18 @@ class Resolve(Resource):
     @ns.doc(
         id="""Resolve""",
         params={
-            'url': 'Url to resolve. Either fully formed with protocol and domain or the absolute path'
+            'url': 'URL to resolve. Either fully formed URL (https://audius.co) or just the absolute path'
         },
         responses={
-            307: 'Internal redirect'
+            302: 'Internal redirect'
         }
     )
     def get(self):
         """
-        Resolves a provided Audius app URL to the canonical API resource it represents.
+        Resolves and redirects a provided Audius app URL to the API resource URL it represents.
 
-        This endpoint returns a 307 redirect to the canonical API route.
-        Follow the redirect to request the resource from the API.
+        This endpoint allows you to lookup and access API resources when you only know the
+        audius.co URL.
         Tracks, Playlists, and Users are supported.
         """
         args = resolve_route_parser.parse_args()
@@ -45,7 +45,7 @@ class Resolve(Resource):
                 if not resolved_url:
                     return abort_not_found(url)
 
-                return redirect(resolved_url, code=307)
+                return redirect(resolved_url, code=302)
 
         except Exception as e:
             logger.warning(e)

--- a/discovery-provider/src/api/v1/utils/resolve_url.py
+++ b/discovery-provider/src/api/v1/utils/resolve_url.py
@@ -1,0 +1,54 @@
+import re
+from flask.helpers import url_for
+from urllib.parse import urlparse
+from src.models import User
+from src.api.v1 import api as api_v1
+from src.api.v1.helpers import encode_int_id
+from src.api.v1.tracks import ns as tracks_ns
+from src.api.v1.users import ns as users_ns
+from src.api.v1.playlists import ns as playlists_ns
+
+
+track_url_regex = re.compile(
+    r'^/(?P<handle>[^/]*)/(?P<track>[^/]*)(?=-)-(?P<id>[0-9]*)$')
+playlist_url_regex = re.compile(
+    r'/(?P<handle>[^/]*)/(playlist|album)/(?P<track>[^/]*)(?=-)-(?P<id>[0-9]*)$')
+user_url_regex = re.compile(r'^/(?P<handle>[^/]*)$')
+
+
+def ns_url_for(ns, route, **kwargs):
+    return url_for("{0}.{1}_{2}".format(api_v1.bp.name, ns.name, route), **kwargs)
+
+
+def resolve_url(session, url):
+    """
+    Resolves an Audius URL into the cannonical API route.
+    Accepts fully formed urls as well as just url paths.
+    """
+    parsed = urlparse(url)
+    # Will strip out any preceding protocol & domain (e.g. https://audius.co)
+    path = parsed.path
+
+    match = track_url_regex.match(path)
+    if match:
+        track_id = match.group('id')
+        hashed_id = encode_int_id(int(track_id))
+        return ns_url_for(tracks_ns, 'track', track_id=hashed_id)
+
+    match = playlist_url_regex.match(path)
+    if match:
+        playlist_id = match.group('id')
+        hashed_id = encode_int_id(int(playlist_id))
+        return ns_url_for(playlists_ns, 'playlist', playlist_id=hashed_id)
+
+    match = user_url_regex.match(path)
+    if match:
+        handle = match.group('handle')
+        user = session.query(User).filter(
+            User.handle_lc == handle.lower(),
+            User.is_current == True
+        ).one()
+        hashed_id = encode_int_id(user.user_id)
+        return ns_url_for(users_ns, 'user', user_id=hashed_id)
+
+    return None

--- a/discovery-provider/src/api/v1/utils/resolve_url_test.py
+++ b/discovery-provider/src/api/v1/utils/resolve_url_test.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from flask import Flask
+import pytest
+from src.models import User
+from src.api.v1.utils.resolve_url import resolve_url
+from src.api.v1 import api as api_v1
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.register_blueprint(api_v1.bp)
+    yield a
+
+
+def test_resolve_track_url(db_mock, app):
+    """Tests that it resolves a track url"""
+    with app.test_request_context():
+        with db_mock.scoped_session() as session:
+            url = 'https://audius.co/urbanbankai/mb-shola-vivienne-%22westwood%22-87325'
+            resolved_url = resolve_url(session, url)
+
+            assert resolved_url == '/v1/tracks/799Yv'
+
+
+def test_resolve_playlist_url(db_mock, app):
+    """Tests that it resolves a playlist url"""
+    with app.test_request_context():
+        with db_mock.scoped_session() as session:
+            url = 'https://audius.co/urbanbankai/playlist/up-next-atl-august-2020-9801'
+            resolved_url = resolve_url(session, url)
+
+            assert resolved_url == '/v1/playlists/ePkW0'
+
+
+def test_resolve_user_url(db_mock, app):
+    """Tests that it resolves a user url"""
+    with app.test_request_context():
+        with db_mock.scoped_session() as session:
+            User.__table__.create(db_mock._engine)
+            session.add(User(
+                blockhash="0x2969e88561fac17ca19c1749cb3e614211ba15c8e471be55de47d0b8ca6acf5f",
+                is_current=True,
+                updated_at=datetime.now(),
+                created_at=datetime.now(),
+                blocknumber=16914541,
+                handle="Urbanbankai",
+                handle_lc="urbanbankai",
+                user_id=42727
+            ))
+            url = 'https://audius.co/urbanbankai'
+            resolved_url = resolve_url(session, url)
+
+            assert resolved_url == '/v1/users/DE677'
+
+
+def test_resolve_non_fully_qualified_url(db_mock, app):
+    """Tests that it resolves a track url when not fully qualified"""
+    with app.test_request_context():
+        with db_mock.scoped_session() as session:
+            url = '/urbanbankai/mb-shola-vivienne-%22westwood%22-87325'
+            resolved_url = resolve_url(session, url)
+
+            assert resolved_url == '/v1/tracks/799Yv'

--- a/discovery-provider/src/conftest.py
+++ b/discovery-provider/src/conftest.py
@@ -5,6 +5,7 @@ Test fixtures to support unit testing
 from unittest.mock import MagicMock
 import pytest
 import fakeredis
+from src import create_app
 import src.utils.redis_connection
 import src.utils.web3_provider
 import src.utils.db_session


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/dT9GAKUK/1536-api-add-resolve-route

### Description
Adds a resolve endpoint to the API which can be used to translate audius.co links to internal API resources
See https://developers.soundcloud.com/docs/api/guide#resolving

Note, I bumped flask by 2 patch versions to make it work in a pytest fixture, see
https://github.com/pallets/flask/issues/3275

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran discprov against prod, tested locally against a user, track & playlist both with https://audius.co and w/o

Please list the unit test(s) you added to verify your changes.

1. resolve_url_test
