### PR TITLE
Add mechanism to bust contract cache

### DIFF
--- a/libs/src/services/ethContracts/audiusTokenClient.js
+++ b/libs/src/services/ethContracts/audiusTokenClient.js
@@ -6,12 +6,22 @@ class AudiusTokenClient {
 
     this.web3 = this.ethWeb3Manager.getWeb3()
     this.AudiusTokenContract = new this.web3.eth.Contract(this.contractABI, this.contractAddress)
+
+    this.bustCacheNonce = 0
   }
 
   /* ------- GETTERS ------- */
 
+  async bustCache () {
+    this.bustCacheNonce += 1
+  }
+
   async balanceOf (account) {
-    const balance = await this.AudiusTokenContract.methods.balanceOf(account).call()
+    let args
+    if (this.bustCacheNonce > 0) {
+      args = { _audiusBustCache: this.bustCacheNonce }
+    }
+    const balance = await this.AudiusTokenContract.methods.balanceOf(account).call(args)
     return this.web3.utils.toBN(balance)
   }
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Adds a simple mechanism to allow busting the cache for getting token balance for a wallet. Currently there's a bug where if we poll for your balance immediately after claiming/sending tokens, we could display the old balance for a short period of time. This cache busting prevents that.

This could probably be extended to the generic ContractClient class (which this class does not use)

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- Claimed and sent on production with a test account
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

Nope