### PR TITLE
[AUD-532] Add query_start to db_connection monitoring + log duration for db matview refresh ops

### DIFF
--- a/discovery-provider/src/monitors/database.py
+++ b/discovery-provider/src/monitors/database.py
@@ -70,7 +70,8 @@ def get_database_connection_info(**kwargs):
     db = kwargs['db']
     with db.scoped_session() as session:
         q = sqlalchemy.text(
-            'select wait_event_type, wait_event, state, query from pg_stat_activity where datname = current_database()'
+            f"select wait_event_type, wait_event, state, query, to_char(query_start, 'DD Mon YYYY HH:MI:SSPM')" +
+            f"as \"query_start\" from pg_stat_activity where datname = current_database()"
         )
         result = session.execute(q).fetchall()
         connection_info = [dict(row) for row in result]

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -13,7 +13,9 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-        logger.info(f"index_materialized_views.py | Finished updating materialized views in: {time.time()-start_time}")
+        logger.info(
+            f"index_materialized_views.py | Finished updating materialized views in: {time.time()-start_time} sec"
+        )
 
 
 ######## CELERY TASKS ########

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -1,4 +1,5 @@
 import json
+import time
 import logging
 import concurrent.futures
 from datetime import datetime, timedelta
@@ -127,6 +128,7 @@ def sweep_metrics(db, redis):
 
 def refresh_metrics_matviews(db):
     with db.scoped_session() as session:
+        start_time = time.time()
         logger.info('index_metrics.py | refreshing metrics matviews')
         session.execute('REFRESH MATERIALIZED VIEW route_metrics_day_bucket')
         session.execute('REFRESH MATERIALIZED VIEW route_metrics_month_bucket')
@@ -136,7 +138,7 @@ def refresh_metrics_matviews(db):
         session.execute('REFRESH MATERIALIZED VIEW app_name_metrics_trailing_week')
         session.execute('REFRESH MATERIALIZED VIEW app_name_metrics_trailing_month')
         session.execute('REFRESH MATERIALIZED VIEW app_name_metrics_all_time')
-        logger.info('index_metrics.py | refreshed metrics matviews')
+        logger.info(f"index_metrics.py | refreshed metrics matviews in: {time.time()-start_time} sec")
 
 # Perform eth web3 call to fetch endpoint info
 def fetch_discovery_node_info(sp_id, sp_factory_instance):


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

- [x] Expose `query_start` field in `db_connection_info` monitoring object to health_check & logs
- [x] Add time unit for db refresh matview logs to clarify seconds
- [x] Add duration log for metrics matview refresh for visibility

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

DB connection info `query_start` logs:
```
    "db_connections": {
      "database_connection_info": [
        {
          "query": "REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict",
          "query_start": "07 Apr 2021 09:40:02PM",
          "state": "active",
          "wait_event": null,
          "wait_event_type": null
        },
        {
          "query": "select wait_event_type, wait_event, state, query, to_char(query_start, 'DD Mon YYYY HH:MI:SSPM') as \"query_start\" from pg_stat_activity where datname = current_database()",
          "query_start": "07 Apr 2021 09:40:02PM",
          "state": "active",
          "wait_event": null,
          "wait_event_type": null
        },
```

index_materialized_views duration log:
```
{"levelno": 20, "level": "INFO", "msg": "index_materialized_views.py | Finished updating materialized views in: 0.04106926918029785 sec", "timestamp": "2021-04-07 21:35:04,819"}
```

Metrics matview duration log (TODO):
```
{"levelno": 20, "level": "INFO", "msg": "index_metrics.py | refreshed metrics matviews in: 0.030927181243896484 sec", "timestamp": "2021-04-07 21:48:13,008"}
```

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
