### PR TITLE
Fix libs gov getVotes call

### DIFF
--- a/libs/src/services/ethContracts/delegateManagerClient.js
+++ b/libs/src/services/ethContracts/delegateManagerClient.js
@@ -250,6 +250,15 @@ class DelegateManagerClient extends GovernedContractClient {
     return Utils.toBN(info)
   }
 
+  async getTotalDelegatorStake (delegator) {
+    const method = await this.getMethod(
+      'getTotalDelegatorStake',
+      delegator
+    )
+    const info = await method.call()
+    return Utils.toBN(info)
+  }
+
   async getTotalLockedDelegationForServiceProvider (serviceProvider) {
     const method = await this.getMethod(
       'getTotalLockedDelegationForServiceProvider',

--- a/libs/src/services/ethContracts/governanceClient.js
+++ b/libs/src/services/ethContracts/governanceClient.js
@@ -271,7 +271,7 @@ class GovernanceClient extends ContractClient {
     let events = await contract.getPastEvents('ProposalVoteSubmitted', {
       fromBlock: queryStartBlock,
       filter: {
-        proposalId: proposalId
+        _proposalId: proposalId
       }
     })
     return events.map(this.formatVote)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/wuU4JhE4/1720-protocol-dashboard-bug-proposals-show-all-votes-for-all-proposals-under-voter-section

### Description
This proposal has an error in the number of votes - https://dashboard.staging.audius.org/governance/proposal/3
The query for votes per proposal has an incorrect filter, which is causing this issue.

### Services
Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
I ran the staging protocol dashboard with linked libs to ensure the votes call filtered by proposal Id
 