### PR TITLE
Make "fix primary key constraints migration" idempotent

### DIFF
--- a/discovery-provider/alembic/versions/bff7853e0983_fix_primary_key_constraints.py
+++ b/discovery-provider/alembic/versions/bff7853e0983_fix_primary_key_constraints.py
@@ -22,31 +22,31 @@ def upgrade():
     connection.execute('''
         begin;
             ALTER TABLE users DROP CONSTRAINT users_pkey;
-            ALTER TABLE users ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (is_current, user_id, blockhash, txhash);
 
             ALTER TABLE ursm_content_nodes DROP CONSTRAINT ursm_content_nodes_pkey;
-            ALTER TABLE ursm_content_nodes ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE ursm_content_nodes ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE ursm_content_nodes ADD CONSTRAINT ursm_content_nodes_pkey PRIMARY KEY (is_current, cnode_sp_id, blockhash, txhash);
 
             ALTER TABLE tracks DROP CONSTRAINT tracks_pkey;
-            ALTER TABLE tracks ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE tracks ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE tracks ADD CONSTRAINT tracks_pkey PRIMARY KEY (is_current, track_id, blockhash, txhash);
 
             ALTER TABLE playlists DROP CONSTRAINT playlists_pkey;
-            ALTER TABLE playlists ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE playlists ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE playlists ADD CONSTRAINT playlists_pkey PRIMARY KEY (is_current, playlist_id, playlist_owner_id, blockhash, txhash);
 
             ALTER TABLE reposts DROP CONSTRAINT reposts_pkey;
-            ALTER TABLE reposts ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE reposts ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE reposts ADD CONSTRAINT reposts_pkey PRIMARY KEY (is_current, user_id, repost_item_id, repost_type, blockhash, txhash);
 
             ALTER TABLE saves DROP CONSTRAINT saves_pkey;
-            ALTER TABLE saves ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE saves ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE saves ADD CONSTRAINT saves_pkey PRIMARY KEY (is_current, user_id, save_item_id, save_type, blockhash, txhash);
 
             ALTER TABLE follows DROP CONSTRAINT follows_pkey;
-            ALTER TABLE follows ADD COLUMN txhash VARCHAR DEFAULT('') NOT NULL;
+            ALTER TABLE follows ADD COLUMN IF NOT EXISTS txhash VARCHAR DEFAULT('') NOT NULL;
             ALTER TABLE follows ADD CONSTRAINT follows_pkey PRIMARY KEY (is_current, follower_user_id, followee_user_id, blockhash, txhash);
         commit;
     ''')


### PR DESCRIPTION
### Description
If the column exists this throws an error second time around
