### PR TITLE
Add karma to trending

### DIFF
--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -19,6 +19,7 @@ O = 1
 R = 0.25
 i = 0.01
 q = 5.0
+G = 5000
 T = {'week':7, 'month':30, 'year':365, 'allTime': 100000}
 def z(time, track):
     # pylint: disable=W,C,R
@@ -29,9 +30,12 @@ def z(time, track):
     A=track['save_count']
     o=track['created_at']
     l=track['track_owner_follower_count']
+    j=track['karma']
     if l<3:
         return{'score':0,**track}
     H=(N*E+F*e+O*x+R*t+i*A)
+    if j>G:
+        H=H*j
     L=T[time]
     K=datetime.datetime.now()
     w=parse(o)

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -18,8 +18,7 @@ F = 50
 O = 1
 R = 0.25
 i = 0.01
-q = 5.0
-G = 5000
+q = 20.0
 T = {'week':7, 'month':30, 'year':365, 'allTime': 100000}
 def z(time, track):
     # pylint: disable=W,C,R
@@ -33,9 +32,7 @@ def z(time, track):
     j=track['karma']
     if l<3:
         return{'score':0,**track}
-    H=(N*E+F*e+O*x+R*t+i*A)
-    if j>G:
-        H=H*j
+    H=(N*E+F*e+O*x+R*t+i*A)*j
     L=T[time]
     K=datetime.datetime.now()
     w=parse(o)

--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -8,7 +8,7 @@ from src.models import Track, RepostType, Follow, SaveType
 from src.utils.config import shared_config
 from src.queries import response_name_constants
 from src.queries.query_helpers import \
-    get_repost_karma, get_repost_counts, get_save_counts, get_genre_list
+    get_karma, get_repost_counts, get_save_counts, get_genre_list
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ def generate_trending(db, time, genre, limit, offset):
             if save_type == SaveType.track
         }
 
-        karma_query = get_repost_karma(session, tuple(not_deleted_track_ids))
+        karma_query = get_karma(session, tuple(not_deleted_track_ids))
         karma_counts_for_id = {track_id: karma for (track_id, karma) in karma_query}
 
         trending_tracks = []

--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -8,7 +8,7 @@ from src.models import Track, RepostType, Follow, SaveType
 from src.utils.config import shared_config
 from src.queries import response_name_constants
 from src.queries.query_helpers import \
-    get_repost_counts, get_save_counts, get_genre_list
+    get_repost_karma, get_repost_counts, get_save_counts, get_genre_list
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +159,9 @@ def generate_trending(db, time, genre, limit, offset):
             if save_type == SaveType.track
         }
 
+        karma_query = get_repost_karma(session, tuple(not_deleted_track_ids))
+        karma_counts_for_id = {track_id: karma for (track_id, karma) in karma_query}
+
         trending_tracks = []
         for track_entry in listen_counts:
             # Skip over deleted tracks
@@ -211,6 +214,9 @@ def generate_trending(db, time, genre, limit, offset):
                             .isoformat(timespec='seconds')
             else:
                 track_entry[response_name_constants.created_at] = None
+
+            track_entry["karma"] = karma_counts_for_id[track_entry[response_name_constants.track_id]] \
+                if track_entry[response_name_constants.track_id] in karma_counts_for_id else 0
 
             trending_tracks.append(track_entry)
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/tdKmSJ36/1541-api-repost-karma

### Description
Adds karma to trending scorer

Runs in ~0.25 ms on prod dataset
```
SELECT anon_1.track_id, 
       Count(follows.followee_user_id) AS count_1 
FROM   (SELECT anon_2.user_id  AS user_id, 
               anon_2.track_id AS track_id 
        FROM   (SELECT reposts.user_id        AS user_id, 
                       reposts.repost_item_id AS track_id 
                FROM   reposts 
                WHERE  reposts.repost_item_id IN ( 86528 ) 
                       AND reposts.is_current = true 
                UNION ALL
                SELECT saves.user_id      AS user_id, 
                       saves.save_item_id AS track_id 
                FROM   saves 
                WHERE  saves.save_item_id IN ( 86528 ) 
                       AND saves.is_current = true) AS anon_2) AS anon_1 
       JOIN follows 
         ON anon_1.user_id = follows.followee_user_id 
WHERE  follows.is_current = true 
GROUP  BY anon_1.track_id 
```

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran discprov against prod, requested trending and scanned through results
