### PR TITLE
Fix push on undefined identity relay health check

### DIFF
--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -103,7 +103,9 @@ module.exports = function (app) {
               if (senderAddress) {
                 if (!failureTxs[senderAddress]) failureTxs[senderAddress] = [txHash]
                 else failureTxs[senderAddress].push(txHash)
-              } else failureTxs['unknown'].push(txHash)
+              } else {
+                failureTxs['unknown'] = (failureTxs['unknown'] || []).concat(txHash)
+              }
             }
           }
         }


### PR DESCRIPTION
### Trello Card Link
na 

### Description
Fix push on undefined. Should fix internal server error on /relay/health_check endpoint when there is an error with unknown senderaddress. 
![Screen Shot 2020-09-23 at 9 51 01 AM](https://user-images.githubusercontent.com/7064122/94022134-c6234f00-fd82-11ea-802a-8befb60239a7.png)


### Services
- Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
not tested 👀 
