### PR TITLE
[do not merge] Update txRelay to use mod based selection

### DIFF
--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -136,7 +136,6 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
 // to find the index for relayer addresses
 const getRelayerWalletIndex = (walletAddress) => {
   let walletParsedInteger = parseInt(walletAddress, 16)
-  logger.info('number of wallets', relayerWallets.length, relayerWallets)
   return walletParsedInteger % relayerWallets.length
 }
 

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -136,6 +136,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
 // to find the index for relayer addresses
 const getRelayerWalletIndex = (walletAddress) => {
   let walletParsedInteger = parseInt(walletAddress, 16)
+  logger.info('number of wallets', relayerWallets.length, relayerWallets)
   return walletParsedInteger % relayerWallets.length
 }
 

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -132,7 +132,8 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
   return txReceipt
 }
 
-// Calculates index into eth relayer addresses
+// Given a wallet address, converts it to base 10 and calculates the modulo
+// to find the index for relayer addresses
 const getRelayerWalletIndex = (walletAddress) => {
   let walletParsedInteger = parseInt(walletAddress, 16)
   return walletParsedInteger % relayerWallets.length

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -140,9 +140,9 @@ const getRelayerWalletIndex = (walletAddress) => {
 }
 
 const selectWallet = async (senderAddress) => {
-  logger.info('L2 - Acquiring lock for user', senderAddress)
   let selectedWallet
   let idx = getRelayerWalletIndex(senderAddress)
+  logger.info(`L2 - Acquiring lock for user ${senderAddress}, index ${idx}`)
 
   while (relayerWallets[idx].locked) {
     await delay(200)

--- a/identity-service/test/txRelay.js
+++ b/identity-service/test/txRelay.js
@@ -3,7 +3,7 @@ const sinon = require('sinon')
 
 const config = require('../src/config')
 
-describe('test txRelay: selectWallet(walletAddress)', () => {
+describe.only('test txRelay: selectWallet(walletAddress)', () => {
   let relayerWallets, selectWallet
   beforeEach(() => {
     relayerWallets = [
@@ -49,7 +49,7 @@ describe('test txRelay: selectWallet(walletAddress)', () => {
     firstWallet.locked = false
     secondWallet.locked = false
 
-    const thirdWallet = await selectWallet('0x724000024990A67a648D4229fCD5Dd618c62D7D9') // index 0 when calling mod
+    const thirdWallet = await selectWallet('0x8CbFFddd5c9f625b4e18992a641cC88Ea4cD7032') // index 0 when calling mod
     assert(thirdWallet !== undefined)
   })
 })

--- a/identity-service/test/txRelay.js
+++ b/identity-service/test/txRelay.js
@@ -3,7 +3,7 @@ const sinon = require('sinon')
 
 const config = require('../src/config')
 
-describe.only('test txRelay: selectWallet(walletAddress)', () => {
+describe('test txRelay: selectWallet(walletAddress)', () => {
   let relayerWallets, selectWallet
   beforeEach(() => {
     relayerWallets = [

--- a/identity-service/test/txRelay.js
+++ b/identity-service/test/txRelay.js
@@ -6,6 +6,11 @@ const config = require('../src/config')
 describe('test txRelay: selectWallet(walletAddress)', () => {
   let relayerWallets, selectWallet
   beforeEach(() => {
+    // reload the module each time for fresh state
+    delete require.cache[require.resolve('../src/relay/txRelay')]
+    delete require.cache[require.resolve('../src/web3')]
+    sinon.restore()
+
     relayerWallets = [
       {
         publicKey: '0x9d5f71e3F6B454DE13A293A7280B4252D4C1C66E',
@@ -22,13 +27,6 @@ describe('test txRelay: selectWallet(walletAddress)', () => {
     ]
     sinon.stub(config, 'get').withArgs('relayerWallets').returns(relayerWallets)
     selectWallet = require('../src/relay/txRelay').selectWallet
-  })
-
-  afterEach(() => {
-    // reload the module each time for fresh state
-    delete require.cache[require.resolve('../src/relay/txRelay')]
-    delete require.cache[require.resolve('../src/web3')]
-    sinon.restore()
   })
 
   it('should select a random wallet', async () => {

--- a/identity-service/test/txRelay.js
+++ b/identity-service/test/txRelay.js
@@ -3,17 +3,21 @@ const sinon = require('sinon')
 
 const config = require('../src/config')
 
-describe('test txRelay: selectWallet()', () => {
+describe.only('test txRelay: selectWallet(walletAddress)', () => {
   let relayerWallets, selectWallet
   beforeEach(() => {
     relayerWallets = [
       {
-        publicKey: 'publicKey1',
+        publicKey: '0x9d5f71e3F6B454DE13A293A7280B4252D4C1C66E',
         privateKey: 'privateKey1'
       },
       {
-        publicKey: 'publicKey2',
+        publicKey: '0x999e70F3e1B1D9cba35554d0b048136d3855ce18',
         privateKey: 'privateKey2'
+      },
+      {
+        publicKey: '0xBE02c92D20E068930A3EB641862A3Eb68F2d1210',
+        privateKey: 'privateKey3'
       }
     ]
     sinon.stub(config, 'get').withArgs('relayerWallets').returns(relayerWallets)
@@ -27,32 +31,25 @@ describe('test txRelay: selectWallet()', () => {
     sinon.restore()
   })
 
-  it('should select a random wallet', () => {
-    const firstWallet = selectWallet()
-    const secondWallet = selectWallet()
+  it('should select a random wallet', async () => {
+    const firstWallet = await selectWallet('0xc22AA517bd6c0897428Cc4E93Ed5069c548f4Dc7') // index 0 when calling mod
+    const secondWallet = await selectWallet('0x724000024990A67a648D4229fCD5Dd618c62D7D9') // index 1 when calling mod
 
     assert(firstWallet.publicKey !== secondWallet.publicKey)
     assert(firstWallet.privateKey !== secondWallet.privateKey)
   })
 
-  it('should return null when attempting to select a wallet when all are in use', () => {
-    let i = 0
-    let nullWallet
-    while (i++ < 3) {
-      nullWallet = selectWallet()
-    }
+  it('should return an unlocked wallet when all wallets are reset to unlocked', async () => {
+    const firstWallet = await selectWallet('0xc22AA517bd6c0897428Cc4E93Ed5069c548f4Dc7') // index 0 when calling mod
+    const secondWallet = await selectWallet('0x724000024990A67a648D4229fCD5Dd618c62D7D9') // index 1 when calling mod
 
-    assert(nullWallet === undefined)
-  })
-
-  it('should return an unlocked wallet when all wallets are reset to unlocked', () => {
-    const firstWallet = selectWallet()
-    const secondWallet = selectWallet()
+    assert(firstWallet.publicKey !== secondWallet.publicKey)
+    assert(firstWallet.privateKey !== secondWallet.privateKey)
 
     firstWallet.locked = false
     secondWallet.locked = false
 
-    const thirdWallet = selectWallet()
+    const thirdWallet = await selectWallet('0x724000024990A67a648D4229fCD5Dd618c62D7D9') // index 0 when calling mod
     assert(thirdWallet !== undefined)
   })
 })


### PR DESCRIPTION
Co-authored with @vicky-g 

### Trello Card Link
None

### Description
This PR removes the random wallet selection for POA wallets, instead opting to use a deterministic mod based approach similar to the eth tx relay. The two benefits here are:

1. Since particular users are deterministically tied to relayer wallets, if a user performs large number of actions, it only affects that users relays (and others that share their index), but doesn't eat up wallets for the rest of the network.

2. Less computation because we need no iteration with a for/while loop. Doing that computation inside every relay route is unnecessary overhead for the event loop. Instead with this deterministic wallet selection we just poll every 200ms to see if the wallet is unlocked and if we can acquire the lock.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [X] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches relays


### How Has This Been Tested?
Modified the unit tests