### PR TITLE
Fix creator node unit test and run on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,7 @@ jobs:
             export delegatePrivateKey=0xdb527e4d4a2412a443c17e1666764d3bba43e89e61129a35f9abc337ec170a5d
             export storagePath="test_file_storage"
             export ipfsPort=5001
+            npm run test:unit
             npm run test:ci
 
   test-discovery-provider:

--- a/creator-node/src/utils/requestRange.test.js
+++ b/creator-node/src/utils/requestRange.test.js
@@ -45,6 +45,6 @@ describe('Test formatContentRange', () => {
 
   it('Should use size when end is unset', () => {
     const header = formatContentRange(1024, undefined, 4096)
-    assert.strictEqual(header, 'bytes 1024-4096/4096')
+    assert.strictEqual(header, 'bytes 1024-4095/4096')
   })
 })


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/AfnG3wV1/1540-cn-unit-tests-broken-request-range-not-running-on-ci

### Description
Test was not updated to match code changes for content range query (which should should start-size-1 / size)
https://github.com/AudiusProject/audius-protocol/commit/98f8755d166560205a73794c1ff4f7bc10940574

Wasn't caught because unit tests were not run on CI. Fixed that here.

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Fixed unit test
2. CI
