### PR TITLE
Fixed email order column name

### DIFF
--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -49,7 +49,7 @@ async function getEmailNotifications (audius, userId, announcements = [], fromTi
       order: [
         ['timestamp', 'DESC'],
         ['entityId', 'ASC'],
-        [{ model: models.NotificationAction, as: 'actions' }, 'created', 'DESC']
+        [{ model: models.NotificationAction, as: 'actions' }, 'createdAt', 'DESC']
       ],
       include: [{
         model: models.NotificationAction,


### PR DESCRIPTION
### Trello Card Link
na

### Description
Fix for #1039
Column name was wrong, this happened, because it test in `test/emailNotifications/formatEmail.js` was updated, but not the actual code and it should really import the function, but it's a hassle. 
Discovered while testing on staging. 

### Services
Identity Service

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches Email notifications


### How Has This Been Tested?
Made it match the test