### PR TITLE
Turn off discovery lint temporarily until we fix all outstanding lint issues and CircleCI accurately reflects the lint errors 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,12 +474,12 @@ jobs:
           paths:
             - discovery-provider/venv/
           key: disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
-      - run:
-          name: python-lint
-          command: |
-            cd discovery-provider
-            source venv/bin/activate
-            python ./scripts/lint.py
+      # - run:
+      #     name: python-lint
+      #     command: |
+      #       cd discovery-provider
+      #       source venv/bin/activate
+      #       python ./scripts/lint.py
       - restore_cache:
           keys:
           - disc-prov-contracts-{{ checksum "contracts/package.json" }}

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -48,7 +48,7 @@ user_replica_set_manager = None
 contract_addresses = None
 
 logger = logging.getLogger(__name__)
-
+logger.info("hello") # will be removed, just for testing this branch
 
 def init_contracts():
     registry_address = web3.toChecksumAddress(

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -48,7 +48,7 @@ user_replica_set_manager = None
 contract_addresses = None
 
 logger = logging.getLogger(__name__)
-logger.info("hello") # will be removed, just for testing this branch
+
 
 def init_contracts():
     registry_address = web3.toChecksumAddress(


### PR DESCRIPTION
### Description
Turn off discovery lint temporarily until we fix all outstanding lint issues and CircleCI accurately reflects the lint errors 

### Tests
CI no longer runs this step
https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/7838/workflows/e10d3b01-d9f3-4c97-92b4-c2c502aafc46/jobs/58661

Compare to nightly master build https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/7835/workflows/f62f76ff-cb15-402f-9782-f9ea37b356a1/jobs/58640

The actual work to fix lint and have CircleCI reflect it correctly is here https://github.com/AudiusProject/audius-protocol/pull/1220