### PR TITLE
Add user track favorites

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -8,7 +8,7 @@ from src.queries.get_saves import get_saves
 from src.queries.get_users import get_users
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_tracks import get_tracks
-from src.queries.get_full_save_tracks import get_full_save_tracks
+from src.queries.get_save_tracks import get_save_tracks
 from src.queries.get_followees_for_user import get_followees_for_user
 from src.queries.get_followers_for_user import get_followers_for_user
 
@@ -441,7 +441,7 @@ class FavoritedTracks(Resource):
             "offset": offset,
             "with_users": True
         }
-        track_saves = get_full_save_tracks(get_tracks_args)
+        track_saves = get_save_tracks(get_tracks_args)
         tracks = list(map(extend_activity, track_saves))
         return success_response(tracks)
 

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -14,7 +14,7 @@ from src.queries.get_followers_for_user import get_followers_for_user
 
 from src.api.v1.helpers import abort_not_found, decode_with_abort, extend_activity, extend_favorite, extend_track, \
     extend_user, format_limit, format_offset, make_response, search_parser, success_response, abort_bad_request_param, \
-    get_default_max, decode_string_id, encode_int_id
+    get_default_max, decode_string_id
 from .models.tracks import track, track_full
 from .models.activities import activity_model, activity_model_full
 from src.utils.redis_cache import cache

--- a/discovery-provider/src/queries/get_full_save_tracks.py
+++ b/discovery-provider/src/queries/get_full_save_tracks.py
@@ -1,0 +1,58 @@
+from src import exceptions
+from src.models import Track, Playlist, Save, SaveType
+from src.utils import helpers
+from src.utils.db_session import get_db_read_replica
+from src.queries import response_name_constants
+from src.queries.query_helpers import add_query_pagination, populate_track_metadata, \
+  get_users_by_id, get_users_ids
+
+def get_full_save_tracks(args):
+    user_id = args.get('user_id')
+    current_user_id = args.get('current_user_id')
+    limit = args.get('limit')
+    offset = args.get('offset')
+    filter_deleted = args.get("filter_deleted")
+
+    save_results = []
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        base_query = (
+            session.query(Track, Save.created_at)
+            .join(Save, Save.save_item_id == Track.track_id)
+            .filter(
+                Track.is_current == True,
+                Save.user_id == user_id,
+                Save.is_current == True,
+                Save.is_delete == False,
+                Save.save_type == 'track'
+            )
+        )
+
+        # Allow filtering of deletes
+        if filter_deleted:
+          base_query = base_query.filter(
+              Track.is_delete == False
+          )
+
+        base_query = base_query.order_by(Save.created_at.desc(), Track.track_id.desc())
+
+        query_results = add_query_pagination(base_query, limit, offset).all()
+        tracks, save_dates = zip(*query_results)
+        tracks = helpers.query_result_to_list(tracks)
+        track_ids = list(map(lambda track: track["track_id"], tracks))
+
+        # bundle peripheral info into track results
+        tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
+
+        if args.get("with_users", False):
+            user_id_list = get_users_ids(tracks)
+            users = get_users_by_id(session, user_id_list, current_user_id)
+            for track in tracks:
+                user = users[track['owner_id']]
+                if user:
+                    track['user'] = user
+
+        for idx, track in enumerate(tracks):
+            track[response_name_constants.activity_timestamp] = save_dates[idx]
+
+        return tracks

--- a/discovery-provider/src/queries/get_full_save_tracks.py
+++ b/discovery-provider/src/queries/get_full_save_tracks.py
@@ -1,10 +1,9 @@
-from src import exceptions
-from src.models import Track, Playlist, Save, SaveType
+from src.models import Track, Save, SaveType
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
 from src.queries.query_helpers import add_query_pagination, populate_track_metadata, \
-  get_users_by_id, get_users_ids
+    get_users_by_id, get_users_ids
 
 def get_full_save_tracks(args):
     user_id = args.get('user_id')
@@ -13,7 +12,6 @@ def get_full_save_tracks(args):
     offset = args.get('offset')
     filter_deleted = args.get("filter_deleted")
 
-    save_results = []
     db = get_db_read_replica()
     with db.scoped_session() as session:
         base_query = (
@@ -24,17 +22,18 @@ def get_full_save_tracks(args):
                 Save.user_id == user_id,
                 Save.is_current == True,
                 Save.is_delete == False,
-                Save.save_type == 'track'
+                Save.save_type == SaveType.track
             )
         )
 
         # Allow filtering of deletes
         if filter_deleted:
-          base_query = base_query.filter(
-              Track.is_delete == False
-          )
+            base_query = base_query.filter(
+                Track.is_delete == False
+            )
 
-        base_query = base_query.order_by(Save.created_at.desc(), Track.track_id.desc())
+        base_query = base_query.order_by(
+            Save.created_at.desc(), Track.track_id.desc())
 
         query_results = add_query_pagination(base_query, limit, offset).all()
         tracks, save_dates = zip(*query_results)
@@ -42,7 +41,8 @@ def get_full_save_tracks(args):
         track_ids = list(map(lambda track: track["track_id"], tracks))
 
         # bundle peripheral info into track results
-        tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
+        tracks = populate_track_metadata(
+            session, track_ids, tracks, current_user_id)
 
         if args.get("with_users", False):
             user_id_list = get_users_ids(tracks)

--- a/discovery-provider/src/queries/get_save_tracks.py
+++ b/discovery-provider/src/queries/get_save_tracks.py
@@ -5,7 +5,7 @@ from src.queries import response_name_constants
 from src.queries.query_helpers import add_query_pagination, populate_track_metadata, \
     get_users_by_id, get_users_ids
 
-def get_full_save_tracks(args):
+def get_save_tracks(args):
     user_id = args.get('user_id')
     current_user_id = args.get('current_user_id')
     limit = args.get('limit')

--- a/discovery-provider/src/queries/get_savers_for_playlist.py
+++ b/discovery-provider/src/queries/get_savers_for_playlist.py
@@ -70,7 +70,7 @@ def get_savers_for_playlist(args):
         # Fix format to return only Users objects with follower_count field.
         if user_results:
             users, _ = zip(*user_results)
-            user_results = helpers.query_result_to_list(user_results)
+            user_results = helpers.query_result_to_list(users)
             # bundle peripheral info into user results
             user_ids = [user['user_id'] for user in user_results]
             user_results = populate_user_metadata(


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/A7BOsv5J/1476-port-the-new-api-into-the-dapp

### Description
Adds the user track favorite endpoint so that the client does not need to make multiple requests for this information.

Note:  the change to the file discovery-provider/src/queries/get_savers_for_playlist.py fixes a bug I introduced #875 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
I ran it locally against the Prod snapshot db
