### PR TITLE
[AUD-529] Remove req param from _nodeSync()

### DIFF
--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -74,6 +74,9 @@ const initializeApp = (port, serviceRegistry) => {
   // add a newer version of ipfs as app property
   app.set('ipfsLatestAPI', serviceRegistry.ipfsLatest)
 
+  // Eventually, all components should pull services off the serviceRegistry
+  app.set('serviceRegistry', serviceRegistry)
+
   // https://expressjs.com/en/guide/behind-proxies.html
   app.set('trust proxy', true)
 

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -78,7 +78,8 @@ async function saveFileToIPFSFromFS (req, srcPath) {
  * 2. attempt to fetch the CID from a variety of sources
  * 3. throws error if failure, couldn't find the file or file contents don't match CID;
  *    returns expectedStoragePath if successful
- * @param {Object} req request object
+ * @param {Object} serviceRegistry
+ * @param {Object} logger
  * @param {String} multihash IPFS cid
  * @param {String} expectedStoragePath file system path similar to `/file_storage/Qm1`
  *                  for non dir files and `/file_storage/Qmdir/Qm2` for dir files

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -86,7 +86,7 @@ async function saveFileToIPFSFromFS (req, srcPath) {
  * @param {String?} fileNameForImage file name if the multihash is image in dir.
  *                  eg original.jpg or 150x150.jpg
  */
-async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, gatewaysToTry, fileNameForImage = null) {
+async function saveFileForMultihashToFS (ipfs, logger, multihash, expectedStoragePath, gatewaysToTry, fileNameForImage = null) {
   // stores all the stages of this function along with associated information relevant to that step
   // in the try catch below, if any of the nested try/catches throw, it will be caught by the top level try/catch
   // so we only need to print it once in the global catch or after everthing finishes except for any return statements
@@ -149,10 +149,10 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
 
     // If file already stored on disk, return immediately.
     if (await fs.pathExists(expectedStoragePath)) {
-      req.logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
+      logger.debug(`File already stored at ${expectedStoragePath} for ${multihash}`)
       decisionTree.push({ stage: 'File already stored on disk', vals: [expectedStoragePath, multihash], time: Date.now() })
       // since this is early exit, print the decision tree here
-      _printDecisionTreeObj(req, decisionTree)
+      _printDecisionTreeObj(decisionTree, logger)
 
       return expectedStoragePath
     }
@@ -164,7 +164,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     if (gatewayUrlsMapped.length > 0) {
       try {
         let response
-        req.logger.debug(`Attempting to fetch multihash ${multihash} by racing replica set endpoints`)
+        logger.debug(`Attempting to fetch multihash ${multihash} by racing replica set endpoints`)
         decisionTree.push({ stage: 'About to race requests via gateways', vals: gatewayUrlsMapped, time: Date.now() })
 
         const GatewayRetrievalConcurrencyLimit = 5
@@ -205,7 +205,7 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
              * This just means that file retrieval failed from current gatewayUrlsSlice
              */
           } catch (e) {
-            req.logger.error(`Error fetching file from gateways ${gatewayUrlsSlice}`)
+            logger.error(`Error fetching file from gateways ${gatewayUrlsSlice}`)
             decisionTree.push({ stage: 'Could not retrieve file from gateways', vals: gatewayUrlsSlice, time: Date.now() })
 
             continue
@@ -222,59 +222,59 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
         fileFound = true
 
         decisionTree.push({ stage: 'Wrote file to file system after fetching from gateway', vals: expectedStoragePath, time: Date.now() })
-        req.logger.info(`wrote file to ${expectedStoragePath}`)
+        logger.info(`wrote file to ${expectedStoragePath}`)
       } catch (e) {
         const errorMsg = `Failed to retrieve file for multihash ${multihash} from other creator node gateways`
         decisionTree.push({ stage: errorMsg, vals: e.message, time: Date.now() })
-        req.logger.warn(`${errorMsg} || ${e.message}`)
+        logger.warn(`${errorMsg} || ${e.message}`)
       }
     }
 
     // If file not found through gateways, check local ipfs node.
     if (!fileFound) {
-      req.logger.debug(`checking if ${multihash} already available on local ipfs node`)
+      logger.debug(`checking if ${multihash} already available on local ipfs node`)
       try {
         decisionTree.push({ stage: 'About to retrieve file from local ipfs node with cat', vals: multihash, time: Date.now() })
 
         // ipfsCat returns a Buffer
-        let fileBuffer = await Utils.ipfsCat(multihash, req, 1000)
+        let fileBuffer = await Utils.ipfsCat(ipfs, logger, multihash, 1000)
 
         fileFound = true
-        req.logger.debug(`Retrieved file for ${multihash} from  with cat`)
+        logger.debug(`Retrieved file for ${multihash} from  with cat`)
         decisionTree.push({ stage: 'Retrieved file from local ipfs node with cat', vals: multihash, time: Date.now() })
 
         // Write file to disk.
         await fs.writeFile(expectedStoragePath, fileBuffer)
 
-        req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs cat`)
+        logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs cat`)
         decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
       } catch (e) {
-        req.logger.warn(`Multihash ${multihash} is not available on local ipfs node ${e.message}`)
+        logger.warn(`Multihash ${multihash} is not available on local ipfs node ${e.message}`)
         decisionTree.push({ stage: 'File not available on local ipfs node with cat', vals: multihash, time: Date.now() })
       }
     }
 
     // If file not already available on local ipfs node or via gateways, fetch from IPFS.
     if (!fileFound) {
-      req.logger.debug(`Attempting to get ${multihash} from IPFS`)
+      logger.debug(`Attempting to get ${multihash} from IPFS`)
       try {
         decisionTree.push({ stage: 'About to retrieve file from local ipfs node with get', vals: multihash, time: Date.now() })
 
         // ipfsGet returns a BufferListStream object which is not a buffer
         // not compatible into writeFile directly, but it can be streamed to a file
-        let fileBL = await Utils.ipfsGet(multihash, req, 1000)
+        let fileBL = await Utils.ipfsGet(ipfs, logger, multihash, 1000)
 
-        req.logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
+        logger.debug(`retrieved file for multihash ${multihash} from local ipfs node`)
         decisionTree.push({ stage: 'Retrieved file from local ipfs node with get', vals: multihash, time: Date.now() })
 
         // Write file to disk.
         await Utils.writeStreamToFileSystem(fileBL, expectedStoragePath)
 
         fileFound = true
-        req.logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs get`)
+        logger.info(`wrote file to ${expectedStoragePath}, obtained via ipfs get`)
         decisionTree.push({ stage: 'Wrote file to disk', vals: expectedStoragePath, time: Date.now() })
       } catch (e) {
-        req.logger.warn(`Failed to retrieve file for multihash ${multihash} from IPFS ${e.message}`)
+        logger.warn(`Failed to retrieve file for multihash ${multihash} from IPFS ${e.message}`)
         decisionTree.push({ stage: 'File not available on local ipfs node with ipfs get', vals: multihash, time: Date.now() })
       }
     }
@@ -288,7 +288,6 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
     // verify that the contents of the file match the file's cid
     try {
       decisionTree.push({ stage: 'About to verify the file contents for the CID', vals: multihash, time: Date.now() })
-      const ipfs = req.app.get('ipfsLatestAPI')
       const content = fs.createReadStream(expectedStoragePath)
       for await (const result of ipfs.add(content, { onlyHash: true, timeout: 10000 })) {
         if (multihash !== result.cid.toString()) {
@@ -304,20 +303,20 @@ async function saveFileForMultihashToFS (req, multihash, expectedStoragePath, ga
       throw new Error(`Error during content verification for multihash ${multihash} ${e.message}`)
     }
 
-    _printDecisionTreeObj(req, decisionTree)
+    _printDecisionTreeObj(decisionTree, logger)
     return expectedStoragePath
   } catch (e) {
     decisionTree.push({ stage: `saveFileForMultihashToFS error`, vals: e.message, time: Date.now() })
-    _printDecisionTreeObj(req, decisionTree)
+    _printDecisionTreeObj(decisionTree, logger)
     throw new Error(`saveFileForMultihashToFS - ${e}`)
   }
 }
 
-const _printDecisionTreeObj = (req, decisionTree) => {
+const _printDecisionTreeObj = (decisionTree, logger) => {
   try {
-    req.logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
+    logger.info('saveFileForMultihashToFS decision tree', JSON.stringify(decisionTree))
   } catch (e) {
-    req.logger.error('error printing saveFileForMultihashToFS decision tree', decisionTree)
+    logger.error('error printing saveFileForMultihashToFS decision tree', decisionTree)
   }
 }
 

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -53,8 +53,12 @@ async function syncLockMiddleware (req, res, next) {
   next()
 }
 
-/** Blocks writes if node is not the primary for audiusUser associated with wallet. */
+/**
+ * Blocks writes if node is not the primary for audiusUser associated with wallet
+ */
 async function ensurePrimaryMiddleware (req, res, next) {
+  const serviceRegistry = req.app.get('serviceRegistry')
+
   if (config.get('isUserMetadataNode')) {
     return next()
   }

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -67,7 +67,7 @@ async function ensurePrimaryMiddleware (req, res, next) {
 
   let serviceEndpoint
   try {
-    serviceEndpoint = await getOwnEndpoint(req)
+    serviceEndpoint = await getOwnEndpoint(req.app.get('audiusLibs'))
   } catch (e) {
     return sendResponse(req, res, errorResponseServerError(e))
   }
@@ -75,7 +75,8 @@ async function ensurePrimaryMiddleware (req, res, next) {
   let creatorNodeEndpoints
   try {
     creatorNodeEndpoints = await getCreatorNodeEndpoints({
-      req,
+      libs: req.app.get('audiusLibs'),
+      logger: req.logger,
       wallet: req.session.wallet,
       blockNumber: req.body.blockNumber,
       ensurePrimary: true,
@@ -188,9 +189,9 @@ async function triggerSecondarySyncs (req) {
  *    services has been registered, and we can't register the service unless the service starts up.
  *    Bit of a chicken and egg problem here with timing of first time setup, but potential optimization here
  */
-async function getOwnEndpoint (req) {
+async function getOwnEndpoint (libs) {
   if (config.get('isUserMetadataNode')) throw new Error('Not available for userMetadataNode')
-  const libs = req.app.get('audiusLibs')
+  // const libs = req.app.get('audiusLibs')
 
   let creatorNodeEndpoint = config.get('creatorNodeEndpoint')
   if (!creatorNodeEndpoint) throw new Error('Must provide either creatorNodeEndpoint config var.')
@@ -227,7 +228,8 @@ async function getOwnEndpoint (req) {
  *      - Errors if retrieved primary does not match myCnodeEndpoint
  *    - If neither of above conditions are met, falls back to single discprov query without polling
  *
- * @param {Object} req - request object passed throughout route lifespan
+ * @param {Object} libs
+ * @param {Object} logger
  * @param {string} wallet - wallet used to query discprov for user data
  * @param {number} blockNumber - blocknumber of eth TX preceding CN call
  * @param {string} myCnodeEndpoint - endpoint of this CN
@@ -235,13 +237,13 @@ async function getOwnEndpoint (req) {
  *
  * @returns {Array} - array of strings of replica set
  */
-async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimary, myCnodeEndpoint }) {
+async function getCreatorNodeEndpoints ({ libs, logger, wallet, blockNumber, ensurePrimary, myCnodeEndpoint }) {
   if (config.get('isUserMetadataNode')) {
     throw new Error('Not available for userMetadataNode')
   }
 
-  req.logger.info(`Starting getCreatorNodeEndpoints for wallet ${wallet}`)
-  const libs = req.app.get('audiusLibs')
+  logger.info(`Starting getCreatorNodeEndpoints for wallet ${wallet}`)
+  // const libs = req.app.get('audiusLibs')
   const start = Date.now()
 
   let user = null
@@ -258,7 +260,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
 
     let discprovBlockNumber = -1
     for (let retry = 1; retry <= MaxRetries; retry++) {
-      req.logger.info(`getCreatorNodeEndpoints retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`)
+      logger.info(`getCreatorNodeEndpoints retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`)
 
       try {
         const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
@@ -274,11 +276,11 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
           break
         }
       } catch (e) { // Ignore all errors until MaxRetries exceeded.
-        req.logger.info(e)
+        logger.info(e)
       }
 
       await utils.timeout(RetryTimeout)
-      req.logger.info(`getCreatorNodeEndpoints AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`)
+      logger.info(`getCreatorNodeEndpoints AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`)
     }
 
     // Error if discprov doesn't return any user for wallet
@@ -295,7 +297,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
      * Else if ensurePrimary required, polls discprov until it has indexed myCnodeEndpoint (for up to 60 seconds)
      * Errors if retrieved primary does not match myCnodeEndpoint
      */
-    req.logger.info(`getCreatorNodeEndpoints || no blockNumber passed, retrying until DN returns same endpoint`)
+    logger.info(`getCreatorNodeEndpoints || no blockNumber passed, retrying until DN returns same endpoint`)
 
     const start2 = Date.now()
 
@@ -305,7 +307,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
 
     let returnedPrimaryEndpoint = null
     for (let retry = 1; retry <= MaxRetries; retry++) {
-      req.logger.info(`getCreatorNodeEndpoints retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
+      logger.info(`getCreatorNodeEndpoints retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
 
       try {
         const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
@@ -321,11 +323,11 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
           break
         }
       } catch (e) { // Ignore all errors until MaxRetries exceeded
-        req.logger.info(e)
+        logger.info(e)
       }
 
       await utils.timeout(RetryTimeout)
-      req.logger.info(`getCreatorNodeEndpoints AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
+      logger.info(`getCreatorNodeEndpoints AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${Date.now() - start2} myCnodeEndpoint ${myCnodeEndpoint}`)
     }
 
     // Error if discprov doesn't return any user for wallet
@@ -341,7 +343,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
     /**
      * If neither of above conditions are met, falls back to single discprov query without polling
      */
-    req.logger.info(`getCreatorNodeEndpoints || ensurePrimary === false, fetching user without retries`)
+    logger.info(`getCreatorNodeEndpoints || ensurePrimary === false, fetching user without retries`)
     user = await libs.User.getUsers(1, 0, null, wallet)
   }
 
@@ -352,7 +354,7 @@ async function getCreatorNodeEndpoints ({ req, wallet, blockNumber, ensurePrimar
   const endpoint = user[0]['creator_node_endpoint']
   const userReplicaSet = endpoint ? endpoint.split(',') : []
 
-  req.logger.info(`getCreatorNodeEndpoints route time ${Date.now() - start}`)
+  logger.info(`getCreatorNodeEndpoints route time ${Date.now() - start}`)
   return userReplicaSet
 }
 

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -142,15 +142,15 @@ const ipfsStat = (CID, logContext, timeout = 1000) => {
 
 /**
  * Call ipfs.cat on a path with optional timeout and length parameters
+ * @param {*} ipfs
+ * @param {*} logger
  * @param {*} path IPFS cid for file
- * @param {*} req request object
  * @param {*} timeout timeout for IPFS op in ms
  * @param {*} length length of data to retrieve from file
  * @returns {Buffer}
  */
-const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async (resolve, reject) => {
+const ipfsCat = (ipfs, logger, path, timeout = 1000, length = null) => new Promise(async (resolve, reject) => {
   const start = Date.now()
-  let ipfs = req.app.get('ipfsLatestAPI')
 
   try {
     let chunks = []
@@ -170,7 +170,7 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
     for await (const chunk of ipfs.cat(path, options)) {
       chunks.push(chunk)
     }
-    req.logger.debug(`ipfsCat - Retrieved ${path} in ${Date.now() - start}ms`)
+    logger.debug(`ipfsCat - Retrieved ${path} in ${Date.now() - start}ms`)
     resolve(Buffer.concat(chunks))
   } catch (e) {
     reject(e)
@@ -184,9 +184,8 @@ const ipfsCat = (path, req, timeout = 1000, length = null) => new Promise(async 
  * @param {Number} timeout timeout in ms
  * @returns {BufferListStream}
  */
-const ipfsGet = (path, req, timeout = 1000) => new Promise(async (resolve, reject) => {
+const ipfsGet = (ipfs, logger, path, timeout = 1000) => new Promise(async (resolve, reject) => {
   const start = Date.now()
-  let ipfs = req.app.get('ipfsLatestAPI')
 
   try {
     let chunks = []
@@ -211,7 +210,7 @@ const ipfsGet = (path, req, timeout = 1000) => new Promise(async (resolve, rejec
       }
       resolve(content)
     }
-    req.logger.info(`ipfsGet - Retrieved ${path} in ${Date.now() - start}ms`)
+    logger.info(`ipfsGet - Retrieved ${path} in ${Date.now() - start}ms`)
     resolve(Buffer.concat(chunks))
   } catch (e) {
     reject(e)

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -142,7 +142,7 @@ const ipfsStat = (CID, logContext, timeout = 1000) => {
 
 /**
  * Call ipfs.cat on a path with optional timeout and length parameters
- * @param {*} ipfs
+ * @param {*} serviceRegistry
  * @param {*} logger
  * @param {*} path IPFS cid for file
  * @param {*} timeout timeout for IPFS op in ms
@@ -179,8 +179,9 @@ const ipfsCat = ({ ipfsLatest }, logger, path, timeout = 1000, length = null) =>
 
 /**
  * Call ipfs.get on a path with an optional timeout
+ * @param {*} serviceRegistry
+ * @param {*} logger
  * @param {String} path IPFS cid for file
- * @param {Object} req request object
  * @param {Number} timeout timeout in ms
  * @returns {BufferListStream}
  */

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -149,7 +149,7 @@ const ipfsStat = (CID, logContext, timeout = 1000) => {
  * @param {*} length length of data to retrieve from file
  * @returns {Buffer}
  */
-const ipfsCat = (ipfs, logger, path, timeout = 1000, length = null) => new Promise(async (resolve, reject) => {
+const ipfsCat = ({ ipfsLatest }, logger, path, timeout = 1000, length = null) => new Promise(async (resolve, reject) => {
   const start = Date.now()
 
   try {
@@ -165,9 +165,9 @@ const ipfsCat = (ipfs, logger, path, timeout = 1000, length = null) => new Promi
       return reject(new Error('ipfsCat timed out'))
     }, 2 * timeout)
 
-    // ipfs.cat() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
+    // ipfsLatest.cat() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */
-    for await (const chunk of ipfs.cat(path, options)) {
+    for await (const chunk of ipfsLatest.cat(path, options)) {
       chunks.push(chunk)
     }
     logger.debug(`ipfsCat - Retrieved ${path} in ${Date.now() - start}ms`)
@@ -184,7 +184,7 @@ const ipfsCat = (ipfs, logger, path, timeout = 1000, length = null) => new Promi
  * @param {Number} timeout timeout in ms
  * @returns {BufferListStream}
  */
-const ipfsGet = (ipfs, logger, path, timeout = 1000) => new Promise(async (resolve, reject) => {
+const ipfsGet = ({ ipfsLatest }, logger, path, timeout = 1000) => new Promise(async (resolve, reject) => {
   const start = Date.now()
 
   try {
@@ -199,9 +199,9 @@ const ipfsGet = (ipfs, logger, path, timeout = 1000) => new Promise(async (resol
       return reject(new Error('ipfsGet timed out'))
     }, 2 * timeout)
 
-    // ipfs.get() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
+    // ipfsLatest.get() returns an AsyncIterator<Buffer> and its results are iterated over in a for-loop
     /* eslint-disable-next-line no-unused-vars */
-    for await (const file of ipfs.get(path, options)) {
+    for await (const file of ipfsLatest.get(path, options)) {
       if (!file.content) continue
 
       const content = new BufferListStream()

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -77,9 +77,11 @@ describe('test sync queue', function () {
       recurringSyncIds.push(id)
     }
     assert.strictEqual(recurringSyncIds.length, NumRecurringSyncsToAdd, `Failed to add ${NumRecurringSyncsToAdd} recurring syncs`)
+
+    // Assert on range instead of strict value due to non-deterministic timing (by design)
     let syncQueueJobs = await snapback.getSyncQueueJobs()
-    assert.strictEqual(syncQueueJobs.recurringActive.length, 0)
-    assert.strictEqual(syncQueueJobs.recurringWaiting.length, NumRecurringSyncsToAdd)
+    assert.ok(syncQueueJobs.recurringActive.length <= MaxRecurringRequestSyncJobConcurrency)
+    assert.ok(syncQueueJobs.recurringWaiting.length >= NumRecurringSyncsToAdd - MaxRecurringRequestSyncJobConcurrency)
 
     // Enqueue manual requestSync jobs
     const manualSyncIds = []
@@ -93,9 +95,11 @@ describe('test sync queue', function () {
       manualSyncIds.push(id)
     }
     assert.strictEqual(manualSyncIds.length, NumManualSyncsToAdd, `Failed to add ${NumManualSyncsToAdd} manual syncs`)
+
+    // Assert on range instead of strict value due to non-deterministic timing (by design)
     syncQueueJobs = await snapback.getSyncQueueJobs()
-    assert.strictEqual(syncQueueJobs.manualActive.length, 0)
-    assert.strictEqual(syncQueueJobs.manualWaiting.length, NumManualSyncsToAdd)
+    assert.ok(syncQueueJobs.manualActive.length <= MaxManualRequestSyncJobConcurrency)
+    assert.ok(syncQueueJobs.manualWaiting.length >= NumManualSyncsToAdd - MaxManualRequestSyncJobConcurrency)
 
     const totalJobsAddedCount = recurringSyncIds.length + manualSyncIds.length
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This work is a blocker for [moving sync to a bull queue](https://linear.app/audius/issue/AUD-529/move-sync-processing-to-bull-queue-off-main-process-distribute-across) - the function as is accepts a request object which doesn't work with the bull queue job processing pattern. This is also a terrible pattern we've established (largely my fault) so this is a nice forcing function to undo it.

[Every change is documented on this linear card](https://linear.app/audius/issue/AUD-529/move-sync-processing-to-bull-queue-off-main-process-distribute-across)

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

TODO
- [ ] automated tests

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
