### PR TITLE
Fix legacy images

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/file.js
+++ b/libs/src/api/file.js
@@ -3,7 +3,6 @@ if (urlJoin && urlJoin.default) urlJoin = urlJoin.default
 const { Base, Services } = require('./base')
 const { raceRequests } = require('../utils/network')
 const retry = require('async-retry')
-const FETCH_CID_TIMEOUT_MS = 20 /* sec */ * 1000 /* millis */
 
 // Public gateways to send requests to, ordered by precidence.
 const publicGateways = [
@@ -48,9 +47,31 @@ class File extends Base {
         const { response } = await raceRequests(urls, callback, {
           method: 'get',
           responseType: 'blob'
-        }, FETCH_CID_TIMEOUT_MS)
+        }, /* timeout */ null)
+        if (!response) throw new Error(`Could not fetch ${cid}`)
         return response
       } catch (e) {
+
+        // TODO: Remove this fallback logic when no more users/tracks/playlists
+        // contain "legacy" image formats (no dir cid)
+        if (cid.includes('/')) { // dirCID -- an image
+          console.debug(`Attempted to fetch image ${cid} via legacy method`)
+          // Try legacy image format
+          // Lop off anything like /480x480.jpg in the CID
+          const legacyUrls = gateways.map(gateway => urlJoin(gateway, cid.split('/')[0]))
+          try {
+            const { response } = await raceRequests(legacyUrls, callback, {
+              method: 'get',
+              responseType: 'blob'
+            }, /* timeout */ null)
+            if (!response) throw new Error(`Could not fetch ${cid} via legacy method`)
+            return response
+          } catch (e) {
+            throw new Error(`Failed to retrieve ${cid} by legacy method`)
+          }
+        }
+
+        // Throw so we can retry
         throw new Error(`Failed to retrieve ${cid}`)
       }
     }, {

--- a/libs/src/api/file.js
+++ b/libs/src/api/file.js
@@ -51,7 +51,6 @@ class File extends Base {
         if (!response) throw new Error(`Could not fetch ${cid}`)
         return response
       } catch (e) {
-
         // TODO: Remove this fallback logic when no more users/tracks/playlists
         // contain "legacy" image formats (no dir cid)
         if (cid.includes('/')) { // dirCID -- an image

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -116,7 +116,9 @@ async function raceRequests (
         })
     })
   })
-  requests.push(Utils.wait(timeout))
+  if (timeout !== null) {
+    requests.push(Utils.wait(timeout))
+  }
   let response
   let errored
   try {


### PR DESCRIPTION
### Trello Card Link


### Description
Fixes legacy image support

### Services

- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, image fetching


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. http://localhost:3002/capshun loads
2. Went through the app looking at images and made sure the `legacy` console statement never got triggered
