### PR TITLE
set celery logs to info

### DIFF
--- a/discovery-provider/compose/docker-compose.dev.override.yml
+++ b/discovery-provider/compose/docker-compose.dev.override.yml
@@ -5,7 +5,7 @@ services:
   celery-worker:
     build: ../.
     restart: always
-    command: sh -c '/wait && exec celery -A src.worker.celery worker'
+    command: sh -c '/wait && exec celery -A src.worker.celery worker --loglevel info'
     env_file:
       - .env
     depends_on:
@@ -18,7 +18,7 @@ services:
   celery-beat:
     build: ../.
     restart: always
-    command: sh -c '/wait && exec celery -A src.worker.celery beat'
+    command: sh -c '/wait && exec celery -A src.worker.celery beat --loglevel info'
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
### Trello Card Link
none

### Description
We use the new compose files to start up our services locally and did not include log level flags. This PR is to set the log level default to 'INFO'.

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

look! info logs!
```
{"levelno": 20, "level": "INFO", "msg": "Task update_ipld_blacklist[68370fa2-22da-47be-9b91-22bf04faf6c0] succeeded in 0.1130797999794595s: None", "timestamp": "2020-09-09 17:43:21,505", "data": {"id": "68370fa2-22da-47be-9b91-22bf04faf6c0", "name": "update_ipld_blacklist", "return_value": "None", "runtime": 0.1130797999794595}}
{"levelno": 20, "level": "INFO", "msg": "index.py | update_task | Intersect_blockhash : 0x86195c2b61a7265638b26ac022ceb548b67700037d6046656c41e355d66ca2f5", "timestamp": "2020-09-09 17:43:21,524"}
{"levelno": 20, "level": "INFO", "msg": "index.py | update_task | c7d44d94-d983-4c11-b031-e6dee61d45ce | Processing complete within session", "timestamp": "2020-09-09 17:43:21,525"}
{"levelno": 20, "level": "INFO", "msg": "Task update_discovery_provider[c7d44d94-d983-4c11-b031-e6dee61d45ce] succeeded in 0.13410909997764975s: None", "timestamp": "2020-09-09 17:43:21,526", "data": {"id": "c7d44d94-d983-4c11-b031-e6dee61d45ce", "name": "update_discovery_provider", "return_value": "None", "runtime": 0.13410909997764975}}
{"levelno": 20, "level": "INFO", "msg": "index_cache.py | Updated trending cache trending-month", "timestamp": "2020-09-09 17:43:21,529"}
{"levelno": 20, "level": "INFO", "msg": "index_cache.py | Updated trending cache trending-year", "timestamp": "2020-09-09 17:43:21,550"}
```
Please list the unit test(s) you added to verify your changes.

none