### PR TITLE
Print decision tree for saveFileForMultihashToFS

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -121,9 +121,9 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       // calling this on an existing directory doesn't overwrite the existing data or throw an error
       // the mkdir recursive is equivalent to `mkdir -p`
       await mkdir(parsedStoragePath, { recursive: true })
-      decisionTree.push({ stage: 'Successfully called mkdir on local file system', val: parsedStoragePath, time: Date.now() })
+      decisionTree.push({ stage: 'Successfully called mkdir on local file system', vals: parsedStoragePath, time: Date.now() })
     } catch (e) {
-      decisionTree.push({ stage: 'Error calling mkdir on local file system', val: parsedStoragePath, time: Date.now() })
+      decisionTree.push({ stage: 'Error calling mkdir on local file system', vals: parsedStoragePath, time: Date.now() })
       throw new Error(`Error making directory at ${parsedStoragePath} - ${e.message}`)
     }
 
@@ -153,7 +153,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     // If file already stored on disk, return immediately.
     if (fs.existsSync(expectedStoragePath)) {
       req.logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
-      decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash, Date.now()] })
+      decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash], time: Date.now() })
       // since this is early exit, print the decision tree here
       _printDecisionTreeObj(req, decisionTree)
       return expectedStoragePath
@@ -209,7 +209,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         // ..replace(/\/$/, "") removes trailing slashes
         req.logger.debug(`Attempting to fetch multihash ${multihash} by racing replica set endpoints`)
 
-        decisionTree.push({ stage: 'About to race requests via getways', vals: gatewayUrlsMapped, time: Date.now() })
+        decisionTree.push({ stage: 'About to race requests via gateways', vals: gatewayUrlsMapped, time: Date.now() })
         // Note - Requests are intentionally not parallel to minimize additional load on gateways
         for (let index = 0; index < gatewayUrlsMapped.length; index++) {
           const url = gatewayUrlsMapped[index]
@@ -283,7 +283,11 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
 }
 
 const _printDecisionTreeObj = (req, decisionTree) => {
-  req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
+  try {
+    req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
+  } catch (e) {
+    req.logger.error('error printing saveFileForMultihashToFS decision tree', decisionTree)
+  }
 }
 
 /**

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -95,6 +95,8 @@ async function saveFileToIPFSFromFS (req, srcPath) {
  *                  eg original.jpg or 150x150.jpg
  */
 async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, gatewaysToTry, fileNameForImage = null) {
+  let decisionTree = []
+
   try {
     // will be modified to directory compatible route later if directory
     // TODO - don't concat url's by hand like this, use module like urljoin
@@ -102,11 +104,23 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
 
     const parsedStoragePath = path.parse(expectedStoragePath).dir
 
+    decisionTree.push({ stage: 'About to start running saveFileForMultihashToFS', val: {
+        multihash,
+        gatewaysToTry,
+        gatewayUrlsMapped,
+        expectedStoragePath,
+        parsedStoragePath
+      },
+      time: Date.now()
+    })
     try {
       // calling this on an existing directory doesn't overwrite the existing data or throw an error
       // the mkdir recursive is equivalent to `mkdir -p`
       await mkdir(parsedStoragePath, { recursive: true })
+      decisionTree.push({ stage: 'Successfully called mkdir on local file system', val: parsedStoragePath, time: Date.now() })
     } catch (e) {
+      decisionTree.push({ stage: 'Error calling mkdir on local file system', val: parsedStoragePath, time: Date.now() })
+      req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
       throw new Error(`Error making directory at ${parsedStoragePath} - ${e.message}`)
     }
 
@@ -122,9 +136,8 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       // in the case of a directory, override the gatewayUrlsMapped array to look like
       // [https://endpoint.co/ipfs/Qm111/150x150.jpg, https://endpoint.co/ipfs/Qm222/150x150.jpg ...]
       gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${matchObj.outer}/${fileNameForImage}`)
+      decisionTree.push({ stage: 'Updated gatewayUrlsMapped', vals: gatewayUrlsMapped, time: Date.now() })
     }
-
-    req.logger.info(`Calling saveFileForMultihashToFS for multihash ${multihash}, with gatewaysToTry: ${JSON.stringify(gatewaysToTry)}, with expectedStoragePath ${expectedStoragePath} `)
 
     /**
      * Attempts to fetch CID:
@@ -137,6 +150,8 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     // If file already stored on disk, return immediately.
     if (fs.existsSync(expectedStoragePath)) {
       req.logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
+      decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash, Date.now()] })
+      req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
       return expectedStoragePath
     }
 
@@ -147,31 +162,39 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     req.logger.debug(`checking if ${multihash} already available on local ipfs node`)
     try {
       // ipfsCat returns a Buffer
+      decisionTree.push({ stage: 'About to retrieve file from local ipfs node with cat', vals: multihash, time: Date.now() })
       let fileBuffer = await Utils.ipfsCat(multihash, req, 1000)
       fileFound = true
-      req.logger.debug(`Retrieved file for ${multihash} from local ipfs node`)
+      req.logger.debug(`Retrieved file for ${multihash} from  with cat`)
+      decisionTree.push({ stage: 'Retrieved file from local ipfs node with cat', vals: multihash, time: Date.now() })
       // Write file to disk.
       await writeFile(expectedStoragePath, fileBuffer)
       req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs cat`)
+      decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
     } catch (e) {
       req.logger.warn(`Multihash ${multihash} is not available on local ipfs node ${e.message}`)
+      decisionTree.push({ stage: 'File not available on local ipfs node with cat', vals: multihash, time: Date.now() })
     }
 
     // If file not already available on local ipfs node, fetch from IPFS.
     if (!fileFound) {
       req.logger.debug(`Attempting to get ${multihash} from IPFS`)
       try {
+        decisionTree.push({ stage: 'About to retrieve file from local ipfs node with get', vals: multihash, time: Date.now() })
         // ipfsGet returns a BufferListStream object which is not a buffer
         // not compatible into writeFile directly, but it can be streamed to a file
         let fileBL = await Utils.ipfsGet(multihash, req, 5000)
         req.logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
+        decisionTree.push({ stage: 'Retrieved file from local ipfs node with get', vals: multihash, time: Date.now() })
 
         // Write file to disk.
         await Utils.writeStreamToFileSystem(fileBL, expectedStoragePath)
         fileFound = true
         req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs get`)
+        decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
       } catch (e) {
         req.logger.warn(`Failed to retrieve file for multihash ${multihash} from IPFS ${e.message}`)
+        decisionTree.push({ stage: 'File not available on local ipfs node with ipfs get', vals: multihash, time: Date.now() })
       }
     }
 
@@ -182,9 +205,11 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         // ..replace(/\/$/, "") removes trailing slashes
         req.logger.debug(`Attempting to fetch multihash ${multihash} by racing replica set endpoints`)
 
+        decisionTree.push({ stage: 'About to race requests via getways', vals: gatewayUrlsMapped, time: Date.now() })
         // Note - Requests are intentionally not parallel to minimize additional load on gateways
         for (let index = 0; index < gatewayUrlsMapped.length; index++) {
           const url = gatewayUrlsMapped[index]
+          decisionTree.push({ stage: 'Fetching from gateway', vals: url, time: Date.now() })
           try {
             const resp = await axios({
               method: 'get',
@@ -194,15 +219,19 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
             })
             if (resp.data) {
               response = resp
+              decisionTree.push({ stage: 'Retrieved file from gateway', vals: url, time: Date.now() })
               break
             }
           } catch (e) {
             req.logger.error(`Error fetching file from other cnode ${url} ${e.message}`)
+            decisionTree.push({ stage: 'Could not retrieve file from gateway', vals: url, time: Date.now() })
             continue
           }
         }
 
         if (!response || !response.data) {
+          decisionTree.push({ stage: `Couldn't find files on other creator nodes, after trying URLs`, vals: null, time: Date.now() })
+          printDecisionTreeObj(req, decisionTree)
           throw new Error(`Couldn't find files on other creator nodes, after trying URLs: ${gatewayUrlsMapped.toString()}`)
         }
 
@@ -210,34 +239,51 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         await Utils.writeStreamToFileSystem(response.data, expectedStoragePath)
         fileFound = true
 
+        decisionTree.push({ stage: 'Wrote file to file system after fetching from gateway', vals: expectedStoragePath, time: Date.now() })
         req.logger.info(`wrote file to ${expectedStoragePath}`)
       } catch (e) {
+        decisionTree.push({ stage: `Failed to retrieve file for multihash from other creator node gateways`, vals: e.message, time: Date.now() })
+        printDecisionTreeObj(req, decisionTree)
         throw new Error(`Failed to retrieve file for multihash ${multihash} from other creator node gateways: ${e.message}`)
       }
     }
 
     // file was not found on ipfs or any gateway
     if (!fileFound) {
+      decisionTree.push({ stage: 'Failed to retrieve file for multihash after trying ipfs & other creator node gateways', vals: multihash, time: Date.now() })
+      printDecisionTreeObj(req, decisionTree)
       throw new Error(`Failed to retrieve file for multihash ${multihash} after trying ipfs & other creator node gateways`)
     }
 
     // verify that the contents of the file match the file's cid
     try {
+      decisionTree.push({ stage: 'Failed to retrieve file for multihash after trying ipfs & other creator node gateways', vals: multihash, time: Date.now() })
       const ipfs = req.app.get('ipfsLatestAPI')
       const content = fs.createReadStream(expectedStoragePath)
       for await (const result of ipfs.add(content, { onlyHash: true, timeout: 10000 })) {
         if (multihash !== result.cid.toString()) {
+          decisionTree.push({ stage: `File contents don't match IPFS hash multihash`, vals: result.cid.toString(), time: Date.now() })
+          printDecisionTreeObj(req, decisionTree)
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }
       }
     } catch (e) {
+      decisionTree.push({ stage: `Error during content verification for multihash`, vals: multihash, time: Date.now() })
+      printDecisionTreeObj(req, decisionTree)
       throw new Error(`Error during content verification for multihash ${multihash} ${e.message}`)
     }
 
+    printDecisionTreeObj(req, decisionTree)
     return expectedStoragePath
   } catch (e) {
+    decisionTree.push({ stage: `saveFileForMultihashToFS error`, vals: e.message, time: Date.now() })
+    printDecisionTreeObj(req, decisionTree)
     throw new Error(`saveFileForMultihashToFS - ${e}`)
   }
+}
+
+const printDecisionTreeObj = (req, decisionTree) => {
+  req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
 }
 
 /**

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -154,6 +154,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     if (fs.existsSync(expectedStoragePath)) {
       req.logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
       decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash, Date.now()] })
+      // since this is early exit, print the decision tree here
       _printDecisionTreeObj(req, decisionTree)
       return expectedStoragePath
     }
@@ -263,7 +264,6 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       for await (const result of ipfs.add(content, { onlyHash: true, timeout: 10000 })) {
         if (multihash !== result.cid.toString()) {
           decisionTree.push({ stage: `File contents don't match IPFS hash multihash`, vals: result.cid.toString(), time: Date.now() })
-          _printDecisionTreeObj(req, decisionTree)
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }
       }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -104,7 +104,8 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
 
     const parsedStoragePath = path.parse(expectedStoragePath).dir
 
-    decisionTree.push({ stage: 'About to start running saveFileForMultihashToFS', val: {
+    decisionTree.push({ stage: 'About to start running saveFileForMultihashToFS',
+      val: {
         multihash,
         gatewaysToTry,
         gatewayUrlsMapped,

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -124,6 +124,8 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${matchObj.outer}/${fileNameForImage}`)
     }
 
+    req.logger.info(`Calling saveFileForMultihashToFS for multihash ${multihash}, with gatewaysToTry: ${JSON.stringify(gatewaysToTry)}, with expectedStoragePath ${expectedStoragePath} `)
+
     /**
      * Attempts to fetch CID:
      *  - If file already stored on disk, return immediately and store to disk.


### PR DESCRIPTION
### Description
Adds a decision tree to display the steps during saveFileForMultihashToFS. Adds one final log statement to print out every step and branch. An example is:

`
[2021-02-18T16:39:43.554Z]  INFO: audius_creator_node/23160 on c6246db4eae7: saveFileForMultihashToFS decision tree [{"stage":"About to start running saveFileForMultihashToFS","val":{"multihash":"Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","gatewaysToTry":["https://creatornode.audius.co","https://creatornode3.audius.co","https://creatornode2.audius.co","http://docker.for.mac.localhost:4000"],"gatewayUrlsMapped":["https://creatornode.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","https://creatornode3.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","https://creatornode2.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","http://docker.for.mac.localhost:4000/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx"],"expectedStoragePath":"/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","parsedStoragePath":"/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD"},"time":1613666382921},{"stage":"Successfully called mkdir on local file system","val":"/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD","time":1613666382947},{"stage":"Updated gatewayUrlsMapped","vals":["https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","https://creatornode3.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","https://creatornode2.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","http://docker.for.mac.localhost:4000/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg"],"time":1613666382947},{"stage":"About to race requests via getways","vals":["https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","https://creatornode3.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","https://creatornode2.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","http://docker.for.mac.localhost:4000/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg"],"time":1613666382948},{"stage":"Fetching from gateway","vals":"https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","time":1613666382948},{"stage":"Retrieved file from gateway","vals":"https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg","time":1613666383139},{"stage":"Wrote file to file system after fetching from gateway","vals":"/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","time":1613666383529},{"stage":"About to verify the file contents for the CID","vals":"Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx","time":1613666383530}] (requestID=ZymkikEvw, requestMethod=POST, requestHostname=34.237.76.89, requestUrl=/sync)
`
Which when prettified looks like 
```json
[
  {
    "stage": "About to start running saveFileForMultihashToFS",
    "val": {
      "multihash": "Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
      "gatewaysToTry": [
        "https://creatornode.audius.co",
        "https://creatornode3.audius.co",
        "https://creatornode2.audius.co",
        "http://docker.for.mac.localhost:4000"
      ],
      "gatewayUrlsMapped": [
        "https://creatornode.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
        "https://creatornode3.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
        "https://creatornode2.audius.co/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
        "http://docker.for.mac.localhost:4000/ipfs/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx"
      ],
      "expectedStoragePath": "/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
      "parsedStoragePath": "/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD"
    },
    "time": 1613666382921
  },
  {
    "stage": "Successfully called mkdir on local file system",
    "val": "/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD",
    "time": 1613666382947
  },
  {
    "stage": "Updated gatewayUrlsMapped",
    "vals": [
      "https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "https://creatornode3.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "https://creatornode2.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "http://docker.for.mac.localhost:4000/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg"
    ],
    "time": 1613666382947
  },
  {
    "stage": "About to race requests via getways",
    "vals": [
      "https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "https://creatornode3.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "https://creatornode2.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
      "http://docker.for.mac.localhost:4000/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg"
    ],
    "time": 1613666382948
  },
  {
    "stage": "Fetching from gateway",
    "vals": "https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
    "time": 1613666382948
  },
  {
    "stage": "Retrieved file from gateway",
    "vals": "https://creatornode.audius.co/ipfs/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/original.jpg",
    "time": 1613666383139
  },
  {
    "stage": "Wrote file to file system after fetching from gateway",
    "vals": "/file_storage/files/7uW/QmS4PqkJWkU9koWnZgdDEEAmvyikDCV6QgxX8nZo8p7uWD/Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
    "time": 1613666383529
  },
  {
    "stage": "About to verify the file contents for the CID",
    "vals": "Qmc5XbTou14dnPgtBZbduVK5ypzJazurHxSzgF15nesDvx",
    "time": 1613666383530
  }
]
```


### Tests
I synced the state for a few users on my development EC2 box and captured these logs
