### PR TITLE
File storage directory nesting

### DIFF
--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -14,6 +14,7 @@ fi
 
 export storagePath='./test_file_storage'
 export logLevel='info'
+export printSequelizeLogs=false
 
 tear_down () {
   set +e

--- a/creator-node/src/ImageProcessingQueue.js
+++ b/creator-node/src/ImageProcessingQueue.js
@@ -58,7 +58,6 @@ class ImageProcessingQueue {
    * writes the results to file storage
    * @param {string} path to the image file
    * @param {string} fileName name of the original file
-   * @param {string} storagePath app storage path to save files to
    * @param {object<string, number>} sizes
    * @param {string} sizes.key the name of the sized file e.g. 150x150.jpg
    * @param {number} sizes.value the maxWidth resize the image to, e.g. 1000
@@ -81,14 +80,13 @@ class ImageProcessingQueue {
   async resizeImage ({
     file,
     fileName,
-    storagePath,
     sizes,
     square,
     logContext
   }) {
     const job = await this.queue.add(
       PROCESS_NAMES.resizeImage,
-      { file, fileName, storagePath, sizes, square, logContext }
+      { file, fileName, sizes, square, logContext }
     )
     const result = await job.finished()
     return result

--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -2,6 +2,7 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
 
+const DiskManager = require('./diskManager')
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { logger, loggingMiddleware } = require('./logging')
 const { userNodeMiddleware } = require('./userNodeMiddleware')
@@ -47,11 +48,12 @@ function errorHandler (err, req, res, next) {
 }
 app.use(errorHandler)
 
-const initializeApp = (port, storageDir, serviceRegistry) => {
+const initializeApp = (port, serviceRegistry) => {
+  const storagePath = DiskManager.getConfigStoragePath()
   // TODO: Can remove these when all routes
   // consume serviceRegistry
   app.set('ipfsAPI', serviceRegistry.ipfs)
-  app.set('storagePath', storageDir)
+  app.set('storagePath', storagePath)
   app.set('redisClient', serviceRegistry.redis)
   app.set('audiusLibs', serviceRegistry.libs)
   app.set('blacklistManager', serviceRegistry.blacklistManager)

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -2,7 +2,7 @@ const path = require('path')
 const fs = require('fs')
 const config = require('./config')
 
-// use this set to cache existing paths we know we've created so we don't make extraneous file system calls
+// use this set to cache existing directory paths we know we've created so we don't make extraneous file system calls
 let EXISTING_PATHS = new Set()
 
 class DiskManager {
@@ -32,14 +32,14 @@ class DiskManager {
   }
 
   /**
-   *
+   * Given a directory path, this function will create the dirPath if it doesn't exist
+   * If it does exist, it will not overwrite, effectively a no-op
    * @param {*} dirPath fs directory path to create if it does not exist
    */
   static ensureDirPathExists (dirPath) {
     try {
       if (!EXISTING_PATHS.has(dirPath)) {
-        // calling this on an existing directory doesn't overwrite the existing data or throw an error
-        // the mkdir recursive is equivalent to `mkdir -p`
+        // the mkdir recursive option is equivalent to `mkdir -p` and should created nested folders several levels deep
         fs.mkdirSync(dirPath, { recursive: true })
         EXISTING_PATHS.add(dirPath)
       }

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -89,18 +89,15 @@ class DiskManager {
    *    outer should always be defined and can either be a file if not dir, or the dir name if dir
    *    inner will be defined if the file is inside the dir matched by the outer match group
    */
-  static extractCIDsFromPath (fsPath) {
+  static extractCIDsFromFSPath (fsPath) {
     const match = CID_DIRECTORY_REGEX.exec(fsPath)
-    let ret = {}
-
     if (!match || !match.groups) return null
 
+    let ret = null
     if (match && match.groups && match.groups.outer && match.groups.inner) {
       ret = { isDir: true, outer: match.groups.outer, inner: match.groups.inner }
     } else if (match.groups.outer && !match.groups.inner) {
       ret = { isDir: false, outer: match.groups.outer, inner: null }
-    } else {
-      ret = null
     }
 
     return ret

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -1,0 +1,52 @@
+const path = require('path')
+const fs = require('fs')
+const config = require('./config')
+
+// use this set to cache existing paths we know we've created so we don't make extraneous file system calls
+let EXISTING_PATHS = new Set()
+
+class DiskManager {
+  /**
+   * Return the storagePath from the config
+   */
+  static getConfigStoragePath () {
+    return config.get('storagePath')
+  }
+
+  /**
+   * Construct a subdirectory path given a file CID or dir CID
+   * @dev Returns a subdirectory path with the three characters before the last character
+   *      eg QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6 will be eg /file_storage/uU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6
+   * @param {String} fileName file CID or dir CID name
+   */
+  static computeCIDFilePath (fileName) {
+    if (!fileName || fileName.length < 4) throw new Error(`Please pass in a valid fileName to computeCIDFilePath. Passed in ${fileName}`)
+
+    // this is the directory path that file with fileName will go into
+    const parentDirPath = path.join(this.getConfigStoragePath(), fileName.slice(-4, -1))
+
+    // create the subdirectories in parentDirHash if they don't exist
+    this.ensureDirPathExists(parentDirPath)
+
+    return path.join(parentDirPath, fileName)
+  }
+
+  /**
+   *
+   * @param {*} dirPath fs directory path to create if it does not exist
+   */
+  static ensureDirPathExists (dirPath) {
+    try {
+      if (!EXISTING_PATHS.has(dirPath)) {
+        // calling this on an existing directory doesn't overwrite the existing data or throw an error
+        // the mkdir recursive is equivalent to `mkdir -p`
+        fs.mkdirSync(dirPath, { recursive: true })
+        EXISTING_PATHS.add(dirPath)
+      }
+    } catch (e) {
+      throw new Error(`Error making directory at ${dirPath} - ${e.message}`)
+    }
+  }
+}
+
+module.exports = DiskManager

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -20,7 +20,8 @@ class DiskManager {
    * @param {String} fileName file CID or dir CID name
    */
   static computeCIDFilePath (fileName) {
-    // TODO - reject paths here
+    // TODO - reject paths/dirs here
+    // TODO allow path joining for dirCID and file
     if (!fileName || fileName.length < 4) throw new Error(`Please pass in a valid fileName to computeCIDFilePath. Passed in ${fileName}`)
 
     // this is the directory path that file with fileName will go into

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -14,24 +14,49 @@ class DiskManager {
   }
 
   /**
-   * Construct a subdirectory path given a file CID or dir CID
-   * @dev Returns a subdirectory path with the three characters before the last character
+   * Construct the path to a file or directory
+   *
+   * eg. if you have a file `Qmabcxyz`, use this function to get the path /file_storage/files/cxy/Qmabcxyz
+   * eg. if you have a dir `Qmdir123`, use this function to get the path /file_storage/files/r12/Qmdir123/
+   * Use `computeFilePathInDir` if you want to get the path for a file inside a directory.
+   *
+   * @dev Returns a path with the three characters before the last character
    *      eg QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6 will be eg /file_storage/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6
-   * @param {String} fileName file CID or dir CID name
+   * @param {String} fsDest file system destination, either filename or directory name
    */
-  static computeCIDFilePath (fileName) {
-    // TODO - reject paths/dirs here
-    // TODO allow path joining for dirCID and file
-    if (!fileName || fileName.length < 4) throw new Error(`Please pass in a valid fileName to computeCIDFilePath. Passed in ${fileName}`)
+  static computeBasePath (fsDest) {
+    if (!fsDest || fsDest.length < 4) throw new Error(`Please pass in a valid fsDest to computeBasePath. Passed in ${fsDest}`)
+    if (fsDest.includes('/')) throw new Error('Cannot pass in a directory path into this function, please pass in the leaf dir or file name')
 
-    // this is the directory path that file with fileName will go into
-    const parentDirPath = path.join(this.getConfigStoragePath(), fileName.slice(-4, -1))
+    // This is the directory path that file with fsDest will go into.
+    // The reason for nesting `files` inside `/file_storage` is because legacy nodes store files at the root of `/file_storage`, and
+    // that can cause potential collisions if we're creating large amounts of subdirectories. A way to mitigate this is create one
+    // directory in the root `/file_storage` and all other directories inside of it like `file_storage/files/<directoryID>/<fsDest>
+    const directoryID = fsDest.slice(-4, -1)
+    const parentDirPath = path.join(this.getConfigStoragePath(), 'files', directoryID)
     // in order to easily dev against the older and newer paths, the line below is the legacy storage path
     // const parentDirPath = this.getConfigStoragePath()
 
     // create the subdirectories in parentDirHash if they don't exist
     this.ensureDirPathExists(parentDirPath)
 
+    return path.join(parentDirPath, fsDest)
+  }
+
+  /**
+   * Given a directory name and a file name, construct the full file system path for a directory and a folder inside a directory
+   *
+   * eg if you're manually computing the file path to an file `Qmabcxyz` inside a dir `Qmdir123`, use this function to get the
+   * path with both the dir and the file /file_storage/files/r12/Qmdir123/Qmabcxyz
+   * Use `computeBasePath` if you just want to get to the path of a file or directory.
+   *
+   * @param {String} dirName directory name
+   * @param {String} fileName file name
+   */
+  static computeFilePathInDir (dirName, fileName) {
+    if (!dirName || !fileName) throw new Error('Must pass in valid dirName and fileName')
+
+    const parentDirPath = this.computeBasePath(dirName)
     return path.join(parentDirPath, fileName)
   }
 

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -2,9 +2,6 @@ const path = require('path')
 const fs = require('fs')
 const config = require('./config')
 
-// use this set to cache existing directory paths we know we've created so we don't make extraneous file system calls
-let EXISTING_PATHS = new Set()
-
 // regex to check if a directory or just a regular file
 // if directory - will have both outer and inner properties in match.groups
 // else - will have just outer property, no inner
@@ -84,11 +81,8 @@ class DiskManager {
    */
   static ensureDirPathExists (dirPath) {
     try {
-      if (!EXISTING_PATHS.has(dirPath)) {
-        // the mkdir recursive option is equivalent to `mkdir -p` and should created nested folders several levels deep
-        fs.mkdirSync(dirPath, { recursive: true })
-        EXISTING_PATHS.add(dirPath)
-      }
+      // the mkdir recursive option is equivalent to `mkdir -p` and should created nested folders several levels deep
+      fs.mkdirSync(dirPath, { recursive: true })
     } catch (e) {
       throw new Error(`Error making directory at ${dirPath} - ${e.message}`)
     }

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -19,6 +19,17 @@ class DiskManager {
   }
 
   /**
+   * Returns the folder that stores track artifacts uploaded by creators. The reason this is all stored together
+   * is we should be able to delete the contents of this folder without scanning through other folders with the
+   * naming scheme.
+   */
+  static getTmpTrackUploadArtifactsPath () {
+    const dirPath = path.join(config.get('storagePath'), 'files', 'tmp_track_artifacts')
+    this.ensureDirPathExists(dirPath)
+    return dirPath
+  }
+
+  /**
    * Construct the path to a file or directory
    *
    * eg. if you have a file `Qmabcxyz`, use this function to get the path /file_storage/files/cxy/Qmabcxyz

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -29,8 +29,9 @@ class DiskManager {
    *      eg QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6 will be eg /file_storage/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6
    * @param {String} fsDest file system destination, either filename or directory name
    */
-  static computeBasePath (fsDest) {
-    if (!fsDest || fsDest.length < 4) throw new Error(`Please pass in a valid fsDest to computeBasePath. Passed in ${fsDest}`)
+  static computeFilePath (fsDest) {
+    // fsDesk needs to be at least 4 characters because we pick the three characters preceding the last character as the folder name
+    if (!fsDest || fsDest.length < 4) throw new Error(`Please pass in a valid fsDest to computeFilePath. Passed in ${fsDest}`)
     if (fsDest.includes('/')) throw new Error('Cannot pass in a directory path into this function, please pass in the leaf dir or file name')
 
     // This is the directory path that file with fsDest will go into.
@@ -53,7 +54,7 @@ class DiskManager {
    *
    * eg if you're manually computing the file path to an file `Qmabcxyz` inside a dir `Qmdir123`, use this function to get the
    * path with both the dir and the file /file_storage/files/r12/Qmdir123/Qmabcxyz
-   * Use `computeBasePath` if you just want to get to the path of a file or directory.
+   * Use `computeFilePath` if you just want to get to the path of a file or directory.
    *
    * @param {String} dirName directory name
    * @param {String} fileName file name
@@ -61,7 +62,7 @@ class DiskManager {
   static computeFilePathInDir (dirName, fileName) {
     if (!dirName || !fileName) throw new Error('Must pass in valid dirName and fileName')
 
-    const parentDirPath = this.computeBasePath(dirName)
+    const parentDirPath = this.computeFilePath(dirName)
     return path.join(parentDirPath, fileName)
   }
 

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -8,6 +8,10 @@ const { CID } = require('ipfs-http-client-latest')
 // else - will have just outer property, no inner
 const CID_DIRECTORY_REGEX = /\/(?<outer>Qm[a-zA-Z0-9]{44})\/?(?<inner>Qm[a-zA-Z0-9]{44})?/
 
+// variable to cache if we've run `ensureDirPathExists` in getTmpTrackUploadArtifactsPath so we don't run
+// it every time a track is uploaded
+let TMP_TRACK_ARTIFACTS_CREATED = false
+
 class DiskManager {
   /**
    * Return the storagePath from the config
@@ -23,7 +27,10 @@ class DiskManager {
    */
   static getTmpTrackUploadArtifactsPath () {
     const dirPath = path.join(config.get('storagePath'), 'files', 'tmp_track_artifacts')
-    this.ensureDirPathExists(dirPath)
+    if (!TMP_TRACK_ARTIFACTS_CREATED) {
+      this.ensureDirPathExists(dirPath)
+      TMP_TRACK_ARTIFACTS_CREATED = true
+    }
     return dirPath
   }
 

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -20,10 +20,13 @@ class DiskManager {
    * @param {String} fileName file CID or dir CID name
    */
   static computeCIDFilePath (fileName) {
+    // TODO - reject paths here
     if (!fileName || fileName.length < 4) throw new Error(`Please pass in a valid fileName to computeCIDFilePath. Passed in ${fileName}`)
 
     // this is the directory path that file with fileName will go into
     const parentDirPath = path.join(this.getConfigStoragePath(), fileName.slice(-4, -1))
+    // in order to easily dev against the older and newer paths, the line below is the legacy storage path
+    // const parentDirPath = this.getConfigStoragePath()
 
     // create the subdirectories in parentDirHash if they don't exist
     this.ensureDirPathExists(parentDirPath)

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -16,7 +16,7 @@ class DiskManager {
   /**
    * Construct a subdirectory path given a file CID or dir CID
    * @dev Returns a subdirectory path with the three characters before the last character
-   *      eg QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6 will be eg /file_storage/uU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6
+   *      eg QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6 will be eg /file_storage/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6
    * @param {String} fileName file CID or dir CID name
    */
   static computeCIDFilePath (fileName) {

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -67,27 +67,27 @@ describe('Test DiskManager', function () {
   })
 
   /**
-   * extractCIDsFromPath
+   * extractCIDsFromFSPath
    */
-  it('Should pass if extractCIDsFromPath is passed in a directory and file', function () {
+  it('Should pass if extractCIDsFromFSPath is passed in a directory and file', function () {
     const path = '/file_storage/files/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grouter/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner'
-    const matchObj = DiskManager.extractCIDsFromPath(path)
+    const matchObj = DiskManager.extractCIDsFromFSPath(path)
     assert.deepStrictEqual(matchObj.isDir, true)
     assert.deepStrictEqual(matchObj.outer, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grouter')
     assert.deepStrictEqual(matchObj.inner, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner')
   })
 
-  it('Should pass if extractCIDsFromPath is passed in just a file', function () {
+  it('Should pass if extractCIDsFromFSPath is passed in just a file', function () {
     const path = '/file_storage/files/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner'
-    const matchObj = DiskManager.extractCIDsFromPath(path)
+    const matchObj = DiskManager.extractCIDsFromFSPath(path)
     assert.deepStrictEqual(matchObj.isDir, false)
     assert.deepStrictEqual(matchObj.outer, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner')
     assert.deepStrictEqual(matchObj.inner, null)
   })
 
-  it('Should return null if extractCIDsFromPath is passed in no valid CID', function () {
+  it('Should return null if extractCIDsFromFSPath is passed in no valid CID', function () {
     const path = '/file_storage/files/QMcidhere'
-    const matchObj = DiskManager.extractCIDsFromPath(path)
+    const matchObj = DiskManager.extractCIDsFromFSPath(path)
     assert.deepStrictEqual(matchObj, null)
   })
 })

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -9,10 +9,16 @@ describe('Test DiskManager', function () {
     DiskManager.ensureDirPathExists = async () => true
   })
 
+  /**
+   * getConfigStoragePath
+   */
   it('Should pass if storagePath is correctly set', function () {
     assert.deepStrictEqual(config.get('storagePath'), DiskManager.getConfigStoragePath())
   })
 
+  /**
+   * computeBasePath
+   */
   it('Should pass if computeBasePath returns the correct path', function () {
     const fullPath = DiskManager.computeBasePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
@@ -43,6 +49,9 @@ describe('Test DiskManager', function () {
     }
   })
 
+  /**
+   * computeFilePathInDir
+   */
   it('Should pass if computeBasePath returns the correct path', function () {
     const fullPath = DiskManager.computeFilePathInDir('QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
@@ -55,5 +64,30 @@ describe('Test DiskManager', function () {
     } catch (e) {
       assert.ok(e.message.includes('Must pass in valid dirName and fileName'))
     }
+  })
+
+  /**
+   * extractCIDsFromPath
+   */
+  it('Should pass if extractCIDsFromPath is passed in a directory and file', function () {
+    const path = '/file_storage/files/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grouter/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner'
+    const matchObj = DiskManager.extractCIDsFromPath(path)
+    assert.deepStrictEqual(matchObj.isDir, true)
+    assert.deepStrictEqual(matchObj.outer, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grouter')
+    assert.deepStrictEqual(matchObj.inner, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner')
+  })
+
+  it('Should pass if extractCIDsFromPath is passed in just a file', function () {
+    const path = '/file_storage/files/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner'
+    const matchObj = DiskManager.extractCIDsFromPath(path)
+    assert.deepStrictEqual(matchObj.isDir, false)
+    assert.deepStrictEqual(matchObj.outer, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3Grinner')
+    assert.deepStrictEqual(matchObj.inner, null)
+  })
+
+  it('Should return null if extractCIDsFromPath is passed in no valid CID', function () {
+    const path = '/file_storage/files/QMcidhere'
+    const matchObj = DiskManager.extractCIDsFromPath(path)
+    assert.deepStrictEqual(matchObj, null)
   })
 })

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -1,0 +1,36 @@
+const DiskManager = require('./diskManager')
+const assert = require('assert')
+const config = require('./config')
+
+describe('Test DiskManager', function () {
+  before(function () {
+    // stub out this function which ensures the directory path exists to return true
+    DiskManager.ensureDirPathExists = async () => true
+  })
+
+  it('Should pass if storagePath is correctly set', function () {
+    assert.deepStrictEqual(config.get('storagePath'), DiskManager.getConfigStoragePath())
+  })
+
+  it('Should pass if computeCIDFilePath returns the correct path', function () {
+    const fullPath = DiskManager.computeCIDFilePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const validPath = `${config.get('storagePath')}/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6`
+    assert.deepStrictEqual(fullPath, validPath)
+  })
+
+  it('Should fail if fileName is not passed into computeCIDFilePath', function () {
+    try {
+      DiskManager.computeCIDFilePath()
+    } catch (e) {
+      assert.ok(e.message.includes('Please pass in a valid fileName to computeCIDFilePath'))
+    }
+  })
+
+  it(`Should fail if fileName doesn't contain the appropriate amount of characters`, function () {
+    try {
+      DiskManager.computeCIDFilePath('as')
+    } catch (e) {
+      assert.ok(e.message.includes('Please pass in a valid fileName to computeCIDFilePath'))
+    }
+  })
+})

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -1,6 +1,7 @@
 const DiskManager = require('./diskManager')
 const assert = require('assert')
 const config = require('./config')
+const path = require('path')
 
 describe('Test DiskManager', function () {
   before(function () {
@@ -14,7 +15,7 @@ describe('Test DiskManager', function () {
 
   it('Should pass if computeCIDFilePath returns the correct path', function () {
     const fullPath = DiskManager.computeCIDFilePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
-    const validPath = `${DiskManager.getConfigStoragePath()}/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6`
+    const validPath = path.join(DiskManager.getConfigStoragePath(), 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -14,7 +14,7 @@ describe('Test DiskManager', function () {
 
   it('Should pass if computeCIDFilePath returns the correct path', function () {
     const fullPath = DiskManager.computeCIDFilePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
-    const validPath = `${config.get('storagePath')}/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6`
+    const validPath = `${DiskManager.getConfigStoragePath()}/muU/QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6`
     assert.deepStrictEqual(fullPath, validPath)
   })
 
@@ -28,7 +28,7 @@ describe('Test DiskManager', function () {
 
   it(`Should fail if fileName doesn't contain the appropriate amount of characters`, function () {
     try {
-      DiskManager.computeCIDFilePath('as')
+      DiskManager.computeCIDFilePath('asd')
     } catch (e) {
       assert.ok(e.message.includes('Please pass in a valid fileName to computeCIDFilePath'))
     }

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -17,33 +17,33 @@ describe('Test DiskManager', function () {
   })
 
   /**
-   * computeBasePath
+   * computeFilePath
    */
-  it('Should pass if computeBasePath returns the correct path', function () {
-    const fullPath = DiskManager.computeBasePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+  it('Should pass if computeFilePath returns the correct path', function () {
+    const fullPath = DiskManager.computeFilePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
-  it('Should fail if fileName is not passed into computeBasePath', function () {
+  it('Should fail if fileName is not passed into computeFilePath', function () {
     try {
-      DiskManager.computeBasePath()
+      DiskManager.computeFilePath()
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fsDest to computeBasePath'))
+      assert.ok(e.message.includes('Please pass in a valid fsDest to computeFilePath'))
     }
   })
 
   it(`Should fail if fileName doesn't contain the appropriate amount of characters`, function () {
     try {
-      DiskManager.computeBasePath('asd')
+      DiskManager.computeFilePath('asd')
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fsDest to computeBasePath'))
+      assert.ok(e.message.includes('Please pass in a valid fsDest to computeFilePath'))
     }
   })
 
   it(`Should fail if fileName contains a slash`, function () {
     try {
-      DiskManager.computeBasePath('/file_storage/asdf')
+      DiskManager.computeFilePath('/file_storage/asdf')
     } catch (e) {
       assert.ok(e.message.includes('Cannot pass in a directory path into this function, please pass in the leaf dir or file name'))
     }
@@ -52,13 +52,13 @@ describe('Test DiskManager', function () {
   /**
    * computeFilePathInDir
    */
-  it('Should pass if computeBasePath returns the correct path', function () {
+  it('Should pass if computeFilePathInDir returns the correct path', function () {
     const fullPath = DiskManager.computeFilePathInDir('QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
-  it('Should fail if dirName and fileName are not passed into computeBasePath', function () {
+  it('Should fail if dirName and fileName are not passed into computeFilePath', function () {
     try {
       DiskManager.computeFilePathInDir()
     } catch (e) {

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -37,7 +37,7 @@ describe('Test DiskManager', function () {
     try {
       DiskManager.computeFilePath()
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fsDest to computeFilePath'))
+      assert.ok(e.message.includes('Please pass in a valid cid to computeFilePath'))
     }
   })
 
@@ -45,7 +45,7 @@ describe('Test DiskManager', function () {
     try {
       DiskManager.computeFilePath('asd')
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fsDest to computeFilePath'))
+      assert.ok(e.message.includes('Please pass in a valid cid to computeFilePath'))
     }
   })
 
@@ -53,7 +53,7 @@ describe('Test DiskManager', function () {
     try {
       DiskManager.computeFilePath('/file_storage/asdf')
     } catch (e) {
-      assert.ok(e.message.includes('Cannot pass in a directory path into this function, please pass in the leaf dir or file name'))
+      assert.ok(e.message.includes('Please pass in a valid cid to computeFilePath'))
     }
   })
 
@@ -61,16 +61,24 @@ describe('Test DiskManager', function () {
    * computeFilePathInDir
    */
   it('Should pass if computeFilePathInDir returns the correct path', function () {
-    const fullPath = DiskManager.computeFilePathInDir('QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
-    const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const fullPath = DiskManager.computeFilePathInDir('QmRSvU8NtadxPPrP4M72wUPBiTqykqziWDuGr6q2arsYW4', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'sYW', 'QmRSvU8NtadxPPrP4M72wUPBiTqykqziWDuGr6q2arsYW4', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
-  it('Should fail if dirName and fileName are not passed into computeFilePath', function () {
+  it('Should fail if dirName and fileName are not passed into computeFilePathInDir', function () {
     try {
       DiskManager.computeFilePathInDir()
     } catch (e) {
       assert.ok(e.message.includes('Must pass in valid dirName and fileName'))
+    }
+  })
+
+  it('Should fail if dirName or fileName are not a CID passed into computeFilePathInDir', function () {
+    try {
+      DiskManager.computeFilePathInDir('Qmdirhash', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    } catch (e) {
+      assert.ok(e.message.includes('Please pass in a valid cid to computeFilePathInDir for dirName and fileName'))
     }
   })
 

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -15,7 +15,7 @@ describe('Test DiskManager', function () {
 
   it('Should pass if computeBasePath returns the correct path', function () {
     const fullPath = DiskManager.computeBasePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
-    const validPath = path.join(DiskManager.getConfigStoragePath(), 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
@@ -45,13 +45,13 @@ describe('Test DiskManager', function () {
 
   it('Should pass if computeBasePath returns the correct path', function () {
     const fullPath = DiskManager.computeFilePathInDir('QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
-    const validPath = path.join(DiskManager.getConfigStoragePath(), 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const validPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
   it('Should fail if dirName and fileName are not passed into computeBasePath', function () {
     try {
-      const fullPath = DiskManager.computeFilePathInDir()
+      DiskManager.computeFilePathInDir()
     } catch (e) {
       assert.ok(e.message.includes('Must pass in valid dirName and fileName'))
     }

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -13,25 +13,47 @@ describe('Test DiskManager', function () {
     assert.deepStrictEqual(config.get('storagePath'), DiskManager.getConfigStoragePath())
   })
 
-  it('Should pass if computeCIDFilePath returns the correct path', function () {
-    const fullPath = DiskManager.computeCIDFilePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+  it('Should pass if computeBasePath returns the correct path', function () {
+    const fullPath = DiskManager.computeBasePath('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     const validPath = path.join(DiskManager.getConfigStoragePath(), 'muU', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(fullPath, validPath)
   })
 
-  it('Should fail if fileName is not passed into computeCIDFilePath', function () {
+  it('Should fail if fileName is not passed into computeBasePath', function () {
     try {
-      DiskManager.computeCIDFilePath()
+      DiskManager.computeBasePath()
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fileName to computeCIDFilePath'))
+      assert.ok(e.message.includes('Please pass in a valid fsDest to computeBasePath'))
     }
   })
 
   it(`Should fail if fileName doesn't contain the appropriate amount of characters`, function () {
     try {
-      DiskManager.computeCIDFilePath('asd')
+      DiskManager.computeBasePath('asd')
     } catch (e) {
-      assert.ok(e.message.includes('Please pass in a valid fileName to computeCIDFilePath'))
+      assert.ok(e.message.includes('Please pass in a valid fsDest to computeBasePath'))
+    }
+  })
+
+  it(`Should fail if fileName contains a slash`, function () {
+    try {
+      DiskManager.computeBasePath('/file_storage/asdf')
+    } catch (e) {
+      assert.ok(e.message.includes('Cannot pass in a directory path into this function, please pass in the leaf dir or file name'))
+    }
+  })
+
+  it('Should pass if computeBasePath returns the correct path', function () {
+    const fullPath = DiskManager.computeFilePathInDir('QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    const validPath = path.join(DiskManager.getConfigStoragePath(), 'Nam', 'QmdirectoryName', 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    assert.deepStrictEqual(fullPath, validPath)
+  })
+
+  it('Should fail if dirName and fileName are not passed into computeBasePath', function () {
+    try {
+      const fullPath = DiskManager.computeFilePathInDir()
+    } catch (e) {
+      assert.ok(e.message.includes('Must pass in valid dirName and fileName'))
     }
   })
 })

--- a/creator-node/src/diskManager.test.js
+++ b/creator-node/src/diskManager.test.js
@@ -17,6 +17,14 @@ describe('Test DiskManager', function () {
   })
 
   /**
+   * getTmpTrackUploadArtifactsPath
+   */
+  it('Should pass if storagePath is correctly set', function () {
+    const tmpTrackArtifactPath = path.join(DiskManager.getConfigStoragePath(), 'files', 'tmp_track_artifacts')
+    assert.deepStrictEqual(tmpTrackArtifactPath, DiskManager.getTmpTrackUploadArtifactsPath())
+  })
+
+  /**
    * computeFilePath
    */
   it('Should pass if computeFilePath returns the correct path', function () {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -22,6 +22,10 @@ const MAX_MEMORY_FILE_SIZE = parseInt(config.get('maxMemoryFileSizeBytes')) // D
 
 const ALLOWED_UPLOAD_FILE_EXTENSIONS = config.get('allowedUploadFileExtensions') // default set in config.json
 const AUDIO_MIME_TYPE_REGEX = /audio\/(.*)/
+
+// regex to check if a directory or just a regular file
+// if directory - will have both outer and inner properties in match.groups
+// else - will have just outer property, no inner
 const CID_DIRECTORY_REGEX = /\/(?<outer>Qm[a-zA-Z0-9]{44})\/?(?<inner>Qm[a-zA-Z0-9]{44})?/
 
 /**
@@ -114,7 +118,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
     // regex match to check if a directory or just a regular file
     // if directory will have both outer and inner properties in match.groups
     // else will have just outer
-    const match = CID_DIRECTORY_REGEX
+    const match = CID_DIRECTORY_REGEX.exec(expectedStoragePath)
 
     // if this is a directory, make it compatible with our dir cid gateway url
     if (match && match.groups && match.groups.outer && match.groups.inner && fileNameForImage) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -223,7 +223,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
     try {
       const ipfs = req.app.get('ipfsLatestAPI')
       const content = fs.createReadStream(expectedStoragePath)
-      for await (const result of ipfs.add(content, { onlyHash: true, timeout: 2000 })) {
+      for await (const result of ipfs.add(content, { onlyHash: true, timeout: 10000 })) {
         if (multihash !== result.cid.toString()) {
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -113,7 +113,7 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
     // regex match to check if a directory or just a regular file
     // if directory will have both outer and inner properties in match.groups
     // else will have just outer
-    const matchObj = DiskManager.extractCIDsFromPath(expectedStoragePath)
+    const matchObj = DiskManager.extractCIDsFromFSPath(expectedStoragePath)
 
     // if this is a directory, make it compatible with our dir cid gateway url
     if (matchObj && matchObj.isDir && matchObj.outer && fileNameForImage) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -320,7 +320,7 @@ const trackDiskStorage = multer.diskStorage({
   destination: function (req, file, cb) {
     // save file under randomly named folders to avoid collisions
     const randomFileName = getUuid()
-    const fileDir = DiskManager.computeFilePath(randomFileName)
+    const fileDir = path.join(DiskManager.getTmpTrackUploadArtifactsPath(), randomFileName)
 
     // create directories for original file and segments
     fs.mkdirSync(fileDir)

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -23,11 +23,6 @@ const MAX_MEMORY_FILE_SIZE = parseInt(config.get('maxMemoryFileSizeBytes')) // D
 const ALLOWED_UPLOAD_FILE_EXTENSIONS = config.get('allowedUploadFileExtensions') // default set in config.json
 const AUDIO_MIME_TYPE_REGEX = /audio\/(.*)/
 
-// regex to check if a directory or just a regular file
-// if directory - will have both outer and inner properties in match.groups
-// else - will have just outer property, no inner
-const CID_DIRECTORY_REGEX = /\/(?<outer>Qm[a-zA-Z0-9]{44})\/?(?<inner>Qm[a-zA-Z0-9]{44})?/
-
 /**
  * Adds file to IPFS then saves file to disk under /multihash name
  */
@@ -118,15 +113,15 @@ async function saveFileForMultihash (req, multihash, expectedStoragePath, gatewa
     // regex match to check if a directory or just a regular file
     // if directory will have both outer and inner properties in match.groups
     // else will have just outer
-    const match = CID_DIRECTORY_REGEX.exec(expectedStoragePath)
+    const matchObj = DiskManager.extractCIDsFromPath(expectedStoragePath)
 
     // if this is a directory, make it compatible with our dir cid gateway url
-    if (match && match.groups && match.groups.outer && match.groups.inner && fileNameForImage) {
+    if (matchObj && matchObj.isDir && matchObj.outer && fileNameForImage) {
       // override gateway urls to make it compatible with directory given an endpoint
       // eg. before running the line below gatewayUrlsMapped looks like [https://endpoint.co/ipfs/Qm111, https://endpoint.co/ipfs/Qm222 ...]
       // in the case of a directory, override the gatewayUrlsMapped array to look like
       // [https://endpoint.co/ipfs/Qm111/150x150.jpg, https://endpoint.co/ipfs/Qm222/150x150.jpg ...]
-      gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${match.groups.outer}/${fileNameForImage}`)
+      gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${matchObj.outer}/${fileNameForImage}`)
     }
 
     /**

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -38,7 +38,7 @@ async function saveFileFromBufferToIPFSAndDisk (req, buffer) {
   const multihash = (await ipfs.add(buffer, { pin: false }))[0].hash
 
   // Write file to disk by multihash for future retrieval
-  const dstPath = DiskManager.computeBasePath(multihash)
+  const dstPath = DiskManager.computeFilePath(multihash)
   await writeFile(dstPath, buffer)
 
   return { multihash, dstPath }
@@ -61,7 +61,7 @@ async function saveFileToIPFSFromFS (req, srcPath) {
   const multihash = (await ipfs.addFromFs(srcPath, { pin: false }))[0].hash
 
   // store file copy by multihash for future retrieval
-  const dstPath = DiskManager.computeBasePath(multihash)
+  const dstPath = DiskManager.computeFilePath(multihash)
 
   try {
     await copyFile(srcPath, dstPath)
@@ -320,7 +320,7 @@ const trackDiskStorage = multer.diskStorage({
   destination: function (req, file, cb) {
     // save file under randomly named folders to avoid collisions
     const randomFileName = getUuid()
-    const fileDir = DiskManager.computeBasePath(randomFileName)
+    const fileDir = DiskManager.computeFilePath(randomFileName)
 
     // create directories for original file and segments
     fs.mkdirSync(fileDir)

--- a/creator-node/src/index.js
+++ b/creator-node/src/index.js
@@ -11,18 +11,17 @@ const { runMigrations } = require('./migrationManager')
 const { logger } = require('./logging')
 const { logIpfsPeerIds } = require('./ipfsClient')
 const { serviceRegistry } = require('./serviceRegistry')
+const DiskManager = require('./diskManager')
 
 const exitWithError = (...msg) => {
   logger.error(...msg)
   process.exit(1)
 }
 
-const configFileStorage = () => {
-  if (!config.get('storagePath')) {
-    exitWithError('Must set storagePath to use for content repository.')
-  }
-  return (path.resolve('./', config.get('storagePath')))
-}
+// delete configFileStorage, ran test below to confirm equality
+// if ((path.resolve('./', config.get('storagePath'))) === DiskManager.getConfigStoragePath()) {
+//   console.log("paths equal")
+// }
 
 const runDBMigrations = async () => {
   try {
@@ -63,7 +62,6 @@ const startApp = async () => {
   if (walletAddress !== config.get('delegateOwnerWallet').toLowerCase()) {
     throw new Error('Invalid delegatePrivateKey/delegateOwnerWallet pair')
   }
-  const storagePath = configFileStorage()
 
   const mode = getMode()
   let appInfo
@@ -81,7 +79,7 @@ const startApp = async () => {
     await serviceRegistry.initServices()
     logger.info('Initialized services!')
 
-    appInfo = initializeApp(config.get('port'), storagePath, serviceRegistry)
+    appInfo = initializeApp(config.get('port'), serviceRegistry)
   }
 
   // when app terminates, close down any open DB connections gracefully

--- a/creator-node/src/index.js
+++ b/creator-node/src/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const ON_DEATH = require('death')
-const path = require('path')
 const EthereumWallet = require('ethereumjs-wallet')
 
 const initializeApp = require('./app')
@@ -11,17 +10,11 @@ const { runMigrations } = require('./migrationManager')
 const { logger } = require('./logging')
 const { logIpfsPeerIds } = require('./ipfsClient')
 const { serviceRegistry } = require('./serviceRegistry')
-const DiskManager = require('./diskManager')
 
 const exitWithError = (...msg) => {
   logger.error(...msg)
   process.exit(1)
 }
-
-// delete configFileStorage, ran test below to confirm equality
-// if ((path.resolve('./', config.get('storagePath'))) === DiskManager.getConfigStoragePath()) {
-//   console.log("paths equal")
-// }
 
 const runDBMigrations = async () => {
   try {

--- a/creator-node/src/resizeImage.js
+++ b/creator-node/src/resizeImage.js
@@ -148,7 +148,7 @@ module.exports = async (job) => {
   // return the CIDs and storage paths to write to db
   // in the main thread
   const dirCID = ipfsAddResp[ipfsAddResp.length - 1].hash
-  const dirDestPath = DiskManager.computeBasePath(dirCID)
+  const dirDestPath = DiskManager.computeFilePath(dirCID)
 
   const resp = {
     dir: { dirCID, dirDestPath },

--- a/creator-node/src/resizeImage.js
+++ b/creator-node/src/resizeImage.js
@@ -165,7 +165,7 @@ module.exports = async (job) => {
 
     await Promise.all(ipfsFileResps.map(async (fileResp, i) => {
       // Save file to disk
-      const destPath = path.join(dirDestPath, fileResp.hash)
+      const destPath = DiskManager.computeFilePathInDir(dirCID, fileResp.hash)
       await fs.writeFile(destPath, resizes[i])
 
       // Append saved file info to response object

--- a/creator-node/src/resizeImage.js
+++ b/creator-node/src/resizeImage.js
@@ -148,7 +148,7 @@ module.exports = async (job) => {
   // return the CIDs and storage paths to write to db
   // in the main thread
   const dirCID = ipfsAddResp[ipfsAddResp.length - 1].hash
-  const dirDestPath = DiskManager.computeCIDFilePath(dirCID)
+  const dirDestPath = DiskManager.computeBasePath(dirCID)
 
   const resp = {
     dir: { dirCID, dirDestPath },

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -504,7 +504,7 @@ module.exports = function (app) {
     const filePathNormalized = path.normalize(filePath)
 
     // check that the regex works and verify it's not blacklisted
-    const matchObj = DiskManager.extractCIDsFromPath(filePathNormalized)
+    const matchObj = DiskManager.extractCIDsFromFSPath(filePathNormalized)
     if (!matchObj) return sendResponse(req, res, errorResponseBadRequest(`Invalid filePathNormalized provided`))
 
     const { outer, inner } = matchObj

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -27,13 +27,9 @@ const { getIPFSPeerId, ipfsSingleByteCat, ipfsStat, getAllRegisteredCNodes, find
 const ImageProcessingQueue = require('../ImageProcessingQueue')
 const RehydrateIpfsQueue = require('../RehydrateIpfsQueue')
 const DBManager = require('../dbManager')
+const DiskManager = require('../diskManager')
 
 const FILE_CACHE_EXPIRY_SECONDS = 5 * 60
-
-// regex to validate storagePath format passed in for /file_lookup route
-// this will either be of the format /file_storage/<cid> for a file or /file_storage/<cid1>/<cid2> for an dir image
-// there are two named match groups, outer and inner. outer is for file or dirname for dir image. inner is only image cid in dir
-const FILE_SYSTEM_REGEX = /\/file_storage\/(?<outer>Qm[a-zA-Z0-9]{44})\/?(?<inner>Qm[a-zA-Z0-9]{44})?/
 
 /**
  * Helper method to stream file from file system on creator node
@@ -508,10 +504,10 @@ module.exports = function (app) {
     const filePathNormalized = path.normalize(filePath)
 
     // check that the regex works and verify it's not blacklisted
-    const match = FILE_SYSTEM_REGEX.exec(filePathNormalized)
-    if (!match) return sendResponse(req, res, errorResponseBadRequest(`Invalid filePathNormalized provided`))
+    const matchObj = DiskManager.extractCIDsFromPath(filePathNormalized)
+    if (!matchObj) return sendResponse(req, res, errorResponseBadRequest(`Invalid filePathNormalized provided`))
 
-    const { outer, inner } = match.groups
+    const { outer, inner } = matchObj
     if (await req.app.get('blacklistManager').CIDIsInBlacklist(outer)) {
       return sendResponse(req, res, errorResponseForbidden(`CID ${outer} has been blacklisted by this node.`))
     }

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -326,7 +326,6 @@ module.exports = function (app) {
         resizeResp = await ImageProcessingQueue.resizeImage({
           file: imageBufferOriginal,
           fileName: originalFileName,
-          storagePath: req.app.get('storagePath'),
           sizes: {
             '150x150.jpg': 150,
             '480x480.jpg': 480,
@@ -339,7 +338,6 @@ module.exports = function (app) {
         resizeResp = await ImageProcessingQueue.resizeImage({
           file: imageBufferOriginal,
           fileName: originalFileName,
-          storagePath: req.app.get('storagePath'),
           sizes: {
             '640x.jpg': 640,
             '2000x.jpg': 2000

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -4,6 +4,8 @@ const config = require('../config.js')
 const versionInfo = require('../../.version.json')
 const disk = require('diskusage')
 
+const DiskManager = require('../diskManager')
+
 const MAX_DB_CONNECTIONS = config.get('dbConnectionPoolMax')
 const MAX_DISK_USAGE_PERCENT = 90 // 90%
 
@@ -100,7 +102,7 @@ module.exports = function (app) {
     const maxUsageBytes = parseInt(req.query.maxUsageBytes)
     const maxUsagePercent = parseInt(req.query.maxUsagePercent) || MAX_DISK_USAGE_PERCENT
 
-    const storagePath = config.get('storagePath')
+    const storagePath = DiskManager.getConfigStoragePath()
     const { available, total } = await disk.check(storagePath)
     const usagePercent = Math.round((total - available) * 100 / total)
 

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -9,6 +9,7 @@ const models = require('../src/models')
 const ipfsClient = require('../src/ipfsClient')
 const config = require('../src/config')
 const BlacklistManager = require('../src/blacklistManager')
+const DiskManager = require('../src/diskManager')
 
 const { getApp } = require('./lib/app')
 const { createStarterCNodeUser } = require('./lib/dataSeeds')
@@ -153,7 +154,7 @@ describe('Test AudiusUsers with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = path.join(config.get('storagePath'), resp.body.metadataMultihash)
+    const metadataPath = DiskManager.computeCIDFilePath(resp.body.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -153,7 +153,7 @@ describe('Test AudiusUsers with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = DiskManager.computeCIDFilePath(resp.body.metadataMultihash)
+    const metadataPath = DiskManager.computeBasePath(resp.body.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -1,7 +1,6 @@
 const request = require('supertest')
 const assert = require('assert')
 const sinon = require('sinon')
-const path = require('path')
 const fs = require('fs')
 
 const models = require('../src/models')

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -49,7 +49,7 @@ describe('test AudiusUsers with mocked IPFS', function () {
   it('successfully creates Audius user (POST /audius_users/metadata)', async function () {
     const metadata = { test: 'field1' }
     ipfsMock.add.twice().withArgs(Buffer.from(JSON.stringify(metadata)))
-    ipfsMock.pin.add.once().withArgs('testCIDLink')
+    ipfsMock.pin.add.once().withArgs('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
 
     const resp = await request(app)
       .post('/audius_users/metadata')
@@ -57,7 +57,7 @@ describe('test AudiusUsers with mocked IPFS', function () {
       .send({ metadata })
       .expect(200)
 
-    if (resp.body.metadataMultihash !== 'testCIDLink' || !resp.body.metadataFileUUID) {
+    if (resp.body.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6' || !resp.body.metadataFileUUID) {
       throw new Error('invalid return data')
     }
   })
@@ -66,7 +66,7 @@ describe('test AudiusUsers with mocked IPFS', function () {
     const metadata = { test: 'field1' }
 
     ipfsMock.add.twice().withArgs(Buffer.from(JSON.stringify(metadata)))
-    ipfsMock.pin.add.once().withArgs('testCIDLink')
+    ipfsMock.pin.add.once().withArgs('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     libsMock.User.getUsers.exactly(2)
 
     const resp = await request(app)
@@ -75,7 +75,7 @@ describe('test AudiusUsers with mocked IPFS', function () {
       .send({ metadata })
       .expect(200)
 
-    if (resp.body.metadataMultihash !== 'testCIDLink') {
+    if (resp.body.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
       throw new Error('invalid return data')
     }
 

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -153,7 +153,7 @@ describe('Test AudiusUsers with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = DiskManager.computeBasePath(resp.body.metadataMultihash)
+    const metadataPath = DiskManager.computeFilePath(resp.body.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -10,8 +10,8 @@ const { ipfs } = require('../src/ipfsClient')
 const { saveFileToIPFSFromFS, removeTrackFolder, saveFileFromBufferToIPFSAndDisk } = require('../src/fileManager')
 const config = require('../src/config')
 const models = require('../src/models')
-
 const { sortKeys } = require('../src/apiSigning')
+const DiskManager = require('../src/diskManager')
 
 let storagePath = config.get('storagePath')
 storagePath = storagePath.charAt(0) === '/' ? storagePath.slice(1) : storagePath
@@ -135,7 +135,7 @@ describe('test fileManager', () => {
 
       // 1 segment should be saved in <storagePath>/QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd
       const segmentCID = 'QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd'
-      const syncedSegmentPath = path.join(storagePath, segmentCID)
+      const syncedSegmentPath = DiskManager.computeCIDFilePath(segmentCID)
       assert.ok(fs.existsSync(syncedSegmentPath))
 
       // the segment content should match the original sourcefile
@@ -230,7 +230,7 @@ describe('test fileManager', () => {
       }
 
       // check that the metadata file was written to storagePath under its multihash
-      const metadataPath = path.join(storagePath, resp.multihash)
+      const metadataPath = DiskManager.computeCIDFilePath(resp.multihash)
       assert.ok(fs.existsSync(metadataPath))
 
       // check that the contents of the metadata file is what we expect
@@ -253,7 +253,7 @@ describe('test fileManager', () => {
 
 describe('test removeTrackFolder()', async function () {
   const testTrackUploadDir = './test/testTrackUploadDir/'
-  const trackSourceFileDir = path.join(storagePath, 'testTrackSourceFileDir')
+  const trackSourceFileDir = DiskManager.computeCIDFilePath('testTrackSourceFileDir')
 
   // copy test dir into /test_file_storage dir to be deleted by removeTrackFolder()
   beforeEach(async function () {

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -68,7 +68,7 @@ describe('test fileManager', () => {
           info: () => {}
         },
         app: {
-          get: () => { return path.join(storagePath) }
+          get: () => { return DiskManager.getConfigStoragePath() }
         }
       }
 
@@ -170,7 +170,7 @@ describe('test fileManager', () => {
           info: () => {}
         },
         app: {
-          get: () => { return path.join(storagePath) }
+          get: () => { return DiskManager.getConfigStoragePath() }
         }
       }
 

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -253,7 +253,7 @@ describe('test fileManager', () => {
 
 describe('test removeTrackFolder()', async function () {
   const testTrackUploadDir = './test/testTrackUploadDir/'
-  const trackSourceFileDir = DiskManager.computeCIDFilePath('testTrackSourceFileDir')
+  const trackSourceFileDir = path.join(storagePath, 'testTrackSourceFileDir')
 
   // copy test dir into /test_file_storage dir to be deleted by removeTrackFolder()
   beforeEach(async function () {

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -135,7 +135,7 @@ describe('test fileManager', () => {
 
       // 1 segment should be saved in <storagePath>/QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd
       const segmentCID = 'QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd'
-      const syncedSegmentPath = DiskManager.computeCIDFilePath(segmentCID)
+      const syncedSegmentPath = DiskManager.computeBasePath(segmentCID)
       assert.ok(fs.existsSync(syncedSegmentPath))
 
       // the segment content should match the original sourcefile
@@ -230,7 +230,7 @@ describe('test fileManager', () => {
       }
 
       // check that the metadata file was written to storagePath under its multihash
-      const metadataPath = DiskManager.computeCIDFilePath(resp.multihash)
+      const metadataPath = DiskManager.computeBasePath(resp.multihash)
       assert.ok(fs.existsSync(metadataPath))
 
       // check that the contents of the metadata file is what we expect

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -44,7 +44,7 @@ const srcPath = path.join(segmentsDirPath, sourceFile)
 // consts used for testing saveFileFromBufferToIPFSAndDisk()
 const metadata = {
   test: 'field1',
-  track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
+  track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }],
   owner_id: 1
 }
 const buffer = Buffer.from(JSON.stringify(metadata))

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -135,7 +135,7 @@ describe('test fileManager', () => {
 
       // 1 segment should be saved in <storagePath>/QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd
       const segmentCID = 'QmSMQGu2vrE6UwXiZDCxyJwTsCcpPrYNBPJBL4by4LKukd'
-      const syncedSegmentPath = DiskManager.computeBasePath(segmentCID)
+      const syncedSegmentPath = DiskManager.computeFilePath(segmentCID)
       assert.ok(fs.existsSync(syncedSegmentPath))
 
       // the segment content should match the original sourcefile
@@ -230,7 +230,7 @@ describe('test fileManager', () => {
       }
 
       // check that the metadata file was written to storagePath under its multihash
-      const metadataPath = DiskManager.computeBasePath(resp.multihash)
+      const metadataPath = DiskManager.computeFilePath(resp.multihash)
       assert.ok(fs.existsSync(metadataPath))
 
       // check that the contents of the metadata file is what we expect

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -1,5 +1,4 @@
 const { runMigrations, clearDatabase } = require('../../src/migrationManager')
-const config = require('../../src/config')
 const redisClient = require('../../src/redis')
 
 // Initialize private IPFS gateway counters

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -26,7 +26,7 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
     redis: redisClient
   }
 
-  const appInfo = require('../../src/app')(8000, config.get('storagePath'), mockServiceRegistry)
+  const appInfo = require('../../src/app')(8000, mockServiceRegistry)
 
   return appInfo
 }

--- a/creator-node/test/lib/ipfsMock.js
+++ b/creator-node/test/lib/ipfsMock.js
@@ -18,8 +18,8 @@ function getIPFSMock () {
     cat: sinon.stub(),
     get: sinon.stub()
   }
-  ipfsMock.add.returns([{ hash: 'testCIDLink' }])
-  ipfsMock.addFromFs.returns([{ hash: 'testCIDLink' }])
+  ipfsMock.add.returns([{ hash: 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6' }])
+  ipfsMock.addFromFs.returns([{ hash: 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6' }])
   ipfsMock.id.returns({
     addresses: ['/ip4/127.0.0.1/tcp/4001/ipfs/QmPjSNZPCTmQsKAUM7QDjAzymcbxaVVbRcV5pZvBRMZmca']
   })

--- a/creator-node/test/resizeImage.test.js
+++ b/creator-node/test/resizeImage.test.js
@@ -1,6 +1,7 @@
 const { ipfs } = require('../src/ipfsClient')
 const resizeImageJob = require('../src/resizeImage')
 const config = require('../src/config')
+const DiskManager = require('../src/diskManager')
 
 const fs = require('fs')
 const path = require('path')
@@ -156,7 +157,8 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    const dirPath = path.join(storagePath, DIR_CID_SQUARE)
+    // const dirPath = path.join(storagePath, DIR_CID_SQUARE)
+    const dirPath = DiskManager.computeCIDFilePath(DIR_CID_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_150, CID_480, CID_1000, CID_ORIGINAL])
@@ -228,7 +230,7 @@ describe('test resizeImage', () => {
 
     // If hash found in ipfs is not found in file_storage, fail
     ipfsDirContents.map(ipfsFile => {
-      const fsPathForIpfsFile = path.join(storagePath, DIR_CID_SQUARE, ipfsFile.hash)
+      const fsPathForIpfsFile = path.join(DiskManager.computeCIDFilePath(DIR_CID_SQUARE), ipfsFile.hash)
       if (!fs.existsSync(fsPathForIpfsFile)) {
         assert.fail(`File in ipfs not found in file_storage for size ${ipfsFile.name}`)
       }
@@ -266,7 +268,8 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    const dirPath = path.join(storagePath, DIR_CID_NOT_SQUARE)
+    // const dirPath = path.join(storagePath, DIR_CID_NOT_SQUARE)
+    const dirPath = DiskManager.computeCIDFilePath(DIR_CID_NOT_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_640, CID_2000, CID_ORIGINAL])
@@ -335,7 +338,7 @@ describe('test resizeImage', () => {
 
     // If hash found in ipfs is not found in file_storage, fail
     ipfsDirContents.map(ipfsFile => {
-      const fsPathForIpfsFile = path.join(storagePath, DIR_CID_NOT_SQUARE, ipfsFile.hash)
+      const fsPathForIpfsFile = path.join(DiskManager.computeCIDFilePath(DIR_CID_NOT_SQUARE), ipfsFile.hash)
       if (!fs.existsSync(fsPathForIpfsFile)) {
         assert.fail(`File in ipfs not found in file_storage for size ${ipfsFile.name}`)
       }

--- a/creator-node/test/resizeImage.test.js
+++ b/creator-node/test/resizeImage.test.js
@@ -336,7 +336,7 @@ describe('test resizeImage', () => {
 
     // If hash found in ipfs is not found in file_storage, fail
     ipfsDirContents.map(ipfsFile => {
-      const fsPathForIpfsFile = path.join(DiskManager.computeBasePath(DIR_CID_NOT_SQUARE), ipfsFile.hash)
+      const fsPathForIpfsFile = DiskManager.computeFilePathInDir(DIR_CID_NOT_SQUARE, ipfsFile.hash)
       if (!fs.existsSync(fsPathForIpfsFile)) {
         assert.fail(`File in ipfs not found in file_storage for size ${ipfsFile.name}`)
       }

--- a/creator-node/test/resizeImage.test.js
+++ b/creator-node/test/resizeImage.test.js
@@ -157,7 +157,7 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    const dirPath = DiskManager.computeBasePath(DIR_CID_SQUARE)
+    const dirPath = DiskManager.computeFilePath(DIR_CID_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_150, CID_480, CID_1000, CID_ORIGINAL])
@@ -267,7 +267,7 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    const dirPath = DiskManager.computeBasePath(DIR_CID_NOT_SQUARE)
+    const dirPath = DiskManager.computeFilePath(DIR_CID_NOT_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_640, CID_2000, CID_ORIGINAL])

--- a/creator-node/test/resizeImage.test.js
+++ b/creator-node/test/resizeImage.test.js
@@ -157,8 +157,7 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    // const dirPath = path.join(storagePath, DIR_CID_SQUARE)
-    const dirPath = DiskManager.computeCIDFilePath(DIR_CID_SQUARE)
+    const dirPath = DiskManager.computeBasePath(DIR_CID_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_150, CID_480, CID_1000, CID_ORIGINAL])
@@ -230,7 +229,7 @@ describe('test resizeImage', () => {
 
     // If hash found in ipfs is not found in file_storage, fail
     ipfsDirContents.map(ipfsFile => {
-      const fsPathForIpfsFile = path.join(DiskManager.computeCIDFilePath(DIR_CID_SQUARE), ipfsFile.hash)
+      const fsPathForIpfsFile = DiskManager.computeFilePathInDir(DIR_CID_SQUARE, ipfsFile.hash)
       if (!fs.existsSync(fsPathForIpfsFile)) {
         assert.fail(`File in ipfs not found in file_storage for size ${ipfsFile.name}`)
       }
@@ -268,8 +267,7 @@ describe('test resizeImage', () => {
     }
 
     // Check fs contains the dir for square cids
-    // const dirPath = path.join(storagePath, DIR_CID_NOT_SQUARE)
-    const dirPath = DiskManager.computeCIDFilePath(DIR_CID_NOT_SQUARE)
+    const dirPath = DiskManager.computeBasePath(DIR_CID_NOT_SQUARE)
     assert.ok(fs.existsSync(dirPath))
 
     const dirContentCIDs = new Set([CID_640, CID_2000, CID_ORIGINAL])
@@ -338,7 +336,7 @@ describe('test resizeImage', () => {
 
     // If hash found in ipfs is not found in file_storage, fail
     ipfsDirContents.map(ipfsFile => {
-      const fsPathForIpfsFile = path.join(DiskManager.computeCIDFilePath(DIR_CID_NOT_SQUARE), ipfsFile.hash)
+      const fsPathForIpfsFile = path.join(DiskManager.computeBasePath(DIR_CID_NOT_SQUARE), ipfsFile.hash)
       if (!fs.existsSync(fsPathForIpfsFile)) {
         assert.fail(`File in ipfs not found in file_storage for size ${ipfsFile.name}`)
       }

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -487,7 +487,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)
-    const transcodedTrackPath = DiskManager.computeCIDFilePath(resp.body.data.transcodedTrackCID)
+    const transcodedTrackPath = DiskManager.computeBasePath(resp.body.data.transcodedTrackCID)
     const transcodedTrackTestBuf = fs.readFileSync(transcodedTrackPath)
     assert.deepStrictEqual(transcodedTrackAssetBuf.compare(transcodedTrackTestBuf), 0)
 
@@ -498,7 +498,7 @@ describe('test Tracks with real IPFS', function () {
     const segmentCIDs = resp.body.data.track_segments
     assert.deepStrictEqual(segmentCIDs.length, testAudiusFileNumSegments)
     segmentCIDs.map(function (cid, index) {
-      const cidPath = DiskManager.computeCIDFilePath(cid.multihash)
+      const cidPath = DiskManager.computeBasePath(cid.multihash)
 
       // Ensure file exists
       assert.ok(fs.existsSync(cidPath))
@@ -576,7 +576,7 @@ describe('test Tracks with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = DiskManager.computeCIDFilePath(resp.body.data.metadataMultihash)
+    const metadataPath = DiskManager.computeBasePath(resp.body.data.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -10,6 +10,7 @@ const ipfsClient = require('../src/ipfsClient')
 const BlacklistManager = require('../src/blacklistManager')
 const TranscodingQueue = require('../src/TranscodingQueue')
 const models = require('../src/models')
+const DiskManager = require('../src/diskManager')
 
 const { getApp } = require('./lib/app')
 const { createStarterCNodeUser } = require('./lib/dataSeeds')
@@ -489,7 +490,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)
-    const transcodedTrackPath = path.join(storagePath, resp.body.data.transcodedTrackCID)
+    const transcodedTrackPath = DiskManager.computeCIDFilePath(resp.body.data.transcodedTrackCID)
     const transcodedTrackTestBuf = fs.readFileSync(transcodedTrackPath)
     assert.deepStrictEqual(transcodedTrackAssetBuf.compare(transcodedTrackTestBuf), 0)
 
@@ -558,7 +559,7 @@ describe('test Tracks with real IPFS', function () {
     assert.deepStrictEqual(resp.body.error, '/tracks/metadata saveFileFromBufferToIPFSAndDisk op failed: Error: ipfs add failed!')
   })
 
-  it('successfully adds metadata file to filesystem, db, and ipfs', async function () {
+  it.only('successfully adds metadata file to filesystem, db, and ipfs', async function () {
     const metadata = sortKeys({
       test: 'field1',
       track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
@@ -578,7 +579,7 @@ describe('test Tracks with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = path.join(config.get('storagePath'), resp.body.data.metadataMultihash)
+    const metadataPath = DiskManager.computeCIDFilePath(resp.body.data.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -501,7 +501,7 @@ describe('test Tracks with real IPFS', function () {
     const segmentCIDs = resp.body.data.track_segments
     assert.deepStrictEqual(segmentCIDs.length, testAudiusFileNumSegments)
     segmentCIDs.map(function (cid, index) {
-      const cidPath = path.join(storagePath, cid.multihash)
+      const cidPath = DiskManager.computeCIDFilePath(cid.multihash)
 
       // Ensure file exists
       assert.ok(fs.existsSync(cidPath))

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -559,7 +559,7 @@ describe('test Tracks with real IPFS', function () {
     assert.deepStrictEqual(resp.body.error, '/tracks/metadata saveFileFromBufferToIPFSAndDisk op failed: Error: ipfs add failed!')
   })
 
-  it.only('successfully adds metadata file to filesystem, db, and ipfs', async function () {
+  it('successfully adds metadata file to filesystem, db, and ipfs', async function () {
     const metadata = sortKeys({
       test: 'field1',
       track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -124,11 +124,11 @@ describe('test Tracks with mocked IPFS', function () {
       .set('Content-Type', 'multipart/form-data')
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
-
-    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    console.log('trackContentResp', trackContentResp)
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
     assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
-    assert.deepStrictEqual(trackContentResp.body.data.transcodedTrackCID, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.transcodedTrackCID, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(typeof trackContentResp.body.data.transcodedTrackUUID, 'string')
   })
 
@@ -147,7 +147,7 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
     assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
@@ -164,7 +164,7 @@ describe('test Tracks with mocked IPFS', function () {
       .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    assert.deepStrictEqual(trackMetadataResp.body.data.metadataMultihash, 'testCIDLink')
+    assert.deepStrictEqual(trackMetadataResp.body.data.metadataMultihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
   })
 
   // depends on "uploads /track_content"
@@ -182,7 +182,7 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
     assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
@@ -214,7 +214,7 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
     assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
@@ -247,14 +247,14 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
     assert.deepStrictEqual(resp1.body.data.source_file.includes('.mp3'), true)
 
     // creates Audius track
     const metadata = {
       test: 'field1',
-      track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }]
+      track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }]
     }
 
     await request(app)
@@ -279,7 +279,7 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
     assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
@@ -295,7 +295,7 @@ describe('test Tracks with mocked IPFS', function () {
       .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    if (trackMetadataResp.body.data.metadataMultihash !== 'testCIDLink') {
+    if (trackMetadataResp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
       throw new Error('invalid return data')
     }
 
@@ -321,14 +321,14 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(resp1.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(resp1.body.data.track_segments.length, 32)
 
     // creates a downloadable Audius track with no track_id and no source_file
     const metadata = {
       test: 'field1',
       owner_id: 1,
-      track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
+      track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }],
       download: {
         is_downloadable: true,
         requires_follow: false
@@ -357,7 +357,7 @@ describe('test Tracks with mocked IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'testCIDLink')
+    assert.deepStrictEqual(trackContentResp.body.data.track_segments[0].multihash, 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
     assert.deepStrictEqual(trackContentResp.body.data.track_segments.length, 32)
     assert.deepStrictEqual(trackContentResp.body.data.source_file.includes('.mp3'), true)
 
@@ -369,7 +369,7 @@ describe('test Tracks with mocked IPFS', function () {
       download: {
         'is_downloadable': true,
         'requires_follow': false,
-        'cid': 'testCIDLink'
+        'cid': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6'
       }
     }
 
@@ -379,7 +379,7 @@ describe('test Tracks with mocked IPFS', function () {
       .send({ metadata, sourceFile: trackContentResp.body.data.source_file })
       .expect(200)
 
-    if (trackMetadataResp.body.data.metadataMultihash !== 'testCIDLink') {
+    if (trackMetadataResp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
       throw new Error('invalid return data')
     }
 
@@ -526,7 +526,7 @@ describe('test Tracks with real IPFS', function () {
     sinon.stub(BlacklistManager, 'CIDIsInBlacklist').returns(true)
     const metadata = {
       test: 'field1',
-      track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
+      track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }],
       owner_id: 1
     }
 
@@ -543,7 +543,7 @@ describe('test Tracks with real IPFS', function () {
     sinon.stub(ipfs, 'add').rejects(new Error('ipfs add failed!'))
     const metadata = {
       test: 'field1',
-      track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
+      track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }],
       owner_id: 1
     }
 
@@ -559,7 +559,7 @@ describe('test Tracks with real IPFS', function () {
   it('successfully adds metadata file to filesystem, db, and ipfs', async function () {
     const metadata = sortKeys({
       test: 'field1',
-      track_segments: [{ 'multihash': 'testCIDLink', 'duration': 1000 }],
+      track_segments: [{ 'multihash': 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6', 'duration': 1000 }],
       owner_id: 1
     })
 

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -487,7 +487,7 @@ describe('test Tracks with real IPFS', function () {
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)
-    const transcodedTrackPath = DiskManager.computeBasePath(resp.body.data.transcodedTrackCID)
+    const transcodedTrackPath = DiskManager.computeFilePath(resp.body.data.transcodedTrackCID)
     const transcodedTrackTestBuf = fs.readFileSync(transcodedTrackPath)
     assert.deepStrictEqual(transcodedTrackAssetBuf.compare(transcodedTrackTestBuf), 0)
 
@@ -498,7 +498,7 @@ describe('test Tracks with real IPFS', function () {
     const segmentCIDs = resp.body.data.track_segments
     assert.deepStrictEqual(segmentCIDs.length, testAudiusFileNumSegments)
     segmentCIDs.map(function (cid, index) {
-      const cidPath = DiskManager.computeBasePath(cid.multihash)
+      const cidPath = DiskManager.computeFilePath(cid.multihash)
 
       // Ensure file exists
       assert.ok(fs.existsSync(cidPath))
@@ -576,7 +576,7 @@ describe('test Tracks with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = DiskManager.computeBasePath(resp.body.data.metadataMultihash)
+    const metadataPath = DiskManager.computeFilePath(resp.body.data.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified

--- a/creator-node/test/tracks.test.js
+++ b/creator-node/test/tracks.test.js
@@ -484,9 +484,6 @@ describe('test Tracks with real IPFS', function () {
       .set('X-Session-ID', session.sessionToken)
       .expect(200)
 
-    let storagePath = config.get('storagePath')
-    storagePath = storagePath.slice(0, 1) === '/' ? '.' + storagePath : storagePath
-
     // check that the generated transcoded track is the same as the transcoded track in /tests
     const transcodedTrackAssetPath = path.join(__dirname, 'testTranscoded320Track.mp3')
     const transcodedTrackAssetBuf = fs.readFileSync(transcodedTrackAssetPath)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/dyViGxGG/1654-track-upload-errors

### Description
The /file_storage directory is susceptible to hash collisions in ext4 file systems using the half md5 hashing algorithm because we write all files to one directory. Moving to a nested directory model should alleviate these concerns.

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches how files are stored in the file system


### How Has This Been Tested?

1. Created an account, updated my profile picture and cover photo, uploaded a track with the old file storage system. Fetch to metadata and track segment via the ipfs gateway. Fetch a dir image via the ipfs gateway
2. Applied the new file storage system and uploaded more tracks and updated my profile picture and cover photo again. Fetch to metadata and track segment via the ipfs gateway. Fetch a dir image via the ipfs gateway
3. Used the dapp to play the tracks, view the track cover art, my profile picture and cover photo
4. Make sure a sync was triggered and verify clock state for both nodes was the same in the db
5. Verify the number of files in both volumes were the same and the directory structures were identical by listing out all the files, sorting and doing running the diff command
6. Disable fetching through IPFS for sync, only other cnode gateways
7. Upload another track to verify that sync triggered and fetched all files via the gateways
8. Randomly sample and fetch metadata and track segments via the ipfs gateway
9. Randomly sample and fetch dir images via the ipfs gateway
10. Swap the primary between the two nodes, upload another track and hit the ipfs gateway to fetch the content again