### PR TITLE
Update playlist routes to support client

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -62,6 +62,19 @@ def add_playlist_artwork(playlist):
     playlist["artwork"] = artwork
     return playlist
 
+
+def add_playlist_added_timestamps(playlist):
+    if not "playlist_contents" in playlist:
+        return playlist
+    added_timestamps = []
+    for track in playlist["playlist_contents"]["track_ids"]:
+        added_timestamps.append({
+            "track_id": encode_int_id(track["track"]),
+            "timestamp": track["time"]
+        })
+    return added_timestamps
+
+
 def add_user_artwork(user):
     # Legacy CID-only references to images
     user["cover_photo_legacy"] = user["cover_photo"]
@@ -159,7 +172,8 @@ def extend_track(track):
 
     return track
 
-def extend_playlist(playlist):
+
+def extend_playlist(playlist, include_tracks=False):
     playlist_id = encode_int_id(playlist["playlist_id"])
     owner_id = encode_int_id(playlist["playlist_owner_id"])
     playlist["id"] = playlist_id
@@ -168,11 +182,15 @@ def extend_playlist(playlist):
         playlist["user"] = extend_user(playlist["user"])
     playlist = add_playlist_artwork(playlist)
 
+    playlist["followee_favorites"] = list(map(extend_favorite, playlist["followee_saves"]))
     playlist["followee_reposts"] = list(map(extend_repost, playlist["followee_reposts"]))
-    playlist["followee_saves"] = list(map(extend_favorite, playlist["followee_saves"]))
 
     playlist["favorite_count"] = playlist["save_count"]
+    playlist["added_timestamps"] = add_playlist_added_timestamps(playlist)
+    playlist["cover_art"] = playlist["playlist_image_multihash"]
+    playlist["cover_art_sizes"] = playlist["playlist_image_sizes_multihash"]
     return playlist
+
 
 def extend_activity(item):
     if item.get("track_id"):

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -173,7 +173,7 @@ def extend_track(track):
     return track
 
 
-def extend_playlist(playlist, include_tracks=False):
+def extend_playlist(playlist):
     playlist_id = encode_int_id(playlist["playlist_id"])
     owner_id = encode_int_id(playlist["playlist_owner_id"])
     playlist["id"] = playlist_id

--- a/discovery-provider/src/api/v1/models/playlists.py
+++ b/discovery-provider/src/api/v1/models/playlists.py
@@ -9,13 +9,9 @@ playlist_artwork = ns.model('playlist_artwork', {
     "1000x1000": fields.String,
 })
 
-playlist_track = ns.model('playlist_track', {
-    "time": fields.Integer(required=True),
-    "track": fields.Integer(required=True)
-})
-
-playlist_contents = ns.model('playlist_contents', {
-    "track_ids": fields.List(fields.Nested(playlist_track))
+playlist_added_timestamp = ns.model('playlist_added_timestamp', {
+    "timestamp": fields.Integer(required=True),
+    "track_id": fields.String(required=True),
 })
 
 playlist_model = ns.model('playlist', {
@@ -32,14 +28,17 @@ playlist_model = ns.model('playlist', {
 
 full_playlist_model = ns.clone('playlist_full', playlist_model, {
     "created_at": fields.String,
-    "followee_reposts": fields.List(fields.Nested(repost)),
-    "followee_saves": fields.List(fields.Nested(favorite)),
+    "followee_reposts": fields.List(fields.Nested(repost), required=True),
+    "followee_favorites": fields.List(fields.Nested(favorite), required=True),
     "has_current_user_reposted": fields.Boolean(required=True),
     "has_current_user_saved": fields.Boolean(required=True),
     "is_delete": fields.Boolean(required=True),
     "is_private": fields.Boolean(required=True),
     "updated_at": fields.String,
-    "playlist_contents": fields.Nested(playlist_contents, required=True),
+    "added_timestamps": fields.List(fields.Nested(playlist_added_timestamp), required=True),
+    "user_id": fields.String(required=True),
     "user": fields.Nested(user_model_full, required=True),
-    "tracks": fields.List(fields.Nested(track_full), required=True)
+    "tracks": fields.List(fields.Nested(track_full), required=True),
+    "cover_art": fields.String,
+    "cover_art_sizes": fields.String,
 })

--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -231,7 +231,7 @@ playlist_reposts_route_parser.add_argument('limit', required=False, type=int)
 playlist_reposts_route_parser.add_argument('offset', required=False, type=int)
 playlist_reposts_response = make_response("following_response", full_ns, fields.List(fields.Nested(user_model_full)))
 @full_ns.route("/<string:playlist_id>/reposts")
-class FullTrackReposts(Resource):
+class FullPlaylistReposts(Resource):
     @full_ns.expect(playlist_reposts_route_parser)
     @full_ns.doc(
         id="""Get Users that Reposted a Playlist""",

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -1,4 +1,5 @@
 import logging
+from src.api.v1.playlists import get_tracks_for_playlist
 from src.queries.get_repost_feed_for_user import get_repost_feed_for_user
 from flask_restx import Resource, Namespace, fields, reqparse
 from src.api.v1.models.common import favorite
@@ -334,6 +335,9 @@ class FullRepostList(Resource):
             "offset": offset
         }
         reposts = get_repost_feed_for_user(decoded_id, args)
+        for repost in reposts:
+            if "playlist_id" in repost:
+                repost["tracks"] = get_tracks_for_playlist(repost["playlist_id"], current_user_id)
         activities = list(map(extend_activity, reposts))
 
         return success_response(activities)
@@ -376,6 +380,9 @@ class HandleFullRepostList(Resource):
             "offset": offset
         }
         reposts = get_repost_feed_for_user(None, args)
+        for repost in reposts:
+            if "playlist_id" in repost:
+                repost["tracks"] = get_tracks_for_playlist(repost["playlist_id"], current_user_id)
         activities = list(map(extend_activity, reposts))
 
         return success_response(activities)

--- a/discovery-provider/src/queries/get_playlist_tracks.py
+++ b/discovery-provider/src/queries/get_playlist_tracks.py
@@ -4,8 +4,7 @@ import sqlalchemy
 from src.models import Playlist, Track
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
-from src.queries.query_helpers import get_pagination_vars, \
-    populate_track_metadata, add_users_to_tracks
+from src.queries.query_helpers import populate_track_metadata, add_users_to_tracks
 
 logger = logging.getLogger(__name__)
 

--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -106,7 +106,7 @@ def get_playlists(args):
 
             if args.get("with_users", False):
                 user_id_list = get_users_ids(playlists)
-                users = get_users_by_id(session, user_id_list)
+                users = get_users_by_id(session, user_id_list, current_user_id)
                 for playlist in playlists:
                     user = users[playlist['playlist_owner_id']]
                     if user:

--- a/discovery-provider/src/queries/get_repost_feed_for_user.py
+++ b/discovery-provider/src/queries/get_repost_feed_for_user.py
@@ -4,13 +4,15 @@ from src.models import Track, Repost, RepostType, Follow, Playlist, Save, SaveTy
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
-from src.queries.query_helpers import get_current_user_id, get_repost_counts, get_save_counts, \
+from src.queries.query_helpers import get_repost_counts, get_save_counts, \
     paginate_query, get_users_by_id, get_users_ids
 
 
 def get_repost_feed_for_user(user_id, args):
     feed_results = {}
     db = get_db_read_replica()
+    current_user_id = args.get("current_user_id")
+
     with db.scoped_session() as session:
         if "handle" in args:
             handle = args.get("handle")
@@ -116,7 +118,6 @@ def get_repost_feed_for_user(user_id, args):
             if save_type in (SaveType.playlist, SaveType.album)
         }
 
-        current_user_id = get_current_user_id(required=False)
         requested_user_is_current_user = False
         user_reposted_track_ids = {}
         user_reposted_playlist_ids = {}

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -175,7 +175,7 @@ def get_repost_feed_for_user_route(user_id):
     args = to_dict(request.args)
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
-    args["current_user_id"] = get_current_user_id(required=False) 
+    args["current_user_id"] = get_current_user_id(required=False)
     feed_results = get_repost_feed_for_user(user_id, args)
     return api_helpers.success_response(feed_results)
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/A7BOsv5J/1476-port-the-new-api-into-the-dapp

### Description
* Cleans up a few missing fields in playlist response
* Adds `tracks` to the playlist response in get single playlist & get user reposts

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually with the dapp against each route (profile page reposts