### PR TITLE
Fix dictionary comp in get_feed

### DIFF
--- a/discovery-provider/src/queries/get_feed.py
+++ b/discovery-provider/src/queries/get_feed.py
@@ -63,7 +63,7 @@ def get_feed(args):
                 # get all track objects for track ids
                 playlist_tracks = get_unpopulated_tracks(session, playlist_track_ids)
                 playlist_tracks_dict = {
-                    track.track_id: track for track in playlist_tracks}
+                    track["track_id"]: track for track in playlist_tracks}
 
                 # get all track ids that have same owner as playlist and created in "same action"
                 # "same action": track created within [x time] before playlist creation


### PR DESCRIPTION
### Description

Feed is broken due to changes in `get_unpopulated_tracks`

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

It hasn't - straight to staging!