### PR TITLE
Cnode error & test fix

### DIFF
--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -29,7 +29,7 @@ tear_down () {
 run_unit_tests () {
   set +e
   echo Running unit tests...
-  ./node_modules/mocha/bin/mocha src/**/*.test.js
+  ./node_modules/mocha/bin/mocha --recursive 'src/**/*.test.js'
   set -e
 }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -49,21 +49,25 @@ class DiscoveryProviderSelection extends ServiceSelection {
   /** Retrieves a cached discovery provider from localstorage */
   getCached () {
     if (localStorage) {
-      const discProvTimestamp = localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP)
-      if (discProvTimestamp) {
-        const { endpoint: latestEndpoint, timestamp } = JSON.parse(discProvTimestamp)
+      try {
+        const discProvTimestamp = localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP)
+        if (discProvTimestamp) {
+          const { endpoint: latestEndpoint, timestamp } = JSON.parse(discProvTimestamp)
 
-        const inWhitelist = !this.whitelist || this.whitelist.has(latestEndpoint)
+          const inWhitelist = !this.whitelist || this.whitelist.has(latestEndpoint)
 
-        const timeout = this.reselectTimeout
-          ? this.reselectTimeout
-          : DISCOVERY_PROVIDER_RESELECT_TIMEOUT
-        const isExpired = (Date.now() - timestamp) > timeout
-        if (!inWhitelist || isExpired) {
-          this.clearCached()
-        } else {
-          return latestEndpoint
+          const timeout = this.reselectTimeout
+            ? this.reselectTimeout
+            : DISCOVERY_PROVIDER_RESELECT_TIMEOUT
+          const isExpired = (Date.now() - timestamp) > timeout
+          if (!inWhitelist || isExpired) {
+            this.clearCached()
+          } else {
+            return latestEndpoint
+          }
         }
+      } catch (e) {
+        console.error('Could not retrieve cached discovery endpoint from localStorage', e)
       }
     }
     return null


### PR DESCRIPTION
### Description
This PR contains two items:
1. Turns out we weren't running all the creator node unit tests because in a bash script `src/**/*test.js` is actually executed and it's passing in the list of files to mocha. Adding the recursive flag with the single quotes forces it to behave as expected and run all unit tests.
2. Occasionally on creator node restarts we've seen an error where the creator node refuses to come up locally because there's an error thrown that looks like "ENOENT: no such file or directory, open '/usr/src/app/local-storage/%40audius%2Flibs%3Adiscovery-provider-timestamp'"

I added a try/catch around the block where libs tries to fetch the cached discovery service value from localStorage and I've observed that even when we see the "ENOENT: no such file or directory, open '/usr/src/app/local-storage/%40audius%2Flibs%3Adiscovery-provider-timestamp'" error it continues on.

```
[2020-09-15T03:15:25.446Z]  INFO: audius_creator_node/541 on 344d00956772: Completed Processing trackId, userId, and segmentCid blacklists.
Could not retrieve cached discovery endpoint from localStorage { Error: ENOENT: no such file or directory, open '/usr/src/app/local-storage/%40audius%2Flibs%3Adiscovery-provider-timestamp'
    at Object.openSync (fs.js:443:3)
    at Object.readFileSync (fs.js:343:35)
    at LocalStorage.getItem (/usr/src/audius-libs/node_modules/node-localstorage/LocalStorage.js:208:19)
    at DiscoveryProviderSelection.getCached (/usr/src/audius-libs/src/services/discoveryProvider/DiscoveryProviderSelection.js:53:48)
    at DiscoveryProviderSelection.shortcircuit (/usr/src/audius-libs/src/services/discoveryProvider/DiscoveryProviderSelection.js:90:17)
    at DiscoveryProviderSelection.select (/usr/src/audius-libs/src/service-selection/ServiceSelection.js:81:31)
    at DiscoveryProviderSelection.select (/usr/src/audius-libs/src/services/discoveryProvider/DiscoveryProviderSelection.js:94:34)
    at DiscoveryProvider.init (/usr/src/audius-libs/src/services/discoveryProvider/index.js:35:49)
    at AudiusLibs.init (/usr/src/audius-libs/src/index.js:223:36)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path:
   '/usr/src/app/local-storage/%40audius%2Flibs%3Adiscovery-provider-timestamp' }
Selected discprov http://audius-disc-prov_web-server_1:5000 [ { stage: 'Check Short Circuit', val: null },
  { stage: 'Get All Services',
    val: [ 'http://audius-disc-prov_web-server_1:5000' ] },
  { stage: 'Filter To Whitelist',
    val: [ 'http://audius-disc-prov_web-server_1:5000' ] },
  { stage: 'Filter Out Known Unhealthy',
    val: [ 'http://audius-disc-prov_web-server_1:5000' ] },
  { stage: 'Get Selection Round',
    val: [ 'http://audius-disc-prov_web-server_1:5000' ] },
  { stage: 'Raced And Found Best',
    val: 'http://audius-disc-prov_web-server_1:5000' },
  { stage: 'Made A Selection',
    val: 'http://audius-disc-prov_web-server_1:5000' } ]
[2020-09-15T03:15:29.444Z]  INFO: audius_creator_node/541 on 344d00956772: Initialized services!
[2020-09-15T03:15:29.448Z]  INFO: audius_creator_node/541 on 344d00956772: Listening on port 4000...
[nodemon] restarting due to changes...
```


### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [X] Libs
- [ ] Contracts

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

For #1 - just looked at CircleCI runs between master and this branch. Master doesn't actually run the health check tests as can be seen here https://circleci.com/api/v1.1/project/github/AudiusProject/audius-protocol/40073/output/103/0?file=true&allocation-id=5f6173b0ff854b4aa34d29ea-0-build%2F31B0AC9A. Notice that there's 6 unit tests. In our current CircleCI run for this branch there's 8 unit tests including health check https://circleci.com/api/v1.1/project/github/AudiusProject/audius-protocol/40099/output/104/0?file=true&allocation-id=5f618a3f6af4f93b4f43363d-0-build%2F70AFF48F.

For #2 - Tested this both creator node side and dapp side. Service side I was able to get the error to be caught as evident in the stack trace above. Look for log "Could not retrieve cached discovery endpoint from localStorage". For the dapp, I was able to see verify it used both the localStorage value if in localStorage and a full selection if not in localStorage

Incognito
```
Selected discprov http://audius-disc-prov_web-server_1:5000 
(6) [{…}, {…}, {…}, {…}, {…}, {…}]
0: {stage: "Check Short Circuit", val: null}
1: {stage: "Get All Services", val: Array(1)}
2: {stage: "Filter Out Known Unhealthy", val: Array(1)}
3: {stage: "Get Selection Round", val: Array(1)}
4: {stage: "Raced And Found Best", val: "http://audius-disc-prov_web-server_1:5000"}
5: {stage: "Made A Selection", val: "http://audius-disc-prov_web-server_1:5000"}
length: 6
__proto__: Array(0)
```

Cached
```
Selected discprov http://audius-disc-prov_web-server_1:5000 
[{…}]
0: {stage: "Check Short Circuit", val: "http://audius-disc-prov_web-server_1:5000"}
length: 1
__proto__: Array(0)
```