### PR TITLE
[do not review] Add more rate limits

### DIFF
--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -10,7 +10,7 @@
   "logLevel": "debug",
   "redisHost": "localhost",
   "redisPort": 4379,
-  "rateLimiterDefaultMax": 20,
+  "rateLimiterDefaultMax": 30,
   "rateLimitingAudiusUserReqLimit": 3000,
   "rateLimitingUserReqLimit": 3000,
   "rateLimitingMetadataReqLimit": 3000,

--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -10,6 +10,7 @@
   "logLevel": "debug",
   "redisHost": "localhost",
   "redisPort": 4379,
+  "rateLimiterDefaultMax": 20,
   "rateLimitingAudiusUserReqLimit": 3000,
   "rateLimitingUserReqLimit": 3000,
   "rateLimitingMetadataReqLimit": 3000,

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -137,6 +137,12 @@ const config = convict({
     env: 'logLevel',
     default: null
   },
+  rateLimiterDefaultMax: {
+    dec: 'Default rate limiter total requests per hour',
+    format: 'nat',
+    env: 'rateLimiterDefaultMax',
+    default: null
+  },
   rateLimitingAudiusUserReqLimit: {
     doc: 'Total requests per hour rate limit for /audius_user routes',
     format: 'nat',

--- a/creator-node/src/reqLimiter.js
+++ b/creator-node/src/reqLimiter.js
@@ -3,6 +3,12 @@ const config = require('./config.js')
 const RedisStore = require('rate-limit-redis')
 const client = require('./redis.js')
 
+const DEFAULT_MAX = config.get('rateLimiterDefaultMax')
+const DEFAULT_EXPIRY = 60 * 60 // one hour in seconds
+const DEFAULT_KEY_GENERATOR = (req) => {
+  return `${req.path}:${req.ip}`
+}
+
 const userReqLimiter = rateLimit({
   store: new RedisStore({
     client: client,
@@ -63,4 +69,40 @@ const imageReqLimiter = rateLimit({
   }
 })
 
-module.exports = { userReqLimiter, trackReqLimiter, audiusUserReqLimiter, metadataReqLimiter, imageReqLimiter }
+/**
+ * A generic endpoint rate limiter
+ * @param {object} config
+ * @param {string} config.prefix redis cache key prefix
+ * @param {number?} config.max maximum number of requests
+ * @param {expiry?} config.expiry time period of the rate limiter
+ * @param {(req: Request) => string?} config.keyGenerator redis cache
+ *  key suffix (can use the request object)
+ * @param {boolean?} config.skip if true, limiter is avoided
+ */
+const getRateLimiter = ({
+  prefix,
+  max = DEFAULT_MAX,
+  expiry = DEFAULT_EXPIRY, // seconds
+  keyGenerator = DEFAULT_KEY_GENERATOR,
+  skip
+}) => {
+  return rateLimit({
+    store: new RedisStore({
+      client,
+      prefix,
+      expiry
+    }),
+    max, // max requests per hour
+    skip,
+    keyGenerator
+  })
+}
+
+module.exports = {
+  userReqLimiter,
+  trackReqLimiter,
+  audiusUserReqLimiter,
+  metadataReqLimiter,
+  imageReqLimiter,
+  getRateLimiter
+}

--- a/creator-node/src/reqLimiter.js
+++ b/creator-node/src/reqLimiter.js
@@ -89,7 +89,7 @@ const getRateLimiter = ({
   return rateLimit({
     store: new RedisStore({
       client,
-      prefix,
+      prefix: `rate:${prefix}`,
       expiry
     }),
     max, // max requests per hour

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -7,111 +7,129 @@ const { handleResponse, successResponse, errorResponseBadRequest, errorResponseS
 const { getFileUUIDForImageCID } = require('../utils')
 const { authMiddleware, syncLockMiddleware, ensurePrimaryMiddleware, triggerSecondarySyncs } = require('../middlewares')
 const DBManager = require('../dbManager')
+const { getRateLimiter } = require('../reqLimiter')
+
+const audiusUsersRateLimiter = getRateLimiter({
+  prefix: 'audiusUsersRateLimiter'
+})
 
 module.exports = function (app) {
   /**
    * Create AudiusUser from provided metadata, and make metadata available to network
    */
-  app.post('/audius_users/metadata', authMiddleware, syncLockMiddleware, handleResponse(async (req, res) => {
-    // TODO - input validation
-    const metadataJSON = req.body.metadata
-    const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
-    const cnodeUserUUID = req.session.cnodeUserUUID
+  app.post(
+    '/audius_users/metadata',
+    audiusUsersRateLimiter,
+    authMiddleware,
+    syncLockMiddleware,
+    handleResponse(async (req, res) => {
+      // TODO - input validation
+      const metadataJSON = req.body.metadata
+      const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
+      const cnodeUserUUID = req.session.cnodeUserUUID
 
-    // Save file from buffer to IPFS and disk
-    let multihash, dstPath
-    try {
-      const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer)
-      multihash = resp.multihash
-      dstPath = resp.dstPath
-    } catch (e) {
-      return errorResponseServerError(`saveFileFromBufferToIPFSAndDisk op failed: ${e}`)
-    }
-
-    // Record metadata file entry in DB
-    const transaction = await models.sequelize.transaction()
-    let fileUUID
-    try {
-      const createFileQueryObj = {
-        multihash,
-        sourceFile: req.fileName,
-        storagePath: dstPath,
-        type: 'metadata' // TODO - replace with models enum
+      // Save file from buffer to IPFS and disk
+      let multihash, dstPath
+      try {
+        const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer)
+        multihash = resp.multihash
+        dstPath = resp.dstPath
+      } catch (e) {
+        return errorResponseServerError(`saveFileFromBufferToIPFSAndDisk op failed: ${e}`)
       }
-      const file = await DBManager.createNewDataRecord(createFileQueryObj, cnodeUserUUID, models.File, transaction)
-      fileUUID = file.fileUUID
-      await transaction.commit()
-    } catch (e) {
-      await transaction.rollback()
-      return errorResponseServerError(`Could not save to db: ${e}`)
-    }
 
-    return successResponse({
-      'metadataMultihash': multihash,
-      'metadataFileUUID': fileUUID
+      // Record metadata file entry in DB
+      const transaction = await models.sequelize.transaction()
+      let fileUUID
+      try {
+        const createFileQueryObj = {
+          multihash,
+          sourceFile: req.fileName,
+          storagePath: dstPath,
+          type: 'metadata' // TODO - replace with models enum
+        }
+        const file = await DBManager.createNewDataRecord(createFileQueryObj, cnodeUserUUID, models.File, transaction)
+        fileUUID = file.fileUUID
+        await transaction.commit()
+      } catch (e) {
+        await transaction.rollback()
+        return errorResponseServerError(`Could not save to db: ${e}`)
+      }
+
+      return successResponse({
+        'metadataMultihash': multihash,
+        'metadataFileUUID': fileUUID
+      })
     })
-  }))
+  )
 
   /**
    * Given audiusUser blockchainUserId, blockNumber, and metadataFileUUID, creates/updates AudiusUser DB entry
    * and associates image file entries with audiusUser. Ends audiusUser creation/update process.
    */
-  app.post('/audius_users', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, handleResponse(async (req, res) => {
-    const { blockchainUserId, blockNumber, metadataFileUUID } = req.body
+  app.post(
+    '/audius_users',
+    audiusUsersRateLimiter,
+    authMiddleware,
+    ensurePrimaryMiddleware,
+    syncLockMiddleware,
+    handleResponse(async (req, res) => {
+      const { blockchainUserId, blockNumber, metadataFileUUID } = req.body
 
-    if (!blockchainUserId || !blockNumber || !metadataFileUUID) {
-      return errorResponseBadRequest('Must include blockchainUserId, blockNumber, and metadataFileUUID.')
-    }
-
-    // Error on outdated blocknumber.
-    const cnodeUser = req.session.cnodeUser
-    if (!cnodeUser.latestBlockNumber || cnodeUser.latestBlockNumber >= blockNumber) {
-      return errorResponseBadRequest(`Invalid blockNumber param. Must be higher than previously processed blocknumber.`)
-    }
-    const cnodeUserUUID = req.session.cnodeUserUUID
-
-    // Fetch metadataJSON for metadataFileUUID.
-    const file = await models.File.findOne({ where: { fileUUID: metadataFileUUID, cnodeUserUUID } })
-    if (!file) {
-      return errorResponseBadRequest(`No file db record found for provided metadataFileUUID ${metadataFileUUID}.`)
-    }
-    let metadataJSON
-    try {
-      metadataJSON = JSON.parse(fs.readFileSync(file.storagePath))
-    } catch (e) {
-      return errorResponseServerError(`No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}.`)
-    }
-
-    // Get coverArtFileUUID and profilePicFileUUID for multihashes in metadata object, if present.
-    let coverArtFileUUID, profilePicFileUUID
-    try {
-      coverArtFileUUID = await getFileUUIDForImageCID(req, metadataJSON.cover_photo_sizes)
-      profilePicFileUUID = await getFileUUIDForImageCID(req, metadataJSON.profile_picture_sizes)
-    } catch (e) {
-      return errorResponseBadRequest(e.message)
-    }
-
-    // Record AudiusUser entry + update CNodeUser entry in DB
-    const transaction = await models.sequelize.transaction()
-    try {
-      const createAudiusUserQueryObj = {
-        metadataFileUUID,
-        metadataJSON,
-        blockchainId: blockchainUserId,
-        coverArtFileUUID,
-        profilePicFileUUID
+      if (!blockchainUserId || !blockNumber || !metadataFileUUID) {
+        return errorResponseBadRequest('Must include blockchainUserId, blockNumber, and metadataFileUUID.')
       }
-      await DBManager.createNewDataRecord(createAudiusUserQueryObj, cnodeUserUUID, models.AudiusUser, transaction)
 
-      // Update cnodeUser.latestBlockNumber
-      await cnodeUser.update({ latestBlockNumber: blockNumber }, { transaction })
+      // Error on outdated blocknumber.
+      const cnodeUser = req.session.cnodeUser
+      if (!cnodeUser.latestBlockNumber || cnodeUser.latestBlockNumber >= blockNumber) {
+        return errorResponseBadRequest(`Invalid blockNumber param. Must be higher than previously processed blocknumber.`)
+      }
+      const cnodeUserUUID = req.session.cnodeUserUUID
 
-      await transaction.commit()
-      triggerSecondarySyncs(req)
-      return successResponse()
-    } catch (e) {
-      await transaction.rollback()
-      return errorResponseServerError(e.message)
-    }
-  }))
+      // Fetch metadataJSON for metadataFileUUID.
+      const file = await models.File.findOne({ where: { fileUUID: metadataFileUUID, cnodeUserUUID } })
+      if (!file) {
+        return errorResponseBadRequest(`No file db record found for provided metadataFileUUID ${metadataFileUUID}.`)
+      }
+      let metadataJSON
+      try {
+        metadataJSON = JSON.parse(fs.readFileSync(file.storagePath))
+      } catch (e) {
+        return errorResponseServerError(`No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}.`)
+      }
+
+      // Get coverArtFileUUID and profilePicFileUUID for multihashes in metadata object, if present.
+      let coverArtFileUUID, profilePicFileUUID
+      try {
+        coverArtFileUUID = await getFileUUIDForImageCID(req, metadataJSON.cover_photo_sizes)
+        profilePicFileUUID = await getFileUUIDForImageCID(req, metadataJSON.profile_picture_sizes)
+      } catch (e) {
+        return errorResponseBadRequest(e.message)
+      }
+
+      // Record AudiusUser entry + update CNodeUser entry in DB
+      const transaction = await models.sequelize.transaction()
+      try {
+        const createAudiusUserQueryObj = {
+          metadataFileUUID,
+          metadataJSON,
+          blockchainId: blockchainUserId,
+          coverArtFileUUID,
+          profilePicFileUUID
+        }
+        await DBManager.createNewDataRecord(createAudiusUserQueryObj, cnodeUserUUID, models.AudiusUser, transaction)
+
+        // Update cnodeUser.latestBlockNumber
+        await cnodeUser.update({ latestBlockNumber: blockNumber }, { transaction })
+
+        await transaction.commit()
+        triggerSecondarySyncs(req)
+        return successResponse()
+      } catch (e) {
+        await transaction.rollback()
+        return errorResponseServerError(e.message)
+      }
+    })
+  )
 }

--- a/creator-node/src/routes/vectorClock.js
+++ b/creator-node/src/routes/vectorClock.js
@@ -1,9 +1,16 @@
 const models = require('../models')
 const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const axios = require('axios')
+const { getRateLimiter } = require('../reqLimiter')
+
+const vectorClockRateLimiter = getRateLimiter({
+  prefix: 'syncRateLimiter:',
+  max: 20,
+  expiry: 60
+})
 
 module.exports = function (app) {
-  app.post('/vector_clock_backfill/:wallet', handleResponse(async (req, res, next) => {
+  app.post('/vector_clock_backfill/:wallet', vectorClockRateLimiter, handleResponse(async (req, res, next) => {
     const walletPublicKey = req.params.wallet
     const { primary, secondaries } = req.body
     let clock = 0

--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -19,7 +19,7 @@
   "userVerifierPublicKey": "0xbbbb93A6B3A1D6fDd27909729b95CCB0cc9002C0",
   "blacklisterPrivateKey": "87e08695a0c368b9fcbf7420183d266514a1b70791fd0b4254b3cbb8373803c7",
   "blacklisterPublicKey": "0xcccc36bE44D106C6aC14199A2Ed6a29fDa25d5Ae",
-  "rateLimiterDefaultMax": 20,
+  "rateLimiterDefaultMax": 30,
   "rateLimitingReqLimit": 50000,
   "rateLimitingAuthLimit": 5000,
   "rateLimitingTwitterLimit": 5000,

--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -19,6 +19,7 @@
   "userVerifierPublicKey": "0xbbbb93A6B3A1D6fDd27909729b95CCB0cc9002C0",
   "blacklisterPrivateKey": "87e08695a0c368b9fcbf7420183d266514a1b70791fd0b4254b3cbb8373803c7",
   "blacklisterPublicKey": "0xcccc36bE44D106C6aC14199A2Ed6a29fDa25d5Ae",
+  "rateLimiterDefaultMax": 20,
   "rateLimitingReqLimit": 50000,
   "rateLimitingAuthLimit": 5000,
   "rateLimitingTwitterLimit": 5000,

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -1,9 +1,7 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-const rateLimit = require('express-rate-limit')
 const mailgun = require('mailgun-js')
-const RedisStore = require('rate-limit-redis')
 const Redis = require('ioredis')
 const config = require('./config.js')
 const txRelay = require('./relay/txRelay')
@@ -15,9 +13,8 @@ const NotificationProcessor = require('./notifications/index.js')
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { fetchAnnouncements } = require('./announcements')
 const { logger, loggingMiddleware } = require('./logging')
+const { getRateLimiter } = require('./rateLimiter')
 const DOMAIN = 'mail.audius.co'
-const DEFAULT_EXPIRY = 60 * 60 // one hour in seconds
-const DEFAULT_KEY_GENERATOR = (req) => req.ip
 
 class App {
   constructor (port) {
@@ -123,24 +120,11 @@ class App {
     return whitelistRegex && !!ip.match(whitelistRegex)
   }
 
-  _getRateLimiter ({ prefix, max, expiry = DEFAULT_EXPIRY, keyGenerator = DEFAULT_KEY_GENERATOR, skip }) {
-    return rateLimit({
-      store: new RedisStore({
-        client: this.redisClient,
-        prefix,
-        expiry
-      }),
-      max, // max requests per hour
-      skip,
-      keyGenerator
-    })
-  }
-
   // Create rate limits for listens on a per track per user basis and per track per ip basis
   _createRateLimitsForListenCounts (interval, timeInSeconds) {
     const isIPWhitelisted = this._isIPWhitelisted
 
-    const listenCountLimiter = this._getRateLimiter({
+    const listenCountLimiter = getRateLimiter({
       prefix: `listenCountLimiter:::${interval}-track:::`,
       expiry: timeInSeconds,
       max: config.get(`rateLimitingListensPerTrackPer${interval}`), // max requests per interval
@@ -154,7 +138,7 @@ class App {
       }
     })
 
-    const listenCountIPLimiter = this._getRateLimiter({
+    const listenCountIPLimiter = getRateLimiter({
       prefix: `listenCountLimiter:::${interval}-ip:::`,
       expiry: timeInSeconds,
       max: config.get(`rateLimitingListensPerIPPer${interval}`), // max requests per interval
@@ -170,14 +154,14 @@ class App {
   }
 
   setRateLimiters () {
-    const requestRateLimiter = this._getRateLimiter({ prefix: 'reqLimiter', max: config.get('rateLimitingReqLimit') })
+    const requestRateLimiter = getRateLimiter({ prefix: 'reqLimiter', max: config.get('rateLimitingReqLimit') })
     this.express.use(requestRateLimiter)
 
-    const authRequestRateLimiter = this._getRateLimiter({ prefix: 'authLimiter', max: config.get('rateLimitingAuthLimit') })
+    const authRequestRateLimiter = getRateLimiter({ prefix: 'authLimiter', max: config.get('rateLimitingAuthLimit') })
     // This limiter double dips with the reqLimiter. The 5 requests every hour are also counted here
     this.express.use('/authentication/', authRequestRateLimiter)
 
-    const twitterRequestRateLimiter = this._getRateLimiter({ prefix: 'twitterLimiter', max: config.get('rateLimitingTwitterLimit') })
+    const twitterRequestRateLimiter = getRateLimiter({ prefix: 'twitterLimiter', max: config.get('rateLimitingTwitterLimit') })
     // This limiter double dips with the reqLimiter. The 5 requests every hour are also counted here
     this.express.use('/twitter/', twitterRequestRateLimiter)
 
@@ -200,7 +184,7 @@ class App {
     // Eth relay rate limits
     // Default to 50 per ip per day and one of 10 per wallet per day
     const isIPWhitelisted = this._isIPWhitelisted
-    const ethRelayIPRateLimiter = this._getRateLimiter({
+    const ethRelayIPRateLimiter = getRateLimiter({
       prefix: 'ethRelayIPRateLimiter',
       expiry: ONE_HOUR_IN_SECONDS * 24,
       max: config.get('rateLimitingEthRelaysPerIPPerDay'),
@@ -208,7 +192,7 @@ class App {
         return isIPWhitelisted(req.ip)
       }
     })
-    const ethRelayWalletRateLimiter = this._getRateLimiter({
+    const ethRelayWalletRateLimiter = getRateLimiter({
       prefix: `ethRelayWalletRateLimiter`,
       expiry: ONE_HOUR_IN_SECONDS * 24,
       max: config.get('rateLimitingEthRelaysPerWalletPerDay'),

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -132,6 +132,12 @@ const config = convict({
     env: 'blacklisterPublicKey',
     default: null
   },
+  rateLimiterDefaultMax: {
+    dec: 'Default rate limiter total requests per hour',
+    format: 'nat',
+    env: 'rateLimiterDefaultMax',
+    default: null
+  },
   rateLimitingReqLimit: {
     doc: 'Total request per hour rate limit',
     format: 'nat',

--- a/identity-service/src/rateLimiter.js
+++ b/identity-service/src/rateLimiter.js
@@ -31,7 +31,7 @@ const getRateLimiter = ({
   return rateLimit({
     store: new RedisStore({
       client: redisClient,
-      prefix,
+      prefix: `rate:${prefix}`,
       expiry
     }),
     max, // max requests per hour

--- a/identity-service/src/rateLimiter.js
+++ b/identity-service/src/rateLimiter.js
@@ -1,0 +1,43 @@
+const Redis = require('ioredis')
+const RedisStore = require('rate-limit-redis')
+const config = require('./config.js')
+
+const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
+const rateLimit = require('express-rate-limit')
+
+const DEFAULT_MAX = config.get('rateLimiterDefaultMax')
+const DEFAULT_EXPIRY = 60 * 60 // one hour in seconds
+const DEFAULT_KEY_GENERATOR = (req) => {
+  return `${req.path}:${req.ip}`
+}
+
+/**
+ * A generic endpoint rate limiter
+ * @param {object} config
+ * @param {string} config.prefix redis cache key prefix
+ * @param {number?} config.max maximum number of requests
+ * @param {expiry?} config.expiry time period of the rate limiter
+ * @param {(req: Request) => string?} config.keyGenerator redis cache
+ *  key suffix (can use the request object)
+ * @param {boolean?} config.skip if true, limiter is avoided
+ */
+const getRateLimiter = ({
+  prefix,
+  max = DEFAULT_MAX,
+  expiry = DEFAULT_EXPIRY,
+  keyGenerator = DEFAULT_KEY_GENERATOR,
+  skip
+}) => {
+  return rateLimit({
+    store: new RedisStore({
+      client: redisClient,
+      prefix,
+      expiry
+    }),
+    max, // max requests per hour
+    skip,
+    keyGenerator
+  })
+}
+
+module.exports = { getRateLimiter }

--- a/identity-service/src/routes/artistPick.js
+++ b/identity-service/src/routes/artistPick.js
@@ -1,19 +1,28 @@
 const { handleResponse, successResponse, errorResponseBadRequest } = require('../apiHelpers')
 const Sequelize = require('sequelize')
 const models = require('../models')
+const { getRateLimiter } = require('../rateLimiter')
+
+const artistPickRateLimiter = getRateLimiter({
+  prefix: 'artistPickRateLimiter:'
+})
 
 module.exports = function (app) {
-  app.post('/artist_pick', handleResponse(async (req, res, next) => {
-    const { trackId, handle } = req.body
+  app.post(
+    '/artist_pick',
+    artistPickRateLimiter,
+    handleResponse(async (req, res, next) => {
+      const { trackId, handle } = req.body
 
-    if (!handle) return errorResponseBadRequest('Please provide handle')
+      if (!handle) return errorResponseBadRequest('Please provide handle')
 
-    await models.SocialHandles.upsert({
-      handle,
-      pinnedTrackId: trackId || null
+      await models.SocialHandles.upsert({
+        handle,
+        pinnedTrackId: trackId || null
+      })
+      return successResponse()
     })
-    return successResponse()
-  }))
+  )
 
   app.get('/artist_pick', handleResponse(async (req, res, next) => {
     const { handles } = req.query

--- a/identity-service/src/routes/instagram.js
+++ b/identity-service/src/routes/instagram.js
@@ -4,6 +4,11 @@ const models = require('../models')
 const uuidv4 = require('uuid/v4')
 
 const { handleResponse, successResponse, errorResponseBadRequest } = require('../apiHelpers')
+const { getRateLimiter } = require('../rateLimiter.js')
+
+const instagramRateLimiter = getRateLimiter({
+  prefix: 'instagramRateLimiter:'
+})
 
 /**
  * This file contains the instagram endpoints for oauth
@@ -11,87 +16,95 @@ const { handleResponse, successResponse, errorResponseBadRequest } = require('..
  * https://www.instagram.com/developer/authentication/
  */
 module.exports = function (app) {
-  app.post('/instagram', handleResponse(async (req, res, next) => {
-    const { code } = req.body
+  app.post(
+    '/instagram',
+    instagramRateLimiter,
+    handleResponse(async (req, res, next) => {
+      const { code } = req.body
 
-    let reqObj = {
-      method: 'post',
-      url: 'https://api.instagram.com/oauth/access_token',
-      form: {
-        'client_id': config.get('instagramAPIKey'),
-        'client_secret': config.get('instagramAPISecret'),
-        'grant_type': 'authorization_code',
-        'redirect_uri': `${req.headers.origin}`,
-        code
+      let reqObj = {
+        method: 'post',
+        url: 'https://api.instagram.com/oauth/access_token',
+        form: {
+          'client_id': config.get('instagramAPIKey'),
+          'client_secret': config.get('instagramAPISecret'),
+          'grant_type': 'authorization_code',
+          'redirect_uri': `${req.headers.origin}`,
+          code
+        }
       }
-    }
 
-    try {
-      const res = await doRequest(reqObj)
-      const igUser = JSON.parse(res)
-      let {
-        access_token: accessToken,
-        user: profile
-      } = igUser
-      if (!accessToken || !profile) return errorResponseBadRequest(new Error('invalid code'))
-
-      // Store access_token for user in db
       try {
-        let uuid = uuidv4()
-        models.InstagramUser.create({
-          profile,
-          accessToken,
-          uuid
-        })
+        const res = await doRequest(reqObj)
+        const igUser = JSON.parse(res)
+        let {
+          access_token: accessToken,
+          user: profile
+        } = igUser
+        if (!accessToken || !profile) return errorResponseBadRequest(new Error('invalid code'))
 
-        return successResponse({ profile, uuid })
+        // Store access_token for user in db
+        try {
+          let uuid = uuidv4()
+          models.InstagramUser.create({
+            profile,
+            accessToken,
+            uuid
+          })
+
+          return successResponse({ profile, uuid })
+        } catch (err) {
+          return errorResponseBadRequest(err)
+        }
       } catch (err) {
         return errorResponseBadRequest(err)
       }
-    } catch (err) {
-      return errorResponseBadRequest(err)
-    }
-  }))
+    })
+  )
 
   /**
    * After the user finishes onboarding in the client app and has a blockchain userId, we need to associate
    * the blockchainUserId with the instagram profile
    */
-  app.post('/instagram/associate', handleResponse(async (req, res, next) => {
-    let { uuid, userId, handle } = req.body
-    try {
-      let instagramObj = await models.InstagramUser.findOne({ where: { uuid } })
+  app.post(
+    '/instagram/associate',
+    instagramRateLimiter,
+    handleResponse(async (req, res, next) => {
+      let { uuid, userId, handle } = req.body
+      try {
+        let instagramObj = await models.InstagramUser.findOne({ where: { uuid } })
 
-      // only set blockchainUserId if not already set
-      if (instagramObj && !instagramObj.blockchainUserId) {
-        instagramObj.blockchainUserId = userId
+        // only set blockchainUserId if not already set
+        if (instagramObj && !instagramObj.blockchainUserId) {
+          instagramObj.blockchainUserId = userId
 
-        const socialHandle = await models.SocialHandles.findOne({ where: { handle } })
-        if (socialHandle) {
-          socialHandle.instagramHandle = instagramObj.profile.username
-          await socialHandle.save()
-        } else if (instagramObj.profile && instagramObj.profile.username) {
-          await models.SocialHandles.create({
-            handle,
-            instagramHandle: instagramObj.profile.username
-          })
+          const socialHandle = await models.SocialHandles.findOne({ where: { handle } })
+          if (socialHandle) {
+            socialHandle.instagramHandle = instagramObj.profile.username
+            await socialHandle.save()
+          } else if (instagramObj.profile && instagramObj.profile.username) {
+            await models.SocialHandles.create({
+              handle,
+              instagramHandle: instagramObj.profile.username
+            })
+          }
+
+          // the final step is to save userId to db and respond to request
+          try {
+            await instagramObj.save()
+            return successResponse()
+          } catch (e) {
+            return errorResponseBadRequest(e)
+          }
+        } else {
+          req.logger.error('Instagram profile does not exist or userId has already been set', instagramObj)
+          return errorResponseBadRequest('Instagram profile does not exist or userId has already been set')
         }
-
-        // the final step is to save userId to db and respond to request
-        try {
-          await instagramObj.save()
-          return successResponse()
-        } catch (e) {
-          return errorResponseBadRequest(e)
-        }
-      } else {
-        req.logger.error('Instagram profile does not exist or userId has already been set', instagramObj)
-        return errorResponseBadRequest('Instagram profile does not exist or userId has already been set')
+      } catch (err) {
+        return errorResponseBadRequest(err)
       }
-    } catch (err) {
-      return errorResponseBadRequest(err)
-    }
-  }))
+    })
+  )
 }
 
 /**

--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -10,6 +10,7 @@ const config = require('../config')
 const { createPlatformEndpoint, deleteEndpoint } = require('../awsSNS')
 const path = require('path')
 const fs = require('fs')
+const { getRateLimiter } = require('../rateLimiter')
 
 const iOSSNSParams = {
   PlatformApplicationArn: config.get('awsSNSiOSARN')
@@ -48,6 +49,12 @@ const isValidBrowserSubscription = (subscription) => {
     subscription['keys']['auth']
 }
 
+const pushNotificationsRateLimiter = getRateLimiter({
+  prefix: 'pushNotificationsRateLimiter:',
+  max: 10,
+  expiry: 60
+})
+
 module.exports = function (app) {
   /**
    * Get the settings for mobile push notifications for a user
@@ -71,121 +78,136 @@ module.exports = function (app) {
    * Create or update mobile push notification settings
    * POST body contains {userId, settings: {favorites, milestonesAndAchievements, reposts, announcements, followers}}
    */
-  app.post('/push_notifications/settings', authMiddleware, handleResponse(async (req, res, next) => {
-    const userId = req.user.blockchainUserId
-    const { settings } = req.body
+  app.post(
+    '/push_notifications/settings',
+    pushNotificationsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const userId = req.user.blockchainUserId
+      const { settings } = req.body
 
-    if (!userId) return errorResponseBadRequest(`Did not pass in a valid userId`)
+      if (!userId) return errorResponseBadRequest(`Did not pass in a valid userId`)
 
-    try {
-      await models.UserNotificationMobileSettings.upsert({
-        userId,
-        ...settings
-      })
+      try {
+        await models.UserNotificationMobileSettings.upsert({
+          userId,
+          ...settings
+        })
 
-      return successResponse()
-    } catch (e) {
-      req.logger.error(`Unable to create or update push notification settings for userId: ${userId}`, e)
-      return errorResponseServerError(`Unable to create or update push notification settings for userId: ${userId}, Error: ${e.message}`)
-    }
-  }))
+        return successResponse()
+      } catch (e) {
+        req.logger.error(`Unable to create or update push notification settings for userId: ${userId}`, e)
+        return errorResponseServerError(`Unable to create or update push notification settings for userId: ${userId}, Error: ${e.message}`)
+      }
+    })
+  )
 
   /**
    * Register a device token
    * POST body contains {deviceToken: <string>, deviceType: ios/android/safari }
    */
-  app.post('/push_notifications/device_token', authMiddleware, handleResponse(async (req, res, next) => {
-    const userId = req.user.blockchainUserId
-    const { deviceToken, deviceType } = req.body
+  app.post(
+    '/push_notifications/device_token',
+    pushNotificationsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const userId = req.user.blockchainUserId
+      const { deviceToken, deviceType } = req.body
 
-    if (!DEVICE_TYPES.has(deviceType)) {
-      return errorResponseBadRequest('Attempting to register an invalid deviceType')
-    }
-    if (!deviceToken || !userId) {
-      return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
-    }
-
-    try {
-      // Build the aws sns platform params based on device type
-      let params = { Token: deviceToken }
-      if (deviceType === IOS) params = { ...iOSSNSParams, ...params }
-      else if (deviceType === ANDROID) params = { ...androidSNSParams, ...params }
-
-      // If native moblie (ios/android), register the device with aws sns
-      if (deviceType !== SAFARI) {
-        const awsARN = (await createPlatformEndpoint(params))['EndpointArn']
-        await models.NotificationDeviceToken.upsert({
-          deviceToken,
-          deviceType,
-          userId,
-          awsARN
-        })
-      } else {
-        await models.NotificationDeviceToken.upsert({
-          deviceToken,
-          deviceType,
-          userId
-        })
+      if (!DEVICE_TYPES.has(deviceType)) {
+        return errorResponseBadRequest('Attempting to register an invalid deviceType')
+      }
+      if (!deviceToken || !userId) {
+        return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
       }
 
-      return successResponse()
-    } catch (e) {
-      req.logger.error(`Unable to register device token for userId: ${userId} on ${deviceType}`, e)
-      return errorResponseServerError(`Unable to register device token for userId: ${userId} on ${deviceType}, Error: ${e.message}`)
-    }
-  }))
+      try {
+        // Build the aws sns platform params based on device type
+        let params = { Token: deviceToken }
+        if (deviceType === IOS) params = { ...iOSSNSParams, ...params }
+        else if (deviceType === ANDROID) params = { ...androidSNSParams, ...params }
+
+        // If native moblie (ios/android), register the device with aws sns
+        if (deviceType !== SAFARI) {
+          const awsARN = (await createPlatformEndpoint(params))['EndpointArn']
+          await models.NotificationDeviceToken.upsert({
+            deviceToken,
+            deviceType,
+            userId,
+            awsARN
+          })
+        } else {
+          await models.NotificationDeviceToken.upsert({
+            deviceToken,
+            deviceType,
+            userId
+          })
+        }
+
+        return successResponse()
+      } catch (e) {
+        req.logger.error(`Unable to register device token for userId: ${userId} on ${deviceType}`, e)
+        return errorResponseServerError(`Unable to register device token for userId: ${userId} on ${deviceType}, Error: ${e.message}`)
+      }
+    })
+  )
 
   /**
    * Remove a device token from the device token table
    * POST body contains {deviceToken}
    */
-  app.post('/push_notifications/device_token/deregister', authMiddleware, handleResponse(async (req, res, next) => {
-    const userId = req.user.blockchainUserId
-    const { deviceToken } = req.body
+  app.post(
+    '/push_notifications/device_token/deregister',
+    pushNotificationsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const userId = req.user.blockchainUserId
+      const { deviceToken } = req.body
 
-    if (!deviceToken) {
-      return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
-    }
-
-    let tokenDeleted = false
-    let settingsDeleted = false
-    try {
-      // delete device token
-      const tokenObj = await models.NotificationDeviceToken.findOne({
-        where: {
-          deviceToken,
-          userId
-        }
-      })
-
-      let deleteUserNotificationSettings = tokenObj.deviceType !== DEVICE_TYPES.SAFARI
-
-      if (tokenObj) {
-        // delete the endpoint from AWS SNS
-        if (tokenObj.awsARN) await deleteEndpoint({ EndpointArn: tokenObj.awsARN })
-        await tokenObj.destroy()
-        tokenDeleted = true
+      if (!deviceToken) {
+        return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
       }
 
-      // Delete user mobile notification settings if device type is mobile (android or ios)
-      if (deleteUserNotificationSettings) {
-        const settingsObj = await models.UserNotificationMobileSettings.findOne({
+      let tokenDeleted = false
+      let settingsDeleted = false
+      try {
+        // delete device token
+        const tokenObj = await models.NotificationDeviceToken.findOne({
           where: {
+            deviceToken,
             userId
           }
         })
-        if (settingsObj) {
-          await settingsObj.destroy()
-          settingsDeleted = true
-        }
-      }
 
-      return successResponse({ tokenDeleted, settingsDeleted })
-    } catch (e) {
-      req.logger.error(`Unable to deregister device token for deviceToken: ${deviceToken}`, e)
-      return errorResponseServerError(`Unable to deregister device token for deviceToken: ${deviceToken}`, e.message)
-    }
-  }))
+        let deleteUserNotificationSettings = tokenObj.deviceType !== DEVICE_TYPES.SAFARI
+
+        if (tokenObj) {
+          // delete the endpoint from AWS SNS
+          if (tokenObj.awsARN) await deleteEndpoint({ EndpointArn: tokenObj.awsARN })
+          await tokenObj.destroy()
+          tokenDeleted = true
+        }
+
+        // Delete user mobile notification settings if device type is mobile (android or ios)
+        if (deleteUserNotificationSettings) {
+          const settingsObj = await models.UserNotificationMobileSettings.findOne({
+            where: {
+              userId
+            }
+          })
+          if (settingsObj) {
+            await settingsObj.destroy()
+            settingsDeleted = true
+          }
+        }
+
+        return successResponse({ tokenDeleted, settingsDeleted })
+      } catch (e) {
+        req.logger.error(`Unable to deregister device token for deviceToken: ${deviceToken}`, e)
+        return errorResponseServerError(`Unable to deregister device token for deviceToken: ${deviceToken}`, e.message)
+      }
+    })
+  )
 
   /**
    * Checks if a device token/type exists for a userId
@@ -238,24 +260,29 @@ module.exports = function (app) {
    * Create or update browser push notification settings
    * POST body contains {userId, settings: {favorites, milestonesAndAchievements, reposts, followers}}
    */
-  app.post('/push_notifications/browser/settings', authMiddleware, handleResponse(async (req, res, next) => {
-    const userId = req.user.blockchainUserId
-    const { settings } = req.body
+  app.post(
+    '/push_notifications/browser/settings',
+    pushNotificationsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const userId = req.user.blockchainUserId
+      const { settings } = req.body
 
-    if (!userId) return errorResponseBadRequest(`Did not pass in a valid userId`)
+      if (!userId) return errorResponseBadRequest(`Did not pass in a valid userId`)
 
-    try {
-      const browserSettings = await models.UserNotificationBrowserSettings.upsert({
-        ...settings,
-        userId
-      })
+      try {
+        const browserSettings = await models.UserNotificationBrowserSettings.upsert({
+          ...settings,
+          userId
+        })
 
-      return successResponse({ settings: browserSettings })
-    } catch (e) {
-      req.logger.error(`Unable to create or update browser push notification settings for userId: ${userId}`, e)
-      return errorResponseServerError(`Unable to create or update browser push notification settings for userId: ${userId}, Error: ${e.message}`)
-    }
-  }))
+        return successResponse({ settings: browserSettings })
+      } catch (e) {
+        req.logger.error(`Unable to create or update browser push notification settings for userId: ${userId}`, e)
+        return errorResponseServerError(`Unable to create or update browser push notification settings for userId: ${userId}, Error: ${e.message}`)
+      }
+    })
+  )
 
   /*
   * Returns if a user browser subscription exists and is enabled
@@ -283,48 +310,57 @@ module.exports = function (app) {
   /*
   * Creates/Updates a user browser notification bscription exists
   */
-  app.post('/push_notifications/browser/register', authMiddleware, handleResponse(async (req, res, next) => {
-    const { subscription, enabled = true } = req.body
-    if (!isValidBrowserSubscription(subscription)) {
-      return errorResponseBadRequest('Invalid request parameters')
-    }
+  app.post(
+    '/push_notifications/browser/register',
+    pushNotificationsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const { subscription, enabled = true } = req.body
+      if (!isValidBrowserSubscription(subscription)) {
+        return errorResponseBadRequest('Invalid request parameters')
+      }
 
-    try {
-      await models.NotificationBrowserSubscription.upsert({
-        userId: req.user.blockchainUserId,
-        endpoint: subscription.endpoint,
-        p256dhKey: subscription.keys.p256dh,
-        authKey: subscription.keys.auth,
-        enabled
-      })
-      return successResponse()
-    } catch (e) {
-      return errorResponseServerError(`Unable to save browser push notificaiton subscription`, e.message)
-    }
-  }))
+      try {
+        await models.NotificationBrowserSubscription.upsert({
+          userId: req.user.blockchainUserId,
+          endpoint: subscription.endpoint,
+          p256dhKey: subscription.keys.p256dh,
+          authKey: subscription.keys.auth,
+          enabled
+        })
+        return successResponse()
+      } catch (e) {
+        return errorResponseServerError(`Unable to save browser push notificaiton subscription`, e.message)
+      }
+    })
+  )
 
   /*
   * Deletes the browser notification subscription.
   */
-  app.post('/push_notifications/browser/deregister', handleResponse(async (req, res, next) => {
-    const { subscription } = req.body
-    if (!isValidBrowserSubscription(subscription)) {
-      return errorResponseBadRequest('Invalid request parameters')
-    }
+  app.post(
+    '/push_notifications/browser/deregister',
+    pushNotificationsRateLimiter,
+    handleResponse(async (req, res, next) => {
+      const { subscription } = req.body
+      if (!isValidBrowserSubscription(subscription)) {
+        return errorResponseBadRequest('Invalid request parameters')
+      }
 
-    try {
-      await models.NotificationBrowserSubscription.destroy({
-        where: {
-          endpoint: subscription.endpoint,
-          p256dhKey: subscription.keys.p256dh,
-          authKey: subscription.keys.auth
-        }
-      })
-      return successResponse()
-    } catch (e) {
-      return errorResponseServerError(`Unable to deregister push browser subscription`, e.message)
-    }
-  }))
+      try {
+        await models.NotificationBrowserSubscription.destroy({
+          where: {
+            endpoint: subscription.endpoint,
+            p256dhKey: subscription.keys.p256dh,
+            authKey: subscription.keys.auth
+          }
+        })
+        return successResponse()
+      } catch (e) {
+        return errorResponseServerError(`Unable to deregister push browser subscription`, e.message)
+      }
+    })
+  )
 
   /*
   * Downloads the signed safari web push package for authentication.
@@ -360,23 +396,27 @@ module.exports = function (app) {
   * If a user removes permission of a website in Safari preferences, a DELETE request is sent to the following URL:
   * This is done by the safari browser, but the client redundently send a request to device_token/deregister
   */
-  app.delete('/push_notifications/safari/:version/devices/:deviceToken/registrations/:websitePushID', handleResponse(async (req, res, next) => {
-    const { deviceToken } = req.body
+  app.delete(
+    '/push_notifications/safari/:version/devices/:deviceToken/registrations/:websitePushID',
+    pushNotificationsRateLimiter,
+    handleResponse(async (req, res, next) => {
+      const { deviceToken } = req.body
 
-    if (!deviceToken) {
-      return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
-    }
+      if (!deviceToken) {
+        return errorResponseBadRequest('Did not pass in a valid deviceToken or userId for device token registration')
+      }
 
-    try {
-      // delete device token
-      await models.NotificationDeviceToken.destroy({
-        where: { deviceToken }
-      })
-      return successResponse()
-    } catch (e) {
-      return errorResponseServerError(`Unable to delete browser push notificaiton devicetoken`, e.message)
-    }
-  }))
+      try {
+        // delete device token
+        await models.NotificationDeviceToken.destroy({
+          where: { deviceToken }
+        })
+        return successResponse()
+      } catch (e) {
+        return errorResponseServerError(`Unable to delete browser push notificaiton devicetoken`, e.message)
+      }
+    })
+  )
 
   /*
   * Logging Errors

--- a/identity-service/src/routes/socialHandles.js
+++ b/identity-service/src/routes/socialHandles.js
@@ -1,5 +1,10 @@
 const { handleResponse, successResponse, errorResponseBadRequest } = require('../apiHelpers')
 const models = require('../models')
+const { getRateLimiter } = require('../rateLimiter')
+
+const socialHandlesRateLimiter = getRateLimiter({
+  prefix: 'socialHandlesRateLimiter:'
+})
 
 module.exports = function (app) {
   app.get('/social_handles', handleResponse(async (req, res, next) => {
@@ -15,38 +20,42 @@ module.exports = function (app) {
     } else return successResponse()
   }))
 
-  app.post('/social_handles', handleResponse(async (req, res, next) => {
-    let { handle, twitterHandle, instagramHandle, website, donation } = req.body
-    if (!handle) return errorResponseBadRequest('Please provide handle')
+  app.post(
+    '/social_handles',
+    socialHandlesRateLimiter,
+    handleResponse(async (req, res, next) => {
+      let { handle, twitterHandle, instagramHandle, website, donation } = req.body
+      if (!handle) return errorResponseBadRequest('Please provide handle')
 
-    const socialHandles = await models.SocialHandles.findOne({
-      where: { handle }
+      const socialHandles = await models.SocialHandles.findOne({
+        where: { handle }
+      })
+
+      // If twitterUser is verified, audiusHandle must match twitterHandle.
+      const twitterUser = await models.TwitterUser.findOne({ where: {
+        'twitterProfile.screen_name': twitterHandle,
+        verified: true
+      } })
+      if (twitterUser) { handle = twitterHandle }
+
+      if (socialHandles) {
+        await socialHandles.update({
+          handle,
+          twitterHandle,
+          instagramHandle,
+          website,
+          donation
+        })
+      } else {
+        await models.SocialHandles.create({
+          handle,
+          twitterHandle,
+          instagramHandle,
+          website,
+          donation
+        })
+      }
+      return successResponse()
     })
-
-    // If twitterUser is verified, audiusHandle must match twitterHandle.
-    const twitterUser = await models.TwitterUser.findOne({ where: {
-      'twitterProfile.screen_name': twitterHandle,
-      verified: true
-    } })
-    if (twitterUser) { handle = twitterHandle }
-
-    if (socialHandles) {
-      await socialHandles.update({
-        handle,
-        twitterHandle,
-        instagramHandle,
-        website,
-        donation
-      })
-    } else {
-      await models.SocialHandles.create({
-        handle,
-        twitterHandle,
-        instagramHandle,
-        website,
-        donation
-      })
-    }
-    return successResponse()
-  }))
+  )
 }

--- a/identity-service/src/routes/userEvents.js
+++ b/identity-service/src/routes/userEvents.js
@@ -1,6 +1,11 @@
 const { handleResponse, successResponse, errorResponseBadRequest } = require('../apiHelpers')
 const models = require('../models')
 const authMiddleware = require('../authMiddleware')
+const { getRateLimiter } = require('../rateLimiter')
+
+const userEventsRateLimiter = getRateLimiter({
+  prefix: 'userEventsRateLimiter:'
+})
 
 module.exports = function (app) {
   app.get('/userEvents', handleResponse(async (req, res) => {
@@ -27,29 +32,34 @@ module.exports = function (app) {
   *
   * @param {boolean} hasSignedInNativeMobile   If the user has signed in w/ native mobile
   */
-  app.post('/userEvents', authMiddleware, handleResponse(async (req, res) => {
-    const user = await models.User.findOne({
-      where: { id: req.user.id },
-      attributes: ['walletAddress']
-    })
-    const walletAddress = user.walletAddress
-    const hasSignedInNativeMobile = !!req.body.hasSignedInNativeMobile
-    try {
-      if (hasSignedInNativeMobile) {
-        await models.UserEvents.upsert({
-          walletAddress,
-          hasSignedInNativeMobile
-        })
-      } else {
-        // Note: The field `hasSignedInNativeMobile` defaults to false on create, but if already
-        // true, do not convert to false.
-        await models.UserEvents.findOrCreate({ where: { walletAddress } })
+  app.post(
+    '/userEvents',
+    userEventsRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res) => {
+      const user = await models.User.findOne({
+        where: { id: req.user.id },
+        attributes: ['walletAddress']
+      })
+      const walletAddress = user.walletAddress
+      const hasSignedInNativeMobile = !!req.body.hasSignedInNativeMobile
+      try {
+        if (hasSignedInNativeMobile) {
+          await models.UserEvents.upsert({
+            walletAddress,
+            hasSignedInNativeMobile
+          })
+        } else {
+          // Note: The field `hasSignedInNativeMobile` defaults to false on create, but if already
+          // true, do not convert to false.
+          await models.UserEvents.findOrCreate({ where: { walletAddress } })
+        }
+        return successResponse({})
+      } catch (e) {
+        req.logger.error(e)
+        console.log(e)
+        return errorResponseBadRequest('Unable to create user event')
       }
-      return successResponse({})
-    } catch (e) {
-      req.logger.error(e)
-      console.log(e)
-      return errorResponseBadRequest('Unable to create user event')
-    }
-  }))
+    })
+  )
 }

--- a/identity-service/src/routes/userPlaylistFavorites.js
+++ b/identity-service/src/routes/userPlaylistFavorites.js
@@ -1,26 +1,36 @@
 const { handleResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
 const models = require('../models')
 const authMiddleware = require('../authMiddleware')
+const { getRateLimiter } = require('../rateLimiter')
+
+const userPlaylistFavoritesRateLimiter = getRateLimiter({
+  prefix: 'userPlaylistFavoritesRateLimiter'
+})
 
 module.exports = function (app) {
-  app.post('/user_playlist_favorites', authMiddleware, handleResponse(async (req, res, next) => {
-    const { blockchainUserId: userId } = req.user
-    const { favorites } = req.body
+  app.post(
+    '/user_playlist_favorites',
+    userPlaylistFavoritesRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      const { blockchainUserId: userId } = req.user
+      const { favorites } = req.body
 
-    if (!favorites) return errorResponseBadRequest('Please provide a string array of favorites')
+      if (!favorites) return errorResponseBadRequest('Please provide a string array of favorites')
 
-    try {
-      await models.UserPlaylistFavorites.upsert({
-        userId,
-        favorites
-      })
+      try {
+        await models.UserPlaylistFavorites.upsert({
+          userId,
+          favorites
+        })
 
-      return successResponse('Success')
-    } catch (e) {
-      req.logger.error(`Unable to update favorites for: ${userId}`, e)
-      return errorResponseServerError(`Unable to update favorites for: ${userId}, Error: ${e.message}`)
-    }
-  }))
+        return successResponse('Success')
+      } catch (e) {
+        req.logger.error(`Unable to update favorites for: ${userId}`, e)
+        return errorResponseServerError(`Unable to update favorites for: ${userId}, Error: ${e.message}`)
+      }
+    })
+  )
 
   app.get('/user_playlist_favorites', authMiddleware, handleResponse(async (req, res, next) => {
     const { blockchainUserId: userId } = req.user

--- a/identity-service/src/routes/welcomeEmail.js
+++ b/identity-service/src/routes/welcomeEmail.js
@@ -4,6 +4,7 @@ const handlebars = require('handlebars')
 const fs = require('fs')
 const path = require('path')
 const authMiddleware = require('../authMiddleware')
+const { getRateLimiter } = require('../rateLimiter')
 
 const getEmailTemplate = (path) => handlebars.compile(
   fs.readFileSync(path).toString()
@@ -15,68 +16,77 @@ const welcomeTemplate = getEmailTemplate(welcomeTemplatePath)
 const welcomeDownloadTemplatePath = path.resolve(__dirname, '../notifications/emails/welcomeDownload.html')
 const welcomeDownloadTemplate = getEmailTemplate(welcomeDownloadTemplatePath)
 
+const welcomeEmailRateLimiter = getRateLimiter({
+  prefix: 'welcomeEmailRateLimiter:'
+})
+
 module.exports = function (app) {
   /**
    * Send the welcome email information to the requested account
    */
-  app.post('/email/welcome', authMiddleware, handleResponse(async (req, res, next) => {
-    let mg = req.app.get('mailgun')
-    if (!mg) {
-      req.logger.error('Missing api key')
-      // Short-circuit if no api key provided, but do not error
-      return successResponse({ msg: 'No mailgun API Key found', status: true })
-    }
-
-    let { name, isNativeMobile = false } = req.body
-    if (!name) {
-      return errorResponseBadRequest('Please provide a name')
-    }
-
-    const existingUser = await models.User.findOne({
-      where: { id: req.user.id }
-    })
-
-    if (!existingUser) {
-      return errorResponseBadRequest('Invalid signature provided, no user found')
-    }
-
-    const walletAddress = existingUser.walletAddress
-    const htmlTemplate = isNativeMobile ? welcomeTemplate : welcomeDownloadTemplate
-    const welcomeHtml = htmlTemplate({
-      name
-    })
-
-    const emailParams = {
-      from: 'The Audius Team <team@audius.co>',
-      to: existingUser.email,
-      bcc: 'forrest@audius.co',
-      subject: 'The Automated Welcome Email',
-      html: welcomeHtml
-    }
-    try {
-      await new Promise((resolve, reject) => {
-        mg.messages().send(emailParams, (error, body) => {
-          if (error) {
-            reject(error)
-          }
-          resolve(body)
-        })
-      })
-      if (isNativeMobile) {
-        await models.UserEvents.upsert({
-          walletAddress,
-          hasSignedInNativeMobile: true
-        })
-      } else {
-        await models.UserEvents.upsert({
-          walletAddress,
-          hasSignedInNativeMobile: false
-        })
+  app.post(
+    '/email/welcome',
+    welcomeEmailRateLimiter,
+    authMiddleware,
+    handleResponse(async (req, res, next) => {
+      let mg = req.app.get('mailgun')
+      if (!mg) {
+        req.logger.error('Missing api key')
+        // Short-circuit if no api key provided, but do not error
+        return successResponse({ msg: 'No mailgun API Key found', status: true })
       }
-      return successResponse({ status: true })
-    } catch (e) {
-      console.log(e)
-      return errorResponseServerError(e)
-    }
-  }))
+
+      let { name, isNativeMobile = false } = req.body
+      if (!name) {
+        return errorResponseBadRequest('Please provide a name')
+      }
+
+      const existingUser = await models.User.findOne({
+        where: { id: req.user.id }
+      })
+
+      if (!existingUser) {
+        return errorResponseBadRequest('Invalid signature provided, no user found')
+      }
+
+      const walletAddress = existingUser.walletAddress
+      const htmlTemplate = isNativeMobile ? welcomeTemplate : welcomeDownloadTemplate
+      const welcomeHtml = htmlTemplate({
+        name
+      })
+
+      const emailParams = {
+        from: 'The Audius Team <team@audius.co>',
+        to: existingUser.email,
+        bcc: 'forrest@audius.co',
+        subject: 'The Automated Welcome Email',
+        html: welcomeHtml
+      }
+      try {
+        await new Promise((resolve, reject) => {
+          mg.messages().send(emailParams, (error, body) => {
+            if (error) {
+              reject(error)
+            }
+            resolve(body)
+          })
+        })
+        if (isNativeMobile) {
+          await models.UserEvents.upsert({
+            walletAddress,
+            hasSignedInNativeMobile: true
+          })
+        } else {
+          await models.UserEvents.upsert({
+            walletAddress,
+            hasSignedInNativeMobile: false
+          })
+        }
+        return successResponse({ status: true })
+      } catch (e) {
+        console.log(e)
+        return errorResponseServerError(e)
+      }
+    })
+  )
 }


### PR DESCRIPTION
### Trello Card Link


### Description
Adds more rate limiting to db-write endpoints in identity & creator node via a generic getRateLimiter method. Thought it was cleaner to define these rate limits with the endpoints themselves rather than in an app.js, where they're harder to tune / customize to specific endpoints.

Unless otherwise specified, each post has a rate limiter defined to restrict writes to 30 / hour (by endpoint + ip)

Note: the diff is not as large as it looks, mostly indentation changes.

### Services

- [x] Creator Node
- [x] Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this rate limits writes


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran entire system locally and as I added each rate limiter, I verified that I could exercise it with the following snippet:

```
let url = 'http://localhost:4000/vector_clock_backfill/abc'; let s = async () => { for (let i = 0; i < 40; ++i) { const res = await fetch(url, { method: 'POST' }); console.log(res.status); } }; s()
```

2. Ran dapp against the local setup, created account, uploaded tracks, changed profile info
