### PR TITLE
Remove celerybeatpid on startup

### DIFF
--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -63,7 +63,7 @@
     "host": "audius-disc-prov_web-server_1",
     "port": 5000,
     "up": [
-      "cd discovery-provider; rm celerybeat.pid",
+      "cd discovery-provider; [[ ! -e celerybeat.pid ]] || rm celerybeat.pid",
       "cd discovery-provider; docker-compose -f compose/docker-compose.base.override.yml -f compose/docker-compose.dev.override.yml -f compose/docker-compose.ipfs.override.yml up --build -d",
       "echo 'Waiting 5 seconds...'",
       "sleep 5"

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -63,7 +63,7 @@
     "host": "audius-disc-prov_web-server_1",
     "port": 5000,
     "up": [
-      "cd discovery-provider; [[ ! -e celerybeat.pid ]] || rm celerybeat.pid",
+      "cd discovery-provider; [ ! -e celerybeat.pid ] || rm celerybeat.pid",
       "cd discovery-provider; docker-compose -f compose/docker-compose.base.override.yml -f compose/docker-compose.dev.override.yml -f compose/docker-compose.ipfs.override.yml up --build -d",
       "echo 'Waiting 5 seconds...'",
       "sleep 5"

--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -67,7 +67,7 @@ const execShellCommand = (command, service, { verbose }) => {
     proc.on('close', exitCode => {
       // Running `make stop` when no containers are up exits with a non-zero exit code
       // Ignore that error if occurs (could be better message)
-      if (exitCode !== 0 && service !== 'STOPPING ANY PRE-EXISTING SERVICES' && !command.includes('rm celerybeat.pid')) {
+      if (exitCode !== 0 && service !== 'STOPPING ANY PRE-EXISTING SERVICES') {
         reject(
           new Error(`${service} failed to start for the command: ${command}`)
         )


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/L95S2KCc/1569-update-removing-celerybeatpid-in-tooling-to-handle-file-not-present-error

### Description
Make celerybeat.pid deletion more robust. Using `[` is OK in this scenario even though `[[` is ["more powerful"](http://mywiki.wooledge.org/BashFAQ/031) because almost all shells use `[` but not necessarily `[[`. Also, for the use case of checking if a file exists, there is no difference between the two.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [x] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Ran all up command and works