### PR TITLE
Add play check to discprov

### DIFF
--- a/discovery-provider/src/queries/get_latest_play.py
+++ b/discovery-provider/src/queries/get_latest_play.py
@@ -1,0 +1,14 @@
+from src.models import Play
+from src.utils import db_session
+
+def get_latest_play():
+    """
+    Gets the latest play in the database
+    """
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        play_query = session.query(Play.created_at).order_by(
+            Play.created_at.desc()
+        ).limit(1)
+        play = play_query.scalar()
+        return play

--- a/discovery-provider/src/queries/get_latest_play_test.py
+++ b/discovery-provider/src/queries/get_latest_play_test.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from src.queries.get_latest_play import get_latest_play
+from src.models import Play
+
+def test_get_latest_play(db_mock):
+    """Tests that the latest play is returned"""
+    date1 = datetime(2020, 10, 4, 10, 35, 0)
+    date2 = datetime(2020, 10, 1, 10, 10, 0)
+    date3 = datetime(2020, 9, 20, 8, 1, 0)
+
+    with db_mock.scoped_session() as session:
+        Play.__table__.create(db_mock._engine)
+        session.add(Play(
+            user_id=1,
+            play_item_id=1,
+            created_at=date1
+        ))
+        session.add(Play(
+            user_id=2,
+            play_item_id=1,
+            created_at=date2
+        ))
+        session.add(Play(
+            user_id=3,
+            play_item_id=2,
+            created_at=date3
+        ))
+
+    latest_play = get_latest_play()
+    assert latest_play == date1

--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -76,7 +76,10 @@ def get_playlists(args):
             # if we passed in a current_user_id, filter out all privte playlists where
             # the owner_id doesn't match the current_user_id
             if current_user_id:
-                playlists = list(filter(lambda playlist: (not playlist["is_private"]) or playlist["playlist_owner_id"] == current_user_id, playlists))
+                playlists = list(filter(
+                    lambda playlist: (not playlist["is_private"]) or playlist["playlist_owner_id"] == current_user_id,
+                    playlists)
+                )
 
             # retrieve playlist ids list
             playlist_ids = list(map(lambda playlist: playlist["playlist_id"], playlists))

--- a/discovery-provider/src/queries/health_check.py
+++ b/discovery-provider/src/queries/health_check.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import logging
-from src.queries.get_latest_play import get_latest_play
 from flask import Blueprint, request
+from src.queries.get_latest_play import get_latest_play
 from src.queries.queries import parse_bool_param
 from src.api_helpers import success_response, success_response_backwards_compat
 from src.queries.get_health import get_health

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -1,8 +1,8 @@
 import datetime
-from json.encoder import JSONEncoder
 import logging
 import os
 import json
+from json.encoder import JSONEncoder
 import re
 import time
 import contextlib


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/wM570Sl6/1607-add-play-check-to-discprov

### Description
Adds a /play_check to discprov that returns the latest created Play in the db. Endpoint takes an optional max_drift query param that is used to check whether to return a 500.

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Local discprov, tested with and without query param

Please list the unit test(s) you added to verify your changes.

1. get_latest_play_test.py
