### PR TITLE
Fix only inadvertently added to test

### DIFF
--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -101,7 +101,7 @@ describe('test fileManager', () => {
      * When: file copying fails
      * Then: an error is thrown
      */
-    it.only('should throw an error if file copy fails', async () => {
+    it('should throw an error if file copy fails', async () => {
       const copyFileStub = sinon.stub().throws((new Error('Failed to copy files!!')))
       const utilStub = { promisify: sinon.stub().callsFake(() => copyFileStub) }
       const { saveFileToIPFSFromFS } = proxyquire('../src/fileManager', {


### PR DESCRIPTION
### Trello Card Link


### Description
Removes .only added in #1046

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope

