### PR TITLE
[AUD-150] Remove duplicate data in responses

### DIFF
--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -139,8 +139,6 @@ module.exports.successResponse = (obj = {}) => {
     data: {
       ...obj
     },
-    // TODO: remove duplication of obj -- kept for backwards compatibility
-    ...obj,
     signer: config.get('delegateOwnerWallet'),
     ...versionInfo
   }

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -1,7 +1,6 @@
 const config = require('./config')
 
 const { requestNotExcludedFromLogging } = require('./logging')
-const versionInfo = require('../.version.json')
 const { generateTimestampAndSignature } = require('./apiSigning')
 
 module.exports.handleResponse = (func) => {
@@ -139,8 +138,7 @@ module.exports.successResponse = (obj = {}) => {
     data: {
       ...obj
     },
-    signer: config.get('delegateOwnerWallet'),
-    ...versionInfo
+    signer: config.get('delegateOwnerWallet')
   }
 
   const { timestamp, signature } = generateTimestampAndSignature(toSignData, config.get('delegatePrivateKey'))
@@ -249,12 +247,11 @@ module.exports.parseCNodeResponse = (respObj, requiredFields = []) => {
   })
 
   return {
-    ...respObj.data.data,
+    responseData: respObj.data.data,
     signatureData: {
       signer: respObj.data.signer,
       timestamp: respObj.data.timestamp,
       signature: respObj.data.signature
-    },
-    rawResponse: respObj.data
+    }
   }
 }

--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -201,7 +201,7 @@ class URSMRegistrationManager {
   async _submitRequestForSignature (nodeEndpoint, spID) {
     const { timestamp, signature } = generateTimestampAndSignature({ spID }, this.delegatePrivateKey)
 
-    let RFPResp = await axios({
+    const RFPResp = await axios({
       baseURL: nodeEndpoint,
       url: '/ursm_request_for_signature',
       method: 'get',
@@ -212,12 +212,12 @@ class URSMRegistrationManager {
         signature
       }
     })
-    RFPResp = parseCNodeResponse(RFPResp, ['spID', 'nonce', 'sig'])
+    const { responseData } = parseCNodeResponse(RFPResp, ['spID', 'nonce', 'sig'])
 
     return {
-      spID: RFPResp.spID,
-      nonce: RFPResp.nonce,
-      sig: RFPResp.sig
+      spID: responseData.spID,
+      nonce: responseData.nonce,
+      sig: responseData.sig
     }
   }
 }

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -57,7 +57,7 @@ describe('test AudiusUsers with mocked IPFS', function () {
       .send({ metadata })
       .expect(200)
 
-    if (resp.body.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6' || !resp.body.metadataFileUUID) {
+    if (resp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6' || !resp.body.data.metadataFileUUID) {
       throw new Error('invalid return data')
     }
   })
@@ -75,14 +75,14 @@ describe('test AudiusUsers with mocked IPFS', function () {
       .send({ metadata })
       .expect(200)
 
-    if (resp.body.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
+    if (resp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
       throw new Error('invalid return data')
     }
 
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.metadataFileUUID })
+      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(200)
   })
 })
@@ -153,7 +153,7 @@ describe('Test AudiusUsers with real IPFS', function () {
       .expect(200)
 
     // check that the metadata file was written to storagePath under its multihash
-    const metadataPath = DiskManager.computeFilePath(resp.body.metadataMultihash)
+    const metadataPath = DiskManager.computeFilePath(resp.body.data.metadataMultihash)
     assert.ok(fs.existsSync(metadataPath))
 
     // check that the metadata file contents match the metadata specified
@@ -163,7 +163,7 @@ describe('Test AudiusUsers with real IPFS', function () {
 
     // check that the correct metadata file properties were written to db
     const file = await models.File.findOne({ where: {
-      multihash: resp.body.metadataMultihash,
+      multihash: resp.body.data.metadataMultihash,
       storagePath: metadataPath,
       type: 'metadata'
     } })
@@ -172,7 +172,7 @@ describe('Test AudiusUsers with real IPFS', function () {
     // check that the metadata file is in IPFS
     let ipfsResp
     try {
-      ipfsResp = await ipfs.cat(resp.body.metadataMultihash)
+      ipfsResp = await ipfs.cat(resp.body.data.metadataMultihash)
     } catch (e) {
       // If CID is not present, will throw timeout error
       assert.fail(e.message)

--- a/creator-node/test/nodesync.test.js
+++ b/creator-node/test/nodesync.test.js
@@ -91,7 +91,7 @@ describe('test nodesync', async function () {
       const file = fs.readFileSync(testAudioFilePath)
 
       // Upload track content
-      const { body: trackContentRespBody } = await request(app)
+      const { body: { data: trackContentRespBody } } = await request(app)
         .post('/track_content')
         .attach('file', file, { filename: 'fname.mp3' })
         .set('Content-Type', 'multipart/form-data')
@@ -111,8 +111,8 @@ describe('test nodesync', async function () {
         .post('/tracks/metadata')
         .set('X-Session-ID', sessionToken)
         .send({ metadata: trackMetadata, source_file: sourceFile })
-      trackMetadataMultihash = trackMetadataResp.body.metadataMultihash
-      trackMetadataFileUUID = trackMetadataResp.body.metadataFileUUID
+      trackMetadataMultihash = trackMetadataResp.body.data.metadataMultihash
+      trackMetadataFileUUID = trackMetadataResp.body.data.metadataFileUUID
 
       // associate track + track metadata with blockchain ID
       await request(app)

--- a/creator-node/test/users.test.js
+++ b/creator-node/test/users.test.js
@@ -108,11 +108,11 @@ describe('test Users', async function () {
         challengeResp = response.body
       })
 
-    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.challenge })
+    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.data.challenge })
 
     await request(app)
       .post('/users/login/challenge')
-      .send({ data: challengeResp.challenge, signature })
+      .send({ data: challengeResp.data.challenge, signature })
       .expect(400)
   })
 
@@ -127,16 +127,16 @@ describe('test Users', async function () {
         challengeResp = response.body
       })
 
-    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.challenge })
+    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.data.challenge })
 
     await request(app)
       .post('/users/login/challenge')
-      .send({ data: challengeResp.challenge, signature })
+      .send({ data: challengeResp.data.challenge, signature })
       .expect(200)
 
     await request(app)
       .post('/users/login/challenge')
-      .send({ data: challengeResp.challenge, signature })
+      .send({ data: challengeResp.data.challenge, signature })
       .expect(400)
   })
 
@@ -151,11 +151,11 @@ describe('test Users', async function () {
         challengeResp = response.body
       })
 
-    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.challenge })
+    const signature = sigUtil.personalSign(Buffer.from(testEthereumConstants.privKeyHex, 'hex'), { data: challengeResp.data.challenge })
 
     await request(app)
       .post('/users/login/challenge')
-      .send({ data: challengeResp.challenge, signature })
+      .send({ data: challengeResp.data.challenge, signature })
       .expect(200)
   })
 
@@ -181,7 +181,7 @@ describe('test Users', async function () {
       .expect(200)
     await request(app)
       .post('/users/logout')
-      .set('X-Session-ID', resp.body.sessionToken)
+      .set('X-Session-ID', resp.body.data.sessionToken)
       .send({})
       .expect(200)
   })

--- a/discovery-provider/src/api_helpers.py
+++ b/discovery-provider/src/api_helpers.py
@@ -32,13 +32,6 @@ class DateTimeEncoder(json.JSONEncoder):
 def error_response(error, error_code=500):
     return jsonify({'success': False, 'error': error}), error_code
 
-# Create a response dict with just data, signature, and timestamp
-# This response will contain a duplicate of response_entity
-def success_response_backwards_compat(response_entity=None, status=200, sign_response=True):
-    starting_response_dictionary = {'data': response_entity, **response_entity}
-    response_dictionary = response_dict_with_metadata(starting_response_dictionary, sign_response)
-    return jsonify(response_dictionary), status
-
 # Create a response dict with metadata, data, signature, and timestamp
 def success_response(response_entity=None, status=200, to_json=True, sign_response=True):
     starting_response_dictionary = {'data': response_entity}

--- a/discovery-provider/src/queries/health_check.py
+++ b/discovery-provider/src/queries/health_check.py
@@ -3,8 +3,8 @@ import logging
 from flask import Blueprint, request
 from src.queries.get_latest_play import get_latest_play
 from src.queries.queries import parse_bool_param
-from src.api_helpers import success_response, success_response_backwards_compat
 from src.queries.get_health import get_health, get_latest_ipld_indexed_block
+from src.api_helpers import success_response
 from src.utils import helpers
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ disc_prov_version = helpers.get_discovery_provider_version()
 
 @bp.route("/version", methods=["GET"])
 def version():
-    return success_response_backwards_compat(
+    return success_response(
         disc_prov_version,
         sign_response=False
     )
@@ -35,7 +35,7 @@ def health_check():
     }
 
     (health_results, error) = get_health(args)
-    return success_response_backwards_compat(
+    return success_response(
         health_results,
         500 if error else 200,
         sign_response=False
@@ -52,7 +52,7 @@ def block_check():
     }
 
     (health_results, error) = get_health(args, use_redis_cache=False)
-    return success_response_backwards_compat(
+    return success_response(
         health_results,
         500 if error else 200,
         sign_response=False


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Removes duplicate data output in discovery and content node responses.

This PR is blocked on release and upgrade of #1189 


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
