### PR TITLE
Bump auth rate limit and lint

### DIFF
--- a/identity-service/src/routes/authentication.js
+++ b/identity-service/src/routes/authentication.js
@@ -14,7 +14,7 @@ const authRateLimiter = rateLimit({
     prefix: 'authRateLimiter:',
     expiry: 60 * 60 * 24 // one day in seconds
   }),
-  max: 20, // max requests per day
+  max: 40, // max requests per day
   keyGenerator: authKeyGenerator
 })
 

--- a/libs/src/services/ethContracts/claimDistributionClient.js
+++ b/libs/src/services/ethContracts/claimDistributionClient.js
@@ -1,5 +1,4 @@
 const ContractClient = require('../contracts/ContractClient')
-const DEFAULT_GAS_AMOUNT = 1000000
 
 class ClaimDistributionClient extends ContractClient {
   // ===================== Contract Methods =====================


### PR DESCRIPTION
### Trello Card Link


### Description
Bump auth rate limit to 40 per day and also fix a lint issue