### PR TITLE
Remove cache on index update

### DIFF
--- a/discovery-provider/src/queries/get_unpopulated_playlists.py
+++ b/discovery-provider/src/queries/get_unpopulated_playlists.py
@@ -5,13 +5,10 @@ from flask.json import dumps
 from src.utils import redis_connection
 from src.models import Playlist
 from src.utils import helpers
+from src.utils.redis_cache import get_playlist_id_cache_key
 
-ttl_sec = 60
-
-
-def get_playlist_id_cache_key(id):
-    return "playlist:id:{}".format(id)
-
+# Cache unpopulated playlists for 5 min
+ttl_sec = 5*60
 
 def get_cached_playlists(playlist_ids):
     redis_playlist_id_keys = map(get_playlist_id_cache_key, playlist_ids)

--- a/discovery-provider/src/queries/get_unpopulated_tracks.py
+++ b/discovery-provider/src/queries/get_unpopulated_tracks.py
@@ -6,14 +6,12 @@ from flask.json import dumps
 from src.utils import redis_connection
 from src.models import Track
 from src.utils import helpers
+from src.utils.redis_cache import get_track_id_cache_key
 
 logger = logging.getLogger(__name__)
 
-ttl_sec = 60
-
-def get_track_id_cache_key(id):
-    return "track:id:{}".format(id)
-
+# Cache unpopulated tracks for 5 min
+ttl_sec = 5*60
 
 def get_cached_tracks(track_ids):
     redis_track_id_keys = map(get_track_id_cache_key, track_ids)

--- a/discovery-provider/src/queries/get_unpopulated_users.py
+++ b/discovery-provider/src/queries/get_unpopulated_users.py
@@ -5,13 +5,11 @@ from flask.json import dumps
 from src.utils import redis_connection
 from src.models import User
 from src.utils import helpers
+from src.utils.redis_cache import get_user_id_cache_key
 
-ttl_sec = 60
 
-
-def get_user_id_cache_key(id):
-    return "user:id:{}".format(id)
-
+# Cache unpopulated users for 5 min
+ttl_sec = 5*60
 
 def get_cached_users(user_ids):
     redis_user_id_keys = map(get_user_id_cache_key, user_ids)

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -15,8 +15,9 @@ def user_state_update(self, update_task, session, user_factory_txs, block_number
     """Return int representing number of User model state changes found in transaction."""
 
     num_total_changes = 0
+    user_ids = set()
     if not user_factory_txs:
-        return num_total_changes
+        return num_total_changes, user_ids
 
     user_abi = update_task.abi_values["UserFactory"]["abi"]
     user_contract = update_task.web3.eth.contract(
@@ -38,6 +39,7 @@ def user_state_update(self, update_task, session, user_factory_txs, block_number
             processedEntries = 0 # if record does not get added, do not count towards num_total_changes
             for entry in user_events_tx:
                 user_id = entry["args"]._userId
+                user_ids.add(user_id)
 
                 # if the user id is not in the lookup object, it hasn't been initialized yet
                 # first, get the user object from the db(if exists or create a new one)
@@ -78,7 +80,7 @@ def user_state_update(self, update_task, session, user_factory_txs, block_number
             invalidate_old_user(session, user_id)
             session.add(value_obj["user"])
 
-    return num_total_changes
+    return num_total_changes, user_ids
 
 
 def lookup_user_record(update_task, session, entry, block_number, block_timestamp):

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -98,3 +98,41 @@ def cache(**kwargs):
             return transform(response)
         return inner_wrap
     return outer_wrap
+
+
+def get_user_id_cache_key(id):
+    return "user:id:{}".format(id)
+
+
+def get_track_id_cache_key(id):
+    return "track:id:{}".format(id)
+
+
+def get_playlist_id_cache_key(id):
+    return "playlist:id:{}".format(id)
+
+
+def remove_cached_user_ids(redis, user_ids):
+    try:
+        user_keys = list(map(get_user_id_cache_key, user_ids))
+        redis.delete(*user_keys)
+    except Exception as e:
+        logger.error(
+            "Unable to remove cached users: %s", e, exc_info=True)
+
+
+def remove_cached_track_ids(redis, track_ids):
+    try:
+        track_keys = list(map(get_track_id_cache_key, track_ids))
+        redis.delete(*track_keys)
+    except Exception as e:
+        logger.error(
+            "Unable to remove cached tracks: %s", e, exc_info=True)
+
+def remove_cached_playlist_ids(redis, playlist_ids):
+    try:
+        playlist_keys = list(map(get_playlist_id_cache_key, playlist_ids))
+        redis.delete(*playlist_keys)
+    except Exception as e:
+        logger.error(
+            "Unable to remove cached playlists: %s", e, exc_info=True)


### PR DESCRIPTION
### Trello Card Link
na

### Description
Clear the cached users/tracks/playlists while indexing if updated

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches the indexing flow


### How Has This Been Tested?
I ran the system locally and checked that when a user/track/playlist was updated that the associated key in redis was removed.
