### PR TITLE
Lower notifs indexing limit to 50

### DIFF
--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -11,7 +11,7 @@ from src.utils.db_session import get_db_read_replica
 logger = logging.getLogger(__name__)
 bp = Blueprint("notifications", __name__)
 
-max_block_diff = 50000
+max_block_diff = 50
 
 
 # pylint: disable=R0911


### PR DESCRIPTION
### Trello Card Link
None

### Description
50k blocks worth of activities to process for notifications takes too long for identity which times out the request. Also such a payload would not be feasible to send. Lower the limit to 50. 

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Tested live on prod through a hotfix to unblock indexing