### PR TITLE
Add index for track owner id and udpate plays mat view to concurrent

### DIFF
--- a/discovery-provider/alembic/versions/281de8af4b93_add_indexes.py
+++ b/discovery-provider/alembic/versions/281de8af4b93_add_indexes.py
@@ -1,0 +1,41 @@
+"""add indexes
+
+Revision ID: 281de8af4b93
+Revises: ffcb2df7b0ee
+Create Date: 2020-09-28 15:27:40.389787
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '281de8af4b93'
+down_revision = 'ffcb2df7b0ee'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    # Add an index for track owner id on the tracks table
+    op.create_index(op.f('track_owner_id_idx'),
+                'tracks', ['owner_id'], unique=False)
+
+    # Update the index on the aggregate_plays materialized view to be unique for concurrent updates
+    connection = op.get_bind()
+    connection.execute('''
+        DROP INDEX play_item_id_idx;
+        CREATE UNIQUE INDEX play_item_id_idx ON aggregate_plays (play_item_id);
+    ''')
+
+def downgrade():
+    # Drop the index for track owner id
+    op.drop_index(op.f('track_owner_id_idx'),
+                  table_name='tracks')
+    connection = op.get_bind()
+
+    # Update the index on the aggregate_plays materialized view to not be unique
+    connection.execute('''
+        DROP INDEX play_item_id_idx;
+        CREATE INDEX play_item_id_idx ON aggregate_plays (play_item_id);
+    ''')
+

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -293,7 +293,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "update_play_count": {
                 "task": "update_play_count",
-                "schedule": timedelta(seconds=10)
+                "schedule": timedelta(seconds=60)
             },
             "update_metrics": {
                 "task": "update_metrics",

--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -18,7 +18,7 @@ JOB = 'index-plays'
 
 def get_time_diff(previous_time):
     # Returns the time difference in milliseconds
-    return int(time.time() - previous_time * 1000)
+    return int((time.time() - previous_time) * 1000)
 
 # Retrieve the play counts from the identity service
 # NOTE: indexing the plays will eventually be a part of `index_blocks`
@@ -33,8 +33,7 @@ def get_track_plays(self, db):
         most_recent_play_date = session.query(
             Play.updated_at
         ).order_by(
-            desc(Play.updated_at),
-            desc(Play.id)
+            desc(Play.updated_at)
         ).first()
         if most_recent_play_date == None:
             # Make the date way back in the past to get the first play count onwards
@@ -42,6 +41,8 @@ def get_track_plays(self, db):
                 2000, 1, 1, 0, 0).timestamp()
         else:
             most_recent_play_date = most_recent_play_date[0].timestamp()
+
+        job_extra_info['most_recent_play_date'] = get_time_diff(start_time)
 
         # Create and query identity service endpoint for track play counts
         identity_url = update_play_count.shared_config['discprov']['identity_service_url']
@@ -187,7 +188,7 @@ def get_track_plays(self, db):
 
         if plays:
             session.bulk_save_objects(plays)
-            session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+            session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY aggregate_plays")
 
         job_extra_info['number_rows_insert'] = len(plays)
         job_extra_info['insert_refresh_time'] = get_time_diff(

--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -33,7 +33,8 @@ def get_track_plays(self, db):
         most_recent_play_date = session.query(
             Play.updated_at
         ).order_by(
-            desc(Play.updated_at)
+            desc(Play.updated_at),
+            desc(Play.id)
         ).first()
         if most_recent_play_date == None:
             # Make the date way back in the past to get the first play count onwards


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/w1WShtHE/1590-dp-indexes-for-optimizations

### Description
In discovery provider: 
* Update the mat view `aggregate_plays` index on play_item_id to be unique so that the mat view refresh can be called with the `concurrently` option. This should speed it up when there are only a few changes. It should also unblock queries to this mat view. 
* Update a few timing logs in the index_plays job
* Add index for the tracks table owner_id column. This was reduced from ~35 ms to a fraction of a millisecond and is a hot query that takes up a good amount of load. 

I wrote up a [notion doc with some DB insights](https://www.notion.so/audiusproject/DP-Query-Optimizations-4e2ff43d23fc4603a5804166e487f319)

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

I booted a RDS instance using a prod snapshot and ran the DB migrations. From there I tested the queries for speed. 
I ran the DP locally against the snapshot and made several queries for users and tracks to make sure that it was all still working.  

I also ran the system locally and simulated plays to test the change to refresh materialized view concurrently and it worked fine. 
