### PR TITLE
[AUD-555] Use aggregate plays where applicable in trending

### DIFF
--- a/discovery-provider/src/tasks/generate_trending.py
+++ b/discovery-provider/src/tasks/generate_trending.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from urllib.parse import unquote
 from sqlalchemy import func, desc
 
-from src.models import Track, RepostType, Follow, SaveType, Play
+from src.models import AggregatePlays, Track, RepostType, Follow, SaveType, Play
 from src.queries import response_name_constants
 from src.queries.query_helpers import \
     get_karma, get_repost_counts, get_save_counts, get_genre_list
@@ -64,17 +64,33 @@ def get_listen_counts(session, time, genre, limit, offset):
                )
 
     # Construct base query
+    if time:
+        # If we want to query plays by time, use the plays table directly
+        base_query = (
+            session
+            .query(Play.play_item_id, func.count(Play.id).label('count'), Track.created_at)
+            .join(Track, Track.track_id == Play.play_item_id)
+        )
+    else:
+        # Otherwise, it's safe to just query over the aggregate plays table (all time)
+        base_query = (
+            session
+            .query(AggregatePlays.play_item_id.label('id'), AggregatePlays.count.label('count'), Track.created_at)
+            .join(Track, Track.track_id == AggregatePlays.play_item_id)
+        )
+
     base_query = (
-        session.query(Play.play_item_id, func.count(Play.id))
-        .join(Track, Track.track_id == Play.play_item_id)
+        base_query
         .filter(
             Track.is_current == True,
             Track.is_delete == False,
             Track.is_unlisted == False,
             Track.stem_of == None
         )
-        .group_by(Play.play_item_id)
     )
+
+    if time:
+        base_query = base_query.group_by(Play.play_item_id, Track.created_at)
 
     # Add filters to query
     base_query = with_time_filter(base_query, time)
@@ -82,14 +98,18 @@ def get_listen_counts(session, time, genre, limit, offset):
 
     # Add limit + offset + sort
     base_query = (base_query
-                  .order_by(desc(func.count(Play.id)))
+                  .order_by(desc('count'))
                   .limit(limit)
                   .offset(offset))
 
     listens = base_query.all()
 
     # Format the results
-    listens = [{"track_id": listen[0], "listens": listen[1]} for listen in listens]
+    listens = [{
+        "track_id": listen[0],
+        "listens": listen[1],
+        "created_at": listen[2]
+    } for listen in listens]
     return listens
 
 def generate_trending(session, time, genre, limit, offset):
@@ -98,16 +118,9 @@ def generate_trending(session, time, genre, limit, offset):
 
     track_ids = [track[response_name_constants.track_id] for track in listen_counts]
 
-    # Get created_at info
-    tracks_created_at = (
-        session.query(Track.track_id, Track.created_at)
-        .filter(Track.track_id.in_(track_ids))
-        .all()
-    )
-
     # Generate track id -> created_at date
     track_created_at_dict = {
-        record[0]: record[1] for record in tracks_created_at
+        record["track_id"]: record["created_at"] for record in listen_counts
     }
 
     # Query repost counts
@@ -204,7 +217,7 @@ def generate_trending(session, time, genre, limit, offset):
         # Populate save counts with respect to time
         track_entry[response_name_constants.windowed_save_count] = track_save_counts_for_time.get(track_id, 0)
 
-        # Populate listen counts
+        # Populate owner follower count
         owner_id = track_owner_dict[track_id]
         owner_follow_count = follower_count_dict.get(owner_id, 0)
         track_entry[response_name_constants.track_owner_id] = owner_id

--- a/discovery-provider/tests/test_generate_trending.py
+++ b/discovery-provider/tests/test_generate_trending.py
@@ -1,46 +1,46 @@
 from datetime import datetime, timedelta
 
 from src.tasks.generate_trending import get_listen_counts
-from src.models import Track, Block, Play
-
-# Test data
-
-# test tracks
-# when creating tracks, track_id == index
-test_tracks = [
-    {"genre": "Electronic"},
-    {"genre": "Pop"},
-    {"genre": "Electronic"},
-
-    # Tracks we don't want to count
-    {"genre": "Electronic", "is_unlisted": True},
-    {"genre": "Electronic", "is_delete": True},
-
-]
-
-test_plays = [
-    # Current Plays
-    {"item_id": 0},
-    {"item_id": 0},
-    {"item_id": 1},
-    {"item_id": 1},
-    {"item_id": 2},
-    {"item_id": 3},
-
-    # > 1 wk plays
-    {"item_id": 2, "created_at": datetime.now() - timedelta(weeks=2)},
-    {"item_id": 2, "created_at": datetime.now() - timedelta(weeks=2)},
-    {"item_id": 3, "created_at": datetime.now() - timedelta(weeks=2)},
-
-    # We don't want to count these guys (tracks deleted/unlisted)
-    {"item_id": 3},
-    {"item_id": 3},
-    {"item_id": 4},
-    {"item_id": 4},
-]
+from src.models import AggregatePlays, Track, Block, Play
 
 # Setup trending from simplified metadata
-def setup_trending(db):
+def setup_trending(db, date):
+    # Test data
+
+    # test tracks
+    # when creating tracks, track_id == index
+    test_tracks = [
+        {"genre": "Electronic"},
+        {"genre": "Pop"},
+        {"genre": "Electronic"},
+
+        # Tracks we don't want to count
+        {"genre": "Electronic", "is_unlisted": True},
+        {"genre": "Electronic", "is_delete": True},
+
+    ]
+
+    test_plays = [
+        # Current Plays
+        {"item_id": 0},
+        {"item_id": 0},
+        {"item_id": 1},
+        {"item_id": 1},
+        {"item_id": 2},
+        {"item_id": 3},
+
+        # > 1 wk plays
+        {"item_id": 2, "created_at": date - timedelta(weeks=2)},
+        {"item_id": 2, "created_at": date - timedelta(weeks=2)},
+        {"item_id": 3, "created_at": date - timedelta(weeks=2)},
+
+        # We don't want to count these guys (tracks deleted/unlisted)
+        {"item_id": 3},
+        {"item_id": 3},
+        {"item_id": 4},
+        {"item_id": 4},
+    ]
+
     # pylint: disable=W0621
     with db.scoped_session() as session:
         # seed tracks + blocks
@@ -63,8 +63,8 @@ def setup_trending(db):
                 route_id='',
                 track_segments=[],
                 genre=track_meta.get("genre", ""),
-                updated_at=track_meta.get("updated_at", datetime.now()),
-                created_at=track_meta.get("created_at", datetime.now()),
+                updated_at=track_meta.get("updated_at", date),
+                created_at=track_meta.get("created_at", date),
                 is_unlisted=track_meta.get("is_unlisted", False)
             )
 
@@ -76,13 +76,25 @@ def setup_trending(db):
             session.add(track)
 
         # seed plays
+        aggregate_plays = {}
         for i, play_meta in enumerate(test_plays):
+            item_id = play_meta.get("item_id")
+            if item_id in aggregate_plays:
+                aggregate_plays[item_id] += 1
+            else:
+                aggregate_plays[item_id] = 1
+
             play = Play(
                 id=i,
-                play_item_id=play_meta.get("item_id"),
-                created_at=play_meta.get("created_at", datetime.now())
+                play_item_id=item_id,
+                created_at=play_meta.get("created_at", date)
             )
             session.add(play)
+        for i, count in aggregate_plays.items():
+            session.add(AggregatePlays(
+                play_item_id=i,
+                count=count
+            ))
 
 
 # Helper to sort results before validating
@@ -95,7 +107,8 @@ def validate_results(actual, expected):
 def test_get_listen_counts_year(postgres_mock_db):
     """Happy path test: test that we get all valid listens from prior year"""
     # setup
-    setup_trending(postgres_mock_db)
+    date = datetime.now()
+    setup_trending(postgres_mock_db, date)
 
     # run
     with postgres_mock_db.scoped_session() as session:
@@ -103,16 +116,17 @@ def test_get_listen_counts_year(postgres_mock_db):
 
     # validate
     expected = [
-        {"track_id": 0, "listens": 2},
-        {"track_id": 1, "listens": 2},
-        {"track_id": 2, "listens": 3}
+        {"track_id": 0, "listens": 2, "created_at": date},
+        {"track_id": 1, "listens": 2, "created_at": date},
+        {"track_id": 2, "listens": 3, "created_at": date}
     ]
     validate_results(res, expected)
 
 def test_get_listen_counts_week(postgres_mock_db):
     """Test slicing by time range"""
     # setup
-    setup_trending(postgres_mock_db)
+    date = datetime.now()
+    setup_trending(postgres_mock_db, date)
 
     # run
     with postgres_mock_db.scoped_session() as session:
@@ -120,21 +134,40 @@ def test_get_listen_counts_week(postgres_mock_db):
 
     # validate
     expected = [
-        {"track_id": 0, "listens": 2},
-        {"track_id": 1, "listens": 2},
-        {"track_id": 2, "listens": 1}
+        {"track_id": 0, "listens": 2, "created_at": date},
+        {"track_id": 1, "listens": 2, "created_at": date},
+        {"track_id": 2, "listens": 1, "created_at": date}
     ]
     validate_results(res, expected)
 
 def test_get_listen_counts_genre_filtered(postgres_mock_db):
     """Test slicing by genre"""
     # setup
-    setup_trending(postgres_mock_db)
+    date = datetime.now()
+    setup_trending(postgres_mock_db, date)
 
     # run
     with postgres_mock_db.scoped_session() as session:
         res = get_listen_counts(session, "year", "Pop", 10, 0)
 
     # validate
-    expected = [{"track_id": 1, "listens": 2}]
+    expected = [{"track_id": 1, "listens": 2, "created_at": date}]
+    validate_results(res, expected)
+
+def test_get_listen_counts_all_time(postgres_mock_db):
+    """Test slicing by genre"""
+    # setup
+    date = datetime.now()
+    setup_trending(postgres_mock_db, date)
+
+    # run
+    with postgres_mock_db.scoped_session() as session:
+        res = get_listen_counts(session, None, None, 10, 0)
+
+    # validate
+    expected = [
+        {"track_id": 0, "listens": 2, "created_at": date},
+        {"track_id": 1, "listens": 2, "created_at": date},
+        {"track_id": 2, "listens": 3, "created_at": date}
+    ]
     validate_results(res, expected)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Most of the time we have to use the Play table directly. Every hour we do compute all time and we're needlessly counting all.

Also remove total queries by 1 because we already have created_at from the plays  join tracks query.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Unit
2. Ran discprov pointed at db snapshot and hit v1/tracks/trending w/ caching off
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
