### PR TITLE
[AUD-391] In content-node track stream, add a fallback to enable streaming if track association didn't complete

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -570,7 +570,7 @@ module.exports = function (app) {
         }
       }
     } catch (e) {
-      logger.info(`Error looking for stream fallback in redis`, e)
+      req.logger.error(`Error looking for stream fallback in redis`, e)
     }
 
     // if track didn't finish the upload process and was never associated, there may not be a trackBlockchainId for the File records,
@@ -639,7 +639,7 @@ module.exports = function (app) {
           redisClient.set(`streamFallback:::${blockchainId}`, JSON.stringify(fileRecord), 'EX', 60 * 60)
         }
       } catch (e) {
-        logger.error(`Error falling back to reconstructing data from discovery to stream`, e)
+        req.logger.error(`Error falling back to reconstructing data from discovery to stream`, e)
       }
     }
 

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -560,17 +560,19 @@ module.exports = function (app) {
       order: [['clock', 'DESC']]
     })
 
-    try {
-      // see if there's a fileRecord in redis so we can short circuit all this logic
-      let redisFileRecord = await redisClient.get(`streamFallback:::${blockchainId}`)
-      if (redisFileRecord) {
-        redisFileRecord = JSON.parse(redisFileRecord)
-        if (redisFileRecord && redisFileRecord.multihash) {
-          fileRecord = redisFileRecord
+    if (!fileRecord) {
+      try {
+        // see if there's a fileRecord in redis so we can short circuit all this logic
+        let redisFileRecord = await redisClient.get(`streamFallback:::${blockchainId}`)
+        if (redisFileRecord) {
+          redisFileRecord = JSON.parse(redisFileRecord)
+          if (redisFileRecord && redisFileRecord.multihash) {
+            fileRecord = redisFileRecord
+          }
         }
+      } catch (e) {
+        req.logger.error(`Error looking for stream fallback in redis`, e)
       }
-    } catch (e) {
-      req.logger.error(`Error looking for stream fallback in redis`, e)
     }
 
     // if track didn't finish the upload process and was never associated, there may not be a trackBlockchainId for the File records,

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -581,16 +581,15 @@ module.exports = function (app) {
       try {
         let trackRecord = await libs.Track.getTracks(1, 0, [blockchainId])
         if (!trackRecord || trackRecord.length === 0 || !trackRecord[0].hasOwnProperty('blocknumber')) {
-          // TODO - return a server err response
           return sendResponse(req, res, errorResponseServerError('Missing or malformatted track fetched from discovery node.'))
         }
 
         trackRecord = trackRecord[0]
 
-        // query the files table for the metadata multihash from discovery
-        // no CNodeUserUUID, but because this track is associated with a user and contains that user_id
-        // inside it, it's unique to this user
-        const file = await models.File.findOne({ where: { multihash: trackRecord.metadata_multihash } })
+        // query the files table for a metadata multihash from discovery for a given track
+        // no need to add CNodeUserUUID to the filter because the track is associated with a user and that contains the
+        // user_id inside it which is unique to the user
+        const file = await models.File.findOne({ where: { multihash: trackRecord.metadata_multihash, type: 'metadata' } })
         if (!file) {
           return sendResponse(req, res, errorResponseServerError('Missing or malformatted track fetched from discovery node.'))
         }

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -538,6 +538,7 @@ module.exports = function (app) {
    **/
   app.get('/tracks/stream/:encodedId', async (req, res, next) => {
     const libs = req.app.get('audiusLibs')
+    const redisClient = req.app.get('redisClient')
     const delegateOwnerWallet = config.get('delegateOwnerWallet')
 
     const encodedId = req.params.encodedId
@@ -550,26 +551,81 @@ module.exports = function (app) {
       return sendResponse(req, res, errorResponseBadRequest(`Invalid ID: ${encodedId}`))
     }
 
-    const { blockchainId: blockchainIdFromTrack } = await models.Track.findOne({
-      attributes: ['blockchainId'],
-      where: { blockchainId },
-      order: [['clock', 'DESC']]
-    })
-
-    if (!blockchainIdFromTrack) {
-      return sendResponse(req, res, errorResponseBadRequest(`No track found for blockchainId ${blockchainId}`))
-    }
-
-    const { multihash } = await models.File.findOne({
+    let fileRecord = await models.File.findOne({
       attributes: ['multihash'],
       where: {
         type: 'copy320',
-        trackBlockchainId: blockchainIdFromTrack
+        trackBlockchainId: blockchainId
       },
       order: [['clock', 'DESC']]
     })
 
-    if (!multihash) {
+    // if track didn't finish the upload process and was never associated, there may not be a trackBlockchainId for the File records,
+    // try to fall back to discovery to fetch the metadata multihash and see if you can deduce the copy320 file
+    if (!fileRecord) {
+      try {
+        let trackRecord = await libs.Track.getTracks(1, 0, [blockchainId])
+        if (!trackRecord || trackRecord.length === 0 || !trackRecord[0].hasOwnProperty('blocknumber')) {
+          // TODO - return a server err response
+          return sendResponse(req, res, errorResponseServerError('Missing or malformatted track fetched from discovery node.'))
+        }
+
+        trackRecord = trackRecord[0]
+
+        // query the files table for the metadata multihash from discovery
+        // no CNodeUserUUID, but because this track is associated with a user and contains that user_id
+        // inside it, it's unique to this user
+        const file = await models.File.findOne({ where: { multihash: trackRecord.metadata_multihash } })
+        if (!file) {
+          return sendResponse(req, res, errorResponseServerError('Missing or malformatted track fetched from discovery node.'))
+        }
+
+        // read the metadata multihash from from the file system
+        let metadataJSON
+
+        const fileBuffer = await readFile(file.storagePath)
+        metadataJSON = JSON.parse(fileBuffer)
+        if (
+          !metadataJSON ||
+          !metadataJSON.track_segments ||
+          !Array.isArray(metadataJSON.track_segments) ||
+          !metadataJSON.track_segments.length
+        ) {
+          return sendResponse(req, res, errorResponseServerError(`Malformatted metadataJSON stored for metadata multihash ${trackRecord.metadata_multihash}.`))
+        }
+
+        // make sure all track segments have the same sourceFile
+        const segments = metadataJSON.track_segments.map(segment => segment.multihash)
+
+        let fileSegmentRecords = await models.File.findAll({
+          attributes: ['sourceFile'],
+          where: {
+            multihash: segments,
+            cnodeUserUUID: file.cnodeUserUUID
+          },
+          raw: true
+        })
+
+        // check that the number of files in the Files table for these segments for this user matches the number of segments from the metadata object
+        if (fileSegmentRecords.length !== metadataJSON.track_segments.length) {
+          return sendResponse(req, res, errorResponseServerError(`Track content mismatch for blockchainId ${blockchainId} - number of segments don't match between local and discovery`))
+        }
+
+        // check that there's a single sourceFile that all File records share by getting an array of uniques
+        const uniqSourceFiles = fileSegmentRecords.map(record => record.sourceFile).filter((v, i, a) => a.indexOf(v) === i)
+
+        if (uniqSourceFiles.length !== 1) {
+          return sendResponse(req, res, errorResponseServerError(`Track content mismatch for blockchainId ${blockchainId} - there's not one sourceFile that matches all segments`))
+        }
+
+        // search for the copy320 record based on the sourceFile
+        fileRecord = await models.File.findOne({ where: { type: 'copy320', sourceFile: uniqSourceFiles[0] } })
+      } catch (e) {
+        logger.error(`Error falling back to reconstructing data from discovery to stream`, e)
+      }
+    }
+
+    if (!fileRecord || !fileRecord.multihash) {
       return sendResponse(req, res, errorResponseBadRequest(`No file found for blockchainId ${blockchainId}`))
     }
 
@@ -580,7 +636,7 @@ module.exports = function (app) {
       libs.identityService.logTrackListen(blockchainId, delegateOwnerWallet, req.ip)
     }
 
-    req.params.CID = multihash
+    req.params.CID = fileRecord.multihash
     req.params.streamable = true
     res.set('Content-Type', 'audio/mpeg')
     next()


### PR DESCRIPTION
### Description
https://www.notion.so/audiusproject/Content-Node-Stream-Route-Bugfix-b585d68f89b24161a776bc70447eae7c
For a small subset of users, the track association doesn't complete. That means they don't have a record in the Tracks table. However, that doesn't mean that we can't gather enough information to stream the track. This removes the check in the Tracks table since that could fail in a small number of cases and adds fallback checks to discovery to get the metadata multihash and then attempts to lookup the copy320 file with a matching sourceFile from the trackSegments. There's also a redis cache to prevent an excessive number of discovery calls



### Tests
Manually set the fileRecord to null and check that it fetches the data and does the logic successfully from discovery. Subsequent loads should use the redis cache. Attached are logs checking the regular flow and the cached flow. Look for the arrows, which are relevant comments

```
[2021-03-09T00:16:15.023Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Begin processing request (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
------> [2021-03-09T00:16:15.027Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Could not find a stream fallback in redis, need to go to discovery
Executing (default): SELECT "fileUUID", "cnodeUserUUID", "trackBlockchainId", "multihash", "sourceFile", "fileName", "dirMultihash", "storagePath", "type", "clock", "createdAt", "updatedAt" FROM "Files" AS "File" WHERE "File"."multihash" = 'QmZPPGjs8bfQJKoNrtJs2WfC1HyZfvwe1zUf7sxGiYgNC6' LIMIT 1;
Executing (default): SELECT "sourceFile" FROM "Files" AS "File" WHERE "File"."multihash" IN ('QmXyhD7n97McnD9L471QJPwycjYisx2cY7hLXUeS6rMoDU', 'QmfVbTd4JfznqCsN2y36AS6gGG5WprDZvNZnrNvb154th4', 'QmasHbK7YKsyBTDchp5qkeLecT2AKQynbm4NQBJqsW6AeL', 'QmWXPZcRWce5Z2jLXTj8KcpPCD5HMSZm3BCpyAJ4NxZK7y', 'QmXRqxJbTpF81V2LWgYkWPbTPNTnidjophQWXCfaBVw1KK', 'QmbGqLaaKFfZ1dxYR9b1E66NJEadtJPeswV4YYgRN6MEcA', 'Qmds2uaqfUpVMtUw2LqQ55dQqW9Knbc1p4aG9e8FuYUmfd', 'QmPA1Qyf6jiB8BtNf6mvcveuGWNE1SdU7YYLBuwSW9eRi9', 'QmTdQGjs9s7EEWLMheu5PLHuwmJDZjNCnvoYpzZ9Sc57HA', 'QmbfM8e7gVHSyXA4wojzH5ur7Qh4NtaF2hwCbcPeMPoSsL', 'QmUfkLxDFwxDncd577ACZQYKcF3zstnYrcDxukLaSMABao', 'QmPwohng8jejzeCnRnihNN1YL3FxYDrD8jhAadfWWtrSnu', 'QmPqidBAbBLsWAzNbf2iT3oGy3NamNTagkAR8e5aofPCq3', 'QmPYwQXuPJW2MzSfeL1P2L6opRPHEBxSELSksQfuGRV45N') AND "File"."cnodeUserUUID" = '5f44a6b5-7844-4226-8ffb-187440f10157';
Executing (default): SELECT "fileUUID", "cnodeUserUUID", "trackBlockchainId", "multihash", "sourceFile", "fileName", "dirMultihash", "storagePath", "type", "clock", "createdAt", "updatedAt" FROM "Files" AS "File" WHERE "File"."type" = 'copy320' AND "File"."sourceFile" = 'a247a245-729a-40dc-a7f8-01572dd91764.mp3' LIMIT 1;
[2021-03-09T00:16:15.101Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Logging listen for track 1 by 0xb9819eaeb8a63a3cce101ad3682665dac2c7e0d4 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.113Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Standalone Request - QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.114Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Stats - Standalone Requests: 5 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.118Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Retrieving /file_storage/files/rpX/QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 directly from filesystem (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
(node:1671) UnhandledPromiseRejectionWarning: Error: Request failed with status code 429
    at createError (/usr/src/app/node_modules/axios/lib/core/createError.js:16:15)
    at settle (/usr/src/app/node_modules/axios/lib/core/settle.js:17:12)
    at IncomingMessage.handleStreamEnd (/usr/src/app/node_modules/axios/lib/adapters/http.js:237:11)
    at IncomingMessage.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:1671) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 10)
[2021-03-09T00:16:15.125Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Adding a rehydrateIpfsFromFsIfNecessary task to the queue!, count: 0 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.132Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Successfully added a rehydrateIpfsFromFsIfNecessary task!, count: 0 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.135Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Processing a rehydrateIpfsFromFsIfNecessary task for QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3, count: 0 (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.188Z]  INFO: audius_creator_node/1671 on 0edbb720c848: ipfsSingleByteCat - Retrieved QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 in 51ms (requestID=_kSFMD92x, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.378Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Begin processing request (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
------> [2021-03-09T00:16:15.382Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Found the stream in redis! No need to hit discovery
[2021-03-09T00:16:15.394Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Logging listen for track 1 by 0xb9819eaeb8a63a3cce101ad3682665dac2c7e0d4 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.408Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Standalone Request - QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.409Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Stats - Standalone Requests: 6 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.412Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Retrieving /file_storage/files/rpX/QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 directly from filesystem (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
(node:1671) UnhandledPromiseRejectionWarning: Error: Request failed with status code 429
    at createError (/usr/src/app/node_modules/axios/lib/core/createError.js:16:15)
    at settle (/usr/src/app/node_modules/axios/lib/core/settle.js:17:12)
    at IncomingMessage.handleStreamEnd (/usr/src/app/node_modules/axios/lib/adapters/http.js:237:11)
    at IncomingMessage.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:1671) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 12)
[2021-03-09T00:16:15.416Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Adding a rehydrateIpfsFromFsIfNecessary task to the queue!, count: 0 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.421Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Successfully added a rehydrateIpfsFromFsIfNecessary task!, count: 0 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.422Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Processing a rehydrateIpfsFromFsIfNecessary task for QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3, count: 0 (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.440Z]  INFO: audius_creator_node/1671 on 0edbb720c848: ipfsSingleByteCat - Retrieved QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 in 17ms (requestID=W47GIaWqP, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:15.470Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Begin processing request (requestID=bu0mOvskFV, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/favicon.ico)
[2021-03-09T00:16:43.592Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Begin processing request (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
------> [2021-03-09T00:16:43.595Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Found the stream in redis! No need to hit discovery
[2021-03-09T00:16:43.596Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Logging listen for track 1 by 0xb9819eaeb8a63a3cce101ad3682665dac2c7e0d4 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.609Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Standalone Request - QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.613Z]  INFO: audius_creator_node/1671 on 0edbb720c848: IPFS Stats - Standalone Requests: 7 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.617Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Retrieving /file_storage/files/rpX/QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 directly from filesystem (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
(node:1671) UnhandledPromiseRejectionWarning: Error: Request failed with status code 429
    at createError (/usr/src/app/node_modules/axios/lib/core/createError.js:16:15)
    at settle (/usr/src/app/node_modules/axios/lib/core/settle.js:17:12)
    at IncomingMessage.handleStreamEnd (/usr/src/app/node_modules/axios/lib/adapters/http.js:237:11)
    at IncomingMessage.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:1671) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 14)
[2021-03-09T00:16:43.621Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Adding a rehydrateIpfsFromFsIfNecessary task to the queue!, count: 0 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.627Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Successfully added a rehydrateIpfsFromFsIfNecessary task!, count: 0 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.628Z] DEBUG: audius_creator_node/1671 on 0edbb720c848: RehydrateIpfsQueue: Processing a rehydrateIpfsFromFsIfNecessary task for QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3, count: 0 (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.657Z]  INFO: audius_creator_node/1671 on 0edbb720c848: ipfsSingleByteCat - Retrieved QmXAnZ6PBMQqycT1yZzyAsh3BJQZy6UZh8XYxgLB6TrpX3 in 27ms (requestID=2HQxgQmt6, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/tracks/stream/7eP5n)
[2021-03-09T00:16:43.907Z]  INFO: audius_creator_node/1671 on 0edbb720c848: Begin processing request (requestID=5-FBdZRZlo, requestMethod=GET, requestHostname=cn3_creator-node_1, requestUrl=/favicon.ico)

```
