### PR TITLE
Fix dp selection infinite loop

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -70,6 +70,7 @@ class DiscoveryProvider {
    * await getUsers(100, 0, [3,2,6]) - Invalid user ids will not be accepted
    */
   async getUsers (limit = 100, offset = 0, idsArray = null, walletAddress = null, handle = null, isCreator = null, minBlockNumber = null) {
+    console.log('i am GETTING USERS!!!!!')
     const req = Requests.getUsers(
       limit,
       offset,
@@ -490,14 +491,13 @@ class DiscoveryProvider {
     }
 
     let axiosRequest = this.createDiscProvRequest(requestObj)
-
     let response
     let parsedResponse
     try {
       response = await axios(axiosRequest)
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
-      console.error(`Failed to make Discovery Provider request: ${e}`)
+      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries+1}: ${e}`)
       return this._makeRequest(requestObj, attemptedRetries + 1)
     }
 
@@ -519,7 +519,7 @@ class DiscoveryProvider {
       ) {
         // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
         // hopes it will catch up
-        console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request...`)
+        console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries+1}...`)
         return this._makeRequest(requestObj, attemptedRetries + 1)
       }
     }
@@ -528,7 +528,7 @@ class DiscoveryProvider {
   }
 
   /**
-   * Gets the healthy discovery provider endpoint used in creating the axious request later.
+   * Gets the healthy discovery provider endpoint used in creating the axios request later.
    * If the number of retries is over the max count for retires, clear the cache and reselect
    * another healthy discovery provider. Else, return the current discovery provider endpoint
    * @param {int} attemptedRetries the number of attempted requests made to the current disc prov endpoint
@@ -537,7 +537,8 @@ class DiscoveryProvider {
     let endpoint = this.discoveryProviderEndpoint
     if (attemptedRetries > MAX_MAKE_REQUEST_RETRY_COUNT) {
       // Add to unhealthy list if current disc prov endpoint has reached max retry count
-      console.info(`Attempted max retries with endpoint ${this.discoveryProviderEndpoint}`)
+      console.info(`Attempted max retries with endpoint ${endpoint}`)
+      this.serviceSelector.addUnhealthy(endpoint)
 
       // Clear the cached endpoint and select new endpoint from backups
       this.serviceSelector.clearCached()

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -501,7 +501,7 @@ class DiscoveryProvider {
       if (e.response && e.response.status && e.response.status/100 === 4) {
         return
       }
-      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries+1} with response ${response}: ${e}`)
+      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries} with response ${response}: ${e}`)
       return this._makeRequest(requestObj, attemptedRetries + 1)
     }
 
@@ -523,7 +523,7 @@ class DiscoveryProvider {
       ) {
         // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
         // hopes it will catch up
-        console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries+1}...`)
+        console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries}...`)
         return this._makeRequest(requestObj, attemptedRetries + 1)
       }
     }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -497,7 +497,6 @@ class DiscoveryProvider {
       response = await axios(axiosRequest)
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
-      // If Discovery Provider responds with 4xx status code, content is unavail. Do not retry. 
       // If Discovery Provider responds with 4xx status code, content is unavailable. Do not retry. 
       if (e.response && e.response.status && e.response.status/100 === 4) {
         return

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -496,11 +496,8 @@ class DiscoveryProvider {
       response = await axios(axiosRequest)
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
-      // If Discovery Provider responds with 4xx status code, content is unavailable. Do not retry.
-      if (e.response && e.response.status && (e.response.status / 100) === 4) {
-        return
-      }
-      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries} with response ${response}: ${e}`)
+      const errMsg = e.response && e.response.data ? e.response.data : e
+      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${errMsg}`)
       return this._makeRequest(requestObj, attemptedRetries + 1)
     }
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -497,8 +497,8 @@ class DiscoveryProvider {
       response = await axios(axiosRequest)
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
-      // If Discovery Provider responds with 4xx status code, content is unavailable. Do not retry. 
-      if (e.response && e.response.status && e.response.status/100 === 4) {
+      // If Discovery Provider responds with 4xx status code, content is unavailable. Do not retry.
+      if (e.response && e.response.status && (e.response.status / 100) === 4) {
         return
       }
       console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries} with response ${response}: ${e}`)

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -70,7 +70,6 @@ class DiscoveryProvider {
    * await getUsers(100, 0, [3,2,6]) - Invalid user ids will not be accepted
    */
   async getUsers (limit = 100, offset = 0, idsArray = null, walletAddress = null, handle = null, isCreator = null, minBlockNumber = null) {
-    console.log('i am GETTING USERS!!!!!')
     const req = Requests.getUsers(
       limit,
       offset,

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -497,7 +497,12 @@ class DiscoveryProvider {
       response = await axios(axiosRequest)
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
-      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries+1}: ${e}`)
+      // If Discovery Provider responds with 4xx status code, content is unavail. Do not retry. 
+      // If Discovery Provider responds with 4xx status code, content is unavailable. Do not retry. 
+      if (e.response && e.response.status && e.response.status/100 === 4) {
+        return
+      }
+      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries+1} with response ${response}: ${e}`)
       return this._makeRequest(requestObj, attemptedRetries + 1)
     }
 

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -531,7 +531,7 @@ class DiscoveryProvider {
    * Gets the healthy discovery provider endpoint used in creating the axios request later.
    * If the number of retries is over the max count for retires, clear the cache and reselect
    * another healthy discovery provider. Else, return the current discovery provider endpoint
-   * @param {int} attemptedRetries the number of attempted requests made to the current disc prov endpoint
+   * @param {number} attemptedRetries the number of attempted requests made to the current disc prov endpoint
    */
   async getHealthyDiscoveryProviderEndpoint (attemptedRetries) {
     let endpoint = this.discoveryProviderEndpoint


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/KgxYnbbu/1648-fix-infinite-dp-selection-if-dp-returns-error-response

### Description
If the discovery provider returns any error responses, the dp selection infinitely loops. This is because we do not add the dp to the unhealthy set; therefore, when we clear the cache and retry (we clear the cache because [of this](https://github.com/AudiusProject/audius-protocol/pull/857)) it reselects the dp responding with 4xx or 5xx.

Also added a check that if a dp responds with 4xx, do not retry as retrying will not change the response.  

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- 🚨 Yes, this touches **disc prov selection**


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

**before:**
DP selection keeps going (see attempt # is greater than global max of 5):
<img width="740" alt="keeps going" src="https://user-images.githubusercontent.com/60366641/97928931-dd0f7680-1d1c-11eb-88e4-9161b09ba7e2.png">

**after:**
DP selection stops after the global max count (5):
note: updated the log so it's not going to be +1 than the max global (instead of attempt 1...6 -> 0...5)
<img width="740" alt="stopping after max" src="https://user-images.githubusercontent.com/60366641/97928917-d123b480-1d1c-11eb-95e8-c3bbf3ef809f.png">


Please list the unit test(s) you added to verify your changes.

1. Unit test 1
