### PR TITLE
Add a var for retries in claim rewards and initiate round

### DIFF
--- a/libs/src/services/ethContracts/claimsManagerClient.js
+++ b/libs/src/services/ethContracts/claimsManagerClient.js
@@ -88,13 +88,16 @@ class ClaimsManagerClient extends ContractClient {
   }
 
   // Returns boolean indicating whether a claim is considered pending
-  async initiateRound () {
+  async initiateRound (txRetries = 5) {
     const method = await this.getMethod(
       'initiateRound'
     )
     return this.web3Manager.sendTransaction(
       method,
-      DEFAULT_GAS_AMOUNT
+      DEFAULT_GAS_AMOUNT,
+      null,
+      null,
+      txRetries
     )
   }
 

--- a/libs/src/services/ethContracts/delegateManagerClient.js
+++ b/libs/src/services/ethContracts/delegateManagerClient.js
@@ -245,14 +245,17 @@ class DelegateManagerClient extends GovernedContractClient {
     }
   }
 
-  async claimRewards (serviceProvider) {
+  async claimRewards (serviceProvider, txRetries = 5) {
     const method = await this.getMethod(
       'claimRewards',
       serviceProvider
     )
     return this.web3Manager.sendTransaction(
       method,
-      DEFAULT_GAS_AMOUNT
+      DEFAULT_GAS_AMOUNT,
+      null,
+      null,
+      txRetries
     )
   }
 


### PR DESCRIPTION
### Description
This PR adds a variable for the number of retries in claim rewards and initiate round.




### Tests
Tested against a local deployment by running the claims script from `audius-k8s`
