### PR TITLE
Switch to pickle for discprov caching

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -13,7 +13,6 @@ from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
 from .models.tracks import track, track_full, stem_full, remixes_response
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_trending_tracks import get_trending_tracks
-from flask.json import dumps
 from src.utils.redis_cache import cache, extract_key, use_redis_cache
 from flask.globals import request
 from src.utils.redis_metrics import record_metrics

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -1,7 +1,6 @@
 import logging  # pylint: disable=C0302
 import functools
-import json
-from flask.json import dumps
+import pickle
 from flask.globals import request
 from src.utils import redis_connection
 from src.utils.query_params import stringify_query_params
@@ -27,11 +26,11 @@ def use_redis_cache(key, ttl_sec, work_func):
 
     if cached_value:
         logger.info(f"Redis Cache - hit {key}")
-        return json.loads(cached_value)
+        return pickle.loads(cached_value)
 
     logger.info(f"Redis Cache - miss {key}")
     to_cache = work_func()
-    serialized = dumps(to_cache)
+    serialized = pickle.dumps(to_cache)
     redis.set(key, serialized, ttl_sec)
     return to_cache
 
@@ -79,7 +78,7 @@ def cache(**kwargs):
 
                 if cached_resp:
                     logger.info(f"Redis Cache - hit {key}")
-                    deserialized = json.loads(cached_resp)
+                    deserialized = pickle.loads(cached_resp)
                     if transform is not None:
                         return transform(deserialized)
                     return deserialized, 200
@@ -90,10 +89,10 @@ def cache(**kwargs):
             if len(response) == 2:
                 resp, status_code = response
                 if status_code < 400:
-                    serialized = dumps(resp)
+                    serialized = pickle.dumps(resp)
                     redis.set(key, serialized, ttl_sec)
                 return resp, status_code
-            serialized = dumps(response)
+            serialized = pickle.dumps(response)
             redis.set(key, serialized, ttl_sec)
             return transform(response)
         return inner_wrap

--- a/discovery-provider/src/utils/redis_cache_test.py
+++ b/discovery-provider/src/utils/redis_cache_test.py
@@ -1,4 +1,4 @@
-import json
+import pickle
 from time import sleep
 from unittest.mock import patch
 import flask
@@ -27,7 +27,7 @@ def test_cache(redis_mock):
             assert res[1] == 200
 
             cached_resp = redis_mock.get(mock_key_1)
-            deserialized = json.loads(cached_resp)
+            deserialized = pickle.loads(cached_resp)
             assert deserialized == {'name': 'joe'}
 
             # This should call the function and return the cached response
@@ -53,7 +53,7 @@ def test_cache(redis_mock):
             assert res == {'music': 'audius'}
 
             cached_resp = redis_mock.get(mock_key_1)
-            deserialized = json.loads(cached_resp)
+            deserialized = pickle.loads(cached_resp)
             assert deserialized == 'audius'
 
             # This should call the function and return the cached response


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/qsYe7BPE/1611-switch-to-pickle

### Description
Switches various discprov caching opts to pickle.

To test this, I made each serialization op & deserialization op happen 10,000 times per request:

json
dumps 12.662461519241333
loads 5.929422855377197

pickle
dumps 2.408290386199951
loads 2.4702045917510986


### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually ran discprov against prod data & issued queries against
2. Updated unit test