### PR TITLE
Fix mad dog tests with cnode selection changes

### DIFF
--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -185,16 +185,22 @@ class CreatorNodeSelection extends ServiceSelection {
 
     // If not enough secondaries returned from services, select from backups
     remainingSecondaries = this.numberOfNodes - 1 - secondaries.length
-    while (remainingSecondaries-- > 0) {
+    while (remainingSecondaries > 0) {
       const backup = this.selectFromBackups()
-      if (backup && backup !== primary) secondaries.push(backup)
+      if (backup && backup !== primary) {
+        secondaries.push(backup)
+        remainingSecondaries--
+      }
     }
 
     // If not enough secondaries returned from backups, select from unhealthy
     remainingSecondaries = this.numberOfNodes - 1 - secondaries.length
-    while (remainingSecondaries-- > 0) {
+    while (remainingSecondaries > 0) {
       const unhealthy = this.selectFromUnhealthy()
-      if (unhealthy && unhealthy !== primary) secondaries.push(unhealthy)
+      if (unhealthy && unhealthy !== primary) {
+        secondaries.push(unhealthy)
+        remainingSecondaries--
+      }
     }
 
     return secondaries

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -51,7 +51,7 @@ class CreatorNodeSelection extends ServiceSelection {
     const syncResponses = await Promise.all(services.map(service => this.getSyncStatus(service)))
     for (const response of syncResponses) {
       if (response.error) {
-        console.warn(`CreatorNodeSelection - Failed sync status check for ${response.service}: ${response.e}`)
+        console.warn(`CreatorNodeSelection - Failed sync status check for ${response.service}: ${response.error}`)
         this.addUnhealthy(response.service)
         continue
       }
@@ -120,7 +120,7 @@ class CreatorNodeSelection extends ServiceSelection {
     const secondaries = this.getSecondaries(services, primary)
     this.decisionTree.push({
       stage: DECISION_TREE_STATE.SELECT_PRIMARY_AND_SECONDARIES,
-      val: { primary, secondaries: secondaries.toString(), services: servicesMap }
+      val: { primary, secondaries: secondaries.toString(), services: JSON.stringify(Object.keys(servicesMap)) }
     })
 
     console.info('CreatorNodeSelection - final decision tree state', this.decisionTree)

--- a/mad-dog/src/helpers.js
+++ b/mad-dog/src/helpers.js
@@ -74,8 +74,8 @@ const addAndUpgradeUsers = async (
 
         // Wait 1 indexing cycle to get all proper and expected user metadata, as the starter metadata
         // does not contain all necessary fields (blocknumber, track_blocknumber, ...)
-        const userWalletAddress = getLibsWalletAddress(libs)
         await waitForIndexing()
+        const userWalletAddress = getLibsWalletAddress(libs)
         const userAccount = await getUserAccount(libs, userWalletAddress)
         setCurrentUser(libs, userAccount)
       }

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -59,7 +59,7 @@ const makeTest = (name, testFn, { numUsers, numCreatorNodes }) => {
 }
 
 const testRunner = async tests => {
-  const failedTests = []
+  let failedTests = []
   // Run each test
   for (let { testName, test, numUsers } of tests) {
     const date = new Date().toISOString()

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -14,7 +14,7 @@ const NUM_USERS = 2
 
 // Allow command line args for wallet index offset
 const commandLineOffset = parseInt(process.argv.slice(4)[0])
-let accountOffset = commandLineOffset ? commandLineOffset : 0
+let accountOffset = commandLineOffset || 0
 
 const {
   runSetupCommand,
@@ -24,13 +24,13 @@ const {
   allUp
 } = ServiceCommands
 
-async function setupAllServices() {
+async function setupAllServices () {
   logger.info('Setting up all services!')
   await allUp({ numCreatorNodes: NUM_CREATOR_NODES })
   logger.info('All services set up!')
 }
 
-async function tearDownAllServices() {
+async function tearDownAllServices () {
   logger.info('Downing services.')
   await runSetupCommand(Service.ALL, SetupCommand.DOWN)
   logger.info('All services downed.')
@@ -59,7 +59,7 @@ const makeTest = (name, testFn, { numUsers, numCreatorNodes }) => {
 }
 
 const testRunner = async tests => {
-  let failedTests = []
+  const failedTests = []
   // Run each test
   for (let { testName, test, numUsers } of tests) {
     const date = new Date().toISOString()
@@ -118,7 +118,7 @@ const testRunner = async tests => {
 // in the same run as running the tests
 // causes libs init failures, so we stand up services
 // with a separate command.
-async function main() {
+async function main () {
   logger.info('🐶 * Woof Woof * Welcome to Mad-Dog 🐶')
   const cmd = process.argv[3]
 
@@ -140,7 +140,7 @@ async function main() {
       break
     }
     case 'test-snapback': {
-      let snapbackNumUsers = 40
+      const snapbackNumUsers = 40
       const test = makeTest(
         'snapback',
         snapbackSMParallelSyncTest,

--- a/mad-dog/src/tests/test_1.js
+++ b/mad-dog/src/tests/test_1.js
@@ -133,12 +133,17 @@ module.exports = consistency1 = async ({
   })
 
   // Create users, upgrade them to creators
-  const walletIdMap = await addAndUpgradeUsers(
-    numUsers,
-    numCreatorNodes,
-    executeAll,
-    executeOne
-  )
+  let walletIdMap
+  try {
+    walletIdMap = await addAndUpgradeUsers(
+      numUsers,
+      numCreatorNodes,
+      executeAll,
+      executeOne
+    )
+  } catch (e) {
+    return { error: `Issue with creating and upgrading users: ${e}` }
+  }
 
   if (enableFaultInjection) {
     // Create a MadDog instance, responsible for taking down nodes

--- a/mad-dog/src/tests/test_1.js
+++ b/mad-dog/src/tests/test_1.js
@@ -37,7 +37,7 @@ module.exports = consistency1 = async ({
   enableFaultInjection
 }) => {
   // Begin: Test Setup
-  
+
   // create tmp storage dir
   await fs.ensureDir(TEMP_STORAGE_PATH)
 
@@ -208,7 +208,7 @@ const verifyAllCIDsExistOnCNodes = async (trackUploads, executeOne) => {
   const userIds = trackUploads.map(u => u.userId)
   for (const userId of userIds) {
     const user = await executeOne(0, l => getUser(l, userId))
-    userIdRSetMap[userId] = user.creator_node_endpoint.split(",")
+    userIdRSetMap[userId] = user.creator_node_endpoint.split(',')
   }
 
   // Now, confirm each of these CIDs are on the file
@@ -224,10 +224,10 @@ const verifyAllCIDsExistOnCNodes = async (trackUploads, executeOne) => {
     if (!cids) continue
     for (const cid of cids) {
       logger.info(`Verifying CID ${cid} for userID ${userId} on primary: [${endpoint}]`)
-      
+
       // TODO: add `fromFS` option when this is merged back into CN.
       const exists = await verifyCIDExistsOnCreatorNode(cid, endpoint)
-      
+
       logger.info(`Verified CID ${cid} for userID ${userId} on primary: [${endpoint}]!`)
       if (!exists) {
         logger.warn('Found a non-existent cid!')

--- a/mad-dog/src/tests/test_ipldBlacklist.js
+++ b/mad-dog/src/tests/test_ipldBlacklist.js
@@ -86,15 +86,15 @@ const ipldBlacklistTestNewTrackMetadata = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   let trackTxReceipt
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // generate and add cid to be blacklisted as ipld blacklist txn
     const blacklistedCID = await addContentToIpfs({
       someData: 'data' + genRandomString(8)
@@ -150,14 +150,14 @@ const ipldBlacklistTestUpdateTrackMetadata = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // create and upload track
     const track = getRandomTrackMetadata(userId)
     const randomTrackFilePath = await getRandomTrackFilePath(TEMP_STORAGE_PATH)
@@ -207,7 +207,7 @@ const ipldBlacklistTestUpdateTrackMetadata = async ({
 
     if (originalMetadataCID !== uploadedTrack.metadata_multihash) {
       return {
-        error: `Update track with blacklisted metadata CID should not have been indexed.`
+        error: 'Update track with blacklisted metadata CID should not have been indexed.'
       }
     }
   } catch (e) {
@@ -231,15 +231,15 @@ const ipldBlacklistTestNewTrackCoverPhoto = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   let trackTxReceipt
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // generate and add cid to be blacklisted as ipld blacklist txn
     const blacklistedCID = await addContentToIpfs({
       someData: 'data' + genRandomString(8)
@@ -302,16 +302,16 @@ const ipldBlacklistTestUpdateTrackCoverPhoto = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   let trackId
   let blacklistedCID
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // create and upload track
     const track = getRandomTrackMetadata(userId)
     const randomTrackFilePath = await getRandomTrackFilePath(TEMP_STORAGE_PATH)
@@ -393,14 +393,14 @@ const ipldBlacklistTestUpdateUserMetadataCID = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // generate and add cid to be blacklisted as ipld blacklist txn
     const blacklistedCID = await addContentToIpfs({
       someData: 'data' + genRandomString(8)
@@ -455,14 +455,14 @@ const ipldBlacklistTestUpdateUserProfilePhoto = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // Add blacklisted metadata to ipld blacklist
     const blacklistedCID = await addContentToIpfs({
       someData: 'data' + genRandomString(8)
@@ -517,14 +517,14 @@ const ipldBlacklistTestUpdateUserCoverPhoto = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // Add blacklisted metadata to ipld blacklist
     const blacklistedCID = await addContentToIpfs({
       someData: 'data' + genRandomString(8)
@@ -579,14 +579,14 @@ const ipldBlacklistTestUpdatePlaylistCoverPhoto = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // create playlist under userId
     const randomPlaylistName = genRandomString(8)
 
@@ -665,14 +665,14 @@ const ipldBlacklistTestUpdatePlaylistCoverPhotoNoMatch = async ({
   executeOne,
   numCreatorNodes
 }) => {
-  const userId = await getCreatorId({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  })
-
   try {
+    const userId = await getCreatorId({
+      numUsers,
+      executeAll,
+      executeOne,
+      numCreatorNodes
+    })
+
     // create playlist under userId
     const randomPlaylistName = 'playlist_' + genRandomString(8)
     const playlistId = await executeOne(CREATOR_INDEX, libsWrapper => {

--- a/mad-dog/src/tests/test_snapbackSM.js
+++ b/mad-dog/src/tests/test_snapbackSM.js
@@ -3,118 +3,119 @@ const axios = require('axios')
 const ServiceCommands = require('@audius/service-commands')
 const { logger } = require('../logger.js')
 const {
-    addAndUpgradeUsers,
-    getRandomTrackMetadata,
-    getRandomTrackFilePath,
-    delay,
-    genRandomString
+  addAndUpgradeUsers,
+  getRandomTrackMetadata,
+  getRandomTrackFilePath,
+  delay,
+  genRandomString
 } = require('../helpers.js')
 const {
-    uploadTrack,
-    getTrackMetadata,
-    getUser,
-    verifyCIDExistsOnCreatorNode
+  uploadTrack,
+  getTrackMetadata,
+  getUser,
+  verifyCIDExistsOnCreatorNode
 } = ServiceCommands
-
 
 const TEMP_STORAGE_PATH = path.resolve('./local-storage/tmp/')
 let walletIndexToUserIdMap
 
 // Retrieve the current clock value on a node
 const getUserClockValueFromNode = async (wallet, endpoint) => {
-    let resp = await axios({
-      method: 'get',
-      baseURL: endpoint,
-      url: `/users/clock_status/${wallet}`
-    })
-    return resp.data.clockValue
+  const resp = await axios({
+    method: 'get',
+    baseURL: endpoint,
+    url: `/users/clock_status/${wallet}`
+  })
+  return resp.data.clockValue
 }
-
 
 // Monitor ALL users until completed
 // TODO: Maximum timeout?
-const monitorAllUsersSyncStatus = async({ executeAll }) => {
-    await executeAll(async (libs, i) => {
-        let userId = walletIndexToUserIdMap[i]
-        let userInfo = await getUser(libs, userId)
-        let endpoints = userInfo.creator_node_endpoint.split(',')
-        let userWallet = userInfo.wallet
-        let primary = endpoints[0]
-        let secondary1 = endpoints[1]
-        let secondary2 = endpoints[2]
-        logger.info(`Monitoring sync status for ${userId}, ${primary},${secondary1},${secondary2}`)
-        let primaryClockValue, secondary1ClockValue, secondary2ClockValue
-        let synced = false
-        while(!synced) {
-            try {
-                primaryClockValue = await getUserClockValueFromNode(userWallet, primary)
-                secondary1ClockValue = await getUserClockValueFromNode(userWallet, secondary1)
-                secondary2ClockValue = await getUserClockValueFromNode(userWallet, secondary2)
-                logger.info(`Monitoring sync for ${userId} | ${primary}:${primaryClockValue} - ${secondary1}:${secondary1ClockValue} - ${secondary2}:${secondary2ClockValue}`)
+const monitorAllUsersSyncStatus = async ({ executeAll }) => {
+  await executeAll(async (libs, i) => {
+    const userId = walletIndexToUserIdMap[i]
+    const userInfo = await getUser(libs, userId)
+    const endpoints = userInfo.creator_node_endpoint.split(',')
+    const userWallet = userInfo.wallet
+    const primary = endpoints[0]
+    const secondary1 = endpoints[1]
+    const secondary2 = endpoints[2]
+    logger.info(`Monitoring sync status for ${userId}, ${primary},${secondary1},${secondary2}`)
+    let primaryClockValue, secondary1ClockValue, secondary2ClockValue
+    let synced = false
+    while (!synced) {
+      try {
+        primaryClockValue = await getUserClockValueFromNode(userWallet, primary)
+        secondary1ClockValue = await getUserClockValueFromNode(userWallet, secondary1)
+        secondary2ClockValue = await getUserClockValueFromNode(userWallet, secondary2)
+        logger.info(`Monitoring sync for ${userId} | ${primary}:${primaryClockValue} - ${secondary1}:${secondary1ClockValue} - ${secondary2}:${secondary2ClockValue}`)
 
-                if (secondary1ClockValue === primaryClockValue && secondary2ClockValue && primaryClockValue) {
-                    synced = true
-                    logger.info(`Sync completed for user=${userId}!`)
-                }
-            } catch(e) {
-                logger.info(e)
-                throw new Error(`Failed sync monitoring for ${userId}`)
-            }
-            if (!synced) {
-                // Wait 1s
-                await delay(1000)
-            }
+        if (secondary1ClockValue === primaryClockValue && secondary2ClockValue && primaryClockValue) {
+          synced = true
+          logger.info(`Sync completed for user=${userId}!`)
         }
-    })
+      } catch (e) {
+        logger.info(e)
+        throw new Error(`Failed sync monitoring for ${userId}`)
+      }
+      if (!synced) {
+        // Wait 1s
+        await delay(1000)
+      }
+    }
+  })
 }
 
 const snapbackSMParallelSyncTest = async ({
-    numUsers,
-    executeAll,
-    executeOne,
-    numCreatorNodes
-  }) => {
-    // Initialize users
-    if (!walletIndexToUserIdMap) {
-        walletIndexToUserIdMap = await addAndUpgradeUsers(
-          numUsers,
-          numCreatorNodes,
-          executeAll,
-          executeOne
-        )
+  numUsers,
+  executeAll,
+  executeOne,
+  numCreatorNodes
+}) => {
+  // Initialize users
+  if (!walletIndexToUserIdMap) {
+    try {
+      walletIndexToUserIdMap = await addAndUpgradeUsers(
+        numUsers,
+        numCreatorNodes,
+        executeAll,
+        executeOne
+      )
+    } catch (e) {
+      return { error: `Issue with creating and upgrading users: ${e}` }
     }
-
-
-    // Issue parallel uploads for all users
-    await executeAll(async (libs, i) => {
-        // Retrieve user id if known from walletIndexToUserIdMap
-        // NOTE - It might be easier to just create a map of wallets instead of using 'index'
-        const userId = walletIndexToUserIdMap[i]
-        const newTrackMetadata = getRandomTrackMetadata(userId)
-        const randomTrackFilePath = await getRandomTrackFilePath(TEMP_STORAGE_PATH)
-        logger.info(
-            `Uploading Track for userIndex:${i}, userId:${userId}, ${randomTrackFilePath}, ${JSON.stringify(newTrackMetadata)}`
-        )
-        try {
-            let startTime = Date.now()
-            const trackId = await executeOne(i, (l) =>
-                uploadTrack(
-                    l,
-                    newTrackMetadata,
-                    randomTrackFilePath
-                )
-            )
-            let duration = Date.now() - startTime
-            logger.info(`Uploaded track for userId:${userId}, trackId=${trackId} in ${duration}ms`)
-        } catch(e) {
-            logger.error(`Error uploading track for userId:${userId} :${e}`)
-        }
-    })
-
-    // Validate all syncs complete before exiting
-   await monitorAllUsersSyncStatus({ executeAll })
- }
-
-  module.exports = {
-      snapbackSMParallelSyncTest
   }
+
+  // Issue parallel uploads for all users
+  await executeAll(async (libs, i) => {
+    // Retrieve user id if known from walletIndexToUserIdMap
+    // NOTE - It might be easier to just create a map of wallets instead of using 'index'
+    const userId = walletIndexToUserIdMap[i]
+    const newTrackMetadata = getRandomTrackMetadata(userId)
+    const randomTrackFilePath = await getRandomTrackFilePath(TEMP_STORAGE_PATH)
+    logger.info(
+            `Uploading Track for userIndex:${i}, userId:${userId}, ${randomTrackFilePath}, ${JSON.stringify(newTrackMetadata)}`
+    )
+    try {
+      const startTime = Date.now()
+      const trackId = await executeOne(i, (l) =>
+        uploadTrack(
+          l,
+          newTrackMetadata,
+          randomTrackFilePath
+        )
+      )
+      const duration = Date.now() - startTime
+      logger.info(`Uploaded track for userId:${userId}, trackId=${trackId} in ${duration}ms`)
+    } catch (e) {
+      logger.error(`Error uploading track for userId:${userId} :${e}`)
+    }
+  })
+
+  // Validate all syncs complete before exiting
+  await monitorAllUsersSyncStatus({ executeAll })
+}
+
+module.exports = {
+  snapbackSMParallelSyncTest
+}

--- a/service-commands/src/commands/users.js
+++ b/service-commands/src/commands/users.js
@@ -43,6 +43,18 @@ const getUser = async (libs, userId) => {
   return libs.getUser(userId)
 }
 
+const getUserAccount = async (libs, wallet) => {
+  return libs.getUserAccount(wallet)
+}
+
+const getLibsWalletAddress = libs => {
+  return libs.getWalletAddress()
+}
+
+const setCurrentUser = async (libs, userAccount) => {
+  libs.setCurrentUser(userAccount)
+}
+
 const getLibsUserInfo = async libs => {
   return libs.getLibsUserInfo()
 }
@@ -71,6 +83,9 @@ module.exports = {
   addUser,
   upgradeToCreator,
   getUser,
+  getUserAccount,
+  getLibsWalletAddress,
+  setCurrentUser,
   autoSelectCreatorNodes,
   getLibsUserInfo,
   updateMultihash,

--- a/service-commands/src/index.js
+++ b/service-commands/src/index.js
@@ -7,11 +7,16 @@ const {
 } = require('./setup')
 
 const { LibsWrapper, Utils } = require('./libs')
+
+// TODO: should make all of these imports dynamic!!!
 const {
   addUser,
   upgradeToCreator,
   autoSelectCreatorNodes,
   getUser,
+  getUserAccount,
+  getLibsWalletAddress,
+  setCurrentUser,
   getLibsUserInfo,
   updateMultihash,
   updateCoverPhoto,
@@ -42,6 +47,9 @@ module.exports = {
   uploadTrack,
   getTrackMetadata,
   getUser,
+  getUserAccount,
+  getLibsWalletAddress,
+  setCurrentUser,
   getLibsUserInfo,
   updateMultihash,
   updateCoverPhoto,

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -239,8 +239,8 @@ function LibsWrapper (walletIndex = 0) {
   }
 
   /**
-   * Fetch user metadatas from discprov given list of userIds
-   * @param {number[]} userIds
+   * Fetch user account from /user/account with wallet param
+   * @param {string} wallet wallet address
    */
   this.getUserAccount = async wallet => {
     assertLibsDidInit()

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -1,4 +1,5 @@
 const AudiusLibs = require('@audius/libs')
+const CreatorNode = require('@audius/libs/src/services/creatorNode')
 const Utils = require('@audius/libs/src/utils')
 const config = require('../config/config')
 const untildify = require('untildify')
@@ -257,7 +258,7 @@ function LibsWrapper (walletIndex = 0) {
     this.libsInstance.userStateManager.setCurrentUser(userAccount)
     const creatorNodeEndpoints = userAccount.creator_node_endpoint
     if (creatorNodeEndpoints) {
-      const primary = creatorNodeEndpoints ? creatorNodeEndpoints.split(',')[0] : ''
+      const primary = CreatorNode.getPrimary(creatorNodeEndpoints)
       this.creatorNode.setEndpoint(primary)
     }
   }

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -44,7 +44,7 @@ loadLibsVars()
  * Each method may throw.
  * @param {int} walletIndex Ganache can be setup with multiple pre-created wallets. WalletIndex lets you pick which wallet to use for libs.
  */
-function LibsWrapper(walletIndex = 0) {
+function LibsWrapper (walletIndex = 0) {
   this.libsInstance = null
 
   const assertLibsDidInit = () => {
@@ -238,6 +238,31 @@ function LibsWrapper(walletIndex = 0) {
   }
 
   /**
+   * Fetch user metadatas from discprov given list of userIds
+   * @param {number[]} userIds
+   */
+  this.getUserAccount = async wallet => {
+    assertLibsDidInit()
+    const userAccount = await this.libsInstance.discoveryProvider.getUserAccount(wallet)
+
+    if (!userAccount) {
+      throw new Error('No user account found.')
+    }
+
+    return userAccount
+  }
+
+  this.setCurrentUser = async userAccount => {
+    assertLibsDidInit()
+    this.libsInstance.userStateManager.setCurrentUser(userAccount)
+    const creatorNodeEndpoints = userAccount.creator_node_endpoint
+    if (creatorNodeEndpoints) {
+      const primary = creatorNodeEndpoints ? creatorNodeEndpoints.split(',')[0] : ''
+      this.creatorNode.setEndpoint(primary)
+    }
+  }
+
+  /**
    * Gets the user associated with the wallet set in libs
    */
   this.getLibsUserInfo = async () => {
@@ -246,7 +271,7 @@ function LibsWrapper(walletIndex = 0) {
       1,
       0,
       null,
-      this.libsInstance.web3Manager.getWalletAddress()
+      this.getWalletAddress()
     )
 
     if (!users.length) {
@@ -414,6 +439,10 @@ function LibsWrapper(walletIndex = 0) {
     }
 
     return playlists
+  }
+
+  this.getWalletAddress = () => {
+    return this.libsInstance.web3Manager.getWalletAddress()
   }
 }
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/4YQ6bWNx/1704-fix-content-node-selection-tests-on-mad-dog

### Description
Mad dog tests were giving false positives. The content node selection was actually failing with these logs.

[circle ci mad dog logs](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/6770/workflows/9e1bee99-8f2f-40e9-8f79-9dcb4df76250/jobs/50930)
```
2020-11-30T18:15:23.704Z info: 	Upgrading creator wallet index 0 with http://cn3_creator-node_1:4002,http://cn1_creator-node_1:4000,http://cn2_creator-node_1:4001 endpoints
CreatorNodeSelection - final decision tree state [ { stage: 'Get All Services',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter To Whitelist',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter From Blacklist',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter Out Sync In Progress', val: [] },
  { stage: 'Filter Out Unhealthy And Outdated', val: [] },
  { stage: 'Select Primary And Secondaries',
    val: { primary: undefined, secondaries: '', services: {} } } ]
2020-11-30T18:15:23.810Z info: 	Upgrading creator wallet index 1 with  endpoints
2020-11-30T18:15:23.815Z error: 	GOT ERR UPGRADING USER TO CREATOR
2020-11-30T18:15:23.816Z error: 	No creator node endpoint provided
2020-11-30T18:15:23.816Z info: 	Pausing 5000ms for discprov indexing...
```

**Flow for failure:** 
The reason for failure is not due to cnode selection, but how we set up the mad dog tests. The user metadata is not populated with the fields `blockNumber` and `track_blocknumber` in the mad dog tests [(the starter metadata for all users)](https://github.com/AudiusProject/audius-protocol/blob/master/mad-dog/src/helpers.js#L155-L171). 

On the signup flow, we set the starter metadata as the user's actual metadata [code](https://github.com/AudiusProject/audius-protocol/blob/master/libs/src/api/account.js#L187). 

Then, when we check the sync status, we get the current user's metadata and are not able to find `blockNumber` and `track_blocknumber` [code](https://github.com/AudiusProject/audius-protocol/blob/87b18c8dea8407187a2774abb6c017739c1e4387/libs/src/services/creatorNode/index.js#L292-L311).

With these missing fields, the sync checks in content node selection failed, thus causing the above logs.

Also, in mad dog, we always upgrade a user to creator, regardless of whether or not a user is already a creator. This could have potentially caused some weird state in attempting to select a primary and secondaries for creator that already has its creator node endpoints set. 

**The fix:**
1. Poll the discovery node for the proper user metadata (as it is done in [initializing libs](https://github.com/AudiusProject/audius-protocol/blob/87b18c8dea8407187a2774abb6c017739c1e4387/libs/src/services/discoveryProvider/index.js#L39-L40))
2. Check to see if the user is already a creator before upgrading to creator
3. Prevent false positives

**UPDATE 12/2/2020**
Extra fix: 
- libs logs for content node selection
- updating select secondaries logic to not decrement `remainingSecondaries` in the while loop, but to only do so when a secondary has been chosen

### Services

- [ ] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [x] Libs
- [ ] Contracts
- [ ] Service Commands
- [x] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- YES **content node selection**


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Run mad-dog tests to check that 

1. Upgrading a user to a creator works successfully
```
2020-11-30T22:41:18.359Z info: 	Upgrading creator wallet index 0 with http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002,http://cn2_creator-node_1:4001 endpoints
CreatorNodeSelection - final decision tree state [ { stage: 'Get All Services',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter To Whitelist',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter From Blacklist',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter Out Sync In Progress',
    val:
     [ 'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001',
       'http://cn3_creator-node_1:4002' ] },
  { stage: 'Filter Out Unhealthy And Outdated',
    val:
     [ 'http://cn3_creator-node_1:4002',
       'http://cn1_creator-node_1:4000',
       'http://cn2_creator-node_1:4001' ] },
  { stage: 'Select Primary And Secondaries',
    val:
     { primary: 'http://cn3_creator-node_1:4002',
       secondaries:
        'http://cn1_creator-node_1:4000,http://cn2_creator-node_1:4001',
       services:
        '["http://cn3_creator-node_1:4002","http://cn1_creator-node_1:4000","http://cn2_creator-node_1:4001"]' } } ]
```

2. If a user is already a creator, do not upgrade again
```
2020-11-30T22:41:50.912Z info: 	Starting: [Upgrade to creator]...
2020-11-30T22:41:51.054Z info: 	User 1 is already a creator. Skipping upgrade...
```

3. Throw an error in upgrading user instead of just logging the error [(fix)](https://github.com/AudiusProject/audius-protocol/pull/1082/files#diff-90517aa8c4cece9398e751441d7b68afb2ba54452c788fcfee180912529f155fR115)