### PR TITLE
Wait for test db transaction to finish before evaluating db state

### DIFF
--- a/identity-service/test/notifications/helpers.js
+++ b/identity-service/test/notifications/helpers.js
@@ -19,7 +19,7 @@ async function _insertFollowersPreRead () {
       notificationTarget,
       { notifyWeb: true, notifyMobile: false }
     )
-    tx.commit()
+    await tx.commit()
   }
 
   // Notifications - there should be 1 for user 1 and 1 for user 3


### PR DESCRIPTION
### Description
There was no `await` on the DB transaction during the processing of inserts for the DB test. 
So, when evaluating it is possible for the DB query to miss data that was not yet committed and break the tests.
Reference this CI build: https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/8569/workflows/5d87b8aa-1aa2-47b5-a1f1-f2ad2b8856ea/jobs/64849


### Tests
This code is fixing a test, but is untested, but I'm very confident that this will fix the issue at hand.