### PR TITLE
Add a batched image CID route to creator node

### DIFF
--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -39,6 +39,7 @@ app.use('/metadata', metadataReqLimiter)
 app.use('/image_upload', imageReqLimiter)
 app.use('/ursm_request_for_signature', URSMRequestForSignatureReqLimiter)
 app.use('/batch_cids_exist', batchCidsExistReqLimiter)
+app.use('/batch_image_cids_exist', batchCidsExistReqLimiter)
 app.use(getRateLimiterMiddleware())
 
 // import routes


### PR DESCRIPTION
### Description
Continues from: https://github.com/AudiusProject/audius-protocol/pull/1310

Adds a batched image CID route to creator node, so that https://github.com/AudiusProject/audius-protocol/pull/1310 works.


### Tests
Stage testing as well as load testing for the new route is pending.
