### PR TITLE
[eth-contracts] Slash newSpBalance calculation fix

### DIFF
--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -577,11 +577,17 @@ contract DelegateManager is InitializableV2 {
             spDelegateInfo[_slashAddress].totalDelegatedStake.sub(totalDelegatedStakeDecrease)
         );
 
-        // Recalculate SP direct stake
-        uint256 newSpBalance = (
-          totalBalanceInStakingAfterSlash.mul(totalBalanceInSPFactory)
-        ).div(totalBalanceInStakingPreSlash);
-        spFactory.updateServiceProviderStake(_slashAddress, newSpBalance);
+        // Remaining decrease applied to service provider
+        uint256 totalStakeDecrease = (
+            totalBalanceInStakingPreSlash.sub(totalBalanceInStakingAfterSlash)
+        );
+        uint256 totalSPFactoryBalanceDecrease = (
+            totalStakeDecrease.sub(totalDelegatedStakeDecrease)
+        );
+        spFactory.updateServiceProviderStake(
+            _slashAddress,
+            totalBalanceInSPFactory.sub(totalSPFactoryBalanceDecrease)
+        );
     }
 
     /**

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -2318,7 +2318,7 @@ contract('DelegateManager', async (accounts) => {
         await validateAccountStakeBalance(stakerAccount6)
       })
 
-      it.only('Slashing inconsistency', async () => {
+      it('Slashing inconsistency', async () => {
         const staker3Amt = _lib.toBN('384823535956494802781028')
         const staker4Amt = _lib.toBN('462563700468205107730431')
         const staker5Amt = _lib.toBN('221500000000000000000000')
@@ -2327,7 +2327,6 @@ contract('DelegateManager', async (accounts) => {
         await token.transfer(stakerAccount4, INITIAL_BAL, { from: proxyDeployerAddress })
         await token.transfer(stakerAccount5, INITIAL_BAL, { from: proxyDeployerAddress })
         await token.transfer(stakerAccount6, INITIAL_BAL, { from: proxyDeployerAddress })
-        let totalStakedForAccount = await staking.totalStakedFor(stakerAccount)
         await _lib.registerServiceProvider(
           token,
           staking,
@@ -2378,57 +2377,16 @@ contract('DelegateManager', async (accounts) => {
           delegateAmount,
           { from: stakerAccount2 })
 
-        totalStakedForAccount = await staking.totalStakedFor(stakerAccount)
-        let totalStakedForStaker2 = await staking.totalStakedFor(stakerAccount2) 
-        let sp3Stake = (await serviceProviderFactory.getServiceProviderDetails(stakerAccount3)).deployerStake
-        let sp3DelegatedStake = await delegateManager.getTotalDelegatedToServiceProvider(stakerAccount3)
-        let totalStakedForStaker3 = await staking.totalStakedFor(stakerAccount3) 
-        let totalStakedForStaker4 = await staking.totalStakedFor(stakerAccount4) 
-        let totalStakedForStaker5 = await staking.totalStakedFor(stakerAccount5)
-
-        let sp3StakePreSlash = (await serviceProviderFactory.getServiceProviderDetails(stakerAccount3)).deployerStake
-        let sp3DelegatedStakePreSlash = await delegateManager.getTotalDelegatedToServiceProvider(stakerAccount3)
-        let totalStakedForStaker3PreSlash = await staking.totalStakedFor(stakerAccount3) 
-
-        console.log('preslash', {
-          totalStakedForAccount,
-          totalStakedForStaker2,
-          sp3Stake,
-          sp3DelegatedStake,
-          totalStakedForStaker3,
-          totalStakedForStaker4,
-          totalStakedForStaker5
-        })
-
-        let slashAmount = _lib.toBN('184823535956735802285029')
+        // Perform slash
         await _lib.slash('184823535956735802285029', stakerAccount3, governance, delegateManagerKey, guardianAddress)
 
-        totalStakedForAccount = await staking.totalStakedFor(stakerAccount)
-        totalStakedForStaker2 = await staking.totalStakedFor(stakerAccount2) 
-        sp3Stake = (await serviceProviderFactory.getServiceProviderDetails(stakerAccount3)).deployerStake
-        sp3DelegatedStake = await delegateManager.getTotalDelegatedToServiceProvider(stakerAccount3)
-        totalStakedForStaker3 = await staking.totalStakedFor(stakerAccount3) 
-        totalStakedForStaker4 = await staking.totalStakedFor(stakerAccount4) 
-        totalStakedForStaker5 = await staking.totalStakedFor(stakerAccount5)
-
-        let sp3DelegatedSlashAmount = (sp3DelegatedStakePreSlash.mul(slashAmount)).div(totalStakedForStaker3PreSlash)
-        let sp3DelegateAmountAfterSlash = sp3DelegatedStakePreSlash.sub(sp3DelegatedSlashAmount)
-        
-        let sp3StakedSlashAmount = (sp3StakePreSlash.mul(slashAmount)).div(totalStakedForStaker3PreSlash)
-        let sp3StakeAmountAfterSlash = sp3StakePreSlash.sub(sp3StakedSlashAmount)
-        
-
-        console.log('after slash 1', {
-          totalStakedForAccount,
-          totalStakedForStaker2,
-          sp3Stake,
-          sp3DelegatedStake,
-          totalStakedForStaker3,
-          totalStakedForStaker4,
-          totalStakedForStaker5
-        })
-        assert.isTrue(sp3DelegateAmountAfterSlash.eq(sp3DelegatedStake), `Delegate amount after slash: ${sp3DelegatedStake} not equal to expected amount: ${sp3DelegateAmountAfterSlash}`)
-        assert.isTrue(sp3StakeAmountAfterSlash.eq(sp3Stake), `Staked amount after slash: ${sp3StakeAmountAfterSlash} not equal to expected amount: ${sp3Stake}`)
+        // Validate all accounts
+        await validateAccountStakeBalance(stakerAccount)
+        await validateAccountStakeBalance(stakerAccount2)
+        await validateAccountStakeBalance(stakerAccount3)
+        await validateAccountStakeBalance(stakerAccount4)
+        await validateAccountStakeBalance(stakerAccount5)
+        await validateAccountStakeBalance(stakerAccount6)
       })
 
       it('Decrease in reward for pending stake decrease', async () => {


### PR DESCRIPTION
### Description
Fixes imbalance issue from slash path, similar to other fix here (https://github.com/AudiusProject/audius-protocol/pull/826)

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [x] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches CONTRACTS
- ✅ Nope


### How Has This Been Tested

Please list the unit test(s) you added to verify your changes.

1. Repro'd using same state as claim imbalance test from pr linked above - test confirms fix is working as expected