### PR TITLE
Eth Contract retries and multiple providers

### DIFF
--- a/libs/initScripts/helpers/version.js
+++ b/libs/initScripts/helpers/version.js
@@ -15,7 +15,7 @@ async function setServiceVersion (audiusLibs, serviceType, serviceVersionStr, pr
       serviceType,
       serviceVersionStr,
       privateKey)
-      console.log(resp)
+    console.log(resp)
   } catch (e) {
     if (!e.toString().includes('Already registered')) {
       console.log(e)

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -20,6 +20,7 @@ const Track = require('./api/track')
 const Playlist = require('./api/playlist')
 const File = require('./api/file')
 const ServiceProvider = require('./api/serviceProvider')
+const Web3 = require('./web3')
 
 class AudiusLibs {
   /**
@@ -76,21 +77,25 @@ class AudiusLibs {
   /**
    * Configures an internal web3 to use (via Hedgehog)
    * @param {string} registryAddress
-   * @param {string | object | Array<string>} providers web3 provider endpoint(s)
+   * @param {string | Web3 | Array<string>} providers web3 provider endpoint(s)
    */
   static configInternalWeb3 (registryAddress, providers) {
-    if (typeof providers !== 'string' || !Array.isArray(providers)) {
-      throw new Error('Invalid providers list. Must be string or Array.')
-    }
-    if (typeof providers === "string") {
-      providers = providers.split(',')
+    let providerList
+    if (typeof providers === 'string') {
+      providerList = providers.split(',')
+    } else if (providers instanceof Web3) {
+      providerList = [providers]
+    } else if (Array.isArray(providers)) {
+      providerList = providers
+    } else {
+      throw new Error('Providers must be of type string, Array, or Web3 instance')
     }
 
     return {
       registryAddress,
       useExternalWeb3: false,
       internalWeb3Config: {
-        web3ProviderEndpoints: providers
+        web3ProviderEndpoints: providerList
       }
     }
   }
@@ -99,18 +104,22 @@ class AudiusLibs {
    * Configures an eth web3
    * @param {string} tokenAddress
    * @param {string} registryAddress
-   * @param {string | object | Array<string>} providers web3 provider endpoint(s)
+   * @param {string | Web3 | Array<string>} providers web3 provider endpoint(s)
    * @param {string} ownerWallet
    */
   static configEthWeb3 (tokenAddress, registryAddress, providers, ownerWallet) {
-    if (typeof providers !== 'string' || !Array.isArray(providers)) {
-      throw new Error('Invalid providers list. Must be string or Array.')
-    }
-    if (typeof providers === "string") {
-      providers = providers.split(',')
+    let providerList
+    if (typeof providers === 'string') {
+      providerList = providers.split(',')
+    } else if (providers instanceof Web3) {
+      providerList = [providers]
+    } else if (Array.isArray(providers)) {
+      providerList = providers
+    } else {
+      throw new Error('Providers must be of type string, Array, or Web3 instance')
     }
 
-    return { tokenAddress, registryAddress, providers, ownerWallet }
+    return { tokenAddress, registryAddress, providers: providerList, ownerWallet }
   }
 
   /**

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -79,8 +79,11 @@ class AudiusLibs {
    * @param {string | object | Array<string>} providers web3 provider endpoint(s)
    */
   static configInternalWeb3 (registryAddress, providers) {
-    if (typeof providers === 'string' || typeof providers === 'object') {
-      providers = [providers]
+    if (typeof providers !== 'string' || !Array.isArray(providers)) {
+      throw new Error('Invalid providers list. Must be string or Array.')
+    }
+    if (typeof providers === "string") {
+      providers = providers.split(',')
     }
 
     return {
@@ -100,8 +103,11 @@ class AudiusLibs {
    * @param {string} ownerWallet
    */
   static configEthWeb3 (tokenAddress, registryAddress, providers, ownerWallet) {
-    if (typeof providers === 'string' || typeof providers === 'object') {
-      providers = [providers]
+    if (typeof providers !== 'string' || !Array.isArray(providers)) {
+      throw new Error('Invalid providers list. Must be string or Array.')
+    }
+    if (typeof providers === "string") {
+      providers = providers.split(',')
     }
 
     return { tokenAddress, registryAddress, providers, ownerWallet }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -76,7 +76,7 @@ class AudiusLibs {
   /**
    * Configures an internal web3 to use (via Hedgehog)
    * @param {string} registryAddress
-   * @param {string | object | Array<string>} providers web3 provider endpoints
+   * @param {string | object | Array<string>} providers web3 provider endpoint(s)
    */
   static configInternalWeb3 (registryAddress, providers) {
     if (typeof providers === 'string') {
@@ -96,7 +96,7 @@ class AudiusLibs {
    * Configures an eth web3
    * @param {string} tokenAddress
    * @param {string} registryAddress
-   * @param {string | object | Array<string>} providers web3 provider endpoint
+   * @param {string | object | Array<string>} providers web3 provider endpoint(s)
    * @param {string} ownerWallet
    */
   static configEthWeb3 (tokenAddress, registryAddress, providers, ownerWallet) {

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -76,18 +76,18 @@ class AudiusLibs {
   /**
    * Configures an internal web3 to use (via Hedgehog)
    * @param {string} registryAddress
-   * @param {Array} allProviderUrls web3 provider endpoints
+   * @param {string | object | Array<string>} providers web3 provider endpoints
    */
-  static configInternalWeb3 (registryAddress, allProviderUrls) {
-    if (typeof allProviderUrls === 'string') {
-      allProviderUrls = [allProviderUrls]
+  static configInternalWeb3 (registryAddress, providers) {
+    if (typeof providers === 'string') {
+      providers = [providers]
     }
 
     return {
       registryAddress,
       useExternalWeb3: false,
       internalWeb3Config: {
-        web3ProviderEndpoints: allProviderUrls
+        web3ProviderEndpoints: providers
       }
     }
   }
@@ -96,11 +96,15 @@ class AudiusLibs {
    * Configures an eth web3
    * @param {string} tokenAddress
    * @param {string} registryAddress
-   * @param {object} url web3 provider endpoint
+   * @param {string | object | Array<string>} providers web3 provider endpoint
    * @param {string} ownerWallet
    */
-  static configEthWeb3 (tokenAddress, registryAddress, url, ownerWallet) {
-    return { tokenAddress, registryAddress, url, ownerWallet }
+  static configEthWeb3 (tokenAddress, registryAddress, providers, ownerWallet) {
+    if (typeof providers === 'string') {
+      providers = [providers]
+    }
+
+    return { tokenAddress, registryAddress, providers, ownerWallet }
   }
 
   /**

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -79,7 +79,7 @@ class AudiusLibs {
    * @param {string | object | Array<string>} providers web3 provider endpoint(s)
    */
   static configInternalWeb3 (registryAddress, providers) {
-    if (typeof providers === 'string') {
+    if (typeof providers === 'string' || typeof providers === 'object') {
       providers = [providers]
     }
 
@@ -100,7 +100,7 @@ class AudiusLibs {
    * @param {string} ownerWallet
    */
   static configEthWeb3 (tokenAddress, registryAddress, providers, ownerWallet) {
-    if (typeof providers === 'string') {
+    if (typeof providers === 'string' || typeof providers === 'object') {
       providers = [providers]
     }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -87,8 +87,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
 
   /** Allows the selection take a shortcut if there's a cached provider */
   shortcircuit () {
-    // return this.getCached()
-    return null
+    return this.getCached()
   }
 
   async select () {

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -87,7 +87,8 @@ class DiscoveryProviderSelection extends ServiceSelection {
 
   /** Allows the selection take a shortcut if there's a cached provider */
   shortcircuit () {
-    return this.getCached()
+    // return this.getCached()
+    return null
   }
 
   async select () {

--- a/libs/src/services/ethContracts/serviceTypeManagerClient.js
+++ b/libs/src/services/ethContracts/serviceTypeManagerClient.js
@@ -3,7 +3,7 @@ const GovernedContractClient = require('../contracts/GovernedContractClient')
 const DEFAULT_GAS_AMOUNT = 200000
 
 class ServiceTypeManagerClient extends GovernedContractClient {
-  async setServiceVersion (serviceType, serviceVersion, privateKey=null) {
+  async setServiceVersion (serviceType, serviceVersion, privateKey = null) {
     const method = await this.getGovernedMethod(
       'setServiceVersion',
       Utils.utf8ToHex(serviceType),

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -3,8 +3,8 @@ const EthereumTx = require('ethereumjs-tx')
 const retry = require('async-retry')
 const { sample } = require('lodash')
 const DEFAULT_GAS_AMOUNT = 200000
-const MIN_GAS_PRICE = Math.pow(500, 9) // 1 GWei, POA default gas price
-const HIGH_GAS_PRICE = 50 * MIN_GAS_PRICE // 5 GWei
+const MIN_GAS_PRICE = Math.pow(10, 9) // 1 GWei, POA default gas price
+const HIGH_GAS_PRICE = 5 * MIN_GAS_PRICE // 5 GWei
 const GANACHE_GAS_PRICE = 39062500000 // ganache gas price is extremely high, so we hardcode a lower value (0x09184e72a0 from docs here)
 
 /** Singleton state-manager for Audius Eth Contracts */
@@ -16,7 +16,6 @@ class EthWeb3Manager {
 
     // Pick a provider at random to spread the load
     const provider = sample(web3Config.providers)
-    console.log(provider)
 
     this.web3Config = web3Config
     this.web3 = new Web3(provider)
@@ -72,7 +71,6 @@ class EthWeb3Manager {
         retries: txRetries,
         onRetry: (err, i) => {
           if (err) {
-            // eslint-disable-next-line no-console
             console.log(`Retry error : ${err}`)
           }
         }

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -1,6 +1,7 @@
 const Web3 = require('../../web3')
 const EthereumTx = require('ethereumjs-tx')
 const retry = require('async-retry')
+const { sample } = require('lodash')
 const DEFAULT_GAS_AMOUNT = 200000
 const MIN_GAS_PRICE = Math.pow(500, 9) // 1 GWei, POA default gas price
 const HIGH_GAS_PRICE = 50 * MIN_GAS_PRICE // 5 GWei
@@ -10,11 +11,15 @@ const GANACHE_GAS_PRICE = 39062500000 // ganache gas price is extremely high, so
 class EthWeb3Manager {
   constructor (web3Config) {
     if (!web3Config) throw new Error('web3Config object not passed in')
-    if (!web3Config.url) throw new Error('missing web3Config property: url')
+    if (!web3Config.providers) throw new Error('missing web3Config property: providers')
     if (!web3Config.ownerWallet) throw new Error('missing web3Config property: ownerWallet')
 
+    // Pick a provider at random to spread the load
+    const provider = sample(web3Config.providers)
+    console.log(provider)
+
     this.web3Config = web3Config
-    this.web3 = new Web3(web3Config.url)
+    this.web3 = new Web3(provider)
     this.ownerWallet = web3Config.ownerWallet
   }
 

--- a/libs/src/services/web3Manager/index.js
+++ b/libs/src/services/web3Manager/index.js
@@ -157,15 +157,14 @@ class Web3Manager {
           txGasLimit
         )
       }, {
-      // Retry function 5x by default
-      // 1st retry delay = 500ms, 2nd = 1500ms, 3rd...nth retry = 4000 ms (capped)
+        // Retry function 5x by default
+        // 1st retry delay = 500ms, 2nd = 1500ms, 3rd...nth retry = 4000 ms (capped)
         minTimeout: 500,
         maxTimeout: 4000,
         factor: 3,
         retries: txRetries,
         onRetry: (err, i) => {
           if (err) {
-            // eslint-disable-next-line no-console
             console.log(`Retry error : ${err}`)
           }
         }

--- a/libs/tests/providerSelectionTest.js
+++ b/libs/tests/providerSelectionTest.js
@@ -178,7 +178,7 @@ function createContractClientWithExternalWeb3 () {
 
 function createContractClientWithEthWeb3Manager () {
   const web3Config = {
-    url: 'https://audius.eth.network',
+    providers: ['https://audius.eth.network'],
     ownerWallet: '0xwallet'
   }
   const ethWeb3Manager = new EthWeb3Manager(web3Config)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Vgoqodmy/1605-eth-libs-reliability-improvements

### Description
This PR contains 3 improvements to the contracts flow:
1. Eth contracts sendTransaction now includes retry logic (same as web3Manager's sendTransaction)
2. All contracts (via ContractClient) support retries on reads (executed through method.call())
3. Eth contracts now support an array of providers rather than just a single provider

This change is fully backwards compatible, so clients can update to this at will.

### Services

- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches all contract reads & all eth contract writes


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

To test each of the changes:
1. Ran the protocol dashboard & created a new proposal via metamask, testing out the sendTransaction logic
2. Ran the dapp with these libs pointed at prod. Intentionally threw errors in first requests to method.call() so that retries were performed
3. Ran a branch of dapp passing in an array of eth providers https://github.com/AudiusProject/audius-client/compare/rj-multiple-eth-providers?expand=1
