### PR TITLE
Fix mad dog when env var isn't set

### DIFF
--- a/libs/initScripts/configureLocalDiscProv.js
+++ b/libs/initScripts/configureLocalDiscProv.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 const readline = require('readline')
 const ethContractsMigrationOutput = require('../../eth-contracts/migrations/migration-output.json')
 
@@ -6,7 +7,7 @@ const ethContractsMigrationOutput = require('../../eth-contracts/migrations/migr
 // Updates audius_eth_contracts_registry in discovery provider
 const configureLocalDiscProv = async () => {
   let ethRegistryAddress = ethContractsMigrationOutput.registryAddress
-  let envPath = `${process.env.PROTOCOL_DIR}/discovery-provider/compose/.env`
+  let envPath = path.join(process.cwd(), '../../', 'discovery-provider/compose/.env')
   await _updateDiscoveryProviderEnvFile(envPath, envPath, ethRegistryAddress)
 }
 

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -63,7 +63,7 @@
     "host": "audius-disc-prov_web-server_1",
     "port": 5000,
     "up": [
-      "cd libs/initScripts; node configureLocalDiscprov.js",
+      "cd libs/initScripts; node configureLocalDiscProv.js",
       "cd discovery-provider; [ ! -e celerybeat.pid ] || rm celerybeat.pid",
       "cd discovery-provider; docker-compose -f compose/docker-compose.base.override.yml -f compose/docker-compose.dev.override.yml -f compose/docker-compose.ipfs.override.yml up --build -d",
       "echo 'Waiting 5 seconds...'",


### PR DESCRIPTION
### Trello Card Link
None

### Description
Mad dog started failing in this PR (https://github.com/AudiusProject/audius-protocol/pull/1031) because PROTOCOL_DIR isn't set.

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [X] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Ran the system locally, ran mad dog locally and running mad dog on CI