### PR TITLE
[AUD-150] Fix nested data calls in content node (nodesync and snapback), identity (notifs), discovery node  (ipfs_peer_info)

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -250,19 +250,21 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint, dbOnlySync
         resp.data = JSON.parse(resp.request.responseText)
       } else throw new Error(`Malformed response from ${creatorNodeEndpoint}.`)
     }
-    if (!resp.data.hasOwnProperty('cnodeUsers') || !resp.data.hasOwnProperty('ipfsIDObj') || !resp.data.ipfsIDObj.hasOwnProperty('addresses')) {
+    const { data: body } = resp
+
+    if (!body.data.hasOwnProperty('cnodeUsers') || !body.data.hasOwnProperty('ipfsIDObj') || !body.data.ipfsIDObj.hasOwnProperty('addresses')) {
       throw new Error(`Malformed response from ${creatorNodeEndpoint}.`)
     }
     req.logger.info(redisKey, `Successful export from ${creatorNodeEndpoint} for wallets`, walletPublicKeys)
 
     if (!dbOnlySync) {
       // Attempt to connect directly to target CNode's IPFS node.
-      await _initBootstrapAndRefreshPeers(req, resp.data.ipfsIDObj.addresses, redisKey)
+      await _initBootstrapAndRefreshPeers(req, body.data.ipfsIDObj.addresses, redisKey)
       req.logger.info(redisKey, 'IPFS Nodes connected + data export received')
     }
 
     // For each CNodeUser, replace local DB state with retrieved data + fetch + save missing files.
-    for (const fetchedCNodeUser of Object.values(resp.data.cnodeUsers)) {
+    for (const fetchedCNodeUser of Object.values(body.data.cnodeUsers)) {
       // Since different nodes may assign different cnodeUserUUIDs to a given walletPublicKey,
       // retrieve local cnodeUserUUID from fetched walletPublicKey and delete all associated data.
       if (!fetchedCNodeUser.hasOwnProperty('walletPublicKey')) {

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -280,8 +280,8 @@ class SnapbackSM {
             }
           }
           this.log(`Requesting ${walletsToQuery.length} users from ${node}`)
-          let resp = await axios(requestParams)
-          let userClockStatusList = resp.data.users
+          let { data: body } = await axios(requestParams)
+          let userClockStatusList = body.data.users
           // Process returned clock values from this secondary node
           userClockStatusList.map(
             (entry) => {

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -251,7 +251,7 @@ def get_ipfs_info_from_cnode_endpoint(url, self_multiaddr):
         timeout=5,
         params=data
     )
-    json_resp = resp.json()
+    json_resp = resp.json()['data']
     valid_multiaddr = get_valid_multiaddr_from_id_json(json_resp)
     if valid_multiaddr is None:
         raise Exception('Failed to find valid multiaddr')

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -270,14 +270,14 @@ module.exports = function (app) {
     if (maxFromRedis) {
       highestBlockNumber = parseInt(maxFromRedis)
     }
-    let discProvHealthCheck = (await axios({
+    let body = (await axios({
       method: 'get',
       url: `${notifDiscProv}/health_check`
     })).data
-    let discProvDbHighestBlock = discProvHealthCheck['db']['number']
+    let discProvDbHighestBlock = body.data['db']['number']
     let notifBlockDiff = discProvDbHighestBlock - highestBlockNumber
     let resp = {
-      'discProv': discProvHealthCheck,
+      'discProv': body.data,
       'identity': highestBlockNumber,
       'notifBlockDiff': notifBlockDiff
     }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

In nodesync and snapback, use the nested `data` field as opposed to reading directly off the body.

See #1188 prior to review

@SidSethi  Could use your eye on this closely as well to make sure I'm not missing anything here.

Added benefit is that once we clean this up, the /export endpoint will have half the payload

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Using  Created account & track upload and ensured synced metadata exists across both nodes. Didn't see any error logs.
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

Touches node sync & snapback SM. ❗ 
