### PR TITLE
Add `downloadable_only` query param to API search routes

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -185,6 +185,7 @@ def to_dict(multi_dict):
 
 search_parser = reqparse.RequestParser()
 search_parser.add_argument('query', required=True)
+search_parser.add_argument('only_downloadable', required=False, default=False)
 
 trending_parser = reqparse.RequestParser()
 trending_parser.add_argument('genre', required=False)

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -90,13 +90,15 @@ class TrackStream(Resource):
 track_search_result = make_response(
     "track_search", ns, fields.List(fields.Nested(track)))
 
-
 @ns.route("/search")
 class TrackSearchResult(Resource):
     @record_metrics
     @ns.doc(
         id="""Search Tracks""",
-        params={'query': 'Search Query'},
+        params={
+            'query': 'Search Query',
+            'only_downloadable': 'Return only downloadable tracks'
+        },
         responses={
             200: 'Success',
             400: 'Bad request',
@@ -119,7 +121,8 @@ class TrackSearchResult(Resource):
             "current_user_id": None,
             "with_users": True,
             "limit": 10,
-            "offset": 0
+            "offset": 0,
+            "only_downloadable": args["only_downloadable"]
         }
         response = search(search_args)
         tracks = response["tracks"]

--- a/discovery-provider/src/queries/search.py
+++ b/discovery-provider/src/queries/search.py
@@ -41,7 +41,8 @@ def search_full():
         "current_user_id": current_user_id,
         "with_users": False,
         "limit": limit,
-        "offset": offset
+        "offset": offset,
+        "only_downloadable": False
     }
     resp = search(search_args)
     return api_helpers.success_response(resp)
@@ -67,7 +68,8 @@ def search_autocomplete():
         "current_user_id": current_user_id,
         "with_users": False,
         "limit": limit,
-        "offset": offset
+        "offset": offset,
+        "only_downloadable": False
     }
     resp = search(search_args)
     return api_helpers.success_response(resp)

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -2,7 +2,6 @@ from enum import Enum
 import logging  # pylint: disable=C0302
 from flask import Blueprint, request
 import sqlalchemy
-from sqlalchemy.sql.functions import current_user
 
 from src import api_helpers, exceptions
 from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight
@@ -404,7 +403,15 @@ def search(args):
 
     return results
 
-def track_search_query(session, searchStr, limit, offset, personalized, is_auto_complete, current_user_id, only_downloadable):
+def track_search_query(
+        session,
+        searchStr,
+        limit,
+        offset,
+        personalized,
+        is_auto_complete,
+        current_user_id,
+        only_downloadable):
     if personalized and not current_user_id:
         return []
 

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -468,7 +468,7 @@ def track_search_query(
     # track_ids is list of tuples - simplify to 1-D list
     track_ids = [i[0] for i in track_ids]
 
-    tracks_query = (
+    tracks = (
         session.query(Track)
         .filter(
             Track.is_delete == False,
@@ -476,14 +476,9 @@ def track_search_query(
             Track.is_unlisted == False,
             Track.stem_of == None,
             Track.track_id.in_(track_ids),
-        )
+        ).all()
     )
 
-    # Filter to downloadable if needed
-    if only_downloadable:
-        tracks_query = tracks_query.filter(Track.download['is_downloadable'].cast(sqlalchemy.Boolean) == True)
-
-    tracks = tracks_query.all()
     tracks = helpers.query_result_to_list(tracks)
 
     if is_auto_complete == True:

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -326,7 +326,7 @@ def add_users(session, results):
 
 def search(args):
     """ Perform a search. `args` should contain `is_auto_complete`,
-    `query`, `kind`, `current_user_id`, and `with_users`.
+    `query`, `kind`, `current_user_id`, `with_users`, and `only_downloadable`
     """
     searchStr = args.get("query")
 
@@ -337,6 +337,7 @@ def search(args):
     with_users = args.get("with_users")
     is_auto_complete = args.get("is_auto_complete")
     current_user_id = args.get("current_user_id")
+    only_downloadable = args.get("only_downloadable")
     limit = args.get("limit")
     offset = args.get("offset")
 
@@ -354,10 +355,10 @@ def search(args):
 
             if (searchKind in [SearchKind.all, SearchKind.tracks]):
                 results['tracks'] = with_users_added(track_search_query(
-                    session, searchStr, limit, offset, False, is_auto_complete, current_user_id))
+                    session, searchStr, limit, offset, False, is_auto_complete, current_user_id, only_downloadable))
                 if current_user_id:
                     results['saved_tracks'] = with_users_added(track_search_query(
-                        session, searchStr, limit, offset, True, is_auto_complete, current_user_id))
+                        session, searchStr, limit, offset, True, is_auto_complete, current_user_id, only_downloadable))
             if (searchKind in [SearchKind.all, SearchKind.users]):
                 results['users'] = user_search_query(
                     session, searchStr, limit, offset, False, is_auto_complete, current_user_id)
@@ -403,7 +404,7 @@ def search(args):
 
     return results
 
-def track_search_query(session, searchStr, limit, offset, personalized, is_auto_complete, current_user_id):
+def track_search_query(session, searchStr, limit, offset, personalized, is_auto_complete, current_user_id, only_downloadable):
     if personalized and not current_user_id:
         return []
 
@@ -421,10 +422,20 @@ def track_search_query(session, searchStr, limit, offset, personalized, is_auto_
                     if personalized and current_user_id
                     else ""
                 }
+                {
+                    'inner join "tracks" t on t.track_id = d.track_id'
+                    if only_downloadable
+                    else ""
+                }
                 where d."word" % :query
                 {
                     "and s.save_type='track' and s.is_current=true and s.is_delete=false and s.user_id = :current_user_id"
                     if personalized and current_user_id
+                    else ""
+                }
+                {
+                    "and (t.download->>'is_downloadable')::boolean is True"
+                    if only_downloadable
                     else ""
                 }
             ) as results
@@ -450,7 +461,7 @@ def track_search_query(session, searchStr, limit, offset, personalized, is_auto_
     # track_ids is list of tuples - simplify to 1-D list
     track_ids = [i[0] for i in track_ids]
 
-    tracks = (
+    tracks_query = (
         session.query(Track)
         .filter(
             Track.is_delete == False,
@@ -459,8 +470,13 @@ def track_search_query(session, searchStr, limit, offset, personalized, is_auto_
             Track.stem_of == None,
             Track.track_id.in_(track_ids),
         )
-        .all()
     )
+
+    # Filter to downloadable if needed
+    if only_downloadable:
+        tracks_query = tracks_query.filter(Track.download['is_downloadable'].cast(sqlalchemy.Boolean) == True)
+
+    tracks = tracks_query.all()
     tracks = helpers.query_result_to_list(tracks)
 
     if is_auto_complete == True:

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -195,7 +195,7 @@ class IPFSClient:
             if gateway_query_address:
                 try:
                     logger.warning(f"IPFSCLIENT | Querying {gateway_query_address}")
-                    # use a HEAD request instead of a GET so we can just get the status code without the 
+                    # use a HEAD request instead of a GET so we can just get the status code without the
                     # actual image file, which we don't need
                     r = requests.head(gateway_query_address, timeout=3)
                 except Exception as e:

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from src.models import Track, Block, User
+from src.queries.search_queries import track_search_query
+from src.utils.db_session import get_db
+
+def setup_search(db):
+    # Import app so that it'll run migrations against the db
+    now = datetime.now()
+    blocks = [
+        Block(
+            blockhash=hex(1),
+            number=1,
+            parenthash='0x01',
+            is_current=False,
+        ),
+        Block(
+            blockhash=hex(2),
+            number=2,
+            parenthash='0x02',
+            is_current=False,
+        ),
+        Block(
+            blockhash=hex(3),
+            number=3,
+            parenthash='0x03',
+            is_current=True,
+        )
+    ]
+    tracks = [
+        Track(
+            blockhash=hex(1),
+            blocknumber=1,
+            track_id=1,
+            is_current=True,
+            is_delete=False,
+            owner_id=1,
+            route_id='',
+            track_segments=[],
+            genre="",
+            updated_at=now,
+            created_at=now,
+            is_unlisted=False,
+            title="the track 1",
+            download={"cid": None, "is_downloadable": False, "requires_follow": False}
+        ),
+        Track(
+            blockhash=hex(2),
+            blocknumber=2,
+            track_id=2,
+            is_current=True,
+            is_delete=False,
+            owner_id=1,
+            route_id='',
+            track_segments=[],
+            genre="",
+            updated_at=now,
+            created_at=now,
+            is_unlisted=False,
+            title="the track 2",
+            download={"cid": None, "is_downloadable": True, "requires_follow": False}
+        ),
+        Track(
+            blockhash=hex(3),
+            blocknumber=3,
+            track_id=3,
+            is_current=True,
+            is_delete=False,
+            owner_id=1,
+            route_id='',
+            track_segments=[],
+            genre="",
+            updated_at=now,
+            created_at=now,
+            is_unlisted=False,
+            title="random title",
+            download={"cid": None, "is_downloadable": True, "requires_follow": False}
+        )
+    ]
+
+    # need users for the lexeme dict to work
+    users = [
+        User(
+            blockhash=hex(1),
+            blocknumber=1,
+            user_id=1,
+            is_current=True,
+            handle="",
+            wallet="",
+            updated_at=now,
+            created_at=now
+        )
+    ]
+
+    with db.scoped_session() as session:
+        for block in blocks:
+            session.add(block)
+            session.flush()
+        for track in tracks:
+            session.add(track)
+        for user in users:
+            session.add(user)
+            session.flush()
+
+        # Refresh the lexeme matview
+        session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict")
+
+def test_gets_all_results(app):
+    """Tests we get all results, including downloaded"""
+    with app.app_context():
+        db = get_db()
+    setup_search(db)
+    with db.scoped_session() as session:
+        res = track_search_query(session, "the", 10, 0, False, False, None, False)
+        assert len(res) == 2
+
+def test_gets_all_results(app):
+    """Tests we get all results, including downloaded"""
+    with app.app_context():
+        db = get_db()
+        setup_search(db)
+    with db.scoped_session() as session:
+        res = track_search_query(session, "the", 10, 0, False, False, None, True)
+        assert len(res) == 1

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -114,7 +114,7 @@ def test_gets_all_results(app):
         assert len(res) == 2
 
 def test_gets_downloadable_results(app):
-    """Tests we get all results, including downloaded"""
+    """Tests we get only downloadable results"""
     with app.app_context():
         db = get_db()
         setup_search(db)

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -113,7 +113,7 @@ def test_gets_all_results(app):
         res = track_search_query(session, "the", 10, 0, False, False, None, False)
         assert len(res) == 2
 
-def test_gets_all_results(app):
+def test_gets_downloadable_results(app):
     """Tests we get all results, including downloaded"""
     with app.app_context():
         db = get_db()

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -72,7 +72,7 @@ def setup_search(db):
             updated_at=now,
             created_at=now,
             is_unlisted=False,
-            title="random title",
+            title="xyz",
             download={"cid": None, "is_downloadable": True, "requires_follow": False}
         )
     ]
@@ -117,7 +117,7 @@ def test_gets_downloadable_results(app):
     """Tests we get only downloadable results"""
     with app.app_context():
         db = get_db()
-        setup_search(db)
+    setup_search(db)
     with db.scoped_session() as session:
         res = track_search_query(session, "the", 10, 0, False, False, None, True)
         assert len(res) == 1


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/kUo0WXD9/1549-on-call-downloadable-as-a-search-route-query-param

### Description
Adds a 'downloadable_only' query param to API search, enabling API consumers to search for only downloadable tracks.
 
**Note: tests are failing on CI, am investigating**

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- 🚨 Yes, this touches search

### How Has This Been Tested?

Tested against prod snapshot.

Also did performance benchmarking. Adds about about 100ms of latency to the query (~3.2s vs ~3.3s) on average, but strange results where sometimes searching for downloadable only tracks is faster than regular search because there are fewer results to perform similarity comparisons on.

Please list the unit test(s) you added to verify your changes.

1. `test_search.py` (new 🎉)
