### PR TITLE
CN ensurePrimaryMiddleware Fix Logic

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -114,7 +114,7 @@ async function triggerSecondarySyncs (req) {
 
 /**
  * Retrieves current FQDN registered on-chain with node's owner wallet
- * 
+ *
  * @notice TODO - this can all be cached on startup, but we can't validate the spId on startup unless the
  *    services has been registered, and we can't register the service unless the service starts up.
  *    Bit of a chicken and egg problem here with timing of first time setup, but potential optimization here
@@ -151,7 +151,7 @@ async function getOwnEndpoint (req) {
 
 /**
  * Get all creator node endpoints for user by wallet from discprov
- * 
+ *
  * If tx blocknumber provided, poll discprov until it has indexed that blocknumber
  *    Else poll discprov until it returns own endpoint as primary else error
  */
@@ -172,7 +172,7 @@ async function getCreatorNodeEndpoints (req, wallet, ownEndpoint, ensurePrimary)
     // In total, will try for 200 seconds.
     const MaxRetries = 40
     const RetryTimeout = 5000 // 5 seconds
-    
+
     // Initial delay before polling
     await utils.timeout(1000)
 

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -52,7 +52,9 @@ async function syncLockMiddleware (req, res, next) {
 
 /** Blocks writes if node is not the primary for audiusUser associated with wallet. */
 async function ensurePrimaryMiddleware (req, res, next) {
-  if (config.get('isUserMetadataNode')) next()
+  if (config.get('isUserMetadataNode')) {
+    return next()
+  }
 
   const start = Date.now()
 

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -248,7 +248,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
 
     let returnedPrimaryEndpoint = null
     for (let retry = 1; retry <= MaxRetries; retry++) {
-      req.logger.info(`getCreatorNodeEndpoints ENDPOINT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
+      req.logger.info(`getCreatorNodeEndpoints retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
 
       try {
         const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
@@ -268,7 +268,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
       }
 
       await utils.timeout(RetryTimeout)
-      req.logger.info(`getCreatorNodeEndpoints ENDPOINT AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
+      req.logger.info(`getCreatorNodeEndpoints AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
     }
 
     // Error if discprov doesn't return any user for wallet

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -12,7 +12,7 @@ module.exports = function (app) {
   /**
    * Create AudiusUser from provided metadata, and make metadata available to network
    */
-  app.post('/audius_users/metadata', authMiddleware, syncLockMiddleware, handleResponse(async (req, res) => {
+  app.post('/audius_users/metadata', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, handleResponse(async (req, res) => {
     // TODO - input validation
     const metadataJSON = req.body.metadata
     const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -22,7 +22,7 @@ const { recoverWallet } = require('../apiSigning')
 const models = require('../models')
 const config = require('../config.js')
 const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
-const { authMiddleware, syncLockMiddleware, triggerSecondarySyncs } = require('../middlewares')
+const { authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, triggerSecondarySyncs } = require('../middlewares')
 const { getIPFSPeerId, ipfsSingleByteCat, ipfsStat, getAllRegisteredCNodes, findCIDInNetwork } = require('../utils')
 const ImageProcessingQueue = require('../ImageProcessingQueue')
 const RehydrateIpfsQueue = require('../RehydrateIpfsQueue')
@@ -303,7 +303,7 @@ module.exports = function (app) {
   /**
    * Store image in multiple-resolutions on disk + DB and make available via IPFS
    */
-  app.post('/image_upload', authMiddleware, syncLockMiddleware, uploadTempDiskStorage.single('file'), handleResponseWithHeartbeat(async (req, res) => {
+  app.post('/image_upload', authMiddleware, ensurePrimaryMiddleware, syncLockMiddleware, uploadTempDiskStorage.single('file'), handleResponseWithHeartbeat(async (req, res) => {
     if (!req.body.square || !(req.body.square === 'true' || req.body.square === 'false')) {
       return errorResponseBadRequest('Must provide square boolean param in request body')
     }

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -274,7 +274,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
       if (!dbOnlySync) {
         try {
           const myCnodeEndpoint = await getOwnEndpoint(req)
-          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey, myCnodeEndpoint)
+          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey, myCnodeEndpoint, false)
 
           // push user metadata node to user's replica set if defined
           if (config.get('userMetadataNodeUrl')) userReplicaSet.push(config.get('userMetadataNodeUrl'))

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -274,7 +274,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
       if (!dbOnlySync) {
         try {
           const myCnodeEndpoint = await getOwnEndpoint(req)
-          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey)
+          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey, myCnodeEndpoint)
 
           // push user metadata node to user's replica set if defined
           if (config.get('userMetadataNodeUrl')) userReplicaSet.push(config.get('userMetadataNodeUrl'))

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -4,7 +4,7 @@ const models = require('../models')
 const { saveFileForMultihash } = require('../fileManager')
 const { handleResponse, successResponse, errorResponse, errorResponseServerError } = require('../apiHelpers')
 const config = require('../config')
-const middlewares = require('../middlewares')
+const { getOwnEndpoint, getCreatorNodeEndpoints } = require('../middlewares')
 const { getIPFSPeerId } = require('../utils')
 
 // Dictionary tracking currently queued up syncs with debounce
@@ -273,8 +273,8 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
 
       if (!dbOnlySync) {
         try {
-          const myCnodeEndpoint = await middlewares.getOwnEndpoint(req)
-          userReplicaSet = await middlewares.getCreatorNodeEndpoints(req, fetchedWalletPublicKey)
+          const myCnodeEndpoint = await getOwnEndpoint(req)
+          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey)
 
           // push user metadata node to user's replica set if defined
           if (config.get('userMetadataNodeUrl')) userReplicaSet.push(config.get('userMetadataNodeUrl'))

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -274,7 +274,13 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
       if (!dbOnlySync) {
         try {
           const myCnodeEndpoint = await getOwnEndpoint(req)
-          userReplicaSet = await getCreatorNodeEndpoints(req, fetchedWalletPublicKey, myCnodeEndpoint, false)
+          userReplicaSet = await getCreatorNodeEndpoints({
+            req,
+            wallet: fetchedWalletPublicKey,
+            blockNumber: req.body.blockNumber,
+            ensurePrimary: false,
+            myCnodeEndpoint
+          })
 
           // push user metadata node to user's replica set if defined
           if (config.get('userMetadataNodeUrl')) userReplicaSet.push(config.get('userMetadataNodeUrl'))

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -316,15 +316,17 @@ class Users extends Base {
     const oldMetadata = { ...user }
 
     // Update user creator_node_endpoint on chain if applicable
+    let updateEndpointTxBlockNumber = null
     if (newMetadata.creator_node_endpoint !== oldMetadata.creator_node_endpoint) {
-      await this.contracts.UserFactoryClient.updateCreatorNodeEndpoint(userId, newMetadata['creator_node_endpoint'])
+      const { txReceipt: updateEndpointTxReceipt } = await this.contracts.UserFactoryClient.updateCreatorNodeEndpoint(userId, newMetadata['creator_node_endpoint'])
+      updateEndpointTxBlockNumber = updateEndpointTxReceipt.blockNumber
 
       // Ensure DN has indexed creator_node_endpoint change
       await this._waitForCreatorNodeEndpointIndexing(newMetadata.user_id, newMetadata.creator_node_endpoint)
     }
 
     // Upload new metadata object to CN
-    const { metadataMultihash, metadataFileUUID } = await this.creatorNode.uploadCreatorContent(newMetadata)
+    const { metadataMultihash, metadataFileUUID } = await this.creatorNode.uploadCreatorContent(newMetadata, updateEndpointTxBlockNumber)
 
     // Write metadata multihash to chain
     const updatedMultihashDecoded = Utils.decodeMultihash(metadataMultihash)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -137,19 +137,22 @@ class CreatorNode {
    * Uploads creator content to a creator node
    * @param {object} metadata the creator metadata
    */
-  async uploadCreatorContent (metadata) {
+  async uploadCreatorContent (metadata, blockNumber = null) {
     // this does the actual validation before sending to the creator node
     // if validation fails, validate() will throw an error
     try {
       this.schemas[SchemaValidator.userSchemaType].validate(metadata)
 
-      return this._makeRequest({
+      const requestObj = {
         url: '/audius_users/metadata',
         method: 'post',
         data: {
-          metadata
+          metadata,
+          blockNumber
         }
-      })
+      }
+
+      return this._makeRequest(requestObj)
     } catch (e) {
       console.error('Error validating creator metadata', e)
     }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Trello link: https://trello.com/c/W2lqTFJk/1760-race-condition-between-discovery-nodes-with-ensure-primary-on-all-routes

**Problem**
This PR fixes an earlier bug with [this commit](https://github.com/AudiusProject/audius-protocol/commit/a8b8dab2c39e12162645dfdea0a9499ec0a1159d) which locked down all CN POST routes under `ensurePrimaryMiddleware`. The problem is that `libs/src/api/user.js:upgradeToCreator()` makes a call to CN `POST /audius_users/metadata` without passing `blockNumber` in the `req.body`. The CN, inside `ensurePrimaryMiddleware` and internally `getCreatorNodeEndpoints` would not immediately query discprov to see if it is listed as user's primary. This is prone to failure due to a race condition where the client would write the new `creator_node_endpoint` to chain but the CN's selected discprov would not yet have indexed that block

**Solution**
1. First, libs `upgradeToCreator()` flow is modified to retrieve `blockNumber` from the preceding chain `updateCreatorNodeEndpoint` call and pass that into its CN metadata write, ensuring that CN route enters different code path and polls its discprov until it has indexed to that blocknumber
2. since there's no reason to query discprov only once in the `blockNumber === null` case, that case has been modified to instead poll discprov until it returns own endpoint as primary for user

The above two cases are fully backwards compatible and should fix any race conditions

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. confirmed maddog tests pass
2. manual tests with old client (where client does not pass `blockNumber`) to ensure that new discprov endpoint polling logic works. tested: user signup, user state modification, upgrading to creator + track upload, track state modification, modifying replica set, uploading new track
3. manual test with new client (where client passes `blockNumber`) to ensure intended code path is hit and discprov blocknumber polling logic works. tested: user signup, user state modification, upgrading to creator + track upload, track state modification, modifying replica set, uploading new track

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
