### PR TITLE
Remove unnecessary ETH relayer keys

### DIFF
--- a/identity-service/compose/.env
+++ b/identity-service/compose/.env
@@ -42,9 +42,6 @@ notificationDiscoveryProvider=http://audius-disc-prov_web-server_1:5000
 # required params on staging and production, optional on development
 # registryAddress=
 
-# Local development address private key (not sensitive)
-ethRelayerPrivateKey=d0fa087db40d040b2a0f72138a805cf6e64e4f2867e247793fe8cbe06101e4cd
-ethRelayerPublicKey=0x95f1CF13097d49Ce855B99DCc085730a62D2b5d6
 # Local development address keys (not sensitive)
 ethRelayerWallets=[{"publicKey": "0xaaaa90Fc2bfa70028D6b444BB9754066d9E2703b", "privateKey": "34efbbc0431c7f481cdba15d65bbc9ef47196b9cf38d5c4b30afa2bcf86fafba"}, {"publicKey": "0xBE718F98a5B5a473186eB6E30888F26E72be0b66", "privateKey": "d3426cd10c4e75207bdc4802c551d21faa89a287546c2c6b3d9a0476f34934d2"}, {"publicKey": "0xE75dEe171b6472cE30358ede946CcDFfCA70b562", "privateKey": "8a7c63d4aea87647f480e4771ea279f90f8e912fcfe907525bc931f531e564ce"}, {"publicKey": "0x58908c329D3be43261a3768aA2BBF413b36C935C", "privateKey": "712f210f132d2983e1e2d233f38b80aa12b9d5638ef4eeb78792c61622baf3d5"}, {"publicKey": "0xA0614b332312C5d81BE5b1877169E09041e5769F", "privateKey": "fc0ebb16ccb2fc42afb80336a358f17732cb9a47a96d0af1f474798726f92141"}]
 

--- a/identity-service/scripts/run-tests.sh
+++ b/identity-service/scripts/run-tests.sh
@@ -9,8 +9,6 @@ fi
 echo $PG_PORT
 
 export ethTokenAddress=''
-export ethRelayerPrivateKey=''
-export ethRelayerPublicKey=''
 export ethRegistryAddress=''
 export registryAddress=''
 export ethOwnerWallet=''

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -100,19 +100,6 @@ const config = convict({
     env: 'relayerWallets',
     default: null
   },
-  ethRelayerPrivateKey: {
-    doc: 'L1 Relayer(used to make relay transactions) private key. The source of the funds when funding wallet.',
-    format: String,
-    env: 'ethRelayerPrivateKey',
-    default: null,
-    sensitive: true
-  },
-  ethRelayerPublicKey: {
-    doc: 'L1 Relayer(used to make relay transactions) public key. The source of the funds when funding wallet.',
-    format: String,
-    env: 'ethRelayerPublicKey',
-    default: null
-  },
   ethRelayerWallets: {
     doc: 'L1 Relayer wallet objects to send transactions. Stringified array like[{ publicKey, privateKey}, ...]',
     format: 'string-array',

--- a/identity-service/src/relay/ethTxRelay.js
+++ b/identity-service/src/relay/ethTxRelay.js
@@ -179,9 +179,8 @@ const fundEthRelayerIfEmpty = async () => {
   const minimumBalance = ethWeb3.utils.toWei(config.get('minimumBalance').toString(), 'ether')
   for (let ethWallet of ethRelayerWallets) {
     let ethWalletPublicKey = ethWallet.publicKey
-    logger.info(`L1 Querying balance for ethRelayerPublicKey: ${ethWalletPublicKey}`)
     let balance = await ethWeb3.eth.getBalance(ethWalletPublicKey)
-    logger.info(`L1 balance for ethRelayerPublicKey: ${balance}, minimumBalance: ${minimumBalance}`)
+    logger.info(`L1 txRelay - balance for ethWalletPublicKey ${ethWalletPublicKey}: ${balance}, minimumBalance: ${minimumBalance}`)
     let validBalance = parseInt(balance) >= minimumBalance
     if (ENVIRONMENT === 'development') {
       if (!validBalance) {


### PR DESCRIPTION
### Trello Card Link
None

### Description
Remove env vars that are never used

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [X] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Unit tests + Lint + Mad dog
