### PR TITLE
Add distributed tracing

### DIFF
--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -47,7 +47,8 @@ function getRequestLoggingContext (req, requestID) {
 }
 
 function loggingMiddleware (req, res, next) {
-  const requestID = shortid.generate()
+  const providedRequestID = req.header('X-Request-ID')
+  const requestID = providedRequestID || shortid.generate()
   res.set('CN-Request-ID', requestID)
 
   req.logContext = getRequestLoggingContext(req, requestID)

--- a/identity-service/src/logging.js
+++ b/identity-service/src/logging.js
@@ -21,7 +21,9 @@ function requestNotExcludedFromLogging (url) {
 }
 
 function loggingMiddleware (req, res, next) {
-  const requestID = shortid.generate()
+  const providedRequestID = req.header('X-Request-ID')
+  const requestID = providedRequestID || shortid.generate()
+
   const urlParts = req.url.split('?')
   req.startTime = process.hrtime()
   req.logger = logger.child({

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const FormData = require('form-data')
+const uuid = require('../../utils/uuid')
 
 const SchemaValidator = require('../schemaValidator')
 
@@ -567,6 +568,9 @@ class CreatorNode {
       axiosRequestObj.headers['User-Id'] = user.user_id
     }
 
+    const requestId = uuid()
+    axiosRequestObj.headers['X-Request-ID'] = requestId
+
     axiosRequestObj.baseURL = this.creatorNodeEndpoint
 
     // Axios throws for non-200 responses
@@ -615,7 +619,7 @@ class CreatorNode {
         }
       }
 
-      _handleErrorHelper(e, axiosRequestObj.url)
+      _handleErrorHelper(e, axiosRequestObj.url, requestId)
     }
   }
 
@@ -641,6 +645,9 @@ class CreatorNode {
       headers = formData.getHeaders()
     }
     headers['X-Session-ID'] = this.authToken
+
+    const requestId = uuid()
+    headers['X-Request-ID'] = requestId
 
     let total
     const url = this.creatorNodeEndpoint + route
@@ -676,15 +683,16 @@ class CreatorNode {
       onProgress(total, total)
       return resp.data
     } catch (e) {
-      _handleErrorHelper(e, url)
+      _handleErrorHelper(e, url, requestId)
     }
   }
 }
 
-function _handleErrorHelper (e, requestUrl) {
+function _handleErrorHelper (e, requestUrl, requestId = null) {
   if (e.response && e.response.data && e.response.data.error) {
     const cnRequestID = e.response.headers['cn-request-id']
-    const errMessage = `Server returned error: [${e.response.status.toString()}] [${e.response.data.error}] for request: [${cnRequestID}]`
+    // cnRequestID will be the same as requestId if it receives the X-Request-ID header
+    const errMessage = `Server returned error: [${e.response.status.toString()}] [${e.response.data.error}] for request: [${cnRequestID}, ${requestId}]`
 
     console.error(errMessage)
     throw new Error(errMessage)
@@ -692,10 +700,12 @@ function _handleErrorHelper (e, requestUrl) {
     // delete headers, may contain tokens
     if (e.config && e.config.headers) delete e.config.headers
 
-    const errorMsg = `Network error while making request to ${requestUrl}:\nStringified Error:${JSON.stringify(e)}\n`
+    const errorMsg = `Network error while making request ${requestId} to ${requestUrl}:\nStringified Error:${JSON.stringify(e)}\n`
     console.error(errorMsg, e)
     throw new Error(`${errorMsg}${e}`)
   } else {
+    const errorMsg = `Unknown error while making request ${requestId} to ${requestUrl}:\nStringified Error:${JSON.stringify(e)}\n`
+    console.error(errorMsg, e)
     throw e
   }
 }

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -673,6 +673,7 @@ class CreatorNode {
           // Add a 10% inherit processing time for the file upload.
           onUploadProgress: (progressEvent) => {
             if (!total) total = progressEvent.total
+            console.info(`Upload in progress: ${progressEvent.loaded} / ${total}`)
             onProgress(progressEvent.loaded, total)
           }
         }

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const uuid = require('../../utils/uuid')
 
 const Requests = require('./requests')
 
@@ -286,6 +287,12 @@ class IdentityService {
   async _makeRequest (axiosRequestObj) {
     axiosRequestObj.baseURL = this.identityServiceEndpoint
 
+    const requestId = uuid()
+    axiosRequestObj.headers = {
+      ...(axiosRequestObj.headers || {}),
+      'X-Request-ID': requestId
+    }
+
     // Axios throws for non-200 responses
     try {
       const resp = await axios(axiosRequestObj)
@@ -293,7 +300,7 @@ class IdentityService {
     } catch (e) {
       if (e.response && e.response.data && e.response.data.error) {
         console.error(
-          `Server returned error: [${e.response.status.toString()}] ${e.response.data.error}`
+          `Server returned error for requestId ${requestId}: [${e.response.status.toString()}] ${e.response.data.error}`
         )
       }
       throw e

--- a/libs/src/utils/uuid.js
+++ b/libs/src/utils/uuid.js
@@ -1,0 +1,16 @@
+const uuid = () => {
+  // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript/873856#873856
+  const s = []
+  const hexDigits = '0123456789abcdef'
+  for (let i = 0; i < 36; i++) {
+    s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1)
+  }
+  s[14] = '4' // bits 12-15 of the time_hi_and_version field to 0010
+  s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1) // bits 6-7 of the clock_seq_hi_and_reserved to 01
+  s[8] = s[13] = s[18] = s[23] = '-'
+
+  const uuid = s.join('')
+  return uuid
+}
+
+module.exports = uuid


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add X-Request-ID header in libs to optionally log out if present on content node & identity service.
I opted to copy the same uuid() generation method we use in the dapp from SO. We currently include a few different versions of the uuid package in libs (inherited from crypto deps) and I don't want to add more bloat there.


Mad dog errors seem to be URSM related
```
TypeError: Cannot read property 'length' of undefined
    at LibsWrapper.getLibsUserInfo (/home/circleci/project/service-commands/src/libs.js:388:16)
    at process._tickCallback (internal/process/next_tick.js:68:7)
2021-03-23T18:19:44.594Z error: 	Failed test [userReplicaSetManager] with error [Issue with creating and upgrading users: TypeError: Cannot read property 'length' of undefined]
2021-03-23T18:19:44.594Z error: 	Exiting testrunner with errors
2021-03-23T18:19:44.594Z error: 	
```

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Ran stack locally & tested requests from client with a generated X-Request-ID and ensured the service logged that out
2. Ran stack locally & tested that without the client providing X-Request-ID, the old short-form request id is logged
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
