### PR TITLE
Update init repos to reflect mad-dog and service-commands addition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
             source ~/.bash_profile
             nvm install v10.16
             nvm use 10.16
+            cd /home/circleci/project/service-commands/scripts/
+            sh init-repos.sh
             cd /home/circleci/project/libs/
             npm install
             npm link
@@ -39,8 +41,6 @@ jobs:
             npm install
             npm link @audius/libs
             npm link @audius/service-commands
-            cd /home/circleci/project/service-commands/scripts/
-            sh init-repos.sh
             sudo "$(which node)" hosts.js add
             sudo curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             "$(which node)" setup.js up -nc 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,23 +24,21 @@ jobs:
           name: execute
           command: |
             set -e
-            export PROTOCOL_DIR=/home/circleci/project/
+            export PROTOCOL_DIR=/home/circleci/project
             source ~/.bash_profile
             nvm install v10.16
             nvm use 10.16
             cd /home/circleci/project/service-commands/scripts/
             sh init-repos.sh
             cd /home/circleci/project/libs/
-            npm install
             npm link
             cd /home/circleci/project/service-commands/
-            npm install
             npm link
             npm link @audius/libs
             cd /home/circleci/project/mad-dog/
-            npm install
             npm link @audius/libs
             npm link @audius/service-commands
+            cd /home/circleci/project/service-commands/scripts/
             sudo "$(which node)" hosts.js add
             sudo curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             "$(which node)" setup.js up -nc 3

--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -5,6 +5,16 @@ set -x
 cd $PROTOCOL_DIR/
 npm install &
 
+# setup service commands
+cd $PROTOCOL_DIR/
+cd service-commands/
+npm install &
+
+# setup mad dog
+cd $PROTOCOL_DIR/
+cd mad-dog/
+npm install &
+
 # setup contracts
 cd $PROTOCOL_DIR/
 cd contracts/


### PR DESCRIPTION
### Trello Card Link
none

### Description
Add npm installs for two newly added repos

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [x] service-commands and mad-dog :-)

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

ran init-repos and worked