### PR TITLE
Return bad request for the `/version` endpoint in read only mode

### DIFF
--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -1,4 +1,4 @@
-const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
+const { handleResponse, successResponse, errorResponseServerError, errorResponseBadRequest } = require('../apiHelpers')
 const { sequelize } = require('../models')
 const config = require('../config.js')
 const versionInfo = require('../../.version.json')
@@ -90,6 +90,10 @@ module.exports = function (app) {
   }))
 
   app.get('/version', handleResponse(async (req, res) => {
+    if (config.get('isReadOnlyMode') === true) {
+      return errorResponseBadRequest()
+    }
+
     const info = {
       ...versionInfo,
       country: config.get('serviceCountry'),


### PR DESCRIPTION
### Description
Return bad request for the `/version` endpoint when the content node is in read only mode.


### Tests
Tested locally by pinging `http://192.168.3.2:4001/version` with config changes of,
```
isReadOnlyMode = process.env.creatorNodeEndpoint === "http://cn2_creator-node_1:4001"
```