### PR TITLE
Update .gitignore to ignore coverage files

### DIFF
--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -11,3 +11,4 @@ local-storage/
 initScripts/*-config.json
 .npmrc
 .nyc_output/*
+coverage/


### PR DESCRIPTION
### Trello Card Link
none

### Description
Add coverage files to .gitignore

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

My git status does not include the coverage files anymore.

Please list the unit test(s) you added to verify your changes.

none!