### PR TITLE
Add shared caching to get_users

### DIFF
--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -78,8 +78,7 @@ def get_playlists(args):
             if current_user_id:
                 playlists = list(filter(
                     lambda playlist: (not playlist["is_private"]) or playlist["playlist_owner_id"] == current_user_id,
-                    playlists)
-                )
+                    playlists))
 
             # retrieve playlist ids list
             playlist_ids = list(map(lambda playlist: playlist["playlist_id"], playlists))

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -1,6 +1,5 @@
 import logging # pylint: disable=C0302
 
-from flask.globals import request
 from src.models import AggregatePlays, Track, User
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica

--- a/discovery-provider/src/queries/get_users.py
+++ b/discovery-provider/src/queries/get_users.py
@@ -18,7 +18,7 @@ def get_users(args):
     with db.scoped_session() as session:
         def get_users_and_ids():
 
-            can_user_shared_cache = (
+            can_use_shared_cache = (
                 "id" in args and
                 "is_creator" not in args and
                 "wallet" not in args and
@@ -26,7 +26,7 @@ def get_users(args):
                 "handle" not in args
             )
 
-            if can_user_shared_cache:
+            if can_use_shared_cache:
                 users = get_unpopulated_users(session, args.get("id"))
                 ids = list(map(lambda user: user["user_id"], users))
                 return (users, ids)

--- a/discovery-provider/src/queries/get_users.py
+++ b/discovery-provider/src/queries/get_users.py
@@ -6,7 +6,6 @@ from src.models import User
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import populate_user_metadata, paginate_query
-from src.utils.redis_cache import extract_key, use_redis_cache
 from src.queries.get_unpopulated_users import get_unpopulated_users
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Description

Add shared cache to get_users route, which we call repeatedly in feed.

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Locally against snapshot. 
