### PR TITLE
Explicitly use IPFS client 0.33.1 for rehydrate images

### DIFF
--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "^9.0.1",
     "hashids": "^2.2.1",
     "ioredis": "^4.9.3",
-    "ipfs-http-client": "^33.1.1",
+    "ipfs-http-client": "33.1.1",
     "ipfs-http-client-latest": "npm:ipfs-http-client@^42.0.0",
     "jimp": "^0.6.1",
     "lodash": "^4.17.15",

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -369,7 +369,7 @@ async function rehydrateIpfsFromFsIfNecessary (multihash, storagePath, logContex
     }
 
     try {
-      let addResp = await ipfsLatest.add(ipfsAddArray, { pin: false })
+      let addResp = await ipfs.add(ipfsAddArray, { pin: false })
       logger.info(`rehydrateIpfsFromFsIfNecessary - addResp ${JSON.stringify(addResp)}`)
     } catch (e) {
       logger.error(`rehydrateIpfsFromFsIfNecessary - addResp ${e}, ${ipfsAddArray}`)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Standardize ipfs-http-client across resizeImage.js and in rehydrate function, ensuring equivalent output. Prior to this fix, all rehydrate directory image add operations were failing silently.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Upload image to local setup
2. Kill ipfs nodes 1, 2
3. Attempt to `ipfs ls <imageCID` and confirm failure (hangs indefinitely)
4. Initiate rehydrate by visiting `http://cn1_creatornode_1:4000/ipfs/<CID>/2000x.jpg`
5. Confirm addResp succeeds in rehydrate flow
```
[2021-03-09T02:16:37.725Z]  INFO: audius_creator_node/51 on 1df6f3eb4273: rehydrateIpfsFromFsIfNecessary - addResp
[{"path":"blob/original.jpg","hash":"QmUXVqzy9DubDaJ15F4mZ97yTbeSFWREjGeBinCKcPpPxs","size":92882}
,{"path":"blob/2000x.jpg","hash":"QmVy7AC7ZtVvj4aNAa8U23rmb9zBCwbQfbAgZGiiKLDZ7o","size":38380}
,{"path":"blob/640x.jpg","hash":"QmQ7uDq4nCrHAHE7XPBEXF3sn6vvLXQGYqfERwr5yi9oJN","size":19603}
,{"path":"blob","hash":"QmYummbpXAEAshxUozow3XsYf7VojpCU4k2p2kb3WBTB6N","size":151030}] (requestID=-EjEd9K1T,
 requestMethod=GET, requestHostname=cn1_creator-node_1)
```

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
