### PR TITLE
Jowlee dp concurrent search update

### DIFF
--- a/discovery-provider/alembic/versions/579360c7cbf3_search_indices.py
+++ b/discovery-provider/alembic/versions/579360c7cbf3_search_indices.py
@@ -1,0 +1,29 @@
+"""search indices
+
+Revision ID: 579360c7cbf3
+Revises: a88a8ce41f7d
+Create Date: 2021-02-11 20:57:58.269861
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '579360c7cbf3'
+down_revision = 'a88a8ce41f7d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_user_lexeme_dict'), 'user_lexeme_dict', ['user_id', 'user_name', 'word'], unique=True)
+    op.create_index(op.f('ix_track_lexeme_dict'), 'track_lexeme_dict', ['track_id', 'track_title', 'word'], unique=True)
+    op.create_index(op.f('ix_playlist_lexeme_dict'), 'playlist_lexeme_dict', ['playlist_id', 'playlist_name', 'word'], unique=True)
+    op.create_index(op.f('ix_album_lexeme_dict'), 'album_lexeme_dict', ['playlist_id', 'playlist_name', 'word'], unique=True)
+
+def downgrade():
+    op.drop_index(op.f('ix_user_lexeme_dict'), table_name='user_lexeme_dict')
+    op.drop_index(op.f('ix_track_lexeme_dict'), table_name='track_lexeme_dict')
+    op.drop_index(op.f('ix_playlist_lexeme_dict'), table_name='playlist_lexeme_dict')
+    op.drop_index(op.f('ix_album_lexeme_dict'), table_name='album_lexeme_dict')

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -13,7 +13,6 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-        tag_time = time.time()
         logger.info(f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time}")
 
 

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -1,6 +1,6 @@
 import logging
-from src.tasks.celery_app import celery
 import time
+from src.tasks.celery_app import celery
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-        logger.info(f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time}")
+        logger.info(f"index_materialized_views.py | Finished updating materialized views in: {time.time()-start_time}")
 
 
 ######## CELERY TASKS ########

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -1,17 +1,21 @@
 import logging
 from src.tasks.celery_app import celery
+import time
 
 logger = logging.getLogger(__name__)
 
 def update_views(self, db):
     with db.scoped_session() as session:
+        start_time = time.time()
         logger.info('index_materialized_views.py | Updating materialized views')
-        session.execute("REFRESH MATERIALIZED VIEW user_lexeme_dict")
-        session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict")
-        session.execute("REFRESH MATERIALIZED VIEW playlist_lexeme_dict")
-        session.execute("REFRESH MATERIALIZED VIEW album_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY track_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-        logger.info('index_materialized_views.py | Finished updating materialized views')
+        tag_time = time.time()
+        logger.info(f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time}")
+
 
 ######## CELERY TASKS ########
 @celery.task(name="update_materialized_views", bind=True)


### PR DESCRIPTION
### Description
The search query on the client was experiencing periods of extended response times (See chart below for response time)
The extended response times occurred on 60 second intervals which is the same interval we update the mat views for the lexeme tables. 

This PR updates adds a unique index to those tables so that they can be updated concurrently in the job. This prevents the response times from periodically spiking. 
Note that this did increase the time it took to refresh the mat view. Locally running against a prod snapshot, the time to update the 5 mat views increased from ~15-18 sec to ~19-21 sec.

![Screen Shot 2021-02-16 at 1 14 38 PM](https://user-images.githubusercontent.com/7064122/108104155-f254aa80-7058-11eb-9557-99a3383ab89b.png)
_The y-axis is response time and the x-axis is NOT time, it is request number. The spikes do occur at 60 second intervals._

Closes AUD-263

### Tests

I wrote a script to check the time by repeated calling the search endpoint with a random query
```
const getSearchTime = async () => {
  const start = new Date().getTime();
  const query = Math.random().toString(36).substring(7);
  try {
    await axios({
      method: 'get',
      url: `http://localhost:5000/v1/full/search/full?kind=all&limit=4&query=${query}`
      // url: `https://discoveryprovider.staging.audius.co/v1/full/search/full?kind=all&limit=4&query=${query}`
    })
  } catch (err) {
    console.log('err')
  }
  const end = new Date().getTime();
  return end - start; 
}
... 
more code to repeatedly call the function and record times, check interval, calc min, max, avg. 
...
```

I booted the Prod DP instance on RDS as well as a read replica for it and ran discovery node locally against the two RDS instances. Here is a graph of the response times in milliseconds.

### Response time as is
![Screen Shot 2021-02-16 at 11 48 26 AM](https://user-images.githubusercontent.com/7064122/108101785-b835d980-7055-11eb-8168-2a00b891d20b.png)

In this graph, you can see repeated spikes of over 10 seconds to respond. This occurred at 60 second intervals.   

### Response time with the concurrent update mat view
![Screen Shot 2021-02-16 at 11 47 43 AM](https://user-images.githubusercontent.com/7064122/108101799-bec45100-7055-11eb-8a60-029251c07b49.png)

In this graph, you can see that there were no large spikes in response time. 

I also tested that alembic migration work when applied and that it works in the revert migration as well on this RDS DB instance. 
