### PR TITLE
Convert err obj into JSON stringifiable object + update error msg

### DIFF
--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -114,6 +114,11 @@ const sendResponseWithHeartbeatTerminator =
       } else {
         logger.info('Error processing request:', resp.object.error)
       }
+
+      // Converts the error object into an object that JSON.stringify can parse
+      if (resp.object.error) {
+        resp.object.error = Object.getOwnPropertyNames(resp.object.error).reduce((acc, cur) => { acc[cur] = resp.object.error[cur]; return acc }, {})
+      }
     }
 
     // Construct the remainder of the JSON response

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -411,7 +411,7 @@ module.exports = function (app) {
     // Ensure actual and expected dirCIDs match
     const expectedDirCID = ipfsAddRespArr[ipfsAddRespArr.length - 1].cid.toString()
     if (expectedDirCID !== dirCID) {
-      throw new Error(`Image file validation failed - dirCIDs do not match for dirCID ${dirCID}`)
+      throw new Error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}`)
     }
 
     // Record image file entries in DB

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -679,13 +679,14 @@ class CreatorNode {
         }
       )
       if (resp.data && resp.data.error) {
-        throw new Error(resp.data.error)
+        throw new Error(JSON.stringify(resp.data.error))
       }
       onProgress(total, total)
       return resp.data
     } catch (e) {
       if (!e.response && retries > 0) {
-        console.log(`Network Error in request ${requestId} with ${retries} retries... retrying`)
+        console.warn(`Network Error in request ${requestId} with ${retries} retries... retrying`)
+        console.warn(e)
         return this._uploadFile(file, route, onProgress, extraFormDataOptions, retries - 1)
       }
       await this._handleErrorHelper(e, url, requestId)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Context: We've been seeing error messages that look like [Object object]. 
Purpose: 
- This fix is to serialize the error into an object that JSON.stringify() can parse. 
- Also updates the error msg for comparing dir CIDs to include the expected CID


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Ran mad-dog to encounter error

Before:
```
Network Error in request 8e033b4c-e336-4c67-8f40-f3ad0d22b080 with 1 retries... retrying
Error: [object Object]
    at CreatorNode._uploadFile (/Users/vickyguan/Documents/audius/audius-protocol/libs/src/services/creatorNode/index.js:688:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

After:
```
Network Error in request c0acdb1b-9bdd-4481-b9f0-2da5960654f1 with 1 retries... retrying
Error: {"stack":"Error: Image file validation failed - dirCIDs do not match for dirCID=QmTygvnm5QjCxjr53Bgh6aSwvZUQumFFkF6m9NJD6ZV39i expectedCID=QmPhzRHfy3KGaErjMr8mAfaTcMLfZNet1cCUv5AVtdaFw4\n    at app.post.handleResponseWithHeartbeat (/usr/src/app/src/routes/files.js:414:13)\n    at process._tickCallback (internal/process/next_tick.js:68:7)","message":"Image file validation failed - dirCIDs do not match for dirCID=QmTygvnm5QjCxjr53Bgh6aSwvZUQumFFkF6m9NJD6ZV39i expectedCID=QmPhzRHfy3KGaErjMr8mAfaTcMLfZNet1cCUv5AVtdaFw4"}
    at CreatorNode._uploadFile (/Users/vickyguan/Documents/audius/audius-protocol/libs/src/services/creatorNode/index.js:688:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
