### PR TITLE
Modify the content node health check to fail on read only mode

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -46,8 +46,8 @@ const healthCheckVerifySignature = (req, res, next) => {
  * `healthCheckComponentService`.
  */
 const healthCheckController = async (req) => {
-  if (config.get('isReadOnlyMode') === true) {
-    return errorResponseBadRequest()
+  if (config.get('isReadOnlyMode')) {
+    return errorResponseServerError()
   }
 
   const logger = req.logger

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -46,6 +46,10 @@ const healthCheckVerifySignature = (req, res, next) => {
  * `healthCheckComponentService`.
  */
 const healthCheckController = async (req) => {
+  if (config.get('isReadOnlyMode') === true) {
+    return errorResponseBadRequest()
+  }
+
   const logger = req.logger
   const response = await healthCheck(serviceRegistry, logger, sequelize)
   return successResponse(response)

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -15,8 +15,7 @@ module.exports = function (app) {
    */
   app.get('/health_check/ipfs', handleResponse(async (req, res) => {
     if (config.get('isReadOnlyMode')) {
-      res.status(400)
-      return
+      return errorResponseBadRequest()
     }
 
     const ipfs = req.app.get('ipfsAPI')
@@ -90,7 +89,7 @@ module.exports = function (app) {
   }))
 
   app.get('/version', handleResponse(async (req, res) => {
-    if (config.get('isReadOnlyMode') === true) {
+    if (config.get('isReadOnlyMode')) {
       return errorResponseBadRequest()
     }
 

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -1,4 +1,4 @@
-const { handleResponse, successResponse, errorResponseServerError, errorResponseBadRequest } = require('../apiHelpers')
+const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const { sequelize } = require('../models')
 const config = require('../config.js')
 const versionInfo = require('../../.version.json')
@@ -15,7 +15,7 @@ module.exports = function (app) {
    */
   app.get('/health_check/ipfs', handleResponse(async (req, res) => {
     if (config.get('isReadOnlyMode')) {
-      return errorResponseBadRequest()
+      return errorResponseServerError()
     }
 
     const ipfs = req.app.get('ipfsAPI')
@@ -90,7 +90,7 @@ module.exports = function (app) {
 
   app.get('/version', handleResponse(async (req, res) => {
     if (config.get('isReadOnlyMode')) {
-      return errorResponseBadRequest()
+      return errorResponseServerError()
     }
 
     const info = {


### PR DESCRIPTION
### Description
Modify the content node health check to fail on read only mode, so that the client roll over to secondary nodes.

This needs at least two nodes that are not the primary node to work.

The existing primary node is removed when it is changed to read only mode.

I think it might be better to move this to the list of secondaries rather than removing it altogether.


### Tests
Tested locally by pinging `http://192.168.3.2:4000/health_check` with config changes of,
```
isReadOnlyMode = process.env.creatorNodeEndpoint === "http://cn1_creator-node_1:4000"
```
