### PR TITLE
[AUD-557] Increase mad-dog test ci resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ orbs:
   coveralls: coveralls/coveralls@1.0.6
 jobs:
   test-mad-dog-e2e:
+    # https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    # uses medium (2vcpu/4gb) by default
+    resource_class: large # 4vcpu/8gb
     machine:
       image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
     steps:


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Increase instance size of `test-mad-dog-e2e` CI test from `medium` (2vcpu/4gb) to `large` (4vcpu/8gb) to attempt to address high test failure rates. I observed anecdotally that this test fails more frequently in CI env vs my dev env, which is running on `t3.xlarge` (4vcpu/16gb)

This should also hopefully speed up test time

https://circleci.com/docs/2.0/configuration-reference/#resourceclass

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Click into the mad-dog job below to confirm that it is running on "Executor: Machine Linux Large" while remaining jobs run on "Executor: Docker Medium"

See below job success 🙌 

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
