### PR TITLE
Reduce snapback concurrency hotfix

### DIFF
--- a/creator-node/.version.json
+++ b/creator-node/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.30",
+  "version": "0.3.31",
   "service": "content-node"
 }

--- a/creator-node/.version.json
+++ b/creator-node/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.29",
+  "version": "0.3.30",
   "service": "content-node"
 }

--- a/creator-node/src/snapbackSM.js
+++ b/creator-node/src/snapbackSM.js
@@ -564,7 +564,7 @@ class SnapbackSM {
     await this.initializeNodeIdentityConfig()
 
     // Enqueue first state machine operation
-    await this.stateMachineQueue.add({ startTime: Date.now() })
+    // await this.stateMachineQueue.add({ startTime: Date.now() })
   }
 
   async getSyncQueueJobs () {

--- a/discovery-provider/.version.json
+++ b/discovery-provider/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.29",
+  "version": "0.3.30",
   "service": "discovery-node"
 }


### PR DESCRIPTION
### Description
This is on top of the v0.3.31 patch version bump. This PR will not be merged

Turn off the low priority recurring syncs in snapbackSM. 


### Tests
Tested this locally by setting the spId of the node to a valid id and observing that the task starts
<img width="1676" alt="initScripts_—_ubuntu_ip-172-31-79-50____audius-protocol_service-commands_scripts_—_ssh_-i____ssh_audius-production_pem_ubuntu_ec2-34-237-76-89_compute-1_amazonaws_com_—_238×107" src="https://user-images.githubusercontent.com/295938/109050891-eb0c4d00-76a7-11eb-8079-5477e0333634.png">

After disabling that initial task, notice that the state machine queue process never runs
<img width="1676" alt="initScripts_—_ubuntu_ip-172-31-79-50____audius-protocol_service-commands_scripts_—_ssh_-i____ssh_audius-production_pem_ubuntu_ec2-34-237-76-89_compute-1_amazonaws_com_—_238×107" src="https://user-images.githubusercontent.com/295938/109050998-0bd4a280-76a8-11eb-8aa3-52155db85ea3.png">

Also created a user locally and uploaded a track and made sure that high priority syncs from between two content nodes work

<img width="1680" alt="34_237_76_89_4000_health_check_sync" src="https://user-images.githubusercontent.com/295938/109053313-8bfc0780-76aa-11eb-90d5-d1aa2416f844.png">



**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
