### PR TITLE
Add a try/catch in nodesync around peering with primary node's IPFS

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -319,7 +319,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
     } catch (e) {
       // if there's an error peering to an IPFS node, do not stop execution
       // since we have other fallbacks, keep going on with sync
-      req.logger.error(`Error running _initBootstrapAndRefreshPeers`, e)
+      req.logger.error(`Error in _nodeSync calling _initBootstrapAndRefreshPeers`, e)
     }
 
     /**

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -318,7 +318,7 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
       req.logger.info(redisKey, 'IPFS Nodes connected + data export received')
     } catch (e) {
       // if there's an error peering to an IPFS node, do not stop execution
-      // since we have other fallbacks, attempt to keep going
+      // since we have other fallbacks, keep going on with sync
       req.logger.error(`Error running _initBootstrapAndRefreshPeers`, e)
     }
 


### PR DESCRIPTION
### Description
In nodesync, if the secondary is not able to peer with the primary content node it errors out of nodesync entirely. We don't want that because we have fallbacks for IPFS. This just adds a try catch to make sure we don't stop the rest of the nodesync process if this does error.



### Tests
Ran the system locally + tested sync