### PR TITLE
Move notifications max block diff to an env var

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -10,6 +10,7 @@ peer_refresh_interval = 3000
 identity_service_url = https://identityservice.test
 user_metadata_service_url = ''
 healthy_block_diff = 100
+notifications_max_block_diff = 25
 
 [flask]
 debug = true

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -7,11 +7,12 @@ from src.queries import response_name_constants as const
 from src.queries.query_helpers import get_repost_counts, get_save_counts, get_follower_count_dict
 from src.models import Block, Follow, Save, SaveType, Playlist, Track, Repost, RepostType, Remix
 from src.utils.db_session import get_db_read_replica
+from src.utils.config import shared_config
 
 logger = logging.getLogger(__name__)
 bp = Blueprint("notifications", __name__)
 
-max_block_diff = 50
+max_block_diff = int(shared_config["discprov"]["notifications_max_block_diff"])
 
 
 # pylint: disable=R0911


### PR DESCRIPTION
### Trello Card Link
None

### Description
Lets make this an env var so it can be controlled outside of code.

### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Brought the system up locally and verified the min and max blocks have a diff of 25. Then applied an env var and verified it got respected.