### PR TITLE
Fix playlist API bugs

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -38,8 +38,6 @@ def get_playlist(playlist_id, current_user_id):
 def get_tracks_for_playlist(playlist_id, current_user_id=None):
     args = {"playlist_id": playlist_id, "with_users": True, "current_user_id": current_user_id}
     playlist_tracks = get_playlist_tracks(args)
-    if not playlist_tracks:
-        abort_not_found(playlist_id, ns)
     tracks = list(map(extend_track, playlist_tracks))
     return tracks
 
@@ -210,7 +208,7 @@ class FullTrackFavorites(Resource):
         decoded_id = decode_with_abort(playlist_id, full_ns)
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-        
+
         current_user_id = None
         if args.get("user_id"):
             current_user_id = decode_string_id(args["user_id"])
@@ -253,7 +251,7 @@ class FullPlaylistReposts(Resource):
         decoded_id = decode_with_abort(playlist_id, full_ns)
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-        
+
         current_user_id = None
         if args.get("user_id"):
             current_user_id = decode_string_id(args["user_id"])

--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -37,7 +37,6 @@ def get_playlists(args):
     db = get_db_read_replica()
     with db.scoped_session() as session:
         def get_unpopulated_playlists():
-            filter_out_private_playlists = True
             playlist_query = (
                 session.query(Playlist)
                 .filter(Playlist.is_current == True)
@@ -58,13 +57,8 @@ def get_playlists(args):
                     Playlist.playlist_owner_id == user_id
                 )
 
-                # if the current user is the same as the user passed in through the query param then we're trying
-                # to get playlists for, check if the users are the same. if they are the same, the current user is
-                # trying to request their own playlists, so allow them to see private playlists
-                if current_user_id and user_id and (int(current_user_id) == int(user_id)):
-                    filter_out_private_playlists = False
-
-            if filter_out_private_playlists:
+            # If no current_user_id, never show hidden playlists
+            if not current_user_id:
                 playlist_query = playlist_query.filter(
                     Playlist.is_private == False
                 )
@@ -78,6 +72,11 @@ def get_playlists(args):
             playlist_query = playlist_query.order_by(desc(Playlist.created_at))
             playlists = paginate_query(playlist_query).all()
             playlists = helpers.query_result_to_list(playlists)
+
+            # if we passed in a current_user_id, filter out all privte playlists where
+            # the owner_id doesn't match the current_user_id
+            if current_user_id:
+                playlists = list(filter(lambda playlist: (not playlist["is_private"]) or playlist["playlist_owner_id"] == current_user_id, playlists))
 
             # retrieve playlist ids list
             playlist_ids = list(map(lambda playlist: playlist["playlist_id"], playlists))


### PR DESCRIPTION
### Description
Fixes two playlist API bugs:
- Playlists without tracks would 404
- Couldn't fetch private playlists via API 


### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested locally against staging RDS on a playlist that once crashed the dapp.