### PR TITLE
Add indexes to reposts/saves

### DIFF
--- a/discovery-provider/alembic/versions/2ff46a8686fa_add_indexes.py
+++ b/discovery-provider/alembic/versions/2ff46a8686fa_add_indexes.py
@@ -1,0 +1,42 @@
+"""add_indexes
+
+Revision ID: 2ff46a8686fa
+Revises: bff7853e0983
+Create Date: 2021-04-13 10:40:58.154737
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2ff46a8686fa'
+down_revision = 'bff7853e0983'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    connection.execute('''
+        begin;
+            CREATE INDEX save_user_id_idx ON saves (user_id, is_delete, is_current, save_type);
+            CREATE INDEX save_item_id_idx ON saves (save_item_id, is_delete, is_current, save_type);
+            CREATE INDEX repost_user_id_idx ON reposts (user_id, is_delete, is_current, repost_type);
+            CREATE INDEX repost_item_id_idx ON reposts (repost_item_id, is_delete, is_current, repost_type);
+        commit;
+    ''')
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    connection.execute('''
+        begin;
+            DROP INDEX save_user_id_idx;
+            DROP INDEX save_item_id_idx;
+            DROP INDEX repost_user_id_idx;
+            DROP INDEX repost_item_id_idx;
+        commit;
+    ''')


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_
Add missing indexes on reposts + saves to support @jowlee 's work in https://github.com/AudiusProject/audius-protocol/pull/1402

I thought we were missing some around tracks/users/playlists, but it seems like the primary key is indeed covering the query hot paths. Going to look a little more, but wanted to get this change out first.

This speeds up the karma query by 2x as well as makes the matview's work.



### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Manually ran migrations up & down
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
