### PR TITLE
[AUD-195] Populate playlist track users

### DIFF
--- a/discovery-provider/src/queries/get_playlist_tracks.py
+++ b/discovery-provider/src/queries/get_playlist_tracks.py
@@ -50,7 +50,7 @@ def get_playlist_tracks(args):
                 session, playlist_track_ids, tracks, current_user_id)
 
             if args.get("with_users", False):
-                add_users_to_tracks(session, tracks)
+                add_users_to_tracks(session, tracks, current_user_id)
 
             tracks_dict = {track['track_id']: track for track in tracks}
 


### PR DESCRIPTION
### Description

We were failing to populate track users when fetching playlist through the API, causing bugs on the client.

### Tests

Tested locally.


