### PR TITLE
Run db query inside health check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -24,6 +24,9 @@ const healthCheck = async ({ libs } = {}, logger, sequelize) => {
     logger.warn('Health check with no libs')
   }
 
+  // we have a /db_check route for more granular detail, but the service health check should
+  // also check that the db connection is good. having this in the health_check
+  // allows us to get auto restarts from liveness probes etc if the db connection is down
   await sequelize.query('SELECT 1')
 
   return response

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -8,7 +8,7 @@ const config = require('../../config')
  * @param {*} ServiceRegistry
  * @param {*} logger
  */
-const healthCheck = ({ libs } = {}, logger) => {
+const healthCheck = async ({ libs } = {}, logger, sequelize) => {
   let response = {
     ...versionInfo,
     'healthy': true,
@@ -23,6 +23,8 @@ const healthCheck = ({ libs } = {}, logger) => {
   } else {
     logger.warn('Health check with no libs')
   }
+
+  await sequelize.query('SELECT 1')
 
   return response
 }

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -11,6 +11,10 @@ const libsMock = {
   }
 }
 
+const sequelizeMock = {
+  'query': async () => Promise.resolve()
+}
+
 const mockLogger = {
   warn: () => {}
 }
@@ -21,7 +25,7 @@ describe('Test Health Check', function () {
     config.set('spID', 10)
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
-    const res = healthCheck({ libs: libsMock }, mockLogger)
+    const res = healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'creator-node',
@@ -34,7 +38,7 @@ describe('Test Health Check', function () {
   })
 
   it('Should handle no libs', function () {
-    const res = healthCheck({}, mockLogger)
+    const res = healthCheck({}, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'creator-node',

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -20,12 +20,12 @@ const mockLogger = {
 }
 
 describe('Test Health Check', function () {
-  it('Should pass', function () {
+  it('Should pass', async function () {
     config.set('creatorNodeEndpoint', 'http://test.endpoint')
     config.set('spID', 10)
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
-    const res = healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'creator-node',
@@ -37,8 +37,8 @@ describe('Test Health Check', function () {
     })
   })
 
-  it('Should handle no libs', function () {
-    const res = healthCheck({}, mockLogger, sequelizeMock)
+  it('Should handle no libs', async function () {
+    const res = await healthCheck({}, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'creator-node',

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -2,6 +2,7 @@ const express = require('express')
 const { handleResponse, successResponse } = require('../../apiHelpers')
 const { healthCheck } = require('./healthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
+const { sequelize } = require('../../models')
 
 const router = express.Router()
 
@@ -13,7 +14,7 @@ const router = express.Router()
  */
 const healthCheckController = async (req) => {
   const logger = req.logger
-  const response = healthCheck(serviceRegistry, logger)
+  const response = await healthCheck(serviceRegistry, logger, sequelize)
   return successResponse(response)
 }
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/D65EOYvT/1618-misc-cleanup-and-fixes

### Description
We have a dedicated /db_check endpoint, but we should have a db query inside the health check as well. If we do, we get kube liveness probes automatically in case the db connection goes down or something

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Modified the unit tests to work with these changes