### PR TITLE
Libs bugfixes for ContractClient init

### DIFF
--- a/libs/src/services/contracts/ContractClient.js
+++ b/libs/src/services/contracts/ContractClient.js
@@ -36,7 +36,7 @@ class ContractClient {
   }
 
   /** Inits the contract if necessary */
-  async init () {
+  async init (selectNewEndpointOnRetry = true) {
     // No-op if we are already initted
     if (this._isInitialized) return
 
@@ -78,13 +78,15 @@ class ContractClient {
         return
       }
 
-      await this.retryInit()
+      await this.retryInit(selectNewEndpointOnRetry)
     }
   }
 
-  async retryInit () {
+  async retryInit (selectNewEndpoint = true) {
     try {
-      await this.selectNewEndpoint()
+      if (selectNewEndpoint) {
+        await this.selectNewEndpoint()
+      }
       await this.init()
     } catch (e) {
       console.error(e.message)
@@ -96,7 +98,7 @@ class ContractClient {
     this.providerSelector.addUnhealthy(this.web3Manager.getWeb3().currentProvider.host)
 
     if (this.providerSelector.getUnhealthySize() === this.providerSelector.getServicesSize()) {
-      throw new Error(`No available, healthy providers to init contract ${JSON.stringify(this.contractABI)}`)
+      throw new Error(`No available, healthy providers to init contract ${this.contractRegistryKey}`)
     }
 
     // Reset _isInitializing to false to retry init logic and avoid the _isInitialzing check

--- a/libs/src/services/dataContracts/index.js
+++ b/libs/src/services/dataContracts/index.js
@@ -105,7 +105,7 @@ class AudiusContracts {
   // Special case initialization flow for UserReplicaSetManagerClient backwards compatibility
   // Until the contract is deployed and added to the data contract registry, replica set
   // operations will flow through the existing UserFactory
-  async initUserReplicaSetManagerClient (selectNewEndpointOnRetry = true) {
+  async initUserReplicaSetManagerClient (selectNewEndpointOnRetry = false) {
     try {
       if (
         this.UserReplicaSetManagerClient &&

--- a/libs/src/services/dataContracts/index.js
+++ b/libs/src/services/dataContracts/index.js
@@ -136,6 +136,8 @@ class AudiusContracts {
   /**
    * Retrieves contract address from Registry by key, caching previously retrieved data.
    * Refreshes cache if cached value is empty or zero address.
+   * Value is empty during first time call, and zero if call is made before contract is deployed,
+   *    since Registry sets default value of all contract keys to zero address if not registered.
    * @param {string} contractName registry key of contract
    */
   async getRegistryAddressForContract (contractName) {

--- a/libs/src/services/dataContracts/index.js
+++ b/libs/src/services/dataContracts/index.js
@@ -133,10 +133,16 @@ class AudiusContracts {
 
   /* ------- CONTRACT META-FUNCTIONS ------- */
 
+  /**
+   * Retrieves contract address from Registry by key, caching previously retrieved data.
+   * Refreshes cache if cached value is empty or zero address.
+   * @param {string} contractName registry key of contract
+   */
   async getRegistryAddressForContract (contractName) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Computed_property_names
     this.contracts = this.contracts || { [this.registryAddress]: 'registry' }
     this.contractAddresses = this.contractAddresses || { 'registry': this.registryAddress }
+
     if (!this.contractAddresses[contractName] || Utils.isZeroAddress(this.contractAddresses[contractName])) {
       const address = await this.RegistryClient.getContract(contractName)
       this.contracts[address] = contractName

--- a/libs/src/services/dataContracts/index.js
+++ b/libs/src/services/dataContracts/index.js
@@ -105,7 +105,7 @@ class AudiusContracts {
   // Special case initialization flow for UserReplicaSetManagerClient backwards compatibility
   // Until the contract is deployed and added to the data contract registry, replica set
   // operations will flow through the existing UserFactory
-  async initUserReplicaSetManagerClient () {
+  async initUserReplicaSetManagerClient (selectNewEndpointOnRetry = true) {
     try {
       if (
         this.UserReplicaSetManagerClient &&
@@ -120,13 +120,13 @@ class AudiusContracts {
         UserReplicaSetManagerRegistryKey,
         this.getRegistryAddressForContract
       )
-      await this.UserReplicaSetManagerClient.init()
+      await this.UserReplicaSetManagerClient.init(selectNewEndpointOnRetry)
       if (this.UserReplicaSetManagerClient._contractAddress === '0x0000000000000000000000000000000000000000') {
         throw new Error(`Failed retrieve address for ${this.UserReplicaSetManagerClient.contractRegistryKey}`)
       }
     } catch (e) {
       // Nullify failed attempt to initialize
-      console.log(`Failed to initialize UserReplicaSetManagerClient`)
+      console.log(`Failed to initialize UserReplicaSetManagerClient with error ${e.message}`)
       this.UserReplicaSetManagerClient = null
     }
   }
@@ -137,7 +137,7 @@ class AudiusContracts {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Computed_property_names
     this.contracts = this.contracts || { [this.registryAddress]: 'registry' }
     this.contractAddresses = this.contractAddresses || { 'registry': this.registryAddress }
-    if (!this.contractAddresses[contractName]) {
+    if (!this.contractAddresses[contractName] || Utils.isZeroAddress(this.contractAddresses[contractName])) {
       const address = await this.RegistryClient.getContract(contractName)
       this.contracts[address] = contractName
       this.contractAddresses[contractName] = address


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Found these two libs bugs during chain of trust dev on https://github.com/AudiusProject/audius-protocol/pull/1232.
These codepaths are hit from the CN libs instance - it inits all datacontracts and URSM fails since contract is not yet deployed. it then retries this after contract deploy but contractClient init fails. This happens bc:
1. Currently `ContractClient:init()` will always reselect web3 provider endpoint on retryInit, which is logically wrong and also fails if the libs instance was created with only one provider. I fixed this by adding a new `getRegistryAddressForContract` param which I set to false when initting from CN libs instance.
2. When initting URSMClient pre-contract-deploy `getRegistryAddressForContract()` is called and sets address value to 0x00 locally. when retrying URSMClient init after contract-deploy the code would never re-fetch the value due to an incorrect check.

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Tested as part of https://github.com/AudiusProject/audius-protocol/pull/1232
Bugfix 1 adds a new `selectNewEndpointOnRetry` param which is defaulted to true in `ContractClient` to maintain full backwards compatibility and should be a no-op. This is however defaulted to `false` in URSMClient init since that scenario by default should not select a new provider.
Bugfix 2 was tested with COT PR. should be minimal user impact to users as contracts are always deployed, with the exception of URSM. all this does is to refresh cache more frequently.


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
