### PR TITLE
Fix POSIX compliance for `setup.js down` and `check_secrets.sh`

### DIFF
--- a/check_secrets.sh
+++ b/check_secrets.sh
@@ -1,10 +1,7 @@
 # used to exercise the `if command is not git command` logic below. change this to an invalid value to test printing out install message
 COMMAND_PREFIX='secrets'
 
-# 2>&1 sends stderr to stdout
-GIT_SECRET_CMD_OUTPUT=$(git $COMMAND_PREFIX -h 2>&1)
-
-if grep -q "git: '$COMMAND_PREFIX' is not a git command" <<< $GIT_SECRET_CMD_OUTPUT; then
+if ! git secrets > /dev/null 2>&1; then
   echo "Please install 'git-secrets' from https://github.com/awslabs/git-secrets and run 'git secrets --install' in the audius-protocol/ repo"
   exit 1
 fi

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -1,7 +1,7 @@
 {
   "all": {
     "down": [
-      "SERVICES=$(docker ps -aq); if [[ -n $SERVICES ]]; then docker stop ${SERVICES} && docker rm ${SERVICES}; fi",
+      "SERVICES=$(docker ps -aq); docker stop ${SERVICES} && docker rm ${SERVICES}",
       "docker container prune -f",
       "docker volume prune -f",
       "docker network prune -f"

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -1,7 +1,7 @@
 {
   "all": {
     "down": [
-      "SERVICES=$(docker ps -aq); docker stop ${SERVICES} && docker rm ${SERVICES}",
+      "SERVICES=$(docker ps -aq); if [ \"$SERVICES\" != \"\" ]; then docker stop ${SERVICES} && docker rm ${SERVICES}; fi",
       "docker container prune -f",
       "docker volume prune -f",
       "docker network prune -f"


### PR DESCRIPTION
### Description
`node service-commands/scripts/setup.js down` and `sh check_secrets.sh` fail on systems that use `dash` to implement `sh`.

- Resolves the problem in `down` by changing the check for empty strings for dash.
- Resolves the problem in `check_secrets.sh` by adapting the if condition to be more compatible.

### Tests
On a Debian distribution (Eg. Ubuntu)
```
node service-commands/scripts/setup.js down
node service-commands/scripts/setup.js up -nc 2
node service-commands/scripts/setup.js down
node service-commands/scripts/setup.js down
```

```
sudo apt install git-secrets
git commit [...]
sudo apt autoremove git-secrets
git commit [...]
sudo apt install git-secrets
git commit [...]
```