### PR TITLE
[AUD-272] Pin crypto dep versions

### DIFF
--- a/libs/initScripts/manageProdRelayerWallets.js
+++ b/libs/initScripts/manageProdRelayerWallets.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3')
 const crypto = require('crypto')
 const EthereumWallet = require('ethereumjs-wallet')
-const EthereumTx = require('ethereumjs-tx')
+const EthereumTx = require('ethereumjs-tx').Transaction
 const axios = require('axios')
 
 // Switch to mainnet eth - ropsten is enabled by default to prevent accidental prod manipulation

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -3489,11 +3489,6 @@
         }
       }
     },
-    "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-    },
     "ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -3579,39 +3574,12 @@
       "integrity": "sha512-aVUPRLgmXORGXXEVkFYgPhr9TGtpBY2tGhZ9Uh0A3lIUzUDr1x6kQx33SbjPUkLkX3eniPQnIL/2psjkjrOfcQ=="
     },
     "ethereumjs-tx": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        }
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-util": "^6.0.0"
       }
     },
     "ethereumjs-util": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -18,8 +18,8 @@
     "lint-fix": "./node_modules/.bin/standard --fix"
   },
   "dependencies": {
-    "@audius/hedgehog": "^1.0.8",
-    "@ethersproject/solidity": "^5.0.5",
+    "@audius/hedgehog": "1.0.8",
+    "@ethersproject/solidity": "5.0.5",
     "abi-decoder": "1.2.0",
     "ajv": "^6.12.2",
     "async-retry": "^1.2.3",

--- a/libs/package.json
+++ b/libs/package.json
@@ -20,20 +20,20 @@
   "dependencies": {
     "@audius/hedgehog": "^1.0.8",
     "@ethersproject/solidity": "^5.0.5",
-    "abi-decoder": "^1.2.0",
+    "abi-decoder": "1.2.0",
     "ajv": "^6.12.2",
     "async-retry": "^1.2.3",
     "axios": "^0.19.0",
-    "bs58": "^4.0.1",
-    "eth-sig-util": "^2.5.4",
-    "ethereumjs-tx": "^1.3.7",
+    "bs58": "4.0.1",
+    "eth-sig-util": "2.5.4",
+    "ethereumjs-tx": "2.1.2",
     "form-data": "^3.0.0",
     "jsonschema": "^1.2.6",
     "lodash": "^4.17.11",
     "node-localstorage": "^1.3.1",
     "proper-url-join": "^1.2.0",
     "semver": "^6.3.0",
-    "web3": "^1.2.7"
+    "web3": "1.2.7"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.6",

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -1,6 +1,6 @@
 const Web3 = require('../../web3')
 const MultiProvider = require('../../utils/multiProvider')
-const EthereumTx = require('ethereumjs-tx')
+const EthereumTx = require('ethereumjs-tx').Transaction
 const retry = require('async-retry')
 const DEFAULT_GAS_AMOUNT = 200000
 const MIN_GAS_PRICE = Math.pow(10, 9) // 1 GWei, POA default gas price


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Pins versions of crypto packages in libs after major breakage caused by patch upgrade to eth-sig-util (https://github.com/AudiusProject/audius-protocol/pull/1216).

All versions pinned are the same as what they were already set to in package-lock.json, except for 

`ethereum-tx`
which I upped to 2.x.x.

This package is used in two places:
1. manageProdRelayerWallets.js
2. ethWeb3Manager (for non-relayed tx's).

Both of these places use the ctor as the only interaction and from the docs-side this did not change:
https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx

And neither of these locations impact main product flows.

The reason I upped this package is we were already consuming ethereum-tx in several places with ^2.x.x requirements and we were requiring a duplicate dep because of the disparity. ethereum-tx is active dev on 3.x.x now


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. In order to test manageProdRelayerWallets.js, I ran the script to fund wallets with necessary config, which constructed the tx without issues.

2. In order to test ethWeb3Manager's use, the unit tests for audiusTokenClient exercise this call path partially -- I stubbed the code to manually exercise creating the EthereumTx (with a bad private key) and construction went fine
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
