### PR TITLE
Use maxStorageUsedPercent from CN in CreatorNodeSelection

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -48,6 +48,7 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors)
   const country = config.get('serviceCountry')
   const latitude = config.get('serviceLatitude')
   const longitude = config.get('serviceLongitude')
+  const maxStorageUsedPercent = config.get('maxStorageUsedPercent')
 
   // System information
   const [
@@ -88,7 +89,8 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors)
     maxFileDescriptors,
     allocatedFileDescriptors,
     receivedBytesPerSec,
-    transferredBytesPerSec
+    transferredBytesPerSec,
+    maxStorageUsedPercent
   }
 
   return response

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -91,6 +91,7 @@ describe('Test Health Check Verbose', function () {
     config.set('serviceCountry', 'US')
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
+    config.set('maxStorageUsedPercent', 95)
 
     const res = await healthCheckVerbose({}, mockLogger, sequelizeMock, getMonitorsMock)
     assert.deepStrictEqual(res, {
@@ -114,7 +115,8 @@ describe('Test Health Check Verbose', function () {
       maxFileDescriptors: 524288,
       allocatedFileDescriptors: 3392,
       receivedBytesPerSec: 776.7638177541248,
-      transferredBytesPerSec: 269500
+      transferredBytesPerSec: 269500,
+      maxStorageUsedPercent: 95
     })
   })
 })

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,7 +1,6 @@
 const { Base } = require('./base')
 const { timeRequestsAndSortByVersion } = require('../utils/network')
 const CreatorNodeSelection = require('../services/creatorNode/CreatorNodeSelection')
-const axios = require('axios')
 
 const CONTENT_NODE_SERVICE_NAME = 'content-node'
 const DISCOVERY_NODE_SERVICE_NAME = 'discovery-node'
@@ -81,27 +80,14 @@ class ServiceProvider extends Base {
     performSyncCheck = true,
     timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   }) {
-    let creatorNodeSelectionConfig = {
+    const creatorNodeSelection = new CreatorNodeSelection({
       creatorNode: this.creatorNode,
       ethContracts: this.ethContracts,
       numberOfNodes,
       whitelist,
       blacklist,
       timeout
-    }
-
-    try {
-      const healthCheckResp = await axios({
-        url: `${this.creatorNode.creatorNodeEndpoint}/health_check/verbose`,
-        method: 'get',
-        responseType: 'json'
-      })
-      creatorNodeSelectionConfig.maxStorageUsedPercent = healthCheckResp.data.maxStorageUsedPercent
-    } catch (e) {
-      console.warn(`Could not retrieve maxStorageUsedPercent from ${this.creatorNode.creatorNodeEndpoint}`, e)
-    }
-
-    const creatorNodeSelection = new CreatorNodeSelection(creatorNodeSelectionConfig)
+    })
 
     const { primary, secondaries, services } = await creatorNodeSelection.select(performSyncCheck)
     return { primary, secondaries, services }

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,6 +1,7 @@
 const { Base } = require('./base')
 const { timeRequestsAndSortByVersion } = require('../utils/network')
 const CreatorNodeSelection = require('../services/creatorNode/CreatorNodeSelection')
+const axios = require('axios')
 
 const CONTENT_NODE_SERVICE_NAME = 'content-node'
 const DISCOVERY_NODE_SERVICE_NAME = 'discovery-node'
@@ -80,14 +81,27 @@ class ServiceProvider extends Base {
     performSyncCheck = true,
     timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
   }) {
-    const creatorNodeSelection = new CreatorNodeSelection({
+    let creatorNodeSelectionConfig = {
       creatorNode: this.creatorNode,
       ethContracts: this.ethContracts,
       numberOfNodes,
       whitelist,
       blacklist,
       timeout
-    })
+    }
+
+    try {
+      const healthCheckResp = await axios({
+        url: `${this.creatorNode.creatorNodeEndpoint}/health_check/verbose`,
+        method: 'get',
+        responseType: 'json'
+      })
+      creatorNodeSelectionConfig.maxStorageUsedPercent = healthCheckResp.data.maxStorageUsedPercent
+    } catch (e) {
+      console.warn(`Could not retrieve maxStorageUsedPercent from ${this.creatorNode.creatorNodeEndpoint}`, e)
+    }
+
+    const creatorNodeSelection = new CreatorNodeSelection(creatorNodeSelectionConfig)
 
     const { primary, secondaries, services } = await creatorNodeSelection.select(performSyncCheck)
     return { primary, secondaries, services }

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -200,7 +200,11 @@ class CreatorNodeSelection extends ServiceSelection {
           resp.response.data.data.version
         )
         let { storagePathSize, storagePathUsed, maxStorageUsedPercent } = resp.response.data.data
-        this.maxStorageUsedPercent = maxStorageUsedPercent || this.maxStorageUsedPercent
+        if (maxStorageUsedPercent) {
+          this.maxStorageUsedPercent = maxStorageUsedPercent
+        } else {
+          console.warn(`maxStorageUsedPercent not found in health check response. Using constructor value of ${this.maxStorageUsedPercent}% as maxStorageUsedPercent.`)
+        }
         const hasEnoughStorage = this._hasEnoughStorageSpace({ storagePathSize, storagePathUsed })
         isHealthy = isUp && versionIsUpToDate && hasEnoughStorage
       }

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -9,7 +9,7 @@ class CreatorNodeSelection extends ServiceSelection {
     ethContracts,
     whitelist,
     blacklist,
-    maxStorageUsedPercent = 90,
+    maxStorageUsedPercent = 95,
     timeout = null
   }) {
     super({

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -200,7 +200,6 @@ class CreatorNodeSelection extends ServiceSelection {
           resp.response.data.data.version
         )
         let { storagePathSize, storagePathUsed, maxStorageUsedPercent } = resp.response.data.data
-        // If CN does not respond with maxStorageUsedPercent, use the default from constructor
         this.maxStorageUsedPercent = maxStorageUsedPercent || this.maxStorageUsedPercent
         const hasEnoughStorage = this._hasEnoughStorageSpace({ storagePathSize, storagePathUsed })
         isHealthy = isUp && versionIsUpToDate && hasEnoughStorage

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -9,7 +9,7 @@ class CreatorNodeSelection extends ServiceSelection {
     ethContracts,
     whitelist,
     blacklist,
-    maxStorageUsedPercent = 95,
+    maxStorageUsedPercent = 90,
     timeout = null
   }) {
     super({
@@ -188,16 +188,20 @@ class CreatorNodeSelection extends ServiceSelection {
       let isHealthy = false
 
       // Check that the health check:
-      // 1. Responded with status code 200 and that the
+      // 1. Responded with status code 200
       // 2. Version is up to date on major and minor
-      // 3. Has enough storage space -- max capacity defined at the variable `this.maxStorageUsedPercent`
+      // 3. Has enough storage space
+      //    - Max capacity percent is defined from CN health check response. If not present,
+      //      use default from constructor
       if (resp.response) {
         const isUp = resp.response.status === 200
         const versionIsUpToDate = this.ethContracts.hasSameMajorAndMinorVersion(
           this.currentVersion,
           resp.response.data.data.version
         )
-        const { storagePathSize, storagePathUsed } = resp.response.data.data
+        let { storagePathSize, storagePathUsed, maxStorageUsedPercent } = resp.response.data.data
+        // If CN does not respond with maxStorageUsedPercent, use the default from constructor
+        this.maxStorageUsedPercent = maxStorageUsedPercent || this.maxStorageUsedPercent
         const hasEnoughStorage = this._hasEnoughStorageSpace({ storagePathSize, storagePathUsed })
         isHealthy = isUp && versionIsUpToDate && hasEnoughStorage
       }

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -192,7 +192,7 @@ class CreatorNodeSelection extends ServiceSelection {
       // 2. Version is up to date on major and minor
       // 3. Has enough storage space
       //    - Max capacity percent is defined from CN health check response. If not present,
-      //      use default from constructor
+      //      use existing value from `this.maxStorageUsedPercent`
       if (resp.response) {
         const isUp = resp.response.status === 200
         const versionIsUpToDate = this.ethContracts.hasSameMajorAndMinorVersion(

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -348,9 +348,11 @@ describe('test CreatorNodeSelection', () => {
       whitelist: null,
       blacklist: null
     })
+    assert(cns.maxStorageUsedPercent === 95)
 
     const { primary, secondaries, services } = await cns.select()
 
+    assert(cns.maxStorageUsedPercent === 95)
     assert(primary === shouldBePrimary)
     assert(secondaries.length === 2)
     assert(secondaries.includes(shouldBeSecondary1))
@@ -362,7 +364,7 @@ describe('test CreatorNodeSelection', () => {
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 
-  it('overrides with health check resp `maxStorageUsedPercent` even if value is passed into constructor', async () => {
+  it('overrides with health check resp `maxStorageUsedPercent` even if it is passed into constructor', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
       .get('/health_check/verbose')
@@ -458,8 +460,11 @@ describe('test CreatorNodeSelection', () => {
       maxStorageUsedPercent: 50
     })
 
+    assert(cns.maxStorageUsedPercent === 50)
+
     const { primary, secondaries, services } = await cns.select()
 
+    assert(cns.maxStorageUsedPercent === 50)
     assert(primary === shouldBePrimary)
     assert(secondaries.length === 2)
     assert(secondaries.includes(shouldBeSecondary1))

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -52,7 +52,8 @@ let defaultHealthCheckData = {
   'maxFileDescriptors': 524288,
   'allocatedFileDescriptors': 2912,
   'receivedBytesPerSec': 776.7638177541248,
-  'transferredBytesPerSec': 39888.88888888889
+  'transferredBytesPerSec': 39888.88888888889,
+  'maxStorageUsedPercent': 95
 }
 
 describe('test CreatorNodeSelection', () => {
@@ -314,7 +315,7 @@ describe('test CreatorNodeSelection', () => {
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 
-  it('filters out nodes if over 90% of storage is used', async () => {
+  it('filters out nodes if over 95% of storage is used', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
       .get('/health_check/verbose')
@@ -333,7 +334,7 @@ describe('test CreatorNodeSelection', () => {
     const used95PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used95PercentStorage)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 90.354, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 95.354, storagePathSize: 100 } })
 
     const used99PercentStorage = 'https://used99PercentStorage.audius.co'
     nock(used99PercentStorage)
@@ -361,7 +362,7 @@ describe('test CreatorNodeSelection', () => {
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
 
-  it('allows custom maxStorageUsedPercent as constructor param', async () => {
+  it('overrides with health check resp `maxStorageUsedPercent` even if value is passed into constructor', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
       .get('/health_check/verbose')
@@ -370,22 +371,80 @@ describe('test CreatorNodeSelection', () => {
     const shouldBeSecondary1 = 'https://secondary1.audius.co'
     nock(shouldBeSecondary1)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.1', storagePathUsed: 30, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.2', storagePathUsed: 30, storagePathSize: 100 } })
 
     const shouldBeSecondary2 = 'https://secondary2.audius.co'
     nock(shouldBeSecondary2)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0', storagePathUsed: 30, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.1', storagePathUsed: 30, storagePathSize: 100 } })
 
     const used50PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used50PercentStorage)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 50, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0', storagePathUsed: 50, storagePathSize: 100 } })
 
     const used70PercentStorage = 'https://used70PercentStorage.audius.co'
     nock(used70PercentStorage)
       .get('/health_check/verbose')
-      .reply(200, { data: { ...defaultHealthCheckData, storagePathUsed: 70.546, storagePathSize: 100 } })
+      .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0', storagePathUsed: 70.546, storagePathSize: 100 } })
+
+    const cns = new CreatorNodeSelection({
+      creatorNode: mockCreatorNode,
+      numberOfNodes: 3,
+      ethContracts: mockEthContracts(
+        [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2, used50PercentStorage, used70PercentStorage],
+        '1.2.3'
+      ),
+      whitelist: null,
+      blacklist: null,
+      maxStorageUsedPercent: 50
+    })
+
+    assert(cns.maxStorageUsedPercent === 50)
+
+    const { primary, secondaries, services } = await cns.select()
+
+    assert(cns.maxStorageUsedPercent === 95)
+
+    assert(primary === shouldBePrimary)
+    assert(secondaries.length === 2)
+    assert(secondaries.includes(shouldBeSecondary1))
+    assert(secondaries.includes(shouldBeSecondary2))
+
+    const returnedHealthyServices = new Set(Object.keys(services))
+    assert(returnedHealthyServices.size === 5)
+    const healthyServices = [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2]
+    healthyServices.map(service => assert(returnedHealthyServices.has(service)))
+  })
+
+  it('allows custom maxStorageUsedPercent as constructor param if `maxStorageUsedPercent` is not found in health check resp', async () => {
+    let healthCheckResponseWithNoMaxStorageUsedPercent = { ...defaultHealthCheckData }
+    delete healthCheckResponseWithNoMaxStorageUsedPercent.maxStorageUsedPercent
+
+    const shouldBePrimary = 'https://primary.audius.co'
+    nock(shouldBePrimary)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...healthCheckResponseWithNoMaxStorageUsedPercent, storagePathUsed: 30, storagePathSize: 100 } })
+
+    const shouldBeSecondary1 = 'https://secondary1.audius.co'
+    nock(shouldBeSecondary1)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...healthCheckResponseWithNoMaxStorageUsedPercent, version: '1.2.1', storagePathUsed: 30, storagePathSize: 100 } })
+
+    const shouldBeSecondary2 = 'https://secondary2.audius.co'
+    nock(shouldBeSecondary2)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...healthCheckResponseWithNoMaxStorageUsedPercent, version: '1.2.0', storagePathUsed: 30, storagePathSize: 100 } })
+
+    const used50PercentStorage = 'https://used95PercentStorage.audius.co'
+    nock(used50PercentStorage)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...healthCheckResponseWithNoMaxStorageUsedPercent, storagePathUsed: 50, storagePathSize: 100 } })
+
+    const used70PercentStorage = 'https://used70PercentStorage.audius.co'
+    nock(used70PercentStorage)
+      .get('/health_check/verbose')
+      .reply(200, { data: { ...healthCheckResponseWithNoMaxStorageUsedPercent, storagePathUsed: 70.546, storagePathSize: 100 } })
 
     const cns = new CreatorNodeSelection({
       creatorNode: mockCreatorNode,


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

**Context:** The `maxStorageUsedPercent` value in CN is not reflected in the `CreatorNodeSelection` in libs. The two values are different.
**Purpose:** Have `CreatorNodeSelection` consume the `maxStorageUsedPercent` value in CN by exposing that value in `/health_check/verbose`
**In this PR:**
1. Added `maxStorageUsedPercent` to `/health_check/verbose`
2. Have an axios request get `maxStorageUsedPercent` off of `/health_check/verbose` response and consume that value. Default to `95` if axios request fails.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Locally printed out the value of `this.maxStorageUsedPercent` in `CreatorNodeSelection` to make sure it is from the axios response value. If axios request failed, made sure that the value defaulted to the constructor default. 
