### PR TITLE
Add function to calculate quorum for a governance proposal

### DIFF
--- a/libs/src/services/ethContracts/governanceClient.js
+++ b/libs/src/services/ethContracts/governanceClient.js
@@ -401,7 +401,7 @@ class GovernanceClient extends ContractClient {
    * @param {Number} proposalId id of the governance proposal
    * @returns {BN} amount of tokens in wei required to reach quorum
    */
-  async calculateQuoroum (proposalId) {
+  async calculateQuorum (proposalId) {
     const { submissionBlockNumber } = await this.getProposalById(proposalId)
 
     // represented as a value > 0, eg 5% is 5

--- a/libs/src/services/ethContracts/governanceClient.js
+++ b/libs/src/services/ethContracts/governanceClient.js
@@ -399,7 +399,7 @@ class GovernanceClient extends ContractClient {
   /**
    *
    * @param {Number} proposalId id of the governance proposal
-   * @returns {BN} amount of tokens required to reach quorum
+   * @returns {BN} amount of tokens in wei required to reach quorum
    */
   async calculateQuoroum (proposalId) {
     const { submissionBlockNumber } = await this.getProposalById(proposalId)

--- a/libs/src/services/ethContracts/governanceClient.js
+++ b/libs/src/services/ethContracts/governanceClient.js
@@ -1,4 +1,5 @@
 const ContractClient = require('../contracts/ContractClient')
+const Utils = require('../../utils')
 
 const DEFAULT_GAS_AMOUNT = 200000
 
@@ -393,6 +394,26 @@ class GovernanceClient extends ContractClient {
       voterStake: this.toBN(event._voterStake),
       blockNumber: voteEvent.blockNumber
     }
+  }
+
+  /**
+   *
+   * @param {Integer} proposalId id of the governance proposal
+   * @returns {BigNumber} amount of tokens required to reach quorum
+   */
+  async calculateQuoroum (proposalId) {
+    const { submissionBlockNumber } = await this.getProposalById(proposalId)
+
+    // represented as a value > 0, eg 5% is 5
+    const quoroumPercent = await this.getVotingQuorumPercent()
+
+    // retrieve stake at the time of proposal from Staking client
+    const totalStakeAtProposal = await this.stakingProxyClient.totalStakedAt(submissionBlockNumber)
+
+    // quorum = (total staked at proposal * quorum percent) / 100
+    const quorumStake = (totalStakeAtProposal.mul(Utils.toBN(quoroumPercent))).div(Utils.toBN(100))
+
+    return quorumStake
   }
 }
 

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -61,13 +61,6 @@ class EthContracts {
     )
     this.getRegistryAddressForContract = this.getRegistryAddressForContract.bind(this)
 
-    this.GovernanceClient = new GovernanceClient(
-      this.ethWeb3Manager,
-      GovernanceABI,
-      GovernanceRegistryKey,
-      this.getRegistryAddressForContract
-    )
-
     this.ClaimsManagerClient = new ClaimsManagerClient(
       this.ethWeb3Manager,
       ClaimsManagerABI,
@@ -89,6 +82,15 @@ class EthContracts {
       StakingProxyKey,
       this.getRegistryAddressForContract,
       this.AudiusTokenClient
+    )
+
+    this.GovernanceClient = new GovernanceClient(
+      this.ethWeb3Manager,
+      GovernanceABI,
+      GovernanceRegistryKey,
+      this.getRegistryAddressForContract,
+      this.AudiusTokenClient,
+      this.StakingProxyClient
     )
 
     this.ServiceProviderFactoryClient = new ServiceProviderFactoryClient(

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -61,21 +61,6 @@ class EthContracts {
     )
     this.getRegistryAddressForContract = this.getRegistryAddressForContract.bind(this)
 
-    this.ClaimsManagerClient = new ClaimsManagerClient(
-      this.ethWeb3Manager,
-      ClaimsManagerABI,
-      ClaimsManagerProxyKey,
-      this.getRegistryAddressForContract
-    )
-
-    this.ServiceTypeManagerClient = new ServiceTypeManagerClient(
-      this.ethWeb3Manager,
-      ServiceTypeManagerABI,
-      ServiceTypeManagerProxyKey,
-      this.getRegistryAddressForContract,
-      this.GovernanceClient
-    )
-
     this.StakingProxyClient = new StakingProxyClient(
       this.ethWeb3Manager,
       StakingABI,
@@ -92,6 +77,22 @@ class EthContracts {
       this.AudiusTokenClient,
       this.StakingProxyClient
     )
+
+    this.ClaimsManagerClient = new ClaimsManagerClient(
+      this.ethWeb3Manager,
+      ClaimsManagerABI,
+      ClaimsManagerProxyKey,
+      this.getRegistryAddressForContract
+    )
+
+    this.ServiceTypeManagerClient = new ServiceTypeManagerClient(
+      this.ethWeb3Manager,
+      ServiceTypeManagerABI,
+      ServiceTypeManagerProxyKey,
+      this.getRegistryAddressForContract,
+      this.GovernanceClient
+    )
+
 
     this.ServiceProviderFactoryClient = new ServiceProviderFactoryClient(
       this.ethWeb3Manager,

--- a/libs/src/services/ethContracts/index.js
+++ b/libs/src/services/ethContracts/index.js
@@ -93,7 +93,6 @@ class EthContracts {
       this.GovernanceClient
     )
 
-
     this.ServiceProviderFactoryClient = new ServiceProviderFactoryClient(
       this.ethWeb3Manager,
       ServiceProviderFactoryABI,


### PR DESCRIPTION
### Description
Add a function to calculate quorum for a governance proposal given the Id.

### Tests
#### Calculating by hand
I manually calculated the value for proposal 4. The total staked at time of submissions is 173462899182133231522347665 wei so 173462899 tokens. 5% of this is 8673144.95 tokens.
<img width="912" alt="Audius___Protocol_Dashboard_and_err_derive_-_Rust" src="https://user-images.githubusercontent.com/295938/108769147-94c3d080-7526-11eb-8042-2a32dea0481f.png">


#### Using the new function
If I run the new function and compare the value I get the same the same value in wei, which if you trim off the units, becomes 8673144.95
<img width="616" alt="Audius___Protocol_Dashboard" src="https://user-images.githubusercontent.com/295938/108769364-e53b2e00-7526-11eb-9ff7-862d1ef47d70.png">

## Update on the rounding

I have now fixed the rounding down issue (hopefully). If there's a remainder, I round up. The way I tested this is by calculating the result of the current proposal quorum with this function and got 
<img width="610" alt="Audius___Protocol_Dashboard" src="https://user-images.githubusercontent.com/295938/108877839-9eecda00-75cd-11eb-859c-d74660442d26.png">

When I get the precise value from WolframAlpha I get ...83.25, which is then rounded up to 84
<img width="847" alt="8_67314495910666157611738325_×_10^24_-_Wolfram_Alpha" src="https://user-images.githubusercontent.com/295938/108877884-aca25f80-75cd-11eb-87ea-dbf5a15f5f90.png">

