### PR TITLE
Fix stream content type

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -341,7 +341,7 @@ const trackFileUpload = multer({
       req.logger.info(`Mimetype: ${file.mimetype}`)
       cb(null, true)
     } else {
-      req.fileFilterError = `File type not accepted. Must be one of [${ALLOWED_UPLOAD_FILE_EXTENSIONS}], got ${fileExtension}`
+      req.fileFilterError = `File type not accepted. Must be one of [${ALLOWED_UPLOAD_FILE_EXTENSIONS}] with mime type matching ${AUDIO_MIME_TYPE_REGEX}, got file ${fileExtension} with mime ${file.mimetype}`
       cb(null, false)
     }
   }

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -561,6 +561,7 @@ module.exports = function (app) {
 
     req.params.CID = multihash
     req.params.streamable = true
+    res.set('Content-Type', 'audio/mpeg')
     next()
   }, getCID)
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/WcxRoldu/1647-need-content-type-in-response-stream

### Description
Adds content type to stream response + more logging around inbound content type

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually ran creator node & requested track
