### PR TITLE
Async upload file copy + max concurrency

### DIFF
--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -56,8 +56,11 @@ module.exports.handleResponseWithHeartbeat = (func) => {
       sendResponseWithHeartbeatTerminator(req, res, resp)
       next()
     } catch (error) {
-      console.error('HandleResponse', error)
-      next(error)
+      sendResponseWithHeartbeatTerminator(
+        req,
+        res,
+        errorResponse(500, error)
+      )
     }
   }
 }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -62,7 +62,12 @@ async function saveFileToIPFSFromFS (req, srcPath) {
   const dstPath = path.join(req.app.get('storagePath'), multihash)
 
   try {
-    fs.copyFileSync(srcPath, dstPath)
+    await new Promise((resolve, reject) => {
+      fs.copyFile(srcPath, dstPath, (err) => {
+        if (err) reject(err)
+        resolve()
+      })
+    })
   } catch (e) {
     // if we see a ENOSPC error, log out the disk space and inode details from the system
     if (e.message.includes('ENOSPC')) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs')
+const fsExtra = require('fs-extra')
 const multer = require('multer')
 const getUuid = require('uuid/v4')
 const axios = require('axios')
@@ -62,12 +63,7 @@ async function saveFileToIPFSFromFS (req, srcPath) {
   const dstPath = path.join(req.app.get('storagePath'), multihash)
 
   try {
-    await new Promise((resolve, reject) => {
-      fs.copyFile(srcPath, dstPath, (err) => {
-        if (err) reject(err)
-        resolve()
-      })
-    })
+    await fsExtra.copy(srcPath, dstPath)
   } catch (e) {
     // if we see a ENOSPC error, log out the disk space and inode details from the system
     if (e.message.includes('ENOSPC')) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const fs = require('fs')
-const fsExtra = require('fs-extra')
 const multer = require('multer')
 const getUuid = require('uuid/v4')
 const axios = require('axios')
@@ -12,6 +11,7 @@ const unlink = promisify(fs.unlink)
 const rmdir = promisify(fs.rmdir)
 const writeFile = promisify(fs.writeFile)
 const mkdir = promisify(fs.mkdir)
+const copyFile = promisify(fs.copyFile)
 
 const config = require('./config')
 const Utils = require('./utils')
@@ -63,7 +63,7 @@ async function saveFileToIPFSFromFS (req, srcPath) {
   const dstPath = path.join(req.app.get('storagePath'), multihash)
 
   try {
-    await fsExtra.copy(srcPath, dstPath)
+    await copyFile(srcPath, dstPath)
   } catch (e) {
     // if we see a ENOSPC error, log out the disk space and inode details from the system
     if (e.message.includes('ENOSPC')) {

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -4,6 +4,7 @@ const uuid = require('uuid/v4')
 const fs = require('fs')
 const fsExtra = require('fs-extra')
 const path = require('path')
+const proxyquire = require('proxyquire')
 
 const { ipfs } = require('../src/ipfsClient')
 const { saveFileToIPFSFromFS, removeTrackFolder, saveFileFromBufferToIPFSAndDisk } = require('../src/fileManager')
@@ -100,8 +101,12 @@ describe('test fileManager', () => {
      * When: file copying fails
      * Then: an error is thrown
      */
-    it('should throw an error if file copy fails', async () => {
-      sinon.stub(fs, 'copyFileSync').throws(new Error('Failed to copy files!!'))
+    it.only('should throw an error if file copy fails', async () => {
+      const copyFileStub = sinon.stub().throws((new Error('Failed to copy files!!')))
+      const utilStub = { promisify: sinon.stub().callsFake(() => copyFileStub) }
+      const { saveFileToIPFSFromFS } = proxyquire('../src/fileManager', {
+        util: utilStub
+      })
 
       try {
         await saveFileToIPFSFromFS(req, srcPath)


### PR DESCRIPTION
### Trello Card Link


### Description
- Moves file copying in track upload from sync to async & limits max concurrency to 10 (same as nodesync).
- Fixes a small error handling bug in hearbeat

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches track upload


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Ran services locally & uploaded a track. Verified that all segment multihashes and image multihashes were present in /file_storage
2. Manually threw an error in track.js to trigger heartbeat failed response