### PR TITLE
Update init-repos up command to rely on $PROTOCOL_DIR + mad dog sync check fix

### DIFF
--- a/mad-dog/src/helpers.js
+++ b/mad-dog/src/helpers.js
@@ -340,7 +340,7 @@ const ensureReplicaSetSyncIsConsistent = async ({ i, libs, executeOne }) => {
 
       logger.info(`Monitoring sync for user=${userId} | (Primary) ${primary}:${primaryClockValue} - (Secondaries) ${secondary1}:${secondary1ClockValue} - ${secondary2}:${secondary2ClockValue}`)
 
-      if (secondary1ClockValue === primaryClockValue && secondary2ClockValue && primaryClockValue) {
+      if (secondary1ClockValue === primaryClockValue && secondary2ClockValue === primaryClockValue) {
         synced = true
         logger.info(`Sync completed for user=${userId}!`)
       }

--- a/mad-dog/src/helpers.js
+++ b/mad-dog/src/helpers.js
@@ -356,8 +356,7 @@ const ensureReplicaSetSyncIsConsistent = async ({ i, libs, executeOne }) => {
   if (!synced) {
     const errorMsg = `Max sync monitoring timeout reached for user=${userId}`
     logger.error(errorMsg)
-    console.error(e)
-    throw new Error(`${errorMsg}: ${e.message}`)
+    throw new Error(`${errorMsg}`)
   }
 }
 

--- a/mad-dog/src/helpers.js
+++ b/mad-dog/src/helpers.js
@@ -352,6 +352,13 @@ const ensureReplicaSetSyncIsConsistent = async ({ i, libs, executeOne }) => {
     }
     if (!synced) { await delay(1000) }
   }
+
+  if (!synced) {
+    const errorMsg = `Max sync monitoring timeout reached for user=${userId}`
+    logger.error(errorMsg)
+    console.error(e)
+    throw new Error(`${errorMsg}: ${e.message}`)
+  }
 }
 
 /**

--- a/service-commands/README.md
+++ b/service-commands/README.md
@@ -29,7 +29,7 @@ node scripts/setup.js run init-repos up
 
 **Bringing up all services:**
 - In `<service-commands>/scripts/`, run `node setup.js up` to bring all services up.
-- `-nc, --num-cnodes <number>`, by default set to 1. Adjusts the number of creator nodes initialized within the system. 
+- `-nc, --num-cnodes <number>`, by default set to 4. Adjusts the number of creator nodes initialized within the system. 
 
 ```
 node setup.js up
@@ -68,7 +68,7 @@ node setup.js run ipfs-2 up
 node setup.js run contracts up
 ```
 
-`creator-node` is the only service that must be run with a corresponding `-i, --instance-num` flag - when the entire system is initialized with `--num-cnodes` set to 3, the commands that are executed to bring them up are as follows:
+`creator-node` is the only service that must be run with a corresponding `-i, --instance-num` flag - when the entire system is initialized with `--num-cnodes` set to 4, the commands that are executed to bring them up are as follows:
 
 ```
 node setup.js run creator-node up -i 1
@@ -84,7 +84,6 @@ node setup.js run network down
 node setup.js run ipfs down
 node setup.js run discovery-provider down
 node setup.js run contracts down
-
 ```
 
 

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -179,7 +179,7 @@
   },
   "init-repos": {
     "up": [
-      ". scripts/init-repos.sh"
+      ". $PROTOCOL_DIR/service-commands/scripts/init-repos.sh"
     ]
   },
   "user-replica-set-manager": {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Before: 
1. Running `node setup.js run init-repos up` does not work if you are not in the root `service-commands` repo. 
2. Sync check test would fail / false positive

Solution: 
1. This fix makes it so that as long as you run the correct script, you may run this script anywhere.
2. Fix the sync check to check equality properly


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Ran this command in `service-commands` and `~` directories. Installed dependencies as expected.
2. Sync check passes now