### PR TITLE
Only cache if no user_id

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -7,7 +7,7 @@ from flask_restx import Resource, Namespace, fields, reqparse
 from src.queries.get_playlist_tracks import get_playlist_tracks
 from src.api.v1.helpers import abort_not_found, decode_with_abort, extend_playlist, extend_track,\
     make_response, success_response, search_parser, abort_bad_request_param, decode_string_id, \
-    extend_user, get_default_max
+    extend_user, get_default_max, get_current_user_id
 from .models.tracks import track
 from src.queries.search_queries import SearchKind, search
 from src.utils.redis_cache import cache
@@ -75,9 +75,7 @@ class FullPlaylist(Resource):
         """Fetch a playlist."""
         playlist_id = decode_with_abort(playlist_id, full_ns)
         args = full_playlist_parser.parse_args()
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
+        current_user_id = get_current_user_id(args)
 
         playlist = get_playlist(playlist_id, current_user_id)
         if playlist:
@@ -174,7 +172,6 @@ class Top(Resource):
 
         args['with_users'] = True
 
-        logger.warning(args)
         response = get_top_playlists(args.type, args)
 
         playlists = list(map(extend_playlist, response))
@@ -208,10 +205,7 @@ class FullTrackFavorites(Resource):
         decoded_id = decode_with_abort(playlist_id, full_ns)
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
+        current_user_id = get_current_user_id(args)
         args = {
             'save_playlist_id': decoded_id,
             'current_user_id': current_user_id,
@@ -251,10 +245,7 @@ class FullPlaylistReposts(Resource):
         decoded_id = decode_with_abort(playlist_id, full_ns)
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
+        current_user_id = get_current_user_id(args)
         args = {
             'repost_playlist_id': decoded_id,
             'current_user_id': current_user_id,

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -73,9 +73,7 @@ class FullUser(Resource):
     def get(self, user_id):
         user_id = decode_with_abort(user_id, ns)
         args = full_user_parser.parse_args()
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         return get_single_user(user_id, current_user_id)
 
@@ -88,9 +86,7 @@ class FullUserHandle(Resource):
     @cache(ttl_sec=5)
     def get(self, handle):
         args = full_user_handle_parser.parse_args()
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         args = {
             "handle": handle,
@@ -135,9 +131,7 @@ class TrackList(Resource):
         decoded_id = decode_with_abort(user_id, ns)
         args = user_tracks_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         sort = args.get("sort", None)
         offset = format_offset(args)
@@ -181,9 +175,7 @@ class FullTrackList(Resource):
         decoded_id = decode_with_abort(user_id, ns)
         args = user_tracks_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         sort = args.get("sort", None)
         offset = format_offset(args)
@@ -226,9 +218,7 @@ class HandleFullTrackList(Resource):
         """Fetch a list of tracks for a user."""
         args = user_tracks_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         sort = args.get("sort", None)
         offset = format_offset(args)
@@ -277,9 +267,7 @@ class RepostList(Resource):
         decoded_id = decode_with_abort(user_id, ns)
         args = user_reposts_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         offset = format_offset(args)
         limit = format_limit(args)
@@ -320,9 +308,7 @@ class FullRepostList(Resource):
         decoded_id = decode_with_abort(user_id, ns)
         args = user_reposts_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
+        current_user_id = get_current_user_id(args)
 
         offset = format_offset(args)
         limit = format_limit(args)
@@ -364,10 +350,7 @@ class HandleFullRepostList(Resource):
     def get(self, handle):
         args = user_reposts_route_parser.parse_args()
 
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args.get("user_id"))
-
+        current_user_id = get_current_user_id(args)
         offset = format_offset(args)
         limit = format_limit(args)
 
@@ -434,9 +417,7 @@ class FavoritedTracks(Resource):
         """Fetch favorited tracks for a user."""
         args = favorite_route_parser.parse_args()
         decoded_id = decode_with_abort(user_id, ns)
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(user_id)
+        current_user_id = get_current_user_id(args)
 
         offset = format_offset(args)
         limit = format_limit(args)
@@ -519,10 +500,7 @@ class FollowerUsers(Resource):
         args = followers_route_parser.parse_args()
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-        
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
+        current_user_id = get_current_user_id(args)
         args = {
             'followee_user_id': decoded_id,
             'current_user_id': current_user_id,
@@ -563,10 +541,7 @@ class FollowingUsers(Resource):
         args = following_route_parser.parse_args()
         limit = get_default_max(args.get('limit'), 10, 100)
         offset = get_default_max(args.get('offset'), 0)
-        
-        current_user_id = None
-        if args.get("user_id"):
-            current_user_id = decode_string_id(args["user_id"])
+        current_user_id = get_current_user_id(args)
         args = {
             'follower_user_id': decoded_id,
             'current_user_id': current_user_id,


### PR DESCRIPTION
### Trello Card Link
na

### Description
Only cache if the `user_id` param is not present. 
This is because a user/track/playlist that is populated will contain if the user is followed / track is saved/reposted ect. when cached. A social action won't be updated on re-fetching from cache of those fields. 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
It was run locally and logged when hit from cache/re-queried to check. 
