### PR TITLE
Change middleware retry intervals

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -228,11 +228,8 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
     const start2 = Date.now()
 
     // In total, will try for 200 seconds.
-    const MaxRetries = 200
+    const MaxRetries = 201
     const RetryTimeout = 1000 // 1 seconds
-
-    // Initial delay before polling
-    await utils.timeout(1000)
 
     let discprovBlockNumber = -1
     for (let retry = 1; retry <= MaxRetries; retry++) {
@@ -278,11 +275,8 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
     const start2 = Date.now()
 
     // Will poll every sec for up to 1 minute (60 sec)
-    const MaxRetries = 60
+    const MaxRetries = 61
     const RetryTimeout = 1000 // 1 seconds
-
-    // Initial delay before polling
-    await utils.timeout(1000)
 
     let returnedPrimaryEndpoint = null
     for (let retry = 1; retry <= MaxRetries; retry++) {

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -228,8 +228,8 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
     const start2 = Date.now()
 
     // In total, will try for 200 seconds.
-    const MaxRetries = 40
-    const RetryTimeout = 5000 // 5 seconds
+    const MaxRetries = 200
+    const RetryTimeout = 1000 // 1 seconds
 
     // Initial delay before polling
     await utils.timeout(1000)
@@ -277,9 +277,9 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
 
     const start2 = Date.now()
 
-    // Will poll every 5 sec for up to 1 minute (60 sec)
-    const MaxRetries = 12
-    const RetryTimeout = 5000 // 5 seconds
+    // Will poll every sec for up to 1 minute (60 sec)
+    const MaxRetries = 60
+    const RetryTimeout = 1000 // 1 seconds
 
     // Initial delay before polling
     await utils.timeout(1000)


### PR DESCRIPTION
### Description
Lower the retry interval in content node middleware from 5s to 1s. This lag affects all write operations like upload/signup etc. Functionally, there's zero impact on middlewares.

Rationale for this change
Libs already polls on 500ms interval to confirm changes from discovery. Also 5s seems like it was picked so the validation can be in lock step with discovery indexing, but we've observed that indexing changes can be applied quite randomly. When compounded, these 5 second waits can add up.


### Tests
Ran the system locally and did an upload