### PR TITLE
Option to skip rollover nodes

### DIFF
--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -17,7 +17,6 @@ class SanityChecks {
    * @param {Set<string>} creatorNodeWhitelist
    */
   async run (creatorNodeWhitelist = null) {
-    console.log("sanity check run options", this.options)
     await isCreator(this.libs)
     await sanitizeNodes(this.libs)
     await addSecondaries(this.libs)

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -7,8 +7,9 @@ const recoveryEmail = require('./needsRecoveryEmail')
 
 // Checks to run at startup to ensure a user is in a good state.
 class SanityChecks {
-  constructor (libsInstance) {
+  constructor (libsInstance, options = { skipRollover: false }) {
     this.libs = libsInstance
+    this.options = options
   }
 
   /**
@@ -16,11 +17,12 @@ class SanityChecks {
    * @param {Set<string>} creatorNodeWhitelist
    */
   async run (creatorNodeWhitelist = null) {
+    console.log("sanity check run options", this.options)
     await isCreator(this.libs)
     await sanitizeNodes(this.libs)
     await addSecondaries(this.libs)
     await syncNodes(this.libs)
-    await rolloverNodes(this.libs, creatorNodeWhitelist)
+    if (!this.options.skipRollover) await rolloverNodes(this.libs, creatorNodeWhitelist)
     await recoveryEmail(this.libs)
   }
 }


### PR DESCRIPTION
### Description
There are certain instances that we'd want a client to not run rolloverNodes so this lets us control the ability to skip rollover nodes with a given config. Client side PR here https://github.com/AudiusProject/audius-client/pull/311

The specific motivation for adding this now is the UserReplicaSetManager rollout. The only data inconsistency we likely run into during the backfill is a client calls rolloverNodes during the time when we are writing a user's replica set to the URSM contract. There could be a race condition that causes inconsistency between cnode state and on chain replica set state.

### Tests
Linked libs to the client and ran against stage to test.

<img width="1286" alt="Feed_•_Audius" src="https://user-images.githubusercontent.com/295938/112853378-c9253200-907a-11eb-865f-89bb54ec3789.png">

<img width="1279" alt="Feed_•_Audius" src="https://user-images.githubusercontent.com/295938/112853738-28834200-907b-11eb-9125-8f575a46ccf3.png">

Notice that in the first pic, the rolloverNodes debug log is printed so it actually executed the rolloverNodes function. The second pic never prints that, so rolloverNodes was skipped.

I also tested this by not passing in any options to the sanityChecks constructor and ensuring the rolloverNodes ran by default.