### PR TITLE
Fix track association so it only errors if files found < files expected

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -381,7 +381,8 @@ module.exports = function (app) {
           transaction
         })
 
-        if (trackFiles.length !== trackSegmentCIDs.length) {
+        if (trackFiles.length < trackSegmentCIDs.length) {
+          req.logger.error(`Did not find files for every track segment CID for user ${cnodeUserUUID} ${trackFiles} ${trackSegmentCIDs}`)
           throw new Error('Did not find files for every track segment CID.')
         }
         const numAffectedRows = await models.File.update(
@@ -396,7 +397,8 @@ module.exports = function (app) {
             transaction
           }
         )
-        if (parseInt(numAffectedRows, 10) !== trackSegmentCIDs.length) {
+        if (parseInt(numAffectedRows, 10) < trackSegmentCIDs.length) {
+          req.logger.error(`Failed to associate files for every track segment CID ${cnodeUserUUID} ${track.blockchainId} ${numAffectedRows} ${trackSegmentCIDs.length}`)
           throw new Error('Failed to associate files for every track segment CID.')
         }
       } else { /** If track updated, ensure files exist with trackBlockchainId. */

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -313,8 +313,7 @@ module.exports = function (app) {
       const existingTrackEntry = await models.Track.findOne({
         where: {
           cnodeUserUUID,
-          blockchainId: blockchainTrackId,
-          coverArtFileUUID
+          blockchainId: blockchainTrackId
         },
         order: [['clock', 'DESC']],
         transaction


### PR DESCRIPTION
### Trello Card Link


### Description


### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches upload. It's the second leg of upload which is the association of trackBlockchainId


### How Has This Been Tested?

It hasn't, yet

Please list the unit test(s) you added to verify your changes.

None