### PR TITLE
Fail verbose health check on read only mode

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -82,6 +82,10 @@ const healthCheckDurationController = async (req) => {
  * Will be used for cnode selection.
  */
 const healthCheckVerboseController = async (req) => {
+  if (config.get('isReadOnlyMode')) {
+    return errorResponseServerError()
+  }
+
   const logger = req.logger
   const healthCheckResponse = await healthCheckVerbose(
     serviceRegistry,


### PR DESCRIPTION
### Description
Fails the `health_check/verbose` endpoint on read only mode so that we can migrate the content node while on read only mode.




### Tests
NA
