### PR TITLE
Change flush to commit for other db sessions to query

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -230,7 +230,7 @@ def index_blocks(self, db, blocks_list):
             # social state changes are not factored in since they don't affect track_lexeme_dict
             # write out all pending transactions to db before refreshing view
             track_lexeme_state_changed = (user_state_changed or track_state_changed)
-            session.flush()
+            session.commit()
             if user_state_changed:
                 session.execute("REFRESH MATERIALIZED VIEW user_lexeme_dict")
                 if user_ids:


### PR DESCRIPTION
### Trello Card Link
na

### Description
Fix the case where on indexing the changes to the user table are `flushed` but not commited, so that when we clear the redis cached users/tracks/playlists if they are re-requested before the commit, then the cache is in a bad state for 5 minutes. 

Sequence of events that can lead to this bug manifesting
```
1 - user A issues update to their profile
2 - indexing runs and we call session.flush with the changes
3 - we call remove_cached_user_ids(user A)
4 - we wait in matview refresh for a few sec
   4a. - new request comes in requesting user A, which returns stale db data as we have only called flush
   4b. - we cache in redis the response from 4a
5 - session.commit happens after matview refreshes
6 - user A requests their user again, but gets the cached response from 4b, rather than the new data they just wrote in 5
```

### Services
Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches INDEXING FLOW


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

I ran this locally and added a time.wait to in the indexing flow before releasing the session. Before the session released, if you queried for the user, it would miss the DB, but still return the old user. 
After I changed it to commit, I repeated the process and the cached was updated with the new user. 
