### PR TITLE
Add storage criteria cn selection [AUD-241]

### DIFF
--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -191,7 +191,9 @@ class CreatorNodeSelection extends ServiceSelection {
           this.currentVersion,
           resp.response.data.data.version
         )
-        isHealthy = isUp && versionIsUpToDate
+        const { storagePathSize, storagePathUsed } = resp.response.data.data
+        const hasEnoughStorage = this._hasEnoughStorageSpace({ storagePathSize, storagePathUsed })
+        isHealthy = isUp && versionIsUpToDate && hasEnoughStorage
       }
 
       if (!isHealthy) { this.addUnhealthy(endpoint) }
@@ -199,7 +201,7 @@ class CreatorNodeSelection extends ServiceSelection {
       return isHealthy
     })
 
-    this.decisionTree.push({ stage: DECISION_TREE_STATE.FILTER_OUT_UNHEALTHY_AND_OUTDATED, val: services })
+    this.decisionTree.push({ stage: DECISION_TREE_STATE.FILTER_OUT_UNHEALTHY_OUTDATED_AND_NO_STORAGE_SPACE, val: services })
 
     // Create a mapping of healthy services and their responses. Used on dapp to display the healthy services for selection
     // Also update services to be healthy services
@@ -210,6 +212,10 @@ class CreatorNodeSelection extends ServiceSelection {
     })
 
     return { healthyServicesList, healthyServicesMap: servicesMap }
+  }
+
+  _hasEnoughStorageSpace ({ storagePathSize, storagePathUsed }) {
+    return Math.round(100 * (storagePathUsed / storagePathSize)) < 90
   }
 }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -186,8 +186,10 @@ class CreatorNodeSelection extends ServiceSelection {
       const endpoint = resp.request.id
       let isHealthy = false
 
-      // Check that the health check responded with status code 200 and that the
-      // version is up to date on major and minor
+      // Check that the health check:
+      // 1. Responded with status code 200 and that the
+      // 2. Version is up to date on major and minor
+      // 3. Has enough storage space -- max capacity defined at the variable `this.maxStorageUsedPercent`
       if (resp.response) {
         const isUp = resp.response.status === 200
         const versionIsUpToDate = this.ethContracts.hasSameMajorAndMinorVersion(

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -27,6 +27,8 @@ class CreatorNodeSelection extends ServiceSelection {
     this.healthCheckPath = 'health_check/verbose'
     // String array of healthy Content Node endpoints
     this.backupsList = []
+    // Max percentage (represented out of 100) allowed before determining CN is unsuitable for selection
+    this.maxStoragePathUsage = 90
   }
 
   /**
@@ -215,7 +217,7 @@ class CreatorNodeSelection extends ServiceSelection {
   }
 
   _hasEnoughStorageSpace ({ storagePathSize, storagePathUsed }) {
-    return Math.round(100 * (storagePathUsed / storagePathSize)) < 90
+    return Math.round(100 * (storagePathUsed / storagePathSize)) < this.maxStoragePathUsage
   }
 }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -226,7 +226,7 @@ class CreatorNodeSelection extends ServiceSelection {
       storagePathUsed === undefined
     ) { return true }
 
-    return Math.ceil(100 * (storagePathUsed / storagePathSize)) < this.maxStorageUsedPercent
+    return (100 * storagePathUsed / storagePathSize) < this.maxStorageUsedPercent
   }
 }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -352,7 +352,7 @@ describe('test CreatorNodeSelection', () => {
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 
-  it.only('filters out nodes if over 90% of storage is used', async () => {
+  it('filters out nodes if over 90% of storage is used', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
       .get('/health_check/verbose')

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -371,7 +371,7 @@ describe('test CreatorNodeSelection', () => {
     const used95PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used95PercentStorage)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 95, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 90.354, storagePathSize: 100 } })
 
     const used99PercentStorage = 'https://used99PercentStorage.audius.co'
     nock(used99PercentStorage)
@@ -390,64 +390,6 @@ describe('test CreatorNodeSelection', () => {
       },
       numberOfNodes: 3,
       ethContracts: mockEthContracts([shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2, used95PercentStorage, used99PercentStorage], '1.2.3'),
-      whitelist: null,
-      blacklist: null
-    })
-
-    const { primary, secondaries, services } = await cns.select()
-
-    assert(primary === shouldBePrimary)
-    assert(secondaries.length === 2)
-    assert(secondaries.includes(shouldBeSecondary1))
-    assert(secondaries.includes(shouldBeSecondary2))
-
-    const returnedHealthyServices = new Set(Object.keys(services))
-    assert(returnedHealthyServices.size === 3)
-    const healthyServices = [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2]
-    healthyServices.map(service => assert(returnedHealthyServices.has(service)))
-  })
-
-  it('filters out CNs that have used up 89.xx% of storage', async () => {
-    const shouldBePrimary = 'https://primary.audius.co'
-    nock(shouldBePrimary)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 30, storagePathSize: 100 } })
-
-    const shouldBeSecondary1 = 'https://secondary1.audius.co'
-    nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.1', storagePathUsed: 30, storagePathSize: 100 } })
-
-    const shouldBeSecondary2 = 'https://secondary2.audius.co'
-    nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0', storagePathUsed: 30, storagePathSize: 100 } })
-
-    const usedAlmost90PercentStorage1 = 'https://usedAlmost90PercentStorage1.audius.co'
-    nock(usedAlmost90PercentStorage1)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 89.95, storagePathSize: 100 } })
-
-    const usedAlmost90PercentStorage2 = 'https://usedAlmost90PercentStorage2.audius.co'
-    nock(usedAlmost90PercentStorage2)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 89.01, storagePathSize: 100 } })
-
-    const cns = new CreatorNodeSelection({
-      // Mock Creator Node
-      creatorNode: {
-        getSyncStatus: async () => {
-          return {
-            isBehind: false,
-            isConfigured: true
-          }
-        }
-      },
-      numberOfNodes: 3,
-      ethContracts: mockEthContracts(
-        [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2, usedAlmost90PercentStorage1, usedAlmost90PercentStorage2],
-        '1.2.3'
-      ),
       whitelist: null,
       blacklist: null
     })
@@ -489,7 +431,7 @@ describe('test CreatorNodeSelection', () => {
     const used70PercentStorage = 'https://used70PercentStorage.audius.co'
     nock(used70PercentStorage)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 70, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 70.546, storagePathSize: 100 } })
 
     const cns = new CreatorNodeSelection({
       // Mock Creator Node

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -26,42 +26,44 @@ const mockEthContracts = (urls, currrentVersion, previousVersions = null) => ({
   }
 })
 
+// Add fields as necessary
+let defaultHealthCheckData = {
+  'service': CREATOR_NODE_SERVICE_NAME,
+  'version': '1.2.3',
+  'healthy': true,
+  'country': 'US',
+  'latitude': '37.7749',
+  'longitude': '-122.4194',
+  'databaseConnections': 5,
+  'totalMemory': 6237552640,
+  'usedMemory': 6111436800,
+  'storagePathSize': 62725623808,
+  'storagePathUsed': 14723018752,
+  'maxFileDescriptors': 524288,
+  'allocatedFileDescriptors': 2912,
+  'receivedBytesPerSec': null,
+  'transferredBytesPerSec': 39888.88888888889
+}
+
 describe('test CreatorNodeSelection', () => {
   it('selects the fastest healthy service as primary and rest as secondaries', async () => {
     const healthy = 'https://healthy.audius.co'
+
     nock(healthy)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlow = 'https://healthybutslow.audius.co'
     nock(healthyButSlow)
       .get('/health_check/verbose')
       .delay(100)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlowest = 'https://healthybutslowest.audius.co'
     nock(healthyButSlowest)
       .get('/health_check/verbose')
       .delay(200)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     const cns = new CreatorNodeSelection({
       // Mock Creator Node
@@ -96,46 +98,22 @@ describe('test CreatorNodeSelection', () => {
     const upToDate = 'https://upToDate.audius.co'
     nock(upToDate)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     const behindMajor = 'https://behindMajor.audius.co'
     nock(behindMajor)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '0.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '0.2.3' } })
 
     const behindMinor = 'https://behindMinor.audius.co'
     nock(behindMinor)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.0.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.0.3' } })
 
     const behindPatch = 'https://behindPatch.audius.co'
     nock(behindPatch)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.0',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
     const cns = new CreatorNodeSelection({
       // Mock Creator Node
@@ -165,7 +143,7 @@ describe('test CreatorNodeSelection', () => {
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 
-  it('select from unhealthy if all are unhealthy', async () => {
+  it('return nothing if no services are healthy', async () => {
     const unhealthy1 = 'https://unhealthy1.audius.co'
     nock(unhealthy1)
       .get('/health_check/verbose')
@@ -227,38 +205,20 @@ describe('test CreatorNodeSelection', () => {
     nock(shouldBePrimary)
       .get('/health_check/verbose')
       .delay(200)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     // cold, overnight pizza -- behind by minor version, fast. nope
     const unhealthy2 = 'https://unhealthy2.audius.co'
     nock(unhealthy2)
       .get('/health_check/verbose')
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.0.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.0.3' } })
 
     // stale chips from 2 weeks ago -- behind by major version, kinda slow. still nope
     const unhealthy3 = 'https://unhealthy3.audius.co'
     nock(unhealthy3)
       .get('/health_check/verbose')
       .delay(100)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '0.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '0.2.3' } })
 
     // moldy canned beans -- not available/up at all. for sure nope
     const unhealthy1 = 'https://unhealthy1.audius.co'
@@ -271,13 +231,7 @@ describe('test CreatorNodeSelection', () => {
     nock(shouldBeSecondary)
       .get('/health_check/verbose')
       .delay(100)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.0',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
     const cns = new CreatorNodeSelection({
       // Mock Creator Node
@@ -322,13 +276,7 @@ describe('test CreatorNodeSelection', () => {
       nock(healthyUrl)
         .persist()
         .get('/health_check/verbose')
-        .reply(200, { data: {
-          service: CREATOR_NODE_SERVICE_NAME,
-          version: '1.2.3',
-          country: 'US',
-          latitude: '37.7058',
-          longitude: '-122.4619'
-        } })
+        .reply(200, { data: defaultHealthCheckData })
       contentNodes.push(healthyUrl)
     }
 
@@ -363,25 +311,13 @@ describe('test CreatorNodeSelection', () => {
     nock(shouldBePrimary)
       .get('/health_check/verbose')
       .delay(200)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.3',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: defaultHealthCheckData })
 
     const shouldBeSecondary = 'https://secondary.audius.co'
     nock(shouldBeSecondary)
       .get('/health_check/verbose')
       .delay(100)
-      .reply(200, { data: {
-        service: CREATOR_NODE_SERVICE_NAME,
-        version: '1.2.0',
-        country: 'US',
-        latitude: '37.7058',
-        longitude: '-122.4619'
-      } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
     const unhealthy = 'https://unhealthy.audius.co'
     nock(unhealthy)
@@ -413,6 +349,61 @@ describe('test CreatorNodeSelection', () => {
     const returnedHealthyServices = new Set(Object.keys(services))
     assert(returnedHealthyServices.size === 2)
     const healthyServices = [shouldBePrimary, shouldBeSecondary]
+    healthyServices.map(service => assert(returnedHealthyServices.has(service)))
+  })
+
+  it.only('filters out nodes if over 90% of storage is used', async () => {
+    const shouldBePrimary = 'https://primary.audius.co'
+    nock(shouldBePrimary)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 30, storagePathSize: 100 } })
+
+    const shouldBeSecondary1 = 'https://secondary1.audius.co'
+    nock(shouldBeSecondary1)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.1', storagePathUsed: 30, storagePathSize: 100 } })
+
+    const shouldBeSecondary2 = 'https://secondary2.audius.co'
+    nock(shouldBeSecondary2)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0', storagePathUsed: 30, storagePathSize: 100 } })
+
+    const used95PercentStorage = 'https://used95PercentStorage.audius.co'
+    nock(used95PercentStorage)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 95, storagePathSize: 100 } })
+
+    const used99PercentStorage = 'https://used99PercentStorage.audius.co'
+    nock(used99PercentStorage)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 99, storagePathSize: 100 } })
+
+    const cns = new CreatorNodeSelection({
+      // Mock Creator Node
+      creatorNode: {
+        getSyncStatus: async () => {
+          return {
+            isBehind: false,
+            isConfigured: true
+          }
+        }
+      },
+      numberOfNodes: 3,
+      ethContracts: mockEthContracts([shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2, used95PercentStorage, used99PercentStorage], '1.2.3'),
+      whitelist: null,
+      blacklist: null
+    })
+
+    const { primary, secondaries, services } = await cns.select()
+
+    assert(primary === shouldBePrimary)
+    assert(secondaries.length === 2)
+    assert(secondaries.includes(shouldBeSecondary1))
+    assert(secondaries.includes(shouldBeSecondary2))
+
+    const returnedHealthyServices = new Set(Object.keys(services))
+    assert(returnedHealthyServices.size === 3)
+    const healthyServices = [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2]
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 })

--- a/libs/src/services/creatorNode/constants.js
+++ b/libs/src/services/creatorNode/constants.js
@@ -4,7 +4,7 @@ module.exports = {
     GET_ALL_SERVICES: 'Get All Services',
     FILTER_TO_WHITELIST: 'Filter To Whitelist',
     FILTER_FROM_BLACKLIST: 'Filter From Blacklist',
-    FILTER_OUT_UNHEALTHY_AND_OUTDATED: 'Filter Out Unhealthy And Outdated',
+    FILTER_OUT_UNHEALTHY_OUTDATED_AND_NO_STORAGE_SPACE: 'Filter Out Unhealthy, Outdated, And No Storage Space',
     FILTER_OUT_SYNC_IN_PROGRESS: 'Filter Out Sync In Progress',
     SELECT_PRIMARY_AND_SECONDARIES: 'Select Primary And Secondaries'
   })


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

**Current:**  Content Nodes can be chosen as part of a replica set even if it has almost reached storage capacity. This can allow for potential downtime if further CN writes occur. 

**Proposal:** Content Nodes that do not have sufficient storage should not be chosen as a replica set member. We should filter out nodes that do not have enough storage space.

**New**:
1. Add filter by storage criteria into the Content Node selection logic
2. Add the ability to define what the storage capacity is (default is 90%)
3. If storage data is unavailable, default that the Content Node is available
4. Update decision tree states to include no storage label
5. Unit tests (see below): added test scenarios + refactored default health check responses to a global var instead of recreating it in every test

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Unit Tests: 
1. Should allow for a custom `maxStorageUsedPercent` constructor param and allow for a default value of 90%
2. Should filter out any CNodes that are >=`maxStorageUsedPercent` full
3. Allows for CNodes to be selected if storage information is unavailable from request response

Dapp:
(the logs are not in this PR)
<img width="1563" alt="quick maths" src="https://user-images.githubusercontent.com/60366641/106969401-98222400-66ff-11eb-8173-c9089624591e.png">
