### PR TITLE
[AUD-294] Check resp data field in monitor call

### DIFF
--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -163,7 +163,10 @@ class CreatorNodeSelection extends ServiceSelection {
       }
     }
 
-    this.decisionTree.push({ stage: DECISION_TREE_STATE.FILTER_OUT_SYNC_IN_PROGRESS, val: services })
+    this.decisionTree.push({
+      stage: DECISION_TREE_STATE.FILTER_OUT_SYNC_IN_PROGRESS,
+      val: successfulSyncCheckServices
+    })
 
     return successfulSyncCheckServices
   }
@@ -220,30 +223,32 @@ class CreatorNodeSelection extends ServiceSelection {
     // Record metrics
     if (this.creatorNode.monitoringCallbacks.healthCheck) {
       healthCheckedServices.forEach(check => {
-        const url = new URL(check.request.url)
-        const data = check.response.data.data
-        try {
-          this.creatorNode.monitoringCallbacks.healthCheck({
-            endpoint: url.origin,
-            pathname: url.pathname,
-            queryString: url.queryrString,
-            version: data.version,
-            git: data.git,
-            selectedDiscoveryNode: data.selectedDiscoveryProvider,
-            databaseSize: data.databaseSize,
-            databaseConnections: data.databaseConnections,
-            totalMemory: data.totalMemory,
-            usedMemory: data.usedMemory,
-            totalStorage: data.storagePathSize,
-            usedStorage: data.storagePathUsed,
-            maxFileDescriptors: data.maxFileDescriptors,
-            allocatedFileDescriptors: data.allocatedFileDescriptors,
-            receivedBytesPerSec: data.receivedBytesPerSec,
-            transferredBytesPerSec: data.transferredBytesPerSec
-          })
-        } catch (e) {
-          // Swallow errors -- this method should not throw generally
-          console.error(e)
+        if (check.response && check.response.data) {
+          const url = new URL(check.request.url)
+          const data = check.response.data.data
+          try {
+            this.creatorNode.monitoringCallbacks.healthCheck({
+              endpoint: url.origin,
+              pathname: url.pathname,
+              queryString: url.queryrString,
+              version: data.version,
+              git: data.git,
+              selectedDiscoveryNode: data.selectedDiscoveryProvider,
+              databaseSize: data.databaseSize,
+              databaseConnections: data.databaseConnections,
+              totalMemory: data.totalMemory,
+              usedMemory: data.usedMemory,
+              totalStorage: data.storagePathSize,
+              usedStorage: data.storagePathUsed,
+              maxFileDescriptors: data.maxFileDescriptors,
+              allocatedFileDescriptors: data.allocatedFileDescriptors,
+              receivedBytesPerSec: data.receivedBytesPerSec,
+              transferredBytesPerSec: data.transferredBytesPerSec
+            })
+          } catch (e) {
+            // Swallow errors -- this method should not throw generally
+            console.error(e)
+          }
         }
       })
     }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This takes care of this bug:
```assignReplicaSet() Error -- Phase AUTOSELECT_CONTENT_NODES: TypeError: null is not an object (evaluating 't.response.data')```

But there is still one more
```

assignReplicaSet() Error -- Phase AUTOSELECT_CONTENT_NODES: TypeError: Cannot read property 'data' of null
--

```
That i'm looking for repro of


The root cause in this issue was that when a request times out, it doesn't have a data field in the response


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Manually made a request timeout to one of the content nodes to reproduce
2. Created an account on stage with the change and a content node manually slow
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
