### PR TITLE
Fix mad dog tests

### DIFF
--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -506,7 +506,6 @@ class CreatorNode {
         throw new Error(resp.data.error)
       }
       onProgress(total, total)
-      // console.debug(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
       return resp.data
     } catch (e) {
       _handleErrorHelper(e, url)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -506,7 +506,7 @@ class CreatorNode {
         throw new Error(resp.data.error)
       }
       onProgress(total, total)
-      console.debug(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
+      // console.debug(`Upload file response for ${url}: ${JSON.stringify(resp)}`)
       return resp.data
     } catch (e) {
       _handleErrorHelper(e, url)


### PR DESCRIPTION
### Trello Card Link
None

### Description
This log was breaking mad dog, perhaps because of JSON.stringify on axios response which may cause a circular dependency error.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [X] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Passes for mad dog tests on CI