### PR TITLE
Add full search and user/track/playlist cache

### DIFF
--- a/discovery-provider/src/api/v1/api.py
+++ b/discovery-provider/src/api/v1/api.py
@@ -5,6 +5,7 @@ from src.api.v1.users import ns as users_ns, full_ns as full_users_ns
 from src.api.v1.playlists import ns as playlists_ns, full_ns as full_playlists_ns
 from src.api.v1.tracks import ns as tracks_ns, full_ns as full_tracks_ns
 from src.api.v1.metrics import ns as metrics_ns
+from src.api.v1.search import full_ns as full_search_ns
 from src.api.v1.models.users import ns as models_ns
 from src.api.v1.resolve import ns as resolve_ns
 
@@ -33,3 +34,4 @@ api_v1_full = ApiWithHTTPS(bp_full, version='1.0')
 api_v1_full.add_namespace(full_tracks_ns)
 api_v1_full.add_namespace(full_playlists_ns)
 api_v1_full.add_namespace(full_users_ns)
+api_v1_full.add_namespace(full_search_ns)

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -149,15 +149,21 @@ def parse_unix_epoch_param(time, default=0):
 def extend_track(track):
     track_id = encode_int_id(track["track_id"])
     owner_id = encode_int_id(track["owner_id"])
-    if ("user" in track):
+    if "user" in track:
         track["user"] = extend_user(track["user"])
     track["id"] = track_id
     track["user_id"] = owner_id
-    track["followee_favorites"] = list(map(extend_favorite, track["followee_saves"]))
-    track["followee_resposts"] = list(map(extend_repost, track["followee_reposts"]))
+    if "followee_saves" in track:
+        track["followee_favorites"] = list(map(extend_favorite, track["followee_saves"]))
+    if "followee_reposts" in track:
+        track["followee_reposts"] = list(map(extend_repost, track["followee_reposts"]))
+    if "remix_of" in track:
+        track["remix_of"] = extend_remix_of(track["remix_of"])
+
     track = add_track_artwork(track)
-    track["remix_of"] = extend_remix_of(track["remix_of"])
-    track["favorite_count"] = track["save_count"]
+
+    if "save_count" in track:
+        track["favorite_count"] = track["save_count"]
 
     duration = 0.
     for segment in track["track_segments"]:
@@ -189,14 +195,16 @@ def extend_playlist(playlist):
     owner_id = encode_int_id(playlist["playlist_owner_id"])
     playlist["id"] = playlist_id
     playlist["user_id"] = owner_id
-    if ("user" in playlist):
-        playlist["user"] = extend_user(playlist["user"])
     playlist = add_playlist_artwork(playlist)
+    if "user" in playlist:
+        playlist["user"] = extend_user(playlist["user"])
+    if "followee_saves" in playlist:
+        playlist["followee_favorites"] = list(map(extend_favorite, playlist["followee_saves"]))
+    if "followee_reposts" in playlist:
+        playlist["followee_reposts"] = list(map(extend_repost, playlist["followee_reposts"]))
+    if "save_count" in playlist:
+        playlist["favorite_count"] = playlist["save_count"]
 
-    playlist["followee_favorites"] = list(map(extend_favorite, playlist["followee_saves"]))
-    playlist["followee_reposts"] = list(map(extend_repost, playlist["followee_reposts"]))
-
-    playlist["favorite_count"] = playlist["save_count"]
     playlist["added_timestamps"] = add_playlist_added_timestamps(playlist)
     playlist["cover_art"] = playlist["playlist_image_multihash"]
     playlist["cover_art_sizes"] = playlist["playlist_image_sizes_multihash"]

--- a/discovery-provider/src/api/v1/models/search.py
+++ b/discovery-provider/src/api/v1/models/search.py
@@ -1,0 +1,18 @@
+from flask_restx.fields import Boolean
+from src.api.v1.helpers import make_response
+from flask_restx import fields
+from .common import ns
+from .tracks import track_full
+from .users import user_model_full
+from .playlists import full_playlist_model
+
+search_model = ns.model('search_model', {
+  "users": fields.List(fields.Nested(user_model_full), required=True),
+  "followed_users": fields.List(fields.Nested(user_model_full), required=False),
+  "tracks": fields.List(fields.Nested(track_full), required=True),
+  "saved_tracks": fields.List(fields.Nested(track_full), required=False),
+  "playlists": fields.List(fields.Nested(full_playlist_model), required=True),
+  "saved_playlists": fields.List(fields.Nested(full_playlist_model), required=False),
+  "albums": fields.List(fields.Nested(full_playlist_model), required=True),
+  "saved_albums": fields.List(fields.Nested(full_playlist_model), required=False)
+})

--- a/discovery-provider/src/api/v1/search.py
+++ b/discovery-provider/src/api/v1/search.py
@@ -1,0 +1,130 @@
+import logging  # pylint: disable=C0302
+from flask_restx import Resource, Namespace, fields, reqparse
+from src.api.v1.helpers import extend_track, make_response, get_default_max, \
+    success_response, format_offset, format_limit, decode_string_id, \
+    extend_user, extend_track, extend_playlist
+from src.queries.search_queries import SearchKind, search
+from src.utils.redis_cache import cache, extract_key, use_redis_cache
+from src.utils.redis_metrics import record_metrics
+from src.api.v1.models.search import search_model
+
+logger = logging.getLogger(__name__)
+
+# Models & namespaces
+
+full_ns = Namespace('search', description='Full search operations')
+
+# Helpers
+def extend_search(resp):
+    if 'users' in resp:
+        resp['users'] = list(map(extend_user, resp['users']))
+    if 'followed_users' in resp:
+        resp['followed_users'] = list(map(extend_user, resp['followed_users']))
+    if 'tracks' in resp:
+        resp['tracks'] = list(map(extend_track, resp['tracks']))
+    if 'saved_tracks' in resp:
+        resp['saved_tracks'] = list(map(extend_track, resp['saved_tracks']))
+    if 'playlists' in resp:
+        resp['playlists'] = list(map(extend_playlist, resp['playlists']))
+    if 'saved_playlists' in resp:
+        resp['saved_playlists'] = list(map(extend_playlist, resp['saved_playlists']))
+    if 'albums' in resp:
+        resp['albums'] = list(map(extend_playlist, resp['albums']))
+    if 'saved_albums' in resp:
+        resp['saved_albums'] = list(map(extend_playlist, resp['saved_albums']))
+    return resp
+
+search_route_parser = reqparse.RequestParser()
+search_route_parser.add_argument('user_id', required=False)
+search_route_parser.add_argument(
+    'kind', required=False, type=str, default='all', choices=('all', 'users', 'tracks', 'playlists', 'albums'))
+search_route_parser.add_argument('query', required=True, type=str)
+search_route_parser.add_argument('limit', required=False, type=int)
+search_route_parser.add_argument('offset', required=False, type=int)
+search_full_response = make_response("search_full_response", full_ns, fields.Nested(search_model))
+@full_ns.route("/full")
+class FullSearch(Resource):
+    @full_ns.expect(search_route_parser)
+    @full_ns.doc(
+        id="""Get Users/Tracks/Playlists/ALbums that best match the search query""",
+        params={
+            'user_id': 'A User ID of the requesting user to personalize the response',
+            'query': 'Search query text',
+            'kind': 'The type of response, one of: all, users, tracks, playlists, or albums',
+            'limit': 'Limit',
+            'offset': 'Offset'
+        },
+        responses={
+            200: 'Success',
+            400: 'Bad request',
+            500: 'Server error'
+        }
+    )
+    @full_ns.marshal_with(search_full_response)
+    @cache(ttl_sec=5)
+    def get(self):
+        args = search_route_parser.parse_args()
+        limit = get_default_max(args.get('limit'), 10, 100)
+        offset = get_default_max(args.get('offset'), 0)
+
+        current_user_id = None
+        if args.get("user_id"):
+            current_user_id = decode_string_id(args["user_id"])
+        search_args = {
+          "is_auto_complete": False,
+          "kind": args.get("kind", "all"),
+          "query": args.get("query"),
+          "current_user_id": current_user_id,
+          "with_users": True,
+          "limit": limit,
+          "offset": offset,
+          "only_downloadable": False
+        }
+        resp = search(search_args)
+        resp = extend_search(resp)
+
+        return success_response(resp)
+
+search_autocomplete_response = make_response("search_autocomplete_response", full_ns, fields.Nested(search_model))
+@full_ns.route("/autocomplete")
+class FullSearch(Resource):
+    @full_ns.expect(search_route_parser)
+    @full_ns.doc(
+        id="""Get Users/Tracks/Playlists/ALbums that best match the search query""",
+        params={
+            'user_id': 'A User ID of the requesting user to personalize the response',
+            'query': 'Search query text',
+            'kind': 'The type of response, one of: all, users, tracks, playlists, or albums',
+            'limit': 'Limit',
+            'offset': 'Offset'
+        },
+        responses={
+            200: 'Success',
+            400: 'Bad request',
+            500: 'Server error'
+        }
+    )
+    @full_ns.marshal_with(search_autocomplete_response)
+    @cache(ttl_sec=5)
+    def get(self):
+        args = search_route_parser.parse_args()
+        limit = get_default_max(args.get('limit'), 10, 100)
+        offset = get_default_max(args.get('offset'), 0)
+
+        current_user_id = None
+        if args.get("user_id"):
+            current_user_id = decode_string_id(args["user_id"])
+        search_args = {
+          "is_auto_complete": True,
+          "kind": args.get("kind", "all"),
+          "query": args.get("query"),
+          "current_user_id": current_user_id,
+          "with_users": False,
+          "limit": limit,
+          "offset": offset,
+          "only_downloadable": False
+        }
+        resp = search(search_args)
+        resp = extend_search(resp)
+
+        return success_response(resp)

--- a/discovery-provider/src/api/v1/search.py
+++ b/discovery-provider/src/api/v1/search.py
@@ -46,7 +46,7 @@ search_full_response = make_response("search_full_response", full_ns, fields.Nes
 class FullSearch(Resource):
     @full_ns.expect(search_route_parser)
     @full_ns.doc(
-        id="""Get Users/Tracks/Playlists/ALbums that best match the search query""",
+        id="""Get Users/Tracks/Playlists/Albums that best match the search query""",
         params={
             'user_id': 'A User ID of the requesting user to personalize the response',
             'query': 'Search query text',
@@ -90,7 +90,7 @@ search_autocomplete_response = make_response("search_autocomplete_response", ful
 class FullSearch(Resource):
     @full_ns.expect(search_route_parser)
     @full_ns.doc(
-        id="""Get Users/Tracks/Playlists/ALbums that best match the search query""",
+        id="""Get Users/Tracks/Playlists/albums that best match the search query""",
         params={
             'user_id': 'A User ID of the requesting user to personalize the response',
             'query': 'Search query text',

--- a/discovery-provider/src/queries/get_feed.py
+++ b/discovery-provider/src/queries/get_feed.py
@@ -6,6 +6,7 @@ from src.models import Track, Repost, RepostType, Follow, Playlist, SaveType
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
+from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import get_current_user_id, populate_track_metadata, \
     populate_playlist_metadata, get_pagination_vars, paginate_query, get_users_by_id, get_users_ids
 
@@ -60,14 +61,7 @@ def get_feed(args):
                         playlist_track_ids.add(track["track"])
 
                 # get all track objects for track ids
-                playlist_tracks = (
-                    session.query(Track)
-                    .filter(
-                        Track.is_current == True,
-                        Track.track_id.in_(playlist_track_ids)
-                    )
-                    .all()
-                )
+                playlist_tracks = get_unpopulated_tracks(session, playlist_track_ids)
                 playlist_tracks_dict = {
                     track.track_id: track for track in playlist_tracks}
 

--- a/discovery-provider/src/queries/get_followees_for_user.py
+++ b/discovery-provider/src/queries/get_followees_for_user.py
@@ -1,11 +1,11 @@
 from sqlalchemy import func, desc
 from sqlalchemy.orm import aliased
 
-from src.models import User, Follow
-from src.utils import helpers
+from src.models import Follow
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
 from src.queries.query_helpers import populate_user_metadata, add_query_pagination
+from src.queries.get_unpopulated_users import get_unpopulated_users
 
 def get_followees_for_user(args):
     users = []
@@ -55,15 +55,7 @@ def get_followees_for_user(args):
                     in followee_user_ids_by_follower_count]
 
         # get all users for above user_ids
-        users = (
-            session.query(User)
-            .filter(
-                User.is_current == True,
-                User.user_id.in_(user_ids)
-            )
-            .all()
-        )
-        users = helpers.query_result_to_list(users)
+        users = get_unpopulated_users(session, user_ids)
 
         # bundle peripheral info into user results
         users = populate_user_metadata(

--- a/discovery-provider/src/queries/get_followers_for_user.py
+++ b/discovery-provider/src/queries/get_followers_for_user.py
@@ -1,11 +1,11 @@
 from sqlalchemy import func, asc, desc
 from sqlalchemy.orm import aliased
 
-from src.models import User, Follow
-from src.utils import helpers
+from src.models import Follow
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
 from src.queries.query_helpers import populate_user_metadata, add_query_pagination
+from src.queries.get_unpopulated_users import get_unpopulated_users
 
 def get_followers_for_user(args):
     users = []
@@ -60,15 +60,7 @@ def get_followers_for_user(args):
                     in follower_user_ids_by_follower_count]
 
         # get all users for above user_ids
-        users = (
-            session.query(User)
-            .filter(
-                User.is_current == True,
-                User.user_id.in_(user_ids)
-            )
-            .all()
-        )
-        users = helpers.query_result_to_list(users)
+        users = get_unpopulated_users(session, user_ids)
 
         # bundle peripheral info into user results
         users = populate_user_metadata(

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -5,6 +5,7 @@ from src import exceptions
 from src.models import Track, Repost, RepostType, Save, SaveType, Remix
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
+from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import populate_track_metadata, \
     add_query_pagination, add_users_to_tracks, create_save_count_subquery, \
     create_repost_count_subquery
@@ -28,16 +29,15 @@ def get_remixes_of(args):
 
     with db.scoped_session() as session:
         def get_unpopulated_remixes():
-            # Fetch the parent track to get the track's owner id
-            parent_track = session.query(Track).filter(
-                Track.is_current == True,
-                Track.track_id == track_id
-            ).first()
 
-            if parent_track == None:
+            # Fetch the parent track to get the track's owner id
+            parent_track_res = get_unpopulated_tracks(session, [track_id])
+
+            if not parent_track_res or parent_track_res[0] is None:
                 raise exceptions.ArgumentError("Invalid track_id provided")
 
-            track_owner_id = parent_track.owner_id
+            parent_track = parent_track_res[0]
+            track_owner_id = parent_track['owner_id']
 
             # Create subquery for save counts for sorting
             save_count_subquery = create_save_count_subquery(

--- a/discovery-provider/src/queries/get_top_genre_users.py
+++ b/discovery-provider/src/queries/get_top_genre_users.py
@@ -2,9 +2,9 @@ import logging
 from sqlalchemy import func, asc, desc
 
 from src.models import User, Track, Follow
-from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import populate_user_metadata, paginate_query
+from src.queries.get_unpopulated_users import get_unpopulated_users
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +92,7 @@ def get_top_genre_users(args):
 
         # If the with_users flag is used, retrieve the user metadata
         if with_users:
-            user_query = session.query(User).filter(
-                User.user_id.in_(user_ids),
-                User.is_current == True
-            )
-            users = user_query.all()
-            users = helpers.query_result_to_list(users)
+            users = get_unpopulated_users(session, user_ids)
             queried_user_ids = list(map(lambda user: user["user_id"], users))
             users = populate_user_metadata(
                 session, queried_user_ids, users, None)

--- a/discovery-provider/src/queries/get_tracks_including_unlisted.py
+++ b/discovery-provider/src/queries/get_tracks_including_unlisted.py
@@ -92,7 +92,8 @@ def get_tracks_including_unlisted(args):
             return (tracks, track_ids)
 
         key = make_cache_key(args)
-        (tracks, track_ids) = use_redis_cache(key, UNPOPULATED_TRACK_CACHE_DURATION_SEC, get_unpopulated_track)
+        (tracks, track_ids) = use_redis_cache(
+            key, UNPOPULATED_TRACK_CACHE_DURATION_SEC, get_unpopulated_track)
 
         # Add users
         if args.get("with_users", False):

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -3,9 +3,8 @@ import datetime
 from dateutil.parser import parse
 from flask.globals import request
 
-from src.models import Track
-from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
+from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import populate_track_metadata, \
     get_users_ids, get_users_by_id
 from src.tasks.generate_trending import generate_trending
@@ -65,13 +64,7 @@ def get_trending_tracks(args):
 
             track_ids = [track['track_id'] for track in sorted_track_scores]
 
-            tracks = session.query(Track).filter(
-                Track.is_current == True,
-                Track.is_unlisted == False,
-                Track.stem_of == None,
-                Track.track_id.in_(track_ids)
-            ).all()
-            tracks = helpers.query_result_to_list(tracks)
+            tracks = get_unpopulated_tracks(session, track_ids)
             return (tracks, track_ids)
 
         # get scored trending tracks, either

--- a/discovery-provider/src/queries/get_unpopulated_playlists.py
+++ b/discovery-provider/src/queries/get_unpopulated_playlists.py
@@ -1,0 +1,79 @@
+import json
+from flask.json import dumps
+
+from src.utils import redis_connection
+from src.models import Playlist
+from src.utils import helpers
+
+ttl_sec = 60
+
+
+def get_playlist_id_cache_key(id):
+    return "playlist:id:{}".format(id)
+
+
+def get_cached_playlists(playlist_ids):
+    redis_playlist_id_keys = map(get_playlist_id_cache_key, playlist_ids)
+    redis = redis_connection.get_redis()
+    cached_values = redis.mget(redis_playlist_id_keys)
+    return [json.loads(val) if val is not None else None for val in cached_values]
+
+
+def set_playlists_in_cache(playlists):
+    redis = redis_connection.get_redis()
+    for playlist in playlists:
+        key = get_playlist_id_cache_key(playlist['playlist_id'])
+        serialized = dumps(playlist)
+        redis.set(key, serialized, ttl_sec)
+
+
+def get_unpopulated_playlists(session, playlist_ids):
+    """
+    Fetches playlists by checking the redis cache first then
+    going to DB and writes to cache if not present
+
+    Args:
+        session: DB session
+        playlist_ids: array A list of playlist ids
+
+    Returns:
+        Array of playlists
+    """
+    # Check the cached playlists
+    cached_playlists_results = get_cached_playlists(playlist_ids)
+    has_all_playlists_cached = cached_playlists_results.count(None) == 0
+    if has_all_playlists_cached:
+        return cached_playlists_results
+
+    # Create a dict of cached playlists
+    cached_playlists = {}
+    cached_playlist_ids = set()
+    for cached_playlist in cached_playlists_results:
+        if cached_playlist:
+            cached_playlists[cached_playlist['playlist_id']] = cached_playlist
+            cached_playlist_ids.add(cached_playlist['playlist_id'])
+
+    playlist_ids_to_fetch = filter(
+        lambda playlist_id: playlist_id not in cached_playlist_ids, playlist_ids)
+
+    playlists = (
+        session
+        .query(Playlist)
+        .filter(Playlist.is_current == True)
+        .filter(Playlist.playlist_id.in_(playlist_ids_to_fetch))
+        .all()
+    )
+    playlists = helpers.query_result_to_list(playlists)
+    queried_playlists = {playlist['playlist_id']: playlist for playlist in playlists}
+
+    # cache playlists for future use
+    set_playlists_in_cache(playlists)
+
+    playlists_response = []
+    for playlist_id in playlist_ids:
+        if playlist_id in cached_playlists:
+            playlists_response.append(cached_playlists[playlist_id])
+        elif playlist_id in queried_playlists:
+            playlists_response.append(queried_playlists[playlist_id])
+
+    return playlists_response

--- a/discovery-provider/src/queries/get_unpopulated_users.py
+++ b/discovery-provider/src/queries/get_unpopulated_users.py
@@ -1,0 +1,76 @@
+import json
+from flask.json import dumps
+
+from src.utils import redis_connection
+from src.models import User
+from src.utils import helpers
+
+ttl_sec = 60
+
+
+def get_user_id_cache_key(id):
+    return "user:id:{}".format(id)
+
+
+def get_cached_users(user_ids):
+    redis_user_id_keys = map(get_user_id_cache_key, user_ids)
+    redis = redis_connection.get_redis()
+    cached_values = redis.mget(redis_user_id_keys)
+    return [json.loads(val) if val is not None else None for val in cached_values]
+
+
+def set_users_in_cache(users):
+    redis = redis_connection.get_redis()
+    for user in users:
+        key = get_user_id_cache_key(user['user_id'])
+        serialized = dumps(user)
+        redis.set(key, serialized, ttl_sec)
+
+
+def get_unpopulated_users(session, user_ids):
+    """
+    Fetches users by checking the redis cache first then
+    going to DB and writes to cache if not present
+
+    Args:
+        session: DB session
+        user_ids: array A list of user ids
+
+    Returns:
+        Array of users
+    """
+    cached_users_results = get_cached_users(user_ids)
+    has_all_users_cached = cached_users_results.count(None) == 0
+    if has_all_users_cached:
+        return cached_users_results
+
+    cached_users = {}
+    cached_user_ids = set()
+    for cached_user in cached_users_results:
+        if cached_user:
+            cached_users[cached_user['user_id']] = cached_user
+            cached_user_ids.add(cached_user['user_id'])
+
+    user_ids_to_fetch = filter(
+        lambda user_id: user_id not in cached_user_ids, user_ids)
+
+    users = (
+        session
+        .query(User)
+        .filter(User.is_current == True, User.wallet != None, User.handle != None)
+        .filter(User.user_id.in_(user_ids_to_fetch))
+        .all()
+    )
+    users = helpers.query_result_to_list(users)
+    queried_users = {user['user_id']: user for user in users}
+
+    set_users_in_cache(users)
+
+    users_response = []
+    for user_id in user_ids:
+        if user_id in cached_users:
+            users_response.append(cached_users[user_id])
+        elif user_id in queried_users:
+            users_response.append(queried_users[user_id])
+
+    return users_response

--- a/discovery-provider/src/queries/get_users_account.py
+++ b/discovery-provider/src/queries/get_users_account.py
@@ -5,6 +5,7 @@ from src.models import User, Playlist, Save, SaveType
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import populate_user_metadata
+from src.queries.get_unpopulated_users import get_unpopulated_users
 
 
 def get_users_account(args):
@@ -68,11 +69,8 @@ def get_users_account(args):
             set([playlist['playlist_owner_id'] for playlist in playlists]))
 
         # Get Users for the Playlist/Albums
-        user_query = session.query(User).filter(
-            and_(User.is_current == True, User.user_id.in_(playlist_owner_ids))
-        )
-        users = user_query.all()
-        users = helpers.query_result_to_list(users)
+        users = get_unpopulated_users(session, playlist_owner_ids)
+
         user_map = {}
 
         stripped_playlists = []

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -11,6 +11,7 @@ from src.queries import response_name_constants
 from src.models import User, Track, Repost, RepostType, Follow, Playlist, Save, SaveType, Remix
 from src.utils import helpers
 from src.utils.config import shared_config
+from src.queries.get_unpopulated_users import get_unpopulated_users
 
 logger = logging.getLogger(__name__)
 
@@ -1081,10 +1082,7 @@ def get_genre_list(genre):
 
 
 def get_users_by_id(session, user_ids, current_user_id=None):
-    user_query = session.query(User).filter(
-        User.is_current == True, User.wallet != None, User.handle != None)
-    users_results = user_query.filter(User.user_id.in_(user_ids)).all()
-    users = helpers.query_result_to_list(users_results)
+    users = get_unpopulated_users(session, user_ids)
 
     if not current_user_id:
         current_user_id = get_current_user_id(required=False)

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -5,11 +5,13 @@ import sqlalchemy
 
 from src import api_helpers, exceptions
 from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight
-from src.models import User, Track, RepostType, Playlist, Save, SaveType, Follow
+from src.models import User, Track, RepostType, Save, SaveType, Follow
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
-
+from src.queries.get_unpopulated_users import get_unpopulated_users
+from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
+from src.queries.get_unpopulated_playlists import get_unpopulated_playlists
 from src.queries.query_helpers import get_current_user_id, get_users_by_id, get_users_ids, populate_user_metadata, \
     populate_track_metadata, populate_playlist_metadata, get_pagination_vars, \
     get_track_play_counts
@@ -257,15 +259,7 @@ def search_tags():
                 .all()
             )
             followed_user_ids = [i[0] for i in followed_user_query]
-            followed_users = (
-                session.query(User)
-                .filter(
-                    User.is_current == True,
-                    User.user_id.in_(followed_user_ids)
-                )
-                .all()
-            )
-            followed_users = helpers.query_result_to_list(followed_users)
+            followed_users = get_unpopulated_users(session, followed_user_ids)
             followed_users = \
                 populate_user_metadata(
                     session,
@@ -471,32 +465,12 @@ def track_search_query(
 
     # track_ids is list of tuples - simplify to 1-D list
     track_ids = [i[0] for i in track_ids]
-
-    tracks = (
-        session.query(Track)
-        .filter(
-            Track.is_delete == False,
-            Track.is_current == True,
-            Track.is_unlisted == False,
-            Track.stem_of == None,
-            Track.track_id.in_(track_ids),
-        ).all()
-    )
-
-    tracks = helpers.query_result_to_list(tracks)
+    tracks = get_unpopulated_tracks(session, track_ids)
 
     if is_auto_complete == True:
         # fetch users for tracks
         track_owner_ids = list(map(lambda track: track["owner_id"], tracks))
-        users = (
-            session.query(User)
-            .filter(
-                User.is_current == True,
-                User.user_id.in_(track_owner_ids)
-            )
-            .all()
-        )
-        users = helpers.query_result_to_list(users)
+        users = get_unpopulated_users(session, track_owner_ids)
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to track objects
@@ -559,15 +533,7 @@ def user_search_query(session, searchStr, limit, offset, personalized, is_auto_c
     # user_ids is list of tuples - simplify to 1-D list
     user_ids = [i[0] for i in user_ids]
 
-    users = (
-        session.query(User)
-        .filter(
-            User.is_current == True,
-            User.user_id.in_(user_ids)
-        )
-        .all()
-    )
-    users = helpers.query_result_to_list(users)
+    users = get_unpopulated_users(session, user_ids)
 
     if not is_auto_complete:
         # bundle peripheral info into user results
@@ -637,31 +603,13 @@ def playlist_search_query(session, searchStr, limit, offset, is_album, personali
 
     # playlist_ids is list of tuples - simplify to 1-D list
     playlist_ids = [i[0] for i in playlist_ids]
-
-    playlists = (
-        session.query(Playlist)
-        .filter(
-            Playlist.is_current == True,
-            Playlist.is_album == is_album,
-            Playlist.playlist_id.in_(playlist_ids)
-        )
-        .all()
-    )
-    playlists = helpers.query_result_to_list(playlists)
+    playlists = get_unpopulated_playlists(session, playlist_ids)
 
     if is_auto_complete == True:
         # fetch users for playlists
         playlist_owner_ids = list(
             map(lambda playlist: playlist["playlist_owner_id"], playlists))
-        users = (
-            session.query(User)
-            .filter(
-                User.is_current == True,
-                User.user_id.in_(playlist_owner_ids)
-            )
-            .all()
-        )
-        users = helpers.query_result_to_list(users)
+        users = get_unpopulated_users(session, playlist_owner_ids)
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to playlist objects


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/A7BOsv5J/1476-port-the-new-api-into-the-dapp

### Description
Adds search/full and search/autocomplete to the v1 full api
Adds individual track/user/playlist unpopulated caching.  

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran it against a prod db snapshot and and compared responses. 
