### PR TITLE
IPFS 0.7.0 Upgrade, Local dev patch

### DIFF
--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -47,7 +47,7 @@ if [ "$1" == "standalone_creator" ]; then
 
   if [ ! "${IPFS_EXISTS}" ]; then
     echo "IPFS Container doesn't exist"
-    docker run -d --name $IPFS_CONTAINER -p 127.0.0.1:$ipfsPort:5001 ipfs/go-ipfs:v0.4.23 daemon
+    docker run -d --name $IPFS_CONTAINER -p 127.0.0.1:$ipfsPort:5001 ipfs/go-ipfs:v0.7.0 daemon
   fi
 
   if [ ! "${DB_EXISTS}" ]; then

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -10,7 +10,7 @@ pytest==6.0.1
 SQLAlchemy-Utils==0.33.3
 chance==0.110
 pylint==2.3.1
-ipfshttpclient==0.4.12
+ipfshttpclient==0.6.1
 pytest-cov==2.6.0
 pytest-dotenv==0.5.2
 base58==1.0.0

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -54,7 +54,7 @@ def initialize_blocks_table_if_necessary(db):
                 parenthash=target_blockhash,
                 is_current=True,
             )
-            if target_block.number == 0:
+            if target_block.number == 0 or target_blockhash == default_config_start_hash:
                 block_model.number = None
 
             session.add(block_model)

--- a/libs/scripts/ipfs.sh
+++ b/libs/scripts/ipfs.sh
@@ -3,6 +3,7 @@
 API_PORT=6001
 SWARM_PORT=6002
 CONTAINER_NAME=local_ipfs_node
+IPFS_RELEASE_VERSION=ipfs/go-ipfs:v0.7.0
 
 if [[ "$1" =~ ^up|down$ ]]; then 
   echo "Local ipfs operations:"
@@ -34,13 +35,13 @@ if [[ "$1" == 'up' ]]; then
   fi
 
   # Pull image
-  docker pull ipfs/go-ipfs:v0.4.23
+  docker pull $IPFS_RELEASE_VERSION
 
   if [[ -z "$5" ]]; then
-    docker run -d --name $CONTAINER_NAME -p 127.0.0.1:$API_PORT:5001 -p 127.0.0.1:$SWARM_PORT:4001 --network=audius_dev ipfs/go-ipfs:v0.4.23 daemon
+    docker run -d --name $CONTAINER_NAME -p 127.0.0.1:$API_PORT:5001 -p 127.0.0.1:$SWARM_PORT:4001 --network=audius_dev $IPFS_RELEASE_VERSION daemon
   else
     GATEWAY_PORT=$5
-    docker run -d --name $CONTAINER_NAME -p 127.0.0.1:$API_PORT:5001 -p 127.0.0.1:$SWARM_PORT:4001 -p 127.0.0.1:$GATEWAY_PORT:8080 --network=audius_dev ipfs/go-ipfs:v0.4.23 daemon
+    docker run -d --name $CONTAINER_NAME -p 127.0.0.1:$API_PORT:5001 -p 127.0.0.1:$SWARM_PORT:4001 -p 127.0.0.1:$GATEWAY_PORT:8080 --network=audius_dev $IPFS_RELEASE_VERSION daemon
   fi
 
 elif [[ "$1" == 'down' ]]; then


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/AO4MRegs/1642-update-ipfs-version
https://trello.com/c/ipxxC6am/1674-disc-prov-local-dev-weird-behavior

### Description
**IPFS Version:**
Upgraded to latest 0.7.0 - significant improvements to be found :)

**Local dev weird behavior**
While running the system this error is manifested occasionally and very annoying - this work item is to diagnose and fix this occurrence. Seems like a local specific scenario where a commit occurs in the first block and processing window is < total blocks available.

### Services

- [x] Discovery Provider
- [x] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

In order to verify, let’s do the following steps on staging:

1. Upgrade 1 cn to 0.7.0, validate how the pre-existing key and persisted volume work with the new ipfs version (should be no issue)
1b. Peer from cn 0.7.0 -> dp 0.4.23 confirm this works without issue
1c. Peer from dp 0.4.23 -> cn 0.7.0, confirm this works without issue
2. Upgrade 1 disc prov to 0.7.0, peer from dp 0.7.0 -> cn 0.4.23 confirm this works without issue
3. Peer from dp 0.7.0 -> cn 0.7.0
3b. For all peer verification, explicitly swarm disconnect and reconnect

Local validation
1. Happy flow with all updated 0.7.0 ipfs nodes, just bring up the system and confirm write operations work as expected

2. (from Sid) Ensure old data is supported with new version: upload a bunch of data with old version, bump version and confirm all content is accessible and all functionality is still supported

