### PR TITLE
Fix setting pg_trgm.similarity_threshold on new connection

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -22,7 +22,6 @@ import alembic.config  # pylint: disable=E0611
 
 from src import exceptions
 from src.queries import queries, search, search_queries, health_check, trending, notifications
-from src.queries.search_config import set_search_similarity
 from src.api.v1 import api as api_v1
 from src.utils import helpers, config
 from src.utils.session_manager import SessionManager
@@ -249,15 +248,11 @@ def configure_flask(test_config, app, mode="app"):
         app.config["db"]["url"],
         ast.literal_eval(app.config["db"]["engine_args_literal"]),
     )
-    with app.db_session_manager.scoped_session() as session:
-        set_search_similarity(session)
 
     app.db_read_replica_session_manager = SessionManager(
         app.config["db"]["url_read_replica"],
         ast.literal_eval(app.config["db"]["engine_args_literal"]),
     )
-    with app.db_read_replica_session_manager.scoped_session() as session:
-        set_search_similarity(session)
 
 
     exceptions.register_exception_handlers(app)

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -10,7 +10,7 @@ minSearchSimilarity = 0.1
 logger = logging.getLogger(__name__)
 
 
-def set_search_similarity(session):
+def set_search_similarity(cursor):
     """
     Sets the search similarity threshold to be used by % operator in queries.
     https://www.postgresql.org/docs/9.6/pgtrgm.html
@@ -19,8 +19,8 @@ def set_search_similarity(session):
     https://stackoverflow.com/a/11250001/11435157
     """
     try:
-        session.execute(sqlalchemy.text(
+        cursor.execute(
             f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"
-        ))
+        )
     except Exception as e:
-        logger.error(f"Unable to set similarity_threshold, {0}".format(e))
+        logger.error(f"Unable to set similarity_threshold: {e}")

--- a/discovery-provider/src/utils/session_manager.py
+++ b/discovery-provider/src/utils/session_manager.py
@@ -12,6 +12,8 @@ class SessionManager:
     def __init__(self, db_url, db_engine_args):
         self._engine = create_engine(db_url, **db_engine_args)
         self._session_factory = sessionmaker(bind=self._engine)
+        # Attach a listener for new engine connection.
+        # See https://docs.sqlalchemy.org/en/14/core/event.html
         listen(self._engine, 'connect', self.on_connect)
 
     def on_connect(self, dbapi_conn, connection_record):

--- a/discovery-provider/src/utils/session_manager.py
+++ b/discovery-provider/src/utils/session_manager.py
@@ -1,29 +1,51 @@
 from contextlib import contextmanager
+import logging  # pylint: disable=C0302
 from sqlalchemy import create_engine
+from sqlalchemy.event import listen
 from sqlalchemy.orm import sessionmaker
+from src.queries.search_config import set_search_similarity
+
+logger = logging.getLogger(__name__)
 
 
 class SessionManager:
     def __init__(self, db_url, db_engine_args):
         self._engine = create_engine(db_url, **db_engine_args)
         self._session_factory = sessionmaker(bind=self._engine)
+        listen(self._engine, 'connect', self.on_connect)
+
+    def on_connect(self, dbapi_conn, connection_record):
+        """
+        Callback invoked with a raw DBAPI connection every time the engine assigns a new
+        connection to the session manager.
+
+        Actions that should be fired on new connection should be performed here.
+        For example, pg_trgm.similarity_threshold needs to be set once for each connection,
+        but not if that connection is recycled and used in another session.
+        """
+        logger.debug("Using new DBAPI connection")
+        cursor = dbapi_conn.cursor()
+        set_search_similarity(cursor)
+        cursor.close()
 
     def session(self):
-        """ Get a session for direct management/use. Use not recommended unless absolutely
-            necessary.
+        """
+        Get a session for direct management/use. Use not recommended unless absolutely
+        necessary.
         """
         return self._session_factory()
 
     @contextmanager
     def scoped_session(self, expire_on_commit=True):
-        """ Usage:
-                with scoped_session() as session:
-                    use the session ...
+        """
+        Usage:
+            with scoped_session() as session:
+                use the session ...
 
-            Session commits when leaving the block normally, or rolls back if an exception
-            is thrown.
+        Session commits when leaving the block normally, or rolls back if an exception
+        is thrown.
 
-            Taken from: http://docs.sqlalchemy.org/en/latest/orm/session_basics.html
+        Taken from: http://docs.sqlalchemy.org/en/latest/orm/session_basics.html
         """
         session = self._session_factory()
         session.expire_on_commit = expire_on_commit


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/B8dTGjQO/1706-determine-why-some-search-results-in-api-are-not-returning-successfully-https-discoveryprovideraudiusco-v1-tracks-searchquery3la

### Description
Sets (resets) pg_trgm.similarity_threshold every time the session manager engine creates a new connection. The setting persists across connections (which I had misunderstood before). Once set on the connection, any session that uses the connection will have the setting.

### Services

- [x] Discovery Provider

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

Repro of bug (before change)
1. Ran local discovery provider pointed at a db clone.
2. Updated connection pool timeout to be 60s (instead of 3600s) and pool count to 2. 
3. Added a log statement to query + `SHOW pg_trgm.similarity_threshold` every time the search endpoint would hit.
4. Successfully ran one search query for 3lau+touch+carly+paige
5. Waited 60s
6. Reran search query for 3lau+touch+carly+paige and saw error message that pg_trgm.similarity_threshold was unset

Rolled out this code change & repeated 1-5 and #6 returned successfully
