### PR TITLE
[AUD-45] Exclude owner_wallet from API endpoint response

### DIFF
--- a/discovery-provider/src/api/v1/models/common.py
+++ b/discovery-provider/src/api/v1/models/common.py
@@ -24,7 +24,6 @@ version_metadata = ns.model("version_metadata", {
 full_response = ns.model("full_response", {
     "latest_chain_block": fields.Integer(required=True),
     "latest_indexed_block": fields.Integer(required=True),
-    "owner_wallet": fields.Integer(required=True),
     "signature": fields.String(required=True),
     "timestamp": fields.String(required=True),
     "version": fields.Nested(version_metadata, required=True),


### PR DESCRIPTION
### Description

Removes extra owner_wallet field from full API responses

### Tests

Tested locally.

