### PR TITLE
Libs 1.0.16 and fix remaining creator-node refs

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -17,11 +17,12 @@
       }
     },
     "@audius/libs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.0.0.tgz",
-      "integrity": "sha512-uR0ZD224wj4RZiaMrXsLc58mJO87bmfmyAyznmrX/0HWnTHTrsNA2ABr53s1xPnyf1A9/6cK21XrBOoC1z6JyQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.0.16.tgz",
+      "integrity": "sha512-ZNypc2HYxDa/v75701hMl4wHACcyMzL4d/WJ7cFRuVNt1Ny0PU7x9fFN40y3uWqSAbDQjGUI4X8ngOjXU7dUNQ==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
+        "@ethersproject/solidity": "^5.0.5",
         "abi-decoder": "^1.2.0",
         "ajv": "^6.12.2",
         "async-retry": "^1.2.3",
@@ -39,9 +40,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -383,6 +384,32 @@
         "@ethersproject/strings": ">=5.0.0-beta.130"
       }
     },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
+      "integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
+      "integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      }
+    },
     "@ethersproject/address": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
@@ -394,6 +421,14 @@
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/rlp": "^5.0.3",
         "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.4.tgz",
+      "integrity": "sha512-4KRykQ7BQMeOXfvio1YITwHjxwBzh92UoXIdzxDE1p53CK28bbHPdsPNYo0wl0El7lJAMpT2SOdL0hhbWRnyIA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4"
       }
     },
     "@ethersproject/bignumber": {
@@ -423,13 +458,17 @@
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.5.tgz",
-      "integrity": "sha512-GpI80/h2HDpfNKpCZoxQJCjOQloGnlD5hM1G+tZe8FQDJhEvFjJoPDuWv+NaYjJfOciKS2Axqc4Q4WamdLoUgg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+      "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
       "requires": {
+        "@ethersproject/abstract-signer": "^5.0.6",
+        "@ethersproject/address": "^5.0.5",
+        "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.4",
         "@ethersproject/strings": "^5.0.4"
       }
     },
@@ -454,6 +493,14 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
       "integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
     },
+    "@ethersproject/networks": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
+      "integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
     "@ethersproject/properties": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
@@ -469,6 +516,27 @@
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/sha2": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
+      "integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "hash.js": "1.1.3"
+      },
+      "dependencies": {
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
       }
     },
     "@ethersproject/signing-key": {
@@ -498,6 +566,18 @@
         }
       }
     },
+    "@ethersproject/solidity": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.5.tgz",
+      "integrity": "sha512-DMFQ0ouXmNVoKWbGEUFGi8Urli4SJip9jXafQyFHWPRr5oJUqDVkNfwcyC37k+mhBG93k7qrYXCH2xJnGEOxHg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
     "@ethersproject/strings": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
@@ -522,6 +602,18 @@
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/rlp": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
+      "integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.3",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1292,9 +1384,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.19.0",
@@ -1714,12 +1806,19 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+        }
       }
     },
     "browserify-sha3": {
@@ -1838,18 +1937,11 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "bufferutil": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
-      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
+      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
       "requires": {
-        "node-gyp-build": "~3.7.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
-        }
+        "node-gyp-build": "^4.2.0"
       }
     },
     "builtin-status-codes": {
@@ -5250,9 +5342,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -7151,9 +7243,9 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonschema": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.10.tgz",
-      "integrity": "sha512-CoRSun5gmvgSYMHx5msttse19SnQpaHoPzIqULwE7B9KtR4Od1g70sBqeUriq5r8b9R3ptDc0o7WKpUDjUgLgg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -11486,18 +11578,11 @@
       "dev": true
     },
     "utf-8-validate": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
-      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
+      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
       "requires": {
-        "node-gyp-build": "~3.7.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
-        }
+        "node-gyp-build": "^4.2.0"
       }
     },
     "utf8": {
@@ -11598,9 +11683,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.64",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.64.tgz",
-          "integrity": "sha512-UV1/ZJMC+HcP902wWdpC43cAcGu0IQk/I5bXjP2aSuCjsk3cE74mDvFrLKga7oDC170ugOAYBwfT4DSQW3akDA=="
+          "version": "12.19.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
+          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
         }
       }
     },
@@ -11619,9 +11704,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.64",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.64.tgz",
-          "integrity": "sha512-UV1/ZJMC+HcP902wWdpC43cAcGu0IQk/I5bXjP2aSuCjsk3cE74mDvFrLKga7oDC170ugOAYBwfT4DSQW3akDA=="
+          "version": "12.19.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
+          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
         },
         "bignumber.js": {
           "version": "9.0.1",
@@ -11807,9 +11892,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.64",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.64.tgz",
-          "integrity": "sha512-UV1/ZJMC+HcP902wWdpC43cAcGu0IQk/I5bXjP2aSuCjsk3cE74mDvFrLKga7oDC170ugOAYBwfT4DSQW3akDA=="
+          "version": "12.19.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
+          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
         }
       }
     },

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@audius/libs": "^1.0.14",
+    "@audius/libs": "^1.0.16",
     "JSONStream": "^1.3.5",
     "axios": "^0.19.0",
     "base64-url": "^2.2.0",

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -123,7 +123,7 @@ async function getOwnEndpoint (req) {
 
   const spId = await libs.ethContracts.ServiceProviderFactoryClient.getServiceProviderIdFromEndpoint(creatorNodeEndpoint)
   if (!spId) throw new Error('Cannot get spId for node')
-  const spInfo = await libs.ethContracts.ServiceProviderFactoryClient.getServiceEndpointInfo('creator-node', spId)
+  const spInfo = await libs.ethContracts.ServiceProviderFactoryClient.getServiceEndpointInfo('content-node', spId)
 
   // Confirm on-chain endpoint exists and is valid FQDN
   // Error condition is met if any of the following are true

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -260,7 +260,7 @@ async function getAllRegisteredCNodes (libs) {
       return JSON.parse(cnodesList)
     }
 
-    let creatorNodes = (await libs.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('creator-node'))
+    let creatorNodes = (await libs.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('content-node'))
     creatorNodes = creatorNodes.filter(node => node.endpoint !== config.get('creatorNodeEndpoint'))
     redis.set(cacheKey, JSON.stringify(creatorNodes), 'EX', 60 * 30) // cache this for 30 minutes
     return creatorNodes

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -21,7 +21,7 @@ function getLibsMock () {
     endpoint: 'http://localhost:5000',
     owner: '0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25',
     spID: '1',
-    type: 'creator-node',
+    type: 'content-node',
     blockNumber: 1234,
     delegateOwnerWallet: '0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25'
   })

--- a/creator-node/test/syncAssets/sampleExport.json
+++ b/creator-node/test/syncAssets/sampleExport.json
@@ -1941,7 +1941,7 @@
   },
   "signer": "0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25",
   "version": "0.3.22",
-  "service": "creator-node",
+  "service": "content-node",
   "timestamp": "2020-10-02T18:48:17.781Z",
   "signature": "0x0b15fd18955ac3c610795c2e3dfa396a25a708255814e0133a2710379255078450a22a7dfdfbed4d284b8239f7e4c47af591da894e54986539f38beb7091f9f51c"
 }


### PR DESCRIPTION
### Trello Card Link


### Description
Changes remaining refs for creator-node to content-node

### Services

- [x] Creator Node

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- 🚨 Yes, this touches uploads and syncs


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Manually deployed hotfix on stage
