### PR TITLE
Allow configurable connection pool

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -22,6 +22,12 @@ const config = convict({
     env: 'dbUrl',
     default: null
   },
+  dbConnectionPoolMax: {
+    doc: 'Max connections in database pool',
+    format: 'nat',
+    env: 'dbConnectionPoolMax',
+    default: 100
+  },
   ipfsHost: {
     doc: 'IPFS host address',
     format: String,

--- a/creator-node/src/models/index.js
+++ b/creator-node/src/models/index.js
@@ -13,7 +13,7 @@ const sequelize = new Sequelize(globalConfig.get('dbUrl'), {
   logging: globalConfig.get('printSequelizeLogs'),
   operatorsAliases: false,
   pool: {
-    max: 100,
+    max: globalConfig.get('dbConnectionPoolMax'),
     min: 5,
     acquire: 60000,
     idle: 10000


### PR DESCRIPTION
### Trello Card Link


### Description
Moves connection pool to a config var, currently deployed on staging w/ 2000 max connections.
I'm somewhat convinced that we need to just dramatically increase our max connections. I've noticed that during high load, our RDS instance is totally fine but it seems like simple endpoints like /health_check struggle to grab a connection.
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections
We can definitely up this number a lot, though I'm not sure at which point node is just unable to utilize. I think it's worth a shot on prod though.

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Currently running on staging cn 3 @ 2000. Used locust to load test, saw no noticeable difference in performance when just spamming /health_check, but did see that more than 100 connections were used (500 concurrent requests ended up using 170 connections).

