### PR TITLE
[AUD-198] Use verbose health check instead of version check for cn sel

### DIFF
--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -47,7 +47,7 @@ class ServiceProvider extends Base {
     const timings = await timeRequestsAndSortByVersion(
       creatorNodes.map(node => ({
         id: node.endpoint,
-        url: `${node.endpoint}/version`
+        url: `${node.endpoint}/health_check/verbose`
       })),
       timeout
     )

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -24,7 +24,7 @@ class CreatorNodeSelection extends ServiceSelection {
     this.numberOfNodes = numberOfNodes
     this.ethContracts = ethContracts
     this.timeout = timeout
-    this.healthCheckPath = 'version'
+    this.healthCheckPath = 'health_check/verbose'
     // String array of healthy Content Node endpoints
     this.backupsList = []
   }

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -30,7 +30,7 @@ describe('test CreatorNodeSelection', () => {
   it('selects the fastest healthy service as primary and rest as secondaries', async () => {
     const healthy = 'https://healthy.audius.co'
     nock(healthy)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '1.2.3',
@@ -41,7 +41,7 @@ describe('test CreatorNodeSelection', () => {
 
     const healthyButSlow = 'https://healthybutslow.audius.co'
     nock(healthyButSlow)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(100)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -53,7 +53,7 @@ describe('test CreatorNodeSelection', () => {
 
     const healthyButSlowest = 'https://healthybutslowest.audius.co'
     nock(healthyButSlowest)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(200)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -95,7 +95,7 @@ describe('test CreatorNodeSelection', () => {
   it('select healthy nodes as the primary and secondary, and do not select unhealthy nodes', async () => {
     const upToDate = 'https://upToDate.audius.co'
     nock(upToDate)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '1.2.3',
@@ -106,7 +106,7 @@ describe('test CreatorNodeSelection', () => {
 
     const behindMajor = 'https://behindMajor.audius.co'
     nock(behindMajor)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '0.2.3',
@@ -117,7 +117,7 @@ describe('test CreatorNodeSelection', () => {
 
     const behindMinor = 'https://behindMinor.audius.co'
     nock(behindMinor)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '1.0.3',
@@ -128,7 +128,7 @@ describe('test CreatorNodeSelection', () => {
 
     const behindPatch = 'https://behindPatch.audius.co'
     nock(behindPatch)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '1.2.0',
@@ -168,30 +168,30 @@ describe('test CreatorNodeSelection', () => {
   it('select from unhealthy if all are unhealthy', async () => {
     const unhealthy1 = 'https://unhealthy1.audius.co'
     nock(unhealthy1)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(500, { })
 
     const unhealthy2 = 'https://unhealthy2.audius.co'
     nock(unhealthy2)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(100)
       .reply(500, { })
 
     const unhealthy3 = 'https://unhealthy3.audius.co'
     nock(unhealthy3)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(200)
       .reply(500, { })
 
     const unhealthy4 = 'https://unhealthy4.audius.co'
     nock(unhealthy4)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(300)
       .reply(500, { })
 
     const unhealthy5 = 'https://unhealthy5.audius.co'
     nock(unhealthy5)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(400)
       .reply(500, { })
 
@@ -225,7 +225,7 @@ describe('test CreatorNodeSelection', () => {
     // the cream of the crop -- up to date version, slow. you want this
     const shouldBePrimary = 'https://shouldBePrimary.audius.co'
     nock(shouldBePrimary)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(200)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -238,7 +238,7 @@ describe('test CreatorNodeSelection', () => {
     // cold, overnight pizza -- behind by minor version, fast. nope
     const unhealthy2 = 'https://unhealthy2.audius.co'
     nock(unhealthy2)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
         version: '1.0.3',
@@ -250,7 +250,7 @@ describe('test CreatorNodeSelection', () => {
     // stale chips from 2 weeks ago -- behind by major version, kinda slow. still nope
     const unhealthy3 = 'https://unhealthy3.audius.co'
     nock(unhealthy3)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(100)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -263,13 +263,13 @@ describe('test CreatorNodeSelection', () => {
     // moldy canned beans -- not available/up at all. for sure nope
     const unhealthy1 = 'https://unhealthy1.audius.co'
     nock(unhealthy1)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(500, { })
 
     // your house mate's leftovers from her team outing -- behind by patch, kinda slow. solid
     const shouldBeSecondary = 'https://secondary.audius.co'
     nock(shouldBeSecondary)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(100)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -321,7 +321,7 @@ describe('test CreatorNodeSelection', () => {
       const healthyUrl = `https://healthy${i}.audius.co`
       nock(healthyUrl)
         .persist()
-        .get('/version')
+        .get('/health_check/verbose')
         .reply(200, { data: {
           service: CREATOR_NODE_SERVICE_NAME,
           version: '1.2.3',
@@ -358,10 +358,10 @@ describe('test CreatorNodeSelection', () => {
     }
   })
 
-  it.only('selects 1 secondary if only 1 secondary is available', async () => {
+  it('selects 1 secondary if only 1 secondary is available', async () => {
     const shouldBePrimary = 'https://shouldBePrimary.audius.co'
     nock(shouldBePrimary)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(200)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -373,7 +373,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary = 'https://secondary.audius.co'
     nock(shouldBeSecondary)
-      .get('/version')
+      .get('/health_check/verbose')
       .delay(100)
       .reply(200, { data: {
         service: CREATOR_NODE_SERVICE_NAME,
@@ -385,7 +385,7 @@ describe('test CreatorNodeSelection', () => {
 
     const unhealthy = 'https://unhealthy.audius.co'
     nock(unhealthy)
-      .get('/version')
+      .get('/health_check/verbose')
       .reply(500, { })
 
     const cns = new CreatorNodeSelection({

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -4,6 +4,7 @@ const semver = require('semver')
 const DiscoveryProviderSelection = require('./DiscoveryProviderSelection')
 const DiscoveryProvider = require('.')
 const helpers = require('../../../tests/helpers')
+const { DISCOVERY_PROVIDER_TIMESTAMP } = require('./constants')
 let audiusInstance = helpers.audiusInstance
 
 const mockEthContracts = (urls, currrentVersion, previousVersions = null) => ({
@@ -31,7 +32,7 @@ describe('DiscoveryProviderSelection', () => {
   beforeEach(() => {
     const LocalStorage = require('node-localstorage').LocalStorage
     const localStorage = new LocalStorage('./local-storage')
-    localStorage.removeItem('@audius/libs:discovery-provider-timestamp')
+    localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
   })
   afterEach(() => {
     nock.cleanAll()
@@ -43,7 +44,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -61,7 +62,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -69,7 +70,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(unhealthy)
       .get('/health_check')
       .reply(400, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -87,7 +88,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -95,7 +96,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(outdated)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.2',
         block_difference: 0
       } })
@@ -113,7 +114,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -121,7 +122,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(behind)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 20
       } })
@@ -139,7 +140,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthyButBehind)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 20
       } })
@@ -147,7 +148,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(pastVersionNotBehind)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.2',
         block_difference: 0
       } })
@@ -160,12 +161,12 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(service, pastVersionNotBehind)
     assert.deepStrictEqual(s.backups, {
       [healthyButBehind]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 20
       },
       [pastVersionNotBehind]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.2',
         block_difference: 0
       }
@@ -178,7 +179,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(behind20)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.2',
         block_difference: 20
       } })
@@ -186,7 +187,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(behind40)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 40
       } })
@@ -199,12 +200,12 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(service, behind20)
     assert.deepStrictEqual(s.backups, {
       [behind20]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.2',
         block_difference: 20
       },
       [behind40]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 40
       }
@@ -218,7 +219,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(behind100)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 100
       } })
@@ -226,7 +227,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(behind200)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 200
       } })
@@ -243,12 +244,12 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(service, behind100)
     assert.deepStrictEqual(s.backups, {
       [behind100]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 100
       },
       [behind200]: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 200
       }
@@ -262,7 +263,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(minorBehind)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.1.3',
         block_difference: 20
       } })
@@ -279,7 +280,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy1)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -288,7 +289,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy2)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -311,7 +312,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(healthy1)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -322,7 +323,7 @@ describe('DiscoveryProviderSelection', () => {
     )
     const service = await s.select()
     assert.strictEqual(service, healthy1)
-    const { endpoint } = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+    const { endpoint } = JSON.parse(localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP))
     assert.strictEqual(
       endpoint,
       healthy1
@@ -338,7 +339,7 @@ describe('DiscoveryProviderSelection', () => {
       .get('/health_check')
       .delay(100)
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -348,7 +349,7 @@ describe('DiscoveryProviderSelection', () => {
       .get('/health_check')
       .delay(100)
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -357,7 +358,7 @@ describe('DiscoveryProviderSelection', () => {
     nock(initiallyUnhealthy)
       .get('/health_check')
       .reply(400, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -367,7 +368,7 @@ describe('DiscoveryProviderSelection', () => {
       mockEthContracts([healthy1, healthy2, initiallyUnhealthy], '1.2.3')
     )
     const firstService = await s.select()
-    const { endpoint } = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+    const { endpoint } = JSON.parse(localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP))
     assert.strictEqual(
       endpoint,
       firstService
@@ -384,27 +385,27 @@ describe('DiscoveryProviderSelection', () => {
 
     // Clear the cached service
     s.clearUnhealthy()
-    localStorage.removeItem('@audius/libs:discovery-provider-timestamp')
+    localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
 
     // Make healthy1 start failing but healthy2 succeed
     nock(healthy1)
       .get('/health_check')
       .reply(400, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
     nock(healthy2)
       .get('/health_check')
       .reply(400, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
     nock(initiallyUnhealthy)
       .get('/health_check')
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -426,7 +427,7 @@ describe('DiscoveryProviderSelection', () => {
       .persist()
       .get(uri => true) // hitting any route will respond with 200
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
@@ -437,14 +438,14 @@ describe('DiscoveryProviderSelection', () => {
       .get(uri => true)
       .delay(100)
       .reply(200, { data: {
-        service: 'discovery-provider',
+        service: 'discovery-node',
         version: '1.2.3',
         block_difference: 0
       } })
 
     // Initialize libs and then set disc prov instance with eth contracts mock
     await audiusInstance.init()
-    localStorage.removeItem('@audius/libs:discovery-provider-timestamp')
+    localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
     const mockDP = new DiscoveryProvider(
       null, // whitelist
       audiusInstance.userStateManager,
@@ -457,7 +458,7 @@ describe('DiscoveryProviderSelection', () => {
     audiusInstance.discoveryProvider = mockDP
 
     // Check that healthyThenUnhealthy was chosen and set in local stoarge
-    const discProvLocalStorageData1 = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+    const discProvLocalStorageData1 = JSON.parse(localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP))
     assert.strictEqual(audiusInstance.discoveryProvider.discoveryProviderEndpoint, healthyThenUnhealthy)
     assert.strictEqual(discProvLocalStorageData1.endpoint, healthyThenUnhealthy)
 
@@ -471,7 +472,7 @@ describe('DiscoveryProviderSelection', () => {
 
     // Make a libs request to disc prov; should use healthy
     await audiusInstance.discoveryProvider.getUsers(1)
-    const discProvLocalStorageData2 = JSON.parse(localStorage.getItem('@audius/libs:discovery-provider-timestamp'))
+    const discProvLocalStorageData2 = JSON.parse(localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP))
 
     // Check that healthy was chosen and set in local stoarge
     assert.strictEqual(audiusInstance.discoveryProvider.discoveryProviderEndpoint, healthy)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Also remove .only test that got erroneously added. Turns out a bunch of tests were broken, but not running because of it.
(I think here https://github.com/AudiusProject/audius-protocol/commit/af3715906075ecd9ef412004dd91d4b1dd40edf1#diff-5e62554d6dcc0ec0ba6520cde712ed101010cfe9354544d0d4f3130999b77213R361)

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Units
2. Current /health_check/verbose endpt. contains country, lat & lon https://creatornode2.audius.co/health_check/verbose
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
