### PR TITLE
Add eventlet support and gunicorn config vals

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -23,3 +23,4 @@ fakeredis==1.4.2
 jsonformatter==0.3.0
 py-cid==0.3.0
 pytest-postgresql==2.4.1
+eventlet==0.28.0

--- a/discovery-provider/scripts/prod-server.sh
+++ b/discovery-provider/scripts/prod-server.sh
@@ -6,5 +6,28 @@
 #   "-b :5000" accept requests on port 5000
 #   "--access-logfile - --error-logfile" - log to stdout/stderr
 #   "src.wsgi:app" - app entry point in format: $(MODULE_NAME):$(VARIABLE_NAME)
-exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --workers 2 --threads 8
 
+# Use specified number of workers if present
+if [[ -z "${audius_gunicorn_workers}" ]]
+then
+  WORKERS=2
+else
+  WORKERS="${audius_gunicorn_workers}"
+fi
+
+# Use specified number of threads if present (only used for "sync" workers)
+if [[ -z "${audius_gunicorn_threads}" ]]
+then
+  THREADS=8
+else
+  THREADS="${audius_gunicorn_threads}"
+fi
+
+# If a worker class is specified, use that. Otherwise, use sync workers.
+if [[ -z "${audius_gunicorn_worker_class}" ]]
+then
+  exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --workers=$WORKERS --threads=$THREADS
+else
+  WORKER_CLASS="${audius_gunicorn_worker_class}"
+  exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --worker-class=$WORKER_CLASS --workers=$WORKERS
+fi


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/FJa1ydwW/1619-template-gunicorn-config

### Description
Templates the gunicorn config for discovery provider with env vars.
Corresponding k8s change: https://github.com/AudiusProject/audius-k8s/pull/135

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Update local compose script to run prod-server instead of dev-server and ensured updating .env would change running gunicorn config
2. Pushed branch up as a hotfix & tested the same way on staging (deploying using both audius-k8s at `master` and audius-k8s at the branch)

With new audius-k8s
```
[2020-10-19 19:19:41 +0000] [1] [DEBUG] Current configuration:
  config: None
  bind: [':5000']
  backlog: 2048
  workers: 16
  worker_class: eventlet
  threads: 1
  worker_connections: 1000
```

with old audius-k8s
```
[2020-10-19 19:20:35 +0000] [1] [DEBUG] Current configuration:
  config: None
  bind: [':5000']
  backlog: 2048
  workers: 2
  worker_class: sync
  threads: 8
  worker_connections: 1000
  max_requests: 0
  max_requests_jitter: 0
```

