### PR TITLE
Upgrade identity libs to v1.1.9

### DIFF
--- a/identity-service/package-lock.json
+++ b/identity-service/package-lock.json
@@ -18,11 +18,12 @@
       }
     },
     "@audius/libs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.0.1.tgz",
-      "integrity": "sha512-pXulAxFStSdEQx35wHbmOOzeFLOThsbM3CsnHF2Z6Y36zj0wEksbtxJL3XE3x5PEZzInEJZcZvHd4P889MiX2A==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.9.tgz",
+      "integrity": "sha512-SlmYUFsKomR68Wr9MJT8n/53ifi5N8qXcWjR+KOyv7DJPBgXIiarIMfWq8qaHUKU/8pI4Lqzb8MwZBHExT1Cuw==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
+        "@ethersproject/solidity": "^5.0.5",
         "abi-decoder": "^1.2.0",
         "ajv": "^6.12.2",
         "async-retry": "^1.2.3",
@@ -1089,6 +1090,96 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+      "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+      "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+      "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+      "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "js-sha3": "0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+      "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+    },
+    "@ethersproject/sha2": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
+      "integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "hash.js": "1.1.3"
+      },
+      "dependencies": {
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.8.tgz",
+      "integrity": "sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+      "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -6707,9 +6798,9 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
-      "integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
     },
     "jsonwebtoken": {
       "version": "8.5.1",

--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "./node_modules/.bin/standard --fix"
   },
   "dependencies": {
-    "@audius/libs": "^1.0.0",
+    "@audius/libs": "^1.1.9",
     "apn": "^2.2.0",
     "aws-sdk": "^2.595.0",
     "axios": "^0.19.0",


### PR DESCRIPTION
### Description
Bump identity libs version to 1.1.9

### Tests
Run everything locally and verified relays and notifications. The only other thing that involves libs is social handle verification flow which I have not been able to test locally, but since that's a POA contract function that hasn't been touched I'm fairly confident it's fine.
