### PR TITLE
[AUD-274] Allow skipping db migrations in discovery init

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -31,6 +31,7 @@ url = redis://localhost:5379/0
 [db]
 url = postgresql+psycopg2://postgres@localhost/audius_discovery
 url_read_replica = postgresql+psycopg2://postgres@localhost/audius_discovery
+run_migrations = true
 engine_args_literal = {
     'pool_size': 10,
     'max_overflow': 0,

--- a/discovery-provider/scripts/prod-web-server.sh
+++ b/discovery-provider/scripts/prod-web-server.sh
@@ -20,6 +20,7 @@ docker run \
   -p 5000:5000 \
   -e audius_db_url=$DB_URL \
   -e audius_db_url_read_replica=$DB_URL \
+  -e audius_db_run_migrations=false \
   discprov_read_only  /bin/bash -c ./scripts/dev-server.sh --build web-server
 
 trap stop EXIT

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -243,7 +243,7 @@ def configure_flask(test_config, app, mode="app"):
             # into bool for you
             if shared_config.getboolean("db", "run_migrations"):
                 logger.error('running migrations')
-                # alembic.command.upgrade(alembic_config, "head")
+                alembic.command.upgrade(alembic_config, "head")
 
     if test_config is not None:
         # load the test config if passed in

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -239,8 +239,8 @@ def configure_flask(test_config, app, mode="app"):
         alembic_config.set_main_option("sqlalchemy.url", str(database_url))
         with helpers.cd(alembic_dir):
             # run migrations unless `run_migrations` overridden to false. default value is true
-            # need to call with getboolean because configparser doesn't allow you to store non string types and it coerces
-            # into bool for you
+            # need to call with getboolean because configparser doesn't allow you to
+            # store non string types and it coerces into bool for you
             if shared_config.getboolean("db", "run_migrations"):
                 logger.info('running alembic db migrations')
                 alembic.command.upgrade(alembic_config, "head")

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -238,7 +238,12 @@ def configure_flask(test_config, app, mode="app"):
         alembic_config = alembic.config.Config(f"{alembic_dir}/alembic.ini")
         alembic_config.set_main_option("sqlalchemy.url", str(database_url))
         with helpers.cd(alembic_dir):
-            alembic.command.upgrade(alembic_config, "head")
+            # run migrations unless `run_migrations` overridden to false. default value is true
+            # need to call with getboolean because configparser doesn't allow you to store non string types and it coerces
+            # into bool for you
+            if shared_config.getboolean("db", "run_migrations"):
+                logger.error('running migrations')
+                # alembic.command.upgrade(alembic_config, "head")
 
     if test_config is not None:
         # load the test config if passed in

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -238,7 +238,7 @@ def configure_flask(test_config, app, mode="app"):
         alembic_config = alembic.config.Config(f"{alembic_dir}/alembic.ini")
         alembic_config.set_main_option("sqlalchemy.url", str(database_url))
         with helpers.cd(alembic_dir):
-            # run migrations unless `run_migrations` overridden to false. default value is true
+            # run db migrations unless `run_migrations` overridden to false. default value is true
             # need to call with getboolean because configparser doesn't allow you to
             # store non string types and it coerces into bool for you
             if shared_config.getboolean("db", "run_migrations"):

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -242,7 +242,7 @@ def configure_flask(test_config, app, mode="app"):
             # need to call with getboolean because configparser doesn't allow you to store non string types and it coerces
             # into bool for you
             if shared_config.getboolean("db", "run_migrations"):
-                logger.error('running migrations')
+                logger.info('running alembic db migrations')
                 alembic.command.upgrade(alembic_config, "head")
 
     if test_config is not None:

--- a/discovery-provider/tests/conftest.py
+++ b/discovery-provider/tests/conftest.py
@@ -21,7 +21,12 @@ ENGINE_ARGS_LITERAL = '{ \
     "connect_args": {"options": "-c timezone=utc"},}'
 
 TEST_CONFIG_OVERRIDE = {
-    "db": {"url": DB_URL, "url_read_replica": DB_URL, "engine_args_literal": ENGINE_ARGS_LITERAL}
+    "db": {
+        "url": DB_URL,
+        "url_read_replica": DB_URL,
+        "engine_args_literal": ENGINE_ARGS_LITERAL,
+        "run_migrations": "true"
+    }
 }
 
 


### PR DESCRIPTION
### Description
Right now discovery init always runs migration. While the efficacy of running migrations on server init is debatable, one common pattern that causes problems is connecting to a stage or prod database to test query changes and accidentally running migrations on that database. This PR aims to prevent that by setting `audius_db_run_migrations` to false in prod-web-server.sh, but set to true by default so migrations run in all other cases.


### Tests
I tested this by running against the prod-web-server.sh and toggled the flag to true and false. Here's the test code. I've removed the else condition for the actual commit, but this serves to illustrate the expected behavior.
```python3
with helpers.cd(alembic_dir):
  # run migrations unless `run_migrations` overridden to false. default value is true
  # need to call with getboolean because configparser doesn't allow you to store non string types and it coerces
  # into bool for you
  logger.error(f"value of run_migrations {shared_config.getboolean('db', 'run_migrations')}")
  if shared_config.getboolean("db", "run_migrations"):
      logger.error('running migrations')
  else:
      logger.error('not running migrations')
```
and the results when run_migrations is set to true
```
 * Debugger is active!
 * Debugger PIN: 165-143-728
value of run_migrations True
running migrations
```
and the results when run_migrations is set to false
```
 * Debugger is active!
 * Debugger PIN: 313-711-535
value of run_migrations False
not running migrations
```

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
