### PR TITLE
[AUD-265] Fix signTypedData for non 0x-prefixed strings

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -3448,15 +3448,13 @@
       }
     },
     "eth-sig-util": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.2.tgz",
-      "integrity": "sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
+      "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
       "requires": {
-        "buffer": "^5.2.1",
-        "elliptic": "^6.4.0",
-        "ethereumjs-abi": "0.6.5",
+        "ethereumjs-abi": "0.6.8",
         "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.0",
+        "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.0"
       },
       "dependencies": {
@@ -3567,26 +3565,12 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^4.3.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-          "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
-          "requires": {
-            "bn.js": "^4.8.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.0.0"
-          }
-        }
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
       }
     },
     "ethereumjs-common": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -25,7 +25,7 @@
     "async-retry": "^1.2.3",
     "axios": "^0.19.0",
     "bs58": "^4.0.1",
-    "eth-sig-util": "2.5.2",
+    "eth-sig-util": "^2.5.4",
     "ethereumjs-tx": "^1.3.7",
     "form-data": "^3.0.0",
     "jsonschema": "^1.2.6",

--- a/libs/src/services/web3Manager/index.js
+++ b/libs/src/services/web3Manager/index.js
@@ -127,6 +127,19 @@ class Web3Manager {
     if (this.useExternalWeb3) {
       return ethSignTypedData(this.getWeb3(), this.getWalletAddress(), signatureData)
     } else {
+      // Due to changes in ethereumjs-util's toBuffer method as of v6.2.0
+      // non hex-prefixed string values are not permitted and need to be
+      // provided directly as a buffer.
+      // https://github.com/ethereumjs/ethereumjs-util/releases/tag/v6.2.0
+      Object.keys(signatureData.message).forEach(key => {
+        if (
+          typeof signatureData.message[key] === 'string' &&
+          !signatureData.message[key].startsWith('0x')
+        ) {
+          signatureData.message[key] = Buffer.from(signatureData.message[key])
+        }
+      })
+
       return sigUtil.signTypedData(
         this.ownerWallet.getPrivateKey(),
         { data: signatureData }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Fixes a bug caused by updating the version of eth-sig-util (and transitively ethereumjs-utils). The `Buffer.from` change here effectively emulates what `toBuffer`'s behavior was prior to the upgraded version.

See the linear issue for more details.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Created account pointed against staging (otherwise would not work).
2. Created a playlist on staging as well to test non-user actions
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

Touches all signed data