### PR TITLE
Celery task for refresh materialized view

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -286,7 +286,8 @@ def configure_celery(flask_app, celery, test_config=None):
     # Update celery configuration
     celery.conf.update(
         imports=["src.tasks.index", "src.tasks.index_blacklist",
-                 "src.tasks.index_cache", "src.tasks.index_plays", "src.tasks.index_metrics"],
+                 "src.tasks.index_cache", "src.tasks.index_plays",
+                 "src.tasks.index_metrics", "src.tasks.index_materialized_views"],
         beat_schedule={
             "update_discovery_provider": {
                 "task": "update_discovery_provider",
@@ -307,6 +308,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "update_metrics": {
                 "task": "update_metrics",
                 "schedule": crontab(minute=0, hour="*")
+            },
+            "update_materialized_views": {
+                "task": "update_materialized_views",
+                "schedule": timedelta(seconds=60)
             }
         },
         task_serializer="json",

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -1,0 +1,40 @@
+import logging
+import json
+from src.tasks.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+def update_views(self, db):
+    with db.scoped_session() as session:
+        logger.info('Updating materialized views')
+        session.execute("REFRESH MATERIALIZED VIEW user_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW playlist_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW album_lexeme_dict")
+        logger.info('Finished updating materialized views')
+
+######## CELERY TASKS ########
+@celery.task(name="update_materialized_views", bind=True)
+def update_materialized_views(self):
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/__init__.py
+    db = update_materialized_views.db
+    redis = update_materialized_views.redis
+    # Define lock acquired boolean
+    have_lock = False
+    # Define redis lock object
+    update_lock = redis.lock("update_materialized_views", timeout=7200)
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            update_views(self, db)
+        else:
+            logger.info("index_materialized_views.py | Failed to acquire update_materialized_views")
+    except Exception as e:
+        logger.error("index_materialized_views.py | Fatal error in main loop", exc_info=True)
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -6,12 +6,12 @@ logger = logging.getLogger(__name__)
 
 def update_views(self, db):
     with db.scoped_session() as session:
-        logger.info('Updating materialized views')
+        logger.info('index_materialized_views.py | Updating materialized views')
         session.execute("REFRESH MATERIALIZED VIEW user_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW album_lexeme_dict")
-        logger.info('Finished updating materialized views')
+        logger.info('index_materialized_views.py | Finished updating materialized views')
 
 ######## CELERY TASKS ########
 @celery.task(name="update_materialized_views", bind=True)


### PR DESCRIPTION
### Description
Enable a dedicated task for refreshing materialized views. Significant delays observed at this step during heavy load recently, but view operations are unrelated to indexing and should be safe to separate.

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches indexing

### How Has This Been Tested?
Local validation thus far, best to take to staging prior to prod promotion
