### PR TITLE
Add `spOwnerWallet` to the Health Check endpoint

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -12,11 +12,12 @@ const utils = require('../../utils.js')
 const healthCheck = async ({ libs } = {}, logger, sequelize) => {
   let response = {
     ...versionInfo,
-    'healthy': true,
-    'git': process.env.GIT_SHA,
-    'selectedDiscoveryProvider': 'none',
-    'creatorNodeEndpoint': config.get('creatorNodeEndpoint'),
-    'spID': config.get('spID')
+    healthy: true,
+    git: process.env.GIT_SHA,
+    selectedDiscoveryProvider: 'none',
+    creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
+    spID: config.get('spID'),
+    spOwnerWallet: config.get('spOwnerWallet')
   }
 
   if (libs) {

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -25,6 +25,7 @@ describe('Test Health Check', function () {
     config.set('spID', 10)
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
+    let expectedSpOwnerWallet = config.get('spOwnerWallet')
     const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
@@ -33,6 +34,7 @@ describe('Test Health Check', function () {
       git: undefined,
       selectedDiscoveryProvider: TEST_ENDPOINT,
       spID: expectedSpID,
+      spOwnerWallet: expectedSpOwnerWallet,
       creatorNodeEndpoint: expectedEndpoint
     })
   })
@@ -46,6 +48,7 @@ describe('Test Health Check', function () {
       git: undefined,
       selectedDiscoveryProvider: 'none',
       spID: config.get('spID'),
+      spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint')
     })
   })


### PR DESCRIPTION
### Trello Card Link
N/A

### Description
Add `spOwnerWallet` to the Creator Node's Health Check endpoint.

### Services

- [ ] Discovery Provider
- [x] Creator Node
- [ ] Identity Service
- [ ] Libs
- [ ] Contracts
- [ ] Service Commands
- [ ] Mad Dog

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
- ✅ Nope


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Include log analysis if applicable.

1. Tested locally, and curled localhost:4000 to get the JSON which had a new field for `spOwnerWallet`.

Please list the unit test(s) you added to verify your changes.

1. [healthCheckComponentService.test.js](https://github.com/AudiusProject/audius-protocol/compare/vss-health-check-sp-wallet?expand=1#diff-53cb51da2cc8a51d079b74b780048a78cfc14e9bad36c6f8750cc9c013b2ce70)
