### PR TITLE
[AUD-320] Replace fs sync read calls with async versions

### DIFF
--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -1,5 +1,6 @@
 const { Buffer } = require('ipfs-http-client')
 const fs = require('fs')
+const { promisify } = require('util')
 
 const models = require('../models')
 const { saveFileFromBufferToIPFSAndDisk } = require('../fileManager')
@@ -13,6 +14,8 @@ const {
   triggerSecondarySyncs
 } = require('../middlewares')
 const DBManager = require('../dbManager')
+
+const readFile = promisify(fs.readFile)
 
 module.exports = function (app) {
   /**
@@ -83,9 +86,10 @@ module.exports = function (app) {
     }
     let metadataJSON
     try {
-      metadataJSON = JSON.parse(fs.readFileSync(file.storagePath))
+      const fileBuffer = await readFile(file.storagePath)
+      metadataJSON = JSON.parse(fileBuffer)
     } catch (e) {
-      return errorResponseServerError(`No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}.`)
+      return errorResponseServerError(`No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}: ${e}.`)
     }
 
     // Get coverArtFileUUID and profilePicFileUUID for multihashes in metadata object, if present.

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -34,6 +34,9 @@ const ImageProcessingQueue = require('../ImageProcessingQueue')
 const RehydrateIpfsQueue = require('../RehydrateIpfsQueue')
 const DBManager = require('../dbManager')
 const DiskManager = require('../diskManager')
+const { promisify } = require('util')
+
+const fsStat = promisify(fs.stat)
 
 const FILE_CACHE_EXPIRY_SECONDS = 5 * 60
 
@@ -52,7 +55,7 @@ const streamFromFileSystem = async (req, res, path) => {
     let fileStream
 
     let stat
-    stat = fs.statSync(path)
+    stat = await fsStat(path)
     // Add 'Accept-Ranges' if streamable
     if (req.params.streamable) {
       res.set('Accept-Ranges', 'bytes')

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 const { Buffer } = require('ipfs-http-client')
+const { promisify } = require('util')
 
 const config = require('../config.js')
 const { getSegmentsDuration } = require('../segmentDuration')
@@ -28,6 +29,8 @@ const { getCID } = require('./files')
 const { decode } = require('../hashids.js')
 const RehydrateIpfsQueue = require('../RehydrateIpfsQueue')
 const DBManager = require('../dbManager')
+
+const readFile = promisify(fs.readFile)
 
 const SaveFileToIPFSConcurrencyLimit = 10
 
@@ -311,7 +314,8 @@ module.exports = function (app) {
     }
     let metadataJSON
     try {
-      metadataJSON = JSON.parse(fs.readFileSync(file.storagePath))
+      const fileBuffer = await readFile(file.storagePath)
+      metadataJSON = JSON.parse(fileBuffer)
       if (
         !metadataJSON ||
         !metadataJSON.track_segments ||

--- a/creator-node/src/segmentDuration.js
+++ b/creator-node/src/segmentDuration.js
@@ -1,35 +1,36 @@
 const path = require('path')
 const fs = require('fs')
+const { promisify } = require('util')
+
+const readFile = promisify(fs.readFile)
 
 const SEGMENT_REGEXP = /(segment[0-9]*.ts)/
 
 // Parse m3u8 file from HLS output and return map(segment filePath (segmentName) => segment duration)
 async function getSegmentsDuration (filename, filedir) {
-  return new Promise((resolve, reject) => {
-    try {
-      let splitResults = filename.split('.')
-      let fileRandomName = splitResults[0]
-      let manifestPath = path.join(filedir, `${fileRandomName}.m3u8`)
-      let manifestContents = fs.readFileSync(manifestPath)
-      let splitManifest = manifestContents.toString().split('\n')
-
-      let segmentDurations = {}
-      for (let i = 0; i < splitManifest.length; i += 1) {
-        let matchedResults = splitManifest[i].match(SEGMENT_REGEXP)
-        if (matchedResults === null) {
-          continue
-        }
-        let segmentName = matchedResults[0]
-        let durationString = splitManifest[i - 1]
-        let durationSplit = durationString.split(':')
-        let duration = parseFloat(durationSplit[1])
-        segmentDurations[segmentName] = duration
+  try {
+    let splitResults = filename.split('.')
+    let fileRandomName = splitResults[0]
+    let manifestPath = path.join(filedir, `${fileRandomName}.m3u8`)
+    let manifestContents = await readFile(manifestPath)
+    let splitManifest = manifestContents.toString().split('\n')
+  
+    let segmentDurations = {}
+    for (let i = 0; i < splitManifest.length; i += 1) {
+      let matchedResults = splitManifest[i].match(SEGMENT_REGEXP)
+      if (matchedResults === null) {
+        continue
       }
-      resolve(segmentDurations)
-    } catch (e) {
-      reject(new Error(`Failed - ${e}`))
+      let segmentName = matchedResults[0]
+      let durationString = splitManifest[i - 1]
+      let durationSplit = durationString.split(':')
+      let duration = parseFloat(durationSplit[1])
+      segmentDurations[segmentName] = duration
     }
-  })
+    return segmentDurations
+  } catch (e) {
+    throw new Error(`Failed - ${e}`)
+  }
 }
 
 module.exports = { getSegmentsDuration }

--- a/creator-node/src/segmentDuration.js
+++ b/creator-node/src/segmentDuration.js
@@ -14,7 +14,7 @@ async function getSegmentsDuration (filename, filedir) {
     let manifestPath = path.join(filedir, `${fileRandomName}.m3u8`)
     let manifestContents = await readFile(manifestPath)
     let splitManifest = manifestContents.toString().split('\n')
-  
+
     let segmentDurations = {}
     for (let i = 0; i < splitManifest.length; i += 1) {
       let matchedResults = splitManifest[i].match(SEGMENT_REGEXP)

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -13,6 +13,9 @@ const redis = require('./redis')
 const config = require('./config')
 const BlacklistManager = require('./blacklistManager')
 const { generateTimestampAndSignature } = require('./apiSigning')
+const { promisify } = require('util')
+
+const readFile = promisify(fs.readFile)
 
 class Utils {
   static verifySignature (data, sig) {
@@ -338,7 +341,7 @@ async function rehydrateIpfsFromFsIfNecessary (multihash, storagePath, logContex
     for (var entry of findOriginalFileQuery) {
       let sourceFilePath = entry.storagePath
       try {
-        let bufferedFile = fs.readFileSync(sourceFilePath)
+        let bufferedFile = await readFile(sourceFilePath)
         let originalSource = entry.sourceFile
         ipfsAddArray.push({
           path: originalSource,
@@ -396,7 +399,7 @@ async function rehydrateIpfsDirFromFsIfNecessary (dirHash, logContext) {
   for (let entry of findOriginalFileQuery) {
     let sourceFilePath = entry.storagePath
     try {
-      let bufferedFile = fs.readFileSync(sourceFilePath)
+      let bufferedFile = await readFile(sourceFilePath)
       let originalSource = entry.sourceFile
       ipfsAddArray.push({
         path: originalSource,


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This PR does not touch any of the usage of fs.existsSync. The async version fs.exists has been deprecated and we are told to use fs.access. That should be handled as a separate change because the scope of one is big enough as is.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

[x] Create account
[x] Upload track
[x] Ensure primary and secondary have all synced files
[x] Ensure that images on IPFS are readable from both primary and secondary
[x] Switch secondary to primary
[x] Test CN stream URL
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
