### PR TITLE
[mad-dog] URSM Discovery Provider Block Saturation Test

### DIFF
--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -8,7 +8,8 @@ const {
   coreIntegration,
   snapbackSMParallelSyncTest,
   userReplicaSetManagerTest,
-  IpldBlacklistTest
+  IpldBlacklistTest,
+  userReplicaSetBlockSaturationTest
 } = require('./tests/')
 
 // Configuration.
@@ -47,7 +48,7 @@ const services = [
   [Service.DISCOVERY_PROVIDER, SetupCommand.HEALTH_CHECK],
   [Service.USER_METADATA_NODE, SetupCommand.HEALTH_CHECK],
   [Service.IDENTITY_SERVICE, SetupCommand.HEALTH_CHECK],
-  ...contentNodeHealthChecks
+  // ...contentNodeHealthChecks
 ]
 
 async function setupAllServices () {
@@ -207,6 +208,16 @@ async function main () {
         const test = makeTest(
           'userReplicaSetManager',
           userReplicaSetManagerTest,
+          {
+            numUsers: USER_REPLICA_SET_NUM_USERS
+          })
+        await testRunner([test])
+        break
+      }
+      case 'test-ursm-sat': {
+        const test = makeTest(
+          'userReplicaSetBlockSaturationTest',
+          userReplicaSetBlockSaturationTest,
           {
             numUsers: USER_REPLICA_SET_NUM_USERS
           })

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -48,7 +48,7 @@ const services = [
   [Service.DISCOVERY_PROVIDER, SetupCommand.HEALTH_CHECK],
   [Service.USER_METADATA_NODE, SetupCommand.HEALTH_CHECK],
   [Service.IDENTITY_SERVICE, SetupCommand.HEALTH_CHECK],
-  // ...contentNodeHealthChecks
+  ...contentNodeHealthChecks
 ]
 
 async function setupAllServices () {

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -251,12 +251,19 @@ async function main () {
           userReplicaSetManagerTest,
           { numUsers: USER_REPLICA_SET_NUM_USERS }
         )
+        const ursmBlockSaturationTest = makeTest(
+          'userReplicaSetBlockSaturationTest',
+          userReplicaSetBlockSaturationTest,
+          {
+            numUsers: 1
+          })
 
         const tests = [
           coreIntegrationTests,
           snapbackTest,
           ...blacklistTests,
-          ursmTest
+          ursmTest,
+          ursmBlockSaturationTest
         ]
 
         await testRunner(tests)

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -219,7 +219,7 @@ async function main () {
           'userReplicaSetBlockSaturationTest',
           userReplicaSetBlockSaturationTest,
           {
-            numUsers: USER_REPLICA_SET_NUM_USERS
+            numUsers: 1
           })
         await testRunner([test])
         break

--- a/mad-dog/src/tests/index.js
+++ b/mad-dog/src/tests/index.js
@@ -1,11 +1,14 @@
 const coreIntegration = require('./test_integration.js')
 const { snapbackSMParallelSyncTest } = require('./test_snapbackSM.js')
 const IpldBlacklistTest = require('./test_ipldBlacklist')
+const { userReplicaSetBlockSaturationTest } = require('./test_ursmBlockSaturation.js')
 const { userReplicaSetManagerTest } = require('./test_userReplicaSetManager.js')
+
 
 module.exports = {
   coreIntegration,
   snapbackSMParallelSyncTest,
   IpldBlacklistTest,
-  userReplicaSetManagerTest
+  userReplicaSetManagerTest,
+  userReplicaSetBlockSaturationTest
 }

--- a/mad-dog/src/tests/test_ursmBlockSaturation.js
+++ b/mad-dog/src/tests/test_ursmBlockSaturation.js
@@ -1,0 +1,130 @@
+const axios = require('axios')
+const assert = require('assert')
+const _ = require('lodash')
+
+const ServiceCommands = require('@audius/service-commands')
+const { logger } = require('../logger.js')
+const {
+  addAndUpgradeUsers,
+  genRandomUsers
+} = require('../helpers.js')
+
+const DEFAULT_INDEX = 1
+const BOOTSTRAP_SP_IDS = new Set([1,2,3])
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+let contentNodeEndpointToInfoMapping = {}
+let walletIndexToUserIdMap
+
+const {
+    getUser
+} = ServiceCommands
+
+const getLatestIndexedBlock = async (endpoint) => {
+  return (await axios({
+    method: 'get',
+    baseURL: endpoint,
+    url: '/health_check'
+  })).data.latest_indexed_block
+}
+
+const maxIndexingTimeout = 15000
+
+
+const waitForBlock = async (libs, targetBlockNumber) => {
+  let latestIndexedBlock = await getLatestIndexedBlock(libs.getDiscoveryNodeEndpoint())
+  const startTime = Date.now()
+  while (Date.now() - startTime < maxIndexingTimeout) {
+    latestIndexedBlock = await getLatestIndexedBlock(libs.getDiscoveryNodeEndpoint())
+    if (latestIndexedBlock >= targetBlockNumber) {
+      logger.info(`Discovery Node has indexed block #${targetBlockNumber}!`)
+      return true
+    }
+  }
+  throw new Error(`Failed to reach ${targetBlockNumber} in ${maxIndexingTimeout}`)
+}
+
+// Promote each user's secondary1 to primary
+// Replica set transitions: (P=Primary, S1=Secondary1, S2 = Secondary2)
+// P->S1, S1->P, S2->S2
+const promoteSecondary1ToPrimary = async(executeAll) => {
+  await executeAll(async (libs, i) => {
+    // Retrieve user id if known from walletIndexToUserIdMap
+    const userId = walletIndexToUserIdMap[i]
+    let sameBlockTxSubmitted = false
+    // Array of block numbers
+    let blockResponses = []
+    while(!sameBlockTxSubmitted) {
+        let usrReplicaInfoFromContract = await libs.getUserReplicaSet(userId)
+        logger.info(`userId: ${userId}: promoteSecondary1ToPrimary`)
+        let primary = usrReplicaInfoFromContract.primaryId
+        let secondaries = usrReplicaInfoFromContract.secondaryIds
+        let newPrimary = parseInt(secondaries[0])
+        let newSecondaries = [primary, secondaries[1]].map(x=>parseInt(x))
+        logger.info(`userId: ${userId} | P: ${primary}->${newPrimary}`)
+        logger.info(`userId: ${userId} | S1: ${secondaries[0]}->${newSecondaries[0]}`)
+        logger.info(`userId: ${userId} | S2: ${secondaries[1]}->${newSecondaries[1]}`)
+
+        let randomUserInfo = genRandomUsers(1)[0]
+        console.log(randomUserInfo)
+        // Issue 3 concurrent update operations
+        blockResponses = await Promise.all([
+            (async () => {
+                let tx = await libs.updateReplicaSet(userId, newPrimary, newSecondaries)
+                console.log(`userId: ${userId} | Returning ${tx.blockNumber}`)
+                return tx.blockNumber
+            })(),
+            (async () => {
+                let bioTx = await libs.updateBio(userId, randomUserInfo.bio)
+                console.log(`userId: ${userId} | Returning bioTx: ${bioTx.txReceipt.blockNumber}`)
+                return bioTx.txReceipt.blockNumber
+            })(),
+            (async() => {
+                let nameTx = await libs.updateBio(userId, randomUserInfo.name)
+                console.log(`userId: ${userId} | Returning nameTx: ${nameTx.txReceipt.blockNumber}`)
+                return nameTx.txReceipt.blockNumber
+            })()
+        ])
+        console.log(`userId: ${userId} | ${blockResponses}`)
+        sameBlockTxSubmitted = blockResponses[0] === blockResponses[1] === blockResponses[2]
+    }
+    console.log(`userId:${userId} | Submitted same blockNumber for 3 user operations + user replica set: ${blockResponses[0]}`)
+  })
+}
+
+// Verify indexed state matches content nodes registered in UserReplicaSetManager
+// Also confirms UserReplicaSetManager state maches eth-contracts
+const userReplicaSetBlockSaturationTest = async ({
+  numUsers,
+  executeAll,
+  executeOne,
+}) => {
+  // Initialize content node info mapping
+  contentNodeEndpointToInfoMapping = {}
+  let contentNodeList = await executeOne(DEFAULT_INDEX, async (libsWrapper) => {
+    let endpointsList = await libsWrapper.getServices('content-node') 
+    return endpointsList
+  })
+  contentNodeList.forEach((info)=>{
+      contentNodeEndpointToInfoMapping[info.endpoint] = info
+  })
+
+  // Initialize users
+  if (!walletIndexToUserIdMap) {
+    try {
+      walletIndexToUserIdMap = await addAndUpgradeUsers(
+        numUsers,
+        executeAll,
+        executeOne
+      )
+    } catch (e) {
+      return { error: `Issue with creating and upgrading users: ${e}` }
+    }
+  }
+
+  await promoteSecondary1ToPrimary(executeAll)
+}
+
+module.exports = {
+  userReplicaSetBlockSaturationTest
+}

--- a/mad-dog/src/tests/test_ursmBlockSaturation.js
+++ b/mad-dog/src/tests/test_ursmBlockSaturation.js
@@ -1,6 +1,4 @@
 const axios = require('axios')
-const assert = require('assert')
-const _ = require('lodash')
 
 const ServiceCommands = require('@audius/service-commands')
 const { logger } = require('../logger.js')
@@ -10,8 +8,6 @@ const {
 } = require('../helpers.js')
 
 const DEFAULT_INDEX = 0
-const BOOTSTRAP_SP_IDS = new Set([1,2,3])
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 let contentNodeEndpointToInfoMapping = {}
 let walletIndexToUserIdMap

--- a/mad-dog/src/tests/test_ursmBlockSaturation.js
+++ b/mad-dog/src/tests/test_ursmBlockSaturation.js
@@ -9,16 +9,12 @@ const {
   genRandomUsers
 } = require('../helpers.js')
 
-const DEFAULT_INDEX = 1
+const DEFAULT_INDEX = 0
 const BOOTSTRAP_SP_IDS = new Set([1,2,3])
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 let contentNodeEndpointToInfoMapping = {}
 let walletIndexToUserIdMap
-
-const {
-    getUser
-} = ServiceCommands
 
 const getLatestIndexedBlock = async (endpoint) => {
   return (await axios({
@@ -29,7 +25,6 @@ const getLatestIndexedBlock = async (endpoint) => {
 }
 
 const maxIndexingTimeout = 15000
-
 
 const waitForBlock = async (libs, targetBlockNumber) => {
   let latestIndexedBlock = await getLatestIndexedBlock(libs.getDiscoveryNodeEndpoint())
@@ -44,10 +39,13 @@ const waitForBlock = async (libs, targetBlockNumber) => {
   throw new Error(`Failed to reach ${targetBlockNumber} in ${maxIndexingTimeout}`)
 }
 
-// Promote each user's secondary1 to primary
-// Replica set transitions: (P=Primary, S1=Secondary1, S2 = Secondary2)
-// P->S1, S1->P, S2->S2
-const promoteSecondary1ToPrimary = async(executeAll) => {
+// Insert 2 records for a given user in a single block
+// 3 Transactions total: 1 replica set update, 1 bio update, 1 name update
+// UserFactory will reduce both txs into a single record
+// UserRelicaSetManager will insert another record
+// Calling this function 2x for a single user should result in 2 is_current=False records
+//    for a single block on the second update
+const submitParallelUserTxs = async(executeAll) => {
   await executeAll(async (libs, i) => {
     // Retrieve user id if known from walletIndexToUserIdMap
     const userId = walletIndexToUserIdMap[i]
@@ -56,7 +54,7 @@ const promoteSecondary1ToPrimary = async(executeAll) => {
     let blockResponses = []
     while(!sameBlockTxSubmitted) {
         let usrReplicaInfoFromContract = await libs.getUserReplicaSet(userId)
-        logger.info(`userId: ${userId}: promoteSecondary1ToPrimary`)
+        logger.info(`userId: ${userId}: submitParallelUserTxs`)
         let primary = usrReplicaInfoFromContract.primaryId
         let secondaries = usrReplicaInfoFromContract.secondaryIds
         let newPrimary = parseInt(secondaries[0])
@@ -66,7 +64,6 @@ const promoteSecondary1ToPrimary = async(executeAll) => {
         logger.info(`userId: ${userId} | S2: ${secondaries[1]}->${newSecondaries[1]}`)
 
         let randomUserInfo = genRandomUsers(1)[0]
-        console.log(randomUserInfo)
         // Issue 3 concurrent update operations
         blockResponses = await Promise.all([
             (async () => {
@@ -85,10 +82,18 @@ const promoteSecondary1ToPrimary = async(executeAll) => {
                 return nameTx.txReceipt.blockNumber
             })()
         ])
-        console.log(`userId: ${userId} | ${blockResponses}`)
-        sameBlockTxSubmitted = blockResponses[0] === blockResponses[1] === blockResponses[2]
+        sameBlockTxSubmitted = (
+          (blockResponses[0] === blockResponses[1]) && (blockResponses[0] === blockResponses[2])
+        )
+        console.log(`userId: ${userId} | ${blockResponses}, sameBlockSubmitted=${sameBlockTxSubmitted}`)
     }
     console.log(`userId:${userId} | Submitted same blockNumber for 3 user operations + user replica set: ${blockResponses[0]}`)
+    if (blockResponses.length < 3) {
+      throw new Error(`Missing blockNumber response: ${blockResponses}`)
+    }
+
+    // Confirm that the block where all 3 txs were submitted in gets processed
+    await waitForBlock(libs, blockResponses[0])
   })
 }
 
@@ -101,7 +106,7 @@ const userReplicaSetBlockSaturationTest = async ({
 }) => {
   // Initialize content node info mapping
   contentNodeEndpointToInfoMapping = {}
-  let contentNodeList = await executeOne(DEFAULT_INDEX, async (libsWrapper) => {
+   let contentNodeList = await executeOne(DEFAULT_INDEX, async (libsWrapper) => {
     let endpointsList = await libsWrapper.getServices('content-node') 
     return endpointsList
   })
@@ -122,7 +127,18 @@ const userReplicaSetBlockSaturationTest = async ({
     }
   }
 
-  await promoteSecondary1ToPrimary(executeAll)
+  // Submit parallel updates, resulting in 2 User records
+  // record2 = block x, is_current=True
+  // record1 = block x, is_current=False
+  await submitParallelUserTxs(executeAll)
+
+  // Submit parallel updates again, resulting in 2 user records with identical
+  //    blockNumber and is_current=False
+  // record4 = block y, is_current=True
+  // record3 = block y, is_current=False
+  // record2 = block x, is_current=False
+  // record1 = block x, is_current=False
+  await submitParallelUserTxs(executeAll)
 }
 
 module.exports = {

--- a/service-commands/scripts/setup.js
+++ b/service-commands/scripts/setup.js
@@ -8,7 +8,7 @@ const {
   runSetupCommand
 } = ServiceCommands
 
-const NUM_CREATOR_NODES = 3
+const NUM_CREATOR_NODES = 4
 const SERVICE_INSTANCE_NUMBER = 1
 
 const printOptions = () => {

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -18,7 +18,7 @@
   "contracts": {
     "up": [
       "cd contracts/",
-      "docker run --name audius_ganache_cli -d -p 8545:8545 --network=audius_dev trufflesuite/ganache-cli:latest -h 0.0.0.0 -l 8000000 --acctKeys contracts-ganache-accounts.json -a 100",
+      "docker run --name audius_ganache_cli -d -p 8545:8545 --network=audius_dev trufflesuite/ganache-cli:latest -h 0.0.0.0 -l 8000000 --acctKeys contracts-ganache-accounts.json -a 100 -b 5",
       "echo 'Waiting for ganache to fully come online...'",
       "sleep 10",
       "echo 'Migrating contracts'",

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -586,6 +586,14 @@ function LibsWrapper (walletIndex = 0) {
     )
   }
 
+  this.updateBio = async (userId, bioString) => {
+    return this.libsInstance.contracts.UserFactoryClient.updateBio(userId, bioString)
+  }
+
+  this.updateName = async (userId, userName) => {
+    return this.libsInstance.contracts.UserFactoryClient.updateBio(userId, userName)
+  }
+
   this.getDiscoveryNodeEndpoint = () => {
     return this.libsInstance.discoveryProvider.discoveryProviderEndpoint
   }


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

On the weekend of 4/2-4/4 we encountered a stoppage due to 2 distinct record insert operations to the same database table (users.py) in a single block, violating the existing primary key constraint of (user_id, is_current, blocknumber). This test exposes that scenario by forcibly inserting 2 records per block, 2x - the second insert results in the violation.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

 This is a test


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
