### PR TITLE
[AUD-532] Increase refresh search matview window from 1min to 5min for db perf

### DIFF
--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -341,7 +341,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "update_materialized_views": {
                 "task": "update_materialized_views",
-                "schedule": timedelta(seconds=60)
+                "schedule": timedelta(seconds=300)
             },
             "update_network_peers": {
                 "task": "update_network_peers",


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Increase refresh search matview window from 1min to 5min for db perf


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Local: Ran e2e setup and confirmed worker logs
Staging: Confirmed logs appeared 5min apart, also signed up new user and confirmed search endpoint returns newly created user
```
{"levelno": 20, "level": "INFO", "msg": "index_materialized_views.py | Finished updating materialized views in: 2.140812873840332", "timestamp": "2021-04-07 22:19:17,944"}
```
```
{"levelno": 20, "level": "INFO", "msg": "index_materialized_views.py | Finished updating materialized views in: 2.0633435249328613", "timestamp": "2021-04-07 22:24:18,023"}
```

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
