### PR TITLE
Add user, track, playlist mat views

### DIFF
--- a/discovery-provider/alembic/versions/5bcbe23f6c70_user_track_collection_mat_views.py
+++ b/discovery-provider/alembic/versions/5bcbe23f6c70_user_track_collection_mat_views.py
@@ -1,7 +1,7 @@
 """user-track-collection-mat-views
 
 Revision ID: 5bcbe23f6c70
-Revises: bff7853e0983
+Revises: 2ff46a8686fa
 Create Date: 2021-04-12 20:01:40.395480
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5bcbe23f6c70'
-down_revision = 'bff7853e0983'
+down_revision = '2ff46a8686fa'
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/5bcbe23f6c70_user_track_collection_mat_views.py
+++ b/discovery-provider/alembic/versions/5bcbe23f6c70_user_track_collection_mat_views.py
@@ -1,0 +1,235 @@
+"""user-track-collection-mat-views
+
+Revision ID: 5bcbe23f6c70
+Revises: bff7853e0983
+Create Date: 2021-04-12 20:01:40.395480
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5bcbe23f6c70'
+down_revision = 'bff7853e0983'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute('''
+        --- ======================= AGGREGATE USER =======================
+        DROP MATERIALIZED VIEW IF EXISTS aggregate_user;
+        DROP INDEX IF EXISTS aggregate_user_idx;
+
+        CREATE MATERIALIZED VIEW aggregate_user as
+        SELECT
+            u.user_id,
+            COALESCE (user_track.track_count, 0) as track_count,
+            COALESCE (user_playlist.playlist_count, 0) as playlist_count,
+            COALESCE (user_album.album_count, 0) as album_count,
+            COALESCE (user_follower.follower_count, 0) as follower_count,
+            COALESCE (user_followee.followee_count, 0) as following_count,
+            COALESCE (user_repost.repost_count, 0) as repost_count,
+            COALESCE (user_track_save.save_count, 0) as track_save_count
+        FROM 
+            users u
+        -- join on subquery for tracks created
+        LEFT OUTER JOIN (
+            SELECT
+                t.owner_id as owner_id,
+                count(t.owner_id) as track_count
+            FROM
+                tracks t
+            WHERE
+                t.is_current is True AND
+                t.is_delete is False AND
+                t.is_unlisted is False AND
+                t.stem_of is Null
+            GROUP BY t.owner_id
+        ) as user_track ON user_track.owner_id = u.user_id
+        -- join on subquery for playlists created
+        LEFT OUTER JOIN (
+            SELECT
+                p.playlist_owner_id as owner_id,
+                count(p.playlist_owner_id) as playlist_count
+            FROM
+                playlists p
+            WHERE
+                p.is_album is False AND
+                p.is_current is True AND
+                p.is_delete is False AND
+                p.is_private is False
+            GROUP BY p.playlist_owner_id
+        ) as user_playlist ON user_playlist.owner_id = u.user_id
+        -- join on subquery for albums created
+        LEFT OUTER JOIN (
+            SELECT
+                p.playlist_owner_id as owner_id,
+                count(p.playlist_owner_id) as album_count
+            FROM
+                playlists p
+            WHERE
+                p.is_album is True AND
+                p.is_current is True AND
+                p.is_delete is False AND
+                p.is_private is False
+            GROUP BY p.playlist_owner_id
+        ) user_album ON user_album.owner_id = u.user_id
+        -- join on subquery for followers
+        LEFT OUTER JOIN (
+            SELECT
+                f.followee_user_id as followee_user_id,
+                count(f.followee_user_id) as follower_count
+            FROM
+                follows f
+            WHERE
+                f.is_current is True AND
+                f.is_delete is False
+            GROUP BY f.followee_user_id
+        ) user_follower ON user_follower.followee_user_id = u.user_id
+        -- join on subquery for followee
+        LEFT OUTER JOIN (
+            SELECT
+                f.follower_user_id as follower_user_id,
+                count(f.follower_user_id) as followee_count
+            FROM
+                follows f
+            WHERE
+                f.is_current is True AND
+                f.is_delete is False
+            GROUP BY f.follower_user_id
+        ) user_followee ON user_followee.follower_user_id = u.user_id
+        -- join on subquery for reposts
+        LEFT OUTER JOIN (
+            SELECT
+                r.user_id as user_id,
+                count(r.user_id) as repost_count
+            FROM
+                reposts r
+            WHERE
+                r.is_current is True AND
+                r.is_delete is False
+            GROUP BY r.user_id
+        ) user_repost ON user_repost.user_id = u.user_id
+        -- join on subquery for track saves
+        LEFT OUTER JOIN (
+            SELECT
+                s.user_id as user_id,
+                count(s.user_id) as save_count
+            FROM
+                saves s
+            WHERE
+                s.is_current is True AND
+                s.save_type = 'track' AND
+                s.is_delete is False
+            GROUP BY s.user_id
+        ) user_track_save ON user_track_save.user_id = u.user_id
+        WHERE
+            u.is_current is True;
+
+        CREATE UNIQUE INDEX aggregate_user_idx ON aggregate_user (user_id);    
+
+        --- ======================= AGGREGATE TRACK =======================
+        DROP MATERIALIZED VIEW IF EXISTS aggregate_track;
+        DROP INDEX IF EXISTS aggregate_track_idx;
+
+        CREATE MATERIALIZED VIEW aggregate_track as
+        SELECT
+          t.track_id,
+          COALESCE (track_repost.repost_count, 0) as repost_count,
+          COALESCE (track_save.save_count, 0) as save_count
+        FROM 
+          tracks t
+        -- inner join on subquery for reposts
+        LEFT OUTER JOIN (
+          SELECT
+            r.repost_item_id as track_id,
+            count(r.repost_item_id) as repost_count
+          FROM
+            reposts r
+          WHERE
+            r.is_current is True AND
+            r.repost_type = 'track' AND
+            r.is_delete is False
+          GROUP BY r.repost_item_id
+        ) track_repost ON track_repost.track_id = t.track_id
+        -- inner join on subquery for track saves
+        LEFT OUTER JOIN (
+          SELECT
+            s.save_item_id as track_id,
+            count(s.save_item_id) as save_count
+          FROM
+            saves s
+          WHERE
+            s.is_current is True AND
+            s.save_type = 'track' AND
+            s.is_delete is False
+          GROUP BY s.save_item_id
+        ) track_save ON track_save.track_id = t.track_id
+        WHERE
+          t.is_current is True AND
+          t.is_delete is False;
+
+        CREATE UNIQUE INDEX aggregate_track_idx ON aggregate_track (track_id);
+
+        --- ======================= AGGREGATE PLAYLIST =======================
+        DROP MATERIALIZED VIEW IF EXISTS aggregate_playlist;
+        DROP INDEX IF EXISTS aggregate_playlist_idx;
+
+        CREATE MATERIALIZED VIEW aggregate_playlist as
+        SELECT
+          p.playlist_id,
+          p.is_album,
+          COALESCE (playlist_repost.repost_count, 0) as repost_count,
+          COALESCE (playlist_save.save_count, 0) as save_count
+        FROM 
+          playlists p
+        -- inner join on subquery for reposts
+        LEFT OUTER JOIN (
+          SELECT
+            r.repost_item_id as playlist_id,
+            count(r.repost_item_id) as repost_count
+          FROM
+            reposts r
+          WHERE
+            r.is_current is True AND
+            (r.repost_type = 'playlist' OR r.repost_type = 'album') AND
+            r.is_delete is False
+          GROUP BY r.repost_item_id
+        ) playlist_repost ON playlist_repost.playlist_id = p.playlist_id
+        -- inner join on subquery for track saves
+        LEFT OUTER JOIN (
+          SELECT
+            s.save_item_id as playlist_id,
+            count(s.save_item_id) as save_count
+          FROM
+            saves s
+          WHERE
+            s.is_current is True AND
+            (s.save_type = 'playlist' OR s.save_type = 'album') AND
+            s.is_delete is False
+          GROUP BY s.save_item_id
+        ) playlist_save ON playlist_save.playlist_id = p.playlist_id
+        WHERE
+          p.is_current is True AND
+          p.is_delete is False;
+
+        CREATE UNIQUE INDEX aggregate_playlist_idx ON aggregate_playlist (playlist_id);
+
+    ''')
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    # ### end Alembic commands ###
+    connection = op.get_bind()
+    connection.execute('''
+      DROP INDEX IF EXISTS aggregate_user_idx;
+      DROP INDEX IF EXISTS aggregate_track_idx;
+      DROP INDEX IF EXISTS aggregate_playlist_idx;
+      DROP MATERIALIZED VIEW aggregate_user;
+      DROP MATERIALIZED VIEW aggregate_track;
+      DROP MATERIALIZED VIEW aggregate_playlist;
+    ''')

--- a/discovery-provider/src/__init__.py
+++ b/discovery-provider/src/__init__.py
@@ -295,7 +295,8 @@ def configure_celery(flask_app, celery, test_config=None):
                  "src.tasks.index_materialized_views",
                  "src.tasks.index_network_peers", "src.tasks.index_trending",
                  "src.tasks.cache_user_balance", "src.monitors.monitoring_queue",
-                 "src.tasks.cache_trending_playlists"
+                 "src.tasks.cache_trending_playlists",
+                 "src.tasks.index_aggregate_views"
                  ],
         beat_schedule={
             "update_discovery_provider": {
@@ -345,6 +346,18 @@ def configure_celery(flask_app, celery, test_config=None):
             "cache_trending_playlists": {
                 "task": "cache_trending_playlists",
                 "schedule": timedelta(minutes=30)
+            },
+            "update_aggregate_user": {
+                "task": "update_aggregate_user",
+                "schedule": timedelta(seconds=30)
+            },
+            "update_aggregate_track": {
+                "task": "update_aggregate_track",
+                "schedule": timedelta(seconds=30)
+            },
+            "update_aggregate_playlist": {
+                "task": "update_aggregate_playlist",
+                "schedule": timedelta(seconds=30)
             }
         },
         task_serializer="json",

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -788,3 +788,60 @@ is_delete={self.is_delete},\
 id={self.id},\
 user_id={self.user_id},\
 wallet={self.wallet})>"
+
+class AggregateUser(Base):
+    __tablename__ = "aggregate_user"
+
+    user_id = Column(Integer, primary_key=True, nullable=False, index=True)
+    track_count = Column(Integer, nullable=False)
+    playlist_count = Column(Integer, nullable=False)
+    album_count = Column(Integer, nullable=False)
+    follower_count = Column(Integer, nullable=False)
+    following_count = Column(Integer, nullable=False)
+    repost_count = Column(Integer, nullable=False)
+    track_save_count = Column(Integer, nullable=False)
+
+    Index('aggregate_user_idx', 'user_id', unique=True)
+
+    def __repr__(self):
+        return f"<AggregateUser(\
+user_id={self.user_id},\
+track_count={self.track_count},\
+playlist_count={self.playlist_count},\
+album_count={self.album_count},\
+follower_count={self.follower_count},\
+following_count={self.following_count},\
+repost_count={self.repost_count},\
+track_save_count={self.track_save_count}>"
+
+class AggregateTrack(Base):
+    __tablename__ = "aggregate_track"
+
+    track_id = Column(Integer, primary_key=True, nullable=False, index=True)
+    repost_count = Column(Integer, nullable=False)
+    save_count = Column(Integer, nullable=False)
+
+    Index('aggregate_track_idx', 'track_id', unique=True)
+
+    def __repr__(self):
+        return f"<AggregateTrack(\
+track_id={self.track_id},\
+repost_count={self.repost_count},\
+save_count={self.save_count}>"
+
+class AggregatePlaylist(Base):
+    __tablename__ = "aggregate_playlist"
+
+    playlist_id = Column(Integer, primary_key=True, nullable=False, index=True)
+    is_album = Column(Boolean, nullable=False)
+    repost_count = Column(Integer, nullable=False)
+    save_count = Column(Integer, nullable=False)
+
+    Index('aggregate_playlist_idx', 'playlist_id', unique=True)
+
+    def __repr__(self):
+        return f"<AggregatePlaylist(\
+playlist_id={self.playlist_id},\
+is_album={self.is_album},\
+repost_count={self.repost_count},\
+save_count={self.save_count}>"

--- a/discovery-provider/src/queries/get_reposters_for_playlist.py
+++ b/discovery-provider/src/queries/get_reposters_for_playlist.py
@@ -1,7 +1,7 @@
 from sqlalchemy import func, desc
 
 from src import exceptions
-from src.models import User, Playlist, Repost, RepostType, Follow
+from src.models import User, Playlist, Repost, RepostType, AggregateUser
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
@@ -25,31 +25,16 @@ def get_reposters_for_playlist(args):
         if playlist_entry is None:
             raise exceptions.NotFoundError('Resource not found for provided playlist id')
 
-        # Subquery to get all (user_id, follower_count) entries from Follows table.
-        follower_count_subquery = (
-            session.query(
-                Follow.followee_user_id,
-                func.count(Follow.followee_user_id).label(
-                    response_name_constants.follower_count)
-            )
-            .filter(
-                Follow.is_current == True,
-                Follow.is_delete == False
-            )
-            .group_by(Follow.followee_user_id)
-            .subquery()
-        )
-
         # Get all Users that reposted Playlist, ordered by follower_count desc & paginated.
         query = (
             session.query(
                 User,
                 # Replace null values from left outer join with 0 to ensure sort works correctly.
-                (func.coalesce(follower_count_subquery.c.follower_count, 0)).label(
+                (func.coalesce(AggregateUser.follower_count, 0)).label(
                     response_name_constants.follower_count)
             )
             # Left outer join to associate users with their follower count.
-            .outerjoin(follower_count_subquery, follower_count_subquery.c.followee_user_id == User.user_id)
+            .outerjoin(AggregateUser, AggregateUser.user_id == User.user_id)
             .filter(
                 User.is_current == True,
                 # Only select users that reposted given playlist.

--- a/discovery-provider/src/queries/get_reposters_for_track.py
+++ b/discovery-provider/src/queries/get_reposters_for_track.py
@@ -1,7 +1,7 @@
 from sqlalchemy import func, desc
 
 from src import exceptions
-from src.models import User, Track, Repost, RepostType, Follow
+from src.models import User, Track, Repost, RepostType, AggregateUser
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
@@ -25,31 +25,16 @@ def get_reposters_for_track(args):
         if track_entry is None:
             raise exceptions.NotFoundError('Resource not found for provided track id')
 
-        # Subquery to get all (user_id, follower_count) entries from Follows table.
-        follower_count_subquery = (
-            session.query(
-                Follow.followee_user_id,
-                func.count(Follow.followee_user_id).label(
-                    response_name_constants.follower_count)
-            )
-            .filter(
-                Follow.is_current == True,
-                Follow.is_delete == False
-            )
-            .group_by(Follow.followee_user_id)
-            .subquery()
-        )
-
         # Get all Users that reposted track, ordered by follower_count desc & paginated.
         query = (
             session.query(
                 User,
                 # Replace null values from left outer join with 0 to ensure sort works correctly.
-                (func.coalesce(follower_count_subquery.c.follower_count, 0)).label(
+                (func.coalesce(AggregateUser.follower_count, 0)).label(
                     response_name_constants.follower_count)
             )
             # Left outer join to associate users with their follower count.
-            .outerjoin(follower_count_subquery, follower_count_subquery.c.followee_user_id == User.user_id)
+            .outerjoin(AggregateUser, AggregateUser.user_id == User.user_id)
             .filter(
                 User.is_current == True,
                 # Only select users that reposted given track.

--- a/discovery-provider/src/queries/get_savers_for_track.py
+++ b/discovery-provider/src/queries/get_savers_for_track.py
@@ -1,7 +1,7 @@
 from sqlalchemy import func, desc
 
 from src import exceptions
-from src.models import User, Track, Save, SaveType, Follow
+from src.models import User, Track, Save, SaveType, AggregateUser
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 from src.queries import response_name_constants
@@ -24,31 +24,16 @@ def get_savers_for_track(args):
         if track_entry is None:
             raise exceptions.NotFoundError('Resource not found for provided track id')
 
-        # Subquery to get all (user_id, follower_count) entries from Follows table.
-        follower_count_subquery = (
-            session.query(
-                Follow.followee_user_id,
-                func.count(Follow.followee_user_id).label(
-                    response_name_constants.follower_count)
-            )
-            .filter(
-                Follow.is_current == True,
-                Follow.is_delete == False
-            )
-            .group_by(Follow.followee_user_id)
-            .subquery()
-        )
-
         # Get all Users that saved track, ordered by follower_count desc & paginated.
         query = (
             session.query(
                 User,
                 # Replace null values from left outer join with 0 to ensure sort works correctly.
-                (func.coalesce(follower_count_subquery.c.follower_count, 0)).label(
+                (func.coalesce(AggregateUser.follower_count, 0)).label(
                     response_name_constants.follower_count)
             )
             # Left outer join to associate users with their follower count.
-            .outerjoin(follower_count_subquery, follower_count_subquery.c.followee_user_id == User.user_id)
+            .outerjoin(AggregateUser, AggregateUser.user_id == User.user_id)
             .filter(
                 User.is_current == True,
                 # Only select users that saved given track.

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -6,7 +6,8 @@ from dateutil.parser import parse
 
 from src.utils.db_session import get_db_read_replica
 from src.utils.redis_cache import use_redis_cache
-from src.models import Track, RepostType, Follow, SaveType, User, AggregatePlays
+from src.models import Track, RepostType, Follow, SaveType, User, \
+    AggregatePlays, AggregateUser
 from src.queries.query_helpers import \
     get_karma, get_repost_counts, get_save_counts
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -5,7 +5,8 @@ from sqlalchemy import desc, func
 from src import api_helpers
 from src.queries import response_name_constants as const
 from src.queries.query_helpers import get_repost_counts, get_save_counts, get_follower_count_dict
-from src.models import Block, Follow, Save, SaveType, Playlist, Track, Repost, RepostType, Remix
+from src.models import Block, Follow, Save, SaveType, Playlist, Track, Repost, \
+    RepostType, Remix, AggregateUser
 from src.utils.db_session import get_db_read_replica
 from src.utils.config import shared_config
 

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -757,15 +757,12 @@ def milestones_followers():
     with db.scoped_session() as session:
         follower_counts = (
             session.query(
-                Follow.followee_user_id,
-                func.count(Follow.followee_user_id)
+                AggregateUser.user_id,
+                AggregateUser.follower_count
             )
             .filter(
-                Follow.is_current == True,
-                Follow.is_delete == False,
-                Follow.followee_user_id.in_(user_ids)
+                AggregateUser.user_id.in_(user_ids)
             )
-            .group_by(Follow.followee_user_id)
             .all()
         )
         follower_count_dict = \

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -1,6 +1,6 @@
 import logging  # pylint: disable=C0302
 from flask import Blueprint, request
-from sqlalchemy import desc, func
+from sqlalchemy import desc
 
 from src import api_helpers
 from src.queries import response_name_constants as const

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -7,7 +7,8 @@ from flask import request
 from src import exceptions
 from src.queries import response_name_constants
 from src.models import User, Track, Repost, RepostType, Follow, \
-    Playlist, Save, SaveType, Remix, AggregatePlays
+    Playlist, Save, SaveType, Remix, AggregatePlays,  \
+    AggregateUser, AggregateTrack, AggregatePlaylist
 from src.utils import helpers, redis_connection
 from src.queries.get_unpopulated_users import get_unpopulated_users
 from src.queries.get_balances import get_balances, enqueue_balance_refresh
@@ -102,132 +103,44 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
     if current_user_id:
         enqueue_balance_refresh(redis, [current_user_id])
 
-    # build dict of user id --> track count
-    track_counts = (
+    aggregate_user = (
         session.query(
-            Track.owner_id,
-            func.count(Track.owner_id)
+            AggregateUser.user_id,
+            AggregateUser.track_count,
+            AggregateUser.playlist_count,
+            AggregateUser.album_count,
+            AggregateUser.follower_count,
+            AggregateUser.following_count,
+            AggregateUser.repost_count,
+            AggregateUser.track_save_count
         )
         .filter(
-            Track.is_current == True,
-            Track.is_delete == False,
-            Track.is_unlisted == False,
-            Track.stem_of == None,
-            Track.owner_id.in_(user_ids)
+            AggregateUser.user_id.in_(user_ids)
         )
-        .group_by(Track.owner_id)
         .all()
     )
-    track_count_dict = {user_id: track_count for (
-        user_id, track_count) in track_counts}
 
-    # build dict of user id --> playlist count
-    playlist_counts = (
-        session.query(
-            Playlist.playlist_owner_id,
-            func.count(Playlist.playlist_owner_id)
-        )
-        .filter(
-            Playlist.is_current == True,
-            Playlist.is_album == False,
-            Playlist.is_private == False,
-            Playlist.is_delete == False,
-            Playlist.playlist_owner_id.in_(user_ids)
-        )
-        .group_by(Playlist.playlist_owner_id)
-        .all()
-    )
-    playlist_count_dict = {user_id: playlist_count for (
-        user_id, playlist_count) in playlist_counts}
-
-    # build dict of user id --> album count
-    album_counts = (
-        session.query(
-            Playlist.playlist_owner_id,
-            func.count(Playlist.playlist_owner_id)
-        )
-        .filter(
-            Playlist.is_current == True,
-            Playlist.is_album == True,
-            Playlist.is_private == False,
-            Playlist.is_delete == False,
-            Playlist.playlist_owner_id.in_(user_ids)
-        )
-        .group_by(Playlist.playlist_owner_id)
-        .all()
-    )
-    album_count_dict = {user_id: album_count for (
-        user_id, album_count) in album_counts}
-
-    # build dict of user id --> follower count
-    follower_counts = (
-        session.query(
-            Follow.followee_user_id,
-            func.count(Follow.followee_user_id)
-        )
-        .filter(
-            Follow.is_current == True,
-            Follow.is_delete == False,
-            Follow.followee_user_id.in_(user_ids)
-        )
-        .group_by(Follow.followee_user_id)
-        .all()
-    )
-    follower_count_dict = {user_id: follower_count for (
-        user_id, follower_count) in follower_counts}
-
-    # build dict of user id --> followee count
-    followee_counts = (
-        session.query(
-            Follow.follower_user_id,
-            func.count(Follow.follower_user_id)
-        )
-        .filter(
-            Follow.is_current == True,
-            Follow.is_delete == False,
-            Follow.follower_user_id.in_(user_ids)
-        )
-        .group_by(Follow.follower_user_id)
-        .all()
-    )
-    followee_count_dict = {user_id: followee_count for (
-        user_id, followee_count) in followee_counts}
-
-    # build dict of user id --> repost count
-    repost_counts = (
-        session.query(
-            Repost.user_id,
-            func.count(Repost.user_id)
-        )
-        .filter(
-            Repost.is_current == True,
-            Repost.is_delete == False,
-            Repost.user_id.in_(user_ids)
-        )
-        .group_by(Repost.user_id)
-        .all()
-    )
-    repost_count_dict = {user_id: repost_count for (
-        user_id, repost_count) in repost_counts}
-    track_save_count_dict = {}
-    if with_track_save_count:
-        # build dict of user id --> track save count
-        track_save_counts = (
-            session.query(
-                Save.user_id,
-                func.count(Save.user_id)
-            )
-            .filter(
-                Save.is_current == True,
-                Save.is_delete == False,
-                Save.save_type == SaveType.track,
-                Save.user_id.in_(user_ids)
-            )
-            .group_by(Save.user_id)
-            .all()
-        )
-        track_save_count_dict = {user_id: user_track_save_count for (
-            user_id, user_track_save_count) in track_save_counts}
+    # build dict of user id --> track/playlist/album/follower/followee/repost/track save counts
+    count_dict = {
+        user_id: {
+            response_name_constants.track_count: track_count,
+            response_name_constants.playlist_count: playlist_count,
+            response_name_constants.album_count: album_count,
+            response_name_constants.follower_count: follower_count,
+            response_name_constants.followee_count: following_count,
+            response_name_constants.repost_count: repost_count,
+            response_name_constants.track_save_count: track_save_count
+        } for (
+            user_id,
+            track_count,
+            playlist_count,
+            album_count,
+            follower_count,
+            following_count,
+            repost_count,
+            track_save_count
+        ) in aggregate_user
+    }
 
     # build dict of user id --> track blocknumber
     track_blocknumbers = (
@@ -297,23 +210,23 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
     for user in users:
         user_id = user["user_id"]
         user_balance = balance_dict.get(user_id, {})
-        user[response_name_constants.track_count] = track_count_dict.get(
-            user_id, 0)
-        user[response_name_constants.playlist_count] = playlist_count_dict.get(
-            user_id, 0)
-        user[response_name_constants.album_count] = album_count_dict.get(
-            user_id, 0)
-        user[response_name_constants.follower_count] = follower_count_dict.get(
-            user_id, 0)
-        user[response_name_constants.followee_count] = followee_count_dict.get(
-            user_id, 0)
-        user[response_name_constants.repost_count] = repost_count_dict.get(
-            user_id, 0)
+        user[response_name_constants.track_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.track_count, 0)
+        user[response_name_constants.playlist_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.playlist_count, 0)
+        user[response_name_constants.album_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.album_count, 0)
+        user[response_name_constants.follower_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.follower_count, 0)
+        user[response_name_constants.followee_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.followee_count, 0)
+        user[response_name_constants.repost_count] = count_dict.get(
+            user_id, {}).get(response_name_constants.repost_count, 0)
         user[response_name_constants.track_blocknumber] = track_blocknumber_dict.get(
             user_id, -1)
         if with_track_save_count:
-            user[response_name_constants.track_save_count] = track_save_count_dict.get(
-                user_id, 0)
+            user[response_name_constants.track_save_count] = count_dict.get(
+                user_id, {}).get(response_name_constants.track_save_count, 0)
         # current user specific
         user[response_name_constants.does_current_user_follow] = current_user_followed_user_ids.get(
             user_id, False)
@@ -329,17 +242,15 @@ def populate_user_follower_counts(session, user_ids, users):
     """Gets user follower counts for an array of user_ids and corresponding users"""
     follower_counts = (
         session.query(
-            Follow.followee_user_id,
-            func.count(Follow.followee_user_id)
+            AggregateUser.user_id,
+            AggregateUser.follower_count
         )
         .filter(
-            Follow.is_current == True,
-            Follow.is_delete == False,
-            Follow.followee_user_id.in_(user_ids)
+            AggregateUser.user_id.in_(user_ids)
         )
-        .group_by(Follow.followee_user_id)
         .all()
     )
+
     follower_count_dict = {user_id: follower_count for (
         user_id, follower_count) in follower_counts}
     for user in users:
@@ -371,40 +282,28 @@ def get_track_play_count_dict(session, track_ids):
 #   if current_user_id available, populates followee_reposts, has_current_user_reposted, has_current_user_saved
 def populate_track_metadata(session, track_ids, tracks, current_user_id):
     # build dict of track id --> repost count
-    repost_counts = (
+    counts = (
         session.query(
-            Repost.repost_item_id,
-            func.count(Repost.repost_item_id)
+            AggregateTrack.track_id,
+            AggregateTrack.repost_count,
+            AggregateTrack.save_count
         )
         .filter(
-            Repost.is_current == True,
-            Repost.is_delete == False,
-            Repost.repost_item_id.in_(track_ids),
-            Repost.repost_type == RepostType.track
+            AggregateTrack.track_id.in_(track_ids),
         )
-        .group_by(Repost.repost_item_id)
         .all()
     )
-    repost_count_dict = {track_id: repost_count for (
-        track_id, repost_count) in repost_counts}
 
-    # build dict of track id --> save count
-    save_counts = (
-        session.query(
-            Save.save_item_id,
-            func.count(Save.save_item_id)
-        )
-        .filter(
-            Save.is_current == True,
-            Save.is_delete == False,
-            Save.save_type == SaveType.track,
-            Save.save_item_id.in_(track_ids)
-        )
-        .group_by(Save.save_item_id)
-        .all()
-    )
-    save_count_dict = {track_id: save_count for (
-        track_id, save_count) in save_counts}
+    count_dict = {
+        track_id: {
+            response_name_constants.repost_count: repost_count,
+            response_name_constants.save_count: save_count
+        } for (
+            track_id,
+            repost_count,
+            save_count
+        ) in counts
+    }
 
     play_count_dict = get_track_play_count_dict(session, track_ids)
 
@@ -497,10 +396,10 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
 
     for track in tracks:
         track_id = track["track_id"]
-        track[response_name_constants.repost_count] = repost_count_dict.get(
-            track_id, 0)
-        track[response_name_constants.save_count] = save_count_dict.get(
-            track_id, 0)
+        track[response_name_constants.repost_count] = count_dict.get(
+            track_id, {}).get(response_name_constants.repost_count, 0)
+        track[response_name_constants.save_count] = count_dict.get(
+            track_id, {}).get(response_name_constants.save_count, 0)
         track[response_name_constants.play_count] = play_count_dict.get(
             track_id, 0)
         # current user specific
@@ -535,16 +434,12 @@ def populate_track_repost_counts(session, track_ids, tracks):
     """Gets track repost counts for an array of track_ids and corresponding tracks"""
     repost_counts = (
         session.query(
-            Repost.repost_item_id,
-            func.count(Repost.repost_item_id)
+            AggregateTrack.track_id,
+            AggregateTrack.repost_count
         )
         .filter(
-            Repost.is_current == True,
-            Repost.is_delete == False,
-            Repost.repost_item_id.in_(track_ids),
-            Repost.repost_type == RepostType.track
+            AggregateTrack.track_id.in_(track_ids),
         )
-        .group_by(Repost.repost_item_id)
         .all()
     )
     repost_count_dict = {track_id: repost_count for (
@@ -684,13 +579,29 @@ def get_track_remix_metadata(session, tracks, current_user_id):
 
 
 def populate_playlist_metadata(session, playlist_ids, playlists, repost_types, save_types, current_user_id):
-    # build dict of playlist id --> repost count
-    playlist_repost_counts = dict(get_repost_counts(
-        session, False, False, playlist_ids, repost_types))
+    # build dict of playlist id --> repost & save count
+    counts = (
+        session.query(
+            AggregatePlaylist.playlist_id,
+            AggregatePlaylist.repost_count,
+            AggregatePlaylist.save_count
+        )
+        .filter(
+            AggregatePlaylist.playlist_id.in_(playlist_ids),
+        )
+        .all()
+    )
 
-    # build dict of playlist id --> save count
-    playlist_save_counts = dict(get_save_counts(
-        session, False, False, playlist_ids, save_types))
+    count_dict = {
+        playlist_id: {
+            response_name_constants.repost_count: repost_count,
+            response_name_constants.save_count: save_count
+        } for (
+            playlist_id,
+            repost_count,
+            save_count
+        ) in counts
+    }
 
     user_reposted_playlist_dict = {}
     user_saved_playlist_dict = {}
@@ -787,10 +698,10 @@ def populate_playlist_metadata(session, playlist_ids, playlists, repost_types, s
 
     for playlist in playlists:
         playlist_id = playlist["playlist_id"]
-        playlist[response_name_constants.repost_count] = playlist_repost_counts.get(
-            playlist_id, 0)
-        playlist[response_name_constants.save_count] = playlist_save_counts.get(
-            playlist_id, 0)
+        playlist[response_name_constants.repost_count] = count_dict.get(
+            playlist_id, {}).get(response_name_constants.repost_count, 0)
+        playlist[response_name_constants.save_count] = count_dict.get(
+            playlist_id, {}).get(response_name_constants.save_count, 0)
 
         total_play_count = 0
         for track in playlist['playlist_contents']['track_ids']:
@@ -1037,27 +948,6 @@ def get_save_counts(
             Save.created_at >= text(interval)
         )
     return save_counts_query.all()
-
-
-def get_followee_count_dict(session, user_ids):
-    # build dict of user id --> followee count
-    followee_counts = (
-        session.query(
-            Follow.follower_user_id,
-            func.count(Follow.follower_user_id)
-        )
-        .filter(
-            Follow.is_current == True,
-            Follow.is_delete == False,
-            Follow.follower_user_id.in_(user_ids)
-        )
-        .group_by(Follow.follower_user_id)
-        .all()
-    )
-    followee_count_dict = {user_id: followee_count for (
-        user_id, followee_count) in followee_counts}
-    return followee_count_dict
-
 
 def get_follower_count_dict(session, user_ids, max_block_number=None):
     follower_counts = (

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -184,8 +184,8 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
                 Follow.is_delete == False,
                 Follow.follower_user_id == current_user_id
             )
+            .subquery()
         )
-        current_user_followees = {r[0]: True for r in current_user_followees}
 
         current_user_followee_follow_counts = (
             session.query(

--- a/discovery-provider/src/tasks/index_aggregate_views.py
+++ b/discovery-provider/src/tasks/index_aggregate_views.py
@@ -14,11 +14,10 @@ DEFAULT_UPDATE_TIMEOUT=60
 def update_view(mat_view_name, db):
     with db.scoped_session() as session:
         start_time = time.time()
-        logger.info(f"index_aggregate_views.py | Updating materialized view {mat_view_name}")
+        logger.info(f"index_aggregate_views.py | Updating {mat_view_name}")
         session.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {mat_view_name}")
         logger.info(
-            f"index_aggregate_views.py | Finished updating materialized view {mat_view_name} in: {
-                time.time()-start_time} sec"
+            f"index_aggregate_views.py | Finished updating {mat_view_name} in: {time.time()-start_time} sec"
         )
 
 def update_materialized_view(db, redis, mat_view_name, timeout=DEFAULT_UPDATE_TIMEOUT):

--- a/discovery-provider/src/tasks/index_aggregate_views.py
+++ b/discovery-provider/src/tasks/index_aggregate_views.py
@@ -9,7 +9,7 @@ AGGREGATE_USER = 'aggregate_user'
 AGGREGATE_TRACK = 'aggregate_track'
 AGGREGATE_PLAYLIST = 'aggregate_playlist'
 
-DEFAULT_UPDATE_TIMEOUT=60
+DEFAULT_UPDATE_TIMEOUT = 60
 
 def update_view(mat_view_name, db):
     with db.scoped_session() as session:

--- a/discovery-provider/src/tasks/index_aggregate_views.py
+++ b/discovery-provider/src/tasks/index_aggregate_views.py
@@ -1,0 +1,61 @@
+import logging
+import time
+from src.tasks.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+# Names of the aggregate tables to update
+AGGREGATE_USER = 'aggregate_user'
+AGGREGATE_TRACK = 'aggregate_track'
+AGGREGATE_PLAYLIST = 'aggregate_playlist'
+
+DEFAULT_UPDATE_TIMEOUT=60
+
+def update_view(mat_view_name, db):
+    with db.scoped_session() as session:
+        start_time = time.time()
+        logger.info(f"index_aggregate_views.py | Updating materialized view {mat_view_name}")
+        session.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {mat_view_name}")
+        logger.info(
+            f"index_aggregate_views.py | Finished updating materialized view {mat_view_name} in: {
+                time.time()-start_time} sec"
+        )
+
+def update_materialized_view(db, redis, mat_view_name, timeout=DEFAULT_UPDATE_TIMEOUT):
+    # Define lock acquired boolean
+    have_lock = False
+    # Define redis lock object
+    update_lock = redis.lock(f"refresh_mat_view:{mat_view_name}", timeout=timeout)
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            update_view(mat_view_name, db)
+        else:
+            logger.info(f"index_aggregate_views.py | Failed to acquire lock refresh_mat_view:{mat_view_name}")
+    except Exception as e:
+        logger.error("index_aggregate_views.py | Fatal error in main loop", exc_info=True)
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()
+
+
+######## CELERY TASKS ########
+@celery.task(name="update_aggregate_user", bind=True)
+def update_aggregate_user(self):
+    db = update_aggregate_user.db
+    redis = update_aggregate_user.redis
+    update_materialized_view(db, redis, AGGREGATE_USER)
+
+@celery.task(name="update_aggregate_track", bind=True)
+def update_aggregate_track(self):
+    db = update_aggregate_track.db
+    redis = update_aggregate_track.redis
+    update_materialized_view(db, redis, AGGREGATE_TRACK)
+
+@celery.task(name="update_aggregate_playlist", bind=True)
+def update_aggregate_playlist(self):
+    db = update_aggregate_playlist.db
+    redis = update_aggregate_playlist.redis
+    update_materialized_view(db, redis, AGGREGATE_PLAYLIST)

--- a/discovery-provider/tests/test_search_user_tags.py
+++ b/discovery-provider/tests/test_search_user_tags.py
@@ -35,6 +35,7 @@ def test_search_user_tags(app):
     with db.scoped_session() as session:
         session.execute("REFRESH MATERIALIZED VIEW tag_track_user")
         session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+        session.execute("REFRESH MATERIALIZED VIEW aggregate_user")
         args = {
             'search_str': 'pop',
             'current_user_id': None,


### PR DESCRIPTION
### Description
* Adds Materialized views for users, tracks, and playlists with aggregate counts. 
* Adds a a recurring jobs w/ celery to concurrently refresh the views. 
* Updates the populate_user_metadata, populate_track_metadata, and populate_playlist_metadata to use the aggregate views. 

NOTES:
It takes about 2-10 seconds to refresh the materialized views against the prod database (Given no indexing or changes are occurring)
This was also w/ the following indexes added
```
CREATE INDEX user_saves_idx ON saves (user_id, is_delete, is_current, save_type);
CREATE INDEX item_saves_idx ON saves (save_item_id, is_delete, is_current, save_type);

CREATE INDEX user_resposts_idx ON reposts (user_id, is_delete, is_current, repost_type);
CREATE INDEX item_reposts_idx ON reposts (repost_item_id, is_delete, is_current, repost_type);
```

Without these indexes the create materialized view query was taking over 5 minutes (I did not let it finish as I was unsure as to how long it would take)

### Tests
I ran the DP against a prod snapshot DB and ran queries for every function to ensure that it was not error and retuning correct order/values depending on the modified queries. 

In raw planning/execution time using aggregate_user query in the populate_user_metadata is over 10x faster. 
* This was calculated by running explain analyze on each of the queries and summing the values vs the single aggregate_user query when searching for 20 user_ids  

When timing the populate_user_metadata in the code starting before the first query and ending after the last query, it was about 2-4 times faster (this includes round trip time to the DB).  


TODO: Add tests