### PR TITLE
Fix limit bug with trending playlists

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -362,5 +362,6 @@ class FullTrendingPlaylists(Resource):
         else:
             key = self.get_cache_key()
             playlists = use_redis_cache(key, TRENDING_TTL_SEC, lambda: get_trending_playlists(args))
+            playlists = playlists[offset: limit + offset]
 
         return success_response(playlists)

--- a/discovery-provider/src/queries/get_trending_playlists.py
+++ b/discovery-provider/src/queries/get_trending_playlists.py
@@ -186,7 +186,7 @@ def get_trending_playlists(args):
 
         # Apply limit + offset early to reduce the amount of
         # population work we have to do
-        if limit and offset:
+        if limit is not None and offset is not None:
             playlists = playlists[offset: limit + offset]
             playlist_ids = playlist_ids[offset: limit + offset]
 


### PR DESCRIPTION
### Description
Python falsy value for limit 0 was causing problems. Also saw that for full & without user_id route, we wouldn't apply limit (currently we would never hit this via app). 

