### PR TITLE
[AUD-291] Sync file fetch optimizations

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -187,7 +187,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         decisionTree.push({ stage: 'About to retrieve file from local ipfs node with get', vals: multihash, time: Date.now() })
         // ipfsGet returns a BufferListStream object which is not a buffer
         // not compatible into writeFile directly, but it can be streamed to a file
-        let fileBL = await Utils.ipfsGet(multihash, req, 5000)
+        let fileBL = await Utils.ipfsGet(multihash, req, 1000)
         req.logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
         decisionTree.push({ stage: 'Retrieved file from local ipfs node with get', vals: multihash, time: Date.now() })
 

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -264,6 +264,8 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       for await (const result of ipfs.add(content, { onlyHash: true, timeout: 10000 })) {
         if (multihash !== result.cid.toString()) {
           decisionTree.push({ stage: `File contents don't match IPFS hash multihash`, vals: result.cid.toString(), time: Date.now() })
+          // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
+          unlink(expectedStoragePath)
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }
       }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -265,7 +265,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         if (multihash !== result.cid.toString()) {
           decisionTree.push({ stage: `File contents don't match IPFS hash multihash`, vals: result.cid.toString(), time: Date.now() })
           // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
-          unlink(expectedStoragePath)
+          await unlink(expectedStoragePath)
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }
       }

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -155,9 +155,10 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
 
     // using a js timeout because IPFS cat sometimes does not resolve the timeout and gets
     // stuck in this function indefinitely
+    // make this timeout 2x the regular timeout to account for possible latency of transferring a large file
     setTimeout(() => {
       return reject(new Error('ipfsCat timed out'))
-    }, timeout)
+    }, 2 * timeout)
 
     // ipfs.cat() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */
@@ -189,9 +190,10 @@ const ipfsGet = (path, req, timeout = 1000) => new Promise(async (resolve, rejec
 
     // using a js timeout because IPFS get sometimes does not resolve the timeout and gets
     // stuck in this function indefinitely
+    // make this timeout 2x the regular timeout to account for possible latency of transferring a large file
     setTimeout(() => {
       return reject(new Error('ipfsGet timed out'))
-    }, timeout)
+    }, 2 * timeout)
 
     // ipfs.get() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -151,7 +151,13 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
     let chunks = []
     let options = {}
     if (length) options.length = length
-    if (timeout) options.timeout = timeout
+
+    // using a js timeout because IPFS cat sometimes does not resolve the timeout and gets
+    // stuck in this function indefinitely
+    setTimeout(() => {
+      reject('ipfsCat timed out')
+    }, timeout)
+
     // ipfs.cat() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */
     for await (const chunk of ipfs.cat(path, options)) {
@@ -178,7 +184,13 @@ const ipfsGet = (path, req, timeout = 1000) => new Promise(async (resolve, rejec
   try {
     let chunks = []
     let options = {}
-    if (timeout) options.timeout = timeout
+
+    // using a js timeout because IPFS get sometimes does not resolve the timeout and gets
+    // stuck in this function indefinitely
+    setTimeout(() => {
+      reject('ipfsGet timed out')
+    }, timeout)
+
     // ipfs.get() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */
     for await (const file of ipfs.get(path, options)) {

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -151,11 +151,12 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
     let chunks = []
     let options = {}
     if (length) options.length = length
+    if (timeout) options.timeout = timeout
 
     // using a js timeout because IPFS cat sometimes does not resolve the timeout and gets
     // stuck in this function indefinitely
     setTimeout(() => {
-      reject('ipfsCat timed out')
+      return reject(new Error('ipfsCat timed out'))
     }, timeout)
 
     // ipfs.cat() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
@@ -184,11 +185,12 @@ const ipfsGet = (path, req, timeout = 1000) => new Promise(async (resolve, rejec
   try {
     let chunks = []
     let options = {}
+    if (timeout) options.timeout = timeout
 
     // using a js timeout because IPFS get sometimes does not resolve the timeout and gets
     // stuck in this function indefinitely
     setTimeout(() => {
-      reject('ipfsGet timed out')
+      return reject(new Error('ipfsGet timed out'))
     }, timeout)
 
     // ipfs.get() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop


### PR DESCRIPTION
### Description
We've seen occasions where IPFS cat and get fail to retrieve a file. This is unrelated to our current IFPS daemon version or client version since we've tried retrieving the files from IPFS v0.7.0 as well as the public gateway nodes. This PR adds two things
1. Add a js timeout to ipfs cat and get and remove the existing IPFS timeout so it doesn't double fire
2. unlink a file if we somehow retrieve corrupted data. Using a newer version of the ipfs http client actually returns corrupted data since the timeout fires without the file being fully retrieved. On our current version of ipfs http client, we don't observe that behavior, but it seems best to check the content addressing and remove the file.



### Tests
Set my local content node to sync the data for several users on production that seemed stuck and it successfully worked.
