### PR TITLE
Dm notifications indexing hotfix

### DIFF
--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -11,7 +11,7 @@ from src.utils.db_session import get_db_read_replica
 logger = logging.getLogger(__name__)
 bp = Blueprint("notifications", __name__)
 
-max_block_diff = 500
+max_block_diff = 50
 
 
 # pylint: disable=R0911

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -11,7 +11,7 @@ from src.utils.db_session import get_db_read_replica
 logger = logging.getLogger(__name__)
 bp = Blueprint("notifications", __name__)
 
-max_block_diff = 50000
+max_block_diff = 500
 
 
 # pylint: disable=R0911


### PR DESCRIPTION
### Trello Card Link
None

### Description
My guess is when we had our incident yesterday the discprov went behind about 1000 blocks. But to fetch notifications for a chunk of 1000 blocks it took > 10 sec which is our axios timeout in identity. So moving this down to a much more reasonable 500