### PR TITLE
User replica set manager additional node bootstrap events

### DIFF
--- a/contracts/contracts/UserReplicaSetManager.sol
+++ b/contracts/contracts/UserReplicaSetManager.sol
@@ -33,9 +33,9 @@ contract UserReplicaSetManager is SigningLogicInitializable, RegistryContract {
 
     /* Events */
     event UpdateReplicaSet(
-        uint _userId,
-        uint _primary,
-        uint[] _secondaries
+        uint indexed _userId,
+        uint indexed _primary,
+        uint[] indexed _secondaries
     );
 
     event AddOrUpdateContentNode(
@@ -353,15 +353,25 @@ contract UserReplicaSetManager is SigningLogicInitializable, RegistryContract {
         address[] memory _bootstrapWallets
     ) internal
     {
+        uint256[3] memory emptyProposerIds = [uint256(0), uint256(0), uint256(0)];
         require(
             _bootstrapSPIDs.length == _bootstrapWallets.length,
             "Mismatched bootstrap array lengths"
         );
         for (uint i = 0; i < _bootstrapSPIDs.length; i++) {
             spIdToContentNodeDelegateWallet[_bootstrapSPIDs[i]] = _bootstrapWallets[i];
+            emit AddOrUpdateContentNode(
+                _bootstrapSPIDs[i],
+                _bootstrapWallets[i],
+                emptyProposerIds,
+                address(0x00),
+                address(0x00),
+                address(0x00)
+            );
         }
     }
 
+    // Confirm sender is valid
     function _validateUpdateOperation (
         address _proposer1Address,
         address _proposer2Address,

--- a/contracts/contracts/UserReplicaSetManager.sol
+++ b/contracts/contracts/UserReplicaSetManager.sol
@@ -33,9 +33,9 @@ contract UserReplicaSetManager is SigningLogicInitializable, RegistryContract {
 
     /* Events */
     event UpdateReplicaSet(
-        uint indexed _userId,
-        uint indexed _primary,
-        uint[] indexed _secondaries
+        uint _userId,
+        uint _primary,
+        uint[] _secondaries
     );
 
     event AddOrUpdateContentNode(

--- a/contracts/test/userReplicaSetManager.js
+++ b/contracts/test/userReplicaSetManager.js
@@ -11,6 +11,7 @@ import {
 import * as _constants from './utils/constants'
 import { eth_signTypedData } from './utils/util'
 import { getNetworkIdForContractInstance } from './utils/getters'
+import { web3 } from '@openzeppelin/test-helpers/src/setup'
 
 const { expectRevert, expectEvent } = require('@openzeppelin/test-helpers');
 const abi = require('ethereumjs-abi')
@@ -22,7 +23,9 @@ const encodeCall = (name, args, values) => {
     return '0x' + methodId + params
 }
 
-contract('UserReplicaSetManager', async (accounts) => {
+const addressZero = '0x0000000000000000000000000000000000000000'
+
+contract.only('UserReplicaSetManager', async (accounts) => {
     const deployer = accounts[0]
     const verifierAddress = accounts[2]
     const userId1 = 1
@@ -93,8 +96,47 @@ contract('UserReplicaSetManager', async (accounts) => {
            initializeUserReplicaSetManagerCalldata,
            { from: deployer }
         )
+
         userReplicaSetManager = await UserReplicaSetManager.at(proxyContractDeployTx.address)
-    })
+
+        // Confirm constructor events were fired as expected
+        await expectEvent.inTransaction(
+            proxyContractDeployTx.transactionHash,
+            UserReplicaSetManager,
+            'AddOrUpdateContentNode',
+            {
+                _newCnodeId: toBN(cnode1SpID),
+                _newCnodeDelegateOwnerWallet: cnode1Account,
+                _proposer1Address: addressZero,
+                _proposer2Address: addressZero,
+                _proposer3Address: addressZero
+           }
+        )
+        await expectEvent.inTransaction(
+            proxyContractDeployTx.transactionHash,
+            UserReplicaSetManager,
+            'AddOrUpdateContentNode',
+            {
+                _newCnodeId: toBN(cnode2SpID),
+                _newCnodeDelegateOwnerWallet: cnode2Account,
+                _proposer1Address: addressZero,
+                _proposer2Address: addressZero,
+                _proposer3Address: addressZero
+           }
+        )
+        await expectEvent.inTransaction(
+            proxyContractDeployTx.transactionHash,
+            UserReplicaSetManager,
+            'AddOrUpdateContentNode',
+            {
+                _newCnodeId: toBN(cnode3SpID),
+                _newCnodeDelegateOwnerWallet: cnode3Account,
+                _proposer1Address: addressZero,
+                _proposer2Address: addressZero,
+                _proposer3Address: addressZero
+           }
+        )
+   })
 
     // Confirm constructor arguments are respected on chain
     const validateBootstrapNodes = async () => {
@@ -422,7 +464,6 @@ contract('UserReplicaSetManager', async (accounts) => {
             userReplicaBootstrapAddress,
             `Expected ${userReplicaBootstrapAddress}, found ${userReplicaBootstrapAddressOnChain}`
         )
-        const addressZero = '0x0000000000000000000000000000000000000000'
         // Confirm failure if update function sent from wrong address
         await expectRevert(
             userReplicaSetManager.updateUserReplicaBootstrapAddress(addressZero),


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

In order to accurately index the incoming `AddOrUpdateContentNode` additional events are emitted in the `initialize` function - will be consumed by this PR (https://github.com/AudiusProject/audius-protocol/pull/1141/files?file-filters%5B%5D=.js&file-filters%5B%5D=.py#diff-8b8ff7747dd21162150caa300b03ef650f094b2bb67c0bdffcb5b4963678a148R58)



### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1.  Corresponding unit tests updated

