### PR TITLE
Remove pkey constraint on stems and remixes

### DIFF
--- a/discovery-provider/alembic/versions/d579207034fc_remove_stems_and_remixes_unique_.py
+++ b/discovery-provider/alembic/versions/d579207034fc_remove_stems_and_remixes_unique_.py
@@ -1,0 +1,32 @@
+"""remove_stems_and_remixes_unique_constraints
+
+Revision ID: d579207034fc
+Revises: 281de8af4b93
+Create Date: 2020-10-26 21:25:20.393863
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd579207034fc'
+down_revision = '281de8af4b93'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute('''
+        ALTER TABLE stems
+        DROP CONSTRAINT IF EXISTS stems_pkey
+    ''')
+    connection.execute('''
+        ALTER TABLE remixes
+        DROP CONSTRAINT IF EXISTS remixes_pkey
+    ''')
+
+def downgrade():
+    op.create_primary_key('stems_pkey', 'stems', ['parent_track_id', 'child_track_id'])
+    op.create_primary_key('remixes_pkey', 'remixes', ['parent_track_id', 'child_track_id'])


### PR DESCRIPTION
### Trello Card Link


### Description
Fixes indexing halting caused by unique constraint

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches stem / remix creation / indexing / querying


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Brought up all services with the constraint removed, uploaded a track w/ stems and a remix track. Made sure all pages loaded and could download stem.

2. Undid migration, manually removed constraint first & ran the migration
