### PR TITLE
Add more logs

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -488,7 +488,7 @@ class CreatorNode {
       // rather than XMLHttpRequest. We force that here.
       // https://github.com/axios/axios/issues/1180
       const isBrowser = typeof window !== 'undefined'
-      console.info(`Uploading file to ${url}`)
+      console.debug(`Uploading file to ${url}`)
       const resp = await axios.post(
         url,
         formData,
@@ -506,7 +506,7 @@ class CreatorNode {
         throw new Error(resp.data.error)
       }
       onProgress(total, total)
-      console.info(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
+      console.debug(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
       return resp.data
     } catch (e) {
       _handleErrorHelper(e, url)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -194,9 +194,13 @@ class CreatorNode {
     }
 
     const sourceFile = trackContentResp.source_file
-    if (!sourceFile) throw new Error('Invalid or missing sourceFile')
+    if (!sourceFile) {
+      throw new Error(`Invalid or missing sourceFile in response: ${JSON.stringify(trackContentResp)}`)
+    }
 
-    if (coverArtResp) metadata.cover_art_sizes = coverArtResp.dirCID
+    if (coverArtResp) {
+      metadata.cover_art_sizes = coverArtResp.dirCID
+    }
     // Creates new track entity on creator node, making track's metadata available on IPFS
     // @returns {Object} {cid: cid of track metadata on IPFS, id: id of track to be used with associate function}
     const metadataResp = await this.uploadTrackMetadata(metadata, sourceFile)
@@ -484,6 +488,7 @@ class CreatorNode {
       // rather than XMLHttpRequest. We force that here.
       // https://github.com/axios/axios/issues/1180
       const isBrowser = typeof window !== 'undefined'
+      console.info(`Uploading file to ${url}`)
       const resp = await axios.post(
         url,
         formData,
@@ -501,6 +506,7 @@ class CreatorNode {
         throw new Error(resp.data.error)
       }
       onProgress(total, total)
+      console.info(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
       return resp.data
     } catch (e) {
       _handleErrorHelper(e, url)
@@ -518,8 +524,9 @@ function _handleErrorHelper (e, requestUrl) {
   } else if (!e.response) {
     // delete headers, may contain tokens
     if (e.config && e.config.headers) delete e.config.headers
+
     console.error(`Network error while making request to ${requestUrl} ${JSON.stringify(e)}`)
-    throw new Error(`Network error while making request to ${requestUrl} ${e}`)
+    throw new Error(`Network error while making request to ${requestUrl} ${JSON.stringify(e)}`)
   } else {
     throw e
   }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -497,7 +497,7 @@ class DiscoveryProvider {
       parsedResponse = Utils.parseDataFromResponse(response)
     } catch (e) {
       const errMsg = e.response && e.response.data ? e.response.data : e
-      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${errMsg}`)
+      console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${JSON.stringify(errMsg)}`)
       if (retry) {
         return this._makeRequest(requestObj, retry, attemptedRetries + 1)
       }


### PR DESCRIPTION
### Trello Card Link


### Description
Adds more logging around upload

### Services

- [x] Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran dapp with linked libs, saw info logs. Can't really exercise the same error conditions as prod though.
