### PR TITLE
Update /users/creator_node route to include non-creator users

### DIFF
--- a/discovery-provider/src/queries/get_users_cnode.py
+++ b/discovery-provider/src/queries/get_users_cnode.py
@@ -32,7 +32,7 @@ def get_users_cnode(cnode_endpoint_string):
                     FROM
                     "users"
                     WHERE
-                    "is_creator" IS TRUE
+                    "creator_node_endpoint" IS NOT NULL
                     AND "is_current" IS TRUE
                     ORDER BY
                     "user_id" ASC


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

I found this bug because it broke SnapbackSM, which relies on this route. Specifically, all recurring syncs for non-creator users were broken. This isn't a p0 because majority of users syncs are going through manual sync flow, but still no bueno.

Discprov `GET /users/creator_node?creator_node_endpoint=<url>` route was not returning data for users that had replica sets but were not creators. Previously this intersection was impossible as we only assigned replica sets after flipping is_creator flag, but recently we changed this in order to assign replica sets to all users on signup to ensure replication of content for all non-creator users.
This bugfix simply replaces the `is_creator` check in this route with a `creator_node_endpoint IS NOT NULL` check.

**There are similar regressions across the codebase, and separately we need to do comb through and update all references to `is_creator`.**


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Tested this locally with bugfix, confirming that non-creator users are also returned by this endoint.

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
