### PR TITLE
Fix user repost feed populate metadata

### DIFF
--- a/discovery-provider/src/queries/get_repost_feed_for_user.py
+++ b/discovery-provider/src/queries/get_repost_feed_for_user.py
@@ -1,11 +1,11 @@
 from sqlalchemy import desc, or_
 
-from src.models import Track, Repost, RepostType, Follow, Playlist, Save, SaveType, User
+from src.models import Track, Repost, RepostType, Playlist, SaveType, User
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
-from src.queries.query_helpers import get_repost_counts, get_save_counts, \
-    paginate_query, get_users_by_id, get_users_ids, populate_playlist_metadata, populate_track_metadata
+from src.queries.query_helpers import paginate_query, get_users_by_id, \
+    get_users_ids, populate_playlist_metadata, populate_track_metadata
 
 
 def get_repost_feed_for_user(user_id, args):
@@ -102,7 +102,7 @@ def get_repost_feed_for_user(user_id, args):
             current_user_id
         )
 
-        # add activity timestamps        
+        # add activity timestamps   
         for track in tracks:
             track[response_name_constants.activity_timestamp] = track_repost_dict[track["track_id"]]["created_at"]
 

--- a/discovery-provider/src/queries/get_repost_feed_for_user.py
+++ b/discovery-provider/src/queries/get_repost_feed_for_user.py
@@ -5,7 +5,7 @@ from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
 from src.queries.query_helpers import get_repost_counts, get_save_counts, \
-    paginate_query, get_users_by_id, get_users_ids
+    paginate_query, get_users_by_id, get_users_ids, populate_playlist_metadata, populate_track_metadata
 
 
 def get_repost_feed_for_user(user_id, args):
@@ -90,171 +90,23 @@ def get_repost_feed_for_user(user_id, args):
         # get playlist ids
         playlist_ids = [playlist["playlist_id"] for playlist in playlists]
 
-        # get repost counts by track and playlist IDs
-        repost_counts = get_repost_counts(
-            session, False, True, track_ids + playlist_ids, None)
-        track_repost_counts = {
-            repost_item_id: repost_count
-            for (repost_item_id, repost_count, repost_type) in repost_counts
-            if repost_type == RepostType.track
-        }
-        playlist_repost_counts = {
-            repost_item_id: repost_count
-            for (repost_item_id, repost_count, repost_type) in repost_counts
-            if repost_type in (RepostType.playlist, RepostType.album)
-        }
+        # populate full metadata
+        tracks = populate_track_metadata(
+            session, track_ids, tracks, current_user_id)
+        playlists = populate_playlist_metadata(
+            session,
+            playlist_ids,
+            playlists,
+            [RepostType.playlist, RepostType.album],
+            [SaveType.playlist, SaveType.album],
+            current_user_id
+        )
 
-        # get save counts for tracks and playlists
-        save_counts = get_save_counts(
-            session, False, True, track_ids + playlist_ids, None)
-        track_save_counts = {
-            save_item_id: save_count
-            for (save_item_id, save_count, save_type) in save_counts
-            if save_type == SaveType.track
-        }
-        playlist_save_counts = {
-            save_item_id: save_count
-            for (save_item_id, save_count, save_type) in save_counts
-            if save_type in (SaveType.playlist, SaveType.album)
-        }
-
-        requested_user_is_current_user = False
-        user_reposted_track_ids = {}
-        user_reposted_playlist_ids = {}
-        user_saved_track_dict = {}
-        user_saved_playlist_dict = {}
-        followees_track_repost_dict = {}
-        followees_playlist_repost_dict = {}
-        if current_user_id:
-            # if current user = user_id, skip current_user_reposted queries and default to true
-            if current_user_id == user_id:
-                requested_user_is_current_user = True
-            else:
-                user_reposted_query = (
-                    session.query(Repost.repost_item_id, Repost.repost_type)
-                    .filter(
-                        Repost.is_current == True,
-                        Repost.is_delete == False,
-                        Repost.user_id == current_user_id,
-                        or_(Repost.repost_item_id.in_(track_ids),
-                            Repost.repost_item_id.in_(playlist_ids))
-                    )
-                    .all()
-                )
-
-                # generate dictionary of track id --> current user reposted status
-                user_reposted_track_ids = {
-                    r[0]: True
-                    for r in user_reposted_query if r[1] == RepostType.track
-                }
-
-                # generate dictionary of playlist id --> current user reposted status
-                user_reposted_playlist_ids = {
-                    r[0]: True
-                    for r in user_reposted_query if r[1] == RepostType.album or r[1] == RepostType.playlist
-                }
-
-            # build dict of tracks and playlists that current user has saved
-
-            #   - query saves by current user from relevant tracks/playlists
-            user_saved_query = (
-                session.query(Save.save_item_id, Save.save_type)
-                .filter(
-                    Save.is_current == True,
-                    Save.is_delete == False,
-                    Save.user_id == current_user_id,
-                    or_(Save.save_item_id.in_(track_ids),
-                        Save.save_item_id.in_(playlist_ids))
-                )
-                .all()
-            )
-            #   - build dict of track id --> current user save status
-            user_saved_track_dict = {
-                save[0]: True
-                for save in user_saved_query if save[1] == SaveType.track
-            }
-            #   - build dict of playlist id --> current user save status
-            user_saved_playlist_dict = {
-                save[0]: True
-                for save in user_saved_query if save[1] == SaveType.playlist or save[1] == SaveType.album
-            }
-
-            # query current user's followees
-            followee_user_ids = (
-                session.query(Follow.followee_user_id)
-                .filter(
-                    Follow.follower_user_id == current_user_id,
-                    Follow.is_current == True,
-                    Follow.is_delete == False
-                )
-                .all()
-            )
-            followee_user_ids = [f[0] for f in followee_user_ids]
-
-            # query all followees' reposts
-            followee_repost_query = (
-                session.query(Repost)
-                .filter(
-                    Repost.is_current == True,
-                    Repost.is_delete == False,
-                    Repost.user_id.in_(followee_user_ids),
-                    or_(Repost.repost_item_id.in_(repost_track_ids),
-                        Repost.repost_item_id.in_(repost_playlist_ids))
-                )
-                .order_by(desc(Repost.created_at))
-            )
-            followee_reposts = paginate_query(followee_repost_query).all()
-            followee_reposts = helpers.query_result_to_list(followee_reposts)
-
-            # build dict of track id --> reposts from followee track reposts
-            for repost in followee_reposts:
-                if repost["repost_type"] == RepostType.track:
-                    if repost["repost_item_id"] not in followees_track_repost_dict:
-                        followees_track_repost_dict[repost["repost_item_id"]] = [
-                        ]
-                    followees_track_repost_dict[repost["repost_item_id"]].append(
-                        repost)
-
-            # build dict of playlist id --> reposts from followee playlist reposts
-            for repost in followee_reposts:
-                if (repost["repost_type"] == RepostType.playlist or repost["repost_type"] == RepostType.album):
-                    if repost["repost_item_id"] not in followees_playlist_repost_dict:
-                        followees_playlist_repost_dict[repost["repost_item_id"]] = [
-                        ]
-                    followees_playlist_repost_dict[repost["repost_item_id"]].append(
-                        repost)
-
-        # populate metadata for track entries
+        # add activity timestamps        
         for track in tracks:
-            track[response_name_constants.repost_count] = track_repost_counts.get(
-                track["track_id"], 0)
-            track[response_name_constants.save_count] = track_save_counts.get(
-                track["track_id"], 0)
-            track[response_name_constants.has_current_user_reposted] = (
-                True if requested_user_is_current_user
-                else user_reposted_track_ids.get(track["track_id"], False)
-            )
-            track[response_name_constants.has_current_user_saved] = user_saved_track_dict.get(
-                track["track_id"], False)
-            track[response_name_constants.followee_reposts] = followees_track_repost_dict.get(
-                track["track_id"], [])
-            track[response_name_constants.followee_saves] = []
             track[response_name_constants.activity_timestamp] = track_repost_dict[track["track_id"]]["created_at"]
 
         for playlist in playlists:
-            playlist[response_name_constants.repost_count] = playlist_repost_counts.get(
-                playlist["playlist_id"], 0)
-            playlist[response_name_constants.save_count] = playlist_save_counts.get(
-                playlist["playlist_id"], 0)
-            playlist[response_name_constants.has_current_user_reposted] = (
-                True if requested_user_is_current_user
-                else user_reposted_playlist_ids.get(playlist["playlist_id"], False)
-            )
-            playlist[response_name_constants.has_current_user_saved] = \
-                user_saved_playlist_dict.get(playlist["playlist_id"], False)
-            playlist[response_name_constants.followee_reposts] = \
-                followees_playlist_repost_dict.get(playlist["playlist_id"], [])
-            playlist[response_name_constants.followee_saves] = []
             playlist[response_name_constants.activity_timestamp] = \
                 playlist_repost_dict[playlist["playlist_id"]]["created_at"]
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/F4sWZtX0/1643-0-play-counts-in-reposts-tab

### Description
Fixes user profile repost feed, which is missing play counts.
What was done here & populate_*_metadata have diverged. This brings that query up to speed!

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran discprov against prod dataset & verified data (play counts, importantly) are populated when using that discprov from the dapp

<img width="417" alt="Screen Shot 2020-10-30 at 12 38 39 PM" src="https://user-images.githubusercontent.com/2731362/97751110-04610c00-1aaf-11eb-90cd-2773b88a8b04.png">
