### PR TITLE
Add sort by version in Creator Node selection

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,6 +1,6 @@
 const { sampleSize } = require('lodash')
 const { Base } = require('./base')
-const { timeRequestsAndSortByVersion } = require('../utils/network')
+const { timeRequests, timeRequestsAndSortByVersion } = require('../utils/network')
 
 const CREATOR_NODE_SERVICE_NAME = 'creator-node'
 const DISCOVERY_PROVIDER_SERVICE_NAME = 'discovery-provider'

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -99,7 +99,7 @@ class ServiceProvider extends Base {
     const timings = await timeRequests(
       creatorNodes.map(node => ({
         id: node,
-        url: `${node}/version`
+        url: `${node}/health_check`
       }))
     )
 
@@ -110,10 +110,9 @@ class ServiceProvider extends Base {
     // Primary: select the lowest-latency
     const primary = timings[0] ? timings[0].request.id : null
 
-    // Secondaries: select randomly
     // TODO: Implement geolocation-based selection
-    const secondaries = sampleSize(timings.slice(1), numberOfNodes - 1)
-      .map(timing => timing.request.id)
+    // Secondaries: Timings will be sorted according to highest version.
+    const secondaries = [timings[1] ? timings[1].request.id : null, timings[2] ? timings[2].request.id : null]
 
     return { primary, secondaries, services }
   }

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -29,7 +29,21 @@ async function timeRequests (requests) {
     timeRequest(request)
   ))
 
-  timings.sort((a, b) => {
+  return timings.sort((a, b) => a.millis - b.millis)
+}
+
+/**
+ * Fetches multiple urls and times each request and returns the results sorted
+ * first by version and then by lowest-latency.
+ * @param {Array<Object>} requests [{id, url}, {id, url}]
+ * @returns { Array<{url, response, millis}> }
+ */
+async function timeRequestsAndSortByVersion (requests) {
+  let timings = await Promise.all(requests.map(async request =>
+    timeRequest(request)
+  ))
+
+  return timings.sort((a, b) => {
     try {
       if (semver.gt(a.response.data.data.version, b.response.data.data.version)) return -1
       if (semver.lt(a.response.data.data.version, b.response.data.data.version)) return 1
@@ -42,8 +56,6 @@ async function timeRequests (requests) {
     // If same version, do a tie breaker on the response time
     return a.millis - b.millis
   })
-
-  return timings
 }
 
 // Races requests for file content
@@ -172,5 +184,6 @@ module.exports = {
   timeRequest,
   timeRequests,
   raceRequests,
-  allRequests
+  allRequests,
+  timeRequestsAndSortByVersion
 }


### PR DESCRIPTION
### Trello Card Link


### Description
This PR is the simple fix to sort by version, then response time in choosing the best Creator Node candidates. 

Let's merge this simple fix first, then let this [more complex CN selection PR](https://github.com/AudiusProject/audius-protocol/pull/1005) soak on staging. This more complex PR uses the `ServiceSelection` class.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Test 1
- Step 1
- Step 2
- Step 3

Please list the unit test(s) you added to verify your changes.

1. Unit test 1
