### PR TITLE
[eth-contracts] Tracking totalDelegated by a given delegator

### DIFF
--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -1,4 +1,3 @@
-import { uniq } from 'lodash'
 import * as _lib from '../utils/lib.js'
 const { time, expectEvent } = require('@openzeppelin/test-helpers')
 
@@ -7,7 +6,6 @@ const ServiceTypeManager = artifacts.require('ServiceTypeManager')
 const ServiceProviderFactory = artifacts.require('ServiceProviderFactory')
 const Staking = artifacts.require('Staking')
 const DelegateManager = artifacts.require('DelegateManager')
-const ClaimsManager = artifacts.require('ClaimsManager')
 
 const stakingProxyKey = web3.utils.utf8ToHex('StakingProxy')
 const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -345,6 +345,11 @@ contract('DelegateManager', async (accounts) => {
     }
   }
 
+  /*
+     Function to re-calculate expected delegator stake total given
+      list of types and IDs, and compare calculated value with 
+      delegator balance tracked on chain
+  */
   const getTotalDelegatorStake = async (delegator) => {
     let validTypes = await serviceTypeManager.getValidServiceTypes()
     let totalDelegatorStake = _lib.toBN(0)
@@ -367,7 +372,7 @@ contract('DelegateManager', async (accounts) => {
       totalDelegatorStake = totalDelegatorStake.add(totalDelegatedToOwner)
     }
 
-    let newTotalFromContract = await delegateManager.getTotalDelegation(delegator)
+    let newTotalFromContract = await delegateManager.getTotalDelegatorStake(delegator)
     assert.isTrue(
       newTotalFromContract.eq(totalDelegatorStake),
       `ERROR STATE Calculated:${totalDelegatorStake}, newTotalFromContract:${newTotalFromContract}`

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -35,7 +35,7 @@ const DECREASE_STAKE_LOCKUP_DURATION = UNDELEGATE_LOCKUP_DURATION
 const callValue0 = _lib.toBN(0)
 
 
-contract.only('DelegateManager', async (accounts) => {
+contract('DelegateManager', async (accounts) => {
   let staking, stakingAddress, token, registry, governance
   let serviceProviderFactory, serviceTypeManager, claimsManager, delegateManager
 


### PR DESCRIPTION
### Description
Explicitly track the total delegation amount from a given address, required for other incoming changes

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [x] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches eth-contracts

### How Has This Been Tested?

Significant validation added in tests by updating `getTotalDelegatorStake` function to assert on the tracked value (newly added) equalling the computed value (already present)