### PR TITLE
Increase the notifications query timeout

### DIFF
--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -234,7 +234,7 @@ class NotificationProcessor {
       method: 'get',
       url: `${discoveryProvider.discoveryProviderEndpoint}/notifications`,
       params,
-      timeout: 10000
+      timeout: 120000 // two minutes
     }
 
     let body = (await axios(reqObj)).data


### PR DESCRIPTION
### Description
Notification requests often time out at 10s, increase this to 2 minutes.

### Tests
N/A