### PR TITLE
Fix historical app metrics aggregation

### DIFF
--- a/discovery-provider/src/queries/get_app_name_metrics.py
+++ b/discovery-provider/src/queries/get_app_name_metrics.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import functools as ft
 from datetime import date, timedelta
 from sqlalchemy import func, desc, asc
 from src import exceptions
@@ -45,8 +44,13 @@ def _get_historical_app_metrics(session):
         .filter(AggregateDailyAppNameMetrics.timestamp < today)
         .all()
     )
-    daily_metrics = ft.reduce(lambda acc, curr: \
-        acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, daily_query, {})
+    daily_metrics = {}
+    for attribute in daily_query:
+        day = str(attribute[0])
+        if day not in daily_metrics:
+            daily_metrics[day] = {attribute[1]: attribute[2]}
+        else:
+            daily_metrics[day][attribute[1]] = attribute[2]
 
     monthly_query = (
         session.query(
@@ -57,8 +61,13 @@ def _get_historical_app_metrics(session):
         .filter(AggregateMonthlyAppNameMetrics.timestamp < first_day_of_month)
         .all()
     )
-    monthly_metrics = ft.reduce(lambda acc, curr: \
-        acc.update({str(curr[0]): {curr[1]: curr[2]}}) or acc, monthly_query, {})
+    monthly_metrics = {}
+    for attribute in monthly_query:
+        month = str(attribute[0])
+        if month not in monthly_metrics:
+            monthly_metrics[month] = {attribute[1]: attribute[2]}
+        else:
+            monthly_metrics[month][attribute[1]] = attribute[2]
 
     return {
         'daily': daily_metrics,

--- a/discovery-provider/tests/test_get_historical_app_metrics.py
+++ b/discovery-provider/tests/test_get_historical_app_metrics.py
@@ -26,6 +26,11 @@ def test_get_historical_app_metrics(app):
             ),
             AggregateDailyAppNameMetrics(
                 application_name='best-app',
+                count=1,
+                timestamp=thirty_days_ago
+            ),
+            AggregateDailyAppNameMetrics(
+                application_name='best-app',
                 count=3,
                 timestamp=yesterday
             ),
@@ -45,6 +50,11 @@ def test_get_historical_app_metrics(app):
                 timestamp=today - timedelta(days=100)
             ),
             AggregateMonthlyAppNameMetrics(
+                application_name='other-app',
+                count=5,
+                timestamp=today - timedelta(days=100)
+            ),
+            AggregateMonthlyAppNameMetrics(
                 application_name='top-app',
                 count=6,
                 timestamp=today
@@ -57,8 +67,10 @@ def test_get_historical_app_metrics(app):
 
         assert len(daily_aggregate_metrics.items()) == 2
         assert daily_aggregate_metrics[str(thirty_days_ago)]['top-app'] == 2
+        assert daily_aggregate_metrics[str(thirty_days_ago)]['best-app'] == 1
         assert daily_aggregate_metrics[str(yesterday)]['best-app'] == 3
 
         assert len(daily_aggregate_metrics.items()) == 2
         assert monthly_aggregate_metrics[str(today - timedelta(days=367))]['top-app'] == 2
         assert monthly_aggregate_metrics[str(today - timedelta(days=100))]['best-app'] == 4
+        assert monthly_aggregate_metrics[str(today - timedelta(days=100))]['other-app'] == 5


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_
Fix the aggregation logic for historical app metrics to return all app records if there are records for more than one app for a given day or month.



### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Wrote unit test that failed before change and passed after change in test_get_historical_app_metrics.py
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
