### PR TITLE
Forward client IP for API streams

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -556,7 +556,7 @@ module.exports = function (app) {
       req.logger.info(`Logging listen for track ${blockchainId} by ${delegateOwnerWallet}`)
       // Fire and forget listen recording
       // TODO: Consider queueing these requests
-      libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet)
+      libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet, req.ip)
     }
 
     req.params.CID = multihash

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -105,14 +105,21 @@ class IdentityService {
    * @param {number} trackId
    * @param {number} userId
    */
-  async logTrackListen (trackId, userId) {
-    return this._makeRequest({
+  async logTrackListen (trackId, userId, listenerAddress) {
+    const request = {
       url: `/tracks/${trackId}/listen`,
       method: 'post',
       data: {
         userId: userId
       }
-    })
+    }
+
+    if (listenerAddress) {
+      request.headers = {
+        'x-forwarded-for': listenerAddress
+      }
+    }
+    return this._makeRequest(request)
   }
 
   /**


### PR DESCRIPTION

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [X] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Linked libs, tested locally logging IP and ensuring listens were rate limited as expected.