### PR TITLE
Aggregate metrics from other discovery nodes

### DIFF
--- a/discovery-provider/.gitignore
+++ b/discovery-provider/.gitignore
@@ -38,3 +38,6 @@ cov_html/*
 build/
 
 .vscode/
+
+# redis dumps
+*_dump

--- a/discovery-provider/alembic/versions/c967ae0fcaf6_add_aggregate_metrics_tables.py
+++ b/discovery-provider/alembic/versions/c967ae0fcaf6_add_aggregate_metrics_tables.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table('daily_unique_users_metrics',
+    op.create_table('aggregate_daily_unique_users_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('count', sa.Integer(), nullable=False),
         sa.Column('timestamp', sa.Date(), nullable=False),
@@ -25,7 +25,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('daily_total_users_metrics',
+    op.create_table('aggregate_daily_total_users_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('count', sa.Integer(), nullable=False),
         sa.Column('timestamp', sa.Date(), nullable=False),
@@ -33,7 +33,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('monthly_unique_users_metrics',
+    op.create_table('aggregate_monthly_unique_users_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('count', sa.Integer(), nullable=False),
         sa.Column('timestamp', sa.Date(), nullable=False),
@@ -41,7 +41,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('monthly_total_users_metrics',
+    op.create_table('aggregate_monthly_total_users_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('count', sa.Integer(), nullable=False),
         sa.Column('timestamp', sa.Date(), nullable=False),
@@ -49,7 +49,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('daily_app_name_metrics',
+    op.create_table('aggregate_daily_app_name_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('application_name', sa.String(), nullable=False),
         sa.Column('count', sa.Integer(), nullable=False),
@@ -58,7 +58,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('monthly_app_name_metrics',
+    op.create_table('aggregate_monthly_app_name_metrics',
         sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
         sa.Column('application_name', sa.String(), nullable=False),
         sa.Column('count', sa.Integer(), nullable=False),
@@ -70,9 +70,9 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('daily_unique_users_metrics')
-    op.drop_table('daily_total_users_metrics')
-    op.drop_table('monthly_unique_users_metrics')
-    op.drop_table('monthly_total_users_metrics')
-    op.drop_table('daily_app_name_metrics')
-    op.drop_table('monthly_app_name_metrics')
+    op.drop_table('aggregate_daily_unique_users_metrics')
+    op.drop_table('aggregate_daily_total_users_metrics')
+    op.drop_table('aggregate_monthly_unique_users_metrics')
+    op.drop_table('aggregate_monthly_total_users_metrics')
+    op.drop_table('aggregate_daily_app_name_metrics')
+    op.drop_table('aggregate_monthly_app_name_metrics')

--- a/discovery-provider/alembic/versions/c967ae0fcaf6_add_aggregate_metrics_tables.py
+++ b/discovery-provider/alembic/versions/c967ae0fcaf6_add_aggregate_metrics_tables.py
@@ -1,0 +1,78 @@
+"""Add aggregate metrics tables
+
+Revision ID: c967ae0fcaf6
+Revises: 579360c7cbf3
+Create Date: 2021-02-24 17:45:45.939947
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c967ae0fcaf6'
+down_revision = '5dd6a55bb738'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('daily_unique_users_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('daily_total_users_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('monthly_unique_users_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('monthly_total_users_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('daily_app_name_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('application_name', sa.String(), nullable=False),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('monthly_app_name_metrics',
+        sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+        sa.Column('application_name', sa.String(), nullable=False),
+        sa.Column('count', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.Date(), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('daily_unique_users_metrics')
+    op.drop_table('daily_total_users_metrics')
+    op.drop_table('monthly_unique_users_metrics')
+    op.drop_table('monthly_total_users_metrics')
+    op.drop_table('daily_app_name_metrics')
+    op.drop_table('monthly_app_name_metrics')

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -28,6 +28,7 @@ from src.utils.session_manager import SessionManager
 from src.utils.config import config_files, shared_config, ConfigIni
 from src.utils.ipfs_lib import IPFSClient
 from src.tasks import celery_app
+from src.utils.redis_metrics import METRICS_INTERVAL
 
 # these global vars will be set in create_celery function
 web3endpoint = None
@@ -324,6 +325,14 @@ def configure_celery(flask_app, celery, test_config=None):
             "update_metrics": {
                 "task": "update_metrics",
                 "schedule": crontab(minute=0, hour="*")
+            },
+            "aggregate_metrics": {
+                "task": "aggregate_metrics",
+                "schedule": timedelta(minutes=METRICS_INTERVAL)
+            },
+            "synchronize_metrics": {
+                "task": "synchronize_metrics",
+                "schedule": crontab(minute=0, hour=1)
             },
             "update_materialized_views": {
                 "task": "update_materialized_views",

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -230,6 +230,9 @@ def extend_activity(item):
         }
     return None
 
+def abort_bad_path_param(param, namespace):
+    namespace.abort(400, "Oh no! Bad path parameter {}.".format(param))
+
 def abort_bad_request_param(param, namespace):
     namespace.abort(400, "Oh no! Bad request parameter {}.".format(param))
 

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -146,6 +146,11 @@ def parse_unix_epoch_param(time, default=0):
         return datetime.utcfromtimestamp(default)
     return datetime.utcfromtimestamp(time)
 
+def parse_unix_epoch_param_non_utc(time, default=0):
+    if time is None:
+        return datetime.fromtimestamp(default)
+    return datetime.fromtimestamp(time)
+
 def extend_track(track):
     track_id = encode_int_id(track["track_id"])
     owner_id = encode_int_id(track["owner_id"])

--- a/discovery-provider/src/api/v1/metrics.py
+++ b/discovery-provider/src/api/v1/metrics.py
@@ -62,7 +62,9 @@ class CachedRouteMetrics(Resource):
     @cache(ttl_sec=5)
     def get(self):
         args = metrics_route_parser.parse_args()
+        logger.info(f"getting cached route metrics at {args.get('start_time')} before parsing")
         start_time = parse_unix_epoch_param_non_utc(args.get("start_time"))
+        logger.info(f"getting cached route metrics at {start_time} UTC")
         metrics = get_redis_route_metrics(start_time)
         response = success_response(metrics)
         return response
@@ -83,7 +85,9 @@ class CachedAppMetrics(Resource):
     @cache(ttl_sec=5)
     def get(self):
         args = metrics_route_parser.parse_args()
+        logger.info(f"getting cached app metrics at {args.get('start_time')} before parsing")
         start_time = parse_unix_epoch_param_non_utc(args.get("start_time"))
+        logger.info(f"getting cached app metrics at {start_time.now()} UTC")
         metrics = get_redis_app_metrics(start_time)
         response = success_response(metrics)
         return response

--- a/discovery-provider/src/api/v1/metrics.py
+++ b/discovery-provider/src/api/v1/metrics.py
@@ -1,19 +1,22 @@
 import logging
 from src.queries.get_genre_metrics import get_genre_metrics
 from src.queries.get_plays_metrics import get_plays_metrics
-from flask import Flask, Blueprint
 from flask_restx import Resource, Namespace, fields, reqparse, inputs
 from src.api.v1.helpers import make_response, success_response, to_dict, \
-    parse_bool_param, parse_unix_epoch_param, abort_bad_request_param
+    parse_bool_param, parse_unix_epoch_param, abort_bad_request_param, \
+    abort_bad_path_param, format_limit
 from .models.metrics import route_metric, app_name_metric, app_name, plays_metric, \
     genre_metric, route_trailing_metric, app_name_trailing_metric
-from src.queries.get_route_metrics import get_route_metrics
-from src.queries.get_app_name_metrics import get_app_name_metrics
+from src.queries.get_route_metrics import get_route_metrics, get_aggregate_route_metrics, \
+    get_historical_route_metrics
+from src.queries.get_app_name_metrics import get_app_name_metrics, get_aggregate_app_metrics, \
+    get_historical_app_metrics
 from src.queries.get_app_names import get_app_names
 from src.queries.get_trailing_metrics import get_monthly_trailing_route_metrics, \
-    get_trailing_app_metrics
+    get_trailing_app_metrics, get_aggregate_route_metrics_trailing_month
 from src.utils.redis_cache import cache
-
+from src.utils.redis_metrics import get_redis_route_metrics, get_redis_app_metrics, \
+    get_aggregate_metrics_info
 logger = logging.getLogger(__name__)
 
 
@@ -37,6 +40,101 @@ metrics_route_parser.add_argument('bucket_size', required=False)
 metrics_route_parser.add_argument('version', required=False, action='append')
 
 valid_date_buckets = ['hour', 'day', 'week', 'month', 'quarter', 'year', 'decade', 'century']
+valid_bucket_sizes = {
+    'week': ['day'],
+    'month': ['day', 'week'],
+    'all_time': ['month', 'week']
+}
+
+@ns.route("/aggregates/info", doc=False)
+class MetricsAggregateInfo(Resource):
+    @cache(ttl_sec=5)
+    def get(self):
+        """Gets aggregate metrics information"""
+        metrics_info = get_aggregate_metrics_info()
+        logger.info(f"metrics info: {metrics_info}")
+        response = success_response(metrics_info)
+        return response
+
+@ns.route("/aggregates/historical", doc=False)
+class MetricsAggregateInfo(Resource):
+    @cache(ttl_sec=30 * 60)
+    def get(self):
+        """Gets historical aggregate metrics"""
+        historical_metrics = {
+            'routes': get_historical_route_metrics(),
+            'apps': get_historical_app_metrics()
+        } 
+        response = success_response(historical_metrics)
+        return response
+
+@ns.route("/aggregates/routes/cached", doc=False)
+class CachedRouteMetrics(Resource):
+    @cache(ttl_sec=5)
+    def get(self):
+        args = metrics_route_parser.parse_args()
+        start_time = parse_unix_epoch_param(args.get("start_time"))
+        metrics = get_redis_route_metrics(start_time)
+        response = success_response(metrics)
+        return response
+
+@ns.route("/aggregates/routes/trailing/month", doc=False)
+class RouteAggregateMetricsTrailingMonth(Resource):
+    @cache(ttl_sec=30 * 60)
+    def get(self):
+        """Gets aggregated route metrics based on time range and bucket size"""
+        metrics = get_aggregate_route_metrics_trailing_month()
+        response = success_response(metrics)
+        return response
+
+aggregate_metrics_route_parser = reqparse.RequestParser()
+aggregate_metrics_route_parser.add_argument('bucket_size', required=False)
+
+@ns.route("/aggregates/routes/<string:time_range>", doc=False)
+class RouteAggregateMetrics(Resource):
+    @cache(ttl_sec=30 * 60)
+    def get(self, time_range):
+        """Gets aggregated route metrics based on time range and bucket size"""
+        if time_range not in valid_bucket_sizes:
+            abort_bad_path_param('time_range', ns)
+
+        args = aggregate_metrics_route_parser.parse_args()
+        valid_buckets = valid_bucket_sizes[time_range]
+        bucket_size = args.get("bucket_size") or valid_buckets[0]
+
+        if bucket_size not in valid_buckets:
+            abort_bad_request_param('bucket_size', ns)
+
+        metrics = get_aggregate_route_metrics(time_range, bucket_size)
+        response = success_response(metrics)
+        return response
+
+@ns.route("/aggregates/apps/cached", doc=False)
+class CachedAppMetrics(Resource):
+    @cache(ttl_sec=5)
+    def get(self):
+        args = metrics_route_parser.parse_args()
+        start_time = parse_unix_epoch_param(args.get("start_time"))
+        metrics = get_redis_app_metrics(start_time)
+        response = success_response(metrics)
+        return response
+
+aggregate_metrics_app_name_parser = reqparse.RequestParser()
+aggregate_metrics_app_name_parser.add_argument('limit', required=False)
+
+@ns.route("/aggregates/apps/<string:time_range>", doc=False)
+class AppNameAggregateMetricsTrailing(Resource):
+    @cache(ttl_sec=30 * 60)
+    def get(self, time_range):
+        """Gets aggregated app metrics based on time range and bucket size"""
+        if time_range not in valid_bucket_sizes:
+            abort_bad_path_param('time_range', ns)
+
+        args = aggregate_metrics_app_name_parser.parse_args()
+        limit = format_limit(args, max_limit=100)
+        metrics = get_aggregate_app_metrics(time_range, limit)
+        response = success_response(metrics)
+        return response
 
 @ns.route("/routes", doc=False)
 class RouteMetrics(Resource):

--- a/discovery-provider/src/api/v1/metrics.py
+++ b/discovery-provider/src/api/v1/metrics.py
@@ -3,8 +3,8 @@ from src.queries.get_genre_metrics import get_genre_metrics
 from src.queries.get_plays_metrics import get_plays_metrics
 from flask_restx import Resource, Namespace, fields, reqparse, inputs
 from src.api.v1.helpers import make_response, success_response, to_dict, \
-    parse_bool_param, parse_unix_epoch_param, abort_bad_request_param, \
-    abort_bad_path_param, format_limit
+    parse_bool_param, parse_unix_epoch_param, parse_unix_epoch_param_non_utc, \
+    abort_bad_request_param, abort_bad_path_param, format_limit
 from .models.metrics import route_metric, app_name_metric, app_name, plays_metric, \
     genre_metric, route_trailing_metric, app_name_trailing_metric
 from src.queries.get_route_metrics import get_route_metrics, get_aggregate_route_metrics, \
@@ -62,7 +62,7 @@ class CachedRouteMetrics(Resource):
     @cache(ttl_sec=5)
     def get(self):
         args = metrics_route_parser.parse_args()
-        start_time = parse_unix_epoch_param(args.get("start_time"))
+        start_time = parse_unix_epoch_param_non_utc(args.get("start_time"))
         metrics = get_redis_route_metrics(start_time)
         response = success_response(metrics)
         return response
@@ -83,7 +83,7 @@ class CachedAppMetrics(Resource):
     @cache(ttl_sec=5)
     def get(self):
         args = metrics_route_parser.parse_args()
-        start_time = parse_unix_epoch_param(args.get("start_time"))
+        start_time = parse_unix_epoch_param_non_utc(args.get("start_time"))
         metrics = get_redis_app_metrics(start_time)
         response = success_response(metrics)
         return response
@@ -113,7 +113,7 @@ class AggregateHistoricalMetrics(Resource):
 class AggregateRouteMetricsTrailingMonth(Resource):
     @cache(ttl_sec=30 * 60)
     def get(self):
-        """Gets aggregated route metrics based on time range and bucket size"""
+        """Gets aggregated route metrics for the last trailing 30 days"""
         metrics = get_aggregate_route_metrics_trailing_month()
         response = success_response(metrics)
         return response

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -485,7 +485,7 @@ class AggregateDailyUniqueUsersMetrics(Base):
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # zeroed out to the day
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -501,7 +501,7 @@ class AggregateDailyTotalUsersMetrics(Base):
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # zeroed out to the day
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -517,7 +517,7 @@ class AggregateMonthlyUniqueUsersMetrics(Base):
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # first day of month
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -533,7 +533,7 @@ class AggregateMonthlyTotalUsersMetrics(Base):
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # first day of month
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -570,7 +570,7 @@ class AggregateDailyAppNameMetrics(Base):
     id = Column(Integer, primary_key=True)
     application_name = Column(String, nullable=False)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # zeroed out to the day
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -588,7 +588,7 @@ class AggregateMonthlyAppNameMetrics(Base):
     id = Column(Integer, primary_key=True)
     application_name = Column(String, nullable=False)
     count = Column(Integer, nullable=False)
-    timestamp = Column(Date, nullable=False)
+    timestamp = Column(Date, nullable=False) # first day of month
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -480,8 +480,8 @@ timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class DailyUniqueUsersMetrics(Base):
-    __tablename__ = "daily_unique_users_metrics"
+class AggregateDailyUniqueUsersMetrics(Base):
+    __tablename__ = "aggregate_daily_unique_users_metrics"
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
@@ -490,14 +490,14 @@ class DailyUniqueUsersMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<DailyUniqueUsersMetrics(\
+        return f"<AggregateDailyUniqueUsersMetrics(\
 count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class DailyTotalUsersMetrics(Base):
-    __tablename__ = "daily_total_users_metrics"
+class AggregateDailyTotalUsersMetrics(Base):
+    __tablename__ = "aggregate_daily_total_users_metrics"
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
@@ -506,14 +506,14 @@ class DailyTotalUsersMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<DailyTotalUsersMetrics(\
+        return f"<AggregateDailyTotalUsersMetrics(\
 count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class MonthlyUniqueUsersMetrics(Base):
-    __tablename__ = "monthly_unique_users_metrics"
+class AggregateMonthlyUniqueUsersMetrics(Base):
+    __tablename__ = "aggregate_monthly_unique_users_metrics"
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
@@ -522,14 +522,14 @@ class MonthlyUniqueUsersMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<MonthlyUniqueUsersMetrics(\
+        return f"<AggregateMonthlyUniqueUsersMetrics(\
 count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class MonthlyTotalUsersMetrics(Base):
-    __tablename__ = "monthly_total_users_metrics"
+class AggregateMonthlyTotalUsersMetrics(Base):
+    __tablename__ = "aggregate_monthly_total_users_metrics"
 
     id = Column(Integer, primary_key=True)
     count = Column(Integer, nullable=False)
@@ -538,7 +538,7 @@ class MonthlyTotalUsersMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<MonthlyTotalUsersMetrics(\
+        return f"<AggregateMonthlyTotalUsersMetrics(\
 count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
@@ -564,8 +564,8 @@ timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class DailyAppNameMetrics(Base):
-    __tablename__ = "daily_app_name_metrics"
+class AggregateDailyAppNameMetrics(Base):
+    __tablename__ = "aggregate_daily_app_name_metrics"
 
     id = Column(Integer, primary_key=True)
     application_name = Column(String, nullable=False)
@@ -575,15 +575,15 @@ class DailyAppNameMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<DailyAppNameMetrics(\
+        return f"<AggregateDailyAppNameMetrics(\
 application_name={self.application_name},\
 count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
-class MonthlyAppNameMetrics(Base):
-    __tablename__ = "monthly_app_name_metrics"
+class AggregateMonthlyAppNameMetrics(Base):
+    __tablename__ = "aggregate_monthly_app_name_metrics"
 
     id = Column(Integer, primary_key=True)
     application_name = Column(String, nullable=False)
@@ -593,7 +593,7 @@ class MonthlyAppNameMetrics(Base):
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<MonthlyAppNameMetrics(\
+        return f"<AggregateMonthlyAppNameMetrics(\
 application_name={self.application_name},\
 count={self.count},\
 timestamp={self.timestamp},\

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Integer,
     String,
     Boolean,
+    Date,
     DateTime,
     ForeignKey,
     Text,
@@ -479,6 +480,70 @@ timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"
 
+class DailyUniqueUsersMetrics(Base):
+    __tablename__ = "daily_unique_users_metrics"
+
+    id = Column(Integer, primary_key=True)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<DailyUniqueUsersMetrics(\
+count={self.count},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
+class DailyTotalUsersMetrics(Base):
+    __tablename__ = "daily_total_users_metrics"
+
+    id = Column(Integer, primary_key=True)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<DailyTotalUsersMetrics(\
+count={self.count},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
+class MonthlyUniqueUsersMetrics(Base):
+    __tablename__ = "monthly_unique_users_metrics"
+
+    id = Column(Integer, primary_key=True)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<MonthlyUniqueUsersMetrics(\
+count={self.count},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
+class MonthlyTotalUsersMetrics(Base):
+    __tablename__ = "monthly_total_users_metrics"
+
+    id = Column(Integer, primary_key=True)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<MonthlyTotalUsersMetrics(\
+count={self.count},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
 class AppNameMetrics(Base):
     __tablename__ = "app_name_metrics"
 
@@ -495,6 +560,42 @@ class AppNameMetrics(Base):
 application_name={self.application_name},\
 count={self.count},\
 ip={self.ip},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
+class DailyAppNameMetrics(Base):
+    __tablename__ = "daily_app_name_metrics"
+
+    id = Column(Integer, primary_key=True)
+    application_name = Column(String, nullable=False)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<DailyAppNameMetrics(\
+application_name={self.application_name},\
+count={self.count},\
+timestamp={self.timestamp},\
+created_at={self.created_at},\
+updated_at={self.updated_at}"
+
+class MonthlyAppNameMetrics(Base):
+    __tablename__ = "monthly_app_name_metrics"
+
+    id = Column(Integer, primary_key=True)
+    application_name = Column(String, nullable=False)
+    count = Column(Integer, nullable=False)
+    timestamp = Column(Date, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<MonthlyAppNameMetrics(\
+application_name={self.application_name},\
+count={self.count},\
 timestamp={self.timestamp},\
 created_at={self.created_at},\
 updated_at={self.updated_at}"

--- a/discovery-provider/src/queries/get_app_name_metrics.py
+++ b/discovery-provider/src/queries/get_app_name_metrics.py
@@ -4,7 +4,7 @@ import functools as ft
 from datetime import date, timedelta
 from sqlalchemy import func, desc, asc
 from src import exceptions
-from src.models import AppNameMetrics, DailyAppNameMetrics, MonthlyAppNameMetrics
+from src.models import AppNameMetrics, AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
 from src.utils import db_session
 
 logger = logging.getLogger(__name__)
@@ -33,12 +33,12 @@ def get_historical_app_metrics():
 
         daily_query = (
             session.query(
-                DailyAppNameMetrics.timestamp,
-                DailyAppNameMetrics.application_name,
-                DailyAppNameMetrics.count
+                AggregateDailyAppNameMetrics.timestamp,
+                AggregateDailyAppNameMetrics.application_name,
+                AggregateDailyAppNameMetrics.count
             )
-            .filter(thirty_days_ago <= DailyAppNameMetrics.timestamp)
-            .filter(DailyAppNameMetrics.timestamp < today)
+            .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+            .filter(AggregateDailyAppNameMetrics.timestamp < today)
             .all()
         )
         daily_metrics = ft.reduce(lambda acc, curr: \
@@ -46,11 +46,11 @@ def get_historical_app_metrics():
 
         monthly_query = (
             session.query(
-                MonthlyAppNameMetrics.timestamp,
-                MonthlyAppNameMetrics.application_name,
-                MonthlyAppNameMetrics.count
+                AggregateMonthlyAppNameMetrics.timestamp,
+                AggregateMonthlyAppNameMetrics.application_name,
+                AggregateMonthlyAppNameMetrics.count
             )
-            .filter(MonthlyAppNameMetrics.timestamp < today)
+            .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
             .all()
         )
         monthly_metrics = ft.reduce(lambda acc, curr: \
@@ -80,38 +80,38 @@ def get_aggregate_app_metrics(time_range, limit):
         if time_range == "week":
             query = (
                 session.query(
-                    DailyAppNameMetrics.application_name,
-                    func.sum(DailyAppNameMetrics.count).label('count')
+                    AggregateDailyAppNameMetrics.application_name,
+                    func.sum(AggregateDailyAppNameMetrics.count).label('count')
                 )
-                .filter(seven_days_ago <= DailyAppNameMetrics.timestamp)
-                .filter(DailyAppNameMetrics.timestamp < today)
-                .group_by(DailyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(DailyAppNameMetrics.application_name))
+                .filter(seven_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+                .filter(AggregateDailyAppNameMetrics.timestamp < today)
+                .group_by(AggregateDailyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
                 .limit(limit)
                 .all()
             )
         elif time_range == "month":
             query = (
                 session.query(
-                    DailyAppNameMetrics.application_name,
-                    func.sum(DailyAppNameMetrics.count).label('count')
+                    AggregateDailyAppNameMetrics.application_name,
+                    func.sum(AggregateDailyAppNameMetrics.count).label('count')
                 )
-                .filter(thirty_days_ago <= DailyAppNameMetrics.timestamp)
-                .filter(DailyAppNameMetrics.timestamp < today)
-                .group_by(DailyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(DailyAppNameMetrics.application_name))
+                .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+                .filter(AggregateDailyAppNameMetrics.timestamp < today)
+                .group_by(AggregateDailyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
                 .limit(limit)
                 .all()
             )
         elif time_range == "all_time":
             query = (
                 session.query(
-                    MonthlyAppNameMetrics.application_name,
-                    func.sum(MonthlyAppNameMetrics.count).label('count')
+                    AggregateMonthlyAppNameMetrics.application_name,
+                    func.sum(AggregateMonthlyAppNameMetrics.count).label('count')
                 )
-                .filter(MonthlyAppNameMetrics.timestamp < today)
-                .group_by(MonthlyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(MonthlyAppNameMetrics.application_name))
+                .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
+                .group_by(AggregateMonthlyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(AggregateMonthlyAppNameMetrics.application_name))
                 .limit(limit)
                 .all()
             )

--- a/discovery-provider/src/queries/get_app_name_metrics.py
+++ b/discovery-provider/src/queries/get_app_name_metrics.py
@@ -1,12 +1,124 @@
 import logging
 import time
-from sqlalchemy import func, desc
-
-from src.models import AppNameMetrics
+import functools as ft
+from datetime import date, timedelta
+from sqlalchemy import func, desc, asc
+from src import exceptions
+from src.models import AppNameMetrics, DailyAppNameMetrics, MonthlyAppNameMetrics
 from src.utils import db_session
 
 logger = logging.getLogger(__name__)
 
+def get_historical_app_metrics():
+    """
+    Returns daily metrics for the last thirty days and all time monthly metrics
+
+    Returns:
+        {
+            daily: {
+                2021/01/15: {app1: ..., app2: ...}
+                ...
+            },
+            monthly: {
+                2021/01/01: {app1: ..., app2: ...}
+                ...
+            }
+        }
+    """
+
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        today = date.today()
+        thirty_days_ago = today - timedelta(days=30)
+
+        daily_query = (
+            session.query(
+                DailyAppNameMetrics.timestamp,
+                DailyAppNameMetrics.application_name,
+                DailyAppNameMetrics.count
+            )
+            .filter(thirty_days_ago <= DailyAppNameMetrics.timestamp)
+            .filter(DailyAppNameMetrics.timestamp < today)
+            .all()
+        )
+        daily_metrics = ft.reduce(lambda acc, curr: \
+            acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, daily_query, {})
+
+        monthly_query = (
+            session.query(
+                MonthlyAppNameMetrics.timestamp,
+                MonthlyAppNameMetrics.application_name,
+                MonthlyAppNameMetrics.count
+            )
+            .filter(MonthlyAppNameMetrics.timestamp < today)
+            .all()
+        )
+        monthly_metrics = ft.reduce(lambda acc, curr: \
+            acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, monthly_query, {})
+
+        return {
+            'daily': daily_metrics,
+            'monthly': monthly_metrics
+        }
+
+def get_aggregate_app_metrics(time_range, limit):
+    """
+    Returns app name metrics for a given time range
+
+    Args:
+        time_range: one of "week", "month", "all_time"
+        limit: number The max number of apps to return
+    Returns:
+        [{ name: string, count: number }, ...]
+    """
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        today = date.today()
+        seven_days_ago = today - timedelta(days=7)
+        thirty_days_ago = today - timedelta(days=30)
+
+        if time_range == "week":
+            query = (
+                session.query(
+                    DailyAppNameMetrics.application_name,
+                    func.sum(DailyAppNameMetrics.count).label('count')
+                )
+                .filter(seven_days_ago <= DailyAppNameMetrics.timestamp)
+                .filter(DailyAppNameMetrics.timestamp < today)
+                .group_by(DailyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(DailyAppNameMetrics.application_name))
+                .limit(limit)
+                .all()
+            )
+        elif time_range == "month":
+            query = (
+                session.query(
+                    DailyAppNameMetrics.application_name,
+                    func.sum(DailyAppNameMetrics.count).label('count')
+                )
+                .filter(thirty_days_ago <= DailyAppNameMetrics.timestamp)
+                .filter(DailyAppNameMetrics.timestamp < today)
+                .group_by(DailyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(DailyAppNameMetrics.application_name))
+                .limit(limit)
+                .all()
+            )
+        elif time_range == "all_time":
+            query = (
+                session.query(
+                    MonthlyAppNameMetrics.application_name,
+                    func.sum(MonthlyAppNameMetrics.count).label('count')
+                )
+                .filter(MonthlyAppNameMetrics.timestamp < today)
+                .group_by(MonthlyAppNameMetrics.application_name)
+                .order_by(desc('count'), asc(MonthlyAppNameMetrics.application_name))
+                .limit(limit)
+                .all()
+            )
+        else:
+            raise exceptions.ArgumentError("Invalid time_range")
+
+        return [{"name": item[0], "count": item[1]} for item in query]
 
 def get_app_name_metrics(app_name, args):
     """

--- a/discovery-provider/src/queries/get_app_name_metrics.py
+++ b/discovery-provider/src/queries/get_app_name_metrics.py
@@ -28,38 +28,41 @@ def get_historical_app_metrics():
 
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
-        today = date.today()
-        thirty_days_ago = today - timedelta(days=30)
+        return _get_historical_app_metrics(session)
 
-        daily_query = (
-            session.query(
-                AggregateDailyAppNameMetrics.timestamp,
-                AggregateDailyAppNameMetrics.application_name,
-                AggregateDailyAppNameMetrics.count
-            )
-            .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
-            .filter(AggregateDailyAppNameMetrics.timestamp < today)
-            .all()
+def _get_historical_app_metrics(session):
+    today = date.today()
+    thirty_days_ago = today - timedelta(days=30)
+
+    daily_query = (
+        session.query(
+            AggregateDailyAppNameMetrics.timestamp,
+            AggregateDailyAppNameMetrics.application_name,
+            AggregateDailyAppNameMetrics.count
         )
-        daily_metrics = ft.reduce(lambda acc, curr: \
-            acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, daily_query, {})
+        .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+        .filter(AggregateDailyAppNameMetrics.timestamp < today)
+        .all()
+    )
+    daily_metrics = ft.reduce(lambda acc, curr: \
+        acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, daily_query, {})
 
-        monthly_query = (
-            session.query(
-                AggregateMonthlyAppNameMetrics.timestamp,
-                AggregateMonthlyAppNameMetrics.application_name,
-                AggregateMonthlyAppNameMetrics.count
-            )
-            .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
-            .all()
+    monthly_query = (
+        session.query(
+            AggregateMonthlyAppNameMetrics.timestamp,
+            AggregateMonthlyAppNameMetrics.application_name,
+            AggregateMonthlyAppNameMetrics.count
         )
-        monthly_metrics = ft.reduce(lambda acc, curr: \
-            acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, monthly_query, {})
+        .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
+        .all()
+    )
+    monthly_metrics = ft.reduce(lambda acc, curr: \
+        acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, monthly_query, {})
 
-        return {
-            'daily': daily_metrics,
-            'monthly': monthly_metrics
-        }
+    return {
+        'daily': daily_metrics,
+        'monthly': monthly_metrics
+    }
 
 def get_aggregate_app_metrics(time_range, limit):
     """
@@ -73,52 +76,55 @@ def get_aggregate_app_metrics(time_range, limit):
     """
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
-        today = date.today()
-        seven_days_ago = today - timedelta(days=7)
-        thirty_days_ago = today - timedelta(days=30)
+        return _get_aggregate_app_metrics(session, time_range, limit)
 
-        if time_range == "week":
-            query = (
-                session.query(
-                    AggregateDailyAppNameMetrics.application_name,
-                    func.sum(AggregateDailyAppNameMetrics.count).label('count')
-                )
-                .filter(seven_days_ago <= AggregateDailyAppNameMetrics.timestamp)
-                .filter(AggregateDailyAppNameMetrics.timestamp < today)
-                .group_by(AggregateDailyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
-                .limit(limit)
-                .all()
-            )
-        elif time_range == "month":
-            query = (
-                session.query(
-                    AggregateDailyAppNameMetrics.application_name,
-                    func.sum(AggregateDailyAppNameMetrics.count).label('count')
-                )
-                .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
-                .filter(AggregateDailyAppNameMetrics.timestamp < today)
-                .group_by(AggregateDailyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
-                .limit(limit)
-                .all()
-            )
-        elif time_range == "all_time":
-            query = (
-                session.query(
-                    AggregateMonthlyAppNameMetrics.application_name,
-                    func.sum(AggregateMonthlyAppNameMetrics.count).label('count')
-                )
-                .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
-                .group_by(AggregateMonthlyAppNameMetrics.application_name)
-                .order_by(desc('count'), asc(AggregateMonthlyAppNameMetrics.application_name))
-                .limit(limit)
-                .all()
-            )
-        else:
-            raise exceptions.ArgumentError("Invalid time_range")
+def _get_aggregate_app_metrics(session, time_range, limit):
+    today = date.today()
+    seven_days_ago = today - timedelta(days=7)
+    thirty_days_ago = today - timedelta(days=30)
 
-        return [{"name": item[0], "count": item[1]} for item in query]
+    if time_range == "week":
+        query = (
+            session.query(
+                AggregateDailyAppNameMetrics.application_name,
+                func.sum(AggregateDailyAppNameMetrics.count).label('count')
+            )
+            .filter(seven_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+            .filter(AggregateDailyAppNameMetrics.timestamp < today)
+            .group_by(AggregateDailyAppNameMetrics.application_name)
+            .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
+            .limit(limit)
+            .all()
+        )
+    elif time_range == "month":
+        query = (
+            session.query(
+                AggregateDailyAppNameMetrics.application_name,
+                func.sum(AggregateDailyAppNameMetrics.count).label('count')
+            )
+            .filter(thirty_days_ago <= AggregateDailyAppNameMetrics.timestamp)
+            .filter(AggregateDailyAppNameMetrics.timestamp < today)
+            .group_by(AggregateDailyAppNameMetrics.application_name)
+            .order_by(desc('count'), asc(AggregateDailyAppNameMetrics.application_name))
+            .limit(limit)
+            .all()
+        )
+    elif time_range == "all_time":
+        query = (
+            session.query(
+                AggregateMonthlyAppNameMetrics.application_name,
+                func.sum(AggregateMonthlyAppNameMetrics.count).label('count')
+            )
+            .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
+            .group_by(AggregateMonthlyAppNameMetrics.application_name)
+            .order_by(desc('count'), asc(AggregateMonthlyAppNameMetrics.application_name))
+            .limit(limit)
+            .all()
+        )
+    else:
+        raise exceptions.ArgumentError("Invalid time_range")
+
+    return [{"name": item[0], "count": item[1]} for item in query]
 
 def get_app_name_metrics(app_name, args):
     """

--- a/discovery-provider/src/queries/get_app_name_metrics.py
+++ b/discovery-provider/src/queries/get_app_name_metrics.py
@@ -33,6 +33,7 @@ def get_historical_app_metrics():
 def _get_historical_app_metrics(session):
     today = date.today()
     thirty_days_ago = today - timedelta(days=30)
+    first_day_of_month = today.replace(day=1)
 
     daily_query = (
         session.query(
@@ -53,7 +54,7 @@ def _get_historical_app_metrics(session):
             AggregateMonthlyAppNameMetrics.application_name,
             AggregateMonthlyAppNameMetrics.count
         )
-        .filter(AggregateMonthlyAppNameMetrics.timestamp < today)
+        .filter(AggregateMonthlyAppNameMetrics.timestamp < first_day_of_month)
         .all()
     )
     monthly_metrics = ft.reduce(lambda acc, curr: \

--- a/discovery-provider/src/queries/get_app_name_metrics_test.py
+++ b/discovery-provider/src/queries/get_app_name_metrics_test.py
@@ -1,2 +1,2 @@
 def test():
-    """See /tests/test_get_app_name_metrics_test.py"""
+    """See /tests/test_get_app_name_metrics.py"""

--- a/discovery-provider/src/queries/get_route_metrics.py
+++ b/discovery-provider/src/queries/get_route_metrics.py
@@ -2,7 +2,7 @@ import logging
 import time
 import functools as ft
 from datetime import date, timedelta
-from sqlalchemy import func, desc, or_
+from sqlalchemy import func, asc, desc, or_
 from src import exceptions
 from src.models import RouteMetrics, RouteMetricsDayMatview, RouteMetricsMonthMatview, \
     AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, \
@@ -129,6 +129,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(seven_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
                 .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             unique_count_records = ft.reduce(lambda acc, curr: \
@@ -141,6 +142,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(seven_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
                 .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             total_count_records = ft.reduce(lambda acc, curr: \
@@ -165,6 +167,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
                 .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             unique_count_records = ft.reduce(lambda acc, curr: \
@@ -177,6 +180,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
                 .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             total_count_records = ft.reduce(lambda acc, curr: \
@@ -200,6 +204,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
                 .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
                 .group_by(func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp))
+                .order_by(asc('timestamp'))
                 .all()
             )
             unique_count_records = ft.reduce(lambda acc, curr: \
@@ -213,6 +218,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
                 .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
                 .group_by(func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp))
+                .order_by(asc('timestamp'))
                 .all()
             )
             total_count_records = ft.reduce(lambda acc, curr: \
@@ -236,6 +242,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                     AggregateMonthlyUniqueUsersMetrics.count
                 )
                 .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             unique_count_records = ft.reduce(lambda acc, curr: \
@@ -247,6 +254,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                     AggregateMonthlyTotalUsersMetrics.count
                 )
                 .filter(AggregateMonthlyTotalUsersMetrics.timestamp < today)
+                .order_by(asc('timestamp'))
                 .all()
             )
             total_count_records = ft.reduce(lambda acc, curr: \
@@ -269,6 +277,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
                 .group_by(func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp))
+                .order_by(asc('timestamp'))
                 .all()
             )
             unique_count_records = ft.reduce(lambda acc, curr: \
@@ -280,6 +289,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                 )
                 .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
                 .group_by(func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp))
+                .order_by(asc('timestamp'))
                 .all()
             )
             total_count_records = ft.reduce(lambda acc, curr: \

--- a/discovery-provider/src/queries/get_route_metrics.py
+++ b/discovery-provider/src/queries/get_route_metrics.py
@@ -5,7 +5,8 @@ from datetime import date, timedelta
 from sqlalchemy import func, desc, or_
 from src import exceptions
 from src.models import RouteMetrics, RouteMetricsDayMatview, RouteMetricsMonthMatview, \
-    AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics
+    AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, \
+    AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics
 from src.utils import db_session
 
 logger = logging.getLogger(__name__)

--- a/discovery-provider/src/queries/get_route_metrics.py
+++ b/discovery-provider/src/queries/get_route_metrics.py
@@ -35,6 +35,7 @@ def get_historical_route_metrics():
 def _get_historical_route_metrics(session):
     today = date.today()
     thirty_days_ago = today - timedelta(days=30)
+    first_day_of_month = today.replace(day=1)
 
     daily_metrics = {}
     unique_daily_counts = (
@@ -74,7 +75,7 @@ def _get_historical_route_metrics(session):
             AggregateMonthlyUniqueUsersMetrics.timestamp,
             AggregateMonthlyUniqueUsersMetrics.count
         )
-        .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < today)
+        .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < first_day_of_month)
         .all()
     )
     unique_monthly_count_records = ft.reduce(lambda acc, curr: \
@@ -85,7 +86,7 @@ def _get_historical_route_metrics(session):
             AggregateMonthlyTotalUsersMetrics.timestamp,
             AggregateMonthlyTotalUsersMetrics.count
         )
-        .filter(AggregateMonthlyTotalUsersMetrics.timestamp < today)
+        .filter(AggregateMonthlyTotalUsersMetrics.timestamp < first_day_of_month)
         .all()
     )
     total_monthly_count_records = ft.reduce(lambda acc, curr: \
@@ -119,6 +120,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
     today = date.today()
     seven_days_ago = today - timedelta(days=7)
     thirty_days_ago = today - timedelta(days=30)
+    first_day_of_month = today.replace(day=1)
 
     if time_range == 'week':
         if bucket_size == 'day':
@@ -241,7 +243,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                     AggregateMonthlyUniqueUsersMetrics.timestamp,
                     AggregateMonthlyUniqueUsersMetrics.count
                 )
-                .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < today)
+                .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < first_day_of_month)
                 .order_by(asc('timestamp'))
                 .all()
             )
@@ -253,7 +255,7 @@ def _get_aggregate_route_metrics(session, time_range, bucket_size):
                     AggregateMonthlyTotalUsersMetrics.timestamp,
                     AggregateMonthlyTotalUsersMetrics.count
                 )
-                .filter(AggregateMonthlyTotalUsersMetrics.timestamp < today)
+                .filter(AggregateMonthlyTotalUsersMetrics.timestamp < first_day_of_month)
                 .order_by(asc('timestamp'))
                 .all()
             )

--- a/discovery-provider/src/queries/get_route_metrics.py
+++ b/discovery-provider/src/queries/get_route_metrics.py
@@ -102,7 +102,7 @@ def get_historical_route_metrics():
 def get_aggregate_route_metrics(time_range, bucket_size):
     """
     Returns a list of timestamp with unique count and total count for all routes
-    based on given time range and grouped give by bucket size
+    based on given time range and grouped by bucket size
 
     Returns:
         [{ timestamp, count, unique_count }]

--- a/discovery-provider/src/queries/get_route_metrics.py
+++ b/discovery-provider/src/queries/get_route_metrics.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 from sqlalchemy import func, desc, or_
 from src import exceptions
 from src.models import RouteMetrics, RouteMetricsDayMatview, RouteMetricsMonthMatview, \
-    DailyUniqueUsersMetrics, DailyTotalUsersMetrics, MonthlyUniqueUsersMetrics, MonthlyTotalUsersMetrics
+    AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics
 from src.utils import db_session
 
 logger = logging.getLogger(__name__)
@@ -35,11 +35,11 @@ def get_historical_route_metrics():
         daily_metrics = {}
         unique_daily_counts = (
             session.query(
-                DailyUniqueUsersMetrics.timestamp,
-                DailyUniqueUsersMetrics.count
+                AggregateDailyUniqueUsersMetrics.timestamp,
+                AggregateDailyUniqueUsersMetrics.count
             )
-            .filter(thirty_days_ago <= DailyUniqueUsersMetrics.timestamp)
-            .filter(DailyUniqueUsersMetrics.timestamp < today)
+            .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
+            .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
             .all()
         )
         unique_daily_count_records = ft.reduce(lambda acc, curr: \
@@ -47,11 +47,11 @@ def get_historical_route_metrics():
 
         total_daily_counts = (
             session.query(
-                DailyTotalUsersMetrics.timestamp,
-                DailyTotalUsersMetrics.count
+                AggregateDailyTotalUsersMetrics.timestamp,
+                AggregateDailyTotalUsersMetrics.count
             )
-            .filter(thirty_days_ago <= DailyTotalUsersMetrics.timestamp)
-            .filter(DailyTotalUsersMetrics.timestamp < today)
+            .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
+            .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
             .all()
         )
         total_daily_count_records = ft.reduce(lambda acc, curr: \
@@ -67,10 +67,10 @@ def get_historical_route_metrics():
         monthly_metrics = {}
         unique_monthly_counts = (
             session.query(
-                MonthlyUniqueUsersMetrics.timestamp,
-                MonthlyUniqueUsersMetrics.count
+                AggregateMonthlyUniqueUsersMetrics.timestamp,
+                AggregateMonthlyUniqueUsersMetrics.count
             )
-            .filter(MonthlyUniqueUsersMetrics.timestamp < today)
+            .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < today)
             .all()
         )
         unique_monthly_count_records = ft.reduce(lambda acc, curr: \
@@ -78,10 +78,10 @@ def get_historical_route_metrics():
 
         total_monthly_counts = (
             session.query(
-                MonthlyTotalUsersMetrics.timestamp,
-                MonthlyTotalUsersMetrics.count
+                AggregateMonthlyTotalUsersMetrics.timestamp,
+                AggregateMonthlyTotalUsersMetrics.count
             )
-            .filter(MonthlyTotalUsersMetrics.timestamp < today)
+            .filter(AggregateMonthlyTotalUsersMetrics.timestamp < today)
             .all()
         )
         total_monthly_count_records = ft.reduce(lambda acc, curr: \
@@ -117,11 +117,11 @@ def get_aggregate_route_metrics(time_range, bucket_size):
             if bucket_size == 'day':
                 unique_counts = (
                     session.query(
-                        DailyUniqueUsersMetrics.timestamp,
-                        DailyUniqueUsersMetrics.count
+                        AggregateDailyUniqueUsersMetrics.timestamp,
+                        AggregateDailyUniqueUsersMetrics.count
                     )
-                    .filter(seven_days_ago <= DailyUniqueUsersMetrics.timestamp)
-                    .filter(DailyUniqueUsersMetrics.timestamp < today)
+                    .filter(seven_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
+                    .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
                     .all()
                 )
                 unique_count_records = ft.reduce(lambda acc, curr: \
@@ -129,11 +129,11 @@ def get_aggregate_route_metrics(time_range, bucket_size):
 
                 total_counts = (
                     session.query(
-                        DailyTotalUsersMetrics.timestamp,
-                        DailyTotalUsersMetrics.count
+                        AggregateDailyTotalUsersMetrics.timestamp,
+                        AggregateDailyTotalUsersMetrics.count
                     )
-                    .filter(seven_days_ago <= DailyTotalUsersMetrics.timestamp)
-                    .filter(DailyTotalUsersMetrics.timestamp < today)
+                    .filter(seven_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
+                    .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
                     .all()
                 )
                 total_count_records = ft.reduce(lambda acc, curr: \
@@ -153,11 +153,11 @@ def get_aggregate_route_metrics(time_range, bucket_size):
             if bucket_size == 'day':
                 unique_counts = (
                     session.query(
-                        DailyUniqueUsersMetrics.timestamp,
-                        DailyUniqueUsersMetrics.count
+                        AggregateDailyUniqueUsersMetrics.timestamp,
+                        AggregateDailyUniqueUsersMetrics.count
                     )
-                    .filter(thirty_days_ago <= DailyUniqueUsersMetrics.timestamp)
-                    .filter(DailyUniqueUsersMetrics.timestamp < today)
+                    .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
+                    .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
                     .all()
                 )
                 unique_count_records = ft.reduce(lambda acc, curr: \
@@ -165,11 +165,11 @@ def get_aggregate_route_metrics(time_range, bucket_size):
 
                 total_counts = (
                     session.query(
-                        DailyTotalUsersMetrics.timestamp,
-                        DailyTotalUsersMetrics.count
+                        AggregateDailyTotalUsersMetrics.timestamp,
+                        AggregateDailyTotalUsersMetrics.count
                     )
-                    .filter(thirty_days_ago <= DailyTotalUsersMetrics.timestamp)
-                    .filter(DailyTotalUsersMetrics.timestamp < today)
+                    .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
+                    .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
                     .all()
                 )
                 total_count_records = ft.reduce(lambda acc, curr: \
@@ -187,12 +187,12 @@ def get_aggregate_route_metrics(time_range, bucket_size):
             if bucket_size == 'week':
                 unique_counts = (
                     session.query(
-                        func.date_trunc(bucket_size, DailyUniqueUsersMetrics.timestamp).label('timestamp'),
-                        func.sum(DailyUniqueUsersMetrics.count).label('count')
+                        func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp).label('timestamp'),
+                        func.sum(AggregateDailyUniqueUsersMetrics.count).label('count')
                     )
-                    .filter(thirty_days_ago <= DailyUniqueUsersMetrics.timestamp)
-                    .filter(DailyUniqueUsersMetrics.timestamp < today)
-                    .group_by(func.date_trunc(bucket_size, DailyUniqueUsersMetrics.timestamp))
+                    .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
+                    .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
+                    .group_by(func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp))
                     .all()
                 )
                 unique_count_records = ft.reduce(lambda acc, curr: \
@@ -200,12 +200,12 @@ def get_aggregate_route_metrics(time_range, bucket_size):
 
                 total_counts = (
                     session.query(
-                        func.date_trunc(bucket_size, DailyTotalUsersMetrics.timestamp).label('timestamp'),
-                        func.sum(DailyTotalUsersMetrics.count).label('count')
+                        func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp).label('timestamp'),
+                        func.sum(AggregateDailyTotalUsersMetrics.count).label('count')
                     )
-                    .filter(thirty_days_ago <= DailyTotalUsersMetrics.timestamp)
-                    .filter(DailyTotalUsersMetrics.timestamp < today)
-                    .group_by(func.date_trunc(bucket_size, DailyTotalUsersMetrics.timestamp))
+                    .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
+                    .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
+                    .group_by(func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp))
                     .all()
                 )
                 total_count_records = ft.reduce(lambda acc, curr: \
@@ -225,10 +225,10 @@ def get_aggregate_route_metrics(time_range, bucket_size):
             if bucket_size == 'month':
                 unique_counts = (
                     session.query(
-                        MonthlyUniqueUsersMetrics.timestamp,
-                        MonthlyUniqueUsersMetrics.count
+                        AggregateMonthlyUniqueUsersMetrics.timestamp,
+                        AggregateMonthlyUniqueUsersMetrics.count
                     )
-                    .filter(MonthlyUniqueUsersMetrics.timestamp < today)
+                    .filter(AggregateMonthlyUniqueUsersMetrics.timestamp < today)
                     .all()
                 )
                 unique_count_records = ft.reduce(lambda acc, curr: \
@@ -236,10 +236,10 @@ def get_aggregate_route_metrics(time_range, bucket_size):
 
                 total_counts = (
                     session.query(
-                        MonthlyTotalUsersMetrics.timestamp,
-                        MonthlyTotalUsersMetrics.count
+                        AggregateMonthlyTotalUsersMetrics.timestamp,
+                        AggregateMonthlyTotalUsersMetrics.count
                     )
-                    .filter(MonthlyTotalUsersMetrics.timestamp < today)
+                    .filter(AggregateMonthlyTotalUsersMetrics.timestamp < today)
                     .all()
                 )
                 total_count_records = ft.reduce(lambda acc, curr: \
@@ -257,22 +257,22 @@ def get_aggregate_route_metrics(time_range, bucket_size):
             if bucket_size == 'week':
                 unique_counts = (
                     session.query(
-                        func.date_trunc(bucket_size, DailyUniqueUsersMetrics.timestamp).label('timestamp'),
-                        func.sum(DailyUniqueUsersMetrics.count).label('count')
+                        func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp).label('timestamp'),
+                        func.sum(AggregateDailyUniqueUsersMetrics.count).label('count')
                     )
-                    .filter(DailyUniqueUsersMetrics.timestamp < today)
-                    .group_by(func.date_trunc(bucket_size, DailyUniqueUsersMetrics.timestamp))
+                    .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
+                    .group_by(func.date_trunc(bucket_size, AggregateDailyUniqueUsersMetrics.timestamp))
                     .all()
                 )
                 unique_count_records = ft.reduce(lambda acc, curr: \
                     acc.update({str(curr[0]): curr[1]}) or acc, unique_counts, {})
                 total_counts = (
                     session.query(
-                        func.date_trunc(bucket_size, DailyTotalUsersMetrics.timestamp).label('timestamp'),
-                        func.sum(DailyTotalUsersMetrics.count).label('count')
+                        func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp).label('timestamp'),
+                        func.sum(AggregateDailyTotalUsersMetrics.count).label('count')
                     )
-                    .filter(DailyTotalUsersMetrics.timestamp < today)
-                    .group_by(func.date_trunc(bucket_size, DailyTotalUsersMetrics.timestamp))
+                    .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
+                    .group_by(func.date_trunc(bucket_size, AggregateDailyTotalUsersMetrics.timestamp))
                     .all()
                 )
                 total_count_records = ft.reduce(lambda acc, curr: \

--- a/discovery-provider/src/queries/get_trailing_metrics.py
+++ b/discovery-provider/src/queries/get_trailing_metrics.py
@@ -3,8 +3,8 @@ from functools import reduce
 from datetime import date, timedelta
 from sqlalchemy import desc, func
 from src.models import RouteMetricsTrailingWeek, RouteMetricsTrailingMonth, RouteMetricsAllTime, \
-    AppMetricsTrailingWeek, AppMetricsTrailingMonth, AppMetricsAllTime, DailyUniqueUsersMetrics, \
-    DailyTotalUsersMetrics
+    AppMetricsTrailingWeek, AppMetricsTrailingMonth, AppMetricsAllTime, AggregateDailyUniqueUsersMetrics, \
+    AggregateDailyTotalUsersMetrics
 from src.utils import db_session
 from src import exceptions
 
@@ -23,17 +23,17 @@ def get_aggregate_route_metrics_trailing_month():
         thirty_days_ago = today - timedelta(days=30)
 
         unique_count = (
-            session.query(func.sum(DailyUniqueUsersMetrics.count))
-            .filter(thirty_days_ago <= DailyUniqueUsersMetrics.timestamp)
-            .filter(DailyUniqueUsersMetrics.timestamp < today)
+            session.query(func.sum(AggregateDailyUniqueUsersMetrics.count))
+            .filter(thirty_days_ago <= AggregateDailyUniqueUsersMetrics.timestamp)
+            .filter(AggregateDailyUniqueUsersMetrics.timestamp < today)
             .first()
         )
         logger.info(f"trailing month unique count: {unique_count}")
 
         total_count = (
-            session.query(func.sum(DailyTotalUsersMetrics.count))
-            .filter(thirty_days_ago <= DailyTotalUsersMetrics.timestamp)
-            .filter(DailyTotalUsersMetrics.timestamp < today)
+            session.query(func.sum(AggregateDailyTotalUsersMetrics.count))
+            .filter(thirty_days_ago <= AggregateDailyTotalUsersMetrics.timestamp)
+            .filter(AggregateDailyTotalUsersMetrics.timestamp < today)
             .first()
         )
         logger.info(f"trailing month total count: {total_count}")

--- a/discovery-provider/src/queries/update_historical_metrics.py
+++ b/discovery-provider/src/queries/update_historical_metrics.py
@@ -1,0 +1,107 @@
+import logging
+from src.models import DailyUniqueUsersMetrics, DailyTotalUsersMetrics, MonthlyUniqueUsersMetrics, \
+    MonthlyTotalUsersMetrics, DailyAppNameMetrics, MonthlyAppNameMetrics
+
+logger = logging.getLogger(__name__)
+
+def update_historical_daily_route_metrics(db, metrics):
+    with db.scoped_session() as session:
+        for day, values in metrics.items():
+            day_unique_record = (
+                session.query(DailyUniqueUsersMetrics)
+                .filter(DailyUniqueUsersMetrics.timestamp == day)
+                .first()
+            )
+            if day_unique_record:
+                day_unique_record.count = values['unique']
+            else:
+                day_unique_record = DailyUniqueUsersMetrics(
+                    timestamp=day,
+                    count=values['unique']
+                )
+            session.add(day_unique_record)
+
+            day_total_record = (
+                session.query(DailyTotalUsersMetrics)
+                .filter(DailyTotalUsersMetrics.timestamp == day)
+                .first()
+            )
+            if day_total_record:
+                day_total_record.count = values['total']
+            else:
+                day_total_record = DailyTotalUsersMetrics(
+                    timestamp=day,
+                    count=values['total']
+                )
+            session.add(day_total_record)
+
+def update_historical_monthly_route_metrics(db, metrics):
+    with db.scoped_session() as session:
+        for month, values in metrics.items():
+            month_unique_record = (
+                session.query(MonthlyUniqueUsersMetrics)
+                .filter(MonthlyUniqueUsersMetrics.timestamp == month)
+                .first()
+            )
+            if month_unique_record:
+                month_unique_record.count = values['unique']
+            else:
+                month_unique_record = MonthlyUniqueUsersMetrics(
+                    timestamp=month,
+                    count=values['unique']
+                )
+            session.add(month_unique_record)
+
+            month_total_record = (
+                session.query(MonthlyTotalUsersMetrics)
+                .filter(MonthlyTotalUsersMetrics.timestamp == month)
+                .first()
+            )
+            if month_total_record:
+                month_total_record.count = values['total']
+            else:
+                month_total_record = MonthlyTotalUsersMetrics(
+                    timestamp=month,
+                    count=values['total']
+                )
+            session.add(month_total_record)
+
+def update_historical_daily_app_metrics(db, metrics):
+    with db.scoped_session() as session:
+        for day, values in metrics.items():
+            for app, count in values.items():
+                day_record = (
+                    session.query(DailyAppNameMetrics)
+                    .filter(DailyAppNameMetrics.timestamp == day)
+                    .filter(DailyAppNameMetrics.application_name == app)
+                    .first()
+                )
+                if day_record:
+                    day_record.count = count
+                else:
+                    day_record = DailyAppNameMetrics(
+                        timestamp=day,
+                        application_name=app,
+                        count=count
+                    )
+                session.add(day_record)
+
+def update_historical_monthly_app_metrics(db, metrics):
+    with db.scoped_session() as session:
+        for month, values in metrics.items():
+            for app, count in values.items():
+                month_record = (
+                    session.query(MonthlyAppNameMetrics)
+                    .filter(MonthlyAppNameMetrics.timestamp == month)
+                    .filter(MonthlyAppNameMetrics.application_name == app)
+                    .first()
+                )
+                if month_record:
+                    month_record.count = count
+                else:
+                    month_record = MonthlyAppNameMetrics(
+                        timestamp=month,
+                        application_name=app,
+                        count=count
+                    )
+                session.add(month_record)

--- a/discovery-provider/src/queries/update_historical_metrics.py
+++ b/discovery-provider/src/queries/update_historical_metrics.py
@@ -1,6 +1,7 @@
 import logging
-from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, AggregateMonthlyUniqueUsersMetrics, \
-    AggregateMonthlyTotalUsersMetrics, AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
+from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, \
+    AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics, \
+    AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
 
 logger = logging.getLogger(__name__)
 

--- a/discovery-provider/src/queries/update_historical_metrics.py
+++ b/discovery-provider/src/queries/update_historical_metrics.py
@@ -1,6 +1,6 @@
 import logging
-from src.models import DailyUniqueUsersMetrics, DailyTotalUsersMetrics, MonthlyUniqueUsersMetrics, \
-    MonthlyTotalUsersMetrics, DailyAppNameMetrics, MonthlyAppNameMetrics
+from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, AggregateMonthlyUniqueUsersMetrics, \
+    AggregateMonthlyTotalUsersMetrics, AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -8,28 +8,28 @@ def update_historical_daily_route_metrics(db, metrics):
     with db.scoped_session() as session:
         for day, values in metrics.items():
             day_unique_record = (
-                session.query(DailyUniqueUsersMetrics)
-                .filter(DailyUniqueUsersMetrics.timestamp == day)
+                session.query(AggregateDailyUniqueUsersMetrics)
+                .filter(AggregateDailyUniqueUsersMetrics.timestamp == day)
                 .first()
             )
             if day_unique_record:
                 day_unique_record.count = values['unique']
             else:
-                day_unique_record = DailyUniqueUsersMetrics(
+                day_unique_record = AggregateDailyUniqueUsersMetrics(
                     timestamp=day,
                     count=values['unique']
                 )
             session.add(day_unique_record)
 
             day_total_record = (
-                session.query(DailyTotalUsersMetrics)
-                .filter(DailyTotalUsersMetrics.timestamp == day)
+                session.query(AggregateDailyTotalUsersMetrics)
+                .filter(AggregateDailyTotalUsersMetrics.timestamp == day)
                 .first()
             )
             if day_total_record:
                 day_total_record.count = values['total']
             else:
-                day_total_record = DailyTotalUsersMetrics(
+                day_total_record = AggregateDailyTotalUsersMetrics(
                     timestamp=day,
                     count=values['total']
                 )
@@ -39,28 +39,28 @@ def update_historical_monthly_route_metrics(db, metrics):
     with db.scoped_session() as session:
         for month, values in metrics.items():
             month_unique_record = (
-                session.query(MonthlyUniqueUsersMetrics)
-                .filter(MonthlyUniqueUsersMetrics.timestamp == month)
+                session.query(AggregateMonthlyUniqueUsersMetrics)
+                .filter(AggregateMonthlyUniqueUsersMetrics.timestamp == month)
                 .first()
             )
             if month_unique_record:
                 month_unique_record.count = values['unique']
             else:
-                month_unique_record = MonthlyUniqueUsersMetrics(
+                month_unique_record = AggregateMonthlyUniqueUsersMetrics(
                     timestamp=month,
                     count=values['unique']
                 )
             session.add(month_unique_record)
 
             month_total_record = (
-                session.query(MonthlyTotalUsersMetrics)
-                .filter(MonthlyTotalUsersMetrics.timestamp == month)
+                session.query(AggregateMonthlyTotalUsersMetrics)
+                .filter(AggregateMonthlyTotalUsersMetrics.timestamp == month)
                 .first()
             )
             if month_total_record:
                 month_total_record.count = values['total']
             else:
-                month_total_record = MonthlyTotalUsersMetrics(
+                month_total_record = AggregateMonthlyTotalUsersMetrics(
                     timestamp=month,
                     count=values['total']
                 )
@@ -71,15 +71,15 @@ def update_historical_daily_app_metrics(db, metrics):
         for day, values in metrics.items():
             for app, count in values.items():
                 day_record = (
-                    session.query(DailyAppNameMetrics)
-                    .filter(DailyAppNameMetrics.timestamp == day)
-                    .filter(DailyAppNameMetrics.application_name == app)
+                    session.query(AggregateDailyAppNameMetrics)
+                    .filter(AggregateDailyAppNameMetrics.timestamp == day)
+                    .filter(AggregateDailyAppNameMetrics.application_name == app)
                     .first()
                 )
                 if day_record:
                     day_record.count = count
                 else:
-                    day_record = DailyAppNameMetrics(
+                    day_record = AggregateDailyAppNameMetrics(
                         timestamp=day,
                         application_name=app,
                         count=count
@@ -91,15 +91,15 @@ def update_historical_monthly_app_metrics(db, metrics):
         for month, values in metrics.items():
             for app, count in values.items():
                 month_record = (
-                    session.query(MonthlyAppNameMetrics)
-                    .filter(MonthlyAppNameMetrics.timestamp == month)
-                    .filter(MonthlyAppNameMetrics.application_name == app)
+                    session.query(AggregateMonthlyAppNameMetrics)
+                    .filter(AggregateMonthlyAppNameMetrics.timestamp == month)
+                    .filter(AggregateMonthlyAppNameMetrics.application_name == app)
                     .first()
                 )
                 if month_record:
                     month_record.count = count
                 else:
-                    month_record = MonthlyAppNameMetrics(
+                    month_record = AggregateMonthlyAppNameMetrics(
                         timestamp=month,
                         application_name=app,
                         count=count

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -231,7 +231,7 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
         start_time = int(start_time_obj.timestamp())
         new_route_metrics, new_app_metrics = get_metrics(node, start_time)
 
-        logger.info(f"did attempt to receive route and app metrics from {node}")
+        logger.info(f"did attempt to receive route and app metrics from {node} at {start_time_obj} ({start_time})")
 
         end_time = datetime.utcnow().strftime(datetime_format_secondary)
         merge_route_metrics(new_route_metrics or {}, end_time, db)

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -5,7 +5,7 @@ import requests
 from src import eth_abi_values
 from src.models import RouteMetrics, AppNameMetrics
 from src.tasks.celery_app import celery
-from src.utils.helpers import redis_set_and_dump, redis_get_or_restore, is_fqdn
+from src.utils.helpers import redis_set_and_dump, redis_get_or_restore
 from src.utils.redis_metrics import metrics_prefix, metrics_applications, \
     metrics_routes, metrics_visited_nodes, merge_route_metrics, merge_app_metrics, \
     parse_metrics_key, get_rounded_date_time, datetime_format_secondary, METRICS_INTERVAL

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -9,7 +9,8 @@ from src.tasks.celery_app import celery
 from src.utils.helpers import redis_set_and_dump, redis_get_or_restore, is_fqdn
 from src.utils.redis_metrics import metrics_prefix, metrics_applications, \
     metrics_routes, metrics_visited_nodes, merge_route_metrics, merge_app_metrics, \
-    parse_metrics_key, get_rounded_date_time, datetime_format_secondary, METRICS_INTERVAL
+    parse_metrics_key, get_rounded_date_time, datetime_format_secondary, METRICS_INTERVAL, \
+    personal_route_metrics, personal_app_metrics
 from src.queries.update_historical_metrics import update_historical_daily_route_metrics, \
     update_historical_monthly_route_metrics, update_historical_daily_app_metrics, \
         update_historical_monthly_app_metrics
@@ -225,6 +226,35 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
 
     one_iteration_ago = datetime.utcnow() - timedelta(minutes=METRICS_INTERVAL)
     one_iteration_ago_str = one_iteration_ago.strftime(datetime_format_secondary)
+    end_time = datetime.utcnow().strftime(datetime_format_secondary)
+
+    # Merge & persist metrics for our personal node
+    personal_route_metrics_str = redis_get_or_restore(redis, personal_route_metrics)
+    personal_route_metrics_dict = json.loads(personal_route_metrics_str) if personal_route_metrics_str else {}
+    new_personal_route_metrics = {}
+    for timestamp, metrics in personal_route_metrics_dict.items():
+        if timestamp > one_iteration_ago_str:
+            for ip, count in metrics.items():
+                if ip in new_personal_route_metrics:
+                    new_personal_route_metrics[ip] += count
+                else:
+                    new_personal_route_metrics[ip] = count
+
+    personal_app_metrics_str = redis_get_or_restore(redis, personal_app_metrics)
+    personal_app_metrics_dict = json.loads(personal_app_metrics_str) if personal_app_metrics_str else {}
+    new_personal_app_metrics = {}
+    for timestamp, metrics in personal_app_metrics_dict.items():
+        if timestamp > one_iteration_ago_str:
+            for app_name, count in metrics.items():
+                if app_name in new_personal_app_metrics:
+                    new_personal_app_metrics[app_name] += count
+                else:
+                    new_personal_app_metrics[app_name] = count
+
+    merge_route_metrics(new_personal_route_metrics, end_time, db)
+    merge_app_metrics(new_personal_app_metrics, end_time, db)
+
+    # Merge & persiste metrics for other nodes
     for node in all_other_nodes:
         start_time_str = visited_node_timestamps[node] if node in visited_node_timestamps else one_iteration_ago_str
         start_time_obj = datetime.strptime(start_time_str, datetime_format_secondary)
@@ -233,7 +263,6 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
 
         logger.info(f"did attempt to receive route and app metrics from {node} at {start_time_obj} ({start_time})")
 
-        end_time = datetime.utcnow().strftime(datetime_format_secondary)
         merge_route_metrics(new_route_metrics or {}, end_time, db)
         merge_app_metrics(new_app_metrics or {}, end_time, db)
 

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -231,12 +231,14 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
         start_time = int(start_time_obj.timestamp())
         new_route_metrics, new_app_metrics = get_metrics(node, start_time)
 
+        logger.info(f"did attempt to receive route and app metrics from {node}")
+
+        end_time = datetime.utcnow().strftime(datetime_format_secondary)
+        merge_route_metrics(new_route_metrics or {}, end_time, db)
+        merge_app_metrics(new_app_metrics or {}, end_time, db)
+
         if new_route_metrics is not None and new_app_metrics is not None:
-            logger.info(f"did receive route and app metrics from {node}")
-            end_time = datetime.utcnow().strftime(datetime_format_secondary)
             visited_node_timestamps[node] = end_time
-            merge_route_metrics(new_route_metrics, end_time, db)
-            merge_app_metrics(new_app_metrics, end_time, db)
 
     logger.info(f"visited node timestamps: {visited_node_timestamps}")
     if visited_node_timestamps:

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -235,10 +235,8 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
             logger.info(f"did receive route and app metrics from {node}")
             end_time = datetime.utcnow().strftime(datetime_format_secondary)
             visited_node_timestamps[node] = end_time
-            if new_route_metrics:
-                merge_route_metrics(new_route_metrics, end_time, db)
-            if new_app_metrics:
-                merge_app_metrics(new_app_metrics, end_time, db)
+            merge_route_metrics(new_route_metrics, end_time, db)
+            merge_app_metrics(new_app_metrics, end_time, db)
 
     logger.info(f"visited node timestamps: {visited_node_timestamps}")
     if visited_node_timestamps:

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -1,14 +1,21 @@
-import logging # pylint: disable=C0302
 import functools
-from datetime import datetime
+import json
+import logging # pylint: disable=C0302
+from datetime import datetime, timedelta
 import redis
 from flask.globals import request
 from src.utils.config import shared_config
+from src.utils.helpers import redis_set_and_dump, redis_get_or_restore
 from src.utils.query_params import stringify_query_params, app_name_param
+from src.models import DailyUniqueUsersMetrics, DailyTotalUsersMetrics, \
+    MonthlyUniqueUsersMetrics, MonthlyTotalUsersMetrics, DailyAppNameMetrics, MonthlyAppNameMetrics
+
 logger = logging.getLogger(__name__)
 
 REDIS_URL = shared_config["redis"]["url"]
 REDIS = redis.Redis.from_url(url=REDIS_URL)
+
+METRICS_INTERVAL = 5
 
 # Redis Key Convention:
 # API_METRICS:routes:<date>:<hour>
@@ -16,7 +23,14 @@ REDIS = redis.Redis.from_url(url=REDIS_URL)
 
 metrics_prefix = "API_METRICS"
 metrics_routes = "routes"
-metrics_application = "applications"
+metrics_applications = "applications"
+metrics_visited_nodes = "visited_nodes"
+personal_route_metrics = "personal_route_metrics"
+daily_route_metrics = "daily_route_metrics"
+monthly_route_metrics = "monthly_route_metrics"
+personal_app_metrics = "personal_app_metrics"
+daily_app_metrics = "daily_app_metrics"
+monthly_app_metrics = "monthly_app_metrics"
 
 '''
 NOTE: if you want to change the time interval to recording metrics,
@@ -27,6 +41,7 @@ def get_rounded_date_time():
     return datetime.utcnow().replace(second=0, microsecond=0) # Remove rounding min.
 '''
 datetime_format = "%Y/%m/%d:%H"
+datetime_format_secondary = "%Y/%m/%d:%H:%M"
 def get_rounded_date_time():
     return datetime.utcnow().replace(minute=0, second=0, microsecond=0)
 
@@ -45,7 +60,7 @@ def parse_metrics_key(key):
     Validates that a key is correctly formatted and returns
     the source: (routes|applications), ip address, and date of key
     """
-    if not metrics_prefix.startswith(metrics_prefix):
+    if not metrics_prefix.startswith(metrics_prefix): # ??? do we mean key.startswith(metrics_prefix)
         logger.warning(f"Bad redis key inserted w/out metrics prefix {key}")
         return None
 
@@ -57,12 +72,198 @@ def parse_metrics_key(key):
     _, source, ip, date, time = fragments
     # Replace the ipv6 _ delimiter back to :
     ip = ip.replace("_", ":")
-    if source not in (metrics_routes, metrics_application):
+    if source not in (metrics_routes, metrics_applications):
         logger.warning(f"Bad redis key inserted: must be routes or application {key}")
         return None
     date_time = datetime.strptime(f"{date}:{time}", datetime_format)
 
     return source, ip, date_time
+
+def persist_route_metrics(db, day, month, count, unique_daily_count, unique_monthly_count):
+    with db.scoped_session() as session:
+        day_unique_record = (
+            session.query(DailyUniqueUsersMetrics)
+            .filter(DailyUniqueUsersMetrics.timestamp == day)
+            .first()
+        )
+        if day_unique_record:
+            day_unique_record.count += unique_daily_count
+        else:
+            day_unique_record = DailyUniqueUsersMetrics(
+                timestamp=day,
+                count=unique_daily_count
+            )
+        session.add(day_unique_record)
+
+        day_total_record = (
+            session.query(DailyTotalUsersMetrics)
+            .filter(DailyTotalUsersMetrics.timestamp == day)
+            .first()
+        )
+        if day_total_record:
+            day_total_record.count += count
+        else:
+            day_total_record = DailyTotalUsersMetrics(
+                timestamp=day,
+                count=count
+            )
+        session.add(day_total_record)
+
+        month_unique_record = (
+            session.query(MonthlyUniqueUsersMetrics)
+            .filter(MonthlyUniqueUsersMetrics.timestamp == month)
+            .first()
+        )
+        if month_unique_record:
+            month_unique_record.count += unique_monthly_count
+        else:
+            month_unique_record = MonthlyUniqueUsersMetrics(
+                timestamp=month,
+                count=unique_monthly_count
+            )
+        session.add(month_unique_record)
+
+        month_total_record = (
+            session.query(MonthlyTotalUsersMetrics)
+            .filter(MonthlyTotalUsersMetrics.timestamp == month)
+            .first()
+        )
+        if month_total_record:
+            month_total_record.count += count
+        else:
+            month_total_record = MonthlyTotalUsersMetrics(
+                timestamp=month,
+                count=count
+            )
+        session.add(month_total_record)
+
+def persist_app_metrics(db, day, month, app_count):
+    with db.scoped_session() as session:
+        for application_name, count in app_count.items():
+            day_record = (
+                session.query(DailyAppNameMetrics)
+                .filter(DailyAppNameMetrics.timestamp == day and \
+                    DailyAppNameMetrics.application_name == application_name)
+                .first()
+            )
+            if day_record:
+                day_record.count += count
+            else:
+                day_record = DailyAppNameMetrics(
+                    timestamp=day,
+                    application_name=application_name,
+                    count=count
+                )
+            session.add(day_record)
+
+            month_record = (
+                session.query(MonthlyAppNameMetrics)
+                .filter(MonthlyAppNameMetrics.timestamp == month and \
+                    MonthlyAppNameMetrics.application_name == application_name)
+                .first()
+            )
+            if month_record:
+                month_record.count += count
+            else:
+                month_record = MonthlyAppNameMetrics(
+                    timestamp=month,
+                    application_name=application_name,
+                    count=count
+                )
+            session.add(month_record)
+
+def merge_metrics(metrics, end_time, metric_type, db):
+    logger.info(f"about to merge {metric_type} metrics: {metrics}")
+    day = end_time.split(':')[0]
+    month = f"{day[:7]}/01"
+
+    daily_key = daily_route_metrics if metric_type == 'route' else daily_app_metrics
+    daily_metrics_str = redis_get_or_restore(REDIS, daily_key)
+    daily_metrics = json.loads(daily_metrics_str) if daily_metrics_str else {}
+
+    monthly_key = monthly_route_metrics if metric_type == 'route' else monthly_app_metrics
+    monthly_metrics_str = redis_get_or_restore(REDIS, monthly_key)
+    monthly_metrics = json.loads(monthly_metrics_str) if monthly_metrics_str else {}
+
+    if day not in daily_metrics:
+        daily_metrics[day] = {}
+    if month not in monthly_metrics:
+        monthly_metrics[month] = {}
+
+    # only relevant for unique users and total api calls
+    unique_daily_count = 0
+    unique_monthly_count = 0
+
+    # only relevant for app metrics
+    app_count = {}
+
+    for new_value, new_count in metrics.items():
+        if metric_type == 'route' and new_value not in daily_metrics[day]:
+            unique_daily_count += 1
+        if metric_type == 'route' and new_value not in monthly_metrics[month]:
+            unique_monthly_count += 1
+        if metric_type == 'app':
+            app_count[new_value] = new_count
+        daily_metrics[day][new_value] = daily_metrics[day][new_value] + new_count \
+            if new_value in daily_metrics[day] else new_count
+        monthly_metrics[month][new_value] = monthly_metrics[month][new_value] + new_count \
+            if new_value in monthly_metrics[month] else new_count
+
+    # remove metrics METRICS_INTERVAL after the end of the day from daily_metrics
+    yesterday_str = (datetime.utcnow() - timedelta(days=1)).strftime(datetime_format_secondary)
+    daily_metrics = {timestamp: metrics for timestamp, metrics in daily_metrics.items() \
+        if timestamp > yesterday_str}
+    if daily_metrics:
+        redis_set_and_dump(REDIS, daily_key, json.dumps(daily_metrics))
+    logger.info(f"updated cached daily {metric_type} metrics: {daily_metrics}")
+
+    # remove metrics METRICS_INTERVAL after the end of the month from monthly_metrics
+    thirty_one_days_ago = (datetime.utcnow() - timedelta(days=31)).strftime(datetime_format_secondary)
+    monthly_metrics = {timestamp: metrics for timestamp, metrics in monthly_metrics.items() \
+        if timestamp > thirty_one_days_ago}
+    if monthly_metrics:
+        redis_set_and_dump(REDIS, monthly_key, json.dumps(monthly_metrics))
+    logger.info(f"updated cached monthly {metric_type} metrics: {monthly_metrics}")
+
+    # persist aggregated metrics from other nodes
+    day_format = datetime_format_secondary.split(':')[0]
+    day_obj = datetime.strptime(day, day_format)
+    month_obj = datetime.strptime(month, day_format)
+    if metric_type == 'route':
+        persist_route_metrics(db, day_obj, month_obj, sum(metrics.values()), unique_daily_count, unique_monthly_count)
+    else:
+        persist_app_metrics(db, day_obj, month_obj, app_count)
+
+def merge_route_metrics(metrics, end_time, db):
+    merge_metrics(metrics, end_time, 'route', db)
+
+def merge_app_metrics(metrics, end_time, db):
+    merge_metrics(metrics, end_time, 'app', db)
+
+def get_redis_metrics(start_time, metric_type):
+    redis_metrics_str = redis_get_or_restore(REDIS, metric_type)
+    metrics = json.loads(redis_metrics_str) if redis_metrics_str else {}
+    if not metrics:
+        return {}
+
+    result = {}
+    for datetime_str, value_counts in metrics.items():
+        datetime_obj = datetime.strptime(datetime_str, datetime_format_secondary)
+        if datetime_obj > start_time:
+            for value, count in value_counts.items():
+                result[value] = result[value] + count if value in result else count
+
+    return result
+
+def get_redis_route_metrics(start_time):
+    return get_redis_metrics(start_time, personal_route_metrics)
+
+def get_redis_app_metrics(start_time):
+    return get_redis_metrics(start_time, personal_app_metrics)
+
+def get_aggregate_metrics_info():
+    info_str = redis_get_or_restore(REDIS, metrics_visited_nodes)
+    return json.loads(info_str) if info_str else {}
 
 def extract_app_name_key():
     """
@@ -78,7 +279,7 @@ def extract_app_name_key():
     ip = get_request_ip(request)
     date_time = get_rounded_date_time().strftime(datetime_format)
 
-    application_key = f"{metrics_prefix}:{metrics_application}:{ip}:{date_time}"
+    application_key = f"{metrics_prefix}:{metrics_applications}:{ip}:{date_time}"
     return (application_key, application_name)
 
 def extract_route_key():
@@ -101,6 +302,34 @@ def extract_route_key():
     route_key = f"{metrics_prefix}:{metrics_routes}:{ip}:{date_time}"
     return (route_key, route)
 
+def update_personal_metrics(key, old_timestamp, timestamp, value, metric_type):
+    values_str = redis_get_or_restore(REDIS, key)
+    values = json.loads(values_str) if values_str else {}
+    if timestamp in values:
+        values[timestamp][value] = values[timestamp][value] + 1 if value in values[timestamp] else 1
+    else:
+        values[timestamp] = {value: 1}
+
+    # clean up and update cached metrics
+    updated_metrics = {timestamp: metrics for timestamp, metrics in values.items() if timestamp > old_timestamp}
+    if updated_metrics:
+        redis_set_and_dump(REDIS, key, json.dumps(updated_metrics))
+    logger.info(f"updated cached {metric_type} metrics: {updated_metrics}")
+
+def record_aggregate_metrics():
+    timestamp = datetime.utcnow().strftime(datetime_format_secondary)
+    old_timestamp = (datetime.utcnow() - timedelta(minutes=METRICS_INTERVAL * 2)).strftime(datetime_format_secondary)
+
+    update_personal_metrics(
+        personal_route_metrics, old_timestamp, timestamp, get_request_ip(request), 'route'
+    )
+
+    application_name = request.args.get(app_name_param, type=str, default=None)
+    if application_name:
+        update_personal_metrics(
+            personal_app_metrics, old_timestamp, timestamp, application_name, 'app'
+        )
+
 # Metrics decorator.
 def record_metrics(func):
     """
@@ -118,6 +347,8 @@ def record_metrics(func):
             REDIS.hincrby(route_key, route, 1)
             if application_name:
                 REDIS.hincrby(application_key, application_name, 1)
+
+            record_aggregate_metrics()
         except Exception as e:
             logger.error('Error while recording metrics: %s', e.message)
 

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -89,12 +89,17 @@ def persist_route_metrics(db, day, month, count, unique_daily_count, unique_mont
             .first()
         )
         if day_unique_record:
+            logger.info(f"unique count record for day {day} before adding new unique count \
+                {unique_daily_count}: {day_unique_record.count}")
             day_unique_record.count += unique_daily_count
+            logger.info(f"unique count record for day {day} after adding new unique count \
+                {unique_daily_count}: {day_unique_record.count}")
         else:
             day_unique_record = AggregateDailyUniqueUsersMetrics(
                 timestamp=day,
                 count=unique_daily_count
             )
+            logger.info(f"new record for daily unique count with day {day} and unique count {unique_daily_count}")
         session.add(day_unique_record)
 
         day_total_record = (
@@ -103,12 +108,17 @@ def persist_route_metrics(db, day, month, count, unique_daily_count, unique_mont
             .first()
         )
         if day_total_record:
+            logger.info(f"total count record for day {day} before adding new total count \
+                {count}: {day_total_record.count}")
             day_total_record.count += count
+            logger.info(f"total count record for day {day} after adding new total count \
+                {count}: {day_total_record.count}")
         else:
             day_total_record = AggregateDailyTotalUsersMetrics(
                 timestamp=day,
                 count=count
             )
+            logger.info(f"new record for daily total count with day {day} and total count {count}")
         session.add(day_total_record)
 
         month_unique_record = (
@@ -117,12 +127,18 @@ def persist_route_metrics(db, day, month, count, unique_daily_count, unique_mont
             .first()
         )
         if month_unique_record:
+            logger.info(f"unique count record for month {month} before adding new unique count \
+                {unique_monthly_count}: {month_unique_record.count}")
             month_unique_record.count += unique_monthly_count
+            logger.info(f"unique count record for month {month} after adding new unique count \
+                {unique_monthly_count}: {month_unique_record.count}")
         else:
             month_unique_record = AggregateMonthlyUniqueUsersMetrics(
                 timestamp=month,
                 count=unique_monthly_count
             )
+            logger.info(f"new record for monthly unique count with month {month} and unique count \
+                {unique_monthly_count}")
         session.add(month_unique_record)
 
         month_total_record = (
@@ -131,12 +147,17 @@ def persist_route_metrics(db, day, month, count, unique_daily_count, unique_mont
             .first()
         )
         if month_total_record:
+            logger.info(f"total count record for month {month} before adding new total count \
+                {count}: {month_total_record.count}")
             month_total_record.count += count
+            logger.info(f"total count record for month {month} after adding new total count \
+                {count}: {month_total_record.count}")
         else:
             month_total_record = AggregateMonthlyTotalUsersMetrics(
                 timestamp=month,
                 count=count
             )
+            logger.info(f"new record for monthly total count with month {month} and total count {count}")
         session.add(month_total_record)
 
 def persist_app_metrics(db, day, month, app_count):
@@ -149,13 +170,19 @@ def persist_app_metrics(db, day, month, app_count):
                 .first()
             )
             if day_record:
+                logger.info(f"daily app record for day {day} and application {application_name} \
+                    before adding new count {count}: {day_record.count}")
                 day_record.count += count
+                logger.info(f"daily app record for day {day} and application {application_name} \
+                    after adding new count {count}: {day_record.count}")
             else:
                 day_record = AggregateDailyAppNameMetrics(
                     timestamp=day,
                     application_name=application_name,
                     count=count
                 )
+                logger.info(f"new record for daily app record with day {day}, \
+                    application {application_name}, and count {count}")
             session.add(day_record)
 
             month_record = (
@@ -165,13 +192,19 @@ def persist_app_metrics(db, day, month, app_count):
                 .first()
             )
             if month_record:
+                logger.info(f"monthly app record for month {month} and application {application_name} \
+                    before adding new count {count}: {month_record.count}")
                 month_record.count += count
+                logger.info(f"monthly app record for month {month} and application {application_name} \
+                    after adding new count {count}: {month_record.count}")
             else:
                 month_record = AggregateMonthlyAppNameMetrics(
                     timestamp=month,
                     application_name=application_name,
                     count=count
                 )
+                logger.info(f"new record for monthly app record with month {month}, \
+                    application {application_name}, and count {count}")
             session.add(month_record)
 
 def merge_metrics(metrics, end_time, metric_type, db):
@@ -244,8 +277,8 @@ def merge_metrics(metrics, end_time, metric_type, db):
 
     # persist aggregated metrics from other nodes
     day_format = datetime_format_secondary.split(':')[0]
-    day_obj = datetime.strptime(day, day_format)
-    month_obj = datetime.strptime(month, day_format)
+    day_obj = datetime.strptime(day, day_format).date()
+    month_obj = datetime.strptime(month, day_format).date()
     if metric_type == 'route':
         persist_route_metrics(db, day_obj, month_obj, sum(metrics.values()), unique_daily_count, unique_monthly_count)
     else:

--- a/discovery-provider/src/utils/test_get_cached_metrics.py
+++ b/discovery-provider/src/utils/test_get_cached_metrics.py
@@ -1,0 +1,64 @@
+import json
+from datetime import datetime, timedelta
+from src.utils.redis_metrics import personal_route_metrics, personal_app_metrics, \
+    datetime_format_secondary, get_redis_metrics
+from src.utils.helpers import redis_set_and_dump
+
+now = datetime.utcnow()
+old_time = now - timedelta(minutes=4)
+recent_time_1 = now - timedelta(minutes=2)
+recent_time_2 = now - timedelta(minutes=1)
+start_time = int((now - timedelta(minutes=3)).timestamp())
+start_time_obj = datetime.fromtimestamp(start_time)
+
+def test_get_cached_route_metrics(redis_mock):
+    metrics = {
+        old_time.strftime(datetime_format_secondary): {
+            'some-ip': 1,
+            'other-ip': 2
+        },
+        recent_time_1.strftime(datetime_format_secondary): {
+            'another-ip': 1,
+            'some-other-ip': 2
+        },
+        recent_time_2.strftime(datetime_format_secondary): {
+            '1.2.3.4': 1,
+            'some-ip': 2,
+            'another-ip': 3
+        }
+    }
+    redis_set_and_dump(redis_mock, personal_route_metrics, json.dumps(metrics))
+
+    result = get_redis_metrics(redis_mock, start_time_obj, personal_route_metrics)
+
+    assert len(result.items()) == 4
+    assert result['another-ip'] == 4
+    assert result['some-other-ip'] == 2
+    assert result['1.2.3.4'] == 1
+    assert result['some-ip'] == 2
+
+def test_get_cached_app_metrics(redis_mock):
+    metrics = {
+        old_time.strftime(datetime_format_secondary): {
+            'some-app': 1,
+            'other-app': 2
+        },
+        recent_time_1.strftime(datetime_format_secondary): {
+            'another-app': 1,
+            'some-other-app': 2
+        },
+        recent_time_2.strftime(datetime_format_secondary): {
+            'top-app': 1,
+            'some-app': 2,
+            'another-app': 3
+        }
+    }
+    redis_set_and_dump(redis_mock, personal_app_metrics, json.dumps(metrics))
+
+    result = get_redis_metrics(redis_mock, start_time_obj, personal_app_metrics)
+
+    assert len(result.items()) == 4
+    assert result['another-app'] == 4
+    assert result['some-other-app'] == 2
+    assert result['top-app'] == 1
+    assert result['some-app'] == 2

--- a/discovery-provider/tests/test_get_aggregate_app_metrics.py
+++ b/discovery-provider/tests/test_get_aggregate_app_metrics.py
@@ -1,0 +1,151 @@
+from datetime import date, timedelta
+from src.models import AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
+from src.queries.get_app_name_metrics import _get_aggregate_app_metrics
+from src.utils.db_session import get_db
+
+limit = 2
+today = date.today()
+yesterday = today - timedelta(days=1)
+
+def test_get_aggregate_app_metrics_week(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-too-old',
+                count=3,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=4,
+                timestamp=yesterday - timedelta(days=1)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-outside-limit',
+                count=1,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
+                count=5,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-too-recent',
+                count=3,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_app_metrics(session, 'week', limit)
+
+        assert len(aggregate_metrics) == limit
+        assert aggregate_metrics[0]['name'] == 'top-app'
+        assert aggregate_metrics[0]['count'] == 7
+        assert aggregate_metrics[1]['name'] == 'best-app'
+        assert aggregate_metrics[1]['count'] == 5
+
+def test_get_aggregate_app_metrics_month(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-too-old',
+                count=20,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
+                count=20,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-outside-limit',
+                count=1,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=5,
+                timestamp=yesterday - timedelta(days=8)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
+                count=5,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=7,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='will-not-return-because-too-recent',
+                count=20,
+                timestamp=today
+            ),
+        ])
+
+        aggregate_metrics = _get_aggregate_app_metrics(session, 'month', limit)
+
+        assert len(aggregate_metrics) == limit
+        assert aggregate_metrics[0]['name'] == 'top-app'
+        assert aggregate_metrics[0]['count'] == 12
+        assert aggregate_metrics[1]['name'] == 'best-app'
+        assert aggregate_metrics[1]['count'] == 5
+
+def test_get_aggregate_app_metrics_all_time(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateMonthlyAppNameMetrics(
+                application_name='awesome-app',
+                count=6,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='will-not-return-because-outside-limit',
+                count=1,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='best-app',
+                count=5,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='top-app',
+                count=15,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='awesome-app',
+                count=7,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='will-not-return-because-too-recent',
+                count=20,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_app_metrics(session, 'all_time', limit)
+
+        assert len(aggregate_metrics) == limit
+        assert aggregate_metrics[0]['name'] == 'top-app'
+        assert aggregate_metrics[0]['count'] == 15
+        assert aggregate_metrics[1]['name'] == 'awesome-app'
+        assert aggregate_metrics[1]['count'] == 13

--- a/discovery-provider/tests/test_get_aggregate_route_metrics.py
+++ b/discovery-provider/tests/test_get_aggregate_route_metrics.py
@@ -164,7 +164,7 @@ def test_get_aggregate_route_metrics_all_time_monthly_bucket(app):
             ),
             AggregateMonthlyUniqueUsersMetrics(
                 count=2,
-                timestamp=yesterday
+                timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyUniqueUsersMetrics(
                 count=3,
@@ -176,7 +176,7 @@ def test_get_aggregate_route_metrics_all_time_monthly_bucket(app):
             ),
             AggregateMonthlyTotalUsersMetrics(
                 count=4,
-                timestamp=yesterday
+                timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyTotalUsersMetrics(
                 count=6,

--- a/discovery-provider/tests/test_get_aggregate_route_metrics.py
+++ b/discovery-provider/tests/test_get_aggregate_route_metrics.py
@@ -1,0 +1,233 @@
+from datetime import date, timedelta
+from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, \
+    AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics
+from src.queries.get_route_metrics import _get_aggregate_route_metrics
+from src.utils.db_session import get_db
+
+limit = 2
+today = date.today()
+yesterday = today - timedelta(days=1)
+
+def test_get_aggregate_route_metrics_week(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=yesterday - timedelta(days=1)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=4,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=yesterday - timedelta(days=1)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=8,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics(session, 'week', 'day')
+
+        assert len(aggregate_metrics) == 2
+        assert aggregate_metrics[0]['unique_count'] == 2
+        assert aggregate_metrics[0]['total_count'] == 4
+        assert aggregate_metrics[1]['unique_count'] == 3
+        assert aggregate_metrics[1]['total_count'] == 6
+
+def test_get_aggregate_route_metrics_month_daily_bucket(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=4,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=8,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics(session, 'month', 'day')
+
+        assert len(aggregate_metrics) == 2
+        assert aggregate_metrics[0]['unique_count'] == 2
+        assert aggregate_metrics[0]['total_count'] == 4
+        assert aggregate_metrics[1]['unique_count'] == 3
+        assert aggregate_metrics[1]['total_count'] == 6
+
+def test_get_aggregate_route_metrics_month_weekly_bucket(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=4,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=today - timedelta(days=8)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=8,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics(session, 'month', 'week')
+
+        assert len(aggregate_metrics) == 2
+        assert aggregate_metrics[0]['unique_count'] == 2
+        assert aggregate_metrics[0]['total_count'] == 4
+        assert aggregate_metrics[1]['unique_count'] == 3
+        assert aggregate_metrics[1]['total_count'] == 6
+
+def test_get_aggregate_route_metrics_all_time_monthly_bucket(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateMonthlyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyUniqueUsersMetrics(
+                count=2,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyUniqueUsersMetrics(
+                count=3,
+                timestamp=today
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=4,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=6,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics(session, 'all_time', 'month')
+
+        assert len(aggregate_metrics) == 2
+        assert aggregate_metrics[0]['unique_count'] == 1
+        assert aggregate_metrics[0]['total_count'] == 2
+        assert aggregate_metrics[1]['unique_count'] == 2
+        assert aggregate_metrics[1]['total_count'] == 4
+
+def test_get_aggregate_route_metrics_all_time_weekly_bucket(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics(session, 'all_time', 'week')
+
+        assert len(aggregate_metrics) == 2
+        assert aggregate_metrics[0]['unique_count'] == 1
+        assert aggregate_metrics[0]['total_count'] == 2
+        assert aggregate_metrics[1]['unique_count'] == 2
+        assert aggregate_metrics[1]['total_count'] == 4

--- a/discovery-provider/tests/test_get_aggregate_route_metrics_trailing_month.py
+++ b/discovery-provider/tests/test_get_aggregate_route_metrics_trailing_month.py
@@ -1,0 +1,53 @@
+from datetime import date, timedelta
+from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics
+from src.queries.get_trailing_metrics import _get_aggregate_route_metrics_trailing_month
+from src.utils.db_session import get_db
+
+limit = 2
+today = date.today()
+yesterday = today - timedelta(days=1)
+
+def test_get_aggregate_route_metrics_trailing_month(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=30)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=4,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=31)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=today - timedelta(days=30)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=8,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_aggregate_route_metrics_trailing_month(session)
+
+        assert aggregate_metrics['unique_count'] == 5
+        assert aggregate_metrics['total_count'] == 10

--- a/discovery-provider/tests/test_get_historical_app_metrics.py
+++ b/discovery-provider/tests/test_get_historical_app_metrics.py
@@ -1,0 +1,64 @@
+from datetime import date, timedelta
+from src.models import AggregateDailyAppNameMetrics, AggregateMonthlyAppNameMetrics
+from src.queries.get_app_name_metrics import _get_historical_app_metrics
+from src.utils.db_session import get_db
+
+limit = 2
+today = date.today()
+yesterday = today - timedelta(days=1)
+thirty_days_ago = today - timedelta(days=30)
+
+def test_get_historical_app_metrics(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=1,
+                timestamp=thirty_days_ago - timedelta(days=1)
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='top-app',
+                count=2,
+                timestamp=thirty_days_ago
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
+                count=4,
+                timestamp=today
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='top-app',
+                count=2,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='best-app',
+                count=4,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyAppNameMetrics(
+                application_name='top-app',
+                count=6,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_historical_app_metrics(session)
+        daily_aggregate_metrics = aggregate_metrics['daily']
+        monthly_aggregate_metrics = aggregate_metrics['monthly']
+
+        assert len(daily_aggregate_metrics.items()) == 2
+        assert daily_aggregate_metrics[str(thirty_days_ago)]['top-app'] == 2
+        assert daily_aggregate_metrics[str(yesterday)]['best-app'] == 3
+
+        assert len(daily_aggregate_metrics.items()) == 2
+        assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['top-app'] == 2
+        assert monthly_aggregate_metrics[str(yesterday)]['best-app'] == 4

--- a/discovery-provider/tests/test_get_historical_app_metrics.py
+++ b/discovery-provider/tests/test_get_historical_app_metrics.py
@@ -42,7 +42,7 @@ def test_get_historical_app_metrics(app):
             AggregateMonthlyAppNameMetrics(
                 application_name='best-app',
                 count=4,
-                timestamp=yesterday
+                timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyAppNameMetrics(
                 application_name='top-app',
@@ -61,4 +61,4 @@ def test_get_historical_app_metrics(app):
 
         assert len(daily_aggregate_metrics.items()) == 2
         assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['top-app'] == 2
-        assert monthly_aggregate_metrics[str(yesterday)]['best-app'] == 4
+        assert monthly_aggregate_metrics[str(today - timedelta(days=100))]['best-app'] == 4

--- a/discovery-provider/tests/test_get_historical_route_metrics.py
+++ b/discovery-provider/tests/test_get_historical_route_metrics.py
@@ -1,0 +1,90 @@
+from datetime import date, timedelta
+from src.models import AggregateDailyUniqueUsersMetrics, AggregateDailyTotalUsersMetrics, \
+    AggregateMonthlyUniqueUsersMetrics, AggregateMonthlyTotalUsersMetrics
+from src.queries.get_route_metrics import _get_historical_route_metrics
+from src.utils.db_session import get_db
+
+limit = 2
+today = date.today()
+yesterday = today - timedelta(days=1)
+thirty_days_ago = today - timedelta(days=30)
+
+def test_get_historical_route_metrics(app):
+    with app.app_context():
+        db_mock = get_db()
+
+    with db_mock.scoped_session() as session:
+        session.bulk_save_objects([
+            AggregateDailyUniqueUsersMetrics(
+                count=1,
+                timestamp=thirty_days_ago - timedelta(days=1)
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=2,
+                timestamp=thirty_days_ago
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=3,
+                timestamp=yesterday
+            ),
+            AggregateDailyUniqueUsersMetrics(
+                count=4,
+                timestamp=today
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=2,
+                timestamp=thirty_days_ago - timedelta(days=1)
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=4,
+                timestamp=thirty_days_ago
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=6,
+                timestamp=yesterday
+            ),
+            AggregateDailyTotalUsersMetrics(
+                count=8,
+                timestamp=today
+            ),
+            AggregateMonthlyUniqueUsersMetrics(
+                count=1,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyUniqueUsersMetrics(
+                count=2,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyUniqueUsersMetrics(
+                count=3,
+                timestamp=today
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=2,
+                timestamp=today - timedelta(days=367)
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=4,
+                timestamp=yesterday
+            ),
+            AggregateMonthlyTotalUsersMetrics(
+                count=6,
+                timestamp=today
+            )
+        ])
+
+        aggregate_metrics = _get_historical_route_metrics(session)
+        daily_aggregate_metrics = aggregate_metrics['daily']
+        monthly_aggregate_metrics = aggregate_metrics['monthly']
+
+        assert len(daily_aggregate_metrics.items()) == 2
+        assert daily_aggregate_metrics[str(thirty_days_ago)]['unique_count'] == 2
+        assert daily_aggregate_metrics[str(thirty_days_ago)]['total_count'] == 4
+        assert daily_aggregate_metrics[str(yesterday)]['unique_count'] == 3
+        assert daily_aggregate_metrics[str(yesterday)]['total_count'] == 6
+
+        assert len(daily_aggregate_metrics.items()) == 2
+        assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['unique_count'] == 1
+        assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['total_count'] == 2
+        assert monthly_aggregate_metrics[str(yesterday)]['unique_count'] == 2
+        assert monthly_aggregate_metrics[str(yesterday)]['total_count'] == 4

--- a/discovery-provider/tests/test_get_historical_route_metrics.py
+++ b/discovery-provider/tests/test_get_historical_route_metrics.py
@@ -53,7 +53,7 @@ def test_get_historical_route_metrics(app):
             ),
             AggregateMonthlyUniqueUsersMetrics(
                 count=2,
-                timestamp=yesterday
+                timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyUniqueUsersMetrics(
                 count=3,
@@ -65,7 +65,7 @@ def test_get_historical_route_metrics(app):
             ),
             AggregateMonthlyTotalUsersMetrics(
                 count=4,
-                timestamp=yesterday
+                timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyTotalUsersMetrics(
                 count=6,
@@ -83,8 +83,8 @@ def test_get_historical_route_metrics(app):
         assert daily_aggregate_metrics[str(yesterday)]['unique_count'] == 3
         assert daily_aggregate_metrics[str(yesterday)]['total_count'] == 6
 
-        assert len(daily_aggregate_metrics.items()) == 2
+        assert len(monthly_aggregate_metrics.items()) == 2
         assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['unique_count'] == 1
         assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['total_count'] == 2
-        assert monthly_aggregate_metrics[str(yesterday)]['unique_count'] == 2
-        assert monthly_aggregate_metrics[str(yesterday)]['total_count'] == 4
+        assert monthly_aggregate_metrics[str(today - timedelta(days=100))]['unique_count'] == 2
+        assert monthly_aggregate_metrics[str(today - timedelta(days=100))]['total_count'] == 4

--- a/service-commands/scripts/setup.js
+++ b/service-commands/scripts/setup.js
@@ -1,6 +1,12 @@
 const ServiceCommands = require('../src/index')
 const { program } = require('commander')
-const { allUp, Service, SetupCommand, runSetupCommand } = ServiceCommands
+const {
+  allUp,
+  discoveryNodeUp,
+  Service,
+  SetupCommand,
+  runSetupCommand
+} = ServiceCommands
 
 const NUM_CREATOR_NODES = 3
 const SERVICE_INSTANCE_NUMBER = 1
@@ -54,6 +60,11 @@ program
     const numCnodes = parseInt(opts.numCnodes)
     await allUp({ numCreatorNodes: numCnodes })
   })
+
+program
+  .command('discovery-node')
+  .description('Bring up relevant services for discovery node')
+  .action(async () => await discoveryNodeUp())
 
 program
   .command('down')

--- a/service-commands/scripts/setup.js
+++ b/service-commands/scripts/setup.js
@@ -62,7 +62,7 @@ program
   })
 
 program
-  .command('discovery-node')
+  .command('discovery-node-stack up')
   .description('Bring up relevant services for discovery node')
   .action(async () => await discoveryNodeUp())
 


### PR DESCRIPTION
### Description
We want each discovery node to give us aggregated metrics across all discovery nodes, so that obtaining the metrics does not depend on all nodes being up.


### Tests
- Spun up locally, hit the new endpoints to make sure they return coherent data.
- Played around with the cron intervals and checked the responses and the logs
- Ran db migration locally to make sure reads and writes are happening
... also working on adding unit tests

Clients for the metrics data (e.g. the dashboard) will need to update the endpoints they make requests to in order to use the new aggregated metrics.