### PR TITLE
Change "creator" to "content" node in identity registered nodes route

### DIFF
--- a/identity-service/src/routes/ethRelay.js
+++ b/identity-service/src/routes/ethRelay.js
@@ -51,7 +51,7 @@ module.exports = function (app) {
    */
   app.get('/registered_creator_nodes', handleResponse(async (req, res, next) => {
     const audiusLibsInstance = req.app.get('audiusLibs')
-    const creatorNodes = await audiusLibsInstance.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('creator-node')
+    const creatorNodes = await audiusLibsInstance.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('content-node')
     return successResponse(creatorNodes)
   }))
 }


### PR DESCRIPTION
### Trello Card Link
None

### Description
The service type change is not reflected in the identity registered_creator_nodes route

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [X] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Tested locally to ensure it returns valid nodes