### PR TITLE
[AUD-531] Optimize CN nodesync saveFileForMultihash timeouts & concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ orbs:
   kubernetes: circleci/kubernetes@0.3.0
   coveralls: coveralls/coveralls@1.0.6
 jobs:
+  resource_class: xlarge
   test-mad-dog-e2e:
     machine:
       image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ orbs:
   kubernetes: circleci/kubernetes@0.3.0
   coveralls: coveralls/coveralls@1.0.6
 jobs:
-  resource_class: xlarge
   test-mad-dog-e2e:
+    resource_class: xlarge
     machine:
       image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
     steps:

--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -43,5 +43,6 @@
   "dataNetworkId": "",
   "userMetadataNodeUrl": "http://docker.for.mac.localhost:4000",
   "rehydrateMaxConcurrency": 10,
+  "nodeSyncFileSaveMaxConcurrency": 10,
   "creatorNodeEndpoint": ""
 }

--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -1357,6 +1357,106 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "array.prototype.map": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.3.tgz",
+      "integrity": "sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
     "asmcrypto.js": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
@@ -3312,6 +3412,139 @@
         "string.prototype.trimright": "^2.0.0"
       }
     },
+    "es-aggregate-error": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz",
+      "integrity": "sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1",
+        "functions-have-names": "^1.2.1",
+        "get-intrinsic": "^1.0.1",
+        "globalthis": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
@@ -5254,6 +5487,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "functions-have-names": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
+    },
     "generic-pool": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
@@ -5386,6 +5624,14 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
     },
     "got": {
       "version": "9.6.0",
@@ -6773,6 +7019,11 @@
         "ip-regex": "^2.0.0"
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
     "is-nan": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -6891,6 +7142,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+    },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7370,6 +7626,20 @@
             "safe-buffer": "~5.2.0"
           }
         }
+      }
+    },
+    "iterate-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+    },
+    "iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "requires": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
       }
     },
     "jimp": {
@@ -9622,6 +9892,108 @@
       "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "requires": {
         "is-promise": "~1"
+      }
+    },
+    "promise.any": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.2.tgz",
+      "integrity": "sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==",
+      "requires": {
+        "array.prototype.map": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0",
+        "es-aggregate-error": "^1.0.3",
+        "get-intrinsic": "^1.1.1",
+        "iterate-value": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "promise.prototype.finally": {

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -50,6 +50,7 @@
     "lodash": "^4.17.15",
     "multer": "^1.4.0",
     "pg": "^7.6.1",
+    "promise.any": "^2.0.2",
     "rate-limit-redis": "^1.6.0",
     "sequelize": "^4.41.2",
     "shortid": "^2.2.14",

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -273,6 +273,14 @@ const config = convict({
     default: -1
   },
 
+  // NodeSync filesave concurrency limit
+  nodeSyncFileSaveMaxConcurrency: {
+    doc: 'Max concurrency of saveFileForMultihashToFS calls inside nodesync',
+    format: 'nat',
+    env: 'nodeSyncFileSaveMaxConcurrency',
+    default: 10
+  },
+
   // wallet information
   delegateOwnerWallet: {
     doc: 'wallet address',

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -1,17 +1,8 @@
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs-extra')
 const multer = require('multer')
 const getUuid = require('uuid/v4')
 const axios = require('axios')
-const { promisify } = require('util')
-
-const lstat = promisify(fs.lstat)
-const readdir = promisify(fs.readdir)
-const unlink = promisify(fs.unlink)
-const rmdir = promisify(fs.rmdir)
-const writeFile = promisify(fs.writeFile)
-const mkdir = promisify(fs.mkdir)
-const copyFile = promisify(fs.copyFile)
 
 const config = require('./config')
 const Utils = require('./utils')
@@ -39,7 +30,7 @@ async function saveFileFromBufferToIPFSAndDisk (req, buffer) {
 
   // Write file to disk by multihash for future retrieval
   const dstPath = DiskManager.computeFilePath(multihash)
-  await writeFile(dstPath, buffer)
+  await fs.writeFile(dstPath, buffer)
 
   return { multihash, dstPath }
 }
@@ -64,7 +55,7 @@ async function saveFileToIPFSFromFS (req, srcPath) {
   const dstPath = DiskManager.computeFilePath(multihash)
 
   try {
-    await copyFile(srcPath, dstPath)
+    await fs.copy(srcPath, dstPath)
   } catch (e) {
     // if we see a ENOSPC error, log out the disk space and inode details from the system
     if (e.message.includes('ENOSPC')) {
@@ -103,6 +94,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
   try {
     // will be modified to directory compatible route later if directory
     // TODO - don't concat url's by hand like this, use module like urljoin
+    // ..replace(/\/$/, "") removes trailing slashes
     let gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${multihash}`)
 
     const parsedStoragePath = path.parse(expectedStoragePath).dir
@@ -120,7 +112,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     try {
       // calling this on an existing directory doesn't overwrite the existing data or throw an error
       // the mkdir recursive is equivalent to `mkdir -p`
-      await mkdir(parsedStoragePath, { recursive: true })
+      await fs.mkdir(parsedStoragePath, { recursive: true })
       decisionTree.push({ stage: 'Successfully called mkdir on local file system', vals: parsedStoragePath, time: Date.now() })
     } catch (e) {
       decisionTree.push({ stage: 'Error calling mkdir on local file system', vals: parsedStoragePath, time: Date.now() })
@@ -138,20 +130,22 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       // eg. before running the line below gatewayUrlsMapped looks like [https://endpoint.co/ipfs/Qm111, https://endpoint.co/ipfs/Qm222 ...]
       // in the case of a directory, override the gatewayUrlsMapped array to look like
       // [https://endpoint.co/ipfs/Qm111/150x150.jpg, https://endpoint.co/ipfs/Qm222/150x150.jpg ...]
+      // ..replace(/\/$/, "") removes trailing slashes
       gatewayUrlsMapped = gatewaysToTry.map(endpoint => `${endpoint.replace(/\/$/, '')}/ipfs/${matchObj.outer}/${fileNameForImage}`)
       decisionTree.push({ stage: 'Updated gatewayUrlsMapped', vals: gatewayUrlsMapped, time: Date.now() })
     }
 
     /**
      * Attempts to fetch CID:
-     *  - If file already stored on disk, return immediately and store to disk.
-     *  - If file not already stored, fetch from IPFS and store to disk. First calls
-     *    IPFS cat, then calls IPFS get
-     *  - If file is not available via IPFS try other cnode gateways for user's replica set.
+     *  - If file already stored on disk, return immediately.
+     *  - If file not already stored, request from user's replica set gateways.
+     *  - If not found, call ipfs.cat(timeout=1000ms)
+     *  - If not found, call ipfs.get(timeout=1000ms)
+     * Each step, if successful, stores retrieved file to disk.
      */
 
     // If file already stored on disk, return immediately.
-    if (fs.existsSync(expectedStoragePath)) {
+    if (fs.pathExists(expectedStoragePath)) {
       req.logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
       decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash], time: Date.now() })
       // since this is early exit, print the decision tree here
@@ -162,76 +156,72 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     // If file not already stored, fetch and store at storagePath.
     let fileFound = false
 
-    // If multihash already available on local ipfs node, cat file from local ipfs node
-    req.logger.debug(`checking if ${multihash} already available on local ipfs node`)
-    try {
-      // ipfsCat returns a Buffer
-      decisionTree.push({ stage: 'About to retrieve file from local ipfs node with cat', vals: multihash, time: Date.now() })
-      let fileBuffer = await Utils.ipfsCat(multihash, req, 1000)
-      fileFound = true
-      req.logger.debug(`Retrieved file for ${multihash} from  with cat`)
-      decisionTree.push({ stage: 'Retrieved file from local ipfs node with cat', vals: multihash, time: Date.now() })
-      // Write file to disk.
-      await writeFile(expectedStoragePath, fileBuffer)
-      req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs cat`)
-      decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
-    } catch (e) {
-      req.logger.warn(`Multihash ${multihash} is not available on local ipfs node ${e.message}`)
-      decisionTree.push({ stage: 'File not available on local ipfs node with cat', vals: multihash, time: Date.now() })
-    }
-
-    // If file not already available on local ipfs node, fetch from IPFS.
-    if (!fileFound) {
-      req.logger.debug(`Attempting to get ${multihash} from IPFS`)
-      try {
-        decisionTree.push({ stage: 'About to retrieve file from local ipfs node with get', vals: multihash, time: Date.now() })
-        // ipfsGet returns a BufferListStream object which is not a buffer
-        // not compatible into writeFile directly, but it can be streamed to a file
-        let fileBL = await Utils.ipfsGet(multihash, req, 1000)
-        req.logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
-        decisionTree.push({ stage: 'Retrieved file from local ipfs node with get', vals: multihash, time: Date.now() })
-
-        // Write file to disk.
-        await Utils.writeStreamToFileSystem(fileBL, expectedStoragePath)
-        fileFound = true
-        req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs get`)
-        decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
-      } catch (e) {
-        req.logger.warn(`Failed to retrieve file for multihash ${multihash} from IPFS ${e.message}`)
-        decisionTree.push({ stage: 'File not available on local ipfs node with ipfs get', vals: multihash, time: Date.now() })
-      }
-    }
-
-    // if file is still null, try to fetch from other cnode gateways if user has nodes in replica set
-    if (!fileFound && gatewayUrlsMapped.length > 0) {
+    // First try to fetch from other cnode gateways if user has non-empty replica set.
+    if (gatewayUrlsMapped.length > 0) {
       try {
         let response
-        // ..replace(/\/$/, "") removes trailing slashes
         req.logger.debug(`Attempting to fetch multihash ${multihash} by racing replica set endpoints`)
-
         decisionTree.push({ stage: 'About to race requests via gateways', vals: gatewayUrlsMapped, time: Date.now() })
-        // Note - Requests are intentionally not parallel to minimize additional load on gateways
-        for (let index = 0; index < gatewayUrlsMapped.length; index++) {
-          const url = gatewayUrlsMapped[index]
-          decisionTree.push({ stage: 'Fetching from gateway', vals: url, time: Date.now() })
+
+        const GatewayRetrievalConcurrencyLimit = 5
+
+        for (let i = 0; i < gatewayUrlsMapped.length; i += GatewayRetrievalConcurrencyLimit) {
+          const gatewayUrlsSlice = gatewayUrlsMapped.slice(i, i + GatewayRetrievalConcurrencyLimit)
+          decisionTree.push({ stage: 'Fetching from gateways', vals: gatewayUrlsSlice, time: Date.now() })
+
+          // Promise.any(promises) resolves to the first promise that resolves, or rejects if all reject
+          // Each internal request must reject after a timeout to ensure this does not wait forever
           try {
-            const resp = await axios({
-              method: 'get',
-              url,
-              responseType: 'stream',
-              timeout: 20000 /* 20 sec - higher timeout to allow enough time to fetch copy320 */
-            })
+            const resp = await Promise.any(gatewayUrlsSlice.map(
+              async url => {
+                const gatewayResp = await axios({
+                  method: 'get',
+                  url,
+                  responseType: 'stream',
+                  timeout: 20000 /* 20 sec - higher timeout to allow enough time to fetch copy320 */
+                })
+
+                if (gatewayResp.data) {
+                  decisionTree.push({ stage: 'Retrieved file from gateway', vals: url, time: Date.now() })
+                  return gatewayResp
+                }
+              }
+            ))
+
             if (resp.data) {
               response = resp
-              decisionTree.push({ stage: 'Retrieved file from gateway', vals: url, time: Date.now() })
               break
             }
+
+            // If Promise.any rejects then file retrieval failed from gatewayUrlsSlice -> progress to next slice
           } catch (e) {
-            req.logger.error(`Error fetching file from other cnode ${url} ${e.message}`)
-            decisionTree.push({ stage: 'Could not retrieve file from gateway', vals: url, time: Date.now() })
+            req.logger.error(`Error fetching file from gateways ${gatewayUrlsSlice}`)
+            decisionTree.push({ stage: 'Could not retrieve file from gateways', vals: gatewayUrlsSlice, time: Date.now() })
             continue
           }
         }
+
+        // for (let index = 0; index < gatewayUrlsMapped.length; index++) {
+        //   const url = gatewayUrlsMapped[index]
+        //   decisionTree.push({ stage: 'Fetching from gateway', vals: url, time: Date.now() })
+        //   try {
+        //     const resp = await axios({
+        //       method: 'get',
+        //       url,
+        //       responseType: 'stream',
+        //       timeout: 20000 /* 20 sec - higher timeout to allow enough time to fetch copy320 */
+        //     })
+        //     if (resp.data) {
+        //       response = resp
+        //       decisionTree.push({ stage: 'Retrieved file from gateway', vals: url, time: Date.now() })
+        //       break
+        //     }
+        //   } catch (e) {
+        //     req.logger.error(`Error fetching file from other cnode ${url} ${e.message}`)
+        //     decisionTree.push({ stage: 'Could not retrieve file from gateway', vals: url, time: Date.now() })
+        //     continue
+        //   }
+        // }
 
         if (!response || !response.data) {
           decisionTree.push({ stage: `Couldn't find files on other creator nodes, after trying URLs`, vals: null, time: Date.now() })
@@ -250,7 +240,56 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       }
     }
 
-    // file was not found on ipfs or any gateway
+    // If file not found through gateways, check local ipfs node.
+    if (!fileFound) {
+      req.logger.debug(`checking if ${multihash} already available on local ipfs node`)
+      try {
+        decisionTree.push({ stage: 'About to retrieve file from local ipfs node with cat', vals: multihash, time: Date.now() })
+
+        // ipfsCat returns a Buffer
+        let fileBuffer = await Utils.ipfsCat(multihash, req, 1000)
+
+        fileFound = true
+        req.logger.debug(`Retrieved file for ${multihash} from  with cat`)
+        decisionTree.push({ stage: 'Retrieved file from local ipfs node with cat', vals: multihash, time: Date.now() })
+
+        // Write file to disk.
+        await fs.writeFile(expectedStoragePath, fileBuffer)
+
+        req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs cat`)
+        decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
+      } catch (e) {
+        req.logger.warn(`Multihash ${multihash} is not available on local ipfs node ${e.message}`)
+        decisionTree.push({ stage: 'File not available on local ipfs node with cat', vals: multihash, time: Date.now() })
+      }
+    }
+
+    // If file not already available on local ipfs node or via gateways, fetch from IPFS.
+    if (!fileFound) {
+      req.logger.debug(`Attempting to get ${multihash} from IPFS`)
+      try {
+        decisionTree.push({ stage: 'About to retrieve file from local ipfs node with get', vals: multihash, time: Date.now() })
+
+        // ipfsGet returns a BufferListStream object which is not a buffer
+        // not compatible into writeFile directly, but it can be streamed to a file
+        let fileBL = await Utils.ipfsGet(multihash, req, 1000)
+
+        req.logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
+        decisionTree.push({ stage: 'Retrieved file from local ipfs node with get', vals: multihash, time: Date.now() })
+
+        // Write file to disk.
+        await Utils.writeStreamToFileSystem(fileBL, expectedStoragePath)
+
+        fileFound = true
+        req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs get`)
+        decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
+      } catch (e) {
+        req.logger.warn(`Failed to retrieve file for multihash ${multihash} from IPFS ${e.message}`)
+        decisionTree.push({ stage: 'File not available on local ipfs node with ipfs get', vals: multihash, time: Date.now() })
+      }
+    }
+
+    // error if file was not found on any gateway or ipfs
     if (!fileFound) {
       decisionTree.push({ stage: 'Failed to retrieve file for multihash after trying ipfs & other creator node gateways', vals: multihash, time: Date.now() })
       throw new Error(`Failed to retrieve file for multihash ${multihash} after trying ipfs & other creator node gateways`)
@@ -265,7 +304,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         if (multihash !== result.cid.toString()) {
           decisionTree.push({ stage: `File contents don't match IPFS hash multihash`, vals: result.cid.toString(), time: Date.now() })
           // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
-          await unlink(expectedStoragePath)
+          await fs.unlink(expectedStoragePath)
           throw new Error(`File contents don't match IPFS hash multihash: ${multihash} result: ${result.cid.toString()}`)
         }
       }
@@ -308,47 +347,47 @@ async function removeTrackFolder (req, fileDir) {
       throw new Error('Cannot remove null fileDir')
     }
 
-    let fileDirInfo = await lstat(fileDir)
+    let fileDirInfo = await fs.lstat(fileDir)
     if (!fileDirInfo.isDirectory()) {
       throw new Error('Expected directory input')
     }
 
     // Remove all contents of track dir (process sequentially to limit cpu load)
-    const files = await readdir(fileDir)
+    const files = await fs.readdir(fileDir)
     for (const file of files) {
       let curPath = path.join(fileDir, file)
 
-      if ((await lstat(curPath)).isDirectory()) {
+      if ((await fs.lstat(curPath)).isDirectory()) {
         // Only the 'segments' subdirectory is expected
         if (file !== 'segments') {
           throw new Error(`Unexpected subdirectory in ${fileDir} - ${curPath}`)
         }
 
         // Delete each segment file inside /fileDir/segments/ (process sequentially to limit cpu load)
-        const segmentFiles = await readdir(curPath)
+        const segmentFiles = await fs.readdir(curPath)
         for (const segmentFile of segmentFiles) {
           let curSegmentPath = path.join(curPath, segmentFile)
 
           // Throw if a subdirectory found in /fileDir/segments/
-          if ((await lstat(curSegmentPath)).isDirectory()) {
+          if ((await fs.lstat(curSegmentPath)).isDirectory()) {
             throw new Error(`Unexpected subdirectory in segments ${fileDir} - ${curPath}`)
           }
 
           // Delete segment file
-          await unlink(curSegmentPath)
+          await fs.unlink(curSegmentPath)
         }
 
         // Delete /fileDir/segments/ directory after all its contents have been deleted
-        await rmdir(curPath)
+        await fs.rmdir(curPath)
       } else {
         // Delete file inside /fileDir/
         req.logger.info(`Removing ${curPath}`)
-        await unlink(curPath)
+        await fs.unlink(curPath)
       }
     }
 
     // Delete fileDir after all its contents have been deleted
-    await rmdir(fileDir)
+    await fs.rmdir(fileDir)
     req.logger.info(`Removed track folder at fileDir ${fileDir}`)
     return null
   } catch (err) {

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -9,8 +9,8 @@ const { getIPFSPeerId } = require('../utils')
 
 // Dictionary tracking currently queued up syncs with debounce
 const syncQueue = {}
-const TrackSaveConcurrencyLimit = 10
-const NonTrackFileSaveConcurrencyLimit = 10
+
+const FileSaveMaxConcurrency = config.get('nodeSyncFileSaveMaxConcurrency')
 
 module.exports = function (app) {
   /**
@@ -472,9 +472,9 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
         const nonTrackFiles = fetchedCNodeUser.files.filter(file => models.File.NonTrackTypes.includes(file.type))
 
         // Save all track files to disk in batches (to limit concurrent load)
-        for (let i = 0; i < trackFiles.length; i += TrackSaveConcurrencyLimit) {
-          const trackFilesSlice = trackFiles.slice(i, i + TrackSaveConcurrencyLimit)
-          req.logger.info(redisKey, `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${i + TrackSaveConcurrencyLimit} out of total ${trackFiles.length}...`)
+        for (let i = 0; i < trackFiles.length; i += FileSaveMaxConcurrency) {
+          const trackFilesSlice = trackFiles.slice(i, i + FileSaveMaxConcurrency)
+          req.logger.info(redisKey, `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${i + FileSaveMaxConcurrency} out of total ${trackFiles.length}...`)
 
           await Promise.all(trackFilesSlice.map(
             trackFile => saveFileForMultihashToFS(req, trackFile.multihash, trackFile.storagePath, userReplicaSet)
@@ -483,9 +483,9 @@ async function _nodesync (req, walletPublicKeys, creatorNodeEndpoint) {
         req.logger.info(redisKey, 'Saved all track files to disk.')
 
         // Save all non-track files to disk in batches (to limit concurrent load)
-        for (let i = 0; i < nonTrackFiles.length; i += NonTrackFileSaveConcurrencyLimit) {
-          const nonTrackFilesSlice = nonTrackFiles.slice(i, i + NonTrackFileSaveConcurrencyLimit)
-          req.logger.info(redisKey, `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${i + NonTrackFileSaveConcurrencyLimit} out of total ${nonTrackFiles.length}...`)
+        for (let i = 0; i < nonTrackFiles.length; i += FileSaveMaxConcurrency) {
+          const nonTrackFilesSlice = nonTrackFiles.slice(i, i + FileSaveMaxConcurrency)
+          req.logger.info(redisKey, `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${i + FileSaveMaxConcurrency} out of total ${nonTrackFiles.length}...`)
           await Promise.all(nonTrackFilesSlice.map(
             nonTrackFile => {
               // Skip over directories since there's no actual content to sync

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -102,11 +102,12 @@ describe('test fileManager', () => {
      * Then: an error is thrown
      */
     it('should throw an error if file copy fails', async () => {
-      const copyFileStub = sinon.stub().throws((new Error('Failed to copy files!!')))
-      const utilStub = { promisify: sinon.stub().callsFake(() => copyFileStub) }
-      const { saveFileToIPFSFromFS } = proxyquire('../src/fileManager', {
-        util: utilStub
-      })
+      const fsExtraStub = { copyFile: (sinon.stub().callsFake(() => {
+        return new Promise((resolve, reject) => reject(new Error('Failed to copy files!!')))
+      })) }
+      const { saveFileToIPFSFromFS } = proxyquire('../src/fileManager',
+        { 'fs-extra': fsExtraStub }
+      )
 
       try {
         await saveFileToIPFSFromFS(req, srcPath)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

- [x] query replicaset in parallel instead of sequential (with max concurrency)
- [x] move gateway retrieval to before ipfs ops to avoid the 2 sequential 1s timeouts
- [x] move all `fs` ops in module to async to prevent event loop blocking
- [x] change `saveFileForMultihash()` concurrency limit to node config to allow easy configuration

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- all automated tests passing
- manual testing
  - required coverage:
    - `saveFileToIPFSFromFS` -> track upload
    - `saveFileFromBufferToIPFSAndDisk` -> user signup; track upload
    - `saveFileForMultihashToFS` -> nodesync
    - `removeTrackFolder` -> `fileManager.test.js`
  - user signup + track upload flow covers all `fileManager` changes + mad-dog covers sync

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
