### PR TITLE
Add nodesync export and sync integration tests

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -383,7 +383,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
           walletPublicKey: fetchedWalletPublicKey,
           latestBlockNumber: fetchedLatestBlockNumber,
           lastLogin: fetchedCNodeUser.lastLogin,
-          clock: fetchedCNodeUser.clock
+          clock: fetchedCNodeUser.clock,
+          createdAt: fetchedCNodeUser.createdAt
         }, { transaction })
         req.logger.info(redisKey, `Inserted nodeUser for cnodeUserUUID ${fetchedCnodeUserUUID}`)
 

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -10,17 +10,13 @@ const { createStarterCNodeUser } = require('./lib/dataSeeds')
 const { getApp } = require('./lib/app')
 const { getIPFSMock } = require('./lib/ipfsMock')
 const { getLibsMock } = require('./lib/libsMock')
+const { getCNodeUser, destroyUsers } = require('./utils')
 
 describe('Test createNewDataRecord()', () => {
   const req = {
     logger: {
       error: (msg) => console.log(msg)
     }
-  }
-
-  const getCNodeUser = async (cnodeUserUUID) => {
-    const cnodeUser = await models.CNodeUser.findOne({ where: { cnodeUserUUID } })
-    return cnodeUser.dataValues
   }
 
   const initialClockVal = 0
@@ -37,12 +33,7 @@ describe('Test createNewDataRecord()', () => {
   /** Reset DB state + Create cnodeUser + confirm initial clock state + define global vars */
   beforeEach(async function () {
     // Wipe all CNodeUsers + dependent data
-    await models.CNodeUser.destroy({
-      where: {},
-      truncate: true,
-      cascade: true // cascades delete to all rows with foreign key on cnodeUser
-    })
-
+    await destroyUsers()
     const resp = await createStarterCNodeUser()
     cnodeUserUUID = resp.cnodeUserUUID
     req.session = { cnodeUserUUID }

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -20,6 +20,7 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
 
   const mockServiceRegistry = {
     ipfs: ipfsMock,
+    ipfsLatest: ipfsMock,
     libs: libsMock,
     blacklistManager: blacklistManager,
     redis: redisClient

--- a/creator-node/test/lib/ipfsMock.js
+++ b/creator-node/test/lib/ipfsMock.js
@@ -1,4 +1,6 @@
 const sinon = require('sinon')
+const { ipfs } = require('../../src/ipfsClient')
+const fs = require('fs')
 
 function getIPFSMock () {
   const ipfsMock = {
@@ -7,10 +9,26 @@ function getIPFSMock () {
     pin: {
       add: sinon.mock(),
       rm: sinon.mock()
-    }
+    },
+    id: sinon.stub(),
+    swarm: {
+      connect: sinon.stub()
+    },
+    bootstrap: {
+      add: sinon.stub()
+    },
+    cat: sinon.stub(),
+    get: sinon.stub()
   }
   ipfsMock.add.returns([{ hash: 'testCIDLink' }])
   ipfsMock.addFromFs.returns([{ hash: 'testCIDLink' }])
+  ipfsMock.id.returns({
+    addresses: ['/ip4/127.0.0.1/tcp/4001/ipfs/QmPjSNZPCTmQsKAUM7QDjAzymcbxaVVbRcV5pZvBRMZmca']
+  })
+  ipfsMock.swarm.connect.returns({ Strings: ["test-res"]})
+  ipfsMock.bootstrap.add.returns("")
+  ipfsMock.cat.throws()
+  ipfsMock.get.throws()
 
   return ipfsMock
 }

--- a/creator-node/test/lib/ipfsMock.js
+++ b/creator-node/test/lib/ipfsMock.js
@@ -1,6 +1,4 @@
 const sinon = require('sinon')
-const { ipfs } = require('../../src/ipfsClient')
-const fs = require('fs')
 
 function getIPFSMock () {
   const ipfsMock = {
@@ -25,8 +23,8 @@ function getIPFSMock () {
   ipfsMock.id.returns({
     addresses: ['/ip4/127.0.0.1/tcp/4001/ipfs/QmPjSNZPCTmQsKAUM7QDjAzymcbxaVVbRcV5pZvBRMZmca']
   })
-  ipfsMock.swarm.connect.returns({ Strings: ["test-res"]})
-  ipfsMock.bootstrap.add.returns("")
+  ipfsMock.swarm.connect.returns({ Strings: ['test-res'] })
+  ipfsMock.bootstrap.add.returns('')
   ipfsMock.cat.throws()
   ipfsMock.get.throws()
 

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -17,7 +17,8 @@ function getLibsMock () {
   }
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderIdFromAddress.returns('1')
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderInfo.returns({ 'endpoint': 'http://localhost:5000' })
-  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://localhost:5000', 'blocknumber': 10, 'track_blocknumber': 10 }])
+  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://localhost:5000', 'blocknumber': 10, 'track_blocknumber': 10 }]).atMo
+  libsMock.User.getUsers.atMost(10)
 
   return libsMock
 }

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -17,7 +17,7 @@ function getLibsMock () {
   }
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderIdFromAddress.returns('1')
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderInfo.returns({ 'endpoint': 'http://localhost:5000' })
-  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://localhost:5000', 'blocknumber': 10, 'track_blocknumber': 10 }]).atMo
+  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://localhost:5000', 'blocknumber': 10, 'track_blocknumber': 10 }])
   libsMock.User.getUsers.atMost(10)
 
   return libsMock

--- a/creator-node/test/nodesync.test.js
+++ b/creator-node/test/nodesync.test.js
@@ -17,335 +17,332 @@ const config = require('../src/config')
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 const sampleExportPath = path.resolve(__dirname, 'syncAssets/sampleExport.json')
 
-let server, app, ipfs
-
 describe('test nodesync', function () {
-  this.timeout(3000000)
+  let server, app
 
-  beforeEach(async function () {
+  afterEach(async function () {
     await destroyUsers()
-  })
-
-  after(async function () {
-    // await destroyUsers()
     await server.close()
   })
 
-  it('test /export', async function () {
-    // SETUP
+  describe('test export', function () {
+    beforeEach(async function () {
+      const ipfs = ipfsClient.ipfs
+      const libsMock = getLibsMock()
+      const appInfo = await getApp(ipfs, libsMock, blacklistManager)
+      server = appInfo.server
+      app = appInfo.app
+    })
 
-    ipfs = ipfsClient.ipfs
-    const libsMock = getLibsMock()
-    const appInfo = await getApp(ipfs, libsMock, blacklistManager)
-    server = appInfo.server
-    app = appInfo.app
+    it('should export the correct json blob for db state with a track and user', async function () {
+      // SETUP
 
-    const MAX_CLOCK_VAL = 37
+      const MAX_CLOCK_VAL = 37
 
-    // Create user
-    const { cnodeUserUUID, sessionToken } = await createStarterCNodeUser()
-    await getCNodeUser(cnodeUserUUID)
+      // Create user
+      const { cnodeUserUUID, sessionToken } = await createStarterCNodeUser()
+      await getCNodeUser(cnodeUserUUID)
 
-    // Set user metadata
-    const metadata = {
-      metadata: {
-        testField: 'testValue'
+      // Set user metadata
+      const metadata = {
+        metadata: {
+          testField: 'testValue'
+        }
       }
-    }
-    const { body: { data: { metadataMultihash, metadataFileUUID } } } = await request(app)
-      .post('/audius_users/metadata')
-      .set('X-Session-ID', sessionToken)
-      .send(metadata)
+      const { body: { data: { metadataMultihash, metadataFileUUID } } } = await request(app)
+        .post('/audius_users/metadata')
+        .set('X-Session-ID', sessionToken)
+        .send(metadata)
 
-    const associateRequest = {
-      blockchainUserId: 1,
-      metadataFileUUID,
-      blockNumber: 10
-    }
+      const associateRequest = {
+        blockchainUserId: 1,
+        metadataFileUUID,
+        blockNumber: 10
+      }
 
-    // Associate user with metadata
-    await request(app)
-      .post('/audius_users/')
-      .set('X-Session-ID', sessionToken)
-      .send(associateRequest)
+      // Associate user with metadata
+      await request(app)
+        .post('/audius_users/')
+        .set('X-Session-ID', sessionToken)
+        .send(associateRequest)
 
-    // Upload a track
-    const file = fs.readFileSync(testAudioFilePath)
-    // set track content
-    const { body: { transcodedTrackCID, transcodedTrackUUID, track_segments: trackSegments, source_file: sourceFile } } = await request(app)
-      .post('/track_content')
-      .attach('file', file, { filename: 'fname.mp3' })
-      .set('Content-Type', 'multipart/form-data')
-      .set('X-Session-ID', sessionToken)
+      // Upload a track
+      const file = fs.readFileSync(testAudioFilePath)
+      // set track content
+      const { body: { transcodedTrackCID, transcodedTrackUUID, track_segments: trackSegments, source_file: sourceFile } } = await request(app)
+        .post('/track_content')
+        .attach('file', file, { filename: 'fname.mp3' })
+        .set('Content-Type', 'multipart/form-data')
+        .set('X-Session-ID', sessionToken)
 
-    // set track metadata
-    const trackMetadata = {
-      test: 'field1',
-      owner_id: 1,
-      track_segments: trackSegments
-    }
-    const { body: { metadataMultihash: trackMetadataMultihash, metadataFileUUID: trackMetadataFileUUID } } = await request(app)
-      .post('/tracks/metadata')
-      .set('X-Session-ID', sessionToken)
-      .send({ metadata: trackMetadata, source_file: sourceFile })
-    // associate track metadata with track
-    await request(app)
-      .post('/tracks')
-      .set('X-Session-ID', sessionToken)
-      .send({
-        blockchainTrackId: 1,
-        blockNumber: 10,
-        metadataFileUUID: trackMetadataFileUUID,
-        transcodedTrackUUID
-      })
+      // set track metadata
+      const trackMetadata = {
+        test: 'field1',
+        owner_id: 1,
+        track_segments: trackSegments
+      }
+      const { body: { metadataMultihash: trackMetadataMultihash, metadataFileUUID: trackMetadataFileUUID } } = await request(app)
+        .post('/tracks/metadata')
+        .set('X-Session-ID', sessionToken)
+        .send({ metadata: trackMetadata, source_file: sourceFile })
+      // associate track metadata with track
+      await request(app)
+        .post('/tracks')
+        .set('X-Session-ID', sessionToken)
+        .send({
+          blockchainTrackId: 1,
+          blockNumber: 10,
+          metadataFileUUID: trackMetadataFileUUID,
+          transcodedTrackUUID
+        })
 
-    // Test: export
+      // Test: export
 
-    const { pubKey } = testEthereumConstants
-    const { body: exportBody } = await request(app)
-      .get(`/export?wallet_public_key=${pubKey.toLowerCase()}`)
+      const { pubKey } = testEthereumConstants
+      const { body: exportBody } = await request(app)
+        .get(`/export?wallet_public_key=${pubKey.toLowerCase()}`)
 
-    // Verify
+      // Verify
 
-    // Get user metadata
-    const userMetadataFile = stringifiedDateFields((await models.File.findOne({
-      where: {
-        multihash: metadataMultihash,
-        fileUUID: metadataFileUUID,
-        clock: 1
-      },
-      raw: true
-    })))
-
-    // get transcoded track file
-    const copy320 = stringifiedDateFields((await models.File.findOne({
-      where: {
-        multihash: transcodedTrackCID,
-        fileUUID: transcodedTrackUUID,
-        clock: 3
-      },
-      raw: true
-    })))
-
-    // get segment files
-    const segmentHashes = trackSegments.map(t => t.multihash)
-    const segmentFiles = await Promise.all(segmentHashes.map(async (hash, i) => {
-      const segment = await models.File.findOne({
+      // Get user metadata
+      const userMetadataFile = stringifiedDateFields((await models.File.findOne({
         where: {
-          multihash: hash,
-          clock: i + 4 // starts @ 4 due to user creation + update
+          multihash: metadataMultihash,
+          fileUUID: metadataFileUUID,
+          clock: 1
         },
         raw: true
-      })
-      return stringifiedDateFields(segment)
-    }))
+      })))
 
-    // Get track metadata file
-    const trackMetadataFile = stringifiedDateFields(await models.File.findOne({
-      where: {
-        multihash: trackMetadataMultihash,
-        fileUUID: trackMetadataFileUUID,
-        clock: 36
-      },
-      raw: true
-    }))
-
-    // get audiusUser
-    const audiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
-      where: {
-        metadataFileUUID,
-        clock: 2
-      },
-      raw: true
-    }))
-
-    // get cnodeUser
-    const cnodeUser = stringifiedDateFields(await models.CNodeUser.findOne({
-      where: {
-        clock: MAX_CLOCK_VAL,
-        cnodeUserUUID
-      },
-      raw: true
-    }))
-
-    // get clock records
-    const clockRecords = await Promise.all(_.range(1, MAX_CLOCK_VAL + 1).map(async (i) => {
-      const record = await models.ClockRecord.findOne({
+      // get transcoded track file
+      const copy320 = stringifiedDateFields((await models.File.findOne({
         where: {
-          clock: i,
+          multihash: transcodedTrackCID,
+          fileUUID: transcodedTrackUUID,
+          clock: 3
+        },
+        raw: true
+      })))
+
+      // get segment files
+      const segmentHashes = trackSegments.map(t => t.multihash)
+      const segmentFiles = await Promise.all(segmentHashes.map(async (hash, i) => {
+        const segment = await models.File.findOne({
+          where: {
+            multihash: hash,
+            clock: i + 4 // starts @ 4 due to user creation + update
+          },
+          raw: true
+        })
+        return stringifiedDateFields(segment)
+      }))
+
+      // Get track metadata file
+      const trackMetadataFile = stringifiedDateFields(await models.File.findOne({
+        where: {
+          multihash: trackMetadataMultihash,
+          fileUUID: trackMetadataFileUUID,
+          clock: 36
+        },
+        raw: true
+      }))
+
+      // get audiusUser
+      const audiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
+        where: {
+          metadataFileUUID,
+          clock: 2
+        },
+        raw: true
+      }))
+
+      // get cnodeUser
+      const cnodeUser = stringifiedDateFields(await models.CNodeUser.findOne({
+        where: {
+          clock: MAX_CLOCK_VAL,
           cnodeUserUUID
         },
         raw: true
-      })
-      return stringifiedDateFields(record)
-    }))
+      }))
 
-    // get track file
-    const trackFile = stringifiedDateFields(await models.Track.findOne({
-      where: {
-        clock: MAX_CLOCK_VAL,
-        cnodeUserUUID,
-        metadataFileUUID: trackMetadataFileUUID
-      },
-      raw: true
-    }))
+      // get clock records
+      const clockRecords = await Promise.all(_.range(1, MAX_CLOCK_VAL + 1).map(async (i) => {
+        const record = await models.ClockRecord.findOne({
+          where: {
+            clock: i,
+            cnodeUserUUID
+          },
+          raw: true
+        })
+        return stringifiedDateFields(record)
+      }))
 
-    // construct the expected response
-    const expectedData = {
-      [cnodeUserUUID]: {
-        ...cnodeUser,
-        audiusUsers: [
-          audiusUser
-        ],
-        tracks: [trackFile],
-        files: [userMetadataFile, copy320, ...segmentFiles, trackMetadataFile],
-        clockRecords
-      }
-    }
+      // get track file
+      const trackFile = stringifiedDateFields(await models.Track.findOne({
+        where: {
+          clock: MAX_CLOCK_VAL,
+          cnodeUserUUID,
+          metadataFileUUID: trackMetadataFileUUID
+        },
+        raw: true
+      }))
 
-    // compare exported data
-    const exportedUserData = exportBody.data.cnodeUsers
-    assert.deepStrictEqual(exportedUserData, expectedData)
-    assert.deepStrictEqual(clockRecords.length, MAX_CLOCK_VAL)
-  })
-
-  it.only('test /sync', async function () {
-    // Setup
-
-    const TEST_ENDPOINT = 'http://test-cn.co'
-    const userMetadataURI = config.get('userMetadataNodeUrl')
-    const ipfsMock = getIPFSMock()
-
-    // Make ipfs add return the cid
-    // used to create the readstream
-    ipfsMock.add = function * (content) {
-      const { path } = content
-      const cid = path.split('/')[1]
-      yield {
-        cid: {
-          toString: () => cid
+      // construct the expected response
+      const expectedData = {
+        [cnodeUserUUID]: {
+          ...cnodeUser,
+          audiusUsers: [
+            audiusUser
+          ],
+          tracks: [trackFile],
+          files: [userMetadataFile, copy320, ...segmentFiles, trackMetadataFile],
+          clockRecords
         }
       }
-    }
-    const libsMock = getLibsMock()
-    const appInfo = await getApp(ipfsMock, libsMock, blacklistManager)
-    server = appInfo.server
-    app = appInfo.app
 
-    const { pubKey } = testEthereumConstants
+      // compare exported data
+      const exportedUserData = exportBody.data.cnodeUsers
+      assert.deepStrictEqual(exportedUserData, expectedData)
+      assert.deepStrictEqual(clockRecords.length, MAX_CLOCK_VAL)
+    })
+  })
 
-    // Get the saved export
-    const sampleExport = JSON.parse(fs.readFileSync(sampleExportPath))
-    const cnodeUser = Object.values(sampleExport.data.cnodeUsers)[0]
-    const audiusUser = cnodeUser.audiusUsers[0]
-    const { tracks, files, clockRecords } = cnodeUser
+  describe('test sync', function () {
+    beforeEach(async function () {
+      const ipfsMock = getIPFSMock()
 
-    // Setup mocked responses
-    nock(TEST_ENDPOINT)
-      .persist()
-      .get(uri => {
-        console.log({ uri })
-        return uri.includes('/export')
-      })
-      .reply(200, sampleExport)
+      // Make ipfs add return the cid
+      // used to create the readstream
+      ipfsMock.add = function * (content) {
+        const { path } = content
+        const cid = path.split('/')[1]
+        yield {
+          cid: {
+            toString: () => cid
+          }
+        }
+      }
 
-    nock(userMetadataURI)
-      .persist()
-      .get(uri => {
-        console.log({ uri })
-        return uri.includes('/ipfs')
-      })
-      .reply(200, { data: Buffer.alloc(32) })
+      const libsMock = getLibsMock()
+      const appInfo = await getApp(ipfsMock, libsMock, blacklistManager)
+      server = appInfo.server
+      app = appInfo.app
+    })
 
-    // test: sync
+    it('inserts the correct db entries for a given export blob', async function () {
+      // Setup
 
-    const { sessionToken } = await createStarterCNodeUser()
-    await request(app)
-      .post('/sync')
-      .set('X-Session-ID', sessionToken)
-      .send({
-        wallet: [pubKey.toLowerCase()],
-        creator_node_endpoint: TEST_ENDPOINT,
-        immediate: true
-      }).expect(200)
+      const TEST_ENDPOINT = 'http://test-cn.co'
+      const userMetadataURI = config.get('userMetadataNodeUrl')
+      const { pubKey } = testEthereumConstants
 
-    // verify: expected files are all on disc
+      // Get the saved export
+      const sampleExport = JSON.parse(fs.readFileSync(sampleExportPath))
+      const cnodeUser = Object.values(sampleExport.data.cnodeUsers)[0]
+      const audiusUser = cnodeUser.audiusUsers[0]
+      const { tracks, files, clockRecords } = cnodeUser
 
-    // verify clock records
-    for (let exportedRecord of clockRecords) {
-      const { cnodeUserUUID, clock, sourceTable, createdAt, updatedAt } = exportedRecord
-      const localRecord = stringifiedDateFields(await models.ClockRecord.findOne({
+      // Setup mocked responses
+      nock(TEST_ENDPOINT)
+        .persist()
+        .get(uri => uri.includes('/export'))
+        .reply(200, sampleExport)
+
+      nock(userMetadataURI)
+        .persist()
+        .get(uri => uri.includes('/ipfs'))
+        .reply(200, { data: Buffer.alloc(32) })
+
+      // test: sync
+
+      const { sessionToken } = await createStarterCNodeUser()
+      await request(app)
+        .post('/sync')
+        .set('X-Session-ID', sessionToken)
+        .send({
+          wallet: [pubKey.toLowerCase()],
+          creator_node_endpoint: TEST_ENDPOINT,
+          immediate: true
+        }).expect(200)
+
+      // verify: expected files are all on disc
+
+      // verify clock records
+      for (let exportedRecord of clockRecords) {
+        const { cnodeUserUUID, clock, sourceTable, createdAt, updatedAt } = exportedRecord
+        const localRecord = stringifiedDateFields(await models.ClockRecord.findOne({
+          where: {
+            clock,
+            cnodeUserUUID,
+            sourceTable,
+            createdAt,
+            updatedAt
+          },
+          raw: true
+        }))
+        assert.deepStrictEqual(localRecord, exportedRecord)
+      }
+
+      // verify files
+      for (let exportedFile of files) {
+        const { fileUUID, cnodeUserUUID, multihash, clock } = exportedFile
+        const localFile = stringifiedDateFields(await models.File.findOne({
+          where: {
+            clock,
+            cnodeUserUUID,
+            multihash,
+            fileUUID
+          },
+          raw: true
+        }))
+        assert.deepStrictEqual(localFile, exportedFile)
+      }
+
+      // verify tracks
+      for (let exportedTrack of tracks) {
+        const { cnodeUserUUID, clock, blockchainId, metadataFileUUID } = exportedTrack
+        const localFile = stringifiedDateFields(await models.Track.findOne({
+          where: {
+            clock,
+            cnodeUserUUID,
+            blockchainId,
+            metadataFileUUID
+          },
+          raw: true
+        }))
+        assert.deepStrictEqual(localFile, exportedTrack)
+      }
+
+      // verify AudiusUser
+      const localAudiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
         where: {
-          clock,
-          cnodeUserUUID,
-          sourceTable,
-          createdAt,
-          updatedAt
+          cnodeUserUUID: audiusUser.cnodeUserUUID,
+          clock: audiusUser.clock
         },
         raw: true
       }))
-      assert.deepStrictEqual(localRecord, exportedRecord)
-    }
 
-    // verify files
-    for (let exportedFile of files) {
-      const { fileUUID, cnodeUserUUID, multihash, clock } = exportedFile
-      const localFile = stringifiedDateFields(await models.File.findOne({
+      const exportedCnodeUser = {
+        cnodeUserUUID: cnodeUser.cnodeUserUUID,
+        walletPublicKey: cnodeUser.walletPublicKey,
+        lastLogin: cnodeUser.lastLogin,
+        latestBlockNumber: cnodeUser.latestBlockNumber,
+        clock: cnodeUser.clock,
+        createdAt: cnodeUser.createdAt
+      }
+
+      assert.deepStrictEqual(localAudiusUser, audiusUser)
+
+      // verify CNodeUser
+      let localCnodeUser = stringifiedDateFields(await models.CNodeUser.find({
         where: {
-          clock,
-          cnodeUserUUID,
-          multihash,
-          fileUUID
+          cnodeUserUUID: cnodeUser.cnodeUserUUID
         },
         raw: true
       }))
-      assert.deepStrictEqual(localFile, exportedFile)
-    }
+      localCnodeUser = _.omit(localCnodeUser, ['updatedAt'])
 
-    // verify tracks
-    for (let exportedTrack of tracks) {
-      const { cnodeUserUUID, clock, blockchainId, metadataFileUUID } = exportedTrack
-      const localFile = stringifiedDateFields(await models.Track.findOne({
-        where: {
-          clock,
-          cnodeUserUUID,
-          blockchainId,
-          metadataFileUUID
-        },
-        raw: true
-      }))
-      assert.deepStrictEqual(localFile, exportedTrack)
-    }
-
-    // verify AudiusUser
-    const localAudiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
-      where: {
-        cnodeUserUUID: audiusUser.cnodeUserUUID,
-        clock: audiusUser.clock
-      },
-      raw: true
-    }))
-
-    const exportedCnodeUser = {
-      cnodeUserUUID: cnodeUser.cnodeUserUUID,
-      walletPublicKey: cnodeUser.walletPublicKey,
-      lastLogin: cnodeUser.lastLogin,
-      latestBlockNumber: cnodeUser.latestBlockNumber,
-      clock: cnodeUser.clock,
-      createdAt: cnodeUser.createdAt
-    }
-
-    assert.deepStrictEqual(localAudiusUser, audiusUser)
-
-    // verify CNodeUser
-    let localCnodeUser = stringifiedDateFields(await models.CNodeUser.find({
-      where: {
-        cnodeUserUUID: cnodeUser.cnodeUserUUID
-      },
-      raw: true
-    }))
-    localCnodeUser = _.omit(localCnodeUser, ['updatedAt'])
-
-    assert.deepStrictEqual(localCnodeUser, exportedCnodeUser)
+      assert.deepStrictEqual(localCnodeUser, exportedCnodeUser)
+    })
   })
 })

--- a/creator-node/test/nodesync.test.js
+++ b/creator-node/test/nodesync.test.js
@@ -1,8 +1,210 @@
+// const assert = require('assert')
+const request = require('supertest')
+const models = require('../src/models')
+const { getApp } = require('./lib/app')
+const { getLibsMock } = require('./lib/libsMock')
+const { createStarterCNodeUser, testEthereumConstants } = require('./lib/dataSeeds')
+const blacklistManager = require('../src/blacklistManager')
+const ipfsClient = require('../src/ipfsClient')
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+const _ = require('lodash')
+
+const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
+
+let server, app, ipfs, libsMock
+
+// TODO: move to helpers + remove from dbManager.test
+const stringifiedDateFields = (obj) => {
+  const newObj = {...obj}
+  if (newObj.createdAt) newObj.createdAt = newObj.createdAt.toISOString()
+  if (newObj.updatedAt) newObj.updatedAt = newObj.updatedAt.toISOString()
+  return newObj
+}
+const destroyUsers = async () => (
+  models.CNodeUser.destroy({
+    where: {},
+    truncate: true,
+    cascade: true // cascades delete to all rows with foreign key on cnodeUser
+  })
+)
+
+const getCNodeUser = async (cnodeUserUUID) => {
+  const { dataValues } = await models.CNodeUser.findOne({ where: { cnodeUserUUID } })
+  return dataValues
+}
+
+
 describe('test nodesync', function () {
-  it('test /export', function () {
-    /**
-         * TODO - mock DB state -> confirm export returns deterministict output
-         */
+  before(async function () {
+    ipfs = ipfsClient.ipfs
+    libsMock = getLibsMock()
+    const appInfo = await getApp(ipfs, libsMock, blacklistManager)
+    server = appInfo.server
+    app = appInfo.app
+  })
+
+  beforeEach(async function () {
+    await destroyUsers()
+  })
+
+  after(async function () {
+    // TODO: destroy users
+    // await destroyUsers()
+    await server.close()
+  })
+
+  it.only('test /export', async function () {
+    const MAX_CLOCK_VAL = 37
+
+    const { cnodeUserUUID, sessionToken } = await createStarterCNodeUser()
+    await getCNodeUser(cnodeUserUUID)
+
+    const metadata = {"metadata":{"is_creator":true,"is_verified":false,"name":"m1","handle":"m1","profile_picture":null,"profile_picture_sizes":null,"cover_photo":null,"cover_photo_sizes":null,"bio":"blhblahblahblahblahlba","location":"Oakland, CA","creator_node_endpoint":"https://creatornode3.staging.audius.co,https://creatornode.staging.audius.co,https://creatornode2.staging.audius.co","user_id":46}}
+
+    const {body: { data: { metadataMultihash, metadataFileUUID }}} = await request(app)
+      .post('/audius_users/metadata')
+      .set('X-Session-ID', sessionToken)
+      .send(metadata)
+
+    const associateRequest = {
+      blockchainUserId: 1,
+      metadataFileUUID,
+      blockNumber:10
+    }
+    const {body: associateBody} = await request(app)
+      .post('/audius_users/')
+      .set('X-Session-ID', sessionToken)
+      .send(associateRequest)
+
+    // Upload a track
+    const file = fs.readFileSync(testAudioFilePath)
+    const {body: { transcodedTrackCID, transcodedTrackUUID, track_segments, source_file}} = await request(app)
+      .post('/track_content')
+      .attach('file', file, { filename: 'fname.mp3' })
+      .set('Content-Type', 'multipart/form-data')
+      .set('X-Session-ID', sessionToken)
+
+    const trackMetadata = {
+      test: 'field1',
+      owner_id: 1,
+      track_segments: track_segments
+    }
+
+    const {body: { metadataMultihash: trackMetadataMultihash, metadataFileUUID: trackMetadataFileUUID}} = await request(app)
+      .post('/tracks/metadata')
+      .set('X-Session-ID', sessionToken)
+      .send({ metadata: trackMetadata, source_file: source_file })
+
+    const associateResp = await request(app)
+      .post('/tracks')
+      .set('X-Session-ID', sessionToken)
+      .send({
+          blockchainTrackId: 1,
+          blockNumber: 10,
+          metadataFileUUID: trackMetadataFileUUID,
+          transcodedTrackUUID
+       })
+
+    const {pubKey} = testEthereumConstants
+    const {body: exportBody} = await request(app)
+      .get(`/export?wallet_public_key=${pubKey.toLowerCase()}`)
+
+    // console.log({exportBody: JSON.stringify(exportBody.data.cnodeUsers[cnodeUserUUID], null, 2)})
+
+    const userMetadataFile = stringifiedDateFields((await models.File.findOne({
+      where: {
+        multihash: metadataMultihash,
+        fileUUID: metadataFileUUID,
+        clock: 1,
+      },
+      raw: true
+    })))
+
+    const copy320 = stringifiedDateFields((await models.File.findOne({
+      where: {
+        multihash: transcodedTrackCID,
+        fileUUID: transcodedTrackUUID,
+        clock: 3,
+      },
+      raw: true
+    })))
+
+    const segmentHashes = track_segments.map(t => t.multihash)
+    // Do this sequentially so we can confirm clock
+    // values for each segment
+    const segmentFiles = await Promise.all(segmentHashes.map(async (hash, i) => {
+      const segment = await models.File.findOne({
+        where: {
+          multihash: hash,
+          clock: i + 4 // starts @ 4 due to user creation + update
+        },
+        raw: true
+      })
+      return stringifiedDateFields(segment)
+    }))
+
+    const trackMetadataFile = stringifiedDateFields(await models.File.findOne({
+      where: {
+        multihash: trackMetadataMultihash,
+        fileUUID: trackMetadataFileUUID,
+        clock: 36
+      },
+      raw: true
+    }))
+
+    const audiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
+      where: {
+        metadataFileUUID,
+        clock: 2,
+      },
+      raw: true
+    }))
+
+    const cnodeUser = stringifiedDateFields(await models.CNodeUser.findOne({
+      where: {
+        clock: MAX_CLOCK_VAL,
+        cnodeUserUUID,
+      },
+      raw: true
+    }))
+
+    const clockRecords = await Promise.all(_.range(1, MAX_CLOCK_VAL + 1).map(async (i) => {
+      const record = await models.ClockRecord.findOne({
+        where: {
+          clock: i,
+          cnodeUserUUID,
+        },
+        raw: true
+      })
+      return stringifiedDateFields(record)
+    }))
+
+    const trackFile = stringifiedDateFields(await models.Track.findOne({
+      where: {
+        clock: MAX_CLOCK_VAL,
+        cnodeUserUUID,
+        metadataFileUUID: trackMetadataFileUUID
+      },
+      raw: true
+    }))
+
+    const expectedData = {
+      [cnodeUserUUID]: {
+        ...cnodeUser,
+        audiusUsers: [
+          audiusUser
+        ],
+        tracks: [trackFile],
+        files: [userMetadataFile, copy320, ...segmentFiles, trackMetadataFile],
+        clockRecords,
+      }
+    }
+
+    const exportedUserData = exportBody.data.cnodeUsers
+    assert.deepStrictEqual(exportedUserData, expectedData)
+    assert.deepStrictEqual(clockRecords.length, MAX_CLOCK_VAL)
   })
 
   it('test /sync', function () {

--- a/creator-node/test/nodesync.test.js
+++ b/creator-node/test/nodesync.test.js
@@ -1,4 +1,3 @@
-// const assert = require('assert')
 const request = require('supertest')
 const models = require('../src/models')
 const { getApp } = require('./lib/app')
@@ -10,31 +9,11 @@ const fs = require('fs')
 const path = require('path')
 const assert = require('assert')
 const _ = require('lodash')
+const { getCNodeUser, stringifiedDateFields, destroyUsers } = require('./utils')
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
 let server, app, ipfs, libsMock
-
-// TODO: move to helpers + remove from dbManager.test
-const stringifiedDateFields = (obj) => {
-  const newObj = {...obj}
-  if (newObj.createdAt) newObj.createdAt = newObj.createdAt.toISOString()
-  if (newObj.updatedAt) newObj.updatedAt = newObj.updatedAt.toISOString()
-  return newObj
-}
-const destroyUsers = async () => (
-  models.CNodeUser.destroy({
-    where: {},
-    truncate: true,
-    cascade: true // cascades delete to all rows with foreign key on cnodeUser
-  })
-)
-
-const getCNodeUser = async (cnodeUserUUID) => {
-  const { dataValues } = await models.CNodeUser.findOne({ where: { cnodeUserUUID } })
-  return dataValues
-}
-
 
 describe('test nodesync', function () {
   before(async function () {
@@ -50,20 +29,26 @@ describe('test nodesync', function () {
   })
 
   after(async function () {
-    // TODO: destroy users
-    // await destroyUsers()
+    await destroyUsers()
     await server.close()
   })
 
-  it.only('test /export', async function () {
+  it('test /export', async function () {
     const MAX_CLOCK_VAL = 37
 
+    // SETUP
+
+    // Create user
     const { cnodeUserUUID, sessionToken } = await createStarterCNodeUser()
     await getCNodeUser(cnodeUserUUID)
 
-    const metadata = {"metadata":{"is_creator":true,"is_verified":false,"name":"m1","handle":"m1","profile_picture":null,"profile_picture_sizes":null,"cover_photo":null,"cover_photo_sizes":null,"bio":"blhblahblahblahblahlba","location":"Oakland, CA","creator_node_endpoint":"https://creatornode3.staging.audius.co,https://creatornode.staging.audius.co,https://creatornode2.staging.audius.co","user_id":46}}
-
-    const {body: { data: { metadataMultihash, metadataFileUUID }}} = await request(app)
+    // Set user metadata
+    const metadata = {
+      metadata: {
+        testField: 'testValue'
+      }
+    }
+    const { body: { data: { metadataMultihash, metadataFileUUID } } } = await request(app)
       .post('/audius_users/metadata')
       .set('X-Session-ID', sessionToken)
       .send(metadata)
@@ -71,69 +56,75 @@ describe('test nodesync', function () {
     const associateRequest = {
       blockchainUserId: 1,
       metadataFileUUID,
-      blockNumber:10
+      blockNumber: 10
     }
-    const {body: associateBody} = await request(app)
+
+    // Associate user with metadata
+    await request(app)
       .post('/audius_users/')
       .set('X-Session-ID', sessionToken)
       .send(associateRequest)
 
     // Upload a track
     const file = fs.readFileSync(testAudioFilePath)
-    const {body: { transcodedTrackCID, transcodedTrackUUID, track_segments, source_file}} = await request(app)
+    // set track content
+    const { body: { transcodedTrackCID, transcodedTrackUUID, track_segments: trackSegments, source_file: sourceFile } } = await request(app)
       .post('/track_content')
       .attach('file', file, { filename: 'fname.mp3' })
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', sessionToken)
 
+    // set track metadata
     const trackMetadata = {
       test: 'field1',
       owner_id: 1,
-      track_segments: track_segments
+      track_segments: trackSegments
     }
-
-    const {body: { metadataMultihash: trackMetadataMultihash, metadataFileUUID: trackMetadataFileUUID}} = await request(app)
+    const { body: { metadataMultihash: trackMetadataMultihash, metadataFileUUID: trackMetadataFileUUID } } = await request(app)
       .post('/tracks/metadata')
       .set('X-Session-ID', sessionToken)
-      .send({ metadata: trackMetadata, source_file: source_file })
-
-    const associateResp = await request(app)
+      .send({ metadata: trackMetadata, source_file: sourceFile })
+    // associate track metadata with track
+    await request(app)
       .post('/tracks')
       .set('X-Session-ID', sessionToken)
       .send({
-          blockchainTrackId: 1,
-          blockNumber: 10,
-          metadataFileUUID: trackMetadataFileUUID,
-          transcodedTrackUUID
-       })
+        blockchainTrackId: 1,
+        blockNumber: 10,
+        metadataFileUUID: trackMetadataFileUUID,
+        transcodedTrackUUID
+      })
 
-    const {pubKey} = testEthereumConstants
-    const {body: exportBody} = await request(app)
+    // Test: export
+
+    const { pubKey } = testEthereumConstants
+    const { body: exportBody } = await request(app)
       .get(`/export?wallet_public_key=${pubKey.toLowerCase()}`)
 
-    // console.log({exportBody: JSON.stringify(exportBody.data.cnodeUsers[cnodeUserUUID], null, 2)})
+    // Verify
 
+    // Get user metadata
     const userMetadataFile = stringifiedDateFields((await models.File.findOne({
       where: {
         multihash: metadataMultihash,
         fileUUID: metadataFileUUID,
-        clock: 1,
+        clock: 1
       },
       raw: true
     })))
 
+    // get transcoded track file
     const copy320 = stringifiedDateFields((await models.File.findOne({
       where: {
         multihash: transcodedTrackCID,
         fileUUID: transcodedTrackUUID,
-        clock: 3,
+        clock: 3
       },
       raw: true
     })))
 
-    const segmentHashes = track_segments.map(t => t.multihash)
-    // Do this sequentially so we can confirm clock
-    // values for each segment
+    // get segment files
+    const segmentHashes = trackSegments.map(t => t.multihash)
     const segmentFiles = await Promise.all(segmentHashes.map(async (hash, i) => {
       const segment = await models.File.findOne({
         where: {
@@ -145,6 +136,7 @@ describe('test nodesync', function () {
       return stringifiedDateFields(segment)
     }))
 
+    // Get track metadata file
     const trackMetadataFile = stringifiedDateFields(await models.File.findOne({
       where: {
         multihash: trackMetadataMultihash,
@@ -154,33 +146,37 @@ describe('test nodesync', function () {
       raw: true
     }))
 
+    // get audiusUser
     const audiusUser = stringifiedDateFields(await models.AudiusUser.findOne({
       where: {
         metadataFileUUID,
-        clock: 2,
+        clock: 2
       },
       raw: true
     }))
 
+    // get cnodeUser
     const cnodeUser = stringifiedDateFields(await models.CNodeUser.findOne({
       where: {
         clock: MAX_CLOCK_VAL,
-        cnodeUserUUID,
+        cnodeUserUUID
       },
       raw: true
     }))
 
+    // get clock records
     const clockRecords = await Promise.all(_.range(1, MAX_CLOCK_VAL + 1).map(async (i) => {
       const record = await models.ClockRecord.findOne({
         where: {
           clock: i,
-          cnodeUserUUID,
+          cnodeUserUUID
         },
         raw: true
       })
       return stringifiedDateFields(record)
     }))
 
+    // get track file
     const trackFile = stringifiedDateFields(await models.Track.findOne({
       where: {
         clock: MAX_CLOCK_VAL,
@@ -190,6 +186,7 @@ describe('test nodesync', function () {
       raw: true
     }))
 
+    // construct the expected response
     const expectedData = {
       [cnodeUserUUID]: {
         ...cnodeUser,
@@ -198,10 +195,11 @@ describe('test nodesync', function () {
         ],
         tracks: [trackFile],
         files: [userMetadataFile, copy320, ...segmentFiles, trackMetadataFile],
-        clockRecords,
+        clockRecords
       }
     }
 
+    // compare exported data
     const exportedUserData = exportBody.data.cnodeUsers
     assert.deepStrictEqual(exportedUserData, expectedData)
     assert.deepStrictEqual(clockRecords.length, MAX_CLOCK_VAL)

--- a/creator-node/test/nodesync.test.js
+++ b/creator-node/test/nodesync.test.js
@@ -14,7 +14,6 @@ const { getCNodeUser, stringifiedDateFields, destroyUsers } = require('./utils')
 const nock = require('nock')
 const config = require('../src/config')
 
-
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 const sampleExportPath = path.resolve(__dirname, 'syncAssets/sampleExport.json')
 
@@ -211,7 +210,6 @@ describe('test nodesync', function () {
   })
 
   it.only('test /sync', async function () {
-
     // Setup
 
     const TEST_ENDPOINT = 'http://test-cn.co'
@@ -221,7 +219,7 @@ describe('test nodesync', function () {
     // Make ipfs add return the cid
     // used to create the readstream
     ipfsMock.add = function * (content) {
-      const {path} = content
+      const { path } = content
       const cid = path.split('/')[1]
       yield {
         cid: {
@@ -240,13 +238,13 @@ describe('test nodesync', function () {
     const sampleExport = JSON.parse(fs.readFileSync(sampleExportPath))
     const cnodeUser = Object.values(sampleExport.data.cnodeUsers)[0]
     const audiusUser = cnodeUser.audiusUsers[0]
-    const {tracks, files, clockRecords} = cnodeUser
+    const { tracks, files, clockRecords } = cnodeUser
 
     // Setup mocked responses
     nock(TEST_ENDPOINT)
       .persist()
       .get(uri => {
-        console.log({uri})
+        console.log({ uri })
         return uri.includes('/export')
       })
       .reply(200, sampleExport)
@@ -254,16 +252,15 @@ describe('test nodesync', function () {
     nock(userMetadataURI)
       .persist()
       .get(uri => {
-        console.log({uri})
+        console.log({ uri })
         return uri.includes('/ipfs')
       })
-      .reply(200, {data: Buffer.alloc(32)})
-
+      .reply(200, { data: Buffer.alloc(32) })
 
     // test: sync
 
     const { sessionToken } = await createStarterCNodeUser()
-     await request(app)
+    await request(app)
       .post('/sync')
       .set('X-Session-ID', sessionToken)
       .send({
@@ -272,12 +269,11 @@ describe('test nodesync', function () {
         immediate: true
       }).expect(200)
 
-
     // verify: expected files are all on disc
 
     // verify clock records
     for (let exportedRecord of clockRecords) {
-      const { cnodeUserUUID, clock, sourceTable, createdAt, updatedAt} = exportedRecord
+      const { cnodeUserUUID, clock, sourceTable, createdAt, updatedAt } = exportedRecord
       const localRecord = stringifiedDateFields(await models.ClockRecord.findOne({
         where: {
           clock,
@@ -293,7 +289,7 @@ describe('test nodesync', function () {
 
     // verify files
     for (let exportedFile of files) {
-      const { fileUUID, cnodeUserUUID, multihash, clock} = exportedFile
+      const { fileUUID, cnodeUserUUID, multihash, clock } = exportedFile
       const localFile = stringifiedDateFields(await models.File.findOne({
         where: {
           clock,
@@ -308,7 +304,7 @@ describe('test nodesync', function () {
 
     // verify tracks
     for (let exportedTrack of tracks) {
-      const { cnodeUserUUID, clock, blockchainId, metadataFileUUID} = exportedTrack
+      const { cnodeUserUUID, clock, blockchainId, metadataFileUUID } = exportedTrack
       const localFile = stringifiedDateFields(await models.Track.findOne({
         where: {
           clock,
@@ -336,7 +332,7 @@ describe('test nodesync', function () {
       lastLogin: cnodeUser.lastLogin,
       latestBlockNumber: cnodeUser.latestBlockNumber,
       clock: cnodeUser.clock,
-      createdAt: cnodeUser.createdAt,
+      createdAt: cnodeUser.createdAt
     }
 
     assert.deepStrictEqual(localAudiusUser, audiusUser)
@@ -344,13 +340,12 @@ describe('test nodesync', function () {
     // verify CNodeUser
     let localCnodeUser = stringifiedDateFields(await models.CNodeUser.find({
       where: {
-        cnodeUserUUID: cnodeUser.cnodeUserUUID,
+        cnodeUserUUID: cnodeUser.cnodeUserUUID
       },
       raw: true
     }))
     localCnodeUser = _.omit(localCnodeUser, ['updatedAt'])
 
     assert.deepStrictEqual(localCnodeUser, exportedCnodeUser)
-
   })
 })

--- a/creator-node/test/syncAssets/sampleExport.json
+++ b/creator-node/test/syncAssets/sampleExport.json
@@ -1,0 +1,1947 @@
+{
+  "data": {
+    "cnodeUsers": {
+      "454d032a-ed79-4332-a3dd-3de2a8f30f47": {
+        "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+        "walletPublicKey": "0xadd36bad12002f1097cdb7ee24085c28e960fc32",
+        "lastLogin": null,
+        "latestBlockNumber": 10,
+        "clock": 37,
+        "createdAt": "2020-10-02T18:48:03.369Z",
+        "updatedAt": "2020-10-02T18:48:17.516Z",
+        "audiusUsers": [
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 2,
+            "blockchainId": "1",
+            "metadataFileUUID": "b37ff266-b947-462c-82f5-0a4053d964ed",
+            "metadataJSON": {
+              "testField": "testValue"
+            },
+            "coverArtFileUUID": null,
+            "profilePicFileUUID": null,
+            "createdAt": "2020-10-02T18:48:04.500Z",
+            "updatedAt": "2020-10-02T18:48:04.500Z"
+          }
+        ],
+        "tracks": [
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 37,
+            "blockchainId": "1",
+            "metadataFileUUID": "5b24a995-d8f6-4572-8ecc-5107cf8d6ef0",
+            "metadataJSON": {
+              "test": "field1",
+              "owner_id": 1,
+              "track_segments": [
+                {
+                  "duration": 6.016,
+                  "multihash": "QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk"
+                },
+                {
+                  "duration": 6.016,
+                  "multihash": "QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8"
+                },
+                {
+                  "duration": 5.994667,
+                  "multihash": "QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp"
+                },
+                {
+                  "duration": 1.456,
+                  "multihash": "QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas"
+                }
+              ]
+            },
+            "coverArtFileUUID": null,
+            "createdAt": "2020-10-02T18:48:17.522Z",
+            "updatedAt": "2020-10-02T18:48:17.522Z"
+          }
+        ],
+        "files": [
+          {
+            "fileUUID": "b37ff266-b947-462c-82f5-0a4053d964ed",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": null,
+            "multihash": "QmcyuCtU24R2N9Ejs5tsm7vebBhs3g6Qnhh6w3ZoEYBrUE",
+            "sourceFile": null,
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmcyuCtU24R2N9Ejs5tsm7vebBhs3g6Qnhh6w3ZoEYBrUE",
+            "type": "metadata",
+            "clock": 1,
+            "createdAt": "2020-10-02T18:48:03.429Z",
+            "updatedAt": "2020-10-02T18:48:03.429Z"
+          },
+          {
+            "fileUUID": "adf37c4b-6912-44f0-bfd7-0beac73de1bd",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmRcVgkrvsyUeY3x3zvc6EhDSFjZJ8QD5qyKowHsPeWKFT",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmRcVgkrvsyUeY3x3zvc6EhDSFjZJ8QD5qyKowHsPeWKFT",
+            "type": "copy320",
+            "clock": 3,
+            "createdAt": "2020-10-02T18:48:15.962Z",
+            "updatedAt": "2020-10-02T18:48:17.542Z"
+          },
+          {
+            "fileUUID": "ee446211-8995-400b-9604-0a305e5fdb5f",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku",
+            "type": "track",
+            "clock": 4,
+            "createdAt": "2020-10-02T18:48:15.973Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "90cf7255-98c4-4383-b417-32bdc0dd7a60",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd",
+            "type": "track",
+            "clock": 5,
+            "createdAt": "2020-10-02T18:48:15.984Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "6a30a091-cceb-47f4-980b-de4da1d800cf",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch",
+            "type": "track",
+            "clock": 6,
+            "createdAt": "2020-10-02T18:48:15.996Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "43820bd5-5fdc-4f7c-add2-ff542afc97a2",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ",
+            "type": "track",
+            "clock": 7,
+            "createdAt": "2020-10-02T18:48:16.011Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "51dd0569-81ba-486e-ac50-7c1dff95cd69",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP",
+            "type": "track",
+            "clock": 8,
+            "createdAt": "2020-10-02T18:48:16.024Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "3b9df1fb-e630-41a1-b45f-45a954eab0b2",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF",
+            "type": "track",
+            "clock": 9,
+            "createdAt": "2020-10-02T18:48:16.037Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "431e0330-f8ef-49b7-9625-78f4d47baf2d",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB",
+            "type": "track",
+            "clock": 10,
+            "createdAt": "2020-10-02T18:48:16.049Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "c6904e22-c603-4743-ae91-281eb67f4187",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan",
+            "type": "track",
+            "clock": 11,
+            "createdAt": "2020-10-02T18:48:16.061Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "4902f34d-cc2c-4373-8214-ed71e3d40939",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr",
+            "type": "track",
+            "clock": 12,
+            "createdAt": "2020-10-02T18:48:16.076Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "894c6c9b-9402-473e-9db9-b6a421b110c3",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB",
+            "type": "track",
+            "clock": 13,
+            "createdAt": "2020-10-02T18:48:16.092Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "4976f227-cd4d-481c-abb4-171bfc9acaad",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi",
+            "type": "track",
+            "clock": 14,
+            "createdAt": "2020-10-02T18:48:16.107Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "b9339fde-2ac9-44be-b1a0-3373604b0915",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik",
+            "type": "track",
+            "clock": 15,
+            "createdAt": "2020-10-02T18:48:16.120Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "d9e8a2c6-5816-4d4e-90f7-c18c6a4f1f3d",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH",
+            "type": "track",
+            "clock": 16,
+            "createdAt": "2020-10-02T18:48:16.131Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "c8153ea3-8ec7-4a27-9695-ae2f23d8134f",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d",
+            "type": "track",
+            "clock": 17,
+            "createdAt": "2020-10-02T18:48:16.145Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "d3ac63d0-b307-49a8-986b-32c63aaf9489",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh",
+            "type": "track",
+            "clock": 18,
+            "createdAt": "2020-10-02T18:48:16.159Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "1d6db106-3673-4c9f-9ff0-e036b602ab97",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9",
+            "type": "track",
+            "clock": 19,
+            "createdAt": "2020-10-02T18:48:16.174Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "3cc4644e-e912-4120-a7ef-daa8cb6872a8",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7",
+            "type": "track",
+            "clock": 20,
+            "createdAt": "2020-10-02T18:48:16.189Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "e83f72d8-3e65-4cf4-a4d0-6309ff56d3aa",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q",
+            "type": "track",
+            "clock": 21,
+            "createdAt": "2020-10-02T18:48:16.205Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "80a5e3a1-9fa2-4a5e-ba03-89b460868955",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot",
+            "type": "track",
+            "clock": 22,
+            "createdAt": "2020-10-02T18:48:16.221Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "3da22ac0-16a9-4d50-b244-822f5d4162de",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA",
+            "type": "track",
+            "clock": 23,
+            "createdAt": "2020-10-02T18:48:16.237Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "ff62119b-6007-4288-be9e-d6a27d59a642",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ",
+            "type": "track",
+            "clock": 24,
+            "createdAt": "2020-10-02T18:48:16.248Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "4d65ebc1-1f6b-431b-9ba8-faa38fd32f80",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx",
+            "type": "track",
+            "clock": 25,
+            "createdAt": "2020-10-02T18:48:16.262Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "5c85c277-2bcb-47a2-a793-63c8e47b8930",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF",
+            "type": "track",
+            "clock": 26,
+            "createdAt": "2020-10-02T18:48:16.275Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "d0cac540-f96c-4ed4-b674-e39dc625beb5",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY",
+            "type": "track",
+            "clock": 27,
+            "createdAt": "2020-10-02T18:48:16.287Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "eda99b1b-9c9d-4b5d-afaf-efa9a8ff0800",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY",
+            "type": "track",
+            "clock": 28,
+            "createdAt": "2020-10-02T18:48:16.300Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "d281c018-d711-487b-acf9-5e0c964f0813",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn",
+            "type": "track",
+            "clock": 29,
+            "createdAt": "2020-10-02T18:48:16.313Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "77d29616-08e9-4d65-b12a-f0de40eecf71",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT",
+            "type": "track",
+            "clock": 30,
+            "createdAt": "2020-10-02T18:48:16.328Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "e7c3a05d-5e10-44da-9422-5759c9ca8204",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk",
+            "type": "track",
+            "clock": 31,
+            "createdAt": "2020-10-02T18:48:16.341Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "7753b1de-ba07-4c52-8e5f-5b21e3504b3d",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy",
+            "type": "track",
+            "clock": 32,
+            "createdAt": "2020-10-02T18:48:16.353Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "878a6ef9-296b-475d-83df-e2d7055accc6",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8",
+            "type": "track",
+            "clock": 33,
+            "createdAt": "2020-10-02T18:48:16.364Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "7a239b4b-3255-4160-b260-6e0dc862837b",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp",
+            "type": "track",
+            "clock": 34,
+            "createdAt": "2020-10-02T18:48:16.379Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "36873c2b-b33d-4da5-a9c8-13e6f699ee5b",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": 1,
+            "multihash": "QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas",
+            "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas",
+            "type": "track",
+            "clock": 35,
+            "createdAt": "2020-10-02T18:48:16.393Z",
+            "updatedAt": "2020-10-02T18:48:17.557Z"
+          },
+          {
+            "fileUUID": "5b24a995-d8f6-4572-8ecc-5107cf8d6ef0",
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "trackBlockchainId": null,
+            "multihash": "QmcYCwJHfCScqDFEXd78hkdFbyn98mJWXhej4QhQx2aPaZ",
+            "sourceFile": null,
+            "fileName": null,
+            "dirMultihash": null,
+            "storagePath": "test_file_storage/QmcYCwJHfCScqDFEXd78hkdFbyn98mJWXhej4QhQx2aPaZ",
+            "type": "metadata",
+            "clock": 36,
+            "createdAt": "2020-10-02T18:48:16.475Z",
+            "updatedAt": "2020-10-02T18:48:16.475Z"
+          }
+        ],
+        "clockRecords": [
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 1,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:03.425Z",
+            "updatedAt": "2020-10-02T18:48:03.425Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 2,
+            "sourceTable": "AudiusUser",
+            "createdAt": "2020-10-02T18:48:04.496Z",
+            "updatedAt": "2020-10-02T18:48:04.496Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 3,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:15.959Z",
+            "updatedAt": "2020-10-02T18:48:15.959Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 4,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:15.970Z",
+            "updatedAt": "2020-10-02T18:48:15.970Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 5,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:15.979Z",
+            "updatedAt": "2020-10-02T18:48:15.979Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 6,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:15.992Z",
+            "updatedAt": "2020-10-02T18:48:15.992Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 7,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.008Z",
+            "updatedAt": "2020-10-02T18:48:16.008Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 8,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.020Z",
+            "updatedAt": "2020-10-02T18:48:16.020Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 9,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.030Z",
+            "updatedAt": "2020-10-02T18:48:16.030Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 10,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.045Z",
+            "updatedAt": "2020-10-02T18:48:16.045Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 11,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.057Z",
+            "updatedAt": "2020-10-02T18:48:16.057Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 12,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.071Z",
+            "updatedAt": "2020-10-02T18:48:16.071Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 13,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.087Z",
+            "updatedAt": "2020-10-02T18:48:16.087Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 14,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.103Z",
+            "updatedAt": "2020-10-02T18:48:16.103Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 15,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.113Z",
+            "updatedAt": "2020-10-02T18:48:16.113Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 16,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.128Z",
+            "updatedAt": "2020-10-02T18:48:16.128Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 17,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.142Z",
+            "updatedAt": "2020-10-02T18:48:16.142Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 18,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.153Z",
+            "updatedAt": "2020-10-02T18:48:16.153Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 19,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.171Z",
+            "updatedAt": "2020-10-02T18:48:16.171Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 20,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.181Z",
+            "updatedAt": "2020-10-02T18:48:16.181Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 21,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.198Z",
+            "updatedAt": "2020-10-02T18:48:16.198Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 22,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.213Z",
+            "updatedAt": "2020-10-02T18:48:16.213Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 23,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.229Z",
+            "updatedAt": "2020-10-02T18:48:16.229Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 24,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.244Z",
+            "updatedAt": "2020-10-02T18:48:16.244Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 25,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.258Z",
+            "updatedAt": "2020-10-02T18:48:16.258Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 26,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.270Z",
+            "updatedAt": "2020-10-02T18:48:16.270Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 27,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.281Z",
+            "updatedAt": "2020-10-02T18:48:16.281Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 28,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.296Z",
+            "updatedAt": "2020-10-02T18:48:16.296Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 29,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.310Z",
+            "updatedAt": "2020-10-02T18:48:16.310Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 30,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.324Z",
+            "updatedAt": "2020-10-02T18:48:16.324Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 31,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.337Z",
+            "updatedAt": "2020-10-02T18:48:16.337Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 32,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.347Z",
+            "updatedAt": "2020-10-02T18:48:16.347Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 33,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.361Z",
+            "updatedAt": "2020-10-02T18:48:16.361Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 34,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.376Z",
+            "updatedAt": "2020-10-02T18:48:16.376Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 35,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.387Z",
+            "updatedAt": "2020-10-02T18:48:16.387Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 36,
+            "sourceTable": "File",
+            "createdAt": "2020-10-02T18:48:16.470Z",
+            "updatedAt": "2020-10-02T18:48:16.470Z"
+          },
+          {
+            "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+            "clock": 37,
+            "sourceTable": "Track",
+            "createdAt": "2020-10-02T18:48:17.518Z",
+            "updatedAt": "2020-10-02T18:48:17.518Z"
+          }
+        ]
+      }
+    },
+    "ipfsIDObj": {
+      "id": "QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "publicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDFr5LdVX9oig5N7FHJkQcUiJXAO9Qa5w9m2CDlfRZ5WL5B04wU0nr2u2AjGSgtlScQueSgvQwcESYeCVI283rk8ekSfUJKt0XXPFbTwdQufSehTlWuPFerrgSlNX3BaE5Rkj8L+1PlpqjH/tRsYOqIyF4LXHYZsppQeFruPwW/xy6jNa/RsJlaI2epVDIBGVDc5VB6sNEZCX2httJJ86t69T2DaLWBv0/5A4MAssftwf4LQIuU0AIMX/UKJlT6XsumplX/5SFwSpzFnD2JKwWF8uT0/P58fEo5BfCNdOfjxCJqWXRt4eVzbg4hkUKM8NGzSKQ2Wj6UG+ad+msYz7hPAgMBAAE=",
+      "addresses": [
+        "/ip4/127.0.0.1/tcp/4001/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/172.17.0.2/tcp/4001/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/54730/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/61166/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/51519/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/58070/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/60833/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/53424/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/53997/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/54011/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/54007/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/57977/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/50404/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52702/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/57941/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/62905/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52377/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52387/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52392/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52883/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/53259/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/58551/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/60788/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/60997/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/61023/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/62016/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/62094/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/64479/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/65142/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/52278/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/53453/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/59140/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/61015/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/62396/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/63364/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/50408/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+        "/ip4/73.157.75.185/tcp/53883/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU"
+      ],
+      "agentVersion": "go-ipfs/0.4.23/6ce9a35",
+      "protocolVersion": "ipfs/0.1.0"
+    }
+  },
+  "cnodeUsers": {
+    "454d032a-ed79-4332-a3dd-3de2a8f30f47": {
+      "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+      "walletPublicKey": "0xadd36bad12002f1097cdb7ee24085c28e960fc32",
+      "lastLogin": null,
+      "latestBlockNumber": 10,
+      "clock": 37,
+      "createdAt": "2020-10-02T18:48:03.369Z",
+      "updatedAt": "2020-10-02T18:48:17.516Z",
+      "audiusUsers": [
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 2,
+          "blockchainId": "1",
+          "metadataFileUUID": "b37ff266-b947-462c-82f5-0a4053d964ed",
+          "metadataJSON": {
+            "testField": "testValue"
+          },
+          "coverArtFileUUID": null,
+          "profilePicFileUUID": null,
+          "createdAt": "2020-10-02T18:48:04.500Z",
+          "updatedAt": "2020-10-02T18:48:04.500Z"
+        }
+      ],
+      "tracks": [
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 37,
+          "blockchainId": "1",
+          "metadataFileUUID": "5b24a995-d8f6-4572-8ecc-5107cf8d6ef0",
+          "metadataJSON": {
+            "test": "field1",
+            "owner_id": 1,
+            "track_segments": [
+              {
+                "duration": 6.016,
+                "multihash": "QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk"
+              },
+              {
+                "duration": 6.016,
+                "multihash": "QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8"
+              },
+              {
+                "duration": 5.994667,
+                "multihash": "QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp"
+              },
+              {
+                "duration": 1.456,
+                "multihash": "QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas"
+              }
+            ]
+          },
+          "coverArtFileUUID": null,
+          "createdAt": "2020-10-02T18:48:17.522Z",
+          "updatedAt": "2020-10-02T18:48:17.522Z"
+        }
+      ],
+      "files": [
+        {
+          "fileUUID": "b37ff266-b947-462c-82f5-0a4053d964ed",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": null,
+          "multihash": "QmcyuCtU24R2N9Ejs5tsm7vebBhs3g6Qnhh6w3ZoEYBrUE",
+          "sourceFile": null,
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmcyuCtU24R2N9Ejs5tsm7vebBhs3g6Qnhh6w3ZoEYBrUE",
+          "type": "metadata",
+          "clock": 1,
+          "createdAt": "2020-10-02T18:48:03.429Z",
+          "updatedAt": "2020-10-02T18:48:03.429Z"
+        },
+        {
+          "fileUUID": "adf37c4b-6912-44f0-bfd7-0beac73de1bd",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmRcVgkrvsyUeY3x3zvc6EhDSFjZJ8QD5qyKowHsPeWKFT",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmRcVgkrvsyUeY3x3zvc6EhDSFjZJ8QD5qyKowHsPeWKFT",
+          "type": "copy320",
+          "clock": 3,
+          "createdAt": "2020-10-02T18:48:15.962Z",
+          "updatedAt": "2020-10-02T18:48:17.542Z"
+        },
+        {
+          "fileUUID": "ee446211-8995-400b-9604-0a305e5fdb5f",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmQQhdN8918ix1MibmSek9orTLKqZSSzqUvJAtEfMqTLku",
+          "type": "track",
+          "clock": 4,
+          "createdAt": "2020-10-02T18:48:15.973Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "90cf7255-98c4-4383-b417-32bdc0dd7a60",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd",
+          "type": "track",
+          "clock": 5,
+          "createdAt": "2020-10-02T18:48:15.984Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "6a30a091-cceb-47f4-980b-de4da1d800cf",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmdkuVqHUDhYePhXska15UEZHPike11NPHu5tsy9eY28Ch",
+          "type": "track",
+          "clock": 6,
+          "createdAt": "2020-10-02T18:48:15.996Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "43820bd5-5fdc-4f7c-add2-ff542afc97a2",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZQd76dJjyd4bLL29gT5urxqY6JRS9vjnAUpuwkS91vKJ",
+          "type": "track",
+          "clock": 7,
+          "createdAt": "2020-10-02T18:48:16.011Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "51dd0569-81ba-486e-ac50-7c1dff95cd69",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmVLLQTLByH65Ht2J3bKyFXZaKjUDho6742dSqk9nqxvgP",
+          "type": "track",
+          "clock": 8,
+          "createdAt": "2020-10-02T18:48:16.024Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "3b9df1fb-e630-41a1-b45f-45a954eab0b2",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZJipWYtJDebvUbti2xSA3cijYxQ6YmVnkotA5SXiqgGF",
+          "type": "track",
+          "clock": 9,
+          "createdAt": "2020-10-02T18:48:16.037Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "431e0330-f8ef-49b7-9625-78f4d47baf2d",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/Qmb5QCepqy2k26gvFKALcP74YvAaPS3AtCqNhXeH9YGMkB",
+          "type": "track",
+          "clock": 10,
+          "createdAt": "2020-10-02T18:48:16.049Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "c6904e22-c603-4743-ae91-281eb67f4187",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmRiU48Xr3vD3n6KhzJAvcuchmPbbumBefa3y7aeNaBzan",
+          "type": "track",
+          "clock": 11,
+          "createdAt": "2020-10-02T18:48:16.061Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "4902f34d-cc2c-4373-8214-ed71e3d40939",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZwxEQSjS6uruo4vXwkh6fUhvjBK4Yp83qq9AHX4R38tr",
+          "type": "track",
+          "clock": 12,
+          "createdAt": "2020-10-02T18:48:16.076Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "894c6c9b-9402-473e-9db9-b6a421b110c3",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmPyxEWcfJ9qnQm8CNPChzLoDinhTbi9zVtyGTJBeoNDxB",
+          "type": "track",
+          "clock": 13,
+          "createdAt": "2020-10-02T18:48:16.092Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "4976f227-cd4d-481c-abb4-171bfc9acaad",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmULEs3yq1kCVMBoiSMSVv7JopVz6K3TgncqcriioNMdWi",
+          "type": "track",
+          "clock": 14,
+          "createdAt": "2020-10-02T18:48:16.107Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "b9339fde-2ac9-44be-b1a0-3373604b0915",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmaqSv1buZQ6enNwsae4B3paPDAXjcXZTRY6cUscPoc2ik",
+          "type": "track",
+          "clock": 15,
+          "createdAt": "2020-10-02T18:48:16.120Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "d9e8a2c6-5816-4d4e-90f7-c18c6a4f1f3d",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmYG4TY55oLoe5RjsABJmcUrAUWgyCc8jRpvBTWkT7ZNjH",
+          "type": "track",
+          "clock": 16,
+          "createdAt": "2020-10-02T18:48:16.131Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "c8153ea3-8ec7-4a27-9695-ae2f23d8134f",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmXyGwndsBXmM2xCW4VaWkRqp3pv4Cr6yAKfHnYDDTn63d",
+          "type": "track",
+          "clock": 17,
+          "createdAt": "2020-10-02T18:48:16.145Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "d3ac63d0-b307-49a8-986b-32c63aaf9489",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmdjBYvYirb4ANjK55ktmE4eokEKVsej9tjeWuZDxasHoh",
+          "type": "track",
+          "clock": 18,
+          "createdAt": "2020-10-02T18:48:16.159Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "1d6db106-3673-4c9f-9ff0-e036b602ab97",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmWbAbeaDGSM3LiARCKk2EWnLtgUqKcD3hK4nvHwdUZJK9",
+          "type": "track",
+          "clock": 19,
+          "createdAt": "2020-10-02T18:48:16.174Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "3cc4644e-e912-4120-a7ef-daa8cb6872a8",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmTacAUYq6qUdMqkNEUPohYLbAu3eEetwAW9QYn53TWmj7",
+          "type": "track",
+          "clock": 20,
+          "createdAt": "2020-10-02T18:48:16.189Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "e83f72d8-3e65-4cf4-a4d0-6309ff56d3aa",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmNbt57KLtgbEKz97qSoJDZ2DteEjmg455ZBvnoCHySQ9q",
+          "type": "track",
+          "clock": 21,
+          "createdAt": "2020-10-02T18:48:16.205Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "80a5e3a1-9fa2-4a5e-ba03-89b460868955",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmNpX6fcViqDTBBJmVKsAVcNmQdqZRV4zqzUuxfP4DJtot",
+          "type": "track",
+          "clock": 22,
+          "createdAt": "2020-10-02T18:48:16.221Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "3da22ac0-16a9-4d50-b244-822f5d4162de",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmcKcZfASQZJUVaHKtFxN7CqyhwD9oiQNeCkZxfDo36EKA",
+          "type": "track",
+          "clock": 23,
+          "createdAt": "2020-10-02T18:48:16.237Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "ff62119b-6007-4288-be9e-d6a27d59a642",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZw9kq8iVcVtNzRapsS9K3zRiaLNsa8bD9Dbw4QBXzHnJ",
+          "type": "track",
+          "clock": 24,
+          "createdAt": "2020-10-02T18:48:16.248Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "4d65ebc1-1f6b-431b-9ba8-faa38fd32f80",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmYCWrB5vGJ3REaTRkL35QgpZNDN25E1XtEpMQVctPVSEx",
+          "type": "track",
+          "clock": 25,
+          "createdAt": "2020-10-02T18:48:16.262Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "5c85c277-2bcb-47a2-a793-63c8e47b8930",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmX9ePR6kL5djVNvGKzXogjigPfRtA75XKj3d71ZiAQELF",
+          "type": "track",
+          "clock": 26,
+          "createdAt": "2020-10-02T18:48:16.275Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "d0cac540-f96c-4ed4-b674-e39dc625beb5",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmPuDcNoaa8NmSa7mYPWneNDPqMmwiDoTnr6pAsrAg5CPY",
+          "type": "track",
+          "clock": 27,
+          "createdAt": "2020-10-02T18:48:16.287Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "eda99b1b-9c9d-4b5d-afaf-efa9a8ff0800",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZjt4SvTXhTqeoKTNPAKTPwfd8QadRWz9tjKXg9fEwDSY",
+          "type": "track",
+          "clock": 28,
+          "createdAt": "2020-10-02T18:48:16.300Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "d281c018-d711-487b-acf9-5e0c964f0813",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmXLcCb5PTVtUusxtyo3pckJjCqeZKUt5VNv1FAbEdiRHn",
+          "type": "track",
+          "clock": 29,
+          "createdAt": "2020-10-02T18:48:16.313Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "77d29616-08e9-4d65-b12a-f0de40eecf71",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmX1mAPkDpBTooEAoZbLv1PWFfaaq2aQ9gLX2Bcktd5TXT",
+          "type": "track",
+          "clock": 30,
+          "createdAt": "2020-10-02T18:48:16.328Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "e7c3a05d-5e10-44da-9422-5759c9ca8204",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmPhEZL5o7uAtes7g1kmxRGaLeRXE9YF4h8CPHk1KYVvSk",
+          "type": "track",
+          "clock": 31,
+          "createdAt": "2020-10-02T18:48:16.341Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "7753b1de-ba07-4c52-8e5f-5b21e3504b3d",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmZEnMbMH9FzkLHn4LW4CGjW5FPHg6dw3PCYhHjCXrLZXy",
+          "type": "track",
+          "clock": 32,
+          "createdAt": "2020-10-02T18:48:16.353Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "878a6ef9-296b-475d-83df-e2d7055accc6",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmekrmmfT4oHvRst8aYioWLTPGAGHcNEj3as8cVgo1TAE8",
+          "type": "track",
+          "clock": 33,
+          "createdAt": "2020-10-02T18:48:16.364Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "7a239b4b-3255-4160-b260-6e0dc862837b",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmckKtz4nhmwsyFGNJ8pLpLSPPkgPGXq44bQRQwi75XTdp",
+          "type": "track",
+          "clock": 34,
+          "createdAt": "2020-10-02T18:48:16.379Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "36873c2b-b33d-4da5-a9c8-13e6f699ee5b",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": 1,
+          "multihash": "QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas",
+          "sourceFile": "50329ff9-c2c5-422a-8152-ff5338102fa6.mp3",
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmbJ9JdEDT6bzdcsY5grX71nq2etzNZXsCM6H84k1GMFas",
+          "type": "track",
+          "clock": 35,
+          "createdAt": "2020-10-02T18:48:16.393Z",
+          "updatedAt": "2020-10-02T18:48:17.557Z"
+        },
+        {
+          "fileUUID": "5b24a995-d8f6-4572-8ecc-5107cf8d6ef0",
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "trackBlockchainId": null,
+          "multihash": "QmcYCwJHfCScqDFEXd78hkdFbyn98mJWXhej4QhQx2aPaZ",
+          "sourceFile": null,
+          "fileName": null,
+          "dirMultihash": null,
+          "storagePath": "test_file_storage/QmcYCwJHfCScqDFEXd78hkdFbyn98mJWXhej4QhQx2aPaZ",
+          "type": "metadata",
+          "clock": 36,
+          "createdAt": "2020-10-02T18:48:16.475Z",
+          "updatedAt": "2020-10-02T18:48:16.475Z"
+        }
+      ],
+      "clockRecords": [
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 1,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:03.425Z",
+          "updatedAt": "2020-10-02T18:48:03.425Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 2,
+          "sourceTable": "AudiusUser",
+          "createdAt": "2020-10-02T18:48:04.496Z",
+          "updatedAt": "2020-10-02T18:48:04.496Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 3,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:15.959Z",
+          "updatedAt": "2020-10-02T18:48:15.959Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 4,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:15.970Z",
+          "updatedAt": "2020-10-02T18:48:15.970Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 5,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:15.979Z",
+          "updatedAt": "2020-10-02T18:48:15.979Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 6,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:15.992Z",
+          "updatedAt": "2020-10-02T18:48:15.992Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 7,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.008Z",
+          "updatedAt": "2020-10-02T18:48:16.008Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 8,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.020Z",
+          "updatedAt": "2020-10-02T18:48:16.020Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 9,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.030Z",
+          "updatedAt": "2020-10-02T18:48:16.030Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 10,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.045Z",
+          "updatedAt": "2020-10-02T18:48:16.045Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 11,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.057Z",
+          "updatedAt": "2020-10-02T18:48:16.057Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 12,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.071Z",
+          "updatedAt": "2020-10-02T18:48:16.071Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 13,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.087Z",
+          "updatedAt": "2020-10-02T18:48:16.087Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 14,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.103Z",
+          "updatedAt": "2020-10-02T18:48:16.103Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 15,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.113Z",
+          "updatedAt": "2020-10-02T18:48:16.113Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 16,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.128Z",
+          "updatedAt": "2020-10-02T18:48:16.128Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 17,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.142Z",
+          "updatedAt": "2020-10-02T18:48:16.142Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 18,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.153Z",
+          "updatedAt": "2020-10-02T18:48:16.153Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 19,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.171Z",
+          "updatedAt": "2020-10-02T18:48:16.171Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 20,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.181Z",
+          "updatedAt": "2020-10-02T18:48:16.181Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 21,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.198Z",
+          "updatedAt": "2020-10-02T18:48:16.198Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 22,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.213Z",
+          "updatedAt": "2020-10-02T18:48:16.213Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 23,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.229Z",
+          "updatedAt": "2020-10-02T18:48:16.229Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 24,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.244Z",
+          "updatedAt": "2020-10-02T18:48:16.244Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 25,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.258Z",
+          "updatedAt": "2020-10-02T18:48:16.258Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 26,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.270Z",
+          "updatedAt": "2020-10-02T18:48:16.270Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 27,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.281Z",
+          "updatedAt": "2020-10-02T18:48:16.281Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 28,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.296Z",
+          "updatedAt": "2020-10-02T18:48:16.296Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 29,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.310Z",
+          "updatedAt": "2020-10-02T18:48:16.310Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 30,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.324Z",
+          "updatedAt": "2020-10-02T18:48:16.324Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 31,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.337Z",
+          "updatedAt": "2020-10-02T18:48:16.337Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 32,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.347Z",
+          "updatedAt": "2020-10-02T18:48:16.347Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 33,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.361Z",
+          "updatedAt": "2020-10-02T18:48:16.361Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 34,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.376Z",
+          "updatedAt": "2020-10-02T18:48:16.376Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 35,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.387Z",
+          "updatedAt": "2020-10-02T18:48:16.387Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 36,
+          "sourceTable": "File",
+          "createdAt": "2020-10-02T18:48:16.470Z",
+          "updatedAt": "2020-10-02T18:48:16.470Z"
+        },
+        {
+          "cnodeUserUUID": "454d032a-ed79-4332-a3dd-3de2a8f30f47",
+          "clock": 37,
+          "sourceTable": "Track",
+          "createdAt": "2020-10-02T18:48:17.518Z",
+          "updatedAt": "2020-10-02T18:48:17.518Z"
+        }
+      ]
+    }
+  },
+  "ipfsIDObj": {
+    "id": "QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+    "publicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDFr5LdVX9oig5N7FHJkQcUiJXAO9Qa5w9m2CDlfRZ5WL5B04wU0nr2u2AjGSgtlScQueSgvQwcESYeCVI283rk8ekSfUJKt0XXPFbTwdQufSehTlWuPFerrgSlNX3BaE5Rkj8L+1PlpqjH/tRsYOqIyF4LXHYZsppQeFruPwW/xy6jNa/RsJlaI2epVDIBGVDc5VB6sNEZCX2httJJ86t69T2DaLWBv0/5A4MAssftwf4LQIuU0AIMX/UKJlT6XsumplX/5SFwSpzFnD2JKwWF8uT0/P58fEo5BfCNdOfjxCJqWXRt4eVzbg4hkUKM8NGzSKQ2Wj6UG+ad+msYz7hPAgMBAAE=",
+    "addresses": [
+      "/ip4/127.0.0.1/tcp/4001/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/172.17.0.2/tcp/4001/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/54730/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/61166/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/51519/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/58070/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/60833/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/53424/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/53997/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/54011/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/54007/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/57977/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/50404/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52702/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/57941/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/62905/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52377/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52387/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52392/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52883/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/53259/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/58551/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/60788/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/60997/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/61023/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/62016/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/62094/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/64479/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/65142/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/52278/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/53453/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/59140/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/61015/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/62396/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/63364/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/50408/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU",
+      "/ip4/73.157.75.185/tcp/53883/ipfs/QmW3xqYHGro1yW5cv9EKEaMCWSKQ7835aFNrXm9SHji7HU"
+    ],
+    "agentVersion": "go-ipfs/0.4.23/6ce9a35",
+    "protocolVersion": "ipfs/0.1.0"
+  },
+  "signer": "0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25",
+  "version": "0.3.22",
+  "service": "creator-node",
+  "timestamp": "2020-10-02T18:48:17.781Z",
+  "signature": "0x0b15fd18955ac3c610795c2e3dfa396a25a708255814e0133a2710379255078450a22a7dfdfbed4d284b8239f7e4c47af591da894e54986539f38beb7091f9f51c"
+}

--- a/creator-node/test/utils.js
+++ b/creator-node/test/utils.js
@@ -1,0 +1,27 @@
+const models = require('../src/models')
+
+const getCNodeUser = async (cnodeUserUUID) => {
+  const { dataValues } = await models.CNodeUser.findOne({ where: { cnodeUserUUID } })
+  return dataValues
+}
+
+const stringifiedDateFields = (obj) => {
+  const newObj = { ...obj }
+  if (newObj.createdAt) newObj.createdAt = newObj.createdAt.toISOString()
+  if (newObj.updatedAt) newObj.updatedAt = newObj.updatedAt.toISOString()
+  return newObj
+}
+
+const destroyUsers = async () => (
+  models.CNodeUser.destroy({
+    where: {},
+    truncate: true,
+    cascade: true // cascades delete to all rows with foreign key on cnodeUser
+  })
+)
+
+module.exports = {
+  getCNodeUser,
+  stringifiedDateFields,
+  destroyUsers
+}


### PR DESCRIPTION
### Trello Card Link


### Description
Adds two integration tests for nodesync:
- export: tests that for a given db state, we export the correct JSON blob
- sync: tests that for a given exported blob, we reconstruct the correct DB state 

Note this does not test the correctness of the file system post sync, though that codepath is lightly exercised (files are 'requested' from another CNode that is mocked to return empty buffers).


### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?
Added  nodesync.test.js
