### PR TITLE
🦃 playlists-containing-track DN endpoint 🦃

### DIFF
--- a/discovery-provider/src/queries/get_playlists_containing_content.py
+++ b/discovery-provider/src/queries/get_playlists_containing_content.py
@@ -1,0 +1,64 @@
+
+import logging
+import sqlalchemy
+
+from sqlalchemy import desc
+from src.models import Playlist, Track
+from src.utils import helpers
+from src.utils.db_session import get_db_read_replica
+from src.queries.query_helpers import create_save_repost_count_subquery
+
+logger = logging.getLogger(__name__)
+
+def get_playlists_containing_track(args):
+    resp = []
+    track_id = args.get('track_id')
+
+    try:
+        db = get_db_read_replica()
+        with db.scoped_session() as session:
+            count_subquery = create_save_repost_count_subquery(session, 'playlist')
+
+            query = sqlalchemy.text(
+                """
+                select a.playlist_id from (
+                    select playlist_id, playlist_contents->>'track_ids' track_ids, jsonb_array_elements(playlist_contents->'track_ids') track_id
+                    from playlists
+                    where
+                    is_current = true and is_delete = false and is_private = false
+                ) as a
+                where
+                    a.track_id @> '{"track": :track_id}'::jsonb
+                """
+            )
+            playlists_containing_track = session.execute(
+                query,
+                { "track_id": track_id }
+            ).fetchall()
+
+            playlists_containing_track = [p[0] for p in playlists_containing_track]
+
+            playlists = (
+                session.query(Playlist)
+                .join(
+                    count_subquery,
+                    count_subquery.c['id'] == Playlist.playlist_id
+                )
+                .filter(
+                    Playlist.playlist_id.in_(playlists_containing_track),
+                    Playlist.is_current == True,
+                    Playlist.is_delete == False,
+                    Playlist.is_private == False
+                )
+                .order_by(
+                    desc(count_subquery.c['count']),
+                    desc(Playlist.playlist_id)
+                )
+                .all()
+            )
+
+            resp = helpers.query_result_to_list(playlists)
+    except Exception as e:
+        logger.error(e)
+
+    return resp

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -33,6 +33,7 @@ from src.queries.get_previously_unlisted_tracks import get_previously_unlisted_t
 from src.queries.get_previously_private_playlists import get_previously_private_playlists
 from src.queries.query_helpers import get_current_user_id, get_pagination_vars
 from src.queries.get_users_cnode import get_users_cnode
+from src.queries.get_playlists_containing_content import get_playlists_containing_track
 
 from src.utils.redis_metrics import record_metrics
 
@@ -463,6 +464,17 @@ def get_top_followee_saves_route(type):
         return api_helpers.error_response(str(e), 400)
 
 
+
+@bp.route("/playlists_containing_track/turkey/<int:track_id>", methods=("GET",))
+def get_playlists_containing_track_route(track_id):
+    try:
+        args = { 'track_id': track_id }
+        resp = get_playlists_containing_track(args)
+        return api_helpers.success_response(resp)
+    except Exception as e:
+        return api_helpers.error_response(str(e), 500)
+
+
 # Retrieves the top users for a requested genre under the follow parameters
 # - A given user can only be associated w/ one genre
 # - The user's associated genre is calculated by tallying the genre of the tracks and taking the max
@@ -538,6 +550,7 @@ def get_previously_private_playlists_route():
         return api_helpers.success_response(playlists)
     except exceptions.ArgumentError as e:
         return api_helpers.error_response(str(e), 400)
+
 
 # Get the users for a given creator node url
 @bp.route("/users/creator_node", methods=("GET",))


### PR DESCRIPTION
### Description
A DN endpoint to get all playlists that contain a given trackId, in descending order of popularity (save+repost count)

TODO
- [ ] lint
- [ ] input validation + error handling
- [ ] pagination
- [ ] libs wrapper
- [ ] optimize query performance
- [ ] attach rate limiter
- [ ] code structure: DN query layer has changed a lot since I last looked at it, and seems like there are a few different patterns in place right now. would be great to get input from a product eng on this

### Services

- [x] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. tested locally against prod DB snapshot with several different track ids

Please list the unit test(s) you added to verify your changes.

1. None
