### PR TITLE
Turn off IPFS health check in read only mode

### DIFF
--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -14,6 +14,11 @@ module.exports = function (app) {
    * Performs diagnostic ipfs operations to confirm functionality
    */
   app.get('/health_check/ipfs', handleResponse(async (req, res) => {
+    if (config.get('isReadOnlyMode')) {
+      res.status(400)
+      return
+    }
+
     const ipfs = req.app.get('ipfsAPI')
     try {
       const start = Date.now()


### PR DESCRIPTION
### Description
This turns off the IPFS health check when the content node is in read only mode, since this health check writes data to the disk.


### Tests
Local testing is in progress
