### PR TITLE
Add heartbeat method to upload

### DIFF
--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -22,6 +22,46 @@ module.exports.handleResponse = (func) => {
   }
 }
 
+/**
+ * Like `handleResponse` but on an interval sends a heartbeat back through
+ * `res.write` as a piece of the JSON result
+ * @param {() => void} func returns the response JSON
+ */
+module.exports.handleResponseWithHeartbeat = (func) => {
+  return async function (req, res, next) {
+    try {
+      // First declare our content type since we will be sending heartbeats back
+      // in JSON
+      res.set('Content-Type', 'application/json; charset=utf-8')
+
+      // set custom CORS headers that's required if you want to response
+      // headers through axios
+      res.set('Access-Control-Expose-Headers', 'CN-Request-ID')
+
+      // Write a key for the heartbeat
+      res.write('{"_h":"')
+
+      // Fire up an interval that will append a single char to the res
+      const heartbeatInterval = setInterval(() => {
+        if (!res.finished) {
+          res.write('1')
+        }
+      }, 1000)
+
+      // Await the work of the endpoint
+      const resp = await func(req, res, next)
+
+      clearInterval(heartbeatInterval)
+
+      sendResponseWithHeartbeatTerminator(req, res, resp)
+      next()
+    } catch (error) {
+      console.error('HandleResponse', error)
+      next(error)
+    }
+  }
+}
+
 const sendResponse = module.exports.sendResponse = (req, res, resp) => {
   const endTime = process.hrtime(req.startTime)
   const duration = Math.round(endTime[0] * 1e3 + endTime[1] * 1e-6)
@@ -50,6 +90,38 @@ const sendResponse = module.exports.sendResponse = (req, res, resp) => {
 
   res.status(resp.statusCode).send(resp.object)
 }
+
+const sendResponseWithHeartbeatTerminator =
+  module.exports.sendResponseWithHeartbeatTerminator = (req, res, resp) => {
+    const endTime = process.hrtime(req.startTime)
+    const duration = Math.round(endTime[0] * 1e3 + endTime[1] * 1e-6)
+    let logger = req.logger.child({
+      statusCode: resp.statusCode,
+      duration
+    })
+    if (resp.statusCode === 200) {
+      if (requestNotExcludedFromLogging(req.originalUrl)) {
+        logger.info('Success')
+      }
+    } else {
+      logger = logger.child({
+        errorMessage: resp.object.error
+      })
+      if (req && req.body) {
+        logger.info('Error processing request:', resp.object.error, '|| Request Body:', req.body)
+      } else {
+        logger.info('Error processing request:', resp.object.error)
+      }
+    }
+
+    // Construct the remainder of the JSON response
+    let response = '",'
+    // Replace the first '{' since we already have that
+    response += JSON.stringify(resp.object).replace('{', '')
+
+    // Terminate the response
+    res.end(response)
+  }
 
 const isValidResponse = module.exports.isValidResponse = (resp) => {
   if (!resp || !resp.statusCode || !resp.object) {

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -46,7 +46,7 @@ module.exports.handleResponseWithHeartbeat = (func) => {
         if (!res.finished) {
           res.write('1')
         }
-      }, 1000)
+      }, 5000)
 
       // Await the work of the endpoint
       const resp = await func(req, res, next)

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const { handleResponse, successResponse, errorResponseBadRequest } = require('../../apiHelpers')
+const { handleResponse, successResponse, errorResponseBadRequest, handleResponseWithHeartbeat } = require('../../apiHelpers')
 const { healthCheck, healthCheckDuration } = require('./healthCheckComponentService')
 const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
@@ -64,5 +64,6 @@ const healthCheckDurationController = async (req) => {
 router.get('/health_check', handleResponse(healthCheckController))
 router.get('/health_check/sync', handleResponse(syncHealthCheckController))
 router.get('/health_check/duration', handleResponse(healthCheckDurationController))
+router.get('/health_check/duration/heartbeat', handleResponseWithHeartbeat(healthCheckDurationController))
 
 module.exports = router

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -305,7 +305,7 @@ module.exports = function (app) {
   /**
    * Store image in multiple-resolutions on disk + DB and make available via IPFS
    */
-  app.post('/image_upload', authMiddleware, syncLockMiddleware, uploadTempDiskStorage.single('file'), handleResponse(async (req, res) => {
+  app.post('/image_upload', authMiddleware, syncLockMiddleware, uploadTempDiskStorage.single('file'), handleResponseWithHeartbeat(async (req, res) => {
     if (!req.body.square || !(req.body.square === 'true' || req.body.square === 'false')) {
       return errorResponseBadRequest('Must provide square boolean param in request body')
     }

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -14,7 +14,8 @@ const {
   errorResponseNotFound,
   errorResponseForbidden,
   errorResponseRangeNotSatisfiable,
-  errorResponseUnauthorized
+  errorResponseUnauthorized,
+  handleResponseWithHeartbeat
 } = require('../apiHelpers')
 const { recoverWallet } = require('../apiSigning')
 

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -8,6 +8,7 @@ const models = require('../models')
 const { saveFileFromBufferToIPFSAndDisk, saveFileToIPFSFromFS, removeTrackFolder, handleTrackContentUpload } = require('../fileManager')
 const {
   handleResponse,
+  handleResponseWithHeartbeat,
   sendResponse,
   successResponse,
   errorResponseBadRequest,
@@ -27,7 +28,7 @@ module.exports = function (app) {
    * upload track segment files and make avail - will later be associated with Audius track
    * @dev - Prune upload artifacts after successful and failed uploads. Make call without awaiting, and let async queue clean up.
    */
-  app.post('/track_content', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, handleTrackContentUpload, handleResponse(async (req, res) => {
+  app.post('/track_content', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, handleTrackContentUpload, handleResponseWithHeartbeat(async (req, res) => {
     if (req.fileSizeError) {
       // Prune upload artifacts
       removeTrackFolder(req, req.fileDir)

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -124,11 +124,11 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(trackContentResp.body.track_segments.length, 32)
-    assert.deepStrictEqual(trackContentResp.body.source_file.includes('.mp3'), true)
-    assert.deepStrictEqual(trackContentResp.body.transcodedTrackCID, 'testCIDLink')
-    assert.deepStrictEqual(typeof trackContentResp.body.transcodedTrackUUID, 'string')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(trackContentResp.body.data.transcodedTrackCID, 'testCIDLink')
+    assert.deepStrictEqual(typeof trackContentResp.body.data.transcodedTrackUUID, 'string')
   })
 
   // depends on "uploads /track_content"
@@ -146,24 +146,24 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(trackContentResp.body.track_segments.length, 32)
-    assert.deepStrictEqual(trackContentResp.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
     // creates Audius track
     const metadata = {
       test: 'field1',
       owner_id: 1,
-      track_segments: trackContentResp.body.track_segments
+      track_segments: trackContentResp.body.data.track_segments
     }
 
     const trackMetadataResp = await request(app)
       .post('/tracks/metadata')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: trackContentResp.body.source_file })
+      .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    assert.deepStrictEqual(trackMetadataResp.body.metadataMultihash, 'testCIDLink')
+    assert.deepStrictEqual(trackMetadataResp.body.data.metadataMultihash, 'testCIDLink')
   })
 
   // depends on "uploads /track_content"
@@ -181,9 +181,9 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(resp1.body.track_segments.length, 32)
-    assert.deepStrictEqual(resp1.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
     // creates Audius track
     const metadata = {
@@ -194,7 +194,7 @@ describe('test Tracks with mocked IPFS', function () {
     await request(app)
       .post('/tracks/metadata')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: resp1.body.source_file })
+      .send({ metadata, sourceFile: resp1.body.data.source_file })
       .expect(400)
   })
 
@@ -213,9 +213,9 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(resp1.body.track_segments.length, 32)
-    assert.deepStrictEqual(resp1.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
     // creates Audius track
     const metadata = {
@@ -227,7 +227,7 @@ describe('test Tracks with mocked IPFS', function () {
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: resp1.body.source_file })
+      .send({ metadata, sourceFile: resp1.body.data.source_file })
       .expect(400)
   })
 
@@ -246,9 +246,9 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(resp1.body.track_segments.length, 32)
-    assert.deepStrictEqual(resp1.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
     // creates Audius track
     const metadata = {
@@ -259,7 +259,7 @@ describe('test Tracks with mocked IPFS', function () {
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: resp1.body.source_file })
+      .send({ metadata, sourceFile: resp1.body.data.source_file })
       .expect(400)
   })
 
@@ -278,30 +278,30 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(trackContentResp.body.track_segments.length, 32)
-    assert.deepStrictEqual(trackContentResp.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
     const metadata = {
       test: 'field1',
-      track_segments: trackContentResp.body.track_segments,
+      track_segments: trackContentResp.body.data.track_segments,
       owner_id: 1
     }
 
     const trackMetadataResp = await request(app)
       .post('/tracks/metadata')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: trackContentResp.body.source_file })
+      .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    if (trackMetadataResp.body.metadataMultihash !== 'testCIDLink') {
+    if (trackMetadataResp.body.data.metadataMultihash !== 'testCIDLink') {
       throw new Error('invalid return data')
     }
 
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
-      .send({ blockchainTrackId: 1, blockNumber: 10, metadataFileUUID: trackMetadataResp.body.metadataFileUUID })
+      .send({ blockchainTrackId: 1, blockNumber: 10, metadataFileUUID: trackMetadataResp.body.data.metadataFileUUID })
       .expect(200)
   })
 
@@ -320,8 +320,8 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(resp1.body.track_segments.length, 32)
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
 
     // creates a downloadable Audius track with no track_id and no source_file
     const metadata = {
@@ -356,14 +356,14 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.track_segments[0].multihash, 'testCIDLink')
-    assert.deepStrictEqual(trackContentResp.body.track_segments.length, 32)
-    assert.deepStrictEqual(trackContentResp.body.source_file.includes('.mp3'), true)
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
+    assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
     // needs debugging as to why this 'cid' key is needed for test to work
     const metadata = {
       test: 'field1',
-      track_segments: trackContentResp.body.track_segments,
+      track_segments: trackContentResp.body.data.track_segments,
       owner_id: 1,
       download: {
         'is_downloadable': true,
@@ -375,17 +375,17 @@ describe('test Tracks with mocked IPFS', function () {
     const trackMetadataResp = await request(app)
       .post('/tracks/metadata')
       .set('X-Session-ID', session.sessionToken)
-      .send({ metadata, sourceFile: trackContentResp.body.source_file })
+      .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    if (trackMetadataResp.body.metadataMultihash !== 'testCIDLink') {
+    if (trackMetadataResp.body.data.metadataMultihash !== 'testCIDLink') {
       throw new Error('invalid return data')
     }
 
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
-      .send({ blockchainTrackId: 1, blockNumber: 10, metadataFileUUID: trackMetadataResp.body.metadataFileUUID })
+      .send({ blockchainTrackId: 1, blockNumber: 10, metadataFileUUID: trackMetadataResp.body.data.metadataFileUUID })
       .expect(200)
   })
 })
@@ -489,7 +489,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)
-    const transcodedTrackPath = path.join(storagePath, resp.body.transcodedTrackCID)
+    const transcodedTrackPath = path.join(storagePath, resp.body.data.transcodedTrackCID)
     const transcodedTrackTestBuf = fs.readFileSync(transcodedTrackPath)
     assert.deepStrictEqual(transcodedTrackAssetBuf.compare(transcodedTrackTestBuf), 0)
 
@@ -497,7 +497,7 @@ describe('test Tracks with real IPFS', function () {
     //    and each segment disk file is exactly as expected
     // Note - The exact output of track segmentation is deterministic only for a given environment/ffmpeg version
     //    This test may break in the future but at that point we should re-generate the reference segment files.
-    const segmentCIDs = resp.body.track_segments
+    const segmentCIDs = resp.body.data.track_segments
     assert.deepStrictEqual(segmentCIDs.length, testAudiusFileNumSegments)
     segmentCIDs.map(function (cid, index) {
       const cidPath = path.join(storagePath, cid.multihash)
@@ -578,7 +578,7 @@ describe('test Tracks with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = path.join(config.get('storagePath'), resp.body.metadataMultihash)
+    const metadataPath = path.join(config.get('storagePath'), resp.body.data.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified
@@ -588,7 +588,7 @@ describe('test Tracks with real IPFS', function () {
 
     // check that the correct metadata file properties were written to db
     const file = await models.File.findOne({ where: {
-      multihash: resp.body.metadataMultihash,
+      multihash: resp.body.data.metadataMultihash,
       storagePath: metadataPath,
       type: 'metadata'
     } })
@@ -597,7 +597,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the metadata file is in IPFS
     let ipfsResp
     try {
-      ipfsResp = await ipfs.cat(resp.body.metadataMultihash)
+      ipfsResp = await ipfs.cat(resp.body.data.metadataMultihash)
     } catch (e) {
       // If CID is not present, will throw timeout error
       assert.fail(e.message)

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -44,12 +44,12 @@ describe('test Tracks with mocked IPFS', function () {
   it('fails to upload when format is not accepted', async function () {
     const file = fs.readFileSync(testAudioFileWrongFormatPath)
 
-    await request(app)
+    const res = await request(app)
       .post('/track_content')
       .attach('file', file, { filename: 'fname.jpg' })
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', session.sessionToken)
-      .expect(400)
+    assert.notStrictEqual(res.error, undefined)
   })
 
   it('fails to upload when maxAudioFileSizeBytes exceeded', async function () {
@@ -426,24 +426,24 @@ describe('test Tracks with real IPFS', function () {
     const file = fs.readFileSync(testAudioFilePath)
     sinon.stub(TranscodingQueue, 'segment').rejects(new Error('failed to segment'))
 
-    await request(app)
+    const res = await request(app)
       .post('/track_content')
       .attach('file', file, { filename: 'fname.mp3' })
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', session.sessionToken)
-      .expect(500)
+    assert.notStrictEqual(res.error, undefined)
   })
 
   it('sends server error response if transcoding fails', async function () {
     const file = fs.readFileSync(testAudioFilePath)
     sinon.stub(TranscodingQueue, 'transcode320').rejects(new Error('failed to transcode'))
 
-    await request(app)
+    const res = await request(app)
       .post('/track_content')
       .attach('file', file, { filename: 'fname.mp3' })
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', session.sessionToken)
-      .expect(500)
+    assert.notStrictEqual(res.error, undefined)
   })
 
   // Note: if hashing logic from ipfs ever changes, this test will fail
@@ -461,12 +461,12 @@ describe('test Tracks with real IPFS', function () {
 
     // Attempt to associate track content and get forbidden error
     const file = fs.readFileSync(testAudioFilePath)
-    await request(app)
+    const res = await request(app)
       .post('/track_content')
       .attach('file', file, { filename: 'fname.mp3' })
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', session.sessionToken)
-      .expect(403)
+    assert.notStrictEqual(res.error, undefined)
 
     // Clear redis of segment CIDs
     await BlacklistManager.removeFromRedis(BlacklistManager.getRedisSegmentCIDKey(), testTrackCIDs)
@@ -489,7 +489,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)
-    const transcodedTrackPath = path.join(storagePath, resp.body.data.transcodedTrackCID)
+    const transcodedTrackPath = path.join(storagePath, resp.body.transcodedTrackCID)
     const transcodedTrackTestBuf = fs.readFileSync(transcodedTrackPath)
     assert.deepStrictEqual(transcodedTrackAssetBuf.compare(transcodedTrackTestBuf), 0)
 

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -497,6 +497,9 @@ class CreatorNode {
           }
         }
       )
+      if (resp.data && resp.data.error) {
+        throw new Error(resp.data.error)
+      }
       onProgress(total, total)
       return resp.data
     } catch (e) {
@@ -516,7 +519,7 @@ function _handleErrorHelper (e, requestUrl) {
     // delete headers, may contain tokens
     if (e.config && e.config.headers) delete e.config.headers
     console.error(`Network error while making request to ${requestUrl} ${JSON.stringify(e)}`)
-    throw new Error(`Network error while making request to ${requestUrl}`)
+    throw new Error(`Network error while making request to ${requestUrl} ${e}`)
   } else {
     throw e
   }


### PR DESCRIPTION
### Trello Card Link


### Description
Adds a heartbeat to /track_content via a new middleware

The same pattern could be applied to relays if we wanted to in identity if we think >= 60s is likely.

### Services

- [x] Creator Node
- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches track upload


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually & on creatornode3 staging
 - Tested uploading a short track & a long track & several tracks together
 - Tested manually throwing an error inside of the /track_content route to trigger the "non success" case, which unfortunately is still a 200 -- but our clients "handle" this ok.

Staging QA List
- [x] - Create new user
- [x] - Upgrade to creator + upload first track
- [x] - Upload track on low quality network (2mb)
- [x] - Upload playlist of 20 things
- [x] - Upload long track (40+min)
- [x] - Upload long track on low network (40+min, 2mb)
- [x] - Switch primary nodes (triggering syncs)
- [x] - Upload track that should throw an error (file type mismatch)
- [x] - Upload 6 tracks, making sure that #5 throws an error (since we do 4 concurrently)
To work totally properly (fixed log traces), requires merging + deploying the libs change in this PR

- [x] - Try to get image upload to fail (many concurrent)

```
doWork = async () => {
	const imageUrl = 'https://picsum.photos/200/300';
	const image = await fetch(imageUrl);
	const blob = await image.blob();
	console.log(blob);

	const formData = new FormData();
	formData.append('file', blob);
	formData.append('square', true);

	const res = await fetch('https://creatornode2.staging.audius.co/image_upload', {
		method: 'POST',
	    body: formData,
	    headers: {
	    	'X-Session-ID': 'MmPofktP7iGxWiKJwYTt07WS7mCDYmYDMARda-SsjsKRHcRUPbGcGw',
	    }
	})
	const json = await res.json()
	console.log(json)
}

(new Array(10)).fill(null).forEach(async () => {
	await doWork();
})
```