### PR TITLE
Add shared tracks cache for get_tracks

### DIFF
--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -6,32 +6,27 @@ from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import paginate_query, parse_sort_param, \
   populate_track_metadata, get_users_ids, get_users_by_id
-from src.utils.redis_cache import extract_key, use_redis_cache
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 
 logger = logging.getLogger(__name__)
 
-UNPOPULATED_TRACK_CACHE_DURATION_SEC = 10
-
-def make_cache_key(args):
-    cache_keys = {
-        "handle": args.get("handle"),
-        "id": args.get("id"),
-        "user_id": args.get("user_id"),
-        "filter_deleted": args.get("filter_deleted"),
-        "min_block_number": args.get("min_block_number"),
-        "sort": args.get("sort"),
-        "with_users": args.get("with_users")
-    }
-    key = extract_key(f"unpopulated-tracks:{request.path}", cache_keys.items())
-    return key
-
 def get_tracks(args):
+    """
+    Gets tracks.
+    A note on caching strategy:
+        - This method is cached at two layers: at the API via the @cache decorator,
+        and within this method using the shared get_unpopulated_tracks cache.
+
+        The shared cache only works when fetching via ID, so calls to fetch tracks
+        via handle, asc/desc sort, or filtering by block_number won't hit the shared cache.
+        These will hit the API cache unless they have a current_user_id included.
+
+    """
     tracks = []
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        def get_unpopulated_track():
+        def get_tracks_and_ids():
             if "handle" in args:
                 handle = args.get("handle")
                 user_id = session.query(User.user_id).filter(User.handle_lc == handle.lower()).first()
@@ -45,13 +40,10 @@ def get_tracks(args):
             )
 
             if can_use_shared_cache:
-                logger.warning("HITTING SHARED CACHE!")
-                # TODO: make sure this is actually a bool LOL
                 should_filter_deleted = args.get("filter_deleted", False)
                 tracks = get_unpopulated_tracks(session, args["id"], should_filter_deleted)
                 track_ids = list(map(lambda track: track["track_id"], tracks))
                 return (tracks, track_ids)
-
 
             # Create initial query
             base_query = session.query(Track)
@@ -108,8 +100,7 @@ def get_tracks(args):
 
             return (tracks, track_ids)
 
-        key = make_cache_key(args)
-        (tracks, track_ids) = use_redis_cache(key, UNPOPULATED_TRACK_CACHE_DURATION_SEC, get_unpopulated_track)
+        (tracks, track_ids) = get_tracks_and_ids()
 
         # bundle peripheral info into track results
         current_user_id = args.get("current_user_id")

--- a/discovery-provider/src/queries/get_unpopulated_tracks.py
+++ b/discovery-provider/src/queries/get_unpopulated_tracks.py
@@ -1,3 +1,4 @@
+import logging # pylint: disable=C0302
 import datetime
 import json
 from flask.json import dumps
@@ -6,8 +7,9 @@ from src.utils import redis_connection
 from src.models import Track
 from src.utils import helpers
 
-ttl_sec = 60
+logger = logging.getLogger(__name__)
 
+ttl_sec = 60
 
 def get_track_id_cache_key(id):
     return "track:id:{}".format(id)
@@ -66,6 +68,7 @@ def get_unpopulated_tracks(session, track_ids, filter_deleted=False, filter_unli
     for cached_track in cached_tracks_results:
         if cached_track:
             cached_tracks[cached_track['track_id']] = cached_track
+            logger.warning(f"Found cached track: {cached_track['track_id']}")
 
     track_ids_to_fetch = filter(
         lambda track_id: track_id not in cached_tracks, track_ids)

--- a/discovery-provider/src/queries/get_unpopulated_tracks.py
+++ b/discovery-provider/src/queries/get_unpopulated_tracks.py
@@ -68,7 +68,6 @@ def get_unpopulated_tracks(session, track_ids, filter_deleted=False, filter_unli
     for cached_track in cached_tracks_results:
         if cached_track:
             cached_tracks[cached_track['track_id']] = cached_track
-            logger.warning(f"Found cached track: {cached_track['track_id']}")
 
     track_ids_to_fetch = filter(
         lambda track_id: track_id not in cached_tracks, track_ids)


### PR DESCRIPTION
### Description

Adds shared caching for `get_tracks`, so we get at leat some level of caching for bulk fetches.

This gets rid of the existing get_unpopulated_tracks caching function. 


### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Tested locally against prod, made sure we returned expected results + hit cache when expected.