### PR TITLE
[AUD-369] Wrap generate token call in try/catch

### DIFF
--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -27,8 +27,12 @@ class IdentityService {
   }
 
   async setUserFn (obj) {
-    const token = await this.captcha.generate('identity/user')
-    obj.token = token
+    try {
+      const token = await this.captcha.generate('identity/user')
+      obj.token = token
+    } catch (e) {
+      console.warn(`CAPTCHA - Recaptcha may not have been instantiated properly`, e)
+    }
 
     return this._makeRequest({
       url: '/user',

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -27,11 +27,13 @@ class IdentityService {
   }
 
   async setUserFn (obj) {
-    try {
-      const token = await this.captcha.generate('identity/user')
-      obj.token = token
-    } catch (e) {
-      console.warn(`CAPTCHA - Recaptcha may not have been instantiated properly`, e)
+    if (this.captcha) {
+      try {
+        const token = await this.captcha.generate('identity/user')
+        obj.token = token
+      } catch (e) {
+        console.warn(`CAPTCHA - Recaptcha failed to generate token:`, e)
+      }
     }
 
     return this._makeRequest({


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

**Context:** In the case that the client does not pass in the recaptcha config, the Captcha instance in libs will be null. This results in trying to call an undefined method.

**Fix:** Wrap recaptcha call in try/catch. If `generate` is undefined, continue on with signup.

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. load dapp with older libs version (i.e. libs without the recaptcha logic)
2. attempt sign up
3. signup should still work 

![Screen Shot 2021-03-04 at 8 42 53 PM](https://user-images.githubusercontent.com/60366641/110068625-ef310e00-7d2a-11eb-80ad-0efd465b33cb.png)
