### PR TITLE
Clear all require caches in between test runs

### DIFF
--- a/creator-node/src/migrationManager.js
+++ b/creator-node/src/migrationManager.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const { sequelize } = require('./models')
 
-function runMigrations () {
+async function runMigrations () {
   const umzug = new Umzug({
     storage: 'sequelize',
 

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -6,8 +6,11 @@ redisClient.set('ipfsGatewayReqs', 0)
 redisClient.set('ipfsStandaloneReqs', 0)
 
 async function getApp (ipfsMock, libsMock, blacklistManager) {
-  _clearRequireCache()
-  console.log("cleared all require caches")
+  // we need to clear the cache that commonjs require builds, otherwise it uses old values for imports etc
+  // eg if you set a new env var, it doesn't propogate well unless you clear the cache for the config file as well
+  // as all files that consume it
+  clearRequireCache()
+  console.log('cleared all require caches')
 
   // run all migrations before each test
   await clearDatabase()
@@ -26,8 +29,8 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
   return appInfo
 }
 
-function _clearRequireCache() {
-  Object.keys(require.cache).forEach(function(key) {
+function clearRequireCache () {
+  Object.keys(require.cache).forEach(function (key) {
     if (key.includes('creator-node/src/')) {
       console.log('deleting cache', key)
       delete require.cache[key]

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -6,12 +6,8 @@ redisClient.set('ipfsGatewayReqs', 0)
 redisClient.set('ipfsStandaloneReqs', 0)
 
 async function getApp (ipfsMock, libsMock, blacklistManager) {
-  delete require.cache[require.resolve('../../src/app')] // force reload between each test
-  delete require.cache[require.resolve('../../src/config')]
-  delete require.cache[require.resolve('../../src/fileManager')]
-  delete require.cache[require.resolve('../../src/blacklistManager')]
-  delete require.cache[require.resolve('../../src/routes/tracks')]
-  delete require.cache[require.resolve('../../src/routes/files')]
+  _clearRequireCache()
+  console.log("cleared all require caches")
 
   // run all migrations before each test
   await clearDatabase()
@@ -28,6 +24,15 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
   const appInfo = require('../../src/app')(8000, mockServiceRegistry)
 
   return appInfo
+}
+
+function _clearRequireCache() {
+  Object.keys(require.cache).forEach(function(key) {
+    if (key.includes('creator-node/src/')) {
+      console.log('deleting cache', key)
+      delete require.cache[key]
+    }
+  })
 }
 
 module.exports = { getApp }

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -6,13 +6,11 @@ redisClient.set('ipfsGatewayReqs', 0)
 redisClient.set('ipfsStandaloneReqs', 0)
 
 async function getApp (ipfsMock, libsMock, blacklistManager) {
-  delete require.cache[require.resolve('../../src/app')] // force reload between each test
-  delete require.cache[require.resolve('../../src/config')]
-  delete require.cache[require.resolve('../../src/fileManager')]
-  delete require.cache[require.resolve('../../src/blacklistManager')]
-  delete require.cache[require.resolve('../../src/routes/tracks')]
-  delete require.cache[require.resolve('../../src/routes/files')]
-  delete require.cache[require.resolve('../../src/routes/nodeSync')]
+  // we need to clear the cache that commonjs require builds, otherwise it uses old values for imports etc
+  // eg if you set a new env var, it doesn't propogate well unless you clear the cache for the config file as well
+  // as all files that consume it
+  clearRequireCache()
+  console.log('cleared all require caches')
 
   // run all migrations before each test
   await clearDatabase()
@@ -29,6 +27,15 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
   const appInfo = require('../../src/app')(8000, mockServiceRegistry)
 
   return appInfo
+}
+
+function clearRequireCache () {
+  Object.keys(require.cache).forEach(function (key) {
+    if (key.includes('creator-node/src/')) {
+      console.log('deleting cache', key)
+      delete require.cache[key]
+    }
+  })
 }
 
 module.exports = { getApp }

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -6,11 +6,12 @@ redisClient.set('ipfsGatewayReqs', 0)
 redisClient.set('ipfsStandaloneReqs', 0)
 
 async function getApp (ipfsMock, libsMock, blacklistManager) {
-  // we need to clear the cache that commonjs require builds, otherwise it uses old values for imports etc
-  // eg if you set a new env var, it doesn't propogate well unless you clear the cache for the config file as well
-  // as all files that consume it
-  clearRequireCache()
-  console.log('cleared all require caches')
+  delete require.cache[require.resolve('../../src/app')] // force reload between each test
+  delete require.cache[require.resolve('../../src/config')]
+  delete require.cache[require.resolve('../../src/fileManager')]
+  delete require.cache[require.resolve('../../src/blacklistManager')]
+  delete require.cache[require.resolve('../../src/routes/tracks')]
+  delete require.cache[require.resolve('../../src/routes/files')]
 
   // run all migrations before each test
   await clearDatabase()
@@ -27,15 +28,6 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
   const appInfo = require('../../src/app')(8000, mockServiceRegistry)
 
   return appInfo
-}
-
-function clearRequireCache () {
-  Object.keys(require.cache).forEach(function (key) {
-    if (key.includes('creator-node/src/')) {
-      console.log('deleting cache', key)
-      delete require.cache[key]
-    }
-  })
 }
 
 module.exports = { getApp }

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -31,6 +31,8 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
 
 function clearRequireCache () {
   Object.keys(require.cache).forEach(function (key) {
+    // exclude src/models/index from the key deletion because it initalizes a new connection pool
+    // every time and we hit a db error if we clear the cache and keep creating new pg pools
     if (key.includes('creator-node/src/') && !key.includes('creator-node/src/models/index.js')) {
       console.log('deleting cache', key)
       delete require.cache[key]

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -12,6 +12,7 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
   delete require.cache[require.resolve('../../src/blacklistManager')]
   delete require.cache[require.resolve('../../src/routes/tracks')]
   delete require.cache[require.resolve('../../src/routes/files')]
+  delete require.cache[require.resolve('../../src/routes/nodeSync')]
 
   // run all migrations before each test
   await clearDatabase()

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -31,7 +31,7 @@ async function getApp (ipfsMock, libsMock, blacklistManager) {
 
 function clearRequireCache () {
   Object.keys(require.cache).forEach(function (key) {
-    if (key.includes('creator-node/src/')) {
+    if (key.includes('creator-node/src/') && !key.includes('creator-node/src/models/index.js')) {
       console.log('deleting cache', key)
       delete require.cache[key]
     }


### PR DESCRIPTION
### Trello Card Link
None

### Description
We should clear all the require caches in between test runs

### Services

- [ ] Discovery Provider
- [X] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
Ran tests locally and verify it passes