### PR TITLE
[AUD-127] Do not reset local storage user state manager in ctor

### DIFF
--- a/libs/src/userStateManager.js
+++ b/libs/src/userStateManager.js
@@ -10,9 +10,6 @@ const supportsLocalStorage = () => typeof window !== 'undefined' && window && wi
 class UserStateManager {
   constructor () {
     this.currentUser = null
-    if (supportsLocalStorage()) {
-      window.localStorage.removeItem(CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY)
-    }
   }
 
   setCurrentUser (currentUser) {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

The user state manager (I believe erroneously) was resetting the local storage "found-user" reference on construction (even if set to true), and then re-setting it to true after a user was fetched.

This behavior opened up a race condition where the dapp would load and fetch the found-user local storage value, see that it was null, and send a signed in user to the splash screen. This happens only very rarely though because most of the time, the UserStateManager is constructed after first JS execution (b/c it's lazy loaded). OR, almost immediately, the local storage value is set back to true in the presence of a signed in user, so the observer never sees the `null` state.

My hunch as to why I probably added the clearing of local storage is that per-session, it would be safer to re-establish that we were in fact logged in. but that was a year ago and i think that assumption was wrong. https://github.com/AudiusProject/audius-protocol/commit/61235ce6cc5106d1d8f55401f3d7ac8c35e8562c

Also, quite interestingly, this is much easier to repro in firefox (https://stackoverflow.com/questions/13852209/localstorage-unreliable-in-firefox/13856156#13856156) because of some extra hidden asynchronicity in the getters/setters, *i think*


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. repeated reloads to make sure we never landed on splash page after logging in
2. added an interval that logged out the local storage value on page load and saw that it was null occasionally before the change, but never after
3. coming in clean as a new user signing in, reloading and seeing the splash screen
4. signing out and coming back shows the splash screen
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
