### PR TITLE
[eth-contracts] Enable zero claim operation, Add slash in random test

### DIFF
--- a/eth-contracts/contracts/ClaimsManager.sol
+++ b/eth-contracts/contracts/ClaimsManager.sol
@@ -348,12 +348,12 @@ contract ClaimsManager is InitializableV2 {
 
         // Once they claim the zero reward amount, stake can be modified once again
         // Subtract total locked amount for SP from stake at fund block
-        uint256 claimerTotalStake = totalStakedAtFundBlockForClaimer.sub(_totalLockedForSP);
+        uint256 totalActiveClaimerStake = totalStakedAtFundBlockForClaimer.sub(_totalLockedForSP);
         uint256 totalStakedAtFundBlock = stakingContract.totalStakedAt(currentRound.fundedBlock);
 
         // Calculate claimer rewards
         uint256 rewardsForClaimer = (
-          claimerTotalStake.mul(fundingAmount)
+          totalActiveClaimerStake.mul(fundingAmount)
         ).div(totalStakedAtFundBlock);
 
         // For a claimer violating bounds, no new tokens are minted
@@ -365,7 +365,7 @@ contract ClaimsManager is InitializableV2 {
                 _claimer,
                 0,
                 totalStakedAtFundBlockForClaimer,
-                claimerTotalStake
+                totalActiveClaimerStake
             );
             return 0;
         }

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -1030,12 +1030,6 @@ contract DelegateManager is InitializableV2 {
             ,,,
         ) = spFactory.getServiceProviderDetails(_serviceProvider);
         // Require active stake to claim any rewards
-        /*
-        require(
-            totalBalanceInSPFactory.sub(spLockedStake) > 0,
-            "DelegateManager: Service Provider stake required"
-        );
-        */
 
         // Amount in delegate manager staked to service provider
         uint256 totalBalanceOutsideStaking = (

--- a/eth-contracts/contracts/DelegateManager.sol
+++ b/eth-contracts/contracts/DelegateManager.sol
@@ -1022,7 +1022,6 @@ contract DelegateManager is InitializableV2 {
 
         // Amount stored in staking contract for owner
         totalBalanceInStaking = Staking(stakingAddress).totalStakedFor(_serviceProvider);
-        require(totalBalanceInStaking > 0, "DelegateManager: Stake required for claim");
 
         // Amount in sp factory for claimer
         (
@@ -1031,10 +1030,12 @@ contract DelegateManager is InitializableV2 {
             ,,,
         ) = spFactory.getServiceProviderDetails(_serviceProvider);
         // Require active stake to claim any rewards
+        /*
         require(
             totalBalanceInSPFactory.sub(spLockedStake) > 0,
             "DelegateManager: Service Provider stake required"
         );
+        */
 
         // Amount in delegate manager staked to service provider
         uint256 totalBalanceOutsideStaking = (

--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -405,9 +405,8 @@ contract ServiceProviderFactory is InitializableV2 {
             spDetails[msg.sender].numberOfEndpoints > 0,
             "ServiceProviderFactory: Registered endpoint required to increase stake"
         );
-        // Prevent increases in stake unless 
         require(
-            !_claimPending(msg.sender) || spDetails[msg.sender].validBounds == false,
+            !_claimPending(msg.sender),
             "ServiceProviderFactory: No claim expected to be pending prior to stake transfer"
         );
 

--- a/eth-contracts/contracts/ServiceProviderFactory.sol
+++ b/eth-contracts/contracts/ServiceProviderFactory.sol
@@ -405,8 +405,9 @@ contract ServiceProviderFactory is InitializableV2 {
             spDetails[msg.sender].numberOfEndpoints > 0,
             "ServiceProviderFactory: Registered endpoint required to increase stake"
         );
+        // Prevent increases in stake unless 
         require(
-            !_claimPending(msg.sender),
+            !_claimPending(msg.sender) || spDetails[msg.sender].validBounds == false,
             "ServiceProviderFactory: No claim expected to be pending prior to stake transfer"
         );
 

--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -2434,8 +2434,8 @@ contract('DelegateManager', async (accounts) => {
       })
 
       it('Slash cancels pending undelegate request', async () => {
-        // Initiate lockup of all 
-        await serviceProviderFactory.requestDecreaseStake(DEFAULT_AMOUNT, { from: stakerAccount })
+        // Lock 1/2 stake
+        await serviceProviderFactory.requestDecreaseStake(DEFAULT_AMOUNT.div(_lib.toBN(2)), { from: stakerAccount })
         let requestInfo = await serviceProviderFactory.getPendingDecreaseStakeRequest(stakerAccount)
         assert.isTrue((requestInfo.lockupExpiryBlock).gt(_lib.toBN(0)), 'Expected lockup expiry block to be set')
         assert.isTrue((requestInfo.amount).gt(_lib.toBN(0)), 'Expected amount to be set')

--- a/eth-contracts/test/random/random.test.js
+++ b/eth-contracts/test/random/random.test.js
@@ -12,6 +12,7 @@ const AudiusToken = artifacts.require('AudiusToken')
 
 const serviceTypeCN = web3.utils.utf8ToHex('creator-node')
 const serviceTypeDP = web3.utils.utf8ToHex('discovery-provider')
+const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
 
 contract('Random testing', async (accounts) => {
     let token, staking, serviceTypeManager, serviceProviderFactory
@@ -25,18 +26,22 @@ contract('Random testing', async (accounts) => {
     let totalClaimedRewards = _lib.toBN(0)
     let totalDeployerStaked = _lib.toBN(0)
     let totalDelegatedAmount = _lib.toBN(0)
+    let totalSlashedAmount = _lib.toBN(0)
     let numDelegateOperations = _lib.toBN(0)
     let numRemoveDelegatorOps = _lib.toBN(0)
     let numDecreaseStakeOperations = _lib.toBN(0)
+    let numSlashOperations = _lib.toBN(0)
 
     const printTestSummary = () => {
         console.log(`\n------------------------ AUDIUS RANDOM TESTING Summary ------------------------`)
         console.log(`totalClaimedRewards: ${totalClaimedRewards}                | Total claimed through protocol rewards`)
         console.log(`totalDeployerStaked: ${totalDeployerStaked}                | Total staked directly deployers`)
         console.log(`totalDelegatedAmount: ${totalDelegatedAmount}              | Total delegated `)
+        console.log(`totalSlashedAmount: ${totalSlashedAmount}                  | Total slashed value `)
         console.log(`numDelegateOperations: ${numDelegateOperations}            | Number of delegate operations`)
         console.log(`numDecreaseStakeOperations: ${numDecreaseStakeOperations}  | Number of successfully evaluated decrease stake operations`)
         console.log(`numRemoveDelegatorOps: ${numRemoveDelegatorOps}            | Number of remove delegator operations`)
+        console.log(`numSlashOperations: ${numSlashOperations}                  | Number of slash operations`)
     }
 
     // proxyDeployerAddress is used to transfer tokens to service accounts as needed
@@ -49,12 +54,10 @@ contract('Random testing', async (accounts) => {
     const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
     const userOffset = 25 
 
-    // const numUsers = 1
-    const numUsers = 15
+    const numUsers = 3// 15
     const minNumServicesPerUser = 1
     const maxNumServicesPerUser = 2 // TODO: CONSUME THIS
 
-    // const numRounds = 15
     const FundingRoundBlockDiffForTest = 200
     const VotingPeriod = 10 
     const ExecutionDelayBlocks = 10
@@ -63,7 +66,8 @@ contract('Random testing', async (accounts) => {
     const RemoveDelegatorLockupDuration = 21
     const DeployerCutLockupDuration = FundingRoundBlockDiffForTest + 1
     const SystemUser = "system"
-    const TestDuration = 3600000
+    // const TestDuration = 3600000
+    const TestDuration = 36000
 
     // TODO: Add non-SP delegators after everything else
     beforeEach(async () => {
@@ -175,21 +179,21 @@ contract('Random testing', async (accounts) => {
         return Math.floor(Math.random() * (max - min) + min)
     }
 
+    const fromWei = (bn) => {
+        return web3.utils.fromWei(bn.toString(), 'ether')
+    }
+
     // Convert from wei -> eth to generate a random number
     // Helper converts back to wei prior to returning 
     const randAmount = (min, max) => {
-        let minNum = fromWei(min)
-        let maxNum = fromWei(max)
+        let minNum = parseInt(fromWei(min))
+        let maxNum = parseInt(fromWei(max))
         let randNum = rand(minNum, maxNum)
         return _lib.toBN(web3.utils.toWei(randNum.toString(), 'ether'))
     }
 
     const makeDummyEndpoint = (user, type) => {
         return `https://${user}-${type}:${rand(0, 10000000000)}`
-    }
-
-    const fromWei = (bn) => {
-        return web3.utils.fromWei(bn.toString(), 'ether')
     }
 
     const testLog = (user, msg) => {
@@ -327,6 +331,35 @@ contract('Random testing', async (accounts) => {
         } catch (e) {
             testLog(delegator, `Error delegating ${amount} from ${delegator} to ${serviceProvider}. ${e}`)
         }
+    }
+
+    const randomlySlash = async () => {
+        let randSlashTarget = users[Math.floor(Math.random()*users.length)] 
+        let targetInfo = await getAccountStakeInfo(randSlashTarget)
+        let totalStakeForSlashTarget = targetInfo.totalInStakingContract 
+        // dice roll to slash ALL or portion
+        // 20% chance of slashing ALL stake
+        let shouldSlashAll = rand(0, 100) > 80
+        let slashAmount
+        sysLog(`Random slash ${randSlashTarget} has ${totalStakeForSlashTarget} tokens, shouldSlashAll=${shouldSlashAll}`)
+        shouldSlashAll = true // tmp
+        if (shouldSlashAll) {
+            slashAmount = totalStakeForSlashTarget
+        } else {
+            // Slash between 1/10 and 1/2 of stake
+            slashAmount = randAmount(totalStakeForSlashTarget.div(_lib.toBN(10)), totalStakeForSlashTarget.div(_lib.toBN(2)))
+        }
+        sysLog(`Randomly slashing ${randSlashTarget} ${slashAmount} tokens`)
+        await _lib.slash(
+            slashAmount.toString(),
+            randSlashTarget,
+            governance,
+            delegateManagerKey,
+            guardianAddress
+        )
+        numSlashOperations = numSlashOperations.add(_lib.toBN(1))
+        totalSlashedAmount = totalSlashedAmount.add(slashAmount)
+        sysLog(`Randomly slashed ${randSlashTarget} ${slashAmount}`)
     }
 
     const randomlyDelegate = async (user) => {
@@ -526,11 +559,24 @@ outside=${info.outsideStake.toString()}=(deployerStake=${info.spDetails.deployer
                 async (user) => {
                     let preClaimInfo = await getAccountStakeInfo(user)
                     let totalForUserAtFundBlock = await staking.totalStakedForAt(user, lastFundedBlock)
-                    let tx = await delegateManager.claimRewards(user, { from: user })
-                    let postClaimInfo = await getAccountStakeInfo(user)
-                    let rewards = postClaimInfo.totalInStakingContract.sub(preClaimInfo.totalInStakingContract)
-                    testLog(user, `Claimed ${rewards}, totalForUserAtFundBlock=${totalForUserAtFundBlock} - validBounds==${preClaimInfo.spDetails.validBounds}`)
-                    totalClaimedRewards = totalClaimedRewards.add(rewards)
+                    try {
+                        let tx = await delegateManager.claimRewards(user, { from: user })
+                        let postClaimInfo = await getAccountStakeInfo(user)
+                        let rewards = postClaimInfo.totalInStakingContract.sub(preClaimInfo.totalInStakingContract)
+                        testLog(user, `Claimed ${rewards}, totalForUserAtFundBlock=${totalForUserAtFundBlock} - validBounds==${preClaimInfo.spDetails.validBounds}`)
+                        totalClaimedRewards = totalClaimedRewards.add(rewards)
+                    } catch(e) {
+                        if (e.message.search('Stake required for claim')) {
+                            // This user has been slashed
+                            let minRequiredStake = preClaimInfo.spDetails.minAccountStake
+                            await token.transfer(user, minRequiredStake, { from: proxyDeployerAddress })
+                            await token.approve(staking.address, minRequiredStake, { from: user })
+                            await serviceProviderFactory.increaseStake(minRequiredStake, { from: user })
+                            testLog(user, `Increased stake to ${minRequiredStake} after failed claim operation`)
+                        } else {
+                            throw e
+                        }
+                    }
                 }
             )
         )
@@ -608,6 +654,9 @@ outside=${info.outsideStake.toString()}=(deployerStake=${info.spDetails.deployer
 
             // TODO: Randomize from which acct the round is initiated
             await initiateRound(users[0])
+
+            await randomlySlash()
+
             await randomlyAdvanceBlocks()
             await claimPendingRewards(users)
             await randomlyAdvanceBlocks()

--- a/eth-contracts/test/random/random.test.js
+++ b/eth-contracts/test/random/random.test.js
@@ -66,7 +66,7 @@ contract('Random testing', async (accounts) => {
     const RemoveDelegatorLockupDuration = 21
     const DeployerCutLockupDuration = FundingRoundBlockDiffForTest + 1
     const SystemUser = "system"
-    const TestDuration = 3600000
+    const TestDuration = 7200000
 
     // TODO: Add non-SP delegators after everything else
     beforeEach(async () => {

--- a/eth-contracts/test/random/random.test.js
+++ b/eth-contracts/test/random/random.test.js
@@ -333,10 +333,10 @@ contract('Random testing', async (accounts) => {
     }
 
     const randomlySlash = async () => {
-        let slashPercent = 30
+        let slashPercent = 50
         let slashDiceRoll = rand(0, 100)
         let shouldSlash = slashDiceRoll < slashPercent
-        sysLog(`Slash rolled ${slashDiceRoll}, max-${slashPercent}%`)
+        sysLog(`Slash rolled ${slashDiceRoll}, probability=${slashPercent}%, shouldSlash=${shouldSlash}`)
         if (!shouldSlash) return
 
         let randSlashTarget = users[Math.floor(Math.random()*users.length)] 

--- a/eth-contracts/test/random/random.test.js
+++ b/eth-contracts/test/random/random.test.js
@@ -66,8 +66,7 @@ contract('Random testing', async (accounts) => {
     const RemoveDelegatorLockupDuration = 21
     const DeployerCutLockupDuration = FundingRoundBlockDiffForTest + 1
     const SystemUser = "system"
-    // const TestDuration = 3600000
-    const TestDuration = 36000
+    const TestDuration = 3600000
 
     // TODO: Add non-SP delegators after everything else
     beforeEach(async () => {
@@ -337,7 +336,7 @@ contract('Random testing', async (accounts) => {
         let slashPercent = 30
         let slashDiceRoll = rand(0, 100)
         let shouldSlash = slashDiceRoll < slashPercent
-        sysLog(`Slash rolled ${slashDiceRoll}, min required ${slashPercent}%`)
+        sysLog(`Slash rolled ${slashDiceRoll}, max-${slashPercent}%`)
         if (!shouldSlash) return
 
         let randSlashTarget = users[Math.floor(Math.random()*users.length)] 


### PR DESCRIPTION
### Description
While adding slash in random test, came across a specific scenario where a user slashed to zero is unable to rectify their state - this is mitigated by enabling zero reward claims for users with >1 endpoint and 0 stake.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [x] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

Unit tests have been updated, random test currently running - will post in this PR when completed.