### PR TITLE
Remove config dep in updateContentBlacklist by extracting api signing

### DIFF
--- a/creator-node/README.md
+++ b/creator-node/README.md
@@ -1,7 +1,7 @@
 An Audius Creator Node maintains the availability of creators' content on IPFS. The information stored includes audius user metadata, images, and audio content. The content is backed by either aws S3 or a local directory.
 
 To blacklist content on an already running node:
-1. export the keys `delegatePrivateKey` and `creatorNodeEndpoint` in your terminal
+1. Export the keys `delegatePrivateKey` and `creatorNodeEndpoint` in your terminal
 ```
 $ export delegatePrivateKey='your_private_key'
 $ export creatorNodeEndpoint='http://the_creator_node_endpoint' 

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -39,3 +39,5 @@ debounceTime=5000
 # Put CNs to debug mode if we're running locally.
 # Can be overriden.
 creatorNodeIsDebug=true
+
+WAIT_HOSTS=

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -39,8 +39,3 @@ debounceTime=5000
 # Put CNs to debug mode if we're running locally.
 # Can be overriden.
 creatorNodeIsDebug=true
-
-# content blacklist
-userBlacklist=
-trackBlacklist=
-WAIT_HOSTS=

--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -35,8 +35,6 @@
   "debounceTime": 30000,
   "discoveryProviderWhitelist": "http://audius-disc-prov_web-server_1:5000",
   "identityService": "http://audius-identity-service_identity-service_1:7000",
-  "userBlacklist": "",
-  "trackBlacklist": "",
   "dataRegistryAddress": "",
   "dataProviderUrl": "http://docker.for.mac.localhost:8545",
   "dataNetworkId": "",

--- a/creator-node/docker-compose/development.env
+++ b/creator-node/docker-compose/development.env
@@ -42,7 +42,3 @@ debounceTime=5000
 
 # not part of the config itself, but required for docker to know when ports are available
 WAIT_HOSTS=docker.for.mac.localhost:4379,docker.for.mac.localhost:4432
-
-# content blacklist
-userBlacklist=
-trackBlacklist=

--- a/creator-node/scripts/updateContentBlacklist.js
+++ b/creator-node/scripts/updateContentBlacklist.js
@@ -1,7 +1,6 @@
 const axios = require('axios')
 
-const models = require('../src/models')
-const { generateTimestampAndSignature } = require('../src/apiHelpers')
+const { generateTimestampAndSignature } = require('../src/apiSigning')
 
 const PRIVATE_KEY = process.env.delegatePrivateKey
 const CREATOR_NODE_ENDPOINT = process.env.creatorNodeEndpoint
@@ -9,7 +8,7 @@ const CREATOR_NODE_ENDPOINT = process.env.creatorNodeEndpoint
 // Available action types
 const ACTION_ARR = ['ADD', 'DELETE']
 const ACTION_SET = new Set(ACTION_ARR)
-const TYPES_ARR = models.ContentBlacklist.Types
+const TYPES_ARR = ['USER', 'TRACK']
 const TYPES_SET = new Set(TYPES_ARR)
 
 // Script usage:

--- a/creator-node/src/apiSigning.js
+++ b/creator-node/src/apiSigning.js
@@ -1,0 +1,44 @@
+const Web3 = require('web3')
+const web3 = new Web3()
+
+/**
+ * Generate the timestamp and signature for api signing
+ * @param {object} data
+ * @param {string} privateKey
+ */
+const generateTimestampAndSignature = (data, privateKey) => {
+  const timestamp = new Date().toISOString()
+  const toSignObj = { ...data, timestamp }
+  // JSON stringify automatically removes white space given 1 param
+  const toSignStr = JSON.stringify(sortKeys(toSignObj))
+  const toSignHash = web3.utils.keccak256(toSignStr)
+  const signedResponse = web3.eth.accounts.sign(toSignHash, privateKey)
+
+  return { timestamp, signature: signedResponse.signature }
+}
+
+/**
+   * Recover the public wallet address
+   * @param {*} data obj with structure {...data, timestamp}
+   * @param {*} signature signature generated with signed data
+   */
+// eslint-disable-next-line no-unused-vars
+const recoverWallet = (data, signature) => {
+  let structuredData = JSON.stringify(sortKeys(data))
+  const hashedData = web3.utils.keccak256(structuredData)
+  const recoveredWallet = web3.eth.accounts.recover(hashedData, signature)
+
+  return recoveredWallet
+}
+
+const sortKeys = x => {
+  if (typeof x !== 'object' || !x) { return x }
+  if (Array.isArray(x)) { return x.map(sortKeys) }
+  return Object.keys(x).sort().reduce((o, k) => ({ ...o, [k]: sortKeys(x[k]) }), {})
+}
+
+module.exports = {
+  generateTimestampAndSignature,
+  recoverWallet,
+  sortKeys
+}

--- a/creator-node/src/components/contentBlacklist/contentBlacklistController.js
+++ b/creator-node/src/components/contentBlacklist/contentBlacklistController.js
@@ -10,9 +10,9 @@ const {
   successResponse,
   errorResponseBadRequest,
   errorResponseUnauthorized,
-  errorResponseServerError,
-  recoverWallet
+  errorResponseServerError
 } = require('../../apiHelpers')
+const { recoverWallet } = require('../../apiSigning')
 const models = require('../../../src/models')
 const config = require('../../config')
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -354,19 +354,6 @@ const config = convict({
     env: 'identityService',
     default: ''
   },
-  /** Manual content blacklists */
-  userBlacklist: {
-    doc: 'Comma-separated list of user blockchain IDs that creator node should avoid serving / storing',
-    format: String,
-    env: 'userBlacklist',
-    default: ''
-  },
-  trackBlacklist: {
-    doc: 'Comma-separated list of track blockchain IDs that creator node should avoid serving / storing',
-    format: String,
-    env: 'trackBlacklist',
-    default: ''
-  },
   creatorNodeIsDebug: {
     doc: 'Whether the creatornode is in debug mode.',
     format: Boolean,

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -14,7 +14,7 @@ const { getApp } = require('./lib/app')
 const { createStarterCNodeUser } = require('./lib/dataSeeds')
 const { getIPFSMock } = require('./lib/ipfsMock')
 const { getLibsMock } = require('./lib/libsMock')
-const { sortKeys } = require('../src/apiHelpers')
+const { sortKeys } = require('../src/apiSigning')
 
 describe('test AudiusUsers with mocked IPFS', function () {
   let app, server, session, ipfsMock, libsMock

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -8,7 +8,7 @@ const BlacklistManager = require('../src/blacklistManager')
 const models = require('../src/models')
 const ipfsClient = require('../src/ipfsClient')
 const redis = require('../src/redis')
-const { generateTimestampAndSignature } = require('../src/apiHelpers')
+const { generateTimestampAndSignature } = require('../src/apiSigning')
 
 const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -10,7 +10,7 @@ const { saveFileToIPFSFromFS, removeTrackFolder, saveFileFromBufferToIPFSAndDisk
 const config = require('../src/config')
 const models = require('../src/models')
 
-const { sortKeys } = require('../src/apiHelpers')
+const { sortKeys } = require('../src/apiSigning')
 
 let storagePath = config.get('storagePath')
 storagePath = storagePath.charAt(0) === '/' ? storagePath.slice(1) : storagePath

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -15,7 +15,7 @@ const { getApp } = require('./lib/app')
 const { createStarterCNodeUser } = require('./lib/dataSeeds')
 const { getIPFSMock } = require('./lib/ipfsMock')
 const { getLibsMock } = require('./lib/libsMock')
-const { sortKeys } = require('../src/apiHelpers')
+const { sortKeys } = require('../src/apiSigning')
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 const testAudioFileWrongFormatPath = path.resolve(__dirname, 'testTrackWrongFormat.jpg')


### PR DESCRIPTION
### Trello Card Link
none

### Description
Running `updateContentBlacklist.js` logs an error about a dep on config. This PR remove the config dep by extracting the api signing logic to another file. 

### Services

- [ ] Discovery Provider
- [x] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches ••Content Blacklist••


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Run the script for a track in staging
2. Check the associated creator nodes on staging that when hitting the route `ipfs/<CID>` an error like this appears:
```
{
  "error": "CID QmPLrsrZ8mGcAcabBWg8vBwCwLSzGGsbgvmk9u8yxKNk81 has been blacklisted by this node."
}
```


Please list the unit test(s) you added to verify your changes.


