### PR TITLE
Allow null in user schema for name

### DIFF
--- a/discovery-provider/src/schemas/user_schema.json
+++ b/discovery-provider/src/schemas/user_schema.json
@@ -7,7 +7,7 @@
             "additionalProperties": true,
             "properties": {
                 "name": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null
                 },
                 "profile_picture": {

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/services/schemaValidator/schemas/userSchema.json
+++ b/libs/src/services/schemaValidator/schemas/userSchema.json
@@ -7,7 +7,7 @@
             "additionalProperties": true,
             "properties": {
                 "name": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null
                 },
                 "profile_picture": {


### PR DESCRIPTION
Tested:

Ran dapp locally w/ linked libs here. Created an account, but disabled setting my name in UserFactoryClient. Account was created with null value for name https://discoveryprovider.staging.audius.co/users?handle=ray104

Discprov indexes this fine. I uploaded a track w.o the code change here and that failed. Then I uploaded one with the code change here and that succeeded. Discprov stayed healthy the whole time.