### PR TITLE
add default version value

### DIFF
--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -21,7 +21,7 @@ def process_route_keys(session, redis, key, ip, date):
             route = key_bstr.decode('utf-8').strip('/')
             val = int(routes[key_bstr].decode('utf-8'))
 
-            version = None
+            version = "0" # default value if version is not present
             path = route
             query_string = None
 

--- a/discovery-provider/src/tasks/index_metrics_test.py
+++ b/discovery-provider/src/tasks/index_metrics_test.py
@@ -12,7 +12,8 @@ def test_process_route_keys(redis_mock, db_mock):
     routes = {
         "/v1/users/search?query=ray": "3",
         "/v1/tracks/trending?genre=rap&timeRange=week": "2",
-        "/v1/playlists/hash": "1"
+        "/v1/playlists/hash": "1",
+        "/tracks": "1"
     }
 
     key = "API_METRICS:routes:192.168.0.1:2020/08/06:19"
@@ -29,7 +30,7 @@ def test_process_route_keys(redis_mock, db_mock):
         process_route_keys(session, redis_mock, key, ip, date)
 
         all_route_metrics = session.query(RouteMetrics).all()
-        assert len(all_route_metrics) == 3
+        assert len(all_route_metrics) == 4
 
         user_search = session.query(RouteMetrics).filter(
             RouteMetrics.version == '1',
@@ -60,6 +61,16 @@ def test_process_route_keys(redis_mock, db_mock):
         ).all()
 
         assert len(playlist_route) == 1
+
+        no_version_tracks = session.query(RouteMetrics).filter(
+            RouteMetrics.version == '0',
+            RouteMetrics.route_path == 'tracks',
+            RouteMetrics.ip == '192.168.0.1',
+            RouteMetrics.count == 1,
+            RouteMetrics.timestamp == date
+        ).all()
+
+        assert len(no_version_tracks) == 1
 
     keys = redis_mock.keys(key)
     assert not keys


### PR DESCRIPTION
### Trello Card Link
none

### Description
Route metrics (originally used to track API metrics) currently have `v1` in their paths. In a prior PR (https://github.com/AudiusProject/audius-protocol/pull/798), route metrics were added to all DP routes. Because there is no version in original DP routes, this error popped up where the value of `version` is null. 

```
[2020-09-09 02:00:00,049] {src.tasks.index_metrics:113} (ERROR) - Error processing route key API_METRICS:routes:192.168.144.14:2020/09/09:01 with error (psycopg2.IntegrityError) null value in column "version" violates not-null constraint
DETAIL:  Failing row contains (users, null, limit=1&offset=0&wallet=0x5201e6f88a963f153cdee5cf2e4412db0aa140..., 38, 2020-09-09 01:00:00, 2020-09-09 02:00:00.047554, 2020-09-09 02:00:00.047554, 1, 192.168.144.14).
 [SQL: 'INSERT INTO route_metrics (route_path, query_string, count, ip, timestamp, created_at, updated_at) VALUES (%(route_path)s, %(query_string)s, %(count)s, %(ip)s, %(timestamp)s, now(), now()) RETURNING route_metrics.id'] [parameters: {'route_path': 'users', 'query_string': 'limit=1&offset=0&wallet=0x5201e6f88a963f153cdee5cf2e4412db0aa1406a', 'count': 38, 'ip': '192.168.144.14', 'timestamp': datetime.datetime(2020, 9, 9, 1, 0)}] (Background on this error at: http://sqlalche.me/e/gkpj)
[2020-09-09 02:00:00,052] {src.tasks.index_metrics:113} (ERROR) - Error processing route key API_METRICS:routes:192.168.144.1:2020/09/09:01 with error This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.IntegrityError) null value in column "version" violates not-null constraint
```

This PR sets a default value for `version`. 

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

When I tested the route metrics PR (linked above), I did not see any relevant errors. I only saw this error running some tests on mad-dog. Will add testing later.