### PR TITLE
Add CN health_check/sync endpoint

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const { handleResponse, successResponse } = require('../../apiHelpers')
 const { healthCheck } = require('./healthCheckComponentService')
+const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
 const { sequelize } = require('../../models')
 
@@ -18,8 +19,18 @@ const healthCheckController = async (req) => {
   return successResponse(response)
 }
 
+/**
+ * Controller for `health_check/sync` route, calls
+ * syncHealthCheckController
+ */
+const syncHealthCheckController = async () => {
+  const response = await syncHealthCheck(serviceRegistry)
+  return successResponse(response)
+}
+
 // Routes
 
 router.get('/health_check', handleResponse(healthCheckController))
+router.get('/health_check/sync', handleResponse(syncHealthCheckController))
 
 module.exports = router

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
@@ -1,0 +1,35 @@
+const { SyncPriority } = require('../../snapbackSM')
+
+const priorityMap = {
+  [SyncPriority.High]: 'HIGH',
+  [SyncPriority.Low]: 'LOW'
+}
+
+const getJobInfo = job => {
+  return {
+    type: job.name,
+    priority: priorityMap[job.opts.priority],
+    id: job.id
+  }
+}
+
+const makeResponse = (pendingJobs, activeJobs) => ({
+  pending: pendingJobs.map(getJobInfo),
+  active: activeJobs.map(getJobInfo),
+  pendingCount: pendingJobs.length
+})
+
+/**
+ * Returns information about sync queue.
+ * Response: {
+ *  pending: Array<{ type, priority, id }>,
+ *  active: Array<{ type, priority, id }>,
+ *  pendingCount: numberI
+ * }
+ */
+const syncHealthCheck = async ({ snapbackSM }) => {
+  const jobs = await snapbackSM.getSyncQueueJobs()
+  return makeResponse(jobs.pending, jobs.active)
+}
+
+module.exports = { syncHealthCheck }

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
@@ -1,9 +1,4 @@
-const { SyncPriority } = require('../../snapbackSM')
-
-const priorityMap = {
-  [SyncPriority.High]: 'HIGH',
-  [SyncPriority.Low]: 'LOW'
-}
+const { priorityMap } = require('../../snapbackSM')
 
 const getJobInfo = job => {
   return {

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
@@ -1,12 +1,10 @@
 const { priorityMap } = require('../../snapbackSM')
 
-const getJobInfo = job => {
-  return {
-    type: job.name,
-    priority: priorityMap[job.opts.priority],
-    id: job.id
-  }
-}
+const getJobInfo = job => ({
+  type: job.name,
+  priority: priorityMap[job.opts.priority],
+  id: job.id
+})
 
 const makeResponse = (pendingJobs, activeJobs) => ({
   pending: pendingJobs.map(getJobInfo),
@@ -19,7 +17,7 @@ const makeResponse = (pendingJobs, activeJobs) => ({
  * Response: {
  *  pending: Array<{ type, priority, id }>,
  *  active: Array<{ type, priority, id }>,
- *  pendingCount: numberI
+ *  pendingCount: number
  * }
  */
 const syncHealthCheck = async ({ snapbackSM }) => {

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
@@ -35,7 +35,7 @@ describe('Test sync health check', function () {
 
     const res = await syncHealthCheck({ snapbackSM: mockSnapback })
     assert.deepStrictEqual(res, {
-      pending: [{ type: 'RECURRING', id: 2, priority: 'LOW'}, { type: 'MANUAL', id: 3, priority: 'HIGH'}],
+      pending: [{ type: 'RECURRING', id: 2, priority: 'LOW' }, { type: 'MANUAL', id: 3, priority: 'HIGH' }],
       active: [{ type: 'MANUAL', id: 1, priority: 'HIGH' }],
       pendingCount: 2
     })

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
@@ -1,0 +1,43 @@
+const { SyncPriority } = require('../../snapbackSM')
+const { syncHealthCheck } = require('./syncHealthCheckComponentService')
+const assert = require('assert')
+
+describe('Test sync health check', function () {
+  it('Should return active and pending jobs', async function () {
+    const mockSnapback = {
+      getSyncQueueJobs: async () => Promise.resolve({
+        pending: [{
+          name: 'RECURRING',
+          id: 2,
+          opts:
+            {
+              priority: SyncPriority.Low
+            }
+        }, {
+          name: 'MANUAL',
+          id: 3,
+          opts:
+            {
+              priority: SyncPriority.High
+            }
+        }
+        ],
+        active: [{
+          name: 'MANUAL',
+          id: 1,
+          opts:
+            {
+              priority: SyncPriority.High
+            }
+        }]
+      })
+    }
+
+    const res = await syncHealthCheck({ snapbackSM: mockSnapback })
+    assert.deepStrictEqual(res, {
+      pending: [{ type: 'RECURRING', id: 2, priority: 'LOW'}, { type: 'MANUAL', id: 3, priority: 'HIGH'}],
+      active: [{ type: 'MANUAL', id: 1, priority: 'HIGH' }],
+      pendingCount: 2
+    })
+  })
+})

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -30,6 +30,12 @@ const SyncPriority = Object.freeze({
   High: 1
 })
 
+// Helpful strings for printing priorities
+const priorityMap = {
+  [SyncPriority.High]: 'HIGH',
+  [SyncPriority.Low]: 'LOW'
+}
+
 // Describes the sync type - Recurring (scheduled) or Manual (triggered
 // by a user action). Currently only used for logging purposes.
 const SyncType = Object.freeze({
@@ -389,6 +395,7 @@ class SnapbackSM {
 
   // Main sync queue job
   async processSyncOperation (job) {
+    const {name: jobType, opts: { priority }, id} = job
     const syncRequestParameters = job.data.syncRequestParameters
     let isValidSyncJobData = (
       ('baseURL' in syncRequestParameters) &&
@@ -404,7 +411,8 @@ class SnapbackSM {
     const syncWallet = syncRequestParameters.data.wallet[0]
     const primaryClockValue = job.data.primaryClockValue
     const secondaryUrl = syncRequestParameters.baseURL
-    this.log(`------------------Process SYNC | User ${syncWallet} | Target: ${secondaryUrl} ------------------`)
+    this.log(`------------------Process SYNC | User ${syncWallet} | Target: ${secondaryUrl} | type: ${jobType} | priority: ${priorityMap[priority]} | jobID: ${id} ------------------`)
+
 
     // Issue sync request to secondary
     await axios(syncRequestParameters)
@@ -414,7 +422,7 @@ class SnapbackSM {
 
     // Exit when sync status is computed
     // Determine how many times to retry this operation
-    this.log('------------------END Process SYNC------------------')
+    this.log(`------------------END Process SYNC | jobID: ${id}------------------`)
   }
 
   // Query eth-contracts chain for endpoint to ID info
@@ -515,4 +523,4 @@ class SnapbackSM {
   }
 }
 
-module.exports = { SnapbackSM, SyncPriority, SyncType }
+module.exports = { SnapbackSM, SyncPriority, SyncType, priorityMap }

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -395,7 +395,7 @@ class SnapbackSM {
 
   // Main sync queue job
   async processSyncOperation (job) {
-    const {name: jobType, opts: { priority }, id} = job
+    const { name: jobType, opts: { priority }, id } = job
     const syncRequestParameters = job.data.syncRequestParameters
     let isValidSyncJobData = (
       ('baseURL' in syncRequestParameters) &&
@@ -412,7 +412,6 @@ class SnapbackSM {
     const primaryClockValue = job.data.primaryClockValue
     const secondaryUrl = syncRequestParameters.baseURL
     this.log(`------------------Process SYNC | User ${syncWallet} | Target: ${secondaryUrl} | type: ${jobType} | priority: ${priorityMap[priority]} | jobID: ${id} ------------------`)
-
 
     // Issue sync request to secondary
     await axios(syncRequestParameters)

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -28,7 +28,7 @@ describe('test sync queue', function () {
     await server.close()
   })
 
-  it.only('prioritizes manual syncs', async function () {
+  it('prioritizes manual syncs', async function () {
     // Mock out the initial call to sync
     nock(constants.secondaryEndpoint)
       .persist()
@@ -42,7 +42,7 @@ describe('test sync queue', function () {
       .delayBody(500)
       .reply(200, { data: { clockValue: constants.primaryClockVal } })
 
-    // Mock out getUserPrimaryClockValues{ id }
+    // Mock out getUserPrimaryClockValues
     await models.CNodeUser.create({
       walletPublicKey: constants.userWallet,
       clock: constants.primaryClockVal
@@ -54,7 +54,7 @@ describe('test sync queue', function () {
     // Setup the recurring syncs
     const recurringSyncIds = new Set()
     for (let i = 0; i < 5; i++) {
-      const job = await snapback.issueSecondarySync({
+      const { id } = await snapback.issueSecondarySync({
         userWallet: constants.userWallet,
         secondaryEndpoint: constants.secondaryEndpoint,
         primaryEndpoint: constants.primaryEndpoint,
@@ -62,8 +62,7 @@ describe('test sync queue', function () {
         syncType: SyncType.Recurring,
         primaryClockValue: constants.primaryClockVal
       })
-      console.log({ job })
-      recurringSyncIds.add(job.id)
+      recurringSyncIds.add(id)
     }
 
     // setup manual syncs


### PR DESCRIPTION

### Description
- Adds observability to sync queue.
- Improves logging around sync queue

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?
- Tested uploading tracks, refreshing healthcheck endpoint
- Added unit test for endpoint