### PR TITLE
Add monitoring for content nodes in libs

### DIFF
--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -64,8 +64,6 @@ class ServiceProvider extends Base {
    * Fetches healthy Content Nodes and autoselects a primary
    * and two secondaries.
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
-   * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)
-   * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
    * @param {boolean} performSyncCheck whether or not to perform sync check
    * @param {number?} timeout ms applied to each request made to a content node
    * @returns { primary, secondaries, services }
@@ -75,8 +73,6 @@ class ServiceProvider extends Base {
    */
   async autoSelectCreatorNodes ({
     numberOfNodes = 3,
-    whitelist = null,
-    blacklist = null,
     performSyncCheck = true,
     timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   }) {
@@ -84,8 +80,6 @@ class ServiceProvider extends Base {
       creatorNode: this.creatorNode,
       ethContracts: this.ethContracts,
       numberOfNodes,
-      whitelist,
-      blacklist,
       timeout
     })
 

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -64,6 +64,8 @@ class ServiceProvider extends Base {
    * Fetches healthy Content Nodes and autoselects a primary
    * and two secondaries.
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
+   * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)	
+   * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
    * @param {boolean} performSyncCheck whether or not to perform sync check
    * @param {number?} timeout ms applied to each request made to a content node
    * @returns { primary, secondaries, services }

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -73,6 +73,8 @@ class ServiceProvider extends Base {
    */
   async autoSelectCreatorNodes ({
     numberOfNodes = 3,
+    whitelist = null,
+    blacklist = null,
     performSyncCheck = true,
     timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   }) {
@@ -80,6 +82,8 @@ class ServiceProvider extends Base {
       creatorNode: this.creatorNode,
       ethContracts: this.ethContracts,
       numberOfNodes,
+      whitelist,
+      blacklist,
       timeout
     })
 

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -64,7 +64,7 @@ class ServiceProvider extends Base {
    * Fetches healthy Content Nodes and autoselects a primary
    * and two secondaries.
    * @param {number} numberOfNodes total number of nodes to fetch (2 secondaries means 3 total)
-   * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)	
+   * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whiltelist)
    * @param {Set<string?} blacklist whether or not to exclude any nodes (default no blacklist)
    * @param {boolean} performSyncCheck whether or not to perform sync check
    * @param {number?} timeout ms applied to each request made to a content node

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -201,13 +201,9 @@ class Users extends Base {
    * This creates a record for that user on the connected creator node.
    * @param {Object} param
    * @param {number} param.userId
-   * @param {Set<string>} param.[passList=null] whether or not to include only specified nodes
-   * @param {Set<string>} param.[blockList=null]  whether or not to exclude any nodes
    */
   async assignReplicaSet ({
-    userId,
-    passList = null,
-    blockList = null
+    userId
   }) {
     this.REQUIRES(Services.CREATOR_NODE)
     const phases = {
@@ -234,9 +230,7 @@ class Users extends Base {
       // Autoselect a new replica set and update the metadata object with new content node endpoints
       phase = phases.AUTOSELECT_CONTENT_NODES
       const response = await this.ServiceProvider.autoSelectCreatorNodes({
-        performSyncCheck: false,
-        whitelist: passList,
-        blacklist: blockList
+        performSyncCheck: false
       })
       // Ideally, 1 primary and n-1 secondaries are chosen. The best-worst case scenario is that at least 1 primary
       // is chosen. If a primary was not selected (which also implies that secondaries were not chosen), throw

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -55,9 +55,20 @@ class AudiusLibs {
    * @param {string} fallbackUrl creator node endpoint to fall back to on requests
    * @param {boolean} lazyConnect whether to delay connection to the node until the first
    * request that requires a connection is made.
+   * @param {Set<string>?} passList whether or not to include only specified nodes (default null)
+   * @param {Set<string>?} blockList whether or not to exclude any nodes (default null)
+   * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
+   *    @param {function} monitoringCallbacks.request
+   *    @param {function} monitoringCallbacks.healthCheck
    */
-  static configCreatorNode (fallbackUrl, lazyConnect = false) {
-    return { fallbackUrl, lazyConnect }
+  static configCreatorNode (
+    fallbackUrl,
+    lazyConnect = false,
+    passList = null,
+    blockList = null,
+    monitoringCallbacks = null
+  ) {
+    return { fallbackUrl, lazyConnect, passList, blockList, monitoringCallbacks }
   }
 
   /**
@@ -269,7 +280,11 @@ class AudiusLibs {
         this.isServer,
         this.userStateManager,
         this.creatorNodeConfig.lazyConnect,
-        this.schemas)
+        this.schemas,
+        this.creatorNodeConfig.passList,
+        this.creatorNodeConfig.blockList,
+        this.creatorNodeConfig.monitoringCallbacks
+      )
       await this.creatorNode.init()
     }
 

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -30,8 +30,8 @@ class AudiusLibs {
    * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
    * @param {(selection: string) => void?} selectionCallback invoked with the select discovery provider
    * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
-   *    @param {function} monitoringCallbacks.request
-   *    @param {function} monitoringCallbacks.healthCheck
+   * @param {function} monitoringCallbacks.request
+   * @param {function} monitoringCallbacks.healthCheck
    */
   static configDiscoveryProvider (
     whitelist = null,
@@ -66,8 +66,8 @@ class AudiusLibs {
    * @param {Set<string>?} passList whether or not to include only specified nodes (default null)
    * @param {Set<string>?} blockList whether or not to exclude any nodes (default null)
    * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
-   *    @param {function} monitoringCallbacks.request
-   *    @param {function} monitoringCallbacks.healthCheck
+   * @param {function} monitoringCallbacks.request
+   * @param {function} monitoringCallbacks.healthCheck
    */
   static configCreatorNode (
     fallbackUrl,

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -29,9 +29,17 @@ class AudiusLibs {
    * @param {Set<string>?} whitelist whether or not to include only specified nodes (default no whitelist)
    * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
    * @param {(selection: string) => void?} selectionCallback invoked with the select discovery provider
+   * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
+   *    @param {function} monitoringCallbacks.request
+   *    @param {function} monitoringCallbacks.healthCheck
    */
-  static configDiscoveryProvider (whitelist = null, reselectTimeout = null, selectionCallback = null) {
-    return { whitelist, reselectTimeout, selectionCallback }
+  static configDiscoveryProvider (
+    whitelist = null,
+    reselectTimeout = null,
+    selectionCallback = null,
+    monitoringCallbacks = {}
+  ) {
+    return { whitelist, reselectTimeout, selectionCallback, monitoringCallbacks }
   }
 
   /**
@@ -66,7 +74,7 @@ class AudiusLibs {
     lazyConnect = false,
     passList = null,
     blockList = null,
-    monitoringCallbacks = null
+    monitoringCallbacks = {}
   ) {
     return { fallbackUrl, lazyConnect, passList, blockList, monitoringCallbacks }
   }
@@ -262,7 +270,8 @@ class AudiusLibs {
         this.ethContracts,
         this.web3Manager,
         this.discoveryProviderConfig.reselectTimeout,
-        this.discoveryProviderConfig.selectionCallback
+        this.discoveryProviderConfig.selectionCallback,
+        this.discoveryProviderConfig.monitoringCallbacks
       )
       await this.discoveryProvider.init()
     }

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -222,24 +222,29 @@ class CreatorNodeSelection extends ServiceSelection {
       healthCheckedServices.forEach(check => {
         const url = new URL(check.request.url)
         const data = check.response.data.data
-        this.creatorNode.monitoringCallbacks.healthCheck({
-          endpoint: url.origin,
-          pathname: url.pathname,
-          queryString: url.queryrString,
-          version: data.version,
-          git: data.git,
-          selectedDiscoveryNode: data.selectedDiscoveryProvider,
-          databaseSize: data.databaseSize,
-          databaseConnections: data.databaseConnections,
-          totalMemory: data.totalMemory,
-          usedMemory: data.usedMemory,
-          totalStorage: data.storagePathSize,
-          usedStorage: data.storagePathUsed,
-          maxFileDescriptors: data.maxFileDescriptors,
-          allocatedFileDescriptors: data.allocatedFileDescriptors,
-          receivedBytesPerSec: data.receivedBytesPerSec,
-          transferredBytesPerSec: data.transferredBytesPerSec
-        })
+        try {
+          this.creatorNode.monitoringCallbacks.healthCheck({
+            endpoint: url.origin,
+            pathname: url.pathname,
+            queryString: url.queryrString,
+            version: data.version,
+            git: data.git,
+            selectedDiscoveryNode: data.selectedDiscoveryProvider,
+            databaseSize: data.databaseSize,
+            databaseConnections: data.databaseConnections,
+            totalMemory: data.totalMemory,
+            usedMemory: data.usedMemory,
+            totalStorage: data.storagePathSize,
+            usedStorage: data.storagePathUsed,
+            maxFileDescriptors: data.maxFileDescriptors,
+            allocatedFileDescriptors: data.allocatedFileDescriptors,
+            receivedBytesPerSec: data.receivedBytesPerSec,
+            transferredBytesPerSec: data.transferredBytesPerSec
+          })
+        } catch (e) {
+          // Swallow errors -- this method should not throw generally
+          console.error(e)
+        }
       })
     }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -20,7 +20,7 @@ class CreatorNodeSelection extends ServiceSelection {
       },
       // Use the content node's configured whitelist if not provided
       whitelist: whitelist || creatorNode.passList,
-      blacklist: whitelist || creatorNode.blockList
+      blacklist: blacklist || creatorNode.blockList
     })
     this.creatorNode = creatorNode
     this.numberOfNodes = numberOfNodes

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -225,10 +225,12 @@ class CreatorNodeSelection extends ServiceSelection {
         this.creatorNode.monitoringCallbacks.healthCheck({
           endpoint: url.origin,
           pathname: url.pathname,
+          queryString: url.queryrString,
           version: data.version,
           git: data.git,
           selectedDiscoveryNode: data.selectedDiscoveryProvider,
           databaseSize: data.databaseSize,
+          databaseConnections: data.databaseConnections,
           totalMemory: data.totalMemory,
           usedMemory: data.usedMemory,
           totalStorage: data.storagePathSize,

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -7,6 +7,8 @@ class CreatorNodeSelection extends ServiceSelection {
     creatorNode,
     numberOfNodes,
     ethContracts,
+    whitelist,
+    blacklist,
     maxStorageUsedPercent = 90,
     timeout = null
   }) {
@@ -16,8 +18,9 @@ class CreatorNodeSelection extends ServiceSelection {
         const services = await this.ethContracts.getServiceProviderList(CREATOR_NODE_SERVICE_NAME)
         return services.map(e => e.endpoint)
       },
-      whitelist: creatorNode.passList,
-      blacklist: creatorNode.blockList
+      // Use the content node's configured whitelist if not provided
+      whitelist: whitelist || creatorNode.passList,
+      blacklist: whitelist || creatorNode.blockList
     })
     this.creatorNode = creatorNode
     this.numberOfNodes = numberOfNodes

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -577,16 +577,21 @@ class CreatorNode {
       const duration = Date.now() - start
 
       if (this.monitoringCallbacks.request) {
-        this.monitoringCallbacks.request({
-          endpoint: url.origin,
-          pathname: url.pathname,
-          queryString: url.search,
-          signer: resp.data.signer,
-          signature: resp.data.signature,
-          requestMethod: axiosRequestObj.method,
-          status: resp.status,
-          responseTimeMillis: duration
-        })
+        try {
+          this.monitoringCallbacks.request({
+            endpoint: url.origin,
+            pathname: url.pathname,
+            queryString: url.search,
+            signer: resp.data.signer,
+            signature: resp.data.signature,
+            requestMethod: axiosRequestObj.method,
+            status: resp.status,
+            responseTimeMillis: duration
+          })
+        } catch (e) {
+          // Swallow errors -- this method should not throw generally
+          console.error(e)
+        }
       }
       // Axios `data` field gets the response body
       return resp.data
@@ -595,14 +600,19 @@ class CreatorNode {
       const duration = Date.now() - start
 
       if (this.monitoringCallbacks.request) {
-        this.monitoringCallbacks.request({
-          endpoint: url.origin,
-          pathname: url.pathname,
-          queryString: url.search,
-          requestMethod: axiosRequestObj.method,
-          status: resp.status,
-          responseTimeMillis: duration
-        })
+        try {
+          this.monitoringCallbacks.request({
+            endpoint: url.origin,
+            pathname: url.pathname,
+            queryString: url.search,
+            requestMethod: axiosRequestObj.method,
+            status: resp.status,
+            responseTimeMillis: duration
+          })
+        } catch (e) {
+          // Swallow errors -- this method should not throw generally
+          console.error(e)
+        }
       }
 
       _handleErrorHelper(e, axiosRequestObj.url)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -80,7 +80,7 @@ class CreatorNode {
    * @param {Web3Manager} web3Manager
    * @param {string} creatorNodeEndpoint fallback creator node endpoint (to be deprecated)
    * @param {boolean} isServer
-   * @param {UserStateManager} userStateManager
+   * @param {UserStateManager} userStateManagern  singleton UserStateManager instance
    * @param {boolean} lazyConnect whether or not to lazy connect (sign in) on load
    * @param {*} schemas
    * @param {Set<string>?} passList whether or not to include only specified nodes (default null)
@@ -570,6 +570,7 @@ class CreatorNode {
     axiosRequestObj.baseURL = this.creatorNodeEndpoint
 
     // Axios throws for non-200 responses
+    const url = new URL(axiosRequestObj.baseURL + axiosRequestObj.url)
     const start = Date.now()
     try {
       const resp = await axios(axiosRequestObj)
@@ -577,8 +578,9 @@ class CreatorNode {
 
       if (this.monitoringCallbacks.request) {
         this.monitoringCallbacks.request({
-          endpoint: axiosRequestObj.baseURL,
-          pathname: axiosRequestObj.url,
+          endpoint: url.origin,
+          pathname: url.pathname,
+          queryString: url.search,
           signer: resp.data.signer,
           signature: resp.data.signature,
           requestMethod: axiosRequestObj.method,
@@ -594,8 +596,9 @@ class CreatorNode {
 
       if (this.monitoringCallbacks.request) {
         this.monitoringCallbacks.request({
-          endpoint: axiosRequestObj.baseURL,
-          pathname: axiosRequestObj.url,
+          endpoint: url.origin,
+          pathname: url.pathname,
+          queryString: url.search,
           requestMethod: axiosRequestObj.method,
           status: resp.status,
           responseTimeMillis: duration

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -86,8 +86,8 @@ class CreatorNode {
    * @param {Set<string>?} passList whether or not to include only specified nodes (default null)
    * @param {Set<string>?} blockList whether or not to exclude any nodes (default null)
    * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
-   *    @param {function} monitoringCallbacks.request
-   *    @param {function} monitoringCallbacks.healthCheck
+   * @param {function} monitoringCallbacks.request
+   * @param {function} monitoringCallbacks.healthCheck
    */
   constructor (
     web3Manager,

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -122,24 +122,29 @@ class DiscoveryProviderSelection extends ServiceSelection {
 
     if (this.monitoringCallbacks.healthCheck) {
       const url = new URL(response.config.url)
-      this.monitoringCallbacks.healthCheck({
-        endpoint: url.origin,
-        pathname: url.pathname,
-        queryString: url.search,
-        version,
-        git: data.data.git,
-        blockDifference: blockDiff,
-        databaseBlockNumber: data.data.db.number,
-        webBlockNumber: data.data.web.blocknumber,
-        databaseSize: data.data.database_size,
-        databaseConnections: data.data.database_connections,
-        totalMemory: data.data.total_memory,
-        usedMemory: data.data.used_memory,
-        totalStorage: data.data.filesystem_size,
-        usedStorage: data.data.filesystem_used,
-        receivedBytesPerSec: data.received_bytes_per_sec,
-        transferredBytesPerSec: data.transferred_bytes_per_sec
-      })
+      try {
+        this.monitoringCallbacks.healthCheck({
+          endpoint: url.origin,
+          pathname: url.pathname,
+          queryString: url.search,
+          version,
+          git: data.data.git,
+          blockDifference: blockDiff,
+          databaseBlockNumber: data.data.db.number,
+          webBlockNumber: data.data.web.blocknumber,
+          databaseSize: data.data.database_size,
+          databaseConnections: data.data.database_connections,
+          totalMemory: data.data.total_memory,
+          usedMemory: data.data.used_memory,
+          totalStorage: data.data.filesystem_size,
+          usedStorage: data.data.filesystem_used,
+          receivedBytesPerSec: data.received_bytes_per_sec,
+          transferredBytesPerSec: data.transferred_bytes_per_sec
+        })
+      } catch (e) {
+        // Swallow errors -- this method should not throw generally
+        console.error(e)
+      }
     }
 
     if (status !== 200) return false

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -36,6 +36,7 @@ class DiscoveryProviderSelection extends ServiceSelection {
     this.currentVersion = null
     this.reselectTimeout = config.reselectTimeout
     this.selectionCallback = config.selectionCallback
+    this.monitoringCallbacks = config.monitoringCallbacks || {}
 
     // Whether or not we are running in `regressed` mode, meaning we were
     // unable to select a discovery provider that was up-to-date. Clients may
@@ -118,6 +119,29 @@ class DiscoveryProviderSelection extends ServiceSelection {
   isHealthy (response, urlMap) {
     const { status, data } = response
     const { block_difference: blockDiff, service, version } = data.data
+
+    if (this.monitoringCallbacks.healthCheck) {
+      const url = new URL(response.config.url)
+      this.monitoringCallbacks.healthCheck({
+        endpoint: url.origin,
+        pathname: url.pathname,
+        queryString: url.search,
+        version,
+        git: data.data.git,
+        blockDifference: blockDiff,
+        databaseBlockNumber: data.data.db.number,
+        webBlockNumber: data.data.web.blocknumber,
+        databaseSize: data.data.database_size,
+        databaseConnections: data.data.database_connections,
+        totalMemory: data.data.total_memory,
+        usedMemory: data.data.used_memory,
+        totalStorage: data.data.filesystem_size,
+        usedStorage: data.data.filesystem_used,
+        receivedBytesPerSec: data.received_bytes_per_sec,
+        transferredBytesPerSec: data.transferred_bytes_per_sec
+      })
+    }
+
     if (status !== 200) return false
     if (service !== DISCOVERY_SERVICE_NAME) return false
     if (!semver.valid(version)) return false

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -24,8 +24,8 @@ const MAX_MAKE_REQUEST_RETRY_COUNT = 5
  * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
  * @param {function} selectionCallback invoked when a discovery node is selected
  * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
- *    @param {function} monitoringCallbacks.request
- *    @param {function} monitoringCallbacks.healthCheck
+ * @param {function} monitoringCallbacks.request
+ * @param {function} monitoringCallbacks.healthCheck
  */
 class DiscoveryProvider {
   constructor (

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -523,16 +523,21 @@ class DiscoveryProvider {
       parsedResponse = Utils.parseDataFromResponse(response)
 
       if (this.monitoringCallbacks.request) {
-        this.monitoringCallbacks.request({
-          endpoint: url.origin,
-          pathname: url.pathname,
-          queryString: url.search,
-          signer: response.data.signer,
-          signature: response.data.signature,
-          requestMethod: axiosRequest.method,
-          status: response.status,
-          responseTimeMillis: duration
-        })
+        try {
+          this.monitoringCallbacks.request({
+            endpoint: url.origin,
+            pathname: url.pathname,
+            queryString: url.search,
+            signer: response.data.signer,
+            signature: response.data.signature,
+            requestMethod: axiosRequest.method,
+            status: response.status,
+            responseTimeMillis: duration
+          })
+        } catch (e) {
+          // Swallow errors -- this method should not throw generally
+          console.error(e)
+        }
       }
     } catch (e) {
       const resp = e.response || {}
@@ -541,14 +546,19 @@ class DiscoveryProvider {
       console.error(`Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${JSON.stringify(errMsg)}`)
 
       if (this.monitoringCallbacks.request) {
-        this.monitoringCallbacks.request({
-          endpoint: url.origin,
-          pathname: url.pathname,
-          queryString: url.search,
-          requestMethod: axiosRequest.method,
-          status: resp.status,
-          responseTimeMillis: duration
-        })
+        try {
+          this.monitoringCallbacks.request({
+            endpoint: url.origin,
+            pathname: url.pathname,
+            queryString: url.search,
+            requestMethod: axiosRequest.method,
+            status: resp.status,
+            responseTimeMillis: duration
+          })
+        } catch (e) {
+          // Swallow errors -- this method should not throw generally
+          console.error(e)
+        }
       }
 
       if (retry) {

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -24,8 +24,8 @@ const MAX_MAKE_REQUEST_RETRY_COUNT = 5
  * @param {number?} reselectTimeout timeout to clear locally cached discovery providers
  * @param {function} selectionCallback invoked when a discovery node is selected
  * @param {object?} monitoringCallbacks callbacks to be invoked with metrics from requests sent to a service
-   *    @param {function} monitoringCallbacks.request
-   *    @param {function} monitoringCallbacks.healthCheck
+ *    @param {function} monitoringCallbacks.request
+ *    @param {function} monitoringCallbacks.healthCheck
  */
 class DiscoveryProvider {
   constructor (


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Clean up the passlist/blocklist interface by pulling it up into the content node service itself. Add the new monitoringCallback functions to that config as well.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Locally invoked request and health check to verify that
2. Tested passlist/blocklist changes by manually supplying a blocklist from the dapp and making sure it was not selected.
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
