### PR TITLE
Allow skip retry in libs discprov makeRequest

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -520,10 +520,10 @@ class DiscoveryProvider {
         !indexedBlock ||
         (chainBlock - indexedBlock) > UNHEALTHY_BLOCK_DIFF
       ) {
-        // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
-        // hopes it will catch up
-        console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries}...`)
         if (retry) {
+          // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
+          // hopes it will catch up
+          console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries}...`)
           return this._makeRequest(requestObj, retry, attemptedRetries + 1)
         }
         return null

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -472,7 +472,7 @@ class DiscoveryProvider {
   // endpoint - base route
   // urlParams - string of url params to be appended after base route
   // queryParams - object of query params to be appended to url
-  async _makeRequest (requestObj, attemptedRetries = 0) {
+  async _makeRequest (requestObj, retry = true, attemptedRetries = 0) {
     try {
       const newDiscProvEndpoint = await this.getHealthyDiscoveryProviderEndpoint(attemptedRetries)
 
@@ -498,7 +498,10 @@ class DiscoveryProvider {
     } catch (e) {
       const errMsg = e.response && e.response.data ? e.response.data : e
       console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${errMsg}`)
-      return this._makeRequest(requestObj, attemptedRetries + 1)
+      if (retry) {
+        return this._makeRequest(requestObj, retry, attemptedRetries + 1)
+      }
+      return null
     }
 
     if (
@@ -520,7 +523,10 @@ class DiscoveryProvider {
         // If disc prov is an unhealthy num blocks behind, retry with same disc prov with
         // hopes it will catch up
         console.info(`${this.discoveryProviderEndpoint} is too far behind. Retrying request at attempt #${attemptedRetries}...`)
-        return this._makeRequest(requestObj, attemptedRetries + 1)
+        if (retry) {
+          return this._makeRequest(requestObj, retry, attemptedRetries + 1)
+        }
+        return null
       }
     }
 


### PR DESCRIPTION
### Trello Card Link


### Description
Allows client to prevent auto retries in discprov make request

### Services

- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Testing via dapp in https://github.com/AudiusProject/audius-client/pull/102