### PR TITLE
[AUD-124] Add global timeout to content node selection process

### DIFF
--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -66,7 +66,7 @@ class ServiceProvider extends Base {
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)
    * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
-   * @param {number?} timeout applied to each request made to a content node
+   * @param {number?} timeout ms applied to each request made to a content node
    * @returns { primary, secondaries, services }
    * // primary: string
    * // secondaries: Array<string>

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -66,7 +66,7 @@ class ServiceProvider extends Base {
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)
    * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
-   * @param {}
+   * @param {number?} timeout applied to each request made to a content node
    * @returns { primary, secondaries, services }
    * // primary: string
    * // secondaries: Array<string>

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -2,8 +2,11 @@ const { Base } = require('./base')
 const { timeRequestsAndSortByVersion } = require('../utils/network')
 const CreatorNodeSelection = require('../services/creatorNode/CreatorNodeSelection')
 
-const CREATOR_NODE_SERVICE_NAME = 'content-node'
-const DISCOVERY_PROVIDER_SERVICE_NAME = 'discovery-node'
+const CONTENT_NODE_SERVICE_NAME = 'content-node'
+const DISCOVERY_NODE_SERVICE_NAME = 'discovery-node'
+
+// Default timeout for each content node's sync and health check
+const CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT = 7500
 
 /**
  * API methods to interact with Audius service providers.
@@ -16,7 +19,7 @@ class ServiceProvider extends Base {
   /* ------- CREATOR NODE  ------- */
 
   async listCreatorNodes () {
-    return this.ethContracts.ServiceProviderFactoryClient.getServiceProviderList(CREATOR_NODE_SERVICE_NAME)
+    return this.ethContracts.ServiceProviderFactoryClient.getServiceProviderList(CONTENT_NODE_SERVICE_NAME)
   }
 
   /**
@@ -26,7 +29,8 @@ class ServiceProvider extends Base {
    */
   async getSelectableCreatorNodes (
     whitelist = null,
-    blacklist = null
+    blacklist = null,
+    timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   ) {
     let creatorNodes = await this.listCreatorNodes()
 
@@ -44,7 +48,8 @@ class ServiceProvider extends Base {
       creatorNodes.map(node => ({
         id: node.endpoint,
         url: `${node.endpoint}/version`
-      }))
+      })),
+      timeout
     )
 
     let services = {}
@@ -61,6 +66,7 @@ class ServiceProvider extends Base {
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)
    * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
+   * @param {}
    * @returns { primary, secondaries, services }
    * // primary: string
    * // secondaries: Array<string>
@@ -69,14 +75,16 @@ class ServiceProvider extends Base {
   async autoSelectCreatorNodes (
     numberOfNodes = 3,
     whitelist = null,
-    blacklist = null
+    blacklist = null,
+    timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   ) {
     const creatorNodeSelection = new CreatorNodeSelection({
       creatorNode: this.creatorNode,
       ethContracts: this.ethContracts,
       numberOfNodes,
       whitelist,
-      blacklist
+      blacklist,
+      timeout
     })
 
     const { primary, secondaries, services } = await creatorNodeSelection.select()
@@ -86,7 +94,7 @@ class ServiceProvider extends Base {
   /* ------- DISCOVERY PROVIDER ------ */
 
   async listDiscoveryProviders () {
-    return this.ethContracts.ServiceProviderFactoryClient.getServiceProviderList(DISCOVERY_PROVIDER_SERVICE_NAME)
+    return this.ethContracts.ServiceProviderFactoryClient.getServiceProviderList(DISCOVERY_NODE_SERVICE_NAME)
   }
 }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -78,7 +78,7 @@ class CreatorNodeSelection extends ServiceSelection {
   /**
    * Checks the sync progress of a Content Node
    * @param {string} service Content Node endopint
-   * @param {number?} timeout
+   * @param {number?} timeout ms
    */
   async getSyncStatus (service, timeout = null) {
     try {
@@ -131,7 +131,7 @@ class CreatorNodeSelection extends ServiceSelection {
    * Performs a sync check for every endpoint in services. Returns an array of successful sync checked endpoints and
    * adds the err'd sync checked endpoints to this.unhealthy
    * @param {string[]} services content node endpoints
-   * @param {number?} timeout applied to each request
+   * @param {number?} timeout ms applied to each request
    */
   async _performSyncChecks (services, timeout = null) {
     const successfulSyncCheckServices = []

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -3,7 +3,14 @@ const { timeRequestsAndSortByVersion } = require('../../utils/network')
 const { CREATOR_NODE_SERVICE_NAME, DECISION_TREE_STATE } = require('./constants')
 
 class CreatorNodeSelection extends ServiceSelection {
-  constructor ({ creatorNode, numberOfNodes, ethContracts, whitelist, blacklist }) {
+  constructor ({
+    creatorNode,
+    numberOfNodes,
+    ethContracts,
+    whitelist,
+    blacklist,
+    timeout = null
+  }) {
     super({
       getServices: async () => {
         this.currentVersion = await ethContracts.getCurrentVersion(CREATOR_NODE_SERVICE_NAME)
@@ -16,6 +23,7 @@ class CreatorNodeSelection extends ServiceSelection {
     this.creatorNode = creatorNode
     this.numberOfNodes = numberOfNodes
     this.ethContracts = ethContracts
+    this.timeout = timeout
     this.healthCheckPath = 'version'
     // String array of healthy Content Node endpoints
     this.backupsList = []
@@ -29,6 +37,7 @@ class CreatorNodeSelection extends ServiceSelection {
    * 3. Filter out unhealthy, outdated, and still syncing nodes via health and sync check
    * 4. Sort by healthiest (highest version -> lowest version); secondary check if equal version based off of responseTime
    * 5. Select a primary and numberOfNodes-1 number of secondaries (most likely 2) from backups
+   * @param {boolean?} performSyncCheck whether or not to check whether the nodes need syncs before selection
    */
   async select (performSyncCheck = true) {
     // Reset decision tree and backups
@@ -48,7 +57,7 @@ class CreatorNodeSelection extends ServiceSelection {
 
     // TODO: add a sample size selection round to not send requests to all available nodes
 
-    if (performSyncCheck) { services = await this._performSyncChecks(services) }
+    if (performSyncCheck) { services = await this._performSyncChecks(services, this.timeout) }
     const { healthyServicesList, healthyServicesMap: servicesMap } = await this._performHealthChecks(services)
     services = healthyServicesList
 
@@ -69,10 +78,11 @@ class CreatorNodeSelection extends ServiceSelection {
   /**
    * Checks the sync progress of a Content Node
    * @param {string} service Content Node endopint
+   * @param {number?} timeout
    */
-  async getSyncStatus (service) {
+  async getSyncStatus (service, timeout = null) {
     try {
-      const syncStatus = await this.creatorNode.getSyncStatus(service)
+      const syncStatus = await this.creatorNode.getSyncStatus(service, timeout)
       return { service, syncStatus, error: null }
     } catch (e) {
       return { service, syncStatus: null, error: e }
@@ -121,10 +131,11 @@ class CreatorNodeSelection extends ServiceSelection {
    * Performs a sync check for every endpoint in services. Returns an array of successful sync checked endpoints and
    * adds the err'd sync checked endpoints to this.unhealthy
    * @param {string[]} services content node endpoints
+   * @param {number?} timeout applied to each request
    */
-  async _performSyncChecks (services) {
+  async _performSyncChecks (services, timeout = null) {
     const successfulSyncCheckServices = []
-    const syncResponses = await Promise.all(services.map(service => this.getSyncStatus(service)))
+    const syncResponses = await Promise.all(services.map(service => this.getSyncStatus(service, timeout)))
     // Perform sync checks on all services
     for (const response of syncResponses) {
       // Could not perform a sync check. Add to unhealthy
@@ -164,7 +175,8 @@ class CreatorNodeSelection extends ServiceSelection {
       services.map(node => ({
         id: node,
         url: `${node}/${this.healthCheckPath}`
-      }))
+      })),
+      this.timeout
     )
 
     const healthyServices = healthCheckedServices.filter(resp => {

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -309,7 +309,7 @@ class CreatorNode {
    * Given a particular endpoint to a creator node, check whether
    * this user has a sync in progress on that node.
    * @param {string} endpoint
-   * @param {number?} timeout
+   * @param {number?} timeout ms
    */
   async getSyncStatus (endpoint, timeout = null) {
     const user = this.userStateManager.getCurrentUser()

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -309,8 +309,9 @@ class CreatorNode {
    * Given a particular endpoint to a creator node, check whether
    * this user has a sync in progress on that node.
    * @param {string} endpoint
+   * @param {number?} timeout
    */
-  async getSyncStatus (endpoint) {
+  async getSyncStatus (endpoint, timeout = null) {
     const user = this.userStateManager.getCurrentUser()
     if (user) {
       const req = {
@@ -318,6 +319,7 @@ class CreatorNode {
         url: `/sync_status/${user.wallet}`,
         method: 'get'
       }
+      if (timeout) req.timeout = timeout
       const status = await axios(req)
       return {
         status: status.data,

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -7,15 +7,20 @@ const promiseFight = require('./promiseFight')
 /**
 * Fetches a url and times how long it took the request to complete.
 * @param {Object} request {id, url}
+* @param {number?} timeout
 * @returns { request, response, millis }
 */
-async function timeRequest (request) {
+async function timeRequest (request, timeout = null) {
   // This is non-perfect because of the js event loop, but enough
   // of a proximation. Don't use for mission-critical timing.
   const startTime = new Date().getTime()
+  let config = {}
+  if (timeout) {
+    config.timeout = timeout
+  }
   let response
   try {
-    response = await axios.get(request.url)
+    response = await axios.get(request.url, config)
   } catch (e) {
     console.debug(`Error with request for ${request.url}: ${e}`)
     return { request, response: null, millis: null }
@@ -28,11 +33,12 @@ async function timeRequest (request) {
  * Fetches multiple urls and times each request and returns the results sorted by
  * lowest-latency.
  * @param {Array<Object>} requests [{id, url}, {id, url}]
+ * @param {number?} timeout applied to each individual request
  * @returns { Array<{url, response, millis}> }
  */
-async function timeRequests (requests) {
+async function timeRequests (requests, timeout = null) {
   let timings = await Promise.all(requests.map(async request =>
-    timeRequest(request)
+    timeRequest(request, timeout)
   ))
 
   return timings
@@ -44,11 +50,12 @@ async function timeRequests (requests) {
  * Fetches multiple urls and times each request and returns the results sorted
  * first by version and then by lowest-latency.
  * @param {Array<Object>} requests [{id, url}, {id, url}]
+ * @param {number?} timeout applied to each individual request
  * @returns { Array<{url, response, millis}> }
  */
-async function timeRequestsAndSortByVersion (requests) {
+async function timeRequestsAndSortByVersion (requests, timeout = null) {
   let timings = await Promise.all(requests.map(async request =>
-    timeRequest(request)
+    timeRequest(request, timeout)
   ))
 
   return timings.sort((a, b) => {

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -33,7 +33,7 @@ async function timeRequest (request, timeout = null) {
  * Fetches multiple urls and times each request and returns the results sorted by
  * lowest-latency.
  * @param {Array<Object>} requests [{id, url}, {id, url}]
- * @param {number?} timeout applied to each individual request
+ * @param {number?} timeout ms applied to each individual request
  * @returns { Array<{url, response, millis}> }
  */
 async function timeRequests (requests, timeout = null) {
@@ -50,7 +50,7 @@ async function timeRequests (requests, timeout = null) {
  * Fetches multiple urls and times each request and returns the results sorted
  * first by version and then by lowest-latency.
  * @param {Array<Object>} requests [{id, url}, {id, url}]
- * @param {number?} timeout applied to each individual request
+ * @param {number?} timeout ms applied to each individual request
  * @returns { Array<{url, response, millis}> }
  */
 async function timeRequestsAndSortByVersion (requests, timeout = null) {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Adds a default global timeout to content node selection processes.

I chose 7500 ms since 1) we used to use this value 2) if all content nodes (now that we have several) take 7.5s to reply, most likely something else is gravely wrong. The good thing about it is since this arg is passed all the way through, we can use optimizely to set it/update it on the fly if it does start introducing problems.

Closes AUD-124.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Autoselected content nodes in the upgrade to creator flow by manually making one content node slow by way of

```
if (request.url === 'https://creatornode.staging.audius.co/version') {
    request.url = 'https://deelay.me/10000/https://creatornode.staging.audius.co/version'
  }
```

2. Repeated same behavior check on the settings page after you are a creator
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
