### PR TITLE
add rollback in catch block

### DIFF
--- a/identity-service/src/notifications/pushAnnouncementNotifications.js
+++ b/identity-service/src/notifications/pushAnnouncementNotifications.js
@@ -6,14 +6,13 @@ const config = require('../config.js')
 const audiusNotificationUrl = config.get('audiusNotificationUrl')
 
 async function pushAnnouncementNotifications () {
-  let tx
+  // Read-only tx
+  const tx = await models.sequelize.transaction()
   try {
     const requestUrl = `${audiusNotificationUrl}/index-mobile.json`
     logger.info(`pushAnnouncementNotifications - ${requestUrl}`)
     const response = await axios.get(requestUrl)
 
-    // Read-only tx
-    tx = await models.sequelize.transaction()
     if (response.data && Array.isArray(response.data.notifications)) {
       // TODO: Worth slicing?
       for (var notif of response.data.notifications) {

--- a/identity-service/src/notifications/pushAnnouncementNotifications.js
+++ b/identity-service/src/notifications/pushAnnouncementNotifications.js
@@ -6,13 +6,14 @@ const config = require('../config.js')
 const audiusNotificationUrl = config.get('audiusNotificationUrl')
 
 async function pushAnnouncementNotifications () {
+  let tx
   try {
     const requestUrl = `${audiusNotificationUrl}/index-mobile.json`
     logger.info(`pushAnnouncementNotifications - ${requestUrl}`)
     const response = await axios.get(requestUrl)
 
     // Read-only tx
-    const tx = await models.sequelize.transaction()
+    tx = await models.sequelize.transaction()
     if (response.data && Array.isArray(response.data.notifications)) {
       // TODO: Worth slicing?
       for (var notif of response.data.notifications) {
@@ -26,7 +27,8 @@ async function pushAnnouncementNotifications () {
     // Drain pending announcements
     await drainPublishedAnnouncements()
   } catch (e) {
-    logger.error(`pushAnnouncementNotifications ${e}`)
+    logger.error(`pushAnnouncementNotifications error: ${e}`)
+    await tx.rollback() // abort the tx
   }
 }
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/qvylpeBH/1525-api-identity-tx-not-being-closed-and-exhausting-our-pg-pool-https-trellocom-c-hblrkdrq-1517-identity-tx-block-never-exiting

### Description
The issue stems from many transactions left in an idle open state (`idle in transaction`) as seen in the photo. When you create a transaction object, you are inherently creating an open connection [according to Sequelize docs](https://sequelize.org/master/manual/transactions.html). In this PR, I added a `rollback()` for a transaction if it ever hits the catch block. 

This fix might not actually target the root cause for those open connections. I ran a query to check identity transaction statuses and did not see any outstanding transactions with the status `idle in transaction` like the card depicted. I also checked the identity service logs for past 12 months and did not see any errors regarding this flow. 

Hopefully this fix does address any potential future flows if push announcements notifs error.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [x] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches **push announcements notifications**


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Ran dapp to make sure that with my changes the dapp works just as expected.
