### PR TITLE
Put manual sync operations on SnapbackSM sync queue

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -168,9 +168,10 @@ module.exports = function (app) {
     const immediate = (req.body.immediate === true || req.body.immediate === 'true')
     // option to sync just the db records as opposed to db records and files on disk, defaults to false
     const dbOnlySync = (req.body.db_only_sync === true || req.body.db_only_sync === 'true')
-    // Log if initiated from SnapbackSM
-    const stateMachineInitiatedSync = (req.body.state_machine === true || req.body.state_machine === 'true')
-    if (stateMachineInitiatedSync) req.logger.info(`SnapbackSM sync initiated for ${walletPublicKeys} from ${creatorNodeEndpoint}`)
+
+    // Log syncType
+    const syncType = req.body.sync_type
+    if (syncType) req.logger.info(`SnapbackSM sync of type: ${syncType} initiated for ${walletPublicKeys} from ${creatorNodeEndpoint}`)
 
     if (!immediate) {
       req.logger.info('debounce time', config.get('debounceTime'))

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -1,7 +1,7 @@
 const redisClient = require('./redis')
 const { ipfs, ipfsLatest } = require('./ipfsClient')
 const BlacklistManager = require('./blacklistManager')
-const SnapbackSM = require('./snapbackSM')
+const { SnapbackSM } = require('./snapbackSM')
 const AudiusLibs = require('@audius/libs')
 const config = require('./config')
 

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -23,6 +23,16 @@ const ModuloBase = 24
 // Delay 1 hour between production state machine jobs
 const ProductionJobDelayInMs = 3600000
 
+const SyncPriority = Object.freeze({
+  Low: 2,
+  High: 1
+})
+
+const SyncType = Object.freeze({
+  Recurring: 'RECURRING',
+  Manual: 'MANUAL'
+})
+
 /*
   SnapbackSM aka Snapback StateMachine
   Ensures file availability through recurring sync operations
@@ -124,8 +134,27 @@ class SnapbackSM {
     }, {})
   }
 
-  // Enqueue a sync request to a particular secondary
-  async issueSecondarySync (userWallet, secondaryEndpoint, primaryEndpoint, primaryClockValue) {
+  // Enqueues a manual (high priority) sync.
+  // Returns the added job.
+  async enqueueManualSync ({ userWallet, secondaryEndpoint, primaryEndpoint }) {
+    try {
+      const primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet]
+      return this.issueSecondarySync({
+        userWallet,
+        secondaryEndpoint,
+        primaryEndpoint,
+        primaryClockValue,
+        priority: SyncPriority.High,
+        syncType: SyncType.Manual
+      })
+    } catch (e) {
+      logger.error(`Error enqueing manual sync for user: ${userWallet}, error: ${e.message}`)
+    }
+  }
+
+  // Enqueue a sync request to a particular secondary.
+  // Returns the added job
+  async issueSecondarySync ({ userWallet, secondaryEndpoint, primaryEndpoint, primaryClockValue, priority, syncType = SyncType.Recurring }) {
     let syncRequestParameters = {
       baseURL: secondaryEndpoint,
       url: '/sync',
@@ -133,10 +162,10 @@ class SnapbackSM {
       data: {
         wallet: [userWallet],
         creator_node_endpoint: primaryEndpoint,
-        state_machine: true // state machine specific flag
+        sync_type: syncType
       }
     }
-    await this.syncQueue.add({ syncRequestParameters, startTime: Date.now(), primaryClockValue })
+    return this.syncQueue.add({ syncRequestParameters, startTime: Date.now(), primaryClockValue }, { priority })
   }
 
   // Main state machine processing function
@@ -267,12 +296,24 @@ class SnapbackSM {
             this.log(`${userWallet} primaryClock=${primaryClockValue}, (secondary1=${secondary1}, clock=${secondary1ClockValue} syncRequired=${secondary1SyncRequired}), (secondary2=${secondary2}, clock=${secondary2ClockValue}, syncRequired=${secondary2SyncRequired})`)
             // Enqueue sync for secondary1 if required
             if (secondary1SyncRequired && secondary1 != null) {
-              await this.issueSecondarySync(userWallet, secondary1, this.endpoint, primaryClockValue)
+              await this.issueSecondarySync({
+                userWallet,
+                secondaryEndpoint: secondary1,
+                primaryEndpoint: this.endpoint,
+                primaryClockValue,
+                priority: SyncPriority.Low
+              })
               numSyncsIssued += 1
             }
             // Enqueue sync for secondary2 if required
             if (secondary2SyncRequired && secondary2 != null) {
-              await this.issueSecondarySync(userWallet, secondary2, this.endpoint, primaryClockValue)
+              await this.issueSecondarySync({
+                userWallet,
+                secondaryEndpoint: secondary2,
+                primaryEndpoint: this.endpoint,
+                primaryClockValue,
+                priority: SyncPriority.Low
+              })
               numSyncsIssued += 1
             }
           } catch (e) {
@@ -312,6 +353,7 @@ class SnapbackSM {
         if (respData.clockValue >= primaryClockValue) {
           syncAttemptCompleted = true
           this.log(`processSync ${syncWallet} clockValue from secondary:${respData.clockValue}, primary:${primaryClockValue}`)
+          break
         }
       } catch (e) {
         this.log(`processSync ${syncWallet} error querying sync_status: ${e}`)
@@ -393,7 +435,8 @@ class SnapbackSM {
   }
 
   // Initialize the state machine
-  async init () {
+  // Optionally accepts `maxSyncJobs` to set sync concurrency limit other than `MaxParallelSyncJobs`
+  async init (maxSyncJobs) {
     await this.stateMachineQueue.empty()
     await this.syncQueue.empty()
 
@@ -427,7 +470,7 @@ class SnapbackSM {
     // Initialize sync queue processor function, as drained will issue syncs
     // A maximum of 10 sync jobs are allowed to be issued at once
     this.syncQueue.process(
-      MaxParallelSyncJobs,
+      maxSyncJobs || MaxParallelSyncJobs,
       async (job, done) => {
         try {
           await this.processSyncOperation(job)
@@ -445,6 +488,10 @@ class SnapbackSM {
     // Enqueue first state machine operation
     await this.stateMachineQueue.add({ startTime: Date.now() })
   }
+
+  async getPendingSyncJobs () {
+    return this.syncQueue.getJobs(['waiting'])
+  }
 }
 
-module.exports = SnapbackSM
+module.exports = { SnapbackSM, SyncPriority, SyncType }

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -23,11 +23,15 @@ const ModuloBase = 24
 // Delay 1 hour between production state machine jobs
 const ProductionJobDelayInMs = 3600000
 
+// Describes the priority of a sync operation in the sync queue.
+// High priority syncs will be processed before low priority ones.
 const SyncPriority = Object.freeze({
   Low: 2,
   High: 1
 })
 
+// Describes the sync type - Recurring (scheduled) or Manual (triggered
+// by a user action). Currently only used for logging purposes.
 const SyncType = Object.freeze({
   Recurring: 'RECURRING',
   Manual: 'MANUAL'
@@ -136,7 +140,11 @@ class SnapbackSM {
 
   // Enqueues a manual (high priority) sync.
   // Returns the added job.
-  async enqueueManualSync ({ userWallet, secondaryEndpoint, primaryEndpoint }) {
+  async enqueueManualSync ({
+    primaryEndpoint,
+    secondaryEndpoint,
+    userWallet
+  }) {
     try {
       const primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet]
       return this.issueSecondarySync({
@@ -154,7 +162,14 @@ class SnapbackSM {
 
   // Enqueue a sync request to a particular secondary.
   // Returns the added job
-  async issueSecondarySync ({ userWallet, secondaryEndpoint, primaryEndpoint, primaryClockValue, priority, syncType = SyncType.Recurring }) {
+  async issueSecondarySync ({
+    primaryEndpoint,
+    secondaryEndpoint,
+    userWallet,
+    primaryClockValue,
+    priority,
+    syncType = SyncType.Recurring
+  }) {
     let syncRequestParameters = {
       baseURL: secondaryEndpoint,
       url: '/sync',

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -1,0 +1,98 @@
+const nock = require('nock')
+const { SnapbackSM, SyncPriority, SyncType } = require('../src/snapbackSM')
+const models = require('../src/models')
+const { getLibsMock } = require('./lib/libsMock')
+const assert = require('assert')
+const utils = require('../src/utils')
+const { getApp } = require('./lib/app')
+
+const constants = {
+  userWallet: 'user_wallet',
+  secondaryEndpoint: 'http://test_cn_2.co',
+  primaryEndpoint: 'http://test_cn.co',
+  primaryClockVal: 1
+}
+
+const MAX_CONCURRENCY = 1
+
+describe('test sync queue', function () {
+  let server
+
+  before(async function () {
+    // init app to run migrations
+    const appInfo = await getApp()
+    server = appInfo.server
+  })
+
+  afterEach(async function () {
+    await server.close()
+  })
+
+  it('prioritizes manual syncs', async function () {
+    // Mock out the initial call to sync
+    nock(constants.secondaryEndpoint)
+      .persist()
+      .post(() => true)
+      .reply(200)
+
+    // Mock out the secondary monitoring response with a 500ms delay
+    nock(constants.secondaryEndpoint)
+      .persist()
+      .get(() => true)
+      .delayBody(500)
+      .reply(200, { data: { clockValue: constants.primaryClockVal } })
+
+    // Mock out getUserPrimaryClockValues
+    await models.CNodeUser.create({
+      walletPublicKey: constants.userWallet,
+      clock: constants.primaryClockVal
+    })
+
+    const snapback = new SnapbackSM(getLibsMock())
+    await snapback.init(MAX_CONCURRENCY)
+
+    // Setup the recurring syncs
+    const recurringSyncIds = new Set()
+    for (let i = 0; i < 5; i++) {
+      const { id } = await snapback.issueSecondarySync({
+        userWallet: constants.userWallet,
+        secondaryEndpoint: constants.secondaryEndpoint,
+        primaryEndpoint: constants.primaryEndpoint,
+        priority: SyncPriority.Low,
+        syncType: SyncType.Manual,
+        primaryClockValue: constants.primaryClockVal
+      })
+      recurringSyncIds.add(id)
+    }
+
+    // setup manual syncs
+    const manualSyncIds = new Set()
+    for (let i = 0; i < 3; i++) {
+      const { id } = await snapback.enqueueManualSync({
+        userWallet: constants.userWallet,
+        secondaryEndpoint: constants.secondaryEndpoint,
+        primaryEndpoint: constants.primaryEndpoint,
+        priority: SyncPriority.High,
+        syncType: SyncType.Manual
+      })
+      manualSyncIds.add(id)
+    }
+
+    // Verify we complete manual jobs first
+    let jobIds = (await snapback.getPendingSyncJobs()).map(job => job.id)
+    let lastRemainingRecurringCount = 0
+
+    while (jobIds.length) {
+      const remainingManualCount = jobIds.filter(id => manualSyncIds.has(id)).length
+      const remainingRecurringCount = jobIds.filter(id => recurringSyncIds.has(id)).length
+      if (remainingManualCount > 0 && remainingRecurringCount < lastRemainingRecurringCount) {
+        assert.fail('Should have done all manual high priority syncs first')
+      }
+
+      lastRemainingRecurringCount = remainingRecurringCount
+
+      await utils.timeout(500)
+      jobIds = (await snapback.getPendingSyncJobs()).map(job => job.id)
+    }
+  })
+})

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -59,7 +59,7 @@ describe('test sync queue', function () {
         secondaryEndpoint: constants.secondaryEndpoint,
         primaryEndpoint: constants.primaryEndpoint,
         priority: SyncPriority.Low,
-        syncType: SyncType.Manual,
+        syncType: SyncType.Recurring,
         primaryClockValue: constants.primaryClockVal
       })
       recurringSyncIds.add(id)
@@ -85,7 +85,13 @@ describe('test sync queue', function () {
     while (jobIds.length) {
       const remainingManualCount = jobIds.filter(id => manualSyncIds.has(id)).length
       const remainingRecurringCount = jobIds.filter(id => recurringSyncIds.has(id)).length
-      if (remainingManualCount > 0 && remainingRecurringCount < lastRemainingRecurringCount) {
+
+      // We know we processed a recurring job before a manual job
+      // if there are still manual jobs left to process but we have fewer
+      // unprocessed recurring jobs remaining than we did last iteration through the loop
+      const didProcessRecurringBeforeManual = remainingManualCount > 0 && remainingRecurringCount < lastRemainingRecurringCount
+
+      if (didProcessRecurringBeforeManual) {
         assert.fail('Should have done all manual high priority syncs first')
       }
 


### PR DESCRIPTION
### Description
Move manual syncs to snapback sync queue 

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- 🚨 Yes, this touches sync


### How Has This Been Tested?

Wrote an integration test for snapbackSM, testing the ordering of queue operations.
Tested local dapp against full protocol stack, ensured syncs still worked as expected.
