### PR TITLE
Add new sanity checks

### DIFF
--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -87,6 +87,7 @@ class ServiceProvider extends Base {
       creatorNodes.map(async node => {
         try {
           const { isBehind, isConfigured } = await this.creatorNode.getSyncStatus(node.endpoint)
+          console.debug(`Got sync status for ${node.endpoint}, isBehind: ${isBehind}, isConfigured: ${isConfigured}`)
           return isConfigured && isBehind ? false : node.endpoint
         } catch (e) {
           return false

--- a/libs/src/sanityChecks/addSecondaries.js
+++ b/libs/src/sanityChecks/addSecondaries.js
@@ -1,0 +1,36 @@
+const CreatorNode = require('../services/creatorNode')
+
+const addSecondaries = async (libs) => {
+  console.debug('Sanity Check - addSecondaries')
+  const user = libs.userStateManager.getCurrentUser()
+
+  if (!user || !user.is_creator) return
+
+  const primary = CreatorNode.getPrimary(user.creator_node_endpoint)
+  const secondaries = CreatorNode.getSecondaries(user.creator_node_endpoint)
+
+  // Get current endpoints and check if we don't have enough secondaries
+  if (secondaries.length < 2) {
+    console.debug(`Sanity Check - addSecondaries - User has only ${secondaries.length}`)
+
+    // Find new healthy secondaries
+    const currentEndpoints = CreatorNode.getEndpoints(user.creator_node_endpoint)
+    const services = await libs.ServiceProvider.getSelectableCreatorNodes(
+      /* whitelist */ null,
+      /* blacklist */ new Set(currentEndpoints)
+    )
+    console.debug(`Sanity Check - addSecondaries - found services ${JSON.stringify(services)}`)
+    const newSecondaries = Object.keys(services)
+      .slice(0, 2 - secondaries.length)
+
+    // Combine primary, current secondaries, and new secondaries
+    const newEndpoints = [primary, ...secondaries, ...newSecondaries]
+
+    const newMetadata = { ...user }
+    newMetadata.creator_node_endpoint = newEndpoints.join(',')
+    console.debug(`Sanity Check - addSecondaries - new nodes ${newMetadata.creator_node_endpoint}`)
+    await libs.User.updateCreator(user.user_id, newMetadata)
+  }
+}
+
+module.exports = addSecondaries

--- a/libs/src/sanityChecks/addSecondaries.js
+++ b/libs/src/sanityChecks/addSecondaries.js
@@ -1,5 +1,9 @@
 const CreatorNode = require('../services/creatorNode')
 
+/**
+ * Add secondary creator nodes for a user if they don't have any
+ * Goal: Make it so users always have a replica set
+ */
 const addSecondaries = async (libs) => {
   console.debug('Sanity Check - addSecondaries')
   const user = libs.userStateManager.getCurrentUser()

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -1,4 +1,6 @@
 const isCreator = require('./isCreator')
+const sanitizeNodes = require('./sanitizeNodes')
+const addSecondaries = require('./addSecondaries')
 const syncNodes = require('./syncNodes')
 const rolloverNodes = require('./rolloverNodes')
 const recoveryEmail = require('./needsRecoveryEmail')
@@ -15,6 +17,8 @@ class SanityChecks {
    */
   async run (creatorNodeWhitelist = null) {
     await isCreator(this.libs)
+    await sanitizeNodes(this.libs)
+    await addSecondaries(this.libs)
     await syncNodes(this.libs)
     await rolloverNodes(this.libs, creatorNodeWhitelist)
     await recoveryEmail(this.libs)

--- a/libs/src/sanityChecks/isCreator.js
+++ b/libs/src/sanityChecks/isCreator.js
@@ -26,6 +26,7 @@ const findCorrectNode = async (nodes, cids) => {
 }
 
 const isCreator = async (libs) => {
+  console.debug('Sanity Check - isCreator')
   const user = libs.userStateManager.getCurrentUser()
   if (
     // There is no currently logged in user
@@ -35,6 +36,8 @@ const isCreator = async (libs) => {
     // The user is a creator and has a creator node endpoint
     (user.is_creator && user.creator_node_endpoint)
   ) return
+
+  console.debug('Sanity Check - isCreator - Running Check')
 
   // Find the CIDs for all of the user's content (tracks + images)
   let cids = [
@@ -58,6 +61,7 @@ const isCreator = async (libs) => {
   // Upgrade the user to a creator
   if (correctNode) {
     try {
+      console.debug('Sanity Check - isCreator - Upgrading to Creator')
       await libs.User.upgradeToCreator(null, correctNode.endpoint)
     } catch (e) {
       console.error(e)

--- a/libs/src/sanityChecks/needsRecoveryEmail.js
+++ b/libs/src/sanityChecks/needsRecoveryEmail.js
@@ -5,11 +5,13 @@
  * out of their account.
  */
 const needsRecoveryEmail = async (libs) => {
+  console.debug('Sanity Check - needsRecoveryEmail')
   const user = libs.userStateManager.getCurrentUser()
   if (!user || !user.wallet) return
 
   const events = await libs.identityService.getUserEvents(user.wallet)
   if (events.needsRecoveryEmail) {
+    console.debug('Sanity Check - needsRecoveryEmail - Sending Email')
     // Send email
     await libs.Account.generateRecoveryLink()
   }

--- a/libs/src/sanityChecks/rolloverNodes.js
+++ b/libs/src/sanityChecks/rolloverNodes.js
@@ -29,6 +29,7 @@ const getNewPrimary = async (libs, secondaries) => {
 }
 
 const rolloverNodes = async (libs, creatorNodeWhitelist) => {
+  console.debug('Sanity Check - rolloverNodes')
   const user = libs.userStateManager.getCurrentUser()
 
   if (!user || !user.is_creator) return
@@ -61,6 +62,7 @@ const rolloverNodes = async (libs, creatorNodeWhitelist) => {
     // Update the user
     const newMetadata = { ...user }
     newMetadata.creator_node_endpoint = newEndpoints.join(',')
+    console.debug(`Sanity Check - rolloverNodes - new nodes ${newMetadata.creator_node_endpoint}`)
     await libs.User.updateCreator(user.user_id, newMetadata)
   } catch (e) {
     console.error(e)

--- a/libs/src/sanityChecks/sanitizeNodes.js
+++ b/libs/src/sanityChecks/sanitizeNodes.js
@@ -1,0 +1,20 @@
+const sanitizeNodes = async (libs, secondaries) => {
+  console.debug('Sanity Check - sanitizeNodes')
+  const user = libs.userStateManager.getCurrentUser()
+
+  if (!user || !user.is_creator) return
+
+  const sanitizedEndpoint = user.creator_node_endpoint
+    .split(',')
+    .filter(Boolean)
+    .join(',')
+
+  if (sanitizedEndpoint !== user.creator_node_endpoint) {
+    console.debug(`Sanity Check - sanitizingNodes - ${user.creator_node_endpoint} -> ${sanitizedEndpoint}`)
+    const newMetadata = { ...user }
+    newMetadata.creator_node_endpoint = sanitizedEndpoint
+    await libs.User.updateCreator(user.user_id, newMetadata)
+  }
+}
+
+module.exports = sanitizeNodes

--- a/libs/src/sanityChecks/sanitizeNodes.js
+++ b/libs/src/sanityChecks/sanitizeNodes.js
@@ -1,3 +1,7 @@
+/**
+ * Sanitize user.creator_node_endpoint
+ * Goal: Make it so we never end up in a state like creator_node_endpoint = "https://cn1.co,,"
+ */
 const sanitizeNodes = async (libs, secondaries) => {
   console.debug('Sanity Check - sanitizeNodes')
   const user = libs.userStateManager.getCurrentUser()

--- a/libs/src/sanityChecks/syncNodes.js
+++ b/libs/src/sanityChecks/syncNodes.js
@@ -7,6 +7,7 @@ const syncNodeIfBehind = async (libs, endpoint) => {
   try {
     const { isBehind, isConfigured } = await libs.creatorNode.getSyncStatus(endpoint)
     if (isBehind || !isConfigured) {
+      console.debug(`Sanity Check - syncNodes - syncing ${endpoint}`)
       await libs.creatorNode.syncSecondary(endpoint)
     }
   } catch (e) {
@@ -15,6 +16,7 @@ const syncNodeIfBehind = async (libs, endpoint) => {
 }
 
 const syncNodes = async (libs) => {
+  console.debug('Sanity Check - syncNodes')
   const user = libs.userStateManager.getCurrentUser()
 
   if (!user || !user.is_creator) return

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -20,6 +20,12 @@ class CreatorNode {
   static getSecondaries (endpoints) { return endpoints ? endpoints.split(',').slice(1) : [] }
 
   /**
+   * Pulls the user's creator nodes out of the list
+   * @param {string} endpoints user.creator_node_endpoint
+   */
+  static getEndpoints (endpoints) { return endpoints ? endpoints.split(',') : [] }
+
+  /**
    * Checks if a download is available from provided creator node endpoints
    * @param {string} endpoints creator node endpoints
    * @param {number} trackId


### PR DESCRIPTION
### Trello Card Link


### Description
Creates two new sanity checks
* Sanitize endpoints (cleans up user.creator_node_endpoint)
* Add secondaries (adds new secondaries, backfilling up to 2)

### Services

- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches initial page loads


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Repaired my account with this
https://discoveryprovider.audius.co/users?handle=rayjacobson

