### PR TITLE
Add wallet + secondary to sync healthcheck

### DIFF
--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.js
@@ -3,7 +3,9 @@ const { priorityMap } = require('../../snapbackSM')
 const getJobInfo = job => ({
   type: job.name,
   priority: priorityMap[job.opts.priority],
-  id: job.id
+  id: job.id,
+  wallet: job.data.syncRequestParameters.data.wallet[0],
+  secondary: job.data.syncRequestParameters.baseURL
 })
 
 const makeResponse = (pendingJobs, activeJobs) => ({

--- a/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/syncHealthCheckComponentService.test.js
@@ -2,6 +2,9 @@ const { SyncPriority } = require('../../snapbackSM')
 const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const assert = require('assert')
 
+const WALLET = 'wallet_addr'
+const SECONDARY = 'http:test-cn.audius.co'
+
 describe('Test sync health check', function () {
   it('Should return active and pending jobs', async function () {
     const mockSnapback = {
@@ -9,6 +12,14 @@ describe('Test sync health check', function () {
         pending: [{
           name: 'RECURRING',
           id: 2,
+          data: {
+            syncRequestParameters: {
+              data: {
+                wallet: [WALLET]
+              },
+              baseURL: SECONDARY
+            }
+          },
           opts:
             {
               priority: SyncPriority.Low
@@ -16,6 +27,14 @@ describe('Test sync health check', function () {
         }, {
           name: 'MANUAL',
           id: 3,
+          data: {
+            syncRequestParameters: {
+              data: {
+                wallet: [WALLET]
+              },
+              baseURL: SECONDARY
+            }
+          },
           opts:
             {
               priority: SyncPriority.High
@@ -25,6 +44,14 @@ describe('Test sync health check', function () {
         active: [{
           name: 'MANUAL',
           id: 1,
+          data: {
+            syncRequestParameters: {
+              data: {
+                wallet: [WALLET]
+              },
+              baseURL: SECONDARY
+            }
+          },
           opts:
             {
               priority: SyncPriority.High
@@ -35,8 +62,8 @@ describe('Test sync health check', function () {
 
     const res = await syncHealthCheck({ snapbackSM: mockSnapback })
     assert.deepStrictEqual(res, {
-      pending: [{ type: 'RECURRING', id: 2, priority: 'LOW' }, { type: 'MANUAL', id: 3, priority: 'HIGH' }],
-      active: [{ type: 'MANUAL', id: 1, priority: 'HIGH' }],
+      pending: [{ type: 'RECURRING', id: 2, priority: 'LOW', wallet: WALLET, secondary: SECONDARY }, { type: 'MANUAL', id: 3, priority: 'HIGH', wallet: WALLET, secondary: SECONDARY }],
+      active: [{ type: 'MANUAL', id: 1, priority: 'HIGH', wallet: WALLET, secondary: SECONDARY }],
       pendingCount: 2
     })
   })


### PR DESCRIPTION
### Description
Added wallet + secondary info to health_check/sync

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested from client