### PR TITLE
[Discuss -- not urgent] Disable ensure primary on first write

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -54,7 +54,7 @@ async function syncLockMiddleware (req, res, next) {
 
 /** Blocks writes if node is not the primary for audiusUser associated with wallet. */
 async function ensurePrimaryMiddleware (req, res, next) {
-  if (config.get('isUserMetadataNode')) {
+  if (config.get('isUserMetadataNode') || req.body.forceWrite) {
     return next()
   }
 

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -176,7 +176,7 @@ class CreatorNode {
    * Uploads creator content to a creator node
    * @param {object} metadata the creator metadata
    */
-  async uploadCreatorContent (metadata, blockNumber = null) {
+  async uploadCreatorContent (metadata, blockNumber = null, forceWrite = false) {
     // this does the actual validation before sending to the creator node
     // if validation fails, validate() will throw an error
     try {
@@ -187,7 +187,8 @@ class CreatorNode {
         method: 'post',
         data: {
           metadata,
-          blockNumber
+          blockNumber,
+          forceWrite
         }
       }
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Since we switched off of UM node, we incur a pretty hefty sign up delay where we try to ensure primary on the node the user is trying to sign up against. I think this change here (disabling ensurePrimary by command) would work, but need to discuss other possible implications.



### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Created account on local setup & saw that primary was indeed set, just after initial metadata is written
```
creator_node_endpoint: "http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000",
```

...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
