### PR TITLE
Fix issues preventing generation of swagger.json

### DIFF
--- a/discovery-provider/src/api/v1/api.py
+++ b/discovery-provider/src/api/v1/api.py
@@ -31,6 +31,7 @@ api_v1.add_namespace(resolve_ns)
 
 bp_full = Blueprint('api_v1_full', __name__, url_prefix='/v1/full')
 api_v1_full = ApiWithHTTPS(bp_full, version='1.0')
+api_v1_full.add_namespace(models_ns)
 api_v1_full.add_namespace(full_tracks_ns)
 api_v1_full.add_namespace(full_playlists_ns)
 api_v1_full.add_namespace(full_users_ns)

--- a/discovery-provider/src/api/v1/models/activities.py
+++ b/discovery-provider/src/api/v1/models/activities.py
@@ -13,7 +13,6 @@ class ItemType(fields.Raw):
             return "playlist"
         raise MarshallingError("Unable to marshal as activity type")
 
-
 class ActivityItem(fields.Raw):
     def format(self, value):
         try:
@@ -23,7 +22,6 @@ class ActivityItem(fields.Raw):
                 return marshal(value, playlist_model)
         except:
             raise MarshallingError("Unable to marshal as activity item")
-
 
 class FullActivityItem(fields.Raw):
     def format(self, value):
@@ -42,7 +40,7 @@ activity_model = ns.model("activity", {
     "item": ActivityItem
 })
 
-activity_model_full = ns.model("activity", {
+activity_model_full = ns.model("activity_full", {
     "timestamp": fields.String(allow_null=True),
     "item_type": ItemType,
     "item": FullActivityItem

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -10,7 +10,7 @@ from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
     format_offset, format_limit, decode_string_id, stem_from_track, \
     get_current_user_id
 
-from .models.tracks import track, track_full, stem_full, remixes_response
+from .models.tracks import track, track_full, stem_full, remixes_response as remixes_response_model
 from src.queries.search_queries import SearchKind, search
 from src.queries.get_trending_tracks import get_trending_tracks
 from src.utils.redis_cache import cache, extract_key, use_redis_cache
@@ -303,7 +303,7 @@ track_favorites_route_parser.add_argument('user_id', required=False)
 track_favorites_route_parser.add_argument('limit', required=False, type=int)
 track_favorites_route_parser.add_argument('offset', required=False, type=int)
 track_favorites_response = make_full_response(
-    "following_response", full_ns, fields.List(fields.Nested(user_model_full)))
+    "track_favorites_response_full", full_ns, fields.List(fields.Nested(user_model_full)))
 
 
 @full_ns.route("/<string:track_id>/favorites")
@@ -348,7 +348,7 @@ track_reposts_route_parser.add_argument('user_id', required=False)
 track_reposts_route_parser.add_argument('limit', required=False, type=int)
 track_reposts_route_parser.add_argument('offset', required=False, type=int)
 track_reposts_response = make_full_response(
-    "following_response", full_ns, fields.List(fields.Nested(user_model_full)))
+    "track_reposts_response_full", full_ns, fields.List(fields.Nested(user_model_full)))
 @full_ns.route("/<string:track_id>/reposts")
 class FullTrackReposts(Resource):
     @full_ns.expect(track_reposts_route_parser)
@@ -399,7 +399,7 @@ class FullTrackStems(Resource):
 
 
 remixes_response = make_full_response(
-    "remixes_response", full_ns, fields.Nested(remixes_response))
+    "remixes_response_full", full_ns, fields.Nested(remixes_response_model))
 remixes_parser = reqparse.RequestParser()
 remixes_parser.add_argument('user_id', required=False)
 remixes_parser.add_argument('limit', required=False, default=10)
@@ -438,7 +438,7 @@ class FullRemixingRoute(Resource):
     @cache(ttl_sec=10)
     def get(self, track_id):
         decoded_id = decode_with_abort(track_id, full_ns)
-        request_args = remixes_parser.parse_args()
+        request_args = remixing_parser.parse_args()
         current_user_id = get_current_user_id(request_args)
 
         args = {

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -244,7 +244,7 @@ user_reposts_route_parser.add_argument('user_id', required=False)
 user_reposts_route_parser.add_argument('limit', required=False, type=int)
 user_reposts_route_parser.add_argument('offset', required=False, type=int)
 
-reposts_response = make_full_response("reposts", full_ns, fields.List(fields.Nested(activity_model)))
+reposts_response = make_response("reposts", ns, fields.List(fields.Nested(activity_model)))
 @ns.route(USER_REPOSTS_ROUTE)
 class RepostList(Resource):
     @record_metrics
@@ -397,7 +397,7 @@ favorite_route_parser = reqparse.RequestParser()
 favorite_route_parser.add_argument('user_id', required=False, type=str)
 favorite_route_parser.add_argument('limit', required=False, type=int)
 favorite_route_parser.add_argument('offset', required=False, type=int)
-favorites_response = make_full_response("favorites_response", full_ns, fields.List(fields.Nested(activity_model_full)))
+favorites_response = make_full_response("favorites_response_full", full_ns, fields.List(fields.Nested(activity_model_full)))
 @full_ns.route("/<string:user_id>/favorites/tracks")
 class FavoritedTracks(Resource):
     @record_metrics


### PR DESCRIPTION

### Description

There were a number of issues preventing us from compiling swagger.json for `/v1` and `/v1/full` routes. This PR fixes those, as well as fixing query param parsing for the `remixing` route.


### Services

- [X] Discovery Provider
- [ ] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?

- ✅ Nope


### How Has This Been Tested?

Tested that swagger.json works for both endpoints. 
