### PR TITLE
Fix disc prov reselection if initial disc prov becomes unhealthy

### DIFF
--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -105,7 +105,7 @@ class ServiceSelection {
     // If there are no services left to try, either pick a backup or return null
     if (filteredServices.length === 0) {
       this.decisionTree.push({ stage: 'No Services Left To Try' })
-      if (Object.keys(this.backups).length > 0) {
+      if (this.getBackupsSize() > 0) {
         // Some backup exists
         const backup = this.selectFromBackups()
         this.decisionTree.push({ stage: 'Selected From Backup', val: backup })
@@ -113,7 +113,7 @@ class ServiceSelection {
       } else {
         // Nothing could be found that was healthy.
         // Reset everything we know so that we might try again.
-        this.unhealthy = []
+        this.unhealthy = new Set([])
         this.backups = {}
         this.decisionTree.push({ stage: 'Failed Everything. Resetting.' })
         return null
@@ -278,12 +278,20 @@ class ServiceSelection {
     this.backups[service] = response
   }
 
+  removeBackup (service) {
+    delete this.backups[service]
+  }
+
   /**
    * Controls how a backup is picked. Overriding methods may choose to use the backup's response.
    * e.g. pick a backup that's the fewest versions behind
    */
   async selectFromBackups () {
     return Object.keys(this.backups)[0]
+  }
+
+  getBackupsSize () {
+    return Object.keys(this.backups).length
   }
 }
 

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -278,10 +278,6 @@ class ServiceSelection {
     this.backups[service] = response
   }
 
-  removeBackup (service) {
-    delete this.backups[service]
-  }
-
   /**
    * Controls how a backup is picked. Overriding methods may choose to use the backup's response.
    * e.g. pick a backup that's the fewest versions behind
@@ -290,6 +286,9 @@ class ServiceSelection {
     return Object.keys(this.backups)[0]
   }
 
+  /**
+   * Returns the size of backups
+   */
   getBackupsSize () {
     return Object.keys(this.backups).length
   }

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -2,6 +2,9 @@ const nock = require('nock')
 const assert = require('assert')
 const semver = require('semver')
 const DiscoveryProviderSelection = require('./DiscoveryProviderSelection')
+const DiscoveryProvider = require('.')
+const helpers = require('../../../tests/helpers')
+let audiusInstance = helpers.audiusInstance
 
 const mockEthContracts = (urls, currrentVersion, previousVersions = null) => ({
   getCurrentVersion: async () => currrentVersion,
@@ -18,6 +21,9 @@ const mockEthContracts = (urls, currrentVersion, previousVersions = null) => ({
       semver.major(version1) === semver.major(version2) &&
       semver.minor(version1) === semver.minor(version2)
     )
+  },
+  isInRegressedMode: () => {
+    return false
   }
 })
 
@@ -29,6 +35,7 @@ describe('DiscoveryProviderSelection', () => {
   })
   afterEach(() => {
     nock.cleanAll()
+    audiusInstance = helpers.audiusInstance // reset libs
   })
 
   it('selects a healthy service', async () => {
@@ -407,5 +414,67 @@ describe('DiscoveryProviderSelection', () => {
 
     const sixthService = await s.select()
     assert.strictEqual(sixthService, initiallyUnhealthy)
+  })
+
+  it('will reselect a healthy disc prov if initialized disc prov is unhealthy', async () => {
+    const LocalStorage = require('node-localstorage').LocalStorage
+    const localStorage = new LocalStorage('./local-storage')
+
+    // Make healthyThenUnhealthy respond with 200 initially
+    const healthyThenUnhealthy = 'https://healthyThenUnhealthy.audius.co'
+    const healthyThenUnhealthyInterceptor = nock(healthyThenUnhealthy)
+      .persist()
+      .get(uri => true) // hitting any route will respond with 200
+      .reply(200, { data: {
+        service: 'discovery-provider',
+        version: '1.2.3',
+        block_difference: 0
+      } })
+
+    const healthy = 'https://healthy.audius.co'
+    nock(healthy)
+      .persist()
+      .get(uri => true)
+      .delay(100)
+      .reply(200, { data: {
+        service: 'discovery-provider',
+        version: '1.2.3',
+        block_difference: 0
+      } })
+
+    // Initialize libs and then set disc prov instance with eth contracts mock
+    await audiusInstance.init()
+    localStorage.removeItem('@audius/libs:discovery-provider-timestamp')
+    const mockDP = new DiscoveryProvider(
+      null, // whitelist
+      audiusInstance.userStateManager,
+      mockEthContracts([healthyThenUnhealthy, healthy], '1.2.3'),
+      audiusInstance.web3Manager,
+      null, // reselectTimeout
+      null // selectionCallback
+    )
+    await mockDP.init()
+    audiusInstance.discoveryProvider = mockDP
+
+    // Check that healthyThenUnhealthy was chosen and set in local stoarge
+    const discProvLocalStorageData1 = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+    assert.strictEqual(audiusInstance.discoveryProvider.discoveryProviderEndpoint, healthyThenUnhealthy)
+    assert.strictEqual(discProvLocalStorageData1.endpoint, healthyThenUnhealthy)
+
+    // Then make healthyThenUnhealthy fail on successive requests
+    // To remove any persistent interceptors: https://stackoverflow.com/a/59885361
+    nock.removeInterceptor(healthyThenUnhealthyInterceptor.interceptors[0])
+    nock(healthyThenUnhealthy)
+      .persist()
+      .get(uri => true)
+      .reply(500, { unhealthy: true })
+
+    // Make a libs request to disc prov; should use healthy
+    await audiusInstance.discoveryProvider.getUsers(1)
+    const discProvLocalStorageData2 = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+
+    // Check that healthy was chosen and set in local stoarge
+    assert.strictEqual(audiusInstance.discoveryProvider.discoveryProviderEndpoint, healthy)
+    assert.strictEqual(discProvLocalStorageData2.endpoint, healthy)
   })
 })

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -416,7 +416,7 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(sixthService, initiallyUnhealthy)
   })
 
-  it('will reselect a healthy disc prov if initialized disc prov is unhealthy', async () => {
+  it('will reselect a healthy disc prov if initialized disc prov becomes unhealthy', async () => {
     const LocalStorage = require('node-localstorage').LocalStorage
     const localStorage = new LocalStorage('./local-storage')
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -484,7 +484,7 @@ class DiscoveryProvider {
         attemptedRetries = 0
       }
     } catch (e) {
-      console.error(e.message)
+      console.error(e)
       return
     }
 
@@ -518,7 +518,7 @@ class DiscoveryProvider {
       ) {
         // If disc prov is an unhealthy num blocks behind,
         console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request...`)
-        this._makeRequest(requestObj, attemptedRetries + 1)
+        return this._makeRequest(requestObj, attemptedRetries + 1)
       }
     }
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -478,8 +478,9 @@ class DiscoveryProvider {
 
       // If new DP endpoint is selected, update disc prov endpoint and reset attemptedRetries count
       if (this.discoveryProviderEndpoint !== newDiscProvEndpoint) {
-        console.info(`Current Discovery Provider endpoint ${this.discoveryProviderEndpoint} is unhealthy. Switching over to
-          the new Discovery Provider endpoint ${newDiscProvEndpoint}!`)
+        let updateDiscProvEndpointMsg = `Current Discovery Provider endpoint ${this.discoveryProviderEndpoint} is unhealthy. `
+        updateDiscProvEndpointMsg += `Switching over to the new Discovery Provider endpoint ${newDiscProvEndpoint}!`
+        console.info(updateDiscProvEndpointMsg)
         this.discoveryProviderEndpoint = newDiscProvEndpoint
         attemptedRetries = 0
       }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -560,7 +560,9 @@ class DiscoveryProvider {
 
     if (urlJoin && urlJoin.default) {
       requestUrl = urlJoin.default(this.discoveryProviderEndpoint, requestObj.endpoint, requestObj.urlParams, { query: requestObj.queryParams })
-    } else { requestUrl = urlJoin(this.discoveryProviderEndpoint, requestObj.endpoint, requestObj.urlParams, { query: requestObj.queryParams }) }
+    } else {
+      requestUrl = urlJoin(this.discoveryProviderEndpoint, requestObj.endpoint, requestObj.urlParams, { query: requestObj.queryParams })
+    }
 
     const headers = {}
     const currentUserId = this.userStateManager.getCurrentUserId()

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -14,7 +14,7 @@ let urlJoin = require('proper-url-join')
 const DiscoveryProviderSelection = require('./DiscoveryProviderSelection')
 if (urlJoin && urlJoin.default) urlJoin = urlJoin.default
 
-const MAX_MAKE_REQUEST_RETRY_COUNT = 20
+const MAX_MAKE_REQUEST_RETRY_COUNT = 5
 
 class DiscoveryProvider {
   constructor (whitelist, userStateManager, ethContracts, web3Manager, reselectTimeout, selectionCallback) {

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -517,7 +517,8 @@ class DiscoveryProvider {
         !indexedBlock ||
         (chainBlock - indexedBlock) > UNHEALTHY_BLOCK_DIFF
       ) {
-        // If disc prov is an unhealthy num blocks behind,
+        // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
+        // hopes it will catch up
         console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request...`)
         return this._makeRequest(requestObj, attemptedRetries + 1)
       }


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/J0Q0JltJ/1581-verify-current-state-of-disc-prov-selection-given-scenarios-and-fix-if-necessary

### Description
If libs initializes with a healthy disc prov, and that specific disc prov becomes unhealthy, the cache short circuits the reselection logic and prevents a new, healthy disc prov from being selected.

This fix is to clear the cache when attempting to reselect a healthy disc prov if the current one is down. 

This PR also includes disc prov selection refactoring to make easier to read.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches **disc prov selection**


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

**Note:** Linking libs with dapp pointing towards staging services **will not work on master. Must checkout a commit prior to `dac9cb31f0a2df9c25083bd3a833d285a4d947ef`** as commits prior to this hash do not contain the new mainnet contracts. For the sake of this task, I also checked out the dapp at a similar timestamp of the protocol hash. 

- New selection logic works with all disc provs as healthy
1. Have libs locally linked with dapp pointing against staging services
2. Create an account and upload a song
3. Check that song is successfully uploaded and is streamable

- New selection logic works with currently selected disc prov as initially healthy, then unhealthy
1. Have libs locally linked with dapp pointing against staging services
2. Block all requests to the selected disc prov staging endpoint (dp3)
3. Create an account and upload a song
4. Initially selected disc prov is unhealthy and attempts max number of retries
5. Max number of retries is attempted
6. Libs reselects a new healthy disc prov (dp2)
7. Check that song is successfully uploaded and is streamable
8. Upload another song
9. Check that song is successfully uploaded and is streamable

Console logs of dapp trying to make requests to initialized disc prov (dp3), then reselecting a new disc prov (dp2)
![Screen Shot 2020-09-25 at 6 34 01 PM](https://user-images.githubusercontent.com/60366641/94327162-0e4a9900-ff5e-11ea-8683-901aba7df402.png)

Console logs of local storage now containing new, healthy disc prov (dp2)
![Screen Shot 2020-09-25 at 6 35 32 PM](https://user-images.githubusercontent.com/60366641/94327224-4225be80-ff5e-11ea-8d44-6bd3f90199c9.png)


Please list the unit test(s) you added to verify your changes.

https://github.com/AudiusProject/audius-protocol/pull/857/files#diff-77a11dab21b7a73c5e4f5d64be231338R419
