### PR TITLE
Fix ip

### DIFF
--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -63,7 +63,7 @@ def extract_app_name_key():
         ie: "audius_dapp"
     """
     application_name = request.args.get(app_name_param, type=str, default=None)
-    ip = request.remote_addr
+    ip = request.headers.get('X-Forwarded-For', request.remote_addr)
     date_time = get_rounded_date_time().strftime(datetime_format)
 
     application_key = f"{metrics_prefix}:{metrics_application}:{ip}:{date_time}"
@@ -83,7 +83,7 @@ def extract_route_key():
     req_args = request.args.items()
     req_args = stringify_query_params(req_args)
     route = f"{path}?{req_args}" if req_args else path
-    ip = request.remote_addr
+    ip = request.headers.get('X-Forwarded-For', request.remote_addr)
     date_time = get_rounded_date_time().strftime(datetime_format)
 
     route_key = f"{metrics_prefix}:{metrics_routes}:{ip}:{date_time}"


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/oe79FXiQ/1505-add-unique-user-eg-ip-based-tracking-to-discprov-per-day-week-month-all-time

### Description
Fixes how we track IP for metrics (because of the Proxy setup, remote_addr is not correct)

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Cut a custom tag on staging and verified that the IP coming in was different from remote_addr

```
# New
{"levelno": 30, "level": "WARNING", "msg": "18.207.165.221", "timestamp": "2020-09-09 18:25:32,820"}
# Old
{"levelno": 30, "level": "WARNING", "msg": "192.168.48.90", "timestamp": "2020-09-09 18:25:32,821"}
```