### PR TITLE
Replace health check info with monitors

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -42,7 +42,7 @@ const healthCheck = async ({ libs } = {}, logger, sequelize) => {
  * @param {*} logger
  */
 const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors) => {
-  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors)
+  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize)
 
   // Location information
   const country = config.get('serviceCountry')

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -1,6 +1,10 @@
 const versionInfo = require('../../../.version.json')
 const config = require('../../config')
 const utils = require('../../utils.js')
+const {
+  getMonitor: getMonitorValue,
+  MONITORS
+} = require('../../monitors/monitors')
 
 /**
  * Perform a basic health check, returning the
@@ -9,7 +13,7 @@ const utils = require('../../utils.js')
  * @param {*} ServiceRegistry
  * @param {*} logger
  */
-const healthCheck = async ({ libs } = {}, logger, sequelize) => {
+const healthCheck = async ({ libs } = {}, logger, getMonitor = getMonitorValue) => {
   let response = {
     ...versionInfo,
     healthy: true,
@@ -29,7 +33,52 @@ const healthCheck = async ({ libs } = {}, logger, sequelize) => {
   // we have a /db_check route for more granular detail, but the service health check should
   // also check that the db connection is good. having this in the health_check
   // allows us to get auto restarts from liveness probes etc if the db connection is down
-  await sequelize.query('SELECT 1')
+  const databaseLiveness = await getMonitor(MONITORS.DATABASE_LIVENESS) === 'true'
+  if (!databaseLiveness) throw new Error('Database connection failed')
+
+  return response
+}
+
+/**
+ * Perform a verbose health check, returning health check results
+ * as well as location info, and system info.
+ * @param {*} ServiceRegistry
+ * @param {*} logger
+ */
+const healthCheckVerbose = async ({ libs } = {}, logger, getMonitor = getMonitorValue) => {
+  const basicHealthCheck = await healthCheck({ libs }, logger, getMonitor)
+
+  // Location information
+  const country = config.get('serviceCountry')
+  const latitude = config.get('serviceLatitude')
+  const longitude = config.get('serviceLongitude')
+
+  // System information
+  const databaseConnections = parseInt(await getMonitor(MONITORS.DATABASE_CONNECTIONS))
+  const totalMemory = parseInt(await getMonitor(MONITORS.TOTAL_MEMORY))
+  const usedMemory = parseInt(await getMonitor(MONITORS.USED_MEMORY))
+  const storagePathSize = parseInt(await getMonitor(MONITORS.STORAGE_PATH_SIZE))
+  const storagePathUsed = parseInt(await getMonitor(MONITORS.STORAGE_PATH_USED))
+  const maxFileDescriptors = parseInt(await getMonitor(MONITORS.MAX_FILE_DESCRIPTORS))
+  const allocatedFileDescriptors = parseInt(await getMonitor(MONITORS.ALLOCATED_FILE_DESCRIPTORS))
+  const receivedBytesPerSec = parseFloat(await getMonitor(MONITORS.RECEIVED_BYTES_PER_SEC))
+  const transferredBytesPerSec = parseFloat(await getMonitor(MONITORS.TRANSFERRED_BYTES_PER_SEC))
+
+  const response = {
+    ...basicHealthCheck,
+    country,
+    latitude,
+    longitude,
+    databaseConnections,
+    totalMemory,
+    usedMemory,
+    storagePathSize,
+    storagePathUsed,
+    maxFileDescriptors,
+    allocatedFileDescriptors,
+    receivedBytesPerSec,
+    transferredBytesPerSec
+  }
 
   return response
 }
@@ -48,5 +97,6 @@ const healthCheckDuration = async () => {
 
 module.exports = {
   healthCheck,
+  healthCheckVerbose,
   healthCheckDuration
 }

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -33,8 +33,7 @@ const healthCheck = async ({ libs } = {}, logger, getMonitors = getMonitorValues
   // we have a /db_check route for more granular detail, but the service health check should
   // also check that the db connection is good. having this in the health_check
   // allows us to get auto restarts from liveness probes etc if the db connection is down
-  const [ databaseLiveness ] = await getMonitors([MONITORS.DATABASE_LIVENESS])
-  if (!databaseLiveness) throw new Error('Database connection failed')
+  await sequelize.query('SELECT 1')
 
   return response
 }

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -1,10 +1,7 @@
 const versionInfo = require('../../../.version.json')
 const config = require('../../config')
 const utils = require('../../utils.js')
-const {
-  getMonitors: getMonitorValues,
-  MONITORS
-} = require('../../monitors/monitors')
+const { MONITORS } = require('../../monitors/monitors')
 
 /**
  * Perform a basic health check, returning the
@@ -13,7 +10,7 @@ const {
  * @param {*} ServiceRegistry
  * @param {*} logger
  */
-const healthCheck = async ({ libs } = {}, logger, getMonitors = getMonitorValues) => {
+const healthCheck = async ({ libs } = {}, logger, sequelize) => {
   let response = {
     ...versionInfo,
     healthy: true,
@@ -44,8 +41,8 @@ const healthCheck = async ({ libs } = {}, logger, getMonitors = getMonitorValues
  * @param {*} ServiceRegistry
  * @param {*} logger
  */
-const healthCheckVerbose = async ({ libs } = {}, logger, getMonitors = getMonitorValues) => {
-  const basicHealthCheck = await healthCheck({ libs }, logger, getMonitors)
+const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors) => {
+  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors)
 
   // Location information
   const country = config.get('serviceCountry')

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -56,6 +56,7 @@ const healthCheckVerbose = async ({ libs } = {}, logger, getMonitors = getMonito
   // System information
   const [
     databaseConnections,
+    databaseSize,
     totalMemory,
     usedMemory,
     storagePathSize,
@@ -66,6 +67,7 @@ const healthCheckVerbose = async ({ libs } = {}, logger, getMonitors = getMonito
     transferredBytesPerSec
   ] = await getMonitors([
     MONITORS.DATABASE_CONNECTIONS,
+    MONITORS.DATABASE_SIZE,
     MONITORS.TOTAL_MEMORY,
     MONITORS.USED_MEMORY,
     MONITORS.STORAGE_PATH_SIZE,
@@ -82,6 +84,7 @@ const healthCheckVerbose = async ({ libs } = {}, logger, getMonitors = getMonito
     latitude,
     longitude,
     databaseConnections,
+    databaseSize,
     totalMemory,
     usedMemory,
     storagePathSize,

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -19,6 +19,8 @@ const getMonitorsMock = async (monitors) => {
         return true
       case MONITORS.DATABASE_CONNECTIONS.name:
         return 5
+      case MONITORS.DATABASE_SIZE.name:
+        return 1102901
       case MONITORS.TOTAL_MEMORY.name:
         return 6237151232
       case MONITORS.USED_MEMORY.name:
@@ -100,6 +102,7 @@ describe('Test Health Check Verbose', function () {
       latitude: '37.7749',
       longitude: '-122.4194',
       databaseConnections: 5,
+      databaseSize: 1102901,
       totalMemory: 6237151232,
       usedMemory: 5969739776,
       storagePathSize: 62725623808,

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -1,7 +1,8 @@
-const { healthCheck } = require('./healthCheckComponentService')
+const { healthCheck, healthCheckVerbose } = require('./healthCheckComponentService')
 const assert = require('assert')
 const version = require('../../../.version.json')
 const config = require('../../../src/config')
+const { MONITORS } = require('../../monitors/monitors')
 
 const TEST_ENDPOINT = 'test_endpoint'
 
@@ -11,8 +12,31 @@ const libsMock = {
   }
 }
 
-const sequelizeMock = {
-  'query': async () => Promise.resolve()
+const getMonitorMock = async (monitor) => {
+  switch (monitor.name) {
+    case MONITORS.DATABASE_LIVENESS.name:
+      return 'true'
+    case MONITORS.DATABASE_CONNECTIONS.name:
+      return '5'
+    case MONITORS.TOTAL_MEMORY.name:
+      return '6237151232'
+    case MONITORS.USED_MEMORY.name:
+      return '5969739776'
+    case MONITORS.STORAGE_PATH_SIZE.name:
+      return '62725623808'
+    case MONITORS.STORAGE_PATH_USED.name:
+      return '54063878144'
+    case MONITORS.MAX_FILE_DESCRIPTORS.name:
+      return '524288'
+    case MONITORS.ALLOCATED_FILE_DESCRIPTORS.name:
+      return '3392'
+    case MONITORS.RECEIVED_BYTES_PER_SEC.name:
+      return '776.7638177541248'
+    case MONITORS.TRANSFERRED_BYTES_PER_SEC.name:
+      return '269500'
+    default:
+      return null
+  }
 }
 
 const mockLogger = {
@@ -26,7 +50,7 @@ describe('Test Health Check', function () {
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
     let expectedSpOwnerWallet = config.get('spOwnerWallet')
-    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, getMonitorMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -40,7 +64,7 @@ describe('Test Health Check', function () {
   })
 
   it('Should handle no libs', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock)
+    const res = await healthCheck({}, mockLogger, getMonitorMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -50,6 +74,38 @@ describe('Test Health Check', function () {
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint')
+    })
+  })
+})
+
+describe('Test Health Check Verbose', function () {
+  it('Should have valid values', async function () {
+    config.set('serviceCountry', 'US')
+    config.set('serviceLatitude', '37.7749')
+    config.set('serviceLongitude', '-122.4194')
+
+    const res = await healthCheckVerbose({}, mockLogger, getMonitorMock)
+    assert.deepStrictEqual(res, {
+      ...version,
+      service: 'content-node',
+      healthy: true,
+      git: undefined,
+      selectedDiscoveryProvider: 'none',
+      spID: config.get('spID'),
+      spOwnerWallet: config.get('spOwnerWallet'),
+      creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
+      country: 'US',
+      latitude: '37.7749',
+      longitude: '-122.4194',
+      databaseConnections: 5,
+      totalMemory: 6237151232,
+      usedMemory: 5969739776,
+      storagePathSize: 62725623808,
+      storagePathUsed: 54063878144,
+      maxFileDescriptors: 524288,
+      allocatedFileDescriptors: 3392,
+      receivedBytesPerSec: 776.7638177541248,
+      transferredBytesPerSec: 269500
     })
   })
 })

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -12,6 +12,10 @@ const libsMock = {
   }
 }
 
+const sequelizeMock = {
+  'query': async () => Promise.resolve()
+}
+
 const getMonitorsMock = async (monitors) => {
   return monitors.map(monitor => {
     switch (monitor.name) {
@@ -54,7 +58,7 @@ describe('Test Health Check', function () {
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
     let expectedSpOwnerWallet = config.get('spOwnerWallet')
-    const res = await healthCheck({ libs: libsMock }, mockLogger, getMonitorsMock)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -12,31 +12,33 @@ const libsMock = {
   }
 }
 
-const getMonitorMock = async (monitor) => {
-  switch (monitor.name) {
-    case MONITORS.DATABASE_LIVENESS.name:
-      return 'true'
-    case MONITORS.DATABASE_CONNECTIONS.name:
-      return '5'
-    case MONITORS.TOTAL_MEMORY.name:
-      return '6237151232'
-    case MONITORS.USED_MEMORY.name:
-      return '5969739776'
-    case MONITORS.STORAGE_PATH_SIZE.name:
-      return '62725623808'
-    case MONITORS.STORAGE_PATH_USED.name:
-      return '54063878144'
-    case MONITORS.MAX_FILE_DESCRIPTORS.name:
-      return '524288'
-    case MONITORS.ALLOCATED_FILE_DESCRIPTORS.name:
-      return '3392'
-    case MONITORS.RECEIVED_BYTES_PER_SEC.name:
-      return '776.7638177541248'
-    case MONITORS.TRANSFERRED_BYTES_PER_SEC.name:
-      return '269500'
-    default:
-      return null
-  }
+const getMonitorsMock = async (monitors) => {
+  return monitors.map(monitor => {
+    switch (monitor.name) {
+      case MONITORS.DATABASE_LIVENESS.name:
+        return true
+      case MONITORS.DATABASE_CONNECTIONS.name:
+        return 5
+      case MONITORS.TOTAL_MEMORY.name:
+        return 6237151232
+      case MONITORS.USED_MEMORY.name:
+        return 5969739776
+      case MONITORS.STORAGE_PATH_SIZE.name:
+        return 62725623808
+      case MONITORS.STORAGE_PATH_USED.name:
+        return 54063878144
+      case MONITORS.MAX_FILE_DESCRIPTORS.name:
+        return 524288
+      case MONITORS.ALLOCATED_FILE_DESCRIPTORS.name:
+        return 3392
+      case MONITORS.RECEIVED_BYTES_PER_SEC.name:
+        return 776.7638177541248
+      case MONITORS.TRANSFERRED_BYTES_PER_SEC.name:
+        return 269500
+      default:
+        return null
+    }
+  })
 }
 
 const mockLogger = {
@@ -50,7 +52,7 @@ describe('Test Health Check', function () {
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
     let expectedSpOwnerWallet = config.get('spOwnerWallet')
-    const res = await healthCheck({ libs: libsMock }, mockLogger, getMonitorMock)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, getMonitorsMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -64,7 +66,7 @@ describe('Test Health Check', function () {
   })
 
   it('Should handle no libs', async function () {
-    const res = await healthCheck({}, mockLogger, getMonitorMock)
+    const res = await healthCheck({}, mockLogger, getMonitorsMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -84,7 +86,7 @@ describe('Test Health Check Verbose', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
 
-    const res = await healthCheckVerbose({}, mockLogger, getMonitorMock)
+    const res = await healthCheckVerbose({}, mockLogger, getMonitorsMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -72,7 +72,7 @@ describe('Test Health Check', function () {
   })
 
   it('Should handle no libs', async function () {
-    const res = await healthCheck({}, mockLogger, getMonitorsMock)
+    const res = await healthCheck({}, mockLogger, sequelizeMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -92,7 +92,7 @@ describe('Test Health Check Verbose', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
 
-    const res = await healthCheckVerbose({}, mockLogger, getMonitorsMock)
+    const res = await healthCheckVerbose({}, mockLogger, sequelizeMock, getMonitorsMock)
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -1,9 +1,8 @@
 const express = require('express')
 const { handleResponse, successResponse, errorResponseBadRequest, handleResponseWithHeartbeat, sendResponse, errorResponseServerError } = require('../../apiHelpers')
-const { healthCheck, healthCheckDuration } = require('./healthCheckComponentService')
+const { healthCheck, healthCheckVerbose, healthCheckDuration } = require('./healthCheckComponentService')
 const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
-const { sequelize } = require('../../models')
 
 const { recoverWallet } = require('../../apiSigning')
 const { handleTrackContentUpload, removeTrackFolder } = require('../../fileManager')
@@ -51,7 +50,7 @@ const healthCheckController = async (req) => {
   }
 
   const logger = req.logger
-  const response = await healthCheck(serviceRegistry, logger, sequelize)
+  const response = await healthCheck(serviceRegistry, logger)
   return successResponse(response)
 }
 
@@ -82,14 +81,11 @@ const healthCheckDurationController = async (req) => {
  */
 const healthCheckVerboseController = async (req) => {
   const logger = req.logger
-  const healthCheckResponse = await healthCheck(serviceRegistry, logger, sequelize)
+  const healthCheckResponse = await healthCheckVerbose(serviceRegistry, logger)
 
   // TODO: add disk usage, current load, and/or node details to response
   return successResponse({
-    ...healthCheckResponse,
-    country: config.get('serviceCountry'),
-    latitude: config.get('serviceLatitude'),
-    longitude: config.get('serviceLongitude')
+    ...healthCheckResponse
   })
 }
 

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -3,6 +3,8 @@ const { handleResponse, successResponse, errorResponseBadRequest, handleResponse
 const { healthCheck, healthCheckVerbose, healthCheckDuration } = require('./healthCheckComponentService')
 const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
+const { sequelize } = require('../../models')
+const { getMonitors } = require('../../monitors/monitors')
 
 const { recoverWallet } = require('../../apiSigning')
 const { handleTrackContentUpload, removeTrackFolder } = require('../../fileManager')
@@ -50,7 +52,7 @@ const healthCheckController = async (req) => {
   }
 
   const logger = req.logger
-  const response = await healthCheck(serviceRegistry, logger)
+  const response = await healthCheck(serviceRegistry, logger, sequelize)
   return successResponse(response)
 }
 
@@ -81,9 +83,13 @@ const healthCheckDurationController = async (req) => {
  */
 const healthCheckVerboseController = async (req) => {
   const logger = req.logger
-  const healthCheckResponse = await healthCheckVerbose(serviceRegistry, logger)
+  const healthCheckResponse = await healthCheckVerbose(
+    serviceRegistry,
+    logger,
+    sequelize,
+    getMonitors
+  )
 
-  // TODO: add disk usage, current load, and/or node details to response
   return successResponse({
     ...healthCheckResponse
   })

--- a/creator-node/src/monitors/monitors.js
+++ b/creator-node/src/monitors/monitors.js
@@ -32,97 +32,117 @@ const MONITORING_REDIS_PREFIX = 'monitoring'
  *  @param {number?} ttl TTL in seconds for how long a cached value is good for.
  *    Since the job runs on a cron, the min TTL a metric can be refreshed is 60s.
  *    If a TTL isn't provided, the metric is refreshed every 60s.
+ *  @param {string?} type Optional type that the value should be parsed to (default is string)
+ *    Options are bool, int, float, string, json
  */
 
 const DATABASE_LIVENESS = {
   name: 'databaseLiveness',
-  func: getDatabaseLiveness
+  func: getDatabaseLiveness,
+  type: 'bool'
 }
 const DATABASE_SIZE = {
   name: 'databaseSize',
   func: getDatabaseSize,
-  ttl: 60 * 2
+  ttl: 60 * 2,
+  type: 'int'
 }
 const DATABASE_CONNECTIONS = {
   name: 'databaseConnections',
-  func: getDatabaseConnections
+  func: getDatabaseConnections,
+  type: 'int'
 }
 const DATABASE_CONNECTION_INFO = {
   name: 'databaseConnectionInfo',
-  func: getDatabaseConnectionInfo
+  func: getDatabaseConnectionInfo,
+  type: 'json'
 }
 
 const TOTAL_MEMORY = {
   name: 'totalMemory',
   func: getTotalMemory,
-  ttl: 60 * 2
+  ttl: 60 * 2,
+  type: 'int'
 }
 const USED_MEMORY = {
   name: 'usedMemory',
   func: getUsedMemory,
-  ttl: 60 * 2
+  ttl: 60 * 2,
+  type: 'int'
 }
 
 const STORAGE_PATH_SIZE = {
   name: 'storagePathSize',
   func: getStoragePathSize,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const STORAGE_PATH_USED = {
   name: 'storagePathUsed',
   func: getStoragePathUsed,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const FILESYSTEM_SIZE = {
   name: 'filesystemSize',
   func: getFilesystemSize,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const FILESYSTEM_USED = {
   name: 'filesystemUsed',
   func: getFilesystemUsed,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const MAX_FILE_DESCRIPTORS = {
   name: 'maxFileDescriptors',
   func: getMaxFileDescriptors,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const ALLOCATED_FILE_DESCRIPTORS = {
   name: 'allocatedFileDescriptors',
   func: getAllocatedFileDescriptors,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 
 const RECEIVED_BYTES_PER_SEC = {
   name: 'receivedBytesPerSec',
-  func: getReceivedBytesPerSec
+  func: getReceivedBytesPerSec,
+  type: 'float'
 }
 const TRANSFERRED_BYTES_PER_SEC = {
   name: 'transferredBytesPerSec',
-  func: getTransferredBytesPerSec
+  func: getTransferredBytesPerSec,
+  type: 'float'
 }
 
 const REDIS_NUM_KEYS = {
   name: 'redisNumKeys',
   func: getRedisNumKeys,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const REDIS_USED_MEMORY = {
   name: 'redisUsedMemory',
   func: getRedisUsedMemory,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 const REDIS_TOTAL_MEMORY = {
   name: 'redisTotalMemory',
   func: getRedisTotalMemory,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'int'
 }
 
 const IPFS_READ_WRITE_STATUS = {
   name: 'IPFSReadWriteStatus',
   func: getIPFSReadWriteStatus,
-  ttl: 60 * 5
+  ttl: 60 * 5,
+  type: 'json'
 }
 
 const MONITORS = {
@@ -148,13 +168,53 @@ const MONITORS = {
 
 const getMonitorRedisKey = (monitor) => `${MONITORING_REDIS_PREFIX}:${monitor.name}`
 
-const getMonitor = async (monitor) => {
-  const key = getMonitorRedisKey(monitor)
-  return redis.get(key)
+/**
+ * Parses a string value into the corresponding type
+ * @param {Object} monitor
+ * @param {string} value
+ */
+const parseValue = (monitor, value) => {
+  try {
+    if (monitor.type) {
+      switch (monitor.type) {
+        case 'bool':
+          return value === 'true'
+        case 'int':
+          return parseInt(value)
+        case 'float':
+          return parseFloat(value)
+        case 'json':
+          return JSON.parse(value)
+        case 'string':
+          return value
+        default:
+          return value
+      }
+    }
+    return value
+  } catch (e) {
+    return value
+  }
+}
+
+/**
+ * Gets monitor values
+ * @param {Array<Object>} monitors the monitor, containing name, func, ttl, and type
+ */
+const getMonitors = async (monitors) => {
+  const pipeline = redis.pipeline()
+  monitors.forEach(monitor => {
+    const key = getMonitorRedisKey(monitor)
+    pipeline.get(key)
+  })
+  return pipeline
+    .exec()
+    // Pull the value off of the result
+    .then((result) => result.map((r, i) => parseValue(monitors[i], r[1])))
 }
 
 module.exports = {
   MONITORS,
   getMonitorRedisKey,
-  getMonitor
+  getMonitors
 }

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -20,13 +20,7 @@ module.exports = function (app) {
       return errorResponseServerError()
     }
 
-    let value
-    if (req.query.pin === 'true') {
-      value = await getMonitor(MONITORS.IPFS_PIN_STATUS)
-    } else {
-      value = await getMonitor(MONITORS.IPFS_READ_WRITE_STATUS)
-    }
-
+    const value = await getMonitor(MONITORS.IPFS_READ_WRITE_STATUS)
     if (!value) {
       return errorResponseServerError({ error: 'IPFS not healthy' })
     }

--- a/creator-node/test/expressApp.test.js
+++ b/creator-node/test/expressApp.test.js
@@ -48,7 +48,7 @@ describe('test expressApp', async function () {
       .expect(401)
   })
 
-  it('succeeds health check', async function () {
+  it.only('succeeds health check', async function () {
     await request(app)
       .get('/health_check')
       .expect(200)

--- a/creator-node/test/expressApp.test.js
+++ b/creator-node/test/expressApp.test.js
@@ -48,7 +48,7 @@ describe('test expressApp', async function () {
       .expect(401)
   })
 
-  it.only('succeeds health check', async function () {
+  it('succeeds health check', async function () {
     await request(app)
       .get('/health_check')
       .expect(200)

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -1,5 +1,6 @@
 const { runMigrations, clearDatabase } = require('../../src/migrationManager')
 const redisClient = require('../../src/redis')
+const MonitoringQueueMock = require('./monitoringQueueMock')
 
 // Initialize private IPFS gateway counters
 redisClient.set('ipfsGatewayReqs', 0)
@@ -21,7 +22,8 @@ async function getApp (ipfsClient, libsClient, blacklistManager, ipfsLatestClien
     ipfsLatest: ipfsLatestClient || ipfsClient,
     libs: libsClient,
     blacklistManager: blacklistManager,
-    redis: redisClient
+    redis: redisClient,
+    monitoringQueue: new MonitoringQueueMock()
   }
 
   const appInfo = require('../../src/app')(8000, mockServiceRegistry)

--- a/creator-node/test/lib/monitoringQueueMock.js
+++ b/creator-node/test/lib/monitoringQueueMock.js
@@ -1,0 +1,14 @@
+const { MONITORS, getMonitorRedisKey } = require('../../src/monitors/monitors')
+const redisClient = require('../../src/redis')
+
+// Mock monitoring queue that sets monitor values on construction
+class MonitoringQueueMock {
+  constructor () {
+    redisClient.set(
+      getMonitorRedisKey(MONITORS.DATABASE_LIVENESS),
+      'true'
+    )
+  }
+}
+
+module.exports = MonitoringQueueMock


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Replace health check info with monitors rather than direct queries


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

New unit tests for health check component and manually verified

*health_check*
```
version: "0.3.29",
service: "content-node",
healthy: true,
git: "",
selectedDiscoveryProvider: "http://audius-disc-prov_web-server_1:5000",
creatorNodeEndpoint: "http://cn2_creator-node_1:4001",
spID: 2,
spOwnerWallet: "0x9dd24cd9920eb0716874d23c5748b07ad354b43d"
```

*health_check/verbose*
```
version: "0.3.29",
service: "content-node",
healthy: true,
git: "",
selectedDiscoveryProvider: "http://audius-disc-prov_web-server_1:5000",
creatorNodeEndpoint: "http://cn2_creator-node_1:4001",
spID: 2,
spOwnerWallet: "0x9dd24cd9920eb0716874d23c5748b07ad354b43d",
country: "US",
latitude: "37.7749",
longitude: "-122.4194",
databaseConnections: 5,
totalMemory: 6237151232,
usedMemory: 5966315520,
storagePathSize: 62725623808,
storagePathUsed: 54069256192,
maxFileDescriptors: 524288,
allocatedFileDescriptors: 3040,
receivedBytesPerSec: 776.7638177541248,
transferredBytesPerSec: 4400
```

*disk_check*
```
available: "8.06 GB",
total: "58.42 GB",
usagePercent: "86%",
maxUsagePercent: "90%",
storagePath: "/file_storage"
```

*health_check/ipfs*
```
hash: "Qmexx5z8EvQr8c5m5JLdQUSjVu6mZhxBL7eq1W6HkDNjg9",
duration: "135ms"
```

*health_check/ipfs?pin=true*
```
hash: "QmWGQKtH95uh6SC4y335nHNDDm5phxoQK8xNzAYZMBwnf1",
duration: "135ms"
```

*db_check*
```
git: "",
connectionStatus: {
total: 5,
active: 2,
idle: 3
},
maxConnections: 100
```

*db_check?verbose=true*
```
git: "",
connectionStatus: {
total: 5,
active: 2,
idle: 3
},
maxConnections: 100,
connectionInfo: [
{
wait_event_type: null,
wait_event: null,
state: "active",
query: "select wait_event_type, wait_event, state, query from pg_stat_activity where datname = 'audius_creator_node'"
},
{
wait_event_type: "Client",
wait_event: "ClientRead",
state: "idle",
query: "SET client_min_messages TO warning; SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE;"
},
{
wait_event_type: "Client",
wait_event: "ClientRead",
state: "idle",
query: "SELECT 1"
},
{
wait_event_type: null,
wait_event: null,
state: "active",
query: "SELECT numbackends from pg_stat_database where datname = current_database()"
},
{
wait_event_type: "Client",
wait_event: "ClientRead",
state: "idle",
query: "SET client_min_messages TO warning; SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE;"
}
]
```
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
