### PR TITLE
[eth-contracts] Enable Governance proposal name field

### DIFF
--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -49,12 +49,6 @@ contract Governance is InitializableV2 {
     /// @dev uint16 gives max possible value of 65,535
     uint16 private maxInProgressProposals;
 
-    /// @notice Max number of bytes allowed in a proposal description string
-    uint16 private maxDescriptionLength;
-
-    /// @notice Max number of bytes allowed in a proposal name string
-    uint16 private maxNameLength;
-
     /**
      * @notice Address of account that has special Governance permissions. Can veto proposals
      *      and execute transactions directly on contracts.
@@ -186,8 +180,6 @@ contract Governance is InitializableV2 {
         uint256 _executionDelay,
         uint256 _votingQuorumPercent,
         uint16 _maxInProgressProposals,
-        uint16 _maxDescriptionLength,
-        uint16 _maxNameLength,
         address _guardianAddress
     ) public initializer {
         require(_registryAddress != address(0x00), ERROR_INVALID_REGISTRY);
@@ -204,12 +196,6 @@ contract Governance is InitializableV2 {
             "Governance: Requires non-zero _maxInProgressProposals"
         );
         maxInProgressProposals = _maxInProgressProposals;
-
-        require(_maxDescriptionLength > 0, "Governance: Requires non-zero _maxDescriptionLength");
-        maxDescriptionLength = _maxDescriptionLength;
-
-        require(_maxNameLength > 0, "Governance: Requires non-zero _maxNameLength");
-        maxNameLength = _maxNameLength;
 
         require(
             _votingQuorumPercent > 0 && _votingQuorumPercent <= 100,
@@ -230,6 +216,9 @@ contract Governance is InitializableV2 {
 
     /**
      * @notice Submit a proposal for vote. Only callable by stakers with non-zero stake.
+     *
+     * @dev _name and _description length is not enforced since they aren't stored on-chain and only event emitted
+     *
      * @param _targetContractRegistryKey - Registry key for the contract concerning this proposal
      * @param _callValue - amount of wei to pass with function call if a token transfer is involved
      * @param _functionSignature - function signature of the function to be executed if proposal is successful
@@ -283,16 +272,12 @@ contract Governance is InitializableV2 {
             "Governance: _functionSignature cannot be empty."
         );
 
-        // Require description length in bytes is within bounds
-        require(
-            bytes(_description).length > 0 && bytes(_description).length <= maxDescriptionLength,
-            "Governance: _description length must be between 1 and maxDescriptionLength"
-        );
-        // Require description name in bytes is within bounds
-        require(
-            bytes(_name).length > 0 && bytes(_name).length <= maxNameLength,
-            "Governance: _name length must be between 1 and maxNameLength"
-        );
+        // Require non-zero description length
+        require(bytes(_description).length > 0, "Governance: _description length must be > 0");
+
+        // Require non-zero name length
+        require(bytes(_name).length > 0, "Governance: _name length must be > 0");
+
 
         // set proposalId
         uint256 newProposalId = lastProposalId.add(1);
@@ -625,38 +610,6 @@ contract Governance is InitializableV2 {
     }
 
     /**
-     * @notice Set the max length in bytes allowed for a proposal description string
-     * @dev Only callable by self via _executeTransaction
-     * @param _newMaxDescriptionLength - new value for maxDescriptionLength
-     */
-    function setMaxDescriptionLength(uint16 _newMaxDescriptionLength) external {
-        _requireIsInitialized();
-
-        require(msg.sender == address(this), "Only callable by self");
-        require(
-            _newMaxDescriptionLength > 0,
-            "Governance: Requires non-zero _newMaxDescriptionLength"
-        );
-        maxDescriptionLength = _newMaxDescriptionLength;
-    }
-
-    /**
-     * @notice Set the max length in bytes allowed for a proposal name string
-     * @dev Only callable by self via _executeTransaction
-     * @param _maxNameLength - new value for maxNameLength
-     */
-    function setMaxNameLength(uint16 _maxNameLength) external {
-        _requireIsInitialized();
-
-        require(msg.sender == address(this), "Only callable by self");
-        require(
-            _maxNameLength > 0,
-            "Governance: Requires non-zero _maxnameLength"
-        );
-        maxNameLength = _maxNameLength;
-    }
-
-    /**
      * @notice Set the execution delay for a proposal
      * @dev Only callable by self via _executeTransaction
      * @param _newExecutionDelay - new value for executionDelay
@@ -789,7 +742,7 @@ contract Governance is InitializableV2 {
         );
     }
 
-     /**
+    /**
      * @notice Get proposal target contract hash by proposalId
      * @dev This is a separate function because the getProposalById returns too many
             variables already and by adding more, you get the error
@@ -880,20 +833,6 @@ contract Governance is InitializableV2 {
         _requireIsInitialized();
 
         return executionDelay;
-    }
-
-    /// @notice Get the max length in bytes of a proposal description string
-    function getMaxDescriptionLength() external view returns (uint16) {
-        _requireIsInitialized();
-
-        return maxDescriptionLength;
-    }
-
-    /// @notice Get the max length in bytes of a proposal name string
-    function getMaxNameLength() external view returns (uint16) {
-        _requireIsInitialized();
-
-        return maxNameLength;
     }
 
     /// @notice Get the array of all InProgress proposal Ids

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -223,8 +223,8 @@ contract Governance is InitializableV2 {
      * @param _callValue - amount of wei to pass with function call if a token transfer is involved
      * @param _functionSignature - function signature of the function to be executed if proposal is successful
      * @param _callData - encoded value(s) to call function with if proposal is successful
-     * @param _name - Text proposal of proposal to be emitted in event
-     * @param _description - Text description of proposal to be emitted in event // TODO: emit name instead?
+     * @param _name - Text name of proposal to be emitted in event
+     * @param _description - Text description of proposal to be emitted in event
      * @return - ID of new proposal
      */
     function submitProposal(

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -130,7 +130,7 @@ contract Governance is InitializableV2 {
     event ProposalSubmitted(
         uint256 indexed proposalId,
         address indexed proposer,
-        string indexed name,
+        string name,
         string description
     );
     event ProposalVoteSubmitted(

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -108,7 +108,6 @@ contract Governance is InitializableV2 {
         uint256 voteMagnitudeNo;
         uint256 numVotes;
         mapping(address => Vote) votes;
-        string description;
         bytes32 contractHash;
     }
 
@@ -128,7 +127,7 @@ contract Governance is InitializableV2 {
     event ProposalSubmitted(
         uint256 indexed proposalId,
         address indexed proposer,
-        uint256 submissionBlockNumber,
+        string indexed name,
         string description
     );
     event ProposalVoteSubmitted(
@@ -228,7 +227,8 @@ contract Governance is InitializableV2 {
      * @param _callValue - amount of wei to pass with function call if a token transfer is involved
      * @param _functionSignature - function signature of the function to be executed if proposal is successful
      * @param _callData - encoded value(s) to call function with if proposal is successful
-     * @param _description - Text description of proposal to be emitted in event
+     * @param _name - Text proposal of proposal to be emitted in event
+     * @param _description - Text description of proposal to be emitted in event // TODO: emit name instead?
      * @return - ID of new proposal
      */
     function submitProposal(
@@ -236,6 +236,7 @@ contract Governance is InitializableV2 {
         uint256 _callValue,
         string calldata _functionSignature,
         bytes calldata _callData,
+        string calldata _name,
         string calldata _description
     ) external returns (uint256)
     {
@@ -298,7 +299,6 @@ contract Governance is InitializableV2 {
             voteMagnitudeYes: 0,
             voteMagnitudeNo: 0,
             numVotes: 0,
-            description: _description,
             contractHash: _getCodeHash(targetContractAddress)
             /* votes: mappings are auto-initialized to default state */
         });
@@ -309,7 +309,7 @@ contract Governance is InitializableV2 {
         emit ProposalSubmitted(
             newProposalId,
             proposer,
-            block.number,
+            _name,
             _description
         );
 
@@ -779,26 +779,6 @@ contract Governance is InitializableV2 {
         );
 
         return (proposals[_proposalId].contractHash);
-    }
-
-     /**
-     * @notice Get proposal description by proposalId
-     * @dev This is a separate function because the getProposalById returns too many
-            variables already and by adding more, you get the error
-            `InternalCompilerError: Stack too deep, try using fewer variables`
-     * @param _proposalId - id of proposal
-     */
-    function getProposalDescriptionById(uint256 _proposalId)
-    external view returns (string memory)
-    {
-        _requireIsInitialized();
-
-        require(
-            _proposalId <= lastProposalId && _proposalId > 0,
-            "Governance: Must provide valid non-zero _proposalId"
-        );
-
-        return (proposals[_proposalId].description);
     }
 
     /**

--- a/eth-contracts/contracts/Governance.sol
+++ b/eth-contracts/contracts/Governance.sol
@@ -52,6 +52,9 @@ contract Governance is InitializableV2 {
     /// @notice Max number of bytes allowed in a proposal description string
     uint16 private maxDescriptionLength;
 
+    /// @notice Max number of bytes allowed in a proposal name string
+    uint16 private maxNameLength;
+
     /**
      * @notice Address of account that has special Governance permissions. Can veto proposals
      *      and execute transactions directly on contracts.
@@ -184,6 +187,7 @@ contract Governance is InitializableV2 {
         uint256 _votingQuorumPercent,
         uint16 _maxInProgressProposals,
         uint16 _maxDescriptionLength,
+        uint16 _maxNameLength,
         address _guardianAddress
     ) public initializer {
         require(_registryAddress != address(0x00), ERROR_INVALID_REGISTRY);
@@ -203,6 +207,9 @@ contract Governance is InitializableV2 {
 
         require(_maxDescriptionLength > 0, "Governance: Requires non-zero _maxDescriptionLength");
         maxDescriptionLength = _maxDescriptionLength;
+
+        require(_maxNameLength > 0, "Governance: Requires non-zero _maxNameLength");
+        maxNameLength = _maxNameLength;
 
         require(
             _votingQuorumPercent > 0 && _votingQuorumPercent <= 100,
@@ -280,6 +287,11 @@ contract Governance is InitializableV2 {
         require(
             bytes(_description).length > 0 && bytes(_description).length <= maxDescriptionLength,
             "Governance: _description length must be between 1 and maxDescriptionLength"
+        );
+        // Require description name in bytes is within bounds
+        require(
+            bytes(_name).length > 0 && bytes(_name).length <= maxNameLength,
+            "Governance: _name length must be between 1 and maxNameLength"
         );
 
         // set proposalId
@@ -629,6 +641,22 @@ contract Governance is InitializableV2 {
     }
 
     /**
+     * @notice Set the max length in bytes allowed for a proposal name string
+     * @dev Only callable by self via _executeTransaction
+     * @param _maxNameLength - new value for maxNameLength
+     */
+    function setMaxNameLength(uint16 _maxNameLength) external {
+        _requireIsInitialized();
+
+        require(msg.sender == address(this), "Only callable by self");
+        require(
+            _maxNameLength > 0,
+            "Governance: Requires non-zero _maxnameLength"
+        );
+        maxNameLength = _maxNameLength;
+    }
+
+    /**
      * @notice Set the execution delay for a proposal
      * @dev Only callable by self via _executeTransaction
      * @param _newExecutionDelay - new value for executionDelay
@@ -859,6 +887,13 @@ contract Governance is InitializableV2 {
         _requireIsInitialized();
 
         return maxDescriptionLength;
+    }
+
+    /// @notice Get the max length in bytes of a proposal name string
+    function getMaxNameLength() external view returns (uint16) {
+        _requireIsInitialized();
+
+        return maxNameLength;
     }
 
     /// @notice Get the array of all InProgress proposal Ids

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -18,9 +18,6 @@ const VotingQuorumPercent = 10
 // - Setting to 100 by default as that is a sufficiently large value that is not at gas limit risk
 const MaxInProgressProposals = 100
 
-const MaxDescriptionLengthBytes = 250
-const MaxNameLengthBytes = 250
-
 // 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646 blocks
 const ExecutionDelayBlocks = 6646
 
@@ -41,12 +38,10 @@ module.exports = (deployer, network, accounts) => {
       'initialize',
       [
         'address',
-        'uint256', 
-        'uint256', 
-        'uint256', 
-        'uint16', 
-        'uint16', 
-        'uint16', 
+        'uint256',
+        'uint256',
+        'uint256',
+        'uint16',
         'address'
       ],
       [
@@ -55,8 +50,6 @@ module.exports = (deployer, network, accounts) => {
         ExecutionDelayBlocks,
         VotingQuorumPercent,
         MaxInProgressProposals,
-        MaxDescriptionLengthBytes,
-        MaxNameLengthBytes,
         guardianAddress
       ]
     )
@@ -71,19 +64,19 @@ module.exports = (deployer, network, accounts) => {
 
     // Set governance Address on Governance proxy contract to enable self-upgradeability
     let govAddrFromProxy = await governanceProxy.getAudiusProxyAdminAddress.call()
-    assert.equal(govAddrFromProxy, proxyAdminAddress)
+    assert.strictEqual(govAddrFromProxy, proxyAdminAddress)
     await governanceProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
     govAddrFromProxy = await governanceProxy.getAudiusProxyAdminAddress.call()
-    assert.equal(govAddrFromProxy, governanceProxy.address)
+    assert.strictEqual(govAddrFromProxy, governanceProxy.address)
 
     // Set governance address on Registry proxy contract to enable upgrades
     await registryProxy.setAudiusProxyAdminAddress(governanceProxy.address, { from: proxyAdminAddress })
     let govAddrFromRegProxy = await registryProxy.getAudiusProxyAdminAddress()
-    assert.equal(govAddrFromRegProxy, governanceProxy.address)
+    assert.strictEqual(govAddrFromRegProxy, governanceProxy.address)
 
     // Transfer registry ownership to Governance
     await registry.transferOwnership(governance.address, { from: proxyDeployerAddress })
-    assert.equal(await registry.owner.call(), governance.address)
+    assert.strictEqual(await registry.owner.call(), governance.address)
 
     // Register contract via governance
     await _lib.registerContract(governance, governanceRegKey, governance.address, guardianAddress)

--- a/eth-contracts/migrations/3_governance_migration.js
+++ b/eth-contracts/migrations/3_governance_migration.js
@@ -19,6 +19,7 @@ const VotingQuorumPercent = 10
 const MaxInProgressProposals = 100
 
 const MaxDescriptionLengthBytes = 250
+const MaxNameLengthBytes = 250
 
 // 24hr * 60min/hr * 60sec/min / ~13 sec/block = 6646 blocks
 const ExecutionDelayBlocks = 6646
@@ -38,8 +39,26 @@ module.exports = (deployer, network, accounts) => {
     const governance0 = await deployer.deploy(Governance, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registryAddress, VotingPeriod, ExecutionDelayBlocks, VotingQuorumPercent, MaxInProgressProposals, MaxDescriptionLengthBytes, guardianAddress]
+      [
+        'address',
+        'uint256', 
+        'uint256', 
+        'uint256', 
+        'uint16', 
+        'uint16', 
+        'uint16', 
+        'address'
+      ],
+      [
+        registryAddress,
+        VotingPeriod,
+        ExecutionDelayBlocks,
+        VotingQuorumPercent,
+        MaxInProgressProposals,
+        MaxDescriptionLengthBytes,
+        MaxNameLengthBytes,
+        guardianAddress
+      ]
     )
     const governanceProxy = await deployer.deploy(
       AudiusAdminUpgradeabilityProxy,

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -43,7 +43,7 @@ const Vote = Object.freeze({
   Yes: 2
 })
 
-contract('Governance.sol', async (accounts) => {
+contract.only('Governance.sol', async (accounts) => {
   let token, registry, staking, stakingProxy, serviceProviderFactory
   let claimsManager, delegateManager, governance, registry0, registryProxy, token0, tokenProxy
 

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -714,7 +714,7 @@ contract('Governance.sol', async (accounts) => {
         )
       )
 
-      // Successfully submit with name
+      // Successfully submit with non-empty name
       const txReceipt = await governance.submitProposal(
         targetContractRegistryKey,
         callValue0,
@@ -754,7 +754,7 @@ contract('Governance.sol', async (accounts) => {
         )
       )
 
-      // Successfully submit with description of correct length
+      // Successfully submit with non-empty description
       const txReceipt = await governance.submitProposal(
         targetContractRegistryKey,
         callValue0,

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -43,7 +43,7 @@ const Vote = Object.freeze({
   Yes: 2
 })
 
-contract('Governance.sol', async (accounts) => {
+contract.only('Governance.sol', async (accounts) => {
   let token, registry, staking, stakingProxy, serviceProviderFactory
   let claimsManager, delegateManager, governance, registry0, registryProxy, token0, tokenProxy
 
@@ -51,6 +51,7 @@ contract('Governance.sol', async (accounts) => {
   const votingQuorumPercent = 10
   const maxInProgressProposals = 20
   const maxDescriptionLength = 250
+  const maxNameLength = 250
   const executionDelay = votingPeriod
   const deployerCutLockupDuration = 11
   const undelegateLockupDuration = votingPeriod + executionDelay + 1
@@ -101,7 +102,8 @@ contract('Governance.sol', async (accounts) => {
       votingQuorumPercent,
       guardianAddress,
       maxInProgressProposals,
-      maxDescriptionLength
+      maxDescriptionLength,
+      maxNameLength
     )
     await registry.addContract(governanceKey, governance.address, { from: proxyDeployerAddress })
 
@@ -318,12 +320,14 @@ contract('Governance.sol', async (accounts) => {
     const governance0 = await Governance.new({ from: proxyDeployerAddress })
     const newMaxInProgressProposals = 100
     const maxDescriptionLength = 100
+    const maxNameLength = maxDescriptionLength
+    const initializeArgumentTypesArray = ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'uint16', 'address']
     
     // Requires non-zero _registryAddress
     let governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [0x0, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, proxyDeployerAddress]
+      initializeArgumentTypesArray,
+      [0x0, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, maxNameLength, proxyDeployerAddress]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -331,15 +335,14 @@ contract('Governance.sol', async (accounts) => {
         proxyAdminAddress,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      'revert'
+      )
     )
 
     // Requires non-zero _votingPeriod
     governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registry.address, 0, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, proxyDeployerAddress]
+      initializeArgumentTypesArray,
+      [registry.address, 0, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, maxNameLength, proxyDeployerAddress]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -347,15 +350,14 @@ contract('Governance.sol', async (accounts) => {
         governance.address,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      "revert"
+      )
     )
 
     // Requires non-zero _votingQuorumPercent
     governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registry.address, votingPeriod, executionDelay, 0, newMaxInProgressProposals, maxDescriptionLength, proxyDeployerAddress]
+      initializeArgumentTypesArray,
+      [registry.address, votingPeriod, executionDelay, 0, newMaxInProgressProposals, maxDescriptionLength, maxNameLength, proxyDeployerAddress]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -363,15 +365,14 @@ contract('Governance.sol', async (accounts) => {
         governance.address,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      "revert"
+      )
     )
 
     // Requires non-zero _guardianAddress
     governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, _lib.addressZero]
+      initializeArgumentTypesArray,
+      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, maxNameLength, _lib.addressZero]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -379,15 +380,14 @@ contract('Governance.sol', async (accounts) => {
         governance.address,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      "revert"
+      )
     )
 
     // Requires non-zero _maxInProgressProposals
     governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, 0, maxDescriptionLength, proxyDeployerAddress]
+      initializeArgumentTypesArray,
+      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, 0, maxDescriptionLength, maxNameLength, proxyDeployerAddress]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -395,15 +395,14 @@ contract('Governance.sol', async (accounts) => {
         governance.address,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      "revert"
+      )
     )
 
     // Requires non-zero _maxDescriptionLength
     governanceCallData = _lib.encodeCall(
       'initialize',
-      ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, 0, proxyDeployerAddress]
+      initializeArgumentTypesArray,
+      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, 0, maxNameLength, proxyDeployerAddress]
     )
     await _lib.assertRevert(
       AudiusAdminUpgradeabilityProxy.new(
@@ -411,8 +410,22 @@ contract('Governance.sol', async (accounts) => {
         governance.address,
         governanceCallData,
         { from: proxyDeployerAddress }
-      ),
-      "revert"
+      )
+    )
+
+    // Requires non-zero _maxNameLength
+    governanceCallData = _lib.encodeCall(
+      'initialize',
+      initializeArgumentTypesArray,
+      [registry.address, votingPeriod, executionDelay, votingQuorumPercent, newMaxInProgressProposals, maxDescriptionLength, 0, proxyDeployerAddress]
+    )
+    await _lib.assertRevert(
+      AudiusAdminUpgradeabilityProxy.new(
+        governance0.address,
+        governance.address,
+        governanceCallData,
+        { from: proxyDeployerAddress }
+      )
     )
   })
 
@@ -711,6 +724,60 @@ contract('Governance.sol', async (accounts) => {
         ),
         "Number of InProgress proposals already at max. Please evaluate if possible, or wait for current proposals' votingPeriods to expire."
       )
+    })
+
+    it('Proposal name', async () => {
+      const proposerAddress = accounts[10]
+      const slashAmount = _lib.toBN(1)
+      const targetAddress = accounts[11]
+      const targetContractRegistryKey = delegateManagerKey
+      const signature = 'slash(uint256,address)'
+      const callData = _lib.abiEncode(['uint256', 'address'], [slashAmount.toNumber(), targetAddress])
+
+      const nameTooShort = ""
+      const nameTooLong = "-".repeat(maxDescriptionLength + 10)
+      const nameCorrect = proposalName
+
+      // Fail to submit with empty description
+      await _lib.assertRevert(
+        governance.submitProposal(
+          targetContractRegistryKey,
+          callValue0,
+          signature,
+          callData,
+          nameTooShort,
+          proposalDescription,
+          { from: proposerAddress }
+        )
+      )
+
+      // Fail to submit with too long description
+      await _lib.assertRevert(
+        governance.submitProposal(
+          targetContractRegistryKey,
+          callValue0,
+          signature,
+          callData,
+          nameTooLong,
+          proposalDescription,
+          { from: proposerAddress }
+        )
+      )
+
+      // Successfully submit with description of correct length
+      const txReceipt = await governance.submitProposal(
+        targetContractRegistryKey,
+        callValue0,
+        signature,
+        callData,
+        nameCorrect,
+        proposalDescription,
+        { from: proposerAddress }
+      )
+      const tx = _lib.parseTx(txReceipt)
+
+      // Confirm description value in event log
+      assert.equal(tx.event.args.name, nameCorrect, "Expected same event.args.name")
     })
 
     it('Proposal description', async () => {

--- a/eth-contracts/test/governance.test.js
+++ b/eth-contracts/test/governance.test.js
@@ -43,7 +43,7 @@ const Vote = Object.freeze({
   Yes: 2
 })
 
-contract.only('Governance.sol', async (accounts) => {
+contract('Governance.sol', async (accounts) => {
   let token, registry, staking, stakingProxy, serviceProviderFactory
   let claimsManager, delegateManager, governance, registry0, registryProxy, token0, tokenProxy
 

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -233,9 +233,7 @@ export const deployGovernance = async (
   executionDelay,
   votingQuorum,
   guardianAddress,
-  maxInProgressProposals = 20,
-  maxDescriptionLength = 250,
-  maxNameLength = 250
+  maxInProgressProposals = 20
 ) => {
   const Governance = artifacts.require('Governance')
   const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
@@ -243,8 +241,8 @@ export const deployGovernance = async (
   const governance0 = await Governance.new({ from: proxyDeployerAddress })
   const governanceInitializeData = encodeCall(
     'initialize',
-    ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'uint16', 'address'],
-    [registry.address, votingPeriod, executionDelay, votingQuorum, maxInProgressProposals, maxDescriptionLength, maxNameLength, guardianAddress]
+    ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'address'],
+    [registry.address, votingPeriod, executionDelay, votingQuorum, maxInProgressProposals, guardianAddress]
   )
   // Initialize proxy with zero address
   const governanceProxy = await AudiusAdminUpgradeabilityProxy.new(

--- a/eth-contracts/utils/lib.js
+++ b/eth-contracts/utils/lib.js
@@ -234,7 +234,8 @@ export const deployGovernance = async (
   votingQuorum,
   guardianAddress,
   maxInProgressProposals = 20,
-  maxDescriptionLength = 250
+  maxDescriptionLength = 250,
+  maxNameLength = 250
 ) => {
   const Governance = artifacts.require('Governance')
   const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
@@ -242,8 +243,8 @@ export const deployGovernance = async (
   const governance0 = await Governance.new({ from: proxyDeployerAddress })
   const governanceInitializeData = encodeCall(
     'initialize',
-    ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'address'],
-    [registry.address, votingPeriod, executionDelay, votingQuorum, maxInProgressProposals, maxDescriptionLength, guardianAddress]
+    ['address', 'uint256', 'uint256', 'uint256', 'uint16', 'uint16', 'uint16', 'address'],
+    [registry.address, votingPeriod, executionDelay, votingQuorum, maxInProgressProposals, maxDescriptionLength, maxNameLength, guardianAddress]
   )
   // Initialize proxy with zero address
   const governanceProxy = await AudiusAdminUpgradeabilityProxy.new(


### PR DESCRIPTION
### Trello Card Link


### Description
Add new proposal name field to governance proposals, remove storage of description and name in struct

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [x] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches eth-contracts


### How Has This Been Tested?

Significant unit test updates added