### PR TITLE
[Wait till next week] Fix no user track saves from erroring

### DIFF
--- a/discovery-provider/src/queries/get_save_tracks.py
+++ b/discovery-provider/src/queries/get_save_tracks.py
@@ -36,6 +36,10 @@ def get_save_tracks(args):
             Save.created_at.desc(), Track.track_id.desc())
 
         query_results = add_query_pagination(base_query, limit, offset).all()
+
+        if not query_results:
+            return []
+
         tracks, save_dates = zip(*query_results)
         tracks = helpers.query_result_to_list(tracks)
         track_ids = list(map(lambda track: track["track_id"], tracks))


### PR DESCRIPTION
### Trello Card Link
na

### Description
If there are no user track saves, the DP route `/v1/full/users/<ENCODED_USER_ID>/favorites/tracks` returns 500
This is b/c of an error in unpacking values where there are no entries returned from the db. 

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran DP locally against a prod DB snapshot and hit the endpoint with a user w/ track favorites and without to make sure both returned as expected. 
