### PR TITLE
Try/catch timeRequest() and filter out unhealthy nodes

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -113,6 +113,7 @@ class ServiceProvider extends Base {
     // Secondaries: select randomly
     // TODO: Implement geolocation-based selection
     const secondaries = sampleSize(timings.slice(1), numberOfNodes - 1)
+      .filter(timing => timing.response)
       .map(timing => timing.request.id)
 
     return { primary, secondaries, services }

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -103,17 +103,17 @@ class ServiceProvider extends Base {
       }))
     )
 
+    // Store all the healthy services in a map. Used in UI to select other available services
     let services = {}
+    const available = []
     timings.forEach(timing => {
+      // Filter out unhealthy nodes (nodes with no response)
       if (timing.response) {
         services[timing.request.id] = timing.response.data
-      } else {
-        services[timing.request.id] = undefined
+        available.push(timing)
       }
     })
-
-    // Filter out unhealthy nodes (nodes with no response)
-    timings = timings.filter(timing => timing.response)
+    timings = available
 
     // Primary: select the lowest-latency
     const primary = timings[0] ? timings[0].request.id : null

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,6 +1,6 @@
 const { sampleSize } = require('lodash')
 const { Base } = require('./base')
-const { timeRequests, timeRequestsAndSortByVersion } = require('../utils/network')
+const { timeRequestsAndSortByVersion } = require('../utils/network')
 
 const CREATOR_NODE_SERVICE_NAME = 'creator-node'
 const DISCOVERY_PROVIDER_SERVICE_NAME = 'discovery-provider'
@@ -40,7 +40,7 @@ class ServiceProvider extends Base {
     }
 
     // Time requests and get version info
-    const timings = await timeRequests(
+    const timings = await timeRequestsAndSortByVersion(
       creatorNodes.map(node => ({
         id: node.endpoint,
         url: `${node.endpoint}/version`

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -96,7 +96,7 @@ class ServiceProvider extends Base {
       .filter(Boolean)
 
     // Time requests and autoselect nodes
-    let timings = await timeRequestsAndSortByVersion(
+    const timings = await timeRequestsAndSortByVersion(
       creatorNodes.map(node => ({
         id: node,
         url: `${node}/version` // TODO: add country data to health_check and switch to health_check

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -99,21 +99,15 @@ class ServiceProvider extends Base {
     let timings = await timeRequestsAndSortByVersion(
       creatorNodes.map(node => ({
         id: node,
-        url: `${node}/health_check`
+        url: `${node}/version` // TODO: add country data to health_check and switch to health_check
       }))
     )
 
     // Store all the healthy services in a map. Used in UI to select other available services
     let services = {}
-    const available = []
     timings.forEach(timing => {
-      // Filter out unhealthy nodes (nodes with no response)
-      if (timing.response) {
-        services[timing.request.id] = timing.response.data
-        available.push(timing)
-      }
+      services[timing.request.id] = timing.response.data
     })
-    timings = available
 
     // Primary: select the lowest-latency
     const primary = timings[0] ? timings[0].request.id : null

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -13,7 +13,12 @@ async function timeRequest (request) {
   // This is non-perfect because of the js event loop, but enough
   // of a proximation. Don't use for mission-critical timing.
   const startTime = new Date().getTime()
-  const response = await axios.get(request.url)
+  let response
+  try {
+    response = await axios.get(request.url)
+  } catch (e) {
+    console.debug(`Error with request for ${request.url}: ${e}`)
+  }
   const millis = new Date().getTime() - startTime
   return { request, response, millis }
 }

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -18,6 +18,7 @@ async function timeRequest (request) {
     response = await axios.get(request.url)
   } catch (e) {
     console.debug(`Error with request for ${request.url}: ${e}`)
+    return null
   }
   const millis = new Date().getTime() - startTime
   return { request, response, millis }
@@ -48,15 +49,9 @@ async function timeRequestsAndSortByVersion (requests) {
     timeRequest(request)
   ))
 
-  return timings.sort((a, b) => {
-    try {
-      if (semver.gt(a.response.data.data.version, b.response.data.data.version)) return -1
-      if (semver.lt(a.response.data.data.version, b.response.data.data.version)) return 1
-    } catch (e) {
-      // Unable to sort by version -- probably failed health check. Send to the back
-      if (!a.response) return 1
-      if (!b.response) return -1
-    }
+  return timings.filter(Boolean).sort((a, b) => {
+    if (semver.gt(a.response.data.data.version, b.response.data.data.version)) return -1
+    if (semver.lt(a.response.data.data.version, b.response.data.data.version)) return 1
 
     // If same version, do a tie breaker on the response time
     return a.millis - b.millis


### PR DESCRIPTION
### Trello Card Link


### Description
Follow up to recent [creator node selection PR](https://github.com/AudiusProject/audius-protocol/pull/1006). Filter out the unhealthy cnodes to prevent selecting them. 

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches <flow>
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Test 1
- Step 1
- Step 2
- Step 3

Please list the unit test(s) you added to verify your changes.

1. Unit test 1
