### PR TITLE
Move hasEnoughStorageSpace into index.js

### DIFF
--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -1,4 +1,5 @@
 const ServiceSelection = require('../../service-selection/ServiceSelection')
+const CreatorNode = require('../../services/creatorNode/index')
 const { timeRequestsAndSortByVersion } = require('../../utils/network')
 const { CREATOR_NODE_SERVICE_NAME, DECISION_TREE_STATE } = require('./constants')
 
@@ -197,7 +198,11 @@ class CreatorNodeSelection extends ServiceSelection {
           resp.response.data.data.version
         )
         const { storagePathSize, storagePathUsed } = resp.response.data.data
-        const hasEnoughStorage = this._hasEnoughStorageSpace({ storagePathSize, storagePathUsed })
+        const hasEnoughStorage = CreatorNode.hasEnoughStorageSpace({
+          storagePathSize,
+          storagePathUsed,
+          maxStorageUsedPercent: this.maxStorageUsedPercent
+        })
         isHealthy = isUp && versionIsUpToDate && hasEnoughStorage
       }
 
@@ -217,18 +222,6 @@ class CreatorNodeSelection extends ServiceSelection {
     this.decisionTree.push({ stage: DECISION_TREE_STATE.FILTER_OUT_UNHEALTHY_OUTDATED_AND_NO_STORAGE_SPACE, val: healthyServicesList })
 
     return { healthyServicesList, healthyServicesMap: servicesMap }
-  }
-
-  _hasEnoughStorageSpace ({ storagePathSize, storagePathUsed }) {
-    // If for any reason these values off the response is falsy value, default to enough storage
-    if (
-      storagePathSize === null ||
-      storagePathSize === undefined ||
-      storagePathUsed === null ||
-      storagePathUsed === undefined
-    ) { return true }
-
-    return (100 * storagePathUsed / storagePathSize) < this.maxStorageUsedPercent
   }
 }
 

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -73,6 +73,25 @@ class CreatorNode {
     return null
   }
 
+  /**
+   * Checks to see if the Content Node has enough Storage
+   * @param {Object} param
+   * @param {number} param.storagePathSize total size of storage
+   * @param {number} param.storagePathUsed total used storage
+   * @param {number} param.maxStorageUsedPercent max percentage of storage allowed to be used before blocking writes
+   */
+  static hasEnoughStorageSpace ({ storagePathSize, storagePathUsed, maxStorageUsedPercent }) {
+    // If for any reason these values off the response is a falsy value, default to enough storage
+    if (
+      storagePathSize === null ||
+      storagePathSize === undefined ||
+      storagePathUsed === null ||
+      storagePathUsed === undefined
+    ) { return true }
+
+    return (100 * storagePathUsed / storagePathSize) < maxStorageUsedPercent
+  }
+
   /* -------------- */
 
   constructor (web3Manager, creatorNodeEndpoint, isServer, userStateManager, lazyConnect, schemas) {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This moves the function `hasEnoughStorageSpace` into `libs/src/services/creatorNode/index.js` so that it may be used in `middleware.js`. 

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

None