### PR TITLE
Set cache header in creator node CID route

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -166,8 +166,6 @@ const getCID = async (req, res) => {
       if (req.params.streamable && range) {
         const { start, end } = range
         if (end >= stat.size) {
-          // Unset the cache-control header so that a bad response is not cached
-          res.removeHeader('cache-control')
           // Set "Requested Range Not Satisfiable" header and exit
           res.status(416)
           return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
@@ -257,8 +255,6 @@ const getDirCID = async (req, res) => {
       await findCIDInNetwork(queryResults.storagePath, CID, req.logger, libs)
       return await streamFromFileSystem(req, res, queryResults.storagePath)
     } catch (e) {
-      // Unset the cache-control header so that a bad response is not cached
-      res.removeHeader('cache-control')
       req.logger.error(`Error calling findCIDInNetwork for path ${queryResults.storagePath}`, e)
     }
   }
@@ -277,6 +273,8 @@ const getDirCID = async (req, res) => {
         .on('error', e => { reject(e) })
     })
   } catch (e) {
+    // Unset the cache-control header so that a bad response is not cached
+    res.removeHeader('cache-control')
     return sendResponse(req, res, errorResponseServerError(e.message))
   }
 }

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -145,8 +145,6 @@ const getCID = async (req, res) => {
       await findCIDInNetwork(queryResults.storagePath, CID, req.logger, libs)
       return await streamFromFileSystem(req, res, queryResults.storagePath)
     } catch (e) {
-      // Unset the cache-control header so that a bad response is not cached
-      res.removeHeader('cache-control')
       req.logger.error(`Error calling findCIDInNetwork for path ${queryResults.storagePath}`, e)
     }
   }
@@ -168,6 +166,8 @@ const getCID = async (req, res) => {
       if (req.params.streamable && range) {
         const { start, end } = range
         if (end >= stat.size) {
+          // Unset the cache-control header so that a bad response is not cached
+          res.removeHeader('cache-control')
           // Set "Requested Range Not Satisfiable" header and exit
           res.status(416)
           return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
@@ -192,6 +192,9 @@ const getCID = async (req, res) => {
         .on('error', e => { reject(e) })
     })
   } catch (e) {
+    // Unset the cache-control header so that a bad response is not cached
+    res.removeHeader('cache-control')
+
     // If the file cannot be retrieved through IPFS, return 500 without attempting to stream file.
     return sendResponse(req, res, errorResponseServerError(e.message))
   }


### PR DESCRIPTION
### Trello Card Link
na

### Description
For the creator node `/ipfs/<CID>` and `/ipfs/<CID>/<File>` routes, a `cache-control` header was added. 
This is to improve client performance, also the ipfs.io and cloudflare public gateways have a header of `cache-control: public, max-age=29030400, immutable` (Cache of almost a yr)
The one added to CN is only for 30 days.

Note: The getCID function is also used in the `/tracks/stream/:encodedId` route which I presume is fine for now b/c we do not allow a track to change its cid. 

Note: I did not add it to the fallback of `catReadableStream` b/c in the case that it fails, I'm unsure about the cache headers. 

### Services
Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran the system locally and checked the the header was present on both the /ipfs/cid and /ipfs/cid/file routes and that on subsequent requests, the browser pulled it from disk cache. 
