### PR TITLE
Add unique job id to identity notifications bull

### DIFF
--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -135,7 +135,7 @@ class NotificationProcessor {
 
       // Wait 10 minutes before re-running the job
       await new Promise(resolve => setTimeout(resolve, 10 * 60 * 1000))
-      await this.emailQueue.add({ type: unreadEmailJob }, { jobId: `${unreadEmailJob}:${Date.now()}` })
+      await this.emailQueue.add({ type: 'unreadEmailJob' }, { jobId: `unreadEmailJob:${Date.now()}` })
       done()
     })
 

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -21,7 +21,6 @@ const processNotifications = require('./processNotifications/index.js')
 const { indexTrendingTracks } = require('./trendingTrackProcessing')
 const sendNotifications = require('./sendNotifications/index.js')
 
-
 // Reference Bull Docs: https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue
 const defaultJobOptions = {
   removeOnComplete: true,
@@ -135,7 +134,7 @@ class NotificationProcessor {
       await processDownloadAppEmail(expressApp, audiusLibs)
 
       // Wait 10 minutes before re-running the job
-      await new Promise(resolve => setTimeout(resolve, 10*60*1000))
+      await new Promise(resolve => setTimeout(resolve, 10 * 60 * 1000))
       await this.emailQueue.add({ type: unreadEmailJob }, { jobId: `${unreadEmailJob}:${Date.now()}` })
       done()
     })


### PR DESCRIPTION
### Description
The email notification queue for identity was stopped for several days. 
I believe it's due to the bull queue being a cron job. 
This PR gives each job a unique jobID and renames the queue as well. 

Reference to fix: https://github.com/OptimalBits/bull/issues/1635

Closes AUD-249

### Tests
I ran the identity service manually and checked that all notification jobs were running!
