### PR TITLE
Drop plays, add plays indices

### DIFF
--- a/discovery-provider/alembic/versions/83e9edcc7014_wipe_plays_table.py
+++ b/discovery-provider/alembic/versions/83e9edcc7014_wipe_plays_table.py
@@ -1,7 +1,7 @@
 """Wipe plays table
 
 Revision ID: 83e9edcc7014
-Revises: ffcb2df7b0ee
+Revises: 4c3784d41d41
 Create Date: 2020-09-15 17:07:41.777345
 
 """
@@ -20,7 +20,7 @@ def upgrade():
     connection = op.get_bind()
     connection.execute('''
         --- Drop all plays
-        DELETE plays;
+        DELETE FROM plays;
     ''')
 
 

--- a/discovery-provider/alembic/versions/83e9edcc7014_wipe_plays_table.py
+++ b/discovery-provider/alembic/versions/83e9edcc7014_wipe_plays_table.py
@@ -1,0 +1,29 @@
+"""Wipe plays table
+
+Revision ID: 83e9edcc7014
+Revises: ffcb2df7b0ee
+Create Date: 2020-09-15 17:07:41.777345
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '83e9edcc7014'
+down_revision = '4c3784d41d41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute('''
+        --- Drop all plays
+        DELETE plays;
+    ''')
+
+
+def downgrade():
+    ### No going back from this one...
+    pass

--- a/discovery-provider/alembic/versions/ffcb2df7b0ee_add_indices_to_plays_table.py
+++ b/discovery-provider/alembic/versions/ffcb2df7b0ee_add_indices_to_plays_table.py
@@ -1,7 +1,7 @@
 """Add indices to plays table
 
 Revision ID: ffcb2df7b0ee
-Revises: 1ec93fb00e69
+Revises: 83e9edcc7014
 Create Date: 2020-09-15 13:27:54.686093
 
 """

--- a/discovery-provider/alembic/versions/ffcb2df7b0ee_add_indices_to_plays_table.py
+++ b/discovery-provider/alembic/versions/ffcb2df7b0ee_add_indices_to_plays_table.py
@@ -1,0 +1,24 @@
+"""Add indices to plays table
+
+Revision ID: ffcb2df7b0ee
+Revises: 1ec93fb00e69
+Create Date: 2020-09-15 13:27:54.686093
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'ffcb2df7b0ee'
+down_revision = '83e9edcc7014'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('play_updated_at_idx'), 'plays', ['updated_at'], unique=False)
+    op.create_index(op.f('play_item_idx'), 'plays', ['play_item_id'], unique=False)
+
+def downgrade():
+    op.drop_index(op.f('play_updated_at_idx'), table_name='plays')
+    op.drop_index(op.f('play_item_idx'), table_name='plays')

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -49,5 +49,5 @@ allow_all = false
 registry = 0x2999e02829DC711B9254187962ba44d1fFcf5481
 
 [delegate]
-owner_wallet =
-private_key =
+owner_wallet = 0xFakeOwnerWallet
+private_key = 0xFakePrivateKey


### PR DESCRIPTION
### Trello Card Link
N/a

### Description
- Drop plays table to allow re-indexing to proceed
- As we realized in yesterday's down time, we need to add plays to the play_item_id and updated_at plays column.
- Also added default values for delegate wallet and pkey to allow for alembic migrations to work. 

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Looked at navicat, saw expected indices were created.
