### PR TITLE
Forward client IP for API streams

### DIFF
--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@audius/libs": "^1.0.0",
+    "@audius/libs": "^1.0.14",
     "JSONStream": "^1.3.5",
     "axios": "^0.19.0",
     "base64-url": "^2.2.0",

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -557,7 +557,7 @@ module.exports = function (app) {
       req.logger.info(`Logging listen for track ${blockchainId} by ${delegateOwnerWallet}`)
       // Fire and forget listen recording
       // TODO: Consider queueing these requests
-      libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet)
+      libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet, req.ip)
     }
 
     req.params.CID = multihash

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -122,7 +122,7 @@ class App {
   }
 
   _getIP (req) {
-    // Gets the IP for ratelistening based on X-Forwarded-For headers
+    // Gets the IP for rate-limiting based on X-Forwarded-For headers
     // Algorithm:
     // If > 1 headers:
     //    If rightmost is CN, then use rightmost - 1 (known to be safe)
@@ -133,18 +133,18 @@ class App {
     let ip = req.ip
     const forwardedFor = req.get('X-Forwarded-For')
 
-    // This shouldn't ever happen since Identity will always be behind CF
+    // This shouldn't ever happen since Identity will always be behind a proxy
     if (!forwardedFor) {
-      console.debug('_getIP: no forwarded-for')
+      req.logger.debug('_getIP: no forwarded-for')
       return ip
     }
 
     const headers = forwardedFor.split(',')
-    // headers length == 1 means that no x-forwarded-for was passed into identity CF,
+    // headers length == 1 means that no x-forwarded-for was passed to identity proxy,
     // so the request wasn't from CN. We can just use req.ip which corresponds
-    // to the forward-for that CF added
+    // to the forward-for that the proxy added
     if (headers.length === 1) {
-      console.debug(`_getIP: recording listen with 1 x-forwarded-for header, ip: ${ip}`)
+      req.logger.debug(`_getIP: recording listen with 1 x-forwarded-for header, ip: ${ip}`)
       return ip
     }
 
@@ -152,10 +152,10 @@ class App {
 
     if (this._isIPWhitelisted(rightMost)) {
       const forwardedIP = headers[headers.length - 2]
-      console.debug(`_getIP: recording listen from creatornode, forwarded IP: ${forwardedIP}`)
+      req.logger.debug(`_getIP: recording listen from creatornode, forwarded IP: ${forwardedIP}`)
       return forwardedIP
     }
-    console.debug(`_getIP: recording listen from 2 headers, but not creator-node, IP: ${rightMost}`)
+    req.logger.debug(`_getIP: recording listen from 2 headers, but not creator-node, IP: ${rightMost}`)
     return rightMost
   }
 

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -105,14 +105,21 @@ class IdentityService {
    * @param {number} trackId
    * @param {number} userId
    */
-  async logTrackListen (trackId, userId) {
-    return this._makeRequest({
+  async logTrackListen (trackId, userId, listenerAddress) {
+    const request = {
       url: `/tracks/${trackId}/listen`,
       method: 'post',
       data: {
         userId: userId
       }
-    })
+    }
+
+    if (listenerAddress) {
+      request.headers = {
+        'x-forwarded-for': listenerAddress
+      }
+    }
+    return this._makeRequest(request)
   }
 
   /**


### PR DESCRIPTION
### Services

- [ ] Discovery Provider
- [X] Creator Node
- [X] Identity Service
- [X] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested on staging hitting CN directly and Identity directly, grepped through logs to make sure we're testing the correct IP.

Tested that actual rate limits are working.