### PR TITLE
Fix discovery lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,10 +490,10 @@ jobs:
           command: |
             cd contracts
             npm install
-      - save_cache:
-          paths:
-            - contracts/node_modules
-          key: disc-prov-contracts-{{ checksum "contracts/package.json" }}
+      # - save_cache:
+      #     paths:
+      #       - contracts/node_modules
+      #     key: disc-prov-contracts-{{ checksum "contracts/package.json" }}
       - run:
           name: discovery provider tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,10 +459,10 @@ jobs:
           condition: << parameters.force >>
           steps:
             - run: ./diff.sh discovery-provider || (echo "no diff" && circleci-agent step halt)
-      - restore_cache:
-          keys:
-            - disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
-            - disc-prov-1-
+      # - restore_cache:
+      #     keys:
+      #       - disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
+      #       - disc-prov-1-
       - run:
           name: python-setup
           command: |
@@ -470,17 +470,21 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install -r requirements.txt
+      # - save_cache:
+      #     paths:
+      #       - discovery-provider/venv/
+      #     key: disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
       - run:
           name: python-lint
           command: |
             cd discovery-provider
             source venv/bin/activate
             python ./scripts/lint.py
-      - restore_cache:
-          keys:
-          - disc-prov-contracts-{{ checksum "contracts/package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - disc-prov-contracts-
+      # - restore_cache:
+      #     keys:
+      #     - disc-prov-contracts-{{ checksum "contracts/package.json" }}
+      #     # fallback to using the latest cache if no exact match is found
+      #     - disc-prov-contracts-
       - run:
           name: contract repo init
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,10 +470,6 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install -r requirements.txt
-      - save_cache:
-          paths:
-            - discovery-provider/venv/
-          key: disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
       - run:
           name: python-lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,7 +479,9 @@ jobs:
           command: |
             cd discovery-provider
             source venv/bin/activate
-            python ./scripts/lint.py
+            pylint src/
+            pylint tests/
+            # python ./scripts/lint.py
       # - restore_cache:
       #     keys:
       #     - disc-prov-contracts-{{ checksum "contracts/package.json" }}

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -48,7 +48,7 @@ user_replica_set_manager = None
 contract_addresses = None
 
 logger = logging.getLogger(__name__)
-
+logger.info("hello") # will be removed, just for testing this branch
 
 def init_contracts():
     registry_address = web3.toChecksumAddress(

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -48,7 +48,6 @@ user_replica_set_manager = None
 contract_addresses = None
 
 logger = logging.getLogger(__name__)
-logger.info("hello") # will be removed, just for testing this branch
 
 def init_contracts():
     registry_address = web3.toChecksumAddress(

--- a/discovery-provider/src/monitors/monitors.py
+++ b/discovery-provider/src/monitors/monitors.py
@@ -144,6 +144,7 @@ def parse_value(monitor, value):
         value: string The value to parse
     """
     try:
+        # pylint: disable=R1705
         if monitor[monitor_names.type] == 'bool':
             return value == 'True'
         elif monitor[monitor_names.type] == 'int':
@@ -154,7 +155,7 @@ def parse_value(monitor, value):
             return json.loads(value)
         else: # string
             return str(value)
-    except Exception as e:
+    except Exception:
         return str(value)
 
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -158,7 +158,8 @@ def update_user_replica_set_manager_address_if_necessary(self):
             logger.info(f"index.py | Updated user_replica_set_manager_address={user_replica_set_manager_address}")
         else:
             logger.info(
-                f"index.py | No update to user_replica_set_manager address, queried {user_replica_set_manager_address} from registry"
+                f"index.py | No update to user_replica_set_manager address, queried "
+                f"{user_replica_set_manager_address} from registry"
             )
 
 def index_blocks(self, db, blocks_list):
@@ -472,7 +473,7 @@ def revert_blocks(self, db, revert_blocks_list):
                 # Remove track entries
                 logger.info(f"Reverting track: {track_to_revert}")
                 session.delete(track_to_revert)
-            
+
             for usrm_content_node_to_revert in revert_usrm_content_node_entries:
                 cnode_sp_id = usrm_content_node_to_revert.cnode_sp_id
                 previous_usrm_content_node_entry = (

--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -39,8 +39,7 @@ def fetch_cnode_info(sp_id, sp_factory_instance):
     ).call()
     pickle_and_set(redis, sp_id_key, cn_endpoint_info, cnode_info_redis_ttl)
     logger.info(
-        f"index_network_peers.py | Configured redis cache with "
-        f"{sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl}"
+        f"index_network_peers.py | Configured redis cache with {sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl}"
     )
     return cn_endpoint_info
 

--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -39,7 +39,8 @@ def fetch_cnode_info(sp_id, sp_factory_instance):
     ).call()
     pickle_and_set(redis, sp_id_key, cn_endpoint_info, cnode_info_redis_ttl)
     logger.info(
-        f"index_network_peers.py | Configured redis cache with {sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl}"
+        f"index_network_peers.py | Configured redis cache with "
+        f"{sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl}"
     )
     return cn_endpoint_info
 


### PR DESCRIPTION
### Description
Fix lint non-determinism in our CI

Update - nondeterminism of passing comes from pylint and our script, not from CircleCI. The script checks if the value of the pylint rating is 10/10 and that's a success. For example, here's a run with a few code errors but the rating is 10/10

```
(venv) circleci@c4d70b56ef9b:~/project/discovery-provider$ python3 scripts/lint.py 
Linting src/
************* Module src.tasks.index_network_peers
 src/tasks/index_network_peers.py:42: convention (C0301, line-too-long, ) Line too long (125/120)
 src/tasks/index_network_peers.py:44: convention (C0301, line-too-long, ) Line too long (154/120)
 
 --------------------------------------------------------------------
 Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
 
  True
Linting tests/

 --------------------------------------------------------------------
 Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
 
  True

```



### Tests
Tests passing in CI
