### PR TITLE
Add blocknumber to API full responses

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -187,7 +187,8 @@ def stem_from_track(track):
         "parent_id": parent_id,
         "category": category,
         "cid": track["download"]["cid"],
-        "user_id": encode_int_id(track["owner_id"])
+        "user_id": encode_int_id(track["owner_id"]),
+        "blocknumber": track["blocknumber"]
     }
 
 def extend_playlist(playlist):

--- a/discovery-provider/src/api/v1/models/playlists.py
+++ b/discovery-provider/src/api/v1/models/playlists.py
@@ -27,7 +27,7 @@ playlist_model = ns.model('playlist', {
 })
 
 full_playlist_model = ns.clone('playlist_full', playlist_model, {
-    "blocknumber": fields.Integer,
+    "blocknumber": fields.Integer(required=True),
     "created_at": fields.String,
     "followee_reposts": fields.List(fields.Nested(repost), required=True),
     "followee_favorites": fields.List(fields.Nested(favorite), required=True),

--- a/discovery-provider/src/api/v1/models/playlists.py
+++ b/discovery-provider/src/api/v1/models/playlists.py
@@ -27,6 +27,7 @@ playlist_model = ns.model('playlist', {
 })
 
 full_playlist_model = ns.clone('playlist_full', playlist_model, {
+    "blocknumber": fields.Integer,
     "created_at": fields.String,
     "followee_reposts": fields.List(fields.Nested(repost), required=True),
     "followee_favorites": fields.List(fields.Nested(favorite), required=True),

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -75,7 +75,7 @@ track = ns.model('Track', {
 })
 
 track_full = ns.clone('track_full', track, {
-    "blocknumber": fields.Integer,
+    "blocknumber": fields.Integer(required=True),
     "create_date": fields.String,
     "cover_art_sizes": fields.String,
     "created_at": fields.String,

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -1,4 +1,4 @@
-from flask_restx.fields import Boolean
+from flask_restx.fields import Boolean, Integer
 from src.api.v1.helpers import make_response
 from flask_restx import fields
 from .users import user_model, user_model_full
@@ -75,6 +75,7 @@ track = ns.model('Track', {
 })
 
 track_full = ns.clone('track_full', track, {
+    "blocknumber": fields.Integer,
     "create_date": fields.String,
     "cover_art_sizes": fields.String,
     "created_at": fields.String,
@@ -105,7 +106,8 @@ stem_full = ns.model('stem_full', {
     "parent_id": fields.String(required=True),
     "category": fields.String(required=True),
     "cid": fields.String(required=True),
-    "user_id": fields.String(required=True)
+    "user_id": fields.String(required=True),
+    "blocknumber": fields.Integer(required=True)
 })
 
 remixes_response = ns.model('remixes_response', {

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -31,7 +31,7 @@ user_model = ns.model("user", {
 })
 
 user_model_full = ns.clone("user_full", user_model, {
-    "blocknumber": fields.Integer,
+    "blocknumber": fields.Integer(required=True),
     "created_at": fields.String(required=True),
     "creator_node_endpoint": fields.String,
     "current_user_followee_follow_count": fields.Integer(required=True),

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -31,6 +31,7 @@ user_model = ns.model("user", {
 })
 
 user_model_full = ns.clone("user_full", user_model, {
+    "blocknumber": fields.Integer,
     "created_at": fields.String(required=True),
     "creator_node_endpoint": fields.String,
     "current_user_followee_follow_count": fields.Integer(required=True),


### PR DESCRIPTION
### Description

Adds block number to API responses to support smarter caching strategy on client.

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested with latest client code locally.

