### PR TITLE
Local setup fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           command: |
             set -e
             export PROTOCOL_DIR=/home/circleci/project
+            export link_libs_override=true
             source ~/.bash_profile
             nvm install v10.16
             nvm use 10.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
           command: |
             set -e
             export PROTOCOL_DIR=/home/circleci/project
-            export CNODE_LINK_LIBS_OVERRIDE=true
             source ~/.bash_profile
             nvm install v10.16
             nvm use 10.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
   test-mad-dog-e2e:
     machine:
       image: ubuntu-1604:201903-01    # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      docker_layer_caching: true
     steps:
       - add_ssh_keys
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
             docker ps
             export ipfsHost="localhost"
             export ipfsPort=6001
+            docker logs cn1_creator-node_1
             npm run start test-ci
   test-libs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
             docker ps
             export ipfsHost="localhost"
             export ipfsPort=6001
-            docker logs cn1_creator-node_1
             npm run start test-ci
   test-libs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,6 @@ jobs:
             export ipfsHost="localhost"
             export ipfsPort=6001
             npm run start test-ci
-            docker logs cn1_creator-node_1
-            docker logs cn2_creator-node_1
-            docker logs cn3_creator-node_1
   test-libs:
     docker:
       # specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             set -e
             export PROTOCOL_DIR=/home/circleci/project
-            export link_libs_override=true
+            export CNODE_LINK_LIBS_OVERRIDE=true
             source ~/.bash_profile
             nvm install v10.16
             nvm use 10.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
   test-mad-dog-e2e:
     machine:
       image: ubuntu-1604:201903-01    # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
-      docker_layer_caching: true
     steps:
       - add_ssh_keys
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ jobs:
             export ipfsHost="localhost"
             export ipfsPort=6001
             npm run start test-ci
+            docker logs cn1_creator-node_1
+            docker logs cn2_creator-node_1
+            docker logs cn3_creator-node_1
   test-libs:
     docker:
       # specify the version you desire here

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=false
+link_libs=true
 
 if [ "$link_libs" = true ]
 then

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,14 +2,7 @@
 set -o xtrace
 set -e
 
-link_libs=false
-
-if [ $CNODE_LINK_LIBS_OVERRIDE ]
-then
-    link_libs=$CNODE_LINK_LIBS_OVERRIDE    
-fi
-
-echo "creator-node link_libs:" $link_libs
+link_libs=true
 
 if [ "$link_libs" = true ]
 then

--- a/creator-node/scripts/dev-server.sh
+++ b/creator-node/scripts/dev-server.sh
@@ -2,7 +2,14 @@
 set -o xtrace
 set -e
 
-link_libs=true
+link_libs=false
+
+if [ $CNODE_LINK_LIBS_OVERRIDE ]
+then
+    link_libs=$CNODE_LINK_LIBS_OVERRIDE    
+fi
+
+echo "creator-node link_libs:" $link_libs
 
 if [ "$link_libs" = true ]
 then

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -22,7 +22,7 @@ session_cookie_secure = false
 [web3]
 host = localhost
 port = 8545
-eth_provider_url = http://docker.for.mac.localhost:8546
+eth_provider_url = http://audius_ganache_cli_eth_contracts:8545
 
 [redis]
 url = redis://localhost:5379/0


### PR DESCRIPTION
### Trello Card Link
None

### Description
This PR has two fixes:
1. Link libs in content node because it's causing local dev and mad dog to fail
2. Remove docker.for.mac.localhost dependency

### Services

- [X] Discovery Provider
- [x] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [x] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Ran locally to validate development flow and ran on Circle to test CI flow