### PR TITLE
Ensure discprovs will peer with new creator nodes as soon as they are registered to unblock indexing

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,6 +1,6 @@
+from urllib.parse import urljoin
 import logging
 import requests
-from urllib.parse import urljoin
 
 from src import contract_addresses
 from src.models import Block, User, Track, Repost, Follow, Playlist, Save
@@ -431,20 +431,20 @@ def revert_blocks(self, db, revert_blocks_list):
 
 # calls GET identityservice/registered_creator_nodes to retrieve creator nodes currently registered on chain
 def fetch_cnode_endpoints_from_chain(task_context):
-  try:
-    identity_url = task_context.shared_config['discprov']['identity_service_url']
-    identity_endpoint = urljoin(identity_url, 'registered_creator_nodes')
+    try:
+        identity_url = task_context.shared_config['discprov']['identity_service_url']
+        identity_endpoint = urljoin(identity_url, 'registered_creator_nodes')
 
-    r = requests.get(identity_endpoint, timeout=3)
-    if r.status_code != 200:
-      raise Exception(f"Query to identity_endpoint failed with status code {r.status_code}")
+        r = requests.get(identity_endpoint, timeout=3)
+        if r.status_code != 200:
+            raise Exception(f"Query to identity_endpoint failed with status code {r.status_code}")
 
-    registered_cnodes = r.json()
-    logger.info(f"Fetched registered creator nodes from chain via {identity_endpoint}")
-    return registered_cnodes
-  except Exception as e:
-    logger.error(f"Identity fetch failed {e}")
-    return []
+        registered_cnodes = r.json()
+        logger.info(f"Fetched registered creator nodes from chain via {identity_endpoint}")
+        return registered_cnodes
+    except Exception as e:
+        logger.error(f"Identity fetch failed {e}")
+        return []
 
 ######## IPFS PEER REFRESH ########
 def refresh_peer_connections(task_context):
@@ -473,13 +473,13 @@ def refresh_peer_connections(task_context):
         # Add user metadata URL to peer connection list
         user_node_url = task_context.shared_config["discprov"]["user_metadata_service_url"]
         cnode_endpoints[user_node_url] = True
-        
+
         # update cnode_endpoints with list of creator nodes registered on chain, on 30s refresh interval
         registered_cnodes = use_redis_cache(
-          'registered_cnodes_from_identity', 30, lambda: fetch_cnode_endpoints_from_chain(task_context)
+            'registered_cnodes_from_identity', 30, lambda: fetch_cnode_endpoints_from_chain(task_context)
         )
         for node_info in registered_cnodes:
-          cnode_endpoints[node_info['endpoint']] = True
+            cnode_endpoints[node_info['endpoint']] = True
 
         # Update creator node list
         ipfs_client.update_cnode_urls(list(cnode_endpoints.keys()))

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -459,6 +459,7 @@ def refresh_peer_connections(task_context):
         cnode_endpoints[user_node_url] = True
 
         # fetch all creator nodes registered on chain
+        # TODO cache locally and refresh intermittently
         try:
           identity_url = task_context.shared_config['discprov']['identity_service_url']
           identity_endpoint = urljoin(identity_url, 'registered_creator_nodes')

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -20,7 +20,7 @@ def extract_key(path, arg_items):
     return key
 
 def use_redis_cache(key, ttl_sec, work_func):
-    """Attemps to return value by key, otherwise cahces and returns `work_func`"""
+    """Attemps to return value by key, otherwise caches and returns `work_func`"""
     redis = redis_connection.get_redis()
     cached_value = redis.get(key)
 

--- a/identity-service/src/routes/ethRelay.js
+++ b/identity-service/src/routes/ethRelay.js
@@ -45,4 +45,13 @@ module.exports = function (app) {
     let gasInfo = await ethTxRelay.getProdGasInfo(req.app.get('redis'), req.logger)
     return successResponse(gasInfo)
   }))
+
+  /**
+   * Queries and returns all registered content nodes from chain
+   */
+  app.get('/registered_creator_nodes', handleResponse(async (req, res, next) => {
+    const audiusLibsInstance = req.app.get('audiusLibs')
+    const creatorNodes = await audiusLibsInstance.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('creator-node')
+    return successResponse(creatorNodes)
+  }))
 }


### PR DESCRIPTION
### Trello Card Link


### Description
Anytime a new creator node is registered and content is uploaded for the first time, discprovs have not peered to the new CN and will fail to fetch the new user metadata from it. This is a temporary fix for this problem: identity already has an eth-contracts connection, so we added a new route to fetch the list of registered cnodes from chain. discprov indexing task now updates its cnode_endpoints list from this route and peers with the new cnodes' ipfs node.

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [x] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Deployed discprov and identity to staging with this code, confirmed it works. Registered new CN (http://54.67.117.176:31818/) on stage to ensure new IP. signed up, selected new CN as primary, and uploaded content. confirmed indexing flow queries identity and fetches new endpoints from identity
```
{"levelno": 20, "level": "INFO", "msg": "Redis Cache - miss registered_cnodes_from_identity", "timestamp": "2020-10-22 02:30:39,520"}
{"levelno": 20, "level": "INFO", "msg": "Fetched registered creator nodes from chain via https://identityservice.staging.audius.co/registered_creator_nodes", "timestamp": "2020-10-22 02:30:40,295"}
```
Upload went through successfully on CN

Please list the unit test(s) you added to verify your changes.

1. -
