### PR TITLE
Add gas estimates to libs

### DIFF
--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -484,7 +484,7 @@ const config = convict({
     doc: 'One of averageGweiHex/fastGweiHex/fastestGweiHex',
     format: String,
     env: 'ethRelayerProdGasTier',
-    default: 'fastGweiHex'
+    default: 'fastestGweiHex'
   },
   captchaScoreSecret: {
     doc: 'The secret necessary to view user captcha scores',

--- a/identity-service/src/routes/ethRelay.js
+++ b/identity-service/src/routes/ethRelay.js
@@ -21,7 +21,11 @@ module.exports = function (app) {
       } catch (e) {
         req.logger.error('Error in transaction:', e.message, reqBodySHA)
 
-        return sendResponse(req, res, errorResponseServerError(`Something caused the transaction to fail for payload ${reqBodySHA}`))
+        return sendResponse(
+          req,
+          res,
+          errorResponseServerError(`Something caused the transaction to fail for payload ${reqBodySHA}, ${e.message}`)
+        )
       }
     } else {
       return sendResponse(

--- a/libs/src/services/dataContracts/playlistFactoryClient.js
+++ b/libs/src/services/dataContracts/playlistFactoryClient.js
@@ -42,8 +42,7 @@ class PlaylistFactoryClient extends ContractClient {
     const tx = await this.web3Manager.sendTransaction(
       method,
       this.contractRegistryKey,
-      contractAddress,
-      8000000
+      contractAddress
     )
     return parseInt(tx.events.PlaylistCreated.returnValues._playlistId, 10)
   }
@@ -92,8 +91,7 @@ class PlaylistFactoryClient extends ContractClient {
     return this.web3Manager.sendTransaction(
       method,
       this.contractRegistryKey,
-      contractAddress,
-      1000000 // TODO move to const
+      contractAddress
     )
   }
 
@@ -122,7 +120,6 @@ class PlaylistFactoryClient extends ContractClient {
       method,
       this.contractRegistryKey,
       contractAddress,
-      undefined, // txGasLimit
       retries
     )
   }
@@ -151,7 +148,6 @@ class PlaylistFactoryClient extends ContractClient {
       method, // contractMethod
       this.contractRegistryKey,
       contractAddress,
-      8000000, // txGasLimit
       retries
     )
   }

--- a/libs/src/services/ethContracts/audiusTokenClient.js
+++ b/libs/src/services/ethContracts/audiusTokenClient.js
@@ -1,5 +1,3 @@
-const DEFAULT_GAS_AMOUNT = 200000
-
 class AudiusTokenClient {
   constructor (ethWeb3Manager, contractABI, contractAddress) {
     this.ethWeb3Manager = ethWeb3Manager
@@ -57,7 +55,6 @@ class AudiusTokenClient {
       method,
       this.contractAddress,
       owner,
-      /* txGasLimit */ DEFAULT_GAS_AMOUNT,
       /* retries */ 0
     )
     return { txReceipt: tx }
@@ -86,7 +83,6 @@ class AudiusTokenClient {
       contractMethod,
       this.contractAddress,
       owner,
-      /* txGasLimit */ DEFAULT_GAS_AMOUNT,
       /* retries */ 0
     )
     return tx
@@ -102,7 +98,6 @@ class AudiusTokenClient {
     } else {
       tx = await this.ethWeb3Manager.sendTransaction(
         contractMethod,
-        1000000,
         this.contractAddress,
         privateKey)
     }

--- a/libs/src/services/ethContracts/audiusTokenClient.js
+++ b/libs/src/services/ethContracts/audiusTokenClient.js
@@ -99,7 +99,8 @@ class AudiusTokenClient {
       tx = await this.ethWeb3Manager.sendTransaction(
         contractMethod,
         this.contractAddress,
-        privateKey)
+        privateKey
+      )
     }
     return { txReceipt: tx }
   }

--- a/libs/src/services/ethContracts/claimsManagerClient.js
+++ b/libs/src/services/ethContracts/claimsManagerClient.js
@@ -1,6 +1,5 @@
 const Utils = require('../../utils')
 const ContractClient = require('../contracts/ContractClient')
-const DEFAULT_GAS_AMOUNT = 1000000
 
 class ClaimsManagerClient extends ContractClient {
   /* ------- GETTERS ------- */
@@ -88,13 +87,12 @@ class ClaimsManagerClient extends ContractClient {
   }
 
   // Returns boolean indicating whether a claim is considered pending
-  async initiateRound (txRetries = 5, gas = DEFAULT_GAS_AMOUNT) {
+  async initiateRound (txRetries = 5) {
     const method = await this.getMethod(
       'initiateRound'
     )
     return this.web3Manager.sendTransaction(
       method,
-      gas,
       null,
       null,
       txRetries

--- a/libs/src/services/ethContracts/delegateManagerClient.js
+++ b/libs/src/services/ethContracts/delegateManagerClient.js
@@ -1,6 +1,5 @@
 const Utils = require('../../utils')
 const GovernedContractClient = require('../contracts/GovernedContractClient')
-const DEFAULT_GAS_AMOUNT = 1000000
 
 class DelegateManagerClient extends GovernedContractClient {
   constructor (
@@ -29,8 +28,7 @@ class DelegateManagerClient extends GovernedContractClient {
       amount
     )
     const tx = await this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
     return {
       txReceipt: tx,
@@ -212,8 +210,7 @@ class DelegateManagerClient extends GovernedContractClient {
       amount
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -222,8 +219,7 @@ class DelegateManagerClient extends GovernedContractClient {
       'cancelUndelegateStakeRequest'
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -233,8 +229,7 @@ class DelegateManagerClient extends GovernedContractClient {
     )
 
     const tx = await this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
 
     return {
@@ -245,14 +240,13 @@ class DelegateManagerClient extends GovernedContractClient {
     }
   }
 
-  async claimRewards (serviceProvider, txRetries = 5, gas = DEFAULT_GAS_AMOUNT) {
+  async claimRewards (serviceProvider, txRetries = 5) {
     const method = await this.getMethod(
       'claimRewards',
       serviceProvider
     )
     return this.web3Manager.sendTransaction(
       method,
-      gas,
       null,
       null,
       txRetries
@@ -266,8 +260,7 @@ class DelegateManagerClient extends GovernedContractClient {
       delegator
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -278,8 +271,7 @@ class DelegateManagerClient extends GovernedContractClient {
       delegator
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -290,8 +282,7 @@ class DelegateManagerClient extends GovernedContractClient {
       delegator
     )
     const tx = await this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
     return {
       txReceipt: tx,
@@ -450,8 +441,7 @@ class DelegateManagerClient extends GovernedContractClient {
       duration
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -461,8 +451,7 @@ class DelegateManagerClient extends GovernedContractClient {
       duration
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 }

--- a/libs/src/services/ethContracts/governanceClient.js
+++ b/libs/src/services/ethContracts/governanceClient.js
@@ -1,8 +1,6 @@
 const ContractClient = require('../contracts/ContractClient')
 const Utils = require('../../utils')
 
-const DEFAULT_GAS_AMOUNT = 200000
-
 /**
  * Transform a method name and its argument types into a string-composed
  * signature, e.g. someMethod(bytes32, int32)
@@ -94,7 +92,7 @@ class GovernanceClient extends ContractClient {
       signature,
       callData
     )
-    return this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    return this.web3Manager.sendTransaction(method)
   }
 
   async getVotingQuorumPercent () {
@@ -121,7 +119,7 @@ class GovernanceClient extends ContractClient {
       signature,
       callData
     )
-    return this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    return this.web3Manager.sendTransaction(method)
   }
 
   async getProposalById (
@@ -205,8 +203,7 @@ class GovernanceClient extends ContractClient {
       name,
       description
     )
-    // Increased gas because submitting can be expensive
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT * 2)
+    const tx = await this.web3Manager.sendTransaction(method)
     if (tx && tx.events && tx.events.ProposalSubmitted && tx.events.ProposalSubmitted.returnValues) {
       const id = tx.events.ProposalSubmitted.returnValues._proposalId
       return id
@@ -223,7 +220,7 @@ class GovernanceClient extends ContractClient {
       proposalId,
       vote
     )
-    await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    await this.web3Manager.sendTransaction(method)
   }
 
   async updateVote ({
@@ -235,7 +232,7 @@ class GovernanceClient extends ContractClient {
       proposalId,
       vote
     )
-    await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    await this.web3Manager.sendTransaction(method)
   }
 
   async evaluateProposalOutcome (
@@ -245,8 +242,7 @@ class GovernanceClient extends ContractClient {
       'evaluateProposalOutcome',
       proposalId
     )
-    // Increase gas because evaluating proposals can be expensive
-    const outcome = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT * 2)
+    const outcome = await this.web3Manager.sendTransaction(method)
     return outcome
   }
 

--- a/libs/src/services/ethContracts/serviceProviderFactoryClient.js
+++ b/libs/src/services/ethContracts/serviceProviderFactoryClient.js
@@ -3,8 +3,6 @@ const GovernedContractClient = require('../contracts/GovernedContractClient')
 const axios = require('axios')
 const { range } = require('lodash')
 
-const DEFAULT_GAS_AMOUNT = 200000
-
 let urlJoin = require('proper-url-join')
 if (urlJoin && urlJoin.default) urlJoin = urlJoin.default
 
@@ -468,8 +466,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       duration
     )
     return this.web3Manager.sendTransaction(
-      method,
-      DEFAULT_GAS_AMOUNT
+      method
     )
   }
 
@@ -497,7 +494,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       updatedDelegateOwnerWallet
     )
 
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 
@@ -508,7 +505,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       oldEndpoint,
       newEndpoint
     )
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 
@@ -518,7 +515,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       ownerAddress,
       deployerCut
     )
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 
@@ -536,7 +533,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       'cancelUpdateDeployerCut',
       ownerAddress
     )
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 
@@ -545,7 +542,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       'updateDeployerCut',
       ownerAddress
     )
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 
@@ -555,7 +552,7 @@ class ServiceProviderFactoryClient extends GovernedContractClient {
       ownerAddress,
       newAmount
     )
-    const tx = await this.web3Manager.sendTransaction(method, DEFAULT_GAS_AMOUNT)
+    const tx = await this.web3Manager.sendTransaction(method)
     return tx
   }
 }

--- a/libs/src/services/ethContracts/serviceTypeManagerClient.js
+++ b/libs/src/services/ethContracts/serviceTypeManagerClient.js
@@ -1,6 +1,5 @@
 const Utils = require('../../utils')
 const GovernedContractClient = require('../contracts/GovernedContractClient')
-const DEFAULT_GAS_AMOUNT = 200000
 
 class ServiceTypeManagerClient extends GovernedContractClient {
   async setServiceVersion (serviceType, serviceVersion, privateKey = null) {
@@ -11,7 +10,6 @@ class ServiceTypeManagerClient extends GovernedContractClient {
     )
     return this.web3Manager.sendTransaction(
       method,
-      DEFAULT_GAS_AMOUNT,
       (await this.governanceClient.getAddress()),
       privateKey
     )
@@ -27,7 +25,6 @@ class ServiceTypeManagerClient extends GovernedContractClient {
 
     return this.web3Manager.sendTransaction(
       method,
-      DEFAULT_GAS_AMOUNT,
       (await this.governanceClient.getAddress()),
       privateKey
     )

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -34,7 +34,10 @@ class EthWeb3Manager {
     txRetries = 5,
     txGasLimit = null
   ) {
-    const gasLimit = txGasLimit || await estimateGas({ method: contractMethod })
+    const gasLimit = txGasLimit || await estimateGas({
+      method: contractMethod,
+      from: this.ownerWallet
+    })
     if (contractAddress && privateKey) {
       let gasPrice = parseInt(await this.web3.eth.getGasPrice())
       if (isNaN(gasPrice) || gasPrice > HIGH_GAS_PRICE) {

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -1,8 +1,8 @@
 const Web3 = require('../../web3')
 const MultiProvider = require('../../utils/multiProvider')
 const EthereumTx = require('ethereumjs-tx').Transaction
+const { estimateGas } = require('../../utils/estimateGas')
 const retry = require('async-retry')
-const DEFAULT_GAS_AMOUNT = 200000
 const MIN_GAS_PRICE = Math.pow(10, 9) // 1 GWei, POA default gas price
 const HIGH_GAS_PRICE = 5 * MIN_GAS_PRICE // 5 GWei
 const GANACHE_GAS_PRICE = 39062500000 // ganache gas price is extremely high, so we hardcode a lower value (0x09184e72a0 from docs here)
@@ -29,11 +29,12 @@ class EthWeb3Manager {
 
   async sendTransaction (
     contractMethod,
-    gasAmount = DEFAULT_GAS_AMOUNT,
     contractAddress = null,
     privateKey = null,
-    txRetries = 5
+    txRetries = 5,
+    txGasLimit = null
   ) {
+    const gasLimit = txGasLimit || await estimateGas({ method: contractMethod })
     if (contractAddress && privateKey) {
       let gasPrice = parseInt(await this.web3.eth.getGasPrice())
       if (isNaN(gasPrice) || gasPrice > HIGH_GAS_PRICE) {
@@ -51,7 +52,7 @@ class EthWeb3Manager {
       const txParams = {
         nonce: this.web3.utils.toHex(txCount),
         gasPrice: gasPrice,
-        gasLimit: '0xf7100',
+        gasLimit,
         data: encodedABI,
         to: contractAddress,
         value: '0x00'
@@ -81,24 +82,25 @@ class EthWeb3Manager {
     }
 
     let gasPrice = parseInt(await this.web3.eth.getGasPrice())
-    return contractMethod.send({ from: this.ownerWallet, gas: gasAmount, gasPrice: gasPrice })
+    return contractMethod.send({ from: this.ownerWallet, gas: gasLimit, gasPrice: gasPrice })
   }
 
   async relayTransaction (
     contractMethod,
     contractAddress,
     ownerWallet,
-    txGasLimit = DEFAULT_GAS_AMOUNT,
-    txRetries = 5
+    txRetries = 5,
+    txGasLimit = null
   ) {
     const encodedABI = contractMethod.encodeABI()
+    const gasLimit = txGasLimit || await estimateGas({ method: contractMethod })
     const response = await retry(async bail => {
       try {
         const attempt = await this.identityService.ethRelay(
           contractAddress,
           ownerWallet,
           encodedABI,
-          txGasLimit
+          gasLimit
         )
         return attempt
       } catch (e) {

--- a/libs/src/services/web3Manager/index.js
+++ b/libs/src/services/web3Manager/index.js
@@ -165,10 +165,13 @@ class Web3Manager {
     txRetries = 5,
     txGasLimit = null
   ) {
-    const gasLimit = txGasLimit || await estimateGas({ method: contractMethod, gasLimitMaximum: DEFAULT_GAS_AMOUNT })
+    const gasLimit = txGasLimit || await estimateGas({
+      method: contractMethod,
+      gasLimitMaximum: DEFAULT_GAS_AMOUNT
+    })
     if (this.useExternalWeb3) {
       return contractMethod.send(
-        { from: this.ownerWallet, gas: txGasLimit }
+        { from: this.ownerWallet, gas: gasLimit }
       )
     } else {
       const encodedABI = contractMethod.encodeABI()

--- a/libs/src/services/web3Manager/index.js
+++ b/libs/src/services/web3Manager/index.js
@@ -1,6 +1,7 @@
 const Web3 = require('../../web3')
 const sigUtil = require('eth-sig-util')
 const retry = require('async-retry')
+const { estimateGas } = require('../../utils/estimateGas')
 const AudiusABIDecoder = require('../ABIDecoder/index')
 const EthereumWallet = require('ethereumjs-wallet')
 let XMLHttpRequestRef
@@ -161,9 +162,10 @@ class Web3Manager {
     contractMethod,
     contractRegistryKey,
     contractAddress,
-    txGasLimit = DEFAULT_GAS_AMOUNT,
-    txRetries = 5
+    txRetries = 5,
+    txGasLimit = null
   ) {
+    const gasLimit = txGasLimit || await estimateGas({ method: contractMethod, gasLimitMaximum: DEFAULT_GAS_AMOUNT })
     if (this.useExternalWeb3) {
       return contractMethod.send(
         { from: this.ownerWallet, gas: txGasLimit }
@@ -177,7 +179,7 @@ class Web3Manager {
           contractAddress,
           this.ownerWallet.getAddressString(),
           encodedABI,
-          txGasLimit
+          gasLimit
         )
       }, {
         // Retry function 5x by default

--- a/libs/src/utils/estimateGas.js
+++ b/libs/src/utils/estimateGas.js
@@ -10,16 +10,18 @@ const GAS_LIMIT_MULTIPLIER = 1.05
  * Returns estimated gas use for a txn for a contract method
  * @param options
  * @param {Method} options.method the contract method
- * @param {number} gasLimitMaximum the maximum amount of gas we will allow
+ * @param {string?} options.from address the method will be sent from (required if the contract requires a certain sender, e.g. guardian)
+ * @param {number?} options.gasLimitMaximum the maximum amount of gas we will allow
  * (likely will return a number much smaller than this)
- * @param {number} multipler the multiplier to safe-guard against estimates that are too low
+ * @param {number?} optionsmultipler the multiplier to safe-guard against estimates that are too low
  */
 const estimateGas = async ({
   method,
+  from,
   gasLimitMaximum = GAS_LIMIT_MAXIMUM,
   multiplier = GAS_LIMIT_MULTIPLIER
 }) => {
-  const estimatedGas = await method.estimateGas({ gas: gasLimitMaximum })
+  const estimatedGas = await method.estimateGas({ from, gas: gasLimitMaximum })
   // Rounding is necessary here as fractional gas limits will break
   const safeEstimatedGas = Math.ceil(estimatedGas * multiplier)
   console.info(`Estimated gas limit ${safeEstimatedGas} for method ${method._method.name}`)

--- a/libs/src/utils/estimateGas.js
+++ b/libs/src/utils/estimateGas.js
@@ -1,0 +1,29 @@
+// The absolute highest we will suggest for a gas limit (upper bound).
+// Normally the gas estimator will estimate far far below this.
+const GAS_LIMIT_MAXIMUM = 1000000
+
+// Default multiplier on top of gas estimate to be extra safe that txns
+// will go through
+const GAS_LIMIT_MULTIPLIER = 1.05
+
+/**
+ * Returns estimated gas use for a txn for a contract method
+ * @param options
+ * @param {Method} options.method the contract method
+ * @param {number} gasLimitMaximum the maximum amount of gas we will allow
+ * (likely will return a number much smaller than this)
+ * @param {number} multipler the multiplier to safe-guard against estimates that are too low
+ */
+const estimateGas = async ({
+  method,
+  gasLimitMaximum = GAS_LIMIT_MAXIMUM,
+  multiplier = GAS_LIMIT_MULTIPLIER
+}) => {
+  const estimatedGas = await method.estimateGas({ gas: gasLimitMaximum })
+  // Rounding is necessary here as fractional gas limits will break
+  const safeEstimatedGas = Math.ceil(estimatedGas * multiplier)
+  console.info(`Estimated gas limit ${safeEstimatedGas} for method ${method._method.name}`)
+  return safeEstimatedGas
+}
+
+module.exports = { estimateGas }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Fix majority of $AUDIO send errors on client

Currently we hard-code gas limits to 200K or 1M. This makes the relayer think it doesn't have enough funds to complete the txn and eth_relay fails to execute transactions (even tho in practice we use hardly that much gas). Users then get rate limited since this one request counts towards their 1 send per day. E.g. gas limit of 200K at a gas price of 250 GWEI (e.g. https://etherscan.io/tx/0x4daa55e106f9f165b48fd8d548380358f140cdc56a5deb02d67f88849088ae86) ends up being 0.00000025 * 200,000 = 0.05 eth, which is exactly what our minimum balance is set to https://identityservice.audius.co/eth_balance_check. 

The estimator here builds in a 5% default buffer, which we can continue to play with.

I also bumped the default gas selection to fastest because we time out requests at 60s and some txns take way longer than that. I've asked cloudflare ent support if we can extend that 60s timeout. Otherwise we would need to build some polling mechanism.

This PR also has the nice benefit of fixing protocol dashboard gas estimation. Will want to run this on a subdomain for protocol dash for a bit before we bump the libs version there.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Ran against prod and sent $AUDIO. Gas estimate for permit is ~50-60K and similar with send. This lines up much more nicely w/ what etherscan shows, e.g. https://etherscan.io/tx/0x4daa55e106f9f165b48fd8d548380358f140cdc56a5deb02d67f88849088ae86
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
