### PR TITLE
Remove bull jobs after processing

### DIFF
--- a/creator-node/src/ImageProcessingQueue.js
+++ b/creator-node/src/ImageProcessingQueue.js
@@ -84,7 +84,8 @@ class ImageProcessingQueue {
   }) {
     const job = await this.queue.add(
       PROCESS_NAMES.resizeImage,
-      { file, fileName, storagePath, sizes, square, logContext }
+      { file, fileName, storagePath, sizes, square, logContext },
+      { removeOnComplete: true, removeOnFail: true }
     )
     const result = await job.finished()
     return result

--- a/creator-node/src/ImageProcessingQueue.js
+++ b/creator-node/src/ImageProcessingQueue.js
@@ -23,6 +23,10 @@ class ImageProcessingQueue {
         redis: {
           port: config.get('redisPort'),
           host: config.get('redisHost')
+        },
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: true
         }
       }
     )
@@ -84,8 +88,7 @@ class ImageProcessingQueue {
   }) {
     const job = await this.queue.add(
       PROCESS_NAMES.resizeImage,
-      { file, fileName, storagePath, sizes, square, logContext },
-      { removeOnComplete: true, removeOnFail: true }
+      { file, fileName, storagePath, sizes, square, logContext }
     )
     const result = await job.finished()
     return result

--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -76,7 +76,8 @@ class RehydrateIpfsQueue {
     if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_file,
-      { multihash, storagePath, filename, logContext }
+      { multihash, storagePath, filename, logContext },
+      { removeOnComplete: true, removeOnFail: true }
     )
     this.logStatus(logContext, 'Successfully added a rehydrateIpfsFromFsIfNecessary task!')
 
@@ -94,7 +95,8 @@ class RehydrateIpfsQueue {
     if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_dir,
-      { multihash, logContext }
+      { multihash, logContext },
+      { removeOnComplete: true, removeOnFail: true }
     )
     this.logStatus(logContext, 'Successfully added a rehydrateIpfsDirFromFsIfNecessary task!')
 

--- a/creator-node/src/RehydrateIpfsQueue.js
+++ b/creator-node/src/RehydrateIpfsQueue.js
@@ -18,6 +18,10 @@ class RehydrateIpfsQueue {
         redis: {
           host: config.get('redisHost'),
           port: config.get('redisPort')
+        },
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: true
         }
       }
     )
@@ -76,8 +80,7 @@ class RehydrateIpfsQueue {
     if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_file,
-      { multihash, storagePath, filename, logContext },
-      { removeOnComplete: true, removeOnFail: true }
+      { multihash, storagePath, filename, logContext }
     )
     this.logStatus(logContext, 'Successfully added a rehydrateIpfsFromFsIfNecessary task!')
 
@@ -95,8 +98,7 @@ class RehydrateIpfsQueue {
     if (count > MAX_COUNT) return
     const job = await this.queue.add(
       PROCESS_NAMES.rehydrate_dir,
-      { multihash, logContext },
-      { removeOnComplete: true, removeOnFail: true }
+      { multihash, logContext }
     )
     this.logStatus(logContext, 'Successfully added a rehydrateIpfsDirFromFsIfNecessary task!')
 

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -25,6 +25,10 @@ class TranscodingQueue {
         redis: {
           port: config.get('redisPort'),
           host: config.get('redisHost')
+        },
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: true
         }
       })
 
@@ -96,8 +100,7 @@ class TranscodingQueue {
   async segment (fileDir, fileName, { logContext }) {
     const job = await this.queue.add(
       PROCESS_NAMES.segment,
-      { fileDir, fileName, logContext },
-      { removeOnComplete: true, removeOnFail: true }
+      { fileDir, fileName, logContext }
     )
     const result = await job.finished()
     return result
@@ -112,8 +115,7 @@ class TranscodingQueue {
   async transcode320 (fileDir, fileName, { logContext }) {
     const job = await this.queue.add(
       PROCESS_NAMES.transcode320,
-      { fileDir, fileName, logContext },
-      { removeOnComplete: true, removeOnFail: true }
+      { fileDir, fileName, logContext }
     )
     const result = await job.finished()
     return result

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -96,7 +96,8 @@ class TranscodingQueue {
   async segment (fileDir, fileName, { logContext }) {
     const job = await this.queue.add(
       PROCESS_NAMES.segment,
-      { fileDir, fileName, logContext }
+      { fileDir, fileName, logContext },
+      { removeOnComplete: true, removeOnFail: true }
     )
     const result = await job.finished()
     return result
@@ -111,7 +112,8 @@ class TranscodingQueue {
   async transcode320 (fileDir, fileName, { logContext }) {
     const job = await this.queue.add(
       PROCESS_NAMES.transcode320,
-      { fileDir, fileName, logContext }
+      { fileDir, fileName, logContext },
+      { removeOnComplete: true, removeOnFail: true }
     )
     const result = await job.finished()
     return result

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -81,6 +81,10 @@ class SnapbackSM {
         redis: {
           port: config.get('redisPort'),
           host: config.get('redisHost')
+        },
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: true
         }
       }
     )
@@ -189,8 +193,7 @@ class SnapbackSM {
     // Note: we pass in syncType as job name for observability
     return this.syncQueue.add(
       syncType,
-      { syncRequestParameters, startTime: Date.now(), primaryClockValue },
-      { priority, removeOnComplete: true, removeOnFail: true }
+      { syncRequestParameters, startTime: Date.now(), primaryClockValue }
     )
   }
 

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -81,6 +81,10 @@ class SnapbackSM {
         redis: {
           port: config.get('redisPort'),
           host: config.get('redisHost')
+        },
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: true
         }
       }
     )
@@ -187,11 +191,7 @@ class SnapbackSM {
       }
     }
     // Note: we pass in syncType as job name for observability
-    return this.syncQueue.add(
-      syncType,
-      { syncRequestParameters, startTime: Date.now(), primaryClockValue },
-      { priority, removeOnComplete: true, removeOnFail: true }
-    )
+    return this.syncQueue.add(syncType, { syncRequestParameters, startTime: Date.now(), primaryClockValue }, { priority })
   }
 
   // Main state machine processing function

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -187,7 +187,11 @@ class SnapbackSM {
       }
     }
     // Note: we pass in syncType as job name for observability
-    return this.syncQueue.add(syncType, { syncRequestParameters, startTime: Date.now(), primaryClockValue }, { priority })
+    return this.syncQueue.add(
+      syncType,
+      { syncRequestParameters, startTime: Date.now(), primaryClockValue },
+      { priority, removeOnComplete: true, removeOnFail: true }
+    )
   }
 
   // Main state machine processing function

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -81,10 +81,6 @@ class SnapbackSM {
         redis: {
           port: config.get('redisPort'),
           host: config.get('redisHost')
-        },
-        defaultJobOptions: {
-          removeOnComplete: true,
-          removeOnFail: true
         }
       }
     )
@@ -193,7 +189,8 @@ class SnapbackSM {
     // Note: we pass in syncType as job name for observability
     return this.syncQueue.add(
       syncType,
-      { syncRequestParameters, startTime: Date.now(), primaryClockValue }
+      { syncRequestParameters, startTime: Date.now(), primaryClockValue },
+      { priority, removeOnComplete: true, removeOnFail: true }
     )
   }
 

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -85,7 +85,8 @@ describe('test sync queue', function () {
     while (jobIds.length) {
       const remainingManualCount = jobIds.filter(id => manualSyncIds.has(id)).length
       const remainingRecurringCount = jobIds.filter(id => recurringSyncIds.has(id)).length
-
+      console.log("remainingManualCount", remainingManualCount, manualSyncIds)
+      console.log("remainingRecurringCount", remainingRecurringCount, recurringSyncIds)
       // We know we processed a recurring job before a manual job
       // if there are still manual jobs left to process but we have fewer
       // unprocessed recurring jobs remaining than we did last iteration through the loop

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -85,8 +85,7 @@ describe('test sync queue', function () {
     while (jobIds.length) {
       const remainingManualCount = jobIds.filter(id => manualSyncIds.has(id)).length
       const remainingRecurringCount = jobIds.filter(id => recurringSyncIds.has(id)).length
-      console.log('remainingManualCount', remainingManualCount, manualSyncIds)
-      console.log('remainingRecurringCount', remainingRecurringCount, recurringSyncIds)
+
       // We know we processed a recurring job before a manual job
       // if there are still manual jobs left to process but we have fewer
       // unprocessed recurring jobs remaining than we did last iteration through the loop

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -85,8 +85,8 @@ describe('test sync queue', function () {
     while (jobIds.length) {
       const remainingManualCount = jobIds.filter(id => manualSyncIds.has(id)).length
       const remainingRecurringCount = jobIds.filter(id => recurringSyncIds.has(id)).length
-      console.log("remainingManualCount", remainingManualCount, manualSyncIds)
-      console.log("remainingRecurringCount", remainingRecurringCount, recurringSyncIds)
+      console.log('remainingManualCount', remainingManualCount, manualSyncIds)
+      console.log('remainingRecurringCount', remainingRecurringCount, recurringSyncIds)
       // We know we processed a recurring job before a manual job
       // if there are still manual jobs left to process but we have fewer
       // unprocessed recurring jobs remaining than we did last iteration through the loop


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Hb52wyQl/1665-remove-bull-jobs-after-processing

### Description
Bull jobs never get cleaned up from Redis so it eats away at system memory slowly. This change cleans it up after each processes

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Locally checked redis before uploading a track to make sure it was empty. Uploaded the track and hit the gateway to make sure the IPFS rehydrate job doesn't leave anything behind in redis

Before any actions
```
127.0.0.1:6379> KEYS *
1) "bull:creator-node-state-machine-1604608258933:stalled-check"
2) "bull:transcoding-queue:stalled-check"
3) "bull:rehydrateIpfs:stalled-check"
4) "bull:image-processing-queue:stalled-check"
5) "bull:creator-node-sync-queue-1604608258934:stalled-check"
```

After upload
```
127.0.0.1:6379> KEYS *
 1) "bull:creator-node-sync-queue-1604608258934:id"
 2) "userReqLimiter::ffff:172.18.0.1"
 3) "rate:/users::ffff:172.18.0.1"
 4) "bull:transcoding-queue:stalled-check"
 5) "bull:image-processing-queue:stalled-check"
 6) "rate:/sync::ffff:172.18.0.1"
 7) "bull:transcoding-queue:1"
 8) "imageReqLimit::ffff:172.18.0.1"
 9) "bull:image-processing-queue:id"
10) "bull:transcoding-queue:active"
11) "bull:transcoding-queue:id"
12) "rate:/audius_users::ffff:172.18.0.1"
13) "bull:image-processing-queue:stalled"
14) "bull:creator-node-sync-queue-1604608258934:1"
15) "bull:creator-node-sync-queue-1604608258934:1:lock"
16) "bull:image-processing-queue:1"
17) "SESSION.bhvwyKcnwNTMCMGdgzjw2UU4G7uFAqxnv_LsCGqSm3pPB-LYOtK73g"
18) "bull:image-processing-queue:1:lock"
19) "trackReqLimiter::ffff:172.18.0.1"
20) "bull:transcoding-queue:2"
21) "bull:rehydrateIpfs:stalled-check"
22) "rate:/users/login/challenge::ffff:172.18.0.1"
23) "bull:transcoding-queue:stalled"
24) "bull:transcoding-queue:2:lock"
25) "bull:transcoding-queue:1:lock"
26) "bull:creator-node-sync-queue-1604608258934:active"
27) "rate:/track_content::ffff:172.18.0.1"
28) "bull:image-processing-queue:active"
29) "rate:/audius_users/metadata::ffff:172.18.0.1"
30) "rate:/image_upload::ffff:172.18.0.1"
```

After secondary sync
```
127.0.0.1:6379> KEYS *
 1) "bull:creator-node-sync-queue-1604608258934:id"
 2) "userReqLimiter::ffff:172.18.0.1"
 3) "rate:/tracks/metadata::ffff:172.18.0.1"
 4) "rate:/users::ffff:172.18.0.1"
 5) "rate:/sync::ffff:172.18.0.1"
 6) "imageReqLimit::ffff:172.18.0.1"
 7) "bull:image-processing-queue:id"
 8) "bull:transcoding-queue:id"
 9) "rate:/audius_users::ffff:172.18.0.1"
10) "bull:image-processing-queue:stalled"
11) "SESSION.bhvwyKcnwNTMCMGdgzjw2UU4G7uFAqxnv_LsCGqSm3pPB-LYOtK73g"
12) "trackReqLimiter::ffff:172.18.0.1"
13) "rate:/users/login/challenge::ffff:172.18.0.1"
14) "bull:transcoding-queue:stalled"
15) "rate:/tracks::ffff:172.18.0.1"
16) "rate:/track_content::ffff:172.18.0.1"
17) "rate:/audius_users/metadata::ffff:172.18.0.1"
18) "rate:/image_upload::ffff:172.18.0.1"
```

Although there are aggregate keys still in redis, It's definitely cleaning up after itself more