### PR TITLE
Hotfix discprov genres

### DIFF
--- a/discovery-provider/src/queries/get_top_genre_users.py
+++ b/discovery-provider/src/queries/get_top_genre_users.py
@@ -10,6 +10,8 @@ def get_top_genre_users(args):
     genres = []
     if "genre" in args:
         genres = args.get("genre")
+        if isinstance(genres, str):
+            genres = [genres]
 
     # If the with_users url arg is provided, then populate the user metadata else return user ids
     with_users = args.get("with_users", False)

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -271,10 +271,8 @@ def parse_track_event(
 
     if event_type == track_event_types_lookup["delete_track"]:
         track_record.is_delete = True
-        if not track_record.stem_of:
-            track_record.stem_of = null()
-        if not track_record.remix_of:
-            track_record.remix_of = null()
+        track_record.stem_of = null()
+        track_record.remix_of = null()
         logger.info(f"Removing track : {track_record.track_id}")
 
     track_record.updated_at = block_datetime


### PR DESCRIPTION
### Description
Query is broken because of arg parsing introduced in refactoring queries.py
https://discoveryprovider.audius.co/users/genre/top?genre=Pop&with_users=true

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually ran against prod db, verified query now works