### PR TITLE
Improve sync-export logging + add export req timeout

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -503,7 +503,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
       }
     }
   } catch (e) {
-    req.logger.error('Sync Error', e)
+    req.logger.error('Sync Error for wallets ', walletPublicKeys, `|| from endpoint ${creatorNodeEndpoint} ||`, e)
     errorObj = e
   } finally {
     // Release all redis locks

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -271,6 +271,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
     if (!resp.data.hasOwnProperty('cnodeUsers') || !resp.data.hasOwnProperty('ipfsIDObj') || !resp.data.ipfsIDObj.hasOwnProperty('addresses')) {
       throw new Error(`Malformed response from ${creatorNodeEndpoint}.`)
     }
+    req.logger.info(`Successful export from ${creatorNodeEndpoint} for wallets`, walletPublicKeys)
 
     if (!dbOnlySync) {
       // Attempt to connect directly to target CNode's IPFS node.

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -153,10 +153,10 @@ module.exports = function (app) {
         }
       }
 
-      req.logger.info('Successful export for wallets', walletPublicKeys, `to source endpoint ${sourceEndpoint} || route duration ${Date.now() - start}`)
+      req.logger.info('Successful export for wallets', walletPublicKeys, `to source endpoint ${sourceEndpoint} || route duration ${Date.now() - start} ms`)
       return successResponse({ cnodeUsers: cnodeUsersDict, ipfsIDObj })
     } catch (e) {
-      req.logger.error('Error in /export for wallets', walletPublicKeys, `to source endpoint ${sourceEndpoint} || route duration ${Date.now() - start} ||`, e)
+      req.logger.error('Error in /export for wallets', walletPublicKeys, `to source endpoint ${sourceEndpoint} || route duration ${Date.now() - start} ms ||`, e)
       await transaction.rollback()
       return errorResponseServerError(e.message)
     }


### PR DESCRIPTION
### Trello Card Link


### Description


### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

ran e2e locally with content + triggered exports / syncs, verified successful + logs

on primary:
```
[2020-10-26T23:44:11.726Z]  INFO: audius_creator_node/273 on 0b7d780cd11b: Successful export for wallets [ '0xea4c0d368dc734bc7260dbe5579beb90d2d3b915' ] to source endpoint http://cn2_creator-node_1:4001 || route duration 27 ms (requestID=tPTOCfS17, requestMethod=GET, requestHostname=cn1_creator-node_1, requestUrl=/export)
```

on secondary:
```
[2020-10-26T23:44:11.771Z]  INFO: audius_creator_node/231 on 29e6ea2e2102: NODESYNC.0xea4c0d368dc734bc7260dbe5579beb90d2d3b915 Successfully retrieved export from http://cn1_creator-node_1:4000 for wallets [ '0xea4c0d368dc734bc7260dbe5579beb90d2d3b915' ] (requestID=gIeP2itgg, requestMethod=POST, requestHostname=cn2_creator-node_1, requestUrl=/sync)
```