### PR TITLE
Fail nodesync if immediate is true

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -192,7 +192,8 @@ module.exports = function (app) {
         req.logger.info('set timeout for', wallet, 'time', Date.now())
       }
     } else {
-      await _nodesync(req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync)
+      let errorObj = await _nodesync(req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync)
+      if (errorObj) return errorResponseServerError(errorObj)
     }
     return successResponse()
   }))


### PR DESCRIPTION
### Trello Card Link
None

### Description
Bad bug that makes libs think sync incorrectly succeeded for user->creator flow even if an error is thrown
https://audius.loggly.com/search#terms=0x97fe32b7f561741a2c4ac87620c8ec2baf7185ff&from=2020-10-28T03:10:34.771Z&until=2020-10-28T03:27:00.000Z&source_group=36033&event=d66dc502-18cc-11eb-8031-0234fe2ede76,1603855361484,138231481614845186

Actual error is 
TimeoutError: Request timed out
    at Timeout.safeTimeout (/usr/src/app/node_modules/ky/umd.js:174:12)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10) name: 'TimeoutError'

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches first time user to creator flow


### How Has This Been Tested?
Testing locally