### PR TITLE
Add timeout to index plays lock

### DIFF
--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -210,8 +210,8 @@ def update_play_count(self):
     # Define lock acquired boolean
     have_lock = False
 
-    # Define redis lock object
-    update_lock = redis.lock("update_play_count_lock", blocking_timeout=25)
+    # Define redis lock object with a timeout of 10 minutes
+    update_lock = redis.lock("update_play_count_lock", timeout=10*60)
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)


### PR DESCRIPTION
### Trello Card Link
na

### Description
The job to index plays on discovery provider occasionally gets stuck because the lock cannot be acquired.
This change adds a timeout of 10 minutes to the redis lock for plays so that it will only be stuck for 10 minutes at most. 
NOTE: if the job were to be run twice, meaning it for some reason takes over 10 minutes to make the queries to update the plays table, there would be an inconsistency in the table for the number of plays. 
Something interesting to note: I queried DP 1 for the message `Failed to acquire update_play_count_lock` and it seems to show up for about 4 min every 3 hrs. I think this is b/c DP restarts in kuberentes? There are logs for the amount of time the job takes, but there was a bug w/ how it was logged, so I can't get the avg, max time the indexing plays takes. 

![Screen Shot 2020-10-09 at 2 14 54 PM](https://user-images.githubusercontent.com/7064122/95617688-d2253700-0a39-11eb-833f-b0600e47bd8e.png)

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran it locally and added time.sleep to the indexing job to force it to take a while to check that the lock was released. 
