### PR TITLE
[AUD-218] Fix discovery init race condition where is_current block is not the correct block

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -53,7 +53,7 @@ def initialize_blocks_table_if_necessary(db):
                 parenthash=target_blockhash,
                 is_current=True,
             )
-            if target_block.number == 0:
+            if target_block.number == 0 or target_blockhash == default_config_start_hash:
                 block_model.number = None
 
             session.add(block_model)


### PR DESCRIPTION
### Description
There was an occasional discovery node init race condition where the blocks table would say the latest block was hash 0x0 and would not index forward. The missing condition should prevent it from going into that state.




### Tests
Ran the system locally to ensure everything comes up as expected, add a user and confirm indexing progressed