### PR TITLE
Fix event name in libs delegate manager return values

### DIFF
--- a/libs/src/services/ethContracts/delegateManagerClient.js
+++ b/libs/src/services/ethContracts/delegateManagerClient.js
@@ -239,9 +239,9 @@ class DelegateManagerClient extends GovernedContractClient {
 
     return {
       txReceipt: tx,
-      delegator: tx.events.DecreaseDelegatedStake.returnValues._delegator,
-      serviceProvider: tx.events.DecreaseDelegatedStake.returnValues._serviceProvider,
-      decreaseAmount: Utils.toBN(tx.events.DecreaseDelegatedStake.returnValues._decreaseAmount)
+      delegator: tx.events.UndelegateStakeRequestEvaluated.returnValues._delegator,
+      serviceProvider: tx.events.UndelegateStakeRequestEvaluated.returnValues._serviceProvider,
+      decreaseAmount: Utils.toBN(tx.events.UndelegateStakeRequestEvaluated.returnValues._amount)
     }
   }
 
@@ -292,9 +292,9 @@ class DelegateManagerClient extends GovernedContractClient {
     )
     return {
       txReceipt: tx,
-      delegator: tx.events.DelegatorRemoved.returnValues._delegator,
-      serviceProvider: tx.events.DelegatorRemoved.returnValues._serviceProvider,
-      unstakedAmount: Utils.toBN(tx.events.DelegatorRemoved.returnValues._unstakedAmount)
+      delegator: tx.events.RemoveDelegatorRequestEvaluated.returnValues._delegator,
+      serviceProvider: tx.events.RemoveDelegatorRequestEvaluated.returnValues._serviceProvider,
+      unstakedAmount: Utils.toBN(tx.events.RemoveDelegatorRequestEvaluated.returnValues._unstakedAmount)
     }
   }
 


### PR DESCRIPTION
### Description
The event name in the return values are wrong. These should have been updated when we updated the event names in the  contracts.
Note - I believe this is causing the issue in https://linear.app/audius/issue/AUD-279/undelegation-error

Events
* https://github.com/AudiusProject/audius-protocol/blob/d5b6d3dbf3956ee0d36528906530ef7a6dcd55d4/eth-contracts/contracts/DelegateManager.sol#L121-L125
* https://github.com/AudiusProject/audius-protocol/blob/d5b6d3dbf3956ee0d36528906530ef7a6dcd55d4/eth-contracts/contracts/DelegateManager.sol#L150-L154

### Tests
I linked libs against the protocol dashboard and ran the two functions against the local chain to verify.
