### PR TITLE
Bump sync lock TTL from 90 sec to 8 hours

### DIFF
--- a/creator-node/src/redis.js
+++ b/creator-node/src/redis.js
@@ -3,7 +3,7 @@ const Redis = require('ioredis')
 
 const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
 
-const EXPIRATION = 90 // seconds
+const EXPIRATION = 60 * 60 * 8 // 8 hours in seconds
 class RedisLock {
   static async setLock (key, expiration = EXPIRATION) {
     console.log(`SETTING LOCK ${key}`)


### PR DESCRIPTION
### Trello Card Link
None

### Description
Our sync lock lasts for 90 seconds. Bump it up to 8 hours
