### PR TITLE
Use Discovery selection for Identity service

### DIFF
--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -9,9 +9,7 @@ async function initAudiusLibs () {
   if (!dataWeb3) throw new Error('Web3 incorrectly configured')
 
   let audiusInstance = new AudiusLibs({
-    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(
-      /** whitelist */ new Set([config.get('notificationDiscoveryProvider')])
-    ),
+    discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(),
     ethWeb3Config: AudiusLibs.configEthWeb3(
       config.get('ethTokenAddress'),
       config.get('ethRegistryAddress'),

--- a/identity-service/src/notifications/trendingTrackProcessing.js
+++ b/identity-service/src/notifications/trendingTrackProcessing.js
@@ -3,7 +3,7 @@ const moment = require('moment')
 
 const models = require('../models')
 const { logger } = require('../logging')
-const config = require('../config.js')
+
 const {
   deviceType,
   notificationTypes
@@ -19,8 +19,6 @@ const {
   notificationResponseTitleMap,
   pushNotificationMessagesMap
 } = require('./formatNotificationMetadata')
-
-const notifDiscProv = config.get('notificationDiscoveryProvider')
 
 const TRENDING_TIME = Object.freeze({
   DAY: 'day',
@@ -41,7 +39,7 @@ const TRENDING_INTERVAL_HOURS = 3
 // The highest rank for which a notification will be sent
 const MAX_TOP_TRACK_RANK = 10
 
-async function getTrendingTracks () {
+async function getTrendingTracks (discProv) {
   try {
     // The owner info is then used to target listenCount milestone notifications
     let params = new URLSearchParams()
@@ -50,7 +48,7 @@ async function getTrendingTracks () {
 
     const trendingTracksResponse = await axios({
       method: 'get',
-      url: `${notifDiscProv}/v1/full/tracks/trending?time=week`,
+      url: `${discProv}/v1/full/tracks/trending?time=week`,
       params,
       timeout: 10000
     })
@@ -171,7 +169,8 @@ async function processTrendingTracks (audiusLibs, blocknumber, trendingTracks, t
 
 async function indexTrendingTracks (audiusLibs, tx) {
   try {
-    const { trendingTracks, blocknumber } = await getTrendingTracks()
+    const discProv = audiusLibs.discoveryProvider.discoveryProviderEndpoint
+    const { trendingTracks, blocknumber } = await getTrendingTracks(discProv)
     await processTrendingTracks(audiusLibs, blocknumber, trendingTracks, tx)
   } catch (err) {
     logger.error(`Unable to process trending track notifications: ${err.message}`)

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -5,7 +5,6 @@ const Hashids = require('hashids/cjs')
 const { logger } = require('../logging')
 
 // default configs
-const notifDiscProv = config.get('notificationDiscoveryProvider')
 const startBlock = config.get('notificationStartBlock')
 // Number of tracks to fetch for new listens on each poll
 const trackListenMilestonePollCount = 100
@@ -13,7 +12,7 @@ const trackListenMilestonePollCount = 100
 /**
  * For any users missing blockchain id, here we query the values from discprov and fill them in
  */
-async function updateBlockchainIds () {
+async function updateBlockchainIds (discProv) {
   let usersWithoutBlockchainId = await models.User.findAll({
     attributes: ['walletAddress', 'handle'],
     where: { blockchainUserId: null }
@@ -24,7 +23,7 @@ async function updateBlockchainIds () {
       logger.info(`Updating user with wallet ${walletAddress}`)
       const response = await axios({
         method: 'get',
-        url: `${notifDiscProv}/users`,
+        url: `${discProv}/users`,
         params: {
           wallet: walletAddress
         }


### PR DESCRIPTION
### Description

Linear Issue: [AUD-236](https://linear.app/audius/issue/AUD-236/identity-service-should-use-discovery-selection-instead-of-having-a)

Deprecates the use of `notificationDiscoveryProvider` from the config and uses discovery selection from audius libs moving forward.

Results in changes to the following,
- Notifications
- Auth Middleware
- Health Check
- Audius Libs Whitelist

The config variable is still in use because I am unsure of how to remove this from, https://github.com/AudiusProject/audius-protocol/blob/4bbf47a6ab00c7436d18b6296a3404d0da1cb4fd/identity-service/src/notifications/fetchNotificationMetadata.js#L12


### Tests
Tested with local deployment, will do additional testing once staging is available.
