### PR TITLE
Add trackUUID index on Files table

### DIFF
--- a/creator-node/sequelize/migrations/20200904183206-add-track-uuid-index.js
+++ b/creator-node/sequelize/migrations/20200904183206-add-track-uuid-index.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('Files', ['trackUUID'], {
+      name: 'files_track_uuid_index',
+      using: 'btree',
+      concurrently: true
+    })
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Files', 'files_track_uuid_index')
+  }
+}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/mojXQ6qU/1542-api-add-index-on-track-uuid-in-files-table

### Description
Adds an index on the track uuid field

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran services locally. uploaded content.

Ran
```
SELECT "multihash" FROM "Files" AS "File" WHERE "File"."type" = 'copy320' AND "File"."trackUUID" = 'e95850a3-8ee0-4bd9-9998-aeda088e7ec2' LIMIT 1;
```

Ensured Seq Scan was used

Ran db:migrate

Ensured Index Scan was used