### PR TITLE
ETH Relay refactors & fixes

### DIFF
--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -37,6 +37,7 @@
   "ethRegistryAddress":"",
   "ethOwnerWallet":"",
   "mailgunApiKey": "",
+  "defiPulseApiKey": "",
   "registryAddress": "",
   "awsAccessKeyId": "",
   "awsSecretAccessKey": "",

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -430,6 +430,12 @@ const config = convict({
     format: 'nat',
     env: 'headersTimeout',
     default: 60 * 1000 // 60s - node.js default value
+  },
+  defiPulseApiKey: {
+    doc: 'API Key used to query eth gas station info',
+    format: String,
+    env: 'defiPulseApiKey',
+    default: ''
   }
 })
 

--- a/identity-service/src/relay/ethTxRelay.js
+++ b/identity-service/src/relay/ethTxRelay.js
@@ -130,7 +130,7 @@ const sendSignedTransactionReturnOnTxHash = async (web3, signedTx, logger, onTxH
           // Resolve this promise with a tx hash has been returned
           onTxHash(hash)
         })
-        .on('error', function (error) { throw error })
+        .on('error', function (error) { reject(error) })
         .then(async function (receipt) {
           logger.info(`L1 txRelay - ${receipt}`)
           resolve(receipt)

--- a/identity-service/src/routes/ethRelay.js
+++ b/identity-service/src/routes/ethRelay.js
@@ -16,16 +16,15 @@ module.exports = function (app) {
           senderAddress: body.senderAddress,
           gasLimit: body.gasLimit || null
         }
-        await ethTxRelay.sendEthTransaction(req, txProps, reqBodySHA, function (txHash) {
-          sendResponse(req, res, successResponse({ txHash }))
-        })
+        const resp = await ethTxRelay.sendEthTransaction(req, txProps, reqBodySHA)
+        return sendResponse(req, res, successResponse({ resp }))
       } catch (e) {
         req.logger.error('Error in transaction:', e.message, reqBodySHA)
 
-        sendResponse(req, res, errorResponseServerError(`Something caused the transaction to fail for payload ${reqBodySHA}`))
+        return sendResponse(req, res, errorResponseServerError(`Something caused the transaction to fail for payload ${reqBodySHA}`))
       }
     } else {
-      sendResponse(
+      return sendResponse(
         req,
         res,
         errorResponseServerError('Missing one of the required fields: contractRegistryKey, contractAddress, senderAddress, encodedABI')

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -2,7 +2,7 @@ const config = require('../config.js')
 const models = require('../models')
 const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const { sequelize } = require('../models')
-const { getRelayerFunds } = require('../relay/txRelay')
+const { getRelayerFunds, fundRelayerIfEmpty } = require('../relay/txRelay')
 const { getEthRelayerFunds } = require('../relay/ethTxRelay')
 const Web3 = require('web3')
 
@@ -178,6 +178,9 @@ module.exports = function (app) {
     let minimumBalance = parseFloat(config.get('minimumBalance'))
     let belowMinimumBalances = []
     let balances = []
+
+    // run fundRelayerIfEmpty so it'll auto top off any accounts below the threshold
+    await fundRelayerIfEmpty()
 
     for (let account of RELAY_HEALTH_ACCOUNTS) {
       let balance = parseFloat(Web3.utils.fromWei(await getRelayerFunds(account), 'ether'))


### PR DESCRIPTION
### Trello Card Link


### Description
Lots of stuff in this PR
1. Rip out early txHash return, instead await the entire receipt for eth_relay
2. Integrate defi pulse API key to get latest gas station network eth gas prices
3. Eagerly fund the POA relayer wallets during /balance_check

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [X] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches relays


### How Has This Been Tested?
On staging