### PR TITLE
[AUD-133] Check instagram handle by lowercase

### DIFF
--- a/identity-service/src/routes/socialHandles.js
+++ b/identity-service/src/routes/socialHandles.js
@@ -11,12 +11,14 @@ module.exports = function (app) {
     })
 
     const twitterUser = await models.TwitterUser.findOne({ where: {
+      // Twitter stores case sensitive screen names
       'twitterProfile.screen_name': handle,
       verified: true
     } })
 
     const instagramUser = await models.InstagramUser.findOne({ where: {
-      'profile.username': handle,
+      // Instagram does not store case sensitive screen names
+      'profile.username': handle.toLowerCase(),
       verified: true
     } })
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Checks instagram handles by lowercase instead of passed in case sensitive because instagram's profile.username field is lowercased.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


Deployed to staging and made queries


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
