### PR TITLE
[AUD-187] Require 2 secondaries explicitly

### DIFF
--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -712,6 +712,11 @@ class Users extends Base {
     }
     let primaryEndpoint = CreatorNode.getPrimary(creatorNodeEndpoint)
     let secondaries = CreatorNode.getSecondaries(creatorNodeEndpoint)
+
+    if (secondaries.length < 2) {
+      throw new Error(`Invalid number of secondaries found - recieved ${secondaries}`)
+    }
+
     let [primarySpID, secondary1SpID, secondary2SpID] = await Promise.all([
       this._retrieveSpIDFromEndpoint(primaryEndpoint),
       this._retrieveSpIDFromEndpoint(secondaries[0]),


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

When pressing the `x` button in service selection UI on a service, we submit an invalid update operation with 1 secondary instead of 2. This is to explicitly handle this error -  corresponding client update to prevent invalid submissions from the client is required as well to re-enable this functionality


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

https://www.notion.so/audiusproject/3-17-21-UM-Deprecation-Re-Dry-Run-ae860dc606254f2d9bc475d69b248b35


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
