### PR TITLE
Update network peers task

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -330,12 +330,8 @@ def configure_celery(flask_app, celery, test_config=None):
     db = SessionManager(database_url, engine_args_literal)
     logger.info('Database instance initialized!')
     # Initialize IPFS client for celery task context
-    gateway_addrs = shared_config["ipfs"]["gateway_hosts"].split(',')
-    gateway_addrs.append(
-        shared_config["discprov"]["user_metadata_service_url"])
-    logger.warning(f"__init__.py | {gateway_addrs}")
     ipfs_client = IPFSClient(
-        shared_config["ipfs"]["host"], shared_config["ipfs"]["port"], gateway_addrs
+        shared_config["ipfs"]["host"], shared_config["ipfs"]["port"]
     )
 
     # Initialize Redis connection

--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -156,8 +156,10 @@ def update_network_peers(self):
         if have_lock:
             # An object returned from web3 chain queries
             peers_from_ethereum = retrieve_peers_from_eth_contracts(self)
+            logger.info(f"index_network_peers.py | Peers from eth-contracts: {peers_from_ethereum}")
             # An object returned from local database queries
             peers_from_local = retrieve_peers_from_db(self)
+            logger.info(f"index_network_peers.py | Peers from db : {peers_from_local}")
             # Combine the set of known peers from ethereum and within local database
             all_peers = peers_from_ethereum
             all_peers.update(peers_from_local)
@@ -167,6 +169,11 @@ def update_network_peers(self):
             for node_info in identity_cnodes_map:
                 all_peers.add(node_info['endpoint'])
 
+            # Legacy user metadata node is always added to set of known peers
+            user_metadata_url = update_network_peers.shared_config["discprov"]["user_metadata_service_url"])
+            all_peers.add(user_metadata_url)
+
+            logger.info(f"index_network_peers.py | All known peers {all_peers}")
             peers_list = list(all_peers)
             # Update creator node url list in IPFS Client
             # This list of known nodes is used to traverse and retrieve metadata from gateways

--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -170,7 +170,7 @@ def update_network_peers(self):
                 all_peers.add(node_info['endpoint'])
 
             # Legacy user metadata node is always added to set of known peers
-            user_metadata_url = update_network_peers.shared_config["discprov"]["user_metadata_service_url"])
+            user_metadata_url = update_network_peers.shared_config["discprov"]["user_metadata_service_url"]
             all_peers.add(user_metadata_url)
 
             logger.info(f"index_network_peers.py | All known peers {all_peers}")

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -15,9 +15,8 @@ logger = logging.getLogger(__name__)
 class IPFSClient:
     """ Helper class for Audius Discovery Provider + IPFS interaction """
 
-    def __init__(self, ipfs_peer_host, ipfs_peer_port, gateway_addresses):
+    def __init__(self, ipfs_peer_host, ipfs_peer_port):
         self._api = ipfshttpclient.connect(f"/dns/{ipfs_peer_host}/tcp/{ipfs_peer_port}/http")
-        self._gateway_addresses = gateway_addresses
         self._cnode_endpoints = []
         self._ipfsid = self._api.id()
         self._multiaddr = get_valid_multiaddr_from_id_json(self._ipfsid)
@@ -115,8 +114,7 @@ class IPFSClient:
         gateway_endpoints = self._cnode_endpoints
         logger.warning(f"IPFSCLIENT | get_metadata_from_gateway, \
                 \ncombined addresses: {gateway_endpoints}, \
-                \ncnode_endpoints: {self._cnode_endpoints}, \
-                \naddresses: {self._gateway_addresses}")
+                \ncnode_endpoints: {self._cnode_endpoints}")
 
         query_urls = ["%s/ipfs/%s" % (addr, multihash) for addr in gateway_endpoints]
         data = self.query_ipfs_metadata_json(query_urls, metadata_format)

--- a/discovery-provider/tests/test_ipfs_functionality.py
+++ b/discovery-provider/tests/test_ipfs_functionality.py
@@ -14,7 +14,7 @@ def test_ipfs(app):
     ipfs_peer_port = app.config["ipfs"]["port"]
 
     # Instantiate IPFS client from src lib
-    ipfsclient = IPFSClient(ipfs_peer_host, ipfs_peer_port, [])
+    ipfsclient = IPFSClient(ipfs_peer_host, ipfs_peer_port)
 
     remove_test_file(json_file)
     api = ipfshttpclient.connect(f"/dns/{ipfs_peer_host}/tcp/{ipfs_peer_port}/http")


### PR DESCRIPTION
Account for legacy state in peering task and enable additional logging.

### Description


### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches network peer indexing


### How Has This Been Tested?

Validated on staging, logs in PR