### PR TITLE
Set end range in content stream if undefined

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -67,14 +67,17 @@ const streamFromFileSystem = async (req, res, path) => {
 
     // TODO - route doesn't support multipart ranges.
     if (stat && range) {
-      const { start, end } = range
+      let { start, end } = range
       if (end >= stat.size) {
         // Set "Requested Range Not Satisfiable" header and exit
         res.status(416)
         return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
       }
 
-      fileStream = fs.createReadStream(path, { start, end: end || (stat.size - 1) })
+      // set end in case end is undefined or null
+      end = end || (stat.size - 1)
+
+      fileStream = fs.createReadStream(path, { start, end })
 
       // Add a content range header to the response
       res.set('Content-Range', formatContentRange(start, end, stat.size))
@@ -183,15 +186,18 @@ const getCID = async (req, res) => {
       const range = getRequestRange(req)
 
       if (req.params.streamable && range) {
-        const { start, end } = range
+        let { start, end } = range
         if (end >= stat.size) {
           // Set "Requested Range Not Satisfiable" header and exit
           res.status(416)
           return sendResponse(req, res, errorResponseRangeNotSatisfiable('Range not satisfiable'))
         }
 
+        // set end in case end is undefined or null
+        end = end || (stat.size - 1)
+
         // Set length to be end - start + 1 so it matches behavior of fs.createReadStream
-        const length = end ? end - start + 1 : stat.size - start
+        const length = end - start + 1
         stream = req.app.get('ipfsAPI').catReadableStream(
           CID, { offset: start, length }
         )


### PR DESCRIPTION
### Description
We observed a sinister bug in Chrome when trying to stream a track from a content node behind a GCP load balancer. Other browsers and infrastructure worked fine, but Chrome would fail to stream.

The cause of this is that GCP LBs would send range `0-` so the end is not set. When we set the headers, this header `res.set('Content-Length', end - start + 1)` would be incorrect because end is an invalid value. I just set end to a valid value so all calculations should be correct.



### Tests
Hotfixed this tag on a stage node behind a GCP load balancer and the track streams.
