### PR TITLE
Fix cn logger request id

### DIFF
--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -20,12 +20,11 @@ function requestNotExcludedFromLogging (url) {
   return (excludedRoutes.indexOf(url) === -1)
 }
 
-function getRequestLoggingContext (req) {
+function getRequestLoggingContext (req, requestID) {
   req.startTime = process.hrtime()
-  const requestID = shortid.generate()
   const urlParts = req.url.split('?')
   return {
-    requestID: requestID,
+    requestID,
     requestMethod: req.method,
     requestHostname: req.hostname,
     requestUrl: urlParts[0],
@@ -39,7 +38,7 @@ function loggingMiddleware (req, res, next) {
   const requestID = shortid.generate()
   res.set('CN-Request-ID', requestID)
 
-  req.logContext = getRequestLoggingContext(req)
+  req.logContext = getRequestLoggingContext(req, requestID)
   req.logger = logger.child(req.logContext)
 
   if (requestNotExcludedFromLogging(req.originalUrl)) {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/L8OEi2H3/1591-cn-requestid-shortid-not-matching-client

### Description
The cnode request ID doesn't match the client

### Services
Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
I ran the cnode locally and compared the response header with the log in the creator node
