### PR TITLE
Hotfix fix rate limits

### DIFF
--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -13,7 +13,7 @@ const NotificationProcessor = require('./notifications/index.js')
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { fetchAnnouncements } = require('./announcements')
 const { logger, loggingMiddleware } = require('./logging')
-const { getRateLimiter, getRateLimiterMiddleware } = require('./rateLimiter.js')
+const { getRateLimiter, getRateLimiterMiddleware, isIPWhitelisted, getIP } = require('./rateLimiter.js')
 
 const DOMAIN = 'mail.audius.co'
 
@@ -117,68 +117,17 @@ class App {
     this.express.use(cors())
   }
 
-  _isIPWhitelisted (ip) {
-    const whitelistRegex = config.get('rateLimitingListensIPWhitelist')
-    return whitelistRegex && !!ip.match(whitelistRegex)
-  }
-
-  _getIP (req) {
-    // Gets the IP for rate-limiting based on X-Forwarded-For headers
-    // Algorithm:
-    // If 1 header or no headers:
-    //   We are not running behind a proxy, something is probably wonky, use req.ip (leftmost)
-    // If > 1 headers:
-    //   This assumes two proxies (some outer proxy like cloudflare and then some proxy like a load balancer)
-    //   Rightmost header is the outer proxy
-    //   Rightmost - 1 header is either a creator node OR the actual user
-    //    If creator node, use Rightmost - 2 (since creator node will pass this along)
-    //    Else, use Rightmost - 1 since it's the actual user
-
-    let ip = req.ip
-    const forwardedFor = req.get('X-Forwarded-For')
-
-    // This shouldn't ever happen since Identity will always be behind a proxy
-    if (!forwardedFor) {
-      req.logger.debug('_getIP: no forwarded-for')
-      return ip
-    }
-
-    const headers = forwardedFor.split(',')
-    // headers length == 1 means that we are not running behind normal 2 layer proxy (probably locally),
-    // We can just use req.ip which corresponds to the best guess forward-for that was added if any
-    if (headers.length === 1) {
-      req.logger.debug(`_getIP: recording listen with 1 x-forwarded-for header, IP: ${ip}, Forwarded-For: ${forwardedFor}`)
-      return ip
-    }
-
-    // Length is at least 2, length - 1 would be the outermost proxy, so length - 2 is the "sender"
-    // either the actual user or a content node
-    const senderIP = headers[headers.length - 2]
-
-    if (this._isIPWhitelisted(senderIP)) {
-      const forwardedIP = headers[headers.length - 3]
-      if (!forwardedIP) {
-        req.logger.debug(`_getIP: content node sent a req that was missing a forwarded-for header, using IP: ${senderIP}, Forwarded-For: ${forwardedFor}`)
-        return senderIP
-      }
-      req.logger.debug(`_getIP: recording listen from creatornode: ${senderIP}, forwarded IP: ${forwardedIP}, Forwarded-For: ${forwardedFor}`)
-      return forwardedIP
-    }
-    req.logger.debug(`_getIP: recording listen from > 2 headers, but not creator-node, IP: ${senderIP}, Forwarded-For: ${forwardedFor}`)
-    return senderIP
-  }
-
   // Create rate limits for listens on a per track per user basis and per track per ip basis
   _createRateLimitsForListenCounts (interval, timeInSeconds) {
-    const isIPWhitelisted = this._isIPWhitelisted
-    const getIP = this._getIP.bind(this)
-
     const listenCountLimiter = getRateLimiter({
       prefix: `listenCountLimiter:::${interval}-track:::`,
       expiry: timeInSeconds,
       max: config.get(`rateLimitingListensPerTrackPer${interval}`), // max requests per interval
       skip: function (req) {
-        return isIPWhitelisted(req.ip)
+        const { ip, senderIP } = getIP(req)
+        const ipToCheck = senderIP || ip
+        // Do not apply user-specific rate limits for any whitelisted IP
+        return isIPWhitelisted(ipToCheck)
       },
       keyGenerator: function (req) {
         const trackId = req.params.id
@@ -193,7 +142,7 @@ class App {
       max: config.get(`rateLimitingListensPerIPPer${interval}`), // max requests per interval
       keyGenerator: function (req) {
         const trackId = req.params.id
-        const ip = getIP(req)
+        const { ip } = getIP(req)
         return `${ip}:::${trackId}`
       }
     })

--- a/identity-service/src/rateLimiter.js
+++ b/identity-service/src/rateLimiter.js
@@ -67,7 +67,7 @@ try {
 
 const getReqKeyGenerator = (options = {}) => (req) => {
   const { query = [], body = [], withIp = true } = options
-  let key = withIp ? getIP(req) : ''
+  let key = withIp ? getIP(req).ip : ''
   if (req.query && query.length > 0) {
     query.forEach(queryKey => {
       if (queryKey in req.query) {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Fix rate limits. Review each commit in isolation.

Commit 1: Fix the issue where req.ip is the incorrect IP to use against checking the whitelist.
See this log record
```
{
    "name": "audius_identity_service",
    "hostname": "ip-10-0-1-207",
    "pid": 1,
    "requestID": "CMRFQTcVPE",
    "requestMethod": "POST",
    "requestHostname": "identityservice.audius.co",
    "requestUrl": "/tracks/1747/listen",
    "requestIP": "73.231.128.127",
    "level": 20,
    "msg": "_getIP: recording listen from creatornode: 54.149.166.176, forwarded IP: 73.231.128.127, Forwarded-For: 73.231.128.127,54.149.166.176, 108.162.245.136",
    "time": "2021-03-03T05:13:32.548Z",
    "v": 0
}
```
requestIP is what is being used to check against whitelist rather than senderIP.

Commit 2: This replaces the global rate limit with the correct getIP method, which right now would artificially cap max requests per day per IP (content node)


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
