### PR TITLE
Stop ignoring build directory when pushing images

### DIFF
--- a/discovery-provider/.dockerignore
+++ b/discovery-provider/.dockerignore
@@ -1,4 +1,3 @@
 venv
 logs
 *.swp
-build


### PR DESCRIPTION
### Description
Observed staging rollout and resolved with this patch - ensures that committed files are pushed to the docker container