### PR TITLE
Playlist images always processed as directory 

### DIFF
--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -247,7 +247,7 @@ def parse_playlist_event(
             logger.info(f"[playlist_cover_photo_updated] | Processing playlist image \
             {playlist_record.playlist_image_multihash}")
             try:
-                is_directory = update_task.ipfs_client.multihash_is_directory(playlist_record.playlist_image_multihash)
+                is_directory = True # update_task.ipfs_client.multihash_is_directory(playlist_record.playlist_image_multihash)
                 if is_directory:
                     playlist_record.playlist_image_sizes_multihash = playlist_record.playlist_image_multihash
                     playlist_record.playlist_image_multihash = None


### PR DESCRIPTION
### Trello Card Link


### Description


### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Test 1
- Step 1
- Step 2
- Step 3

Please list the unit test(s) you added to verify your changes.

1. Unit test 1
