### PR TITLE
Bump sync lock TTL from 90 sec to 8 hours

### DIFF
--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -8,7 +8,7 @@ const PROCESS_NAMES = Object.freeze({
   rehydrate_file: 'rehydrate_file'
 })
 
-const MAX_COUNT = 50000
+const MAX_COUNT = 10000
 
 class RehydrateIpfsQueue {
   constructor () {

--- a/creator-node/src/redis.js
+++ b/creator-node/src/redis.js
@@ -3,7 +3,7 @@ const Redis = require('ioredis')
 
 const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
 
-const EXPIRATION = 60 * 60 * 8 // 8 hours in seconds
+const EXPIRATION = 60 * 60 * 2 // 2 hours in seconds
 class RedisLock {
   static async setLock (key, expiration = EXPIRATION) {
     console.log(`SETTING LOCK ${key}`)

--- a/creator-node/src/redis.js
+++ b/creator-node/src/redis.js
@@ -3,7 +3,7 @@ const Redis = require('ioredis')
 
 const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
 
-const EXPIRATION = 90 // seconds
+const EXPIRATION = 60 * 60 * 8 // 8 hours in seconds
 class RedisLock {
   static async setLock (key, expiration = EXPIRATION) {
     console.log(`SETTING LOCK ${key}`)


### PR DESCRIPTION
### Trello Card Link
None

### Description
Our sync lock lasts for 90 seconds. Bump it up to 8 hours
