### PR TITLE
Bump libs patch

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
### Trello Card Link
na

### Description
Bump libs version to use in protocol dashboard. 
This libs version has a bug fix for querying for governance vote & an added contracts method binding for `getTotalDelegatorStake`

### Services
Libs

### Does it touch a critical flow like Discovery indexing, Creator Node track upload, Creator Node gateway, or Creator Node file system?
Delete an option.
- ✅ Nope


### How Has This Been Tested?
I linked protocol dashboard against libs locally and ran the methods in the version bump.