### PR TITLE
Add api endpoint to get recommended tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.swn
 .vscode
 node_modules/
+
+.idea

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -287,10 +287,10 @@ MIN_LIMIT = 1
 MAX_LIMIT = 500
 DEFAULT_OFFSET = 0
 MIN_OFFSET = 0
-def format_limit(args, max_limit=MAX_LIMIT):
-    lim = args.get("limit", DEFAULT_LIMIT)
+def format_limit(args, max_limit=MAX_LIMIT, default_limit=DEFAULT_LIMIT):
+    lim = args.get("limit", default_limit)
     if lim is None:
-        return DEFAULT_LIMIT
+        return default_limit
 
     return max(min(int(lim), max_limit), MIN_LIMIT)
 

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -1,0 +1,32 @@
+import logging  # pylint: disable=C0302
+import random
+
+from src.api.v1.helpers import extend_track, decode_string_id
+from src.queries.get_trending_tracks import get_trending_tracks
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RANDOM_LIMIT = 10
+
+def get_random_tracks(args):
+    """Gets random tracks from trending by getting the currently cached tracks and then populating them."""
+    exclusion_list = args.get("exclusion_list") or []
+    time = args.get("time") if args.get("time") is not None else 'week'
+    current_user_id = args.get("user_id")
+    args = {
+        'time': time,
+        'genre': args.get("genre", None),
+        'with_users': True,
+        'limit': args.get("limit"),
+        'offset': 0
+    }
+
+    # decode and add user_id if necessary
+    if current_user_id:
+        args["current_user_id"] = decode_string_id(current_user_id)
+
+    tracks = get_trending_tracks(args)
+    filtered_tracks = list(filter(lambda track: track['track_id'] not in exclusion_list, tracks))
+
+    random.shuffle(filtered_tracks)
+    return list(map(extend_track, filtered_tracks))

--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -1,12 +1,9 @@
 import logging  # pylint: disable=C0302
 
-from src.queries.get_trending_tracks import get_trending_tracks
+from src.queries.get_trending_tracks import get_trending_tracks, TRENDING_LIMIT
 from src.api.v1.helpers import extend_track, decode_string_id
 
 logger = logging.getLogger(__name__)
-
-TRENDING_LIMIT = 100
-TRENDING_TTL_SEC = 30 * 60
 
 def get_trending(args):
     """Get Trending, shared between full and regular endpoints."""

--- a/discovery-provider/src/queries/get_trending_ids.py
+++ b/discovery-provider/src/queries/get_trending_ids.py
@@ -1,6 +1,7 @@
 import logging
 from src.utils.redis_cache import extract_key, use_redis_cache
-from src.queries.get_trending import TRENDING_TTL_SEC, get_trending
+from src.queries.get_trending import get_trending
+from src.queries.get_trending_tracks import TRENDING_TTL_SEC
 
 logger = logging.getLogger(__name__)
 

--- a/libs/src/api/track.js
+++ b/libs/src/api/track.js
@@ -25,9 +25,8 @@ class Track extends Base {
     super(...args)
     this.getTracks = this.getTracks.bind(this)
     this.getTracksIncludingUnlisted = this.getTracksIncludingUnlisted.bind(this)
-    this.getTracks = this.getTracks.bind(this)
-    this.getTracksIncludingUnlisted = this.getTracksIncludingUnlisted.bind(this)
     this.getUnlistedTracks = this.getUnlistedTracks.bind(this)
+    this.getRandomTracks = this.getRandomTracks.bind(this)
     this.getStemsForTrack = this.getStemsForTrack.bind(this)
     this.getRemixesOfTrack = this.getRemixesOfTrack.bind(this)
     this.getRemixTrackParents = this.getRemixTrackParents.bind(this)
@@ -106,6 +105,22 @@ class Track extends Base {
   async getUnlistedTracks () {
     this.REQUIRES(Services.CREATOR_NODE)
     return this.creatorNode.getUnlistedTracks()
+  }
+
+  /**
+   * Gets random tracks from trending tracks for a given genre.
+   * If genre not given, will return trending tracks across all genres.
+   * Excludes specified track ids.
+   *
+   * @param {string} genre
+   * @param {number} limit
+   * @param {number[]} exclusionList
+   * @param {string} time
+   * @returns {(Array)} track
+   */
+  async getRandomTracks (genre, limit, exclusionList, time) {
+    this.REQUIRES(Services.DISCOVERY_PROVIDER)
+    return this.discoveryProvider.getRandomTracks(genre, limit, exclusionList, time)
   }
 
   /**

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -161,6 +161,22 @@ class DiscoveryProvider {
   }
 
   /**
+   * Gets random tracks from trending tracks for a given genre.
+   * If genre not given, will return trending tracks across all genres.
+   * Excludes specified track ids.
+   *
+   * @param {string} genre
+   * @param {number} limit
+   * @param {number[]} exclusionList
+   * @param {string} time
+   * @returns {(Array)} track
+   */
+  async getRandomTracks (genre, limit, exclusionList, time) {
+    const req = Requests.getRandomTracks(genre, limit, exclusionList, time)
+    return this._makeRequest(req)
+  }
+
+  /**
    * Gets all stems for a given trackId as an array of tracks.
    * @param {number} trackId
    * @returns {(Array)} track

--- a/libs/src/services/discoveryProvider/requests.js
+++ b/libs/src/services/discoveryProvider/requests.js
@@ -65,6 +65,19 @@ module.exports.getTracksIncludingUnlisted = (identifiers, withUsers = false) => 
   return req
 }
 
+module.exports.getRandomTracks = (genre, limit, exclusionList, time) => {
+  let req = {
+    endpoint: 'tracks/random',
+    queryParams: {
+      genre,
+      limit,
+      exclusionList,
+      time
+    }
+  }
+  return req
+}
+
 module.exports.getStemsForTrack = (trackId) => {
   const req = {
     endpoint: `stems/${trackId}`,


### PR DESCRIPTION
### Description
Add endpoint to fetch random trending tracks for autoplay feature.

### Tests
Spun up local version of discovery provider with the changes and checked that API calls work. The new endpoint shares similar logic to the /tracks/trending endpoint, with some additional processing.
