### PR TITLE
[AUD-438] Expose isRegisteredOnURSM in Content Node health check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -22,7 +22,6 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, randomBytesToSign =
     creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
     spID: config.get('spID'),
     spOwnerWallet: config.get('spOwnerWallet'),
-    delegateOwnerWallet: config.get('delegateOwnerWallet'),
     isRegisteredOnURSM: config.get('isRegisteredOnURSM')
   }
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -21,7 +21,9 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, randomBytesToSign =
     selectedDiscoveryProvider: 'none',
     creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
     spID: config.get('spID'),
-    spOwnerWallet: config.get('spOwnerWallet')
+    spOwnerWallet: config.get('spOwnerWallet'),
+    delegateOwnerWallet: config.get('delegateOwnerWallet'),
+    isRegisteredOnURSM: config.get('isRegisteredOnURSM')
   }
 
   // If optional `randomBytesToSign` query param provided, node will include string in signed object

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -55,10 +55,14 @@ describe('Test Health Check', function () {
   it('Should pass', async function () {
     config.set('creatorNodeEndpoint', 'http://test.endpoint')
     config.set('spID', 10)
+
     let expectedEndpoint = config.get('creatorNodeEndpoint')
     let expectedSpID = config.get('spID')
     let expectedSpOwnerWallet = config.get('spOwnerWallet')
+    const expectedDelegateOwnerWallet = config.get('delegateOwnerWallet')
+
     const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
+
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -67,7 +71,9 @@ describe('Test Health Check', function () {
       selectedDiscoveryProvider: TEST_ENDPOINT,
       spID: expectedSpID,
       spOwnerWallet: expectedSpOwnerWallet,
-      creatorNodeEndpoint: expectedEndpoint
+      creatorNodeEndpoint: expectedEndpoint,
+      delegateOwnerWallet: expectedDelegateOwnerWallet,
+      isRegisteredOnURSM: false
     })
   })
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -67,7 +67,6 @@ describe('Test Health Check', function () {
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
-      delegateOwnerWallet: config.get('delegateOwnerWallet'),
       isRegisteredOnURSM: false
     })
   })
@@ -84,7 +83,6 @@ describe('Test Health Check', function () {
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
-      delegateOwnerWallet: config.get('delegateOwnerWallet'),
       isRegisteredOnURSM: false
     })
   })
@@ -108,7 +106,6 @@ describe('Test Health Check Verbose', function () {
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
-      delegateOwnerWallet: config.get('delegateOwnerWallet'),
       isRegisteredOnURSM: false,
 
       country: 'US',

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -56,11 +56,6 @@ describe('Test Health Check', function () {
     config.set('creatorNodeEndpoint', 'http://test.endpoint')
     config.set('spID', 10)
 
-    let expectedEndpoint = config.get('creatorNodeEndpoint')
-    let expectedSpID = config.get('spID')
-    let expectedSpOwnerWallet = config.get('spOwnerWallet')
-    const expectedDelegateOwnerWallet = config.get('delegateOwnerWallet')
-
     const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock)
 
     assert.deepStrictEqual(res, {
@@ -69,16 +64,17 @@ describe('Test Health Check', function () {
       healthy: true,
       git: undefined,
       selectedDiscoveryProvider: TEST_ENDPOINT,
-      spID: expectedSpID,
-      spOwnerWallet: expectedSpOwnerWallet,
-      creatorNodeEndpoint: expectedEndpoint,
-      delegateOwnerWallet: expectedDelegateOwnerWallet,
+      spID: config.get('spID'),
+      spOwnerWallet: config.get('spOwnerWallet'),
+      creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
+      delegateOwnerWallet: config.get('delegateOwnerWallet'),
       isRegisteredOnURSM: false
     })
   })
 
   it('Should handle no libs', async function () {
     const res = await healthCheck({}, mockLogger, sequelizeMock)
+
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -87,7 +83,9 @@ describe('Test Health Check', function () {
       selectedDiscoveryProvider: 'none',
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
-      creatorNodeEndpoint: config.get('creatorNodeEndpoint')
+      creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
+      delegateOwnerWallet: config.get('delegateOwnerWallet'),
+      isRegisteredOnURSM: false
     })
   })
 })
@@ -100,6 +98,7 @@ describe('Test Health Check Verbose', function () {
     config.set('maxStorageUsedPercent', 95)
 
     const res = await healthCheckVerbose({}, mockLogger, sequelizeMock, getMonitorsMock)
+
     assert.deepStrictEqual(res, {
       ...version,
       service: 'content-node',
@@ -109,6 +108,9 @@ describe('Test Health Check Verbose', function () {
       spID: config.get('spID'),
       spOwnerWallet: config.get('spOwnerWallet'),
       creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
+      delegateOwnerWallet: config.get('delegateOwnerWallet'),
+      isRegisteredOnURSM: false,
+
       country: 'US',
       latitude: '37.7749',
       longitude: '-122.4194',

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -280,6 +280,12 @@ const config = convict({
     env: 'delegatePrivateKey',
     default: null
   },
+  isRegisteredOnURSM: {
+    doc: 'boolean indicating whether or not node has been registered on dataContracts UserReplicaSetManager contract (URSM)',
+    format: Boolean,
+    env: 'isRegisteredOnURSM',
+    default: false
+  },
 
   spID: {
     doc: 'ID of creator node in ethContracts ServiceProviderFactory',

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -280,10 +280,10 @@ const config = convict({
     env: 'delegatePrivateKey',
     default: null
   },
+  // `env` property is not defined as this should never be passed in as an envvar and should only be set programatically
   isRegisteredOnURSM: {
     doc: 'boolean indicating whether or not node has been registered on dataContracts UserReplicaSetManager contract (URSM)',
     format: Boolean,
-    env: 'isRegisteredOnURSM',
     default: false
   },
 

--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -115,6 +115,9 @@ class URSMRegistrationManager {
      * 2-a. Short-circuit if L2 record for node already matches L1 record (i.e. delegateOwnerWallets match)
      */
     if (delegateOwnerWalletFromSPFactory === delegateOwnerWalletFromURSM) {
+      // Update config
+      this.nodeConfig.set('isRegisteredOnURSM', true)
+
       this.logInfo(`Node already registered on URSM with same delegateOwnerWallet`)
       return
     }
@@ -181,6 +184,10 @@ class URSMRegistrationManager {
         receivedSignatures[1].sig,
         receivedSignatures[2].sig
       )
+
+      // Update config
+      this.nodeConfig.set('isRegisteredOnURSM', true)
+
       this.logInfo('Successfully registered self on URSM')
     } catch (e) {
       throw new Error(`URSMRegistration contract call failed ${e}`)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Expose isRegisteredOnURSM in Content Node health check


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Brought up system without URSM deploy -> confirmed health check showed `isRegisteredOnURSM` = false -> deployed URSM -> waited for URSM registration to complete -> confirmed health check showed `isRegisteredOnURSM` = true

Also updated health check unit test


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
