### PR TITLE
Continue in nodesync is holding tx open

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -326,6 +326,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
           } else if (latestClockValue === fetchedLatestClockVal) {
             // Already to update, no sync necessary
             req.logger.info(`User ${fetchedWalletPublicKey} already up to date! fetchedLatestClockVal=${fetchedLatestClockVal}, latestClockValue=${latestClockValue}`)
+            tx.rollback()
             continue
           }
 

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -326,7 +326,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
           } else if (latestClockValue === fetchedLatestClockVal) {
             // Already to update, no sync necessary
             req.logger.info(`User ${fetchedWalletPublicKey} already up to date! fetchedLatestClockVal=${fetchedLatestClockVal}, latestClockValue=${latestClockValue}`)
-            tx.rollback()
+            transaction.rollback()
             continue
           }
 

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -326,6 +326,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
           } else if (latestClockValue === fetchedLatestClockVal) {
             // Already to update, no sync necessary
             req.logger.info(`User ${fetchedWalletPublicKey} already up to date! fetchedLatestClockVal=${fetchedLatestClockVal}, latestClockValue=${latestClockValue}`)
+            // the transaction declared outside the try/catch needs to be closed. if we call the continue
+            // and do not end the tx, it will never be closed
             transaction.rollback()
             continue
           }


### PR DESCRIPTION
### Trello Card Link
None

### Description
The struct of nodesync is
```
for wallet:
   tx = new tx
   try:
     if (noop) continue
     ...other
    catch e:
       error
```

The tx is never committed/rolled back in the event of "continue". So we iterate to the next item in the loop but never rollback the tx