### PR TITLE
Add remixes and stems to API

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -179,7 +179,9 @@ def stem_from_track(track):
     return {
         "id": track_id,
         "parent_id": parent_id,
-        "category": category
+        "category": category,
+        "cid": track["download"]["cid"],
+        "user_id": encode_int_id(track["owner_id"])
     }
 
 def extend_playlist(playlist):

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -237,6 +237,13 @@ def to_dict(multi_dict):
     """Converts a multi dict into a dict where only list entries are not flat"""
     return {k: v if len(v) > 1 else v[0] for (k, v) in multi_dict.to_dict(flat=False).items()}
 
+def get_current_user_id(args):
+    """Gets current_user_id from args featuring a "user_id" key"""
+    if args.get("user_id"):
+        return decode_string_id(args["user_id"])
+    return None
+
+
 
 search_parser = reqparse.RequestParser()
 search_parser.add_argument('query', required=True)

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -172,6 +172,15 @@ def extend_track(track):
 
     return track
 
+def stem_from_track(track):
+    track_id = encode_int_id(track["track_id"])
+    parent_id = encode_int_id(track["stem_of"]["parent_track_id"])
+    category = track["stem_of"]["category"]
+    return {
+        "id": track_id,
+        "parent_id": parent_id,
+        "category": category
+    }
 
 def extend_playlist(playlist):
     playlist_id = encode_int_id(playlist["playlist_id"])

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -99,3 +99,14 @@ track_full = ns.clone('track_full', track, {
     "cover_art": fields.String,
     "remix_of": fields.Nested(full_remix_parent),
 })
+
+stem_full = ns.model('stem_full', {
+    "id": fields.String(required=True),
+    "parent_id": fields.String(required=True),
+    "category": fields.String(required=True)
+})
+
+remixes_response = ns.model('remixes_response', {
+    "count": fields.Integer(required=True),
+    "tracks": fields.List(fields.Nested(track_full))
+})

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -103,7 +103,9 @@ track_full = ns.clone('track_full', track, {
 stem_full = ns.model('stem_full', {
     "id": fields.String(required=True),
     "parent_id": fields.String(required=True),
-    "category": fields.String(required=True)
+    "category": fields.String(required=True),
+    "cid": fields.String(required=True),
+    "user_id": fields.String(required=True)
 })
 
 remixes_response = ns.model('remixes_response', {

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -2,7 +2,6 @@ from urllib.parse import urljoin
 import logging  # pylint: disable=C0302
 from flask import redirect
 from flask_restx import Resource, Namespace, fields, reqparse
-from flask_restx import resource
 from src.queries.get_tracks import get_tracks
 from src.queries.get_track_user_creator_node import get_track_user_creator_node
 from src.api.v1.helpers import abort_not_found, decode_with_abort,  \

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -8,7 +8,9 @@ from src.queries.get_track_user_creator_node import get_track_user_creator_node
 from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
     extend_track, make_response, search_parser, extend_user, get_default_max, \
     trending_parser, full_trending_parser, success_response, abort_bad_request_param, to_dict, \
-    format_offset, format_limit, decode_string_id, stem_from_track
+    format_offset, format_limit, decode_string_id, stem_from_track, \
+    get_current_user_id
+
 from .models.tracks import track, track_full, stem_full, remixes_response
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_trending_tracks import get_trending_tracks
@@ -363,10 +365,8 @@ class FullTrackReposts(Resource):
         decoded_id = decode_with_abort(track_id, full_ns)
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
+        current_user_id = get_current_user_id(args)
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
         args = {
             'repost_track_id': decoded_id,
             'current_user_id': current_user_id,
@@ -386,8 +386,6 @@ class FullTrackStems(Resource):
     def get(self, track_id):
         decoded_id = decode_with_abort(track_id, full_ns)
         stems = get_stems_of(decoded_id)
-        logger.warning("STEMSSS")
-        logger.warning(stems)
         stems = list(map(stem_from_track, stems))
         return success_response(stems)
 
@@ -404,10 +402,12 @@ class FullRemixesRoute(Resource):
     def get(self, track_id):
         decoded_id = decode_with_abort(track_id, full_ns)
         request_args = remixes_parser.parse_args()
+        current_user_id = get_current_user_id(request_args)
+
         args = {
             "with_users": True,
             "track_id": decoded_id,
-            "current_user_id": request_args.get("user_id"),
+            "current_user_id": current_user_id,
             "limit": request_args.get("limit"),
             "offset": request_args.get("offset")
         }
@@ -429,10 +429,12 @@ class FullRemixingRoute(Resource):
     def get(self, track_id):
         decoded_id = decode_with_abort(track_id, full_ns)
         request_args = remixes_parser.parse_args()
+        current_user_id = get_current_user_id(request_args)
+
         args = {
             "with_users": True,
             "track_id": decoded_id,
-            "current_user_id": request_args.get("user_id"),
+            "current_user_id": current_user_id,
             "limit": request_args.get("limit"),
             "offset": request_args.get("offset")
         }

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -395,6 +395,7 @@ remixes_parser = reqparse.RequestParser()
 remixes_parser.add_argument('user_id', required=False)
 remixes_parser.add_argument('limit', required=False, default=10)
 remixes_parser.add_argument('offset', required=False, default=0)
+
 @full_ns.route("/<string:track_id>/remixes")
 class FullRemixesRoute(Resource):
     @full_ns.marshal_with(remixes_response)
@@ -408,12 +409,10 @@ class FullRemixesRoute(Resource):
             "with_users": True,
             "track_id": decoded_id,
             "current_user_id": current_user_id,
-            "limit": request_args.get("limit"),
-            "offset": request_args.get("offset")
+            "limit": format_limit(request_args),
+            "offset": format_offset(request_args)
         }
         response = get_remixes_of(args)
-        logger.warning(f'count: {response["count"]}')
-        logger.warning(f'track: {response["tracks"][0]}')
         response["tracks"] = list(map(extend_track, response["tracks"]))
         return success_response(response)
 
@@ -422,6 +421,7 @@ remixing_parser = reqparse.RequestParser()
 remixing_parser.add_argument('user_id', required=False)
 remixing_parser.add_argument('limit', required=False, default=10)
 remixing_parser.add_argument('offset', required=False, default=0)
+
 @full_ns.route("/<string:track_id>/remixing")
 class FullRemixingRoute(Resource):
     @full_ns.marshal_with(remixing_response)
@@ -435,8 +435,8 @@ class FullRemixingRoute(Resource):
             "with_users": True,
             "track_id": decoded_id,
             "current_user_id": current_user_id,
-            "limit": request_args.get("limit"),
-            "offset": request_args.get("offset")
+            "limit": format_limit(request_args),
+            "offset": format_offset(request_args)
         }
         tracks = get_remix_track_parents(args)
         tracks = list(map(extend_track, tracks))

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -8,8 +8,8 @@ from src.queries.get_track_user_creator_node import get_track_user_creator_node
 from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
     extend_track, make_response, search_parser, extend_user, get_default_max, \
     trending_parser, full_trending_parser, success_response, abort_bad_request_param, to_dict, \
-    format_offset, format_limit, decode_string_id
-from .models.tracks import track, track_full
+    format_offset, format_limit, decode_string_id, stem_from_track
+from .models.tracks import track, track_full, stem_full, remixes_response
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_trending_tracks import get_trending_tracks
 from flask.json import dumps
@@ -20,6 +20,9 @@ from src.api.v1.models.users import user_model_full
 from src.queries.get_reposters_for_track import get_reposters_for_track
 from src.queries.get_savers_for_track import get_savers_for_track
 from src.queries.get_tracks_including_unlisted import get_tracks_including_unlisted
+from src.queries.get_stems_of import get_stems_of
+from src.queries.get_remixes_of import get_remixes_of
+from src.queries.get_remix_track_parents import get_remix_track_parents
 
 logger = logging.getLogger(__name__)
 
@@ -373,3 +376,66 @@ class FullTrackReposts(Resource):
         users = get_reposters_for_track(args)
         users = list(map(extend_user, users))
         return success_response(users)
+
+track_stems_response = make_response("stems_response", full_ns, fields.List(fields.Nested(stem_full)))
+
+@full_ns.route("/<string:track_id>/stems")
+class FullTrackStems(Resource):
+    @full_ns.marshal_with(track_stems_response)
+    @cache(ttl_sec=10)
+    def get(self, track_id):
+        decoded_id = decode_with_abort(track_id, full_ns)
+        stems = get_stems_of(decoded_id)
+        logger.warning("STEMSSS")
+        logger.warning(stems)
+        stems = list(map(stem_from_track, stems))
+        return success_response(stems)
+
+
+remixes_response = make_response("remixes_response", full_ns, fields.Nested(remixes_response))
+remixes_parser = reqparse.RequestParser()
+remixes_parser.add_argument('user_id', required=False)
+remixes_parser.add_argument('limit', required=False, default=10)
+remixes_parser.add_argument('offset', required=False, default=0)
+@full_ns.route("/<string:track_id>/remixes")
+class FullRemixesRoute(Resource):
+    @full_ns.marshal_with(remixes_response)
+    @cache(ttl_sec=10)
+    def get(self, track_id):
+        decoded_id = decode_with_abort(track_id, full_ns)
+        request_args = remixes_parser.parse_args()
+        args = {
+            "with_users": True,
+            "track_id": decoded_id,
+            "current_user_id": request_args.get("user_id"),
+            "limit": request_args.get("limit"),
+            "offset": request_args.get("offset")
+        }
+        response = get_remixes_of(args)
+        logger.warning(f'count: {response["count"]}')
+        logger.warning(f'track: {response["tracks"][0]}')
+        response["tracks"] = list(map(extend_track, response["tracks"]))
+        return success_response(response)
+
+remixing_response = make_response("remixing_response", full_ns, fields.List(fields.Nested(track_full)))
+remixing_parser = reqparse.RequestParser()
+remixing_parser.add_argument('user_id', required=False)
+remixing_parser.add_argument('limit', required=False, default=10)
+remixing_parser.add_argument('offset', required=False, default=0)
+@full_ns.route("/<string:track_id>/remixing")
+class FullRemixingRoute(Resource):
+    @full_ns.marshal_with(remixing_response)
+    @cache(ttl_sec=10)
+    def get(self, track_id):
+        decoded_id = decode_with_abort(track_id, full_ns)
+        request_args = remixes_parser.parse_args()
+        args = {
+            "with_users": True,
+            "track_id": decoded_id,
+            "current_user_id": request_args.get("user_id"),
+            "limit": request_args.get("limit"),
+            "offset": request_args.get("offset")
+        }
+        tracks = get_remix_track_parents(args)
+        tracks = list(map(extend_track, tracks))
+        return success_response(tracks)

--- a/discovery-provider/src/queries/get_remix_track_parents.py
+++ b/discovery-provider/src/queries/get_remix_track_parents.py
@@ -1,44 +1,73 @@
 from sqlalchemy import desc, and_
-
+import logging  # pylint: disable=C0302
+from flask.globals import request
 from src.models import Track, Remix
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import populate_track_metadata, \
     add_query_pagination, add_users_to_tracks
+from src.utils.redis_cache import extract_key, use_redis_cache
 
+logger = logging.getLogger(__name__)
+
+UNPOPULATED_REMIX_PARENTS_CACHE_DURATION_SEC = 10
+
+def make_cache_key(args):
+    cache_keys = {
+        "limit": args.get("limit"),
+        "offset": args.get("offset"),
+        "track_id": args.get("track_id")
+    }
+    return extract_key(f"unpopulated-remix-parents:{request.path}", cache_keys.items())
 
 def get_remix_track_parents(args):
+    """Fetch remix parents for a given track.
+
+    Args:
+        args:dict
+        args.track_id: track id
+        args.limit: limit
+        args.offset: offset
+        args.with_users: with users
+        args.current_user_id: current user ID
+    """
     track_id = args.get("track_id")
     current_user_id = args.get("current_user_id")
     limit = args.get("limit")
     offset = args.get("offset")
     db = get_db_read_replica()
+
     with db.scoped_session() as session:
-        base_query = (
-            session.query(Track)
-            .join(
-                Remix,
-                and_(
-                    Remix.parent_track_id == Track.track_id,
-                    Remix.child_track_id == track_id
+        def get_unpopulated_remix_parents():
+            base_query = (
+                session.query(Track)
+                .join(
+                    Remix,
+                    and_(
+                        Remix.parent_track_id == Track.track_id,
+                        Remix.child_track_id == track_id
+                    )
+                )
+                .filter(
+                    Track.is_current == True,
+                    Track.is_unlisted == False
+                )
+                .order_by(
+                    desc(Track.created_at),
+                    desc(Track.track_id)
                 )
             )
-            .filter(
-                Track.is_current == True,
-                Track.is_unlisted == False
-            )
-            .order_by(
-                desc(Track.created_at),
-                desc(Track.track_id)
-            )
-        )
 
-        tracks = add_query_pagination(base_query, limit, offset).all()
-        tracks = helpers.query_result_to_list(tracks)
-        track_ids = list(map(lambda track: track["track_id"], tracks))
+            tracks = add_query_pagination(base_query, limit, offset).all()
+            tracks = helpers.query_result_to_list(tracks)
+            track_ids = list(map(lambda track: track["track_id"], tracks))
+            return (tracks, track_ids)
+
+        key = make_cache_key(args)
+        (tracks, track_ids) = use_redis_cache(key, UNPOPULATED_REMIX_PARENTS_CACHE_DURATION_SEC, get_unpopulated_remix_parents)
+
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
-
         if args.get("with_users", False):
-            add_users_to_tracks(session, tracks)
+            add_users_to_tracks(session, tracks, current_user_id)
 
     return tracks

--- a/discovery-provider/src/queries/get_remix_track_parents.py
+++ b/discovery-provider/src/queries/get_remix_track_parents.py
@@ -1,5 +1,5 @@
-from sqlalchemy import desc, and_
 import logging  # pylint: disable=C0302
+from sqlalchemy import desc, and_
 from flask.globals import request
 from src.models import Track, Remix
 from src.utils import helpers
@@ -64,7 +64,11 @@ def get_remix_track_parents(args):
             return (tracks, track_ids)
 
         key = make_cache_key(args)
-        (tracks, track_ids) = use_redis_cache(key, UNPOPULATED_REMIX_PARENTS_CACHE_DURATION_SEC, get_unpopulated_remix_parents)
+        (tracks, track_ids) = use_redis_cache(
+            key,
+            UNPOPULATED_REMIX_PARENTS_CACHE_DURATION_SEC,
+            get_unpopulated_remix_parents
+        )
 
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
         if args.get("with_users", False):

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -98,7 +98,7 @@ def get_remixes_of(args):
                         case(
                             [
                                 (and_(Repost.created_at == None,
-                                    Save.created_at == None), 0),
+                                      Save.created_at == None), 0),
                             ],
                             else_=(
                                 func.coalesce(repost_count_subquery.c.repost_count, 0) + \
@@ -123,7 +123,11 @@ def get_remixes_of(args):
             return (tracks, track_ids, count)
 
         key = make_cache_key(args)
-        (tracks, track_ids, count) = use_redis_cache(key, UNPOPULATED_REMIXES_CACHE_DURATION_SEC, get_unpopulated_remixes)
+        (tracks, track_ids, count) = use_redis_cache(
+            key,
+            UNPOPULATED_REMIXES_CACHE_DURATION_SEC,
+            get_unpopulated_remixes
+        )
 
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -21,9 +21,9 @@ def make_cache_key(args):
     return extract_key(f"unpopulated-remix-parents:{request.path}", cache_keys.items())
 
 def get_remixes_of(args):
-    track_id = args["track_id"]
-    current_user_id = args["current_user_id"]
-    limit, offset = args["limit"], args["offset"]
+    track_id = args.get("track_id")
+    current_user_id = args.get("current_user_id")
+    limit, offset = args.get("limit"), args.get("offset")
     db = get_db_read_replica()
 
     with db.scoped_session() as session:
@@ -121,6 +121,7 @@ def get_remixes_of(args):
             tracks = helpers.query_result_to_list(tracks)
             track_ids = list(map(lambda track: track["track_id"], tracks))
             return (tracks, track_ids, count)
+
         key = make_cache_key(args)
         (tracks, track_ids, count) = use_redis_cache(key, UNPOPULATED_REMIXES_CACHE_DURATION_SEC, get_unpopulated_remixes)
 

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -1,5 +1,6 @@
 from sqlalchemy import func, desc, case, and_
 
+from flask.globals import request
 from src import exceptions
 from src.models import Track, Repost, RepostType, Save, SaveType, Remix
 from src.utils import helpers
@@ -7,7 +8,17 @@ from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import populate_track_metadata, \
     add_query_pagination, add_users_to_tracks, create_save_count_subquery, \
     create_repost_count_subquery
+from src.utils.redis_cache import extract_key, use_redis_cache
 
+UNPOPULATED_REMIXES_CACHE_DURATION_SEC = 10
+
+def make_cache_key(args):
+    cache_keys = {
+        "limit": args.get("limit"),
+        "offset": args.get("offset"),
+        "track_id": args.get("track_id")
+    }
+    return extract_key(f"unpopulated-remix-parents:{request.path}", cache_keys.items())
 
 def get_remixes_of(args):
     track_id = args["track_id"]
@@ -16,102 +27,106 @@ def get_remixes_of(args):
     db = get_db_read_replica()
 
     with db.scoped_session() as session:
-        # Fetch the parent track to get the track's owner id
-        parent_track = session.query(Track).filter(
-            Track.is_current == True,
-            Track.track_id == track_id
-        ).first()
-
-        if parent_track == None:
-            raise exceptions.ArgumentError("Invalid track_id provided")
-
-        track_owner_id = parent_track.owner_id
-
-        # Create subquery for save counts for sorting
-        save_count_subquery = create_save_count_subquery(
-            session, SaveType.track)
-
-        # Create subquery for repost counts for sorting
-        repost_count_subquery = create_repost_count_subquery(
-            session, RepostType.track)
-
-        # Get the 'children' remix tracks
-        # Use the track owner id to fetch reposted/saved tracks returned first
-        base_query = (
-            session.query(
-                Track
-            )
-            .join(
-                Remix,
-                and_(
-                    Remix.child_track_id == Track.track_id,
-                    Remix.parent_track_id == track_id
-                )
-            ).outerjoin(
-                Save,
-                and_(
-                    Save.save_item_id == Track.track_id,
-                    Save.save_type == SaveType.track,
-                    Save.is_current == True,
-                    Save.is_delete == False,
-                    Save.user_id == track_owner_id
-                )
-            ).outerjoin(
-                Repost,
-                and_(
-                    Repost.repost_item_id == Track.track_id,
-                    Repost.user_id == track_owner_id,
-                    Repost.repost_type == RepostType.track,
-                    Repost.is_current == True,
-                    Repost.is_delete == False
-                )
-            ).outerjoin(
-                repost_count_subquery,
-                repost_count_subquery.c['id'] == Track.track_id
-            ).outerjoin(
-                save_count_subquery,
-                save_count_subquery.c['id'] == Track.track_id
-            )
-            .filter(
+        def get_unpopulated_remixes():
+            # Fetch the parent track to get the track's owner id
+            parent_track = session.query(Track).filter(
                 Track.is_current == True,
-                Track.is_delete == False,
-                Track.is_unlisted == False
-            )
-            # 1. Co-signed tracks ordered by save + repost count
-            # 2. Other tracks ordered by save + repost count
-            .order_by(
-                desc(
-                    # If there is no "co-sign" for the track (no repost or save from the parent owner),
-                    # defer to secondary sort
-                    case(
-                        [
-                            (and_(Repost.created_at == None,
-                                  Save.created_at == None), 0),
-                        ],
-                        else_=(
-                            func.coalesce(repost_count_subquery.c.repost_count, 0) + \
-                            func.coalesce(save_count_subquery.c.save_count, 0)
-                        )
-                    )
-                ),
-                # Order by saves + reposts
-                desc(
-                    func.coalesce(repost_count_subquery.c.repost_count, 0) + \
-                    func.coalesce(save_count_subquery.c.save_count, 0)
-                ),
-                # Ties, pick latest track id
-                desc(Track.track_id)
-            )
-        )
+                Track.track_id == track_id
+            ).first()
 
-        (tracks, count) = add_query_pagination(base_query, limit, offset, True, True)
-        tracks = tracks.all()
-        tracks = helpers.query_result_to_list(tracks)
-        track_ids = list(map(lambda track: track["track_id"], tracks))
+            if parent_track == None:
+                raise exceptions.ArgumentError("Invalid track_id provided")
+
+            track_owner_id = parent_track.owner_id
+
+            # Create subquery for save counts for sorting
+            save_count_subquery = create_save_count_subquery(
+                session, SaveType.track)
+
+            # Create subquery for repost counts for sorting
+            repost_count_subquery = create_repost_count_subquery(
+                session, RepostType.track)
+
+            # Get the 'children' remix tracks
+            # Use the track owner id to fetch reposted/saved tracks returned first
+            base_query = (
+                session.query(
+                    Track
+                )
+                .join(
+                    Remix,
+                    and_(
+                        Remix.child_track_id == Track.track_id,
+                        Remix.parent_track_id == track_id
+                    )
+                ).outerjoin(
+                    Save,
+                    and_(
+                        Save.save_item_id == Track.track_id,
+                        Save.save_type == SaveType.track,
+                        Save.is_current == True,
+                        Save.is_delete == False,
+                        Save.user_id == track_owner_id
+                    )
+                ).outerjoin(
+                    Repost,
+                    and_(
+                        Repost.repost_item_id == Track.track_id,
+                        Repost.user_id == track_owner_id,
+                        Repost.repost_type == RepostType.track,
+                        Repost.is_current == True,
+                        Repost.is_delete == False
+                    )
+                ).outerjoin(
+                    repost_count_subquery,
+                    repost_count_subquery.c['id'] == Track.track_id
+                ).outerjoin(
+                    save_count_subquery,
+                    save_count_subquery.c['id'] == Track.track_id
+                )
+                .filter(
+                    Track.is_current == True,
+                    Track.is_delete == False,
+                    Track.is_unlisted == False
+                )
+                # 1. Co-signed tracks ordered by save + repost count
+                # 2. Other tracks ordered by save + repost count
+                .order_by(
+                    desc(
+                        # If there is no "co-sign" for the track (no repost or save from the parent owner),
+                        # defer to secondary sort
+                        case(
+                            [
+                                (and_(Repost.created_at == None,
+                                    Save.created_at == None), 0),
+                            ],
+                            else_=(
+                                func.coalesce(repost_count_subquery.c.repost_count, 0) + \
+                                func.coalesce(save_count_subquery.c.save_count, 0)
+                            )
+                        )
+                    ),
+                    # Order by saves + reposts
+                    desc(
+                        func.coalesce(repost_count_subquery.c.repost_count, 0) + \
+                        func.coalesce(save_count_subquery.c.save_count, 0)
+                    ),
+                    # Ties, pick latest track id
+                    desc(Track.track_id)
+                )
+            )
+
+            (tracks, count) = add_query_pagination(base_query, limit, offset, True, True)
+            tracks = tracks.all()
+            tracks = helpers.query_result_to_list(tracks)
+            track_ids = list(map(lambda track: track["track_id"], tracks))
+            return (tracks, track_ids, count)
+        key = make_cache_key(args)
+        (tracks, track_ids, count) = use_redis_cache(key, UNPOPULATED_REMIXES_CACHE_DURATION_SEC, get_unpopulated_remixes)
+
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)
-
         if args.get("with_users", False):
-            add_users_to_tracks(session, tracks)
+            add_users_to_tracks(session, tracks, current_user_id)
 
     return {'tracks': tracks, 'count': count}

--- a/discovery-provider/src/queries/get_tracks_including_unlisted.py
+++ b/discovery-provider/src/queries/get_tracks_including_unlisted.py
@@ -81,7 +81,7 @@ def get_tracks_including_unlisted(args):
             def filter_fn(track):
                 input_track = identifiers_map[track["track_id"]]
                 route_id = helpers.create_track_route_id(input_track["url_title"],
-                                                        input_track["handle"])
+                                                         input_track["handle"])
 
                 return not track["is_unlisted"] or track["route_id"] == route_id
 

--- a/discovery-provider/src/queries/get_tracks_including_unlisted.py
+++ b/discovery-provider/src/queries/get_tracks_including_unlisted.py
@@ -40,6 +40,7 @@ def get_tracks_including_unlisted(args):
     for i in identifiers:
         helpers.validate_arguments(i, ["handle", "id", "url_title"])
 
+    current_user_id = args.get("current_user_id")
     db = get_db_read_replica()
     with db.scoped_session() as session:
         def get_unpopulated_track():
@@ -86,13 +87,6 @@ def get_tracks_including_unlisted(args):
 
             tracks = list(filter(filter_fn, tracks))
 
-            if args.get("with_users", False):
-                user_id_list = get_users_ids(tracks)
-                users = get_users_by_id(session, user_id_list)
-                for track in tracks:
-                    user = users[track['owner_id']]
-                    if user:
-                        track['user'] = user
 
             track_ids = list(map(lambda track: track["track_id"], tracks))
             return (tracks, track_ids)
@@ -100,8 +94,15 @@ def get_tracks_including_unlisted(args):
         key = make_cache_key(args)
         (tracks, track_ids) = use_redis_cache(key, UNPOPULATED_TRACK_CACHE_DURATION_SEC, get_unpopulated_track)
 
+        # Add users
+        if args.get("with_users", False):
+            user_id_list = get_users_ids(tracks)
+            users = get_users_by_id(session, user_id_list, current_user_id)
+            for track in tracks:
+                user = users[track['owner_id']]
+                if user:
+                    track['user'] = user
         # Populate metadata
-        current_user_id = args.get("current_user_id")
         tracks = populate_track_metadata(
             session, track_ids, tracks, current_user_id)
 

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -487,10 +487,15 @@ def get_top_genre_users_route():
 @record_metrics
 def get_remixes_of_route(track_id):
     args = to_dict(request.args)
+    args["track_id"] = track_id
+    args["current_user_id"] = get_current_user_id(required=False)
+    limit, offset = get_pagination_vars()
+    args["limit"] = limit
+    args["offset"] = offset
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
     try:
-        remixes = get_remixes_of(track_id, args)
+        remixes = get_remixes_of(args)
         return api_helpers.success_response(remixes)
     except exceptions.ArgumentError as e:
         return api_helpers.error_response(str(e), 400)
@@ -503,7 +508,12 @@ def get_remix_track_parents_route(track_id):
     args = to_dict(request.args)
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
-    tracks = get_remix_track_parents(track_id, args)
+    args["track_id"] = track_id
+    args["current_user_id"] = get_current_user_id(required=False)
+    limit, offset = get_pagination_vars()
+    args["limit"] = limit
+    args["offset"] = offset
+    tracks = get_remix_track_parents(args)
     return api_helpers.success_response(tracks)
 
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -1374,7 +1374,7 @@ def filter_to_playlist_mood(session, mood, query, correlation):
     )
 
 
-def add_users_to_tracks(session, tracks):
+def add_users_to_tracks(session, tracks, current_user_id=None):
     """
     Fetches the owners for the tracks and adds them to the track dict under the key 'user'
 
@@ -1388,7 +1388,7 @@ def add_users_to_tracks(session, tracks):
     Returns: None
     """
     user_id_list = get_users_ids(tracks)
-    users = get_users_by_id(session, user_id_list)
+    users = get_users_by_id(session, user_id_list, current_user_id)
     for track in tracks:
         user = users[track['owner_id']]
         if user:

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -26,9 +26,11 @@ def use_redis_cache(key, ttl_sec, work_func):
     cached_value = redis.get(key)
 
     if cached_value:
+        logger.info("HIT USE CACHE")
         logger.info(f"Redis Cache - hit {key}")
         return json.loads(cached_value)
 
+    logger.info("MISS USE CACHE")
     logger.info(f"Redis Cache - miss {key}")
     to_cache = work_func()
     serialized = dumps(to_cache)

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -26,11 +26,9 @@ def use_redis_cache(key, ttl_sec, work_func):
     cached_value = redis.get(key)
 
     if cached_value:
-        logger.info("HIT USE CACHE")
         logger.info(f"Redis Cache - hit {key}")
         return json.loads(cached_value)
 
-    logger.info("MISS USE CACHE")
     logger.info(f"Redis Cache - miss {key}")
     to_cache = work_func()
     serialized = dumps(to_cache)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/A7BOsv5J

### Description
Adds full endpoints:
- tracks/id/stems
- tracks/id/remixes
- tracks/id/remixing


Also caught a bug in the tracks endpoint, where we were including the track users
inside the redis cache fn - they can't be inside because they're customized by current_user_id.


### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested manually hitting endpoints.