### PR TITLE
Add more logs to upload

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -322,6 +322,7 @@ const trackDiskStorage = multer.diskStorage({
     const fileExtension = getFileExtension(file.originalname)
     req.fileName = randomFileName + fileExtension
 
+    req.logger.info(`Created track disk storage: ${req.fileDir}, ${req.fileName}`)
     cb(null, fileDir)
   },
   filename: function (req, file, cb) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -333,13 +333,14 @@ const trackFileUpload = multer({
   storage: trackDiskStorage,
   limits: { fileSize: MAX_AUDIO_FILE_SIZE },
   fileFilter: function (req, file, cb) {
+    const fileExtension = getFileExtension(file.originalname).slice(1)
     // the function should call `cb` with a boolean to indicate if the file should be accepted
-    if (ALLOWED_UPLOAD_FILE_EXTENSIONS.includes(getFileExtension(file.originalname).slice(1)) && AUDIO_MIME_TYPE_REGEX.test(file.mimetype)) {
-      req.logger.info(`Filetype : ${getFileExtension(file.originalname).slice(1)}`)
+    if (ALLOWED_UPLOAD_FILE_EXTENSIONS.includes(fileExtension) && AUDIO_MIME_TYPE_REGEX.test(file.mimetype)) {
+      req.logger.info(`Filetype: ${fileExtension}`)
       req.logger.info(`Mimetype: ${file.mimetype}`)
       cb(null, true)
     } else {
-      req.fileFilterError = `File type not accepted. Must be one of [${ALLOWED_UPLOAD_FILE_EXTENSIONS}]`
+      req.fileFilterError = `File type not accepted. Must be one of [${ALLOWED_UPLOAD_FILE_EXTENSIONS}], got ${fileExtension}`
       cb(null, false)
     }
   }
@@ -350,6 +351,10 @@ const handleTrackContentUpload = (req, res, next) => {
     if (err) {
       if (err.code === 'LIMIT_FILE_SIZE') {
         req.fileSizeError = err
+      } else if (err instanceof multer.MulterError) {
+        req.logger.error(`Multer error: ${err}`)
+      } else {
+        req.logger.error(`Content upload error: ${err}`)
       }
     }
     next()


### PR DESCRIPTION
### Trello Card Link

### Description
Adds more logs to upload flow. I have a suspicion that some uploads are failing in b/w multer & the track_content handler itself.
https://audius.loggly.com/search#terms=json.requestUrl:%22%2Ftrack_content%22%20%20json.requestID:%22c7UOicUVAH%22&from=2020-10-29T07:21:20.000Z&until=2020-10-29T07:25:24.000Z&source_group=&filter=json.hostname;creator-1-backend-76c58f7fc4-ckljk
^ Lots of errors with "Network Error" end up logging out Mime type as the last message on that request id, which means it's not even getting into transcoding.

Another
https://audius.loggly.com/search#terms=json.requestUrl:%22%2Ftrack_content%22%20json.requestID:%22xfXkoR8bn24%22&from=2020-10-30T09:02:27.157Z&until=2020-10-30T09:12:27.157Z&source_group=&filter=json.hostname;creator-1-backend-76c58f7fc4-ckljk&filter=json.hostname;creator-1-backend-b7bc95967-88br6

Versus (successful)
https://audius.loggly.com/search#terms=json.requestID:%22K6BHzw3WTxF%22&from=2020-10-30T09:10:54.137Z&until=2020-10-30T09:20:54.137Z&source_group=

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Just logs
