### PR TITLE
Script + Local setup - Add Content Node ServiceType

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -34,7 +34,7 @@ describe('Test Health Check', function () {
     const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
-      service: 'creator-node',
+      service: 'content-node',
       healthy: true,
       git: undefined,
       selectedDiscoveryProvider: TEST_ENDPOINT,
@@ -50,7 +50,7 @@ describe('Test Health Check', function () {
     const res = await healthCheck({}, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
-      service: 'creator-node',
+      service: 'content-node',
       healthy: true,
       git: undefined,
       selectedDiscoveryProvider: 'none',

--- a/eth-contracts/migrations/7_versioning_service_migration.js
+++ b/eth-contracts/migrations/7_versioning_service_migration.js
@@ -20,7 +20,7 @@ const claimsManagerProxyKey = web3.utils.utf8ToHex('ClaimsManagerProxy')
 
 // Known service types
 const serviceTypeCN = web3.utils.utf8ToHex('creator-node')
-// Creator node
+// Creator node 
 // Minimum: 200,000
 // Maximum: 3,000,000
 const cnTypeMin = _lib.audToWei(200000)
@@ -31,14 +31,6 @@ const cnTypeMax = _lib.audToWei(3000000)
 const serviceTypeDP = web3.utils.utf8ToHex('discovery-provider')
 const dpTypeMin = _lib.audToWei(200000)
 const dpTypeMax = _lib.audToWei(2000000)
-
-// Content node
-// Minimum: 200,000
-// Maximum: 10,000,000
-const serviceTypeContentNode = web3.utils.utf8ToHex('content-node')
-const contentNodeTypeMin = _lib.audToWei(200000)
-const contentNodeTypeMax = _lib.audToWei(10000000)
-
 // stake lockup duration = 1 wk in blocks
 // - 1/13 block/s * 604800 s/wk ~= 46523 block/wk
 const decreaseStakeLockupDuration = 46523
@@ -114,22 +106,6 @@ module.exports = (deployer, network, accounts) => {
     assert.ok(_lib.toBN(dpTypeMin).eq(serviceTypeDPInfo.minStake), 'Expected same minStake')
     assert.ok(_lib.toBN(dpTypeMax).eq(serviceTypeDPInfo.maxStake), 'Expected same maxStake')
 
-    // TMP Register new type
-     const callDataContentNode = _lib.abiEncode(
-      ['bytes32', 'uint256', 'uint256'],
-      [serviceTypeContentNode, contentNodeTypeMin, contentNodeTypeMax]
-    )
-    await governance.guardianExecuteTransaction(
-      serviceTypeManagerProxyKey,
-      callValue0,
-      signatureAddServiceType,
-      callDataContentNode,
-      { from: guardianAddress }
-    )
-    const contentNodeTypeInfo = await serviceTypeManager.getServiceTypeInfo.call(serviceTypeContentNode)
-    assert.ok(_lib.toBN(contentNodeTypeMin).eq(contentNodeTypeInfo.minStake), 'Expected same minStake')
-    assert.ok(_lib.toBN(contentNodeTypeMax).eq(contentNodeTypeInfo.maxStake), 'Expected same maxStake')
-
     // Deploy ServiceProviderFactory logic and proxy contracts + register proxy
     const serviceProviderFactory0 = await deployer.deploy(ServiceProviderFactory, { from: proxyDeployerAddress })
     const serviceProviderFactoryCalldata = _lib.encodeCall(
@@ -202,7 +178,7 @@ module.exports = (deployer, network, accounts) => {
       'setClaimsManagerAddress(address)',
       _lib.abiEncode(['address'], [process.env.claimsManagerAddress]),
       { from: guardianAddress })
-
+    
     let claimsManagerAddressFromSPFactory = await serviceProviderFactory.getClaimsManagerAddress()
     console.log(`ClaimsManager Address from ServiceProviderFactory.sol: ${claimsManagerAddressFromSPFactory}`);
     // TODO - add DelegateManager

--- a/eth-contracts/package.json
+++ b/eth-contracts/package.json
@@ -5,8 +5,8 @@
   "author": "AudiusProject",
   "license": "Apache-2.0",
   "scripts": {
-    "ganache": "docker run --name audius_ganache_cli_eth_contracts -d -p 8546:8545 trufflesuite/ganache-cli:v6.11.0 -h 0.0.0.0 -a 50 --chainId 1337",
-    "ganache-test": "docker run --name audius_ganache_cli_eth_contracts_test -d -p 8556:8545 trufflesuite/ganache-cli:v6.11.0 -h 0.0.0.0 -a 50 --chainId 1337",
+    "ganache": "docker run --name audius_ganache_cli_eth_contracts -d -p 8546:8545 trufflesuite/ganache-cli:v6.9.1 -h 0.0.0.0 -a 50",
+    "ganache-test": "docker run --name audius_ganache_cli_eth_contracts_test -d -p 8556:8545 trufflesuite/ganache-cli:v6.9.1 -h 0.0.0.0 -a 50",
     "ganache-i": "docker ps",
     "ganache-q": "docker rm -f audius_ganache_cli_eth_contracts > /dev/null",
     "ganache-test-q": "docker rm -f audius_ganache_cli_eth_contracts_test > /dev/null",

--- a/eth-contracts/package.json
+++ b/eth-contracts/package.json
@@ -5,8 +5,8 @@
   "author": "AudiusProject",
   "license": "Apache-2.0",
   "scripts": {
-    "ganache": "docker run --name audius_ganache_cli_eth_contracts -d -p 8546:8545 trufflesuite/ganache-cli:v6.9.1 -h 0.0.0.0 -a 50",
-    "ganache-test": "docker run --name audius_ganache_cli_eth_contracts_test -d -p 8556:8545 trufflesuite/ganache-cli:v6.9.1 -h 0.0.0.0 -a 50",
+    "ganache": "docker run --name audius_ganache_cli_eth_contracts -d -p 8546:8545 trufflesuite/ganache-cli:v6.11.0 -h 0.0.0.0 -a 50 --chainId 1337",
+    "ganache-test": "docker run --name audius_ganache_cli_eth_contracts_test -d -p 8556:8545 trufflesuite/ganache-cli:v6.11.0 -h 0.0.0.0 -a 50 --chainId 1337",
     "ganache-i": "docker ps",
     "ganache-q": "docker rm -f audius_ganache_cli_eth_contracts > /dev/null",
     "ganache-test-q": "docker rm -f audius_ganache_cli_eth_contracts_test > /dev/null",

--- a/libs/initScripts/helpers/version.js
+++ b/libs/initScripts/helpers/version.js
@@ -45,12 +45,14 @@ async function addServiceType (audiusLibs, serviceType, serviceTypeMin, serviceT
   if (!audiusLibs) throw new Error('audiusLibs is not defined')
 
   console.log('----addServiceType---')
+  let weiMin = web3.utils.toWei(serviceTypeMin.toString(), 'ether')
+  let weiMax = web3.utils.toWei(serviceTypeMax.toString(), 'ether')
 
   try {
     const resp = await audiusLibs.ethContracts.ServiceTypeManagerClient.addServiceType(
       serviceType,
-      web3.utils.toWei(serviceTypeMin.toString(), 'ether'),
-      web3.utils.toWei(serviceTypeMax.toString(), 'ether'),
+      weiMin,
+      weiMax,
       privateKey)
     console.log(resp)
   } catch (e) {
@@ -58,8 +60,9 @@ async function addServiceType (audiusLibs, serviceType, serviceTypeMin, serviceT
   }
 
   let serviceTypeInfo = await audiusLibs.ethContracts.ServiceTypeManagerClient.getServiceTypeInfo(serviceType)
-  console.log(`Expected values for ${serviceType} | expected min ${serviceTypeMin} | expected max ${serviceTypeMax}`)
-  console.log(`got values from contract: ${JSON.stringify(serviceTypeInfo)}`)
+  console.log(`Expected values for ${serviceType} | expected min ${weiMin} | expected max ${weiMax}`)
+  console.log(`Values from contract: ${JSON.stringify(serviceTypeInfo)}`)
+  console.log(`Min: ${serviceTypeInfo.minStake.toString()} Max: ${serviceTypeInfo.maxStake.toString()}`)
 
   console.log('/----addServiceType---')
 }

--- a/libs/initScripts/local.js
+++ b/libs/initScripts/local.js
@@ -3,7 +3,7 @@ const readline = require('readline')
 
 const initAudiusLibs = require('../examples/initAudiusLibs')
 const { distributeTokens } = require('./helpers/distributeTokens')
-const { setServiceVersion } = require('./helpers/version')
+const { setServiceVersion, addServiceType } = require('./helpers/version')
 const {
   registerLocalService,
   queryLocalServices,
@@ -24,6 +24,11 @@ const creatorNodeEndpoint2 = 'http://cn2_creator-node_1:4001'
 const creatorNodeEndpoint3 = 'http://cn3_creator-node_1:4002'
 const creatorNodeEndpoint4 = 'http://cn4_creator-node_1:4003'
 const amountOfAuds = 2000000
+
+const contentNodeType = 'content-node'
+const contentNodeTypeMin = 200000
+const contentNodeTypeMax = 10000000
+
 
 // try to dynamically get versions from .version.json
 let serviceVersions = {}
@@ -155,8 +160,11 @@ const run = async () => {
 
 run()
 
+
+
 const _initializeLocalEnvironment = async (audiusLibs, ethAccounts) => {
   await distributeTokens(audiusLibs, amountOfAuds)
+  await _initEthContractTypes(audiusLibs)
   await _initAllVersions(audiusLibs)
   await queryLocalServices(audiusLibs, serviceTypesList)
 }
@@ -233,6 +241,12 @@ const _initAllVersions = async (audiusLibs) => {
   for (let serviceType of serviceTypesList) {
     await setServiceVersion(audiusLibs, serviceType, serviceVersions[serviceType])
   }
+}
+
+const _initEthContractTypes = async (libs) => {
+  console.log(`Registering additional service type ${contentNodeType} - Min=${contentNodeTypeMin}, Max=${contentNodeTypeMax}`)
+  // Add content-node serviceType
+  await addServiceType(libs, contentNodeType, contentNodeTypeMin, contentNodeTypeMax)
 }
 
 // Write an update to either the common .sh file for creator nodes or docker env file

--- a/libs/initScripts/local.js
+++ b/libs/initScripts/local.js
@@ -29,7 +29,6 @@ const contentNodeType = 'content-node'
 const contentNodeTypeMin = 200000
 const contentNodeTypeMax = 10000000
 
-
 // try to dynamically get versions from .version.json
 let serviceVersions = {}
 let serviceTypesList = []
@@ -159,8 +158,6 @@ const run = async () => {
 }
 
 run()
-
-
 
 const _initializeLocalEnvironment = async (audiusLibs, ethAccounts) => {
   await distributeTokens(audiusLibs, amountOfAuds)


### PR DESCRIPTION
### Trello Card Link


### Description
Add new content type handling in local setup - includes a manual addition prior to services coming up as well as script changes necessary to run against ropsten/main ethereum network

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches service registration

