### PR TITLE
Add creator node selection class + unit tests

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -15,7 +15,10 @@ const healthCheck = async ({ libs } = {}, logger, sequelize) => {
     'git': process.env.GIT_SHA,
     'selectedDiscoveryProvider': 'none',
     'creatorNodeEndpoint': config.get('creatorNodeEndpoint'),
-    'spID': config.get('spID')
+    'spID': config.get('spID'),
+    country: config.get('serviceCountry'),
+    latitude: config.get('serviceLatitude'),
+    longitude: config.get('serviceLongitude')
   }
 
   if (libs) {

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,6 +1,6 @@
-const { sampleSize } = require('lodash')
 const { Base } = require('./base')
 const { timeRequests } = require('../utils/network')
+const CreatorNodeSelection = require('../services/creatorNode/CreatorNodeSelection')
 
 const CREATOR_NODE_SERVICE_NAME = 'creator-node'
 const DISCOVERY_PROVIDER_SERVICE_NAME = 'discovery-provider'
@@ -71,50 +71,15 @@ class ServiceProvider extends Base {
     whitelist = null,
     blacklist = null
   ) {
-    let creatorNodes = await this.listCreatorNodes()
-
-    // Filter whitelist
-    if (whitelist) {
-      creatorNodes = creatorNodes.filter(node => whitelist.has(node.endpoint))
-    }
-    // Filter blacklist
-    if (blacklist) {
-      creatorNodes = creatorNodes.filter(node => !blacklist.has(node.endpoint))
-    }
-
-    // Filter to healthy nodes
-    creatorNodes = (await Promise.all(
-      creatorNodes.map(async node => {
-        try {
-          const { isBehind, isConfigured } = await this.creatorNode.getSyncStatus(node.endpoint)
-          return isConfigured && isBehind ? false : node.endpoint
-        } catch (e) {
-          return false
-        }
-      })
-    ))
-      .filter(Boolean)
-
-    // Time requests and autoselect nodes
-    const timings = await timeRequests(
-      creatorNodes.map(node => ({
-        id: node,
-        url: `${node}/version`
-      }))
-    )
-
-    let services = {}
-    timings.forEach(timing => {
-      services[timing.request.id] = timing.response.data
+    const creatorNodeSelection = new CreatorNodeSelection({
+      creatorNode: this.creatorNode,
+      ethContracts: this.ethContracts,
+      numberOfNodes,
+      whitelist,
+      blacklist
     })
-    // Primary: select the lowest-latency
-    const primary = timings[0] ? timings[0].request.id : null
 
-    // Secondaries: select randomly
-    // TODO: Implement geolocation-based selection
-    const secondaries = sampleSize(timings.slice(1), numberOfNodes - 1)
-      .map(timing => timing.request.id)
-
+    const { primary, secondaries, services } = await creatorNodeSelection.select()
     return { primary, secondaries, services }
   }
 

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -225,7 +225,7 @@ class ServiceSelection {
 
   /**
    * What the criteria is for a healthy service
-   * @param {Response} response axios response
+   * @param {response} response axios response
    * @param {{ [key: string]: string}} urlMap health check urls mapped to their cannonical url
    * e.g. https://discoveryprovider.audius.co/health_check => https://discoveryprovider.audius.co
    */
@@ -233,7 +233,7 @@ class ServiceSelection {
     return response.status === 200
   }
 
-  /** Races requests against eachother with provided timeouts and health checks */
+  /** Races requests against each other with provided timeouts and health checks */
   async race (services) {
     // Key the services by their health check endpoint
     const map = services.reduce((acc, s) => {

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -10,7 +10,7 @@ class CreatorNodeSelection extends ServiceSelection {
       getServices: async () => {
         this.currentVersion = await ethContracts.getCurrentVersion(CREATOR_NODE_SERVICE_NAME)
         const services = await this.ethContracts.getServiceProviderList(CREATOR_NODE_SERVICE_NAME)
-        return services.map(e => e.endpoint) // ? might need to map like services.map(e => e.endpoint)
+        return services.map(e => e.endpoint)
       },
       whitelist
     })
@@ -30,7 +30,7 @@ class CreatorNodeSelection extends ServiceSelection {
    * 2. Filter from/out creator nodes based off of the whitelist and blacklist
    * 3. Init a map of default stats of each service
    * 4. Perform a health check and sync status check to determine health and update stats
-   * 5. Sort by healthiest (highest version -> lowest version; secondary check if equal version based off of responseTime)
+   * 5. Sort by healthiest (highest version -> lowest version); secondary check if equal version based off of responseTime)
    * 6. Select a primary and numberOfNodes-1 number of secondaries
    */
   async select () {
@@ -128,7 +128,7 @@ class CreatorNodeSelection extends ServiceSelection {
   }
 
   /**
-   * Sort by highest version number. If the compared services are of the same, sort by
+   * Sort by highest version number. If the compared services are of the same version, sort by
    * its response time.
    * @param {[{endpoint, version, responseTime}]} services
    */
@@ -139,7 +139,6 @@ class CreatorNodeSelection extends ServiceSelection {
 
       return a.responseTime - b.responseTime
     })
-    return services
   }
 
   /**

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -1,0 +1,154 @@
+const axios = require('axios')
+const semver = require('semver')
+
+const ServiceSelection = require('../../service-selection/ServiceSelection')
+const { CREATOR_NODE_SERVICE_NAME } = require('./constants')
+
+class CreatorNodeSelection extends ServiceSelection {
+  constructor ({ creatorNode, numberOfNodes, ethContracts, whitelist, blacklist }) {
+    super({
+      getServices: async () => {
+        this.currentVersion = await ethContracts.getCurrentVersion(CREATOR_NODE_SERVICE_NAME)
+        const services = await this.ethContracts.getServiceProviderList(CREATOR_NODE_SERVICE_NAME)
+        return services.map(e => e.endpoint) // ? might need to map like services.map(e => e.endpoint)
+      },
+      whitelist
+    })
+    this.creatorNode = creatorNode
+    this.numberOfNodes = numberOfNodes
+    this.ethContracts = ethContracts
+    this.blacklist = blacklist
+
+    // List of valid past creator node versions registered on chain
+    this.validVersions = null
+  }
+
+  /**
+   * Selects a primary and secondary creator nodes
+   *
+   * 1. Retrieve all the creator node services
+   * 2. Filter from/out creator nodes based off of the whitelist and blacklist
+   * 3. Init a map of default stats of each service
+   * 4. Perform a health check and sync status check to determine health and update stats
+   * 5. Sort by healthiest (highest version -> lowest version; secondary check if equal version based off of responseTime)
+   * 6. Select a primary and numberOfNodes-1 number of secondaries
+   */
+  async select () {
+    // Reset decision tree
+    this.decisionTree = []
+
+    // Get all the creator node endpoints on chain and filter
+    let services = await this.getServices()
+    this.decisionTree.push({ stage: 'Get All Services', val: services })
+
+    if (this.whitelist && this.whitelist.length > 0) {
+      services = this.filterToWhitelist(services)
+      this.decisionTree.push({ stage: 'Filtered To Whitelist', val: services })
+    }
+
+    if (this.blacklist && this.blacklist.length > 0) {
+      services = this.filterFromBlacklist(services)
+      this.decisionTree.push({ stage: 'Filtered From Blacklist', val: services })
+    }
+
+    // Init map of creator node endpoints and their default stats
+    const map = {}
+    services.map(service => {
+      map[service] = {
+        version: null,
+        healthCheckEndpoint: `${service}/health_check`,
+        healthCheckResponseTime: null,
+        isHealthy: false,
+        isBehind: true,
+        isConfigured: false,
+        geographicData: {}
+        // todo: add other criteria we should evaluate like diskUsage, currentNumberOfRequests
+      }
+    })
+
+    const healthyEndpoints = []
+    const healthyServices = []
+    for (const service of services) {
+      const start = Date.now()
+      try {
+        // Check health and sync status, and then update stats per service
+        let healthCheckResp = await axios({
+          method: 'get',
+          url: map[service].healthCheckEndpoint
+        })
+        healthCheckResp = healthCheckResp.data.data
+
+        map[service].healthCheckResponseTime = Date.now() - start
+        map[service].version = healthCheckResp.version
+        const { isBehind, isConfigured } = await this.creatorNode.getSyncStatus(service)
+        map[service].isBehind = isBehind
+        map[service].isConfigured = isConfigured
+        map[service].geographicData = {
+          country: healthCheckResp.country,
+          latitude: healthCheckResp.latitude,
+          longitude: healthCheckResp.longitude
+        }
+
+        // If service is not configured, behind in blocks, or its major + minor version is behind, mark as unhealthy
+        map[service].isHealthy = isConfigured && !isBehind &&
+          this.ethContracts.hasSameMajorAndMinorVersion(this.currentVersion, healthCheckResp.version)
+
+        // Add to healthyServices list; used and sorted to select primary and secondaries
+        if (map[service].isHealthy) {
+          healthyEndpoints.push(service)
+          healthyServices.push({ endpoint: service, version: map[service].version, responseTime: map[service].healthCheckResponseTime })
+        }
+      } catch (e) {
+        console.error(`CreatorNodeSelection - Error with checking ${service} health: ${e}`)
+      }
+    }
+    this.decisionTree.push({ stage: 'Filtered Out Known Unhealthy', val: healthyEndpoints })
+
+    // Prioritize higher versions for selected creator nodes
+    this.sortBySemver(healthyServices)
+
+    // Index 0 of healthyServices will be the most optimal creator node candidate
+    const primary = healthyServices[0] ? healthyServices[0].endpoint : null
+
+    // Index 1 to n of healthyServices will be sorted in highest version -> lowest version
+    // Return up to numberOfNodes-1 of secondaries that is not null and not the primary
+    let numSecondariesReturned = 0
+    const secondaries = healthyServices
+      .filter(service =>
+        service && service.endpoint !== primary && numSecondariesReturned++ < this.numberOfNodes
+      )
+      .map(service => service.endpoint)
+
+    this.decisionTree.push({ stage: 'Made A Selection of a Primary and Secondaries', val: { primary, secondaries: secondaries.toString() } })
+
+    console.info('CreatorNodeSelection - final decision tree state', this.decisionTree)
+
+    // not sure about the structure of services
+    return { primary, secondaries, services: map }
+  }
+
+  /**
+   * Sort by highest version number. If the compared services are of the same, sort by
+   * its response time.
+   * @param {[{endpoint, version, responseTime}]} services
+   */
+  sortBySemver (services) {
+    services.sort((a, b) => {
+      if (semver.gt(a.version, b.version)) return -1
+      if (semver.lt(a.version, b.version)) return 1
+
+      return a.responseTime - b.responseTime
+    })
+    return services
+  }
+
+  /**
+   * Filter out services that are in the blacklist
+   * @param {[string]} services endpoints
+   */
+  filterFromBlacklist (services) {
+    return services.filter(s => !this.blacklist.has(s))
+  }
+}
+
+module.exports = CreatorNodeSelection

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -51,11 +51,11 @@ describe('test CreatorNodeSelection', () => {
       responseTime: 100 // ms
     }]
 
-    const sortedServices = cns.sortBySemver(services)
+    cns.sortBySemver(services)
 
-    assert(sortedServices[0].version === '10.23.20')
-    assert(sortedServices[1].version === '10.13.95')
-    assert(sortedServices[2].version === '4.30.95')
+    assert(services[0].version === '10.23.20')
+    assert(services[1].version === '10.13.95')
+    assert(services[2].version === '4.30.95')
   })
 
   it('sorts by ascending time,', () => {
@@ -83,11 +83,11 @@ describe('test CreatorNodeSelection', () => {
       responseTime: 300 // ms
     }]
 
-    const sortedServices = cns.sortBySemver(services)
+    cns.sortBySemver(services)
 
-    assert(sortedServices[0].responseTime === 100)
-    assert(sortedServices[1].responseTime === 200)
-    assert(sortedServices[2].responseTime === 300)
+    assert(services[0].responseTime === 100)
+    assert(services[1].responseTime === 200)
+    assert(services[2].responseTime === 300)
   })
 
   it('selects the fastest healthy service as primary and rest secondaries', async () => {

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -62,7 +62,7 @@ describe('test CreatorNodeSelection', () => {
     const cns = new CreatorNodeSelection({
       creatorNode: null,
       numberOfNodes: 3,
-      ethContracts: mockEthContracts,
+      ethContracts: mockEthContracts([], '1.2.3'),
       whitelist: null,
       blacklist: null
     })
@@ -90,7 +90,7 @@ describe('test CreatorNodeSelection', () => {
     assert(services[2].responseTime === 300)
   })
 
-  it('selects the fastest healthy service as primary and rest secondaries', async () => {
+  it('selects the fastest healthy service as primary and rest as secondaries', async () => {
     const healthy = 'https://healthy.audius.co'
     nock(healthy)
       .get('/health_check')

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -1,0 +1,222 @@
+const nock = require('nock')
+const assert = require('assert')
+const semver = require('semver')
+
+const { CREATOR_NODE_SERVICE_NAME } = require('./constants')
+const CreatorNodeSelection = require('./CreatorNodeSelection')
+
+const mockEthContracts = (urls, currrentVersion, previousVersions = null) => ({
+  getCurrentVersion: async () => currrentVersion,
+  getNumberOfVersions: async (spType) => 2,
+  getVersion: async (spType, queryIndex) => {
+    if (previousVersions) {
+      return previousVersions[queryIndex]
+    }
+    return ['1.2.2', '1.2.3'][queryIndex]
+  },
+  getServiceProviderList: async () => urls.map(u => ({ endpoint: u })),
+  hasSameMajorAndMinorVersion: (version1, version2) => {
+    return (
+      semver.major(version1) === semver.major(version2) &&
+        semver.minor(version1) === semver.minor(version2)
+    )
+  },
+  isInRegressedMode: () => {
+    return false
+  }
+})
+
+describe('test CreatorNodeSelection', () => {
+  it('sorts by descending semver', () => {
+    const cns = new CreatorNodeSelection({
+      creatorNode: null,
+      numberOfNodes: 3,
+      ethContracts: mockEthContracts([], '1.2.3'),
+      whitelist: null,
+      blacklist: null
+    })
+    const services = [{
+      endpoint: 'creator_node_1.com',
+      version: '4.30.95',
+      responseTime: 100 // ms
+    },
+    {
+      endpoint: 'creator_node_2.com',
+      version: '10.13.95',
+      responseTime: 100 // ms
+    },
+    {
+      endpoint: 'creator_node_3.com',
+      version: '10.23.20',
+      responseTime: 100 // ms
+    }]
+
+    const sortedServices = cns.sortBySemver(services)
+
+    assert(sortedServices[0].version === '10.23.20')
+    assert(sortedServices[1].version === '10.13.95')
+    assert(sortedServices[2].version === '4.30.95')
+  })
+
+  it('sorts by ascending time,', () => {
+    const cns = new CreatorNodeSelection({
+      creatorNode: null,
+      numberOfNodes: 3,
+      ethContracts: mockEthContracts,
+      whitelist: null,
+      blacklist: null
+    })
+
+    const services = [{
+      endpoint: 'creator_node_1.com',
+      version: '4.30.95',
+      responseTime: 100 // ms
+    },
+    {
+      endpoint: 'creator_node_2.com',
+      version: '4.30.95',
+      responseTime: 200 // ms
+    },
+    {
+      endpoint: 'creator_node_3.com',
+      version: '4.30.95',
+      responseTime: 300 // ms
+    }]
+
+    const sortedServices = cns.sortBySemver(services)
+
+    assert(sortedServices[0].responseTime === 100)
+    assert(sortedServices[1].responseTime === 200)
+    assert(sortedServices[2].responseTime === 300)
+  })
+
+  it('selects the fastest healthy service as primary and rest secondaries', async () => {
+    const healthy = 'https://healthy.audius.co'
+    nock(healthy)
+      .get('/health_check')
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.2.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const healthyButSlow = 'https://healthybutslow.audius.co'
+    nock(healthyButSlow)
+      .get('/health_check')
+      .delay(100)
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.2.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const healthyButSlowest = 'https://healthybutslowest.audius.co'
+    nock(healthyButSlowest)
+      .get('/health_check')
+      .delay(200)
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.2.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const cns = new CreatorNodeSelection({
+      // Mock Creator Node
+      creatorNode: {
+        getSyncStatus: async () => {
+          return {
+            isBehind: false,
+            isConfigured: true
+          }
+        }
+      },
+      numberOfNodes: 3,
+      ethContracts: mockEthContracts([healthy, healthyButSlow, healthyButSlowest], '1.2.3'),
+      whitelist: null,
+      blacklist: null
+    })
+
+    const { primary, secondaries } = await cns.select()
+
+    assert(primary === healthy)
+    assert(secondaries.length === 2)
+    assert(!secondaries.includes(primary))
+    assert(secondaries.includes(healthyButSlow))
+    assert(secondaries.includes(healthyButSlowest))
+  })
+
+  it('filter out behind creator nodes, select the highest version as primary and rest as secondaries', async () => {
+    const upToDate = 'https://upToDate.audius.co'
+    nock(upToDate)
+      .get('/health_check')
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.2.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const behindMajor = 'https://behindMajor.audius.co'
+    nock(behindMajor)
+      .get('/health_check')
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '0.2.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const behindMinor = 'https://behindMinor.audius.co'
+    nock(behindMinor)
+      .get('/health_check')
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.0.3',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const behindPatch = 'https://behindPatch.audius.co'
+    nock(behindPatch)
+      .get('/health_check')
+      .reply(200, { data: {
+        service: CREATOR_NODE_SERVICE_NAME,
+        version: '1.2.0',
+        country: 'US',
+        latitude: '37.7058',
+        longitude: '-122.4619'
+      } })
+
+    const cns = new CreatorNodeSelection({
+      // Mock Creator Node
+      creatorNode: {
+        getSyncStatus: async () => {
+          return {
+            isBehind: false,
+            isConfigured: true
+          }
+        }
+      },
+      numberOfNodes: 2,
+      ethContracts: mockEthContracts([upToDate, behindMajor, behindMinor, behindPatch], '1.2.3'),
+      whitelist: null,
+      blacklist: null
+    })
+
+    const { primary, secondaries } = await cns.select()
+
+    assert(primary === upToDate)
+    assert(secondaries.length === 1)
+    assert(!secondaries.includes(primary))
+    assert(secondaries.includes(behindPatch))
+  })
+})

--- a/libs/src/services/creatorNode/constants.js
+++ b/libs/src/services/creatorNode/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  CREATOR_NODE_SERVICE_NAME: 'creator-node'
+}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/eVKqXcKS/1639-add-creator-node-selection-logic

### Description
Instead of just selecting healthy creator nodes as viable options, this PR allows us to prioritize first based on version, then based on its request response time

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches **creator node selection**



### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Test 1
- Step 1
- Step 2
- Step 3

Please list the unit test(s) you added to verify your changes.

pls refer to PR
