### PR TITLE
Add more logging to indexing flow

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -340,7 +340,7 @@ def index_blocks(self, db, blocks_list):
 
             track_lexeme_state_changed = (user_state_changed or track_state_changed)
             session.commit()
-            logger.info(f"index.py | session commmited to db")
+            logger.info(f"index.py | session commmited to db for block=${block_number}")
 
             if user_state_changed:
                 if user_ids:
@@ -354,12 +354,12 @@ def index_blocks(self, db, blocks_list):
             if playlist_state_changed:
                 if playlist_ids:
                     remove_cached_playlist_ids(redis, playlist_ids)
-            logger.info(f"index.py | redis cache clean operations complete")
+            logger.info(f"index.py | redis cache clean operations complete for block=${block_number}")
 
         # add the block number of the most recently processed block to redis
         redis.set(most_recent_indexed_block_redis_key, block.number)
         redis.set(most_recent_indexed_block_hash_redis_key, block.hash.hex())
-        logger.info(f"index.py | update most recently processed block complete")
+        logger.info(f"index.py | update most recently processed block complete for block=${block_number}")
 
     if num_blocks > 0:
         logger.warning(f"index.py | index_blocks | Indexed {num_blocks} blocks")

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -279,7 +279,7 @@ def index_blocks(self, db, blocks_list):
             user_state_changed = total_user_changes > 0
             logger.info(
                 f"index.py | user_state_update completed"
-                f" user_state_changed={user_state_changed}"
+                f" user_state_changed={user_state_changed} for block={block_number}"
             )
 
             total_track_changes, track_ids = track_state_update(
@@ -288,7 +288,7 @@ def index_blocks(self, db, blocks_list):
             track_state_changed = total_track_changes > 0
             logger.info(
                 f"index.py | track_state_update completed"
-                f" track_state_changed={track_state_changed}"
+                f" track_state_changed={track_state_changed} for block={block_number}"
             )
 
             social_feature_state_changed = ( # pylint: disable=W0612
@@ -299,7 +299,7 @@ def index_blocks(self, db, blocks_list):
             )
             logger.info(
                 f"index.py | social_feature_state_update completed"
-                f" social_feature_state_changed={social_feature_state_changed}"
+                f" social_feature_state_changed={social_feature_state_changed} for block={block_number}"
             )
 
             # Index UserReplicaSet changes
@@ -317,7 +317,7 @@ def index_blocks(self, db, blocks_list):
             user_replica_set_state_changed = total_user_replica_set_changes > 0
             logger.info(
                 f"index.py | user_replica_set_state_update completed"
-                f" user_replica_set_state_changed={user_replica_set_state_changed}"
+                f" user_replica_set_state_changed={user_replica_set_state_changed} for block={block_number}"
             )
 
             # Playlist state operations processed in bulk
@@ -327,7 +327,7 @@ def index_blocks(self, db, blocks_list):
             playlist_state_changed = total_playlist_changes > 0
             logger.info(
                 f"index.py | playlist_state_update completed"
-                f" playlist_state_changed={playlist_state_changed}"
+                f" playlist_state_changed={playlist_state_changed} for block={block_number}"
             )
 
             user_library_state_changed = user_library_state_update( # pylint: disable=W0612
@@ -335,7 +335,7 @@ def index_blocks(self, db, blocks_list):
             )
             logger.info(
                 f"index.py | user_library_state_update completed"
-                f" user_library_state_changed={user_library_state_changed}"
+                f" user_library_state_changed={user_library_state_changed} for block={block_number}"
             )
 
             track_lexeme_state_changed = (user_state_changed or track_state_changed)

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -64,10 +64,10 @@ def playlist_state_update(
 
             num_total_changes += processedEntries
 
-    logger.info(f"[playlist indexing] There are {num_total_changes} events processed.")
+    logger.info(f"index.py | playlists.py | There are {num_total_changes} events processed.")
 
     for playlist_id, value_obj in playlist_events_lookup.items():
-        logger.info(f"playlists.py | Adding {value_obj['playlist']})")
+        logger.info(f"index.py | playlists.py | Adding {value_obj['playlist']})")
         if value_obj["events"]:
             invalidate_old_playlist(session, playlist_id)
             session.add(value_obj["playlist"])
@@ -140,7 +140,7 @@ def parse_playlist_event(
     block_integer_time = int(block_timestamp)
 
     if event_type == playlist_event_types_lookup["playlist_created"]:
-        logger.info(f"[playlist_created] | Creating playlist {playlist_record.playlist_id}")
+        logger.info(f"index.py | playlists.py | Creating playlist {playlist_record.playlist_id}")
         playlist_record.playlist_owner_id = event_args._playlistOwnerId
         playlist_record.is_private = event_args._isPrivate
         playlist_record.is_album = event_args._isAlbum
@@ -155,12 +155,12 @@ def parse_playlist_event(
         playlist_record.created_at = block_datetime
 
     if event_type == playlist_event_types_lookup["playlist_deleted"]:
-        logger.info(f"[playlist_deleted] | Deleting playlist {playlist_record.playlist_id}")
+        logger.info(f"index.py | playlists.py | Deleting playlist {playlist_record.playlist_id}")
         playlist_record.is_delete = True
 
     if event_type == playlist_event_types_lookup["playlist_track_added"]:
         if getattr(playlist_record, 'playlist_contents') is not None:
-            logger.info(f"[playlist_track_added] | Adding track {event_args._addedTrackId} to playlist \
+            logger.info(f"index.py | playlists.py | Adding track {event_args._addedTrackId} to playlist \
             {playlist_record.playlist_id}")
             old_playlist_content_array = playlist_record.playlist_contents["track_ids"]
             new_playlist_content_array = old_playlist_content_array
@@ -173,7 +173,7 @@ def parse_playlist_event(
 
     if event_type == playlist_event_types_lookup["playlist_track_deleted"]:
         if getattr(playlist_record, 'playlist_contents') is not None:
-            logger.info(f"[playlist_track_deleted] | Removing track {event_args._deletedTrackId} from \
+            logger.info(f"index.py | playlists.py | Removing track {event_args._deletedTrackId} from \
             playlist {playlist_record.playlist_id}")
             old_playlist_content_array = playlist_record.playlist_contents["track_ids"]
             new_playlist_content_array = []
@@ -192,7 +192,7 @@ def parse_playlist_event(
 
     if event_type == playlist_event_types_lookup["playlist_tracks_ordered"]:
         if getattr(playlist_record, 'playlist_contents') is not None:
-            logger.info(f"[playlist_tracks_ordered] | Ordering playlist {playlist_record.playlist_id}")
+            logger.info(f"index.py | playlists.py | Ordering playlist {playlist_record.playlist_id}")
             old_playlist_content_array = playlist_record.playlist_contents["track_ids"]
 
             intermediate_track_time_lookup_dict = {}
@@ -220,12 +220,12 @@ def parse_playlist_event(
             playlist_record.playlist_contents = {"track_ids": playlist_content_array}
 
     if event_type == playlist_event_types_lookup["playlist_name_updated"]:
-        logger.info(f"[playlist_name_updated] | Updating playlist {playlist_record.playlist_id} name \
+        logger.info(f"index.py | playlists.py | Updating playlist {playlist_record.playlist_id} name \
         to {event_args._updatedPlaylistName}")
         playlist_record.playlist_name = event_args._updatedPlaylistName
 
     if event_type == playlist_event_types_lookup["playlist_privacy_updated"]:
-        logger.info(f"[playlist_privacy_updated] | Updating playlist {playlist_record.playlist_id} \
+        logger.info(f"index.py | playlists.py | Updating playlist {playlist_record.playlist_id} \
         privacy to {event_args._updatedIsPrivate}")
         playlist_record.is_private = event_args._updatedIsPrivate
 
@@ -238,7 +238,7 @@ def parse_playlist_event(
         is_blacklisted = is_blacklisted_ipld(session, playlist_record.playlist_image_multihash)
         if is_blacklisted:
             logger.info(
-                "[playlist_cover_photo_updated] | Encountered blacklisted CID %s in indexing \
+                "index.py | playlists.py | Encountered blacklisted CID %s in indexing \
                 playlist image multihash",
                 playlist_record.playlist_image_multihash
             )
@@ -246,18 +246,18 @@ def parse_playlist_event(
 
         # All incoming playlist images are set to ipfs dir in column playlist_image_sizes_multihash
         if playlist_record.playlist_image_multihash:
-            logger.info(f"[playlist_cover_photo_updated] | Processing playlist image \
+            logger.info(f"index.py | playlists.py | Processing playlist image \
             {playlist_record.playlist_image_multihash}")
             playlist_record.playlist_image_sizes_multihash = playlist_record.playlist_image_multihash
             playlist_record.playlist_image_multihash = None
 
     if event_type == playlist_event_types_lookup["playlist_description_updated"]:
-        logger.info(f"[playlist_description_updated] | Updating playlist {playlist_record.playlist_id} \
+        logger.info(f"index.py | playlists.py | Updating playlist {playlist_record.playlist_id} \
         description to {event_args._playlistDescription}")
         playlist_record.description = event_args._playlistDescription
 
     if event_type == playlist_event_types_lookup["playlist_upc_updated"]:
-        logger.info(f"[playlist_upc_updated] | Updating playlist {playlist_record.playlist_id} UPC \
+        logger.info(f"index.py | playlists.py | Updating playlist {playlist_record.playlist_id} UPC \
         to {event_args._playlistUPC}")
         playlist_record.upc = helpers.bytes32_to_str(event_args._playlistUPC)
 

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -75,11 +75,11 @@ def track_state_update(self, update_task, session, track_factory_txs, block_numb
 
             num_total_changes += processedEntries
 
-    logger.info(f"[track indexing] There are {num_total_changes} events processed.")
+    logger.info(f"index.py | tracks.py | [track indexing] There are {num_total_changes} events processed.")
 
     for track_id, value_obj in track_events.items():
         if value_obj['events']:
-            logger.info(f"tracks.py | Adding {value_obj['track']}")
+            logger.info(f"index.py | tracks.py | Adding {value_obj['track']}")
             invalidate_old_track(session, track_id)
             session.add(value_obj["track"])
 
@@ -182,12 +182,15 @@ def parse_track_event(
             bytes.fromhex(track_metadata_digest), track_metadata_hash_fn
         )
         track_metadata_multihash = multihash.to_b58_string(buf)
-        logger.info(f"track metadata ipld : {track_metadata_multihash}")
+        logger.info(f"index.py | tracks.py | track metadata ipld : {track_metadata_multihash}")
 
         # If the IPLD is blacklisted, do not keep processing the current entry
         # continue with the next entry in the update_track_events list
         if is_blacklisted_ipld(session, track_metadata_multihash):
-            logger.info(f"Encountered blacklisted metadata CID {track_metadata_multihash} in indexing new track")
+            logger.info(
+                f"index.py | tracks.py | Encountered blacklisted metadata CID:"
+                f"{track_metadata_multihash} in indexing new track"
+            )
             return None
 
         owner_id = event_args._trackOwnerId
@@ -217,10 +220,13 @@ def parse_track_event(
         if track_record.cover_art:
             # If CID is in IPLD blacklist table, do not continue with indexing
             if is_blacklisted_ipld(session, track_record.cover_art):
-                logger.info(f"Encountered blacklisted cover art CID {track_record.cover_art} in indexing new track")
+                logger.info(
+                    f"index.py | tracks.py | Encountered blacklisted cover art CID:"
+                    f"{track_record.cover_art} in indexing new track"
+                )
                 return None
 
-            logger.warning(f"tracks.py | Processing track cover art {track_record.cover_art}")
+            logger.warning(f"index.py | tracks.py | Processing track cover art {track_record.cover_art}")
             track_record.cover_art_sizes = track_record.cover_art
             track_record.cover_art = None
 
@@ -234,12 +240,15 @@ def parse_track_event(
             bytes.fromhex(upd_track_metadata_digest), upd_track_metadata_hash_fn
         )
         upd_track_metadata_multihash = multihash.to_b58_string(update_buf)
-        logger.info(f"update track metadata ipld : {upd_track_metadata_multihash}")
+        logger.info(f"index.py | tracks.py | update track metadata ipld : {upd_track_metadata_multihash}")
 
         # If the IPLD is blacklisted, do not keep processing the current entry
         # continue with the next entry in the update_track_events list
         if is_blacklisted_ipld(session, upd_track_metadata_multihash):
-            logger.info(f"Encountered blacklisted metadata CID {upd_track_metadata_multihash} in indexing update track")
+            logger.info(
+                f"index.py | tracks.py | Encountered blacklisted metadata CID:"
+                f"{upd_track_metadata_multihash} in indexing update track"
+            )
             return None
 
         owner_id = event_args._trackOwnerId
@@ -270,10 +279,13 @@ def parse_track_event(
         if track_record.cover_art:
             # If CID is in IPLD blacklist table, do not continue with indexing
             if is_blacklisted_ipld(session, track_record.cover_art):
-                logger.info(f"Encountered blacklisted cover art CID {track_record.cover_art} in indexing update track")
+                logger.info(
+                    f"index.py | tracks.py | Encountered blacklisted cover art CID:"
+                    f"{track_record.cover_art} in indexing update track"
+                )
                 return None
 
-            logger.info(f"tracks.py | Processing track cover art {track_record.cover_art}")
+            logger.info(f"index.py | tracks.py | Processing track cover art {track_record.cover_art}")
             track_record.cover_art_sizes = track_record.cover_art
             track_record.cover_art = None
 
@@ -283,7 +295,7 @@ def parse_track_event(
         track_record.is_delete = True
         track_record.stem_of = null()
         track_record.remix_of = null()
-        logger.info(f"Removing track : {track_record.track_id}")
+        logger.info(f"index.py | tracks.py | Removing track : {track_record.track_id}")
 
     track_record.updated_at = block_datetime
 

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -116,12 +116,12 @@ def user_replica_set_state_update(
     # for each record in user_replica_set_events_lookup, invalidate the old record and add the new record
     # we do this after all processing has completed so the user record is atomic by block, not tx
     for user_id, value_obj in user_replica_set_events_lookup.items():
-        logger.info(f"user_replica_set.py | Replica Set Processing Adding {value_obj['user']}")
+        logger.info(f"index.py | user_replica_set.py | Replica Set Processing Adding {value_obj['user']}")
         invalidate_old_user(session, user_id)
         session.add(value_obj["user"])
 
     for content_node_id, value_obj in cnode_events_lookup.items():
-        logger.info(f"user_replica_set.py | Content Node Processing Adding {value_obj['content_node']}")
+        logger.info(f"index.py | user_replica_set.py | Content Node Processing Adding {value_obj['content_node']}")
         invalidate_old_cnode_record(session, content_node_id)
         session.add(value_obj["content_node"])
 
@@ -160,13 +160,17 @@ def get_endpoint_string_from_sp_ids(
             )
             # Conditionally log if endpoint is None after fetching
             if not secondary_endpoint:
-                logger.info(f"user_replica_set.py | Failed to find secondary info for {secondary_id}")
+                logger.info(f"index.py | user_replica_set.py | Failed to find secondary info for {secondary_id}")
             # Append to endpoint string regardless of status
             endpoint_string = f"{endpoint_string},{secondary_endpoint}"
     except Exception as exc:
-        logger.error(f"user_replica_set.py | ERROR in get_endpoint_string_from_sp_ids {exc}")
+        logger.error(f"index.py | user_replica_set.py | ERROR in get_endpoint_string_from_sp_ids {exc}")
         raise exc
-    logger.info(f"user_replica_set.py | constructed {endpoint_string} from {primary},{secondaries}", exc_info=True)
+    logger.info(
+        f"index.py | user_replica_set.py | constructed:"
+        f"{endpoint_string} from {primary},{secondaries}",
+        exc_info=True
+    )
     return endpoint_string
 
 # Helper function to query endpoint in ursm cnode record parsing
@@ -180,7 +184,7 @@ def get_ursm_cnode_endpoint(update_task, sp_id):
             sp_id
         )
     except Exception as exc:
-        logger.error(f"user_replica_set.py | ERROR in get_ursm_cnode_endpoint {exc}", exc_info=True)
+        logger.error(f"index.py | user_replica_set.py | ERROR in get_ursm_cnode_endpoint {exc}", exc_info=True)
         raise exc
     return endpoint
 
@@ -194,11 +198,11 @@ def get_endpoint_from_id(update_task, sp_factory_inst, sp_id):
     sp_info_cached = get_pickled_key(update_task.redis, cache_key)
     if sp_info_cached:
         endpoint = sp_info_cached[1]
-        logger.info(f"user_replica_set.py | CACHE HIT FOR {cache_key}, found {sp_info_cached}")
+        logger.info(f"index.py | user_replica_set.py | CACHE HIT FOR {cache_key}, found {sp_info_cached}")
         return sp_factory_inst, endpoint
 
     if not endpoint:
-        logger.info(f"user_replica_set.py | CACHE MISS FOR {cache_key}, found {sp_info_cached}")
+        logger.info(f"index.py | user_replica_set.py | CACHE MISS FOR {cache_key}, found {sp_info_cached}")
         if sp_factory_inst is None:
             sp_factory_inst = get_sp_factory_inst(update_task)
 
@@ -206,7 +210,7 @@ def get_endpoint_from_id(update_task, sp_factory_inst, sp_id):
             content_node_service_type,
             sp_id
         ).call()
-        logger.info(f"user_replica_set.py | spID={sp_id} fetched {cn_endpoint_info}")
+        logger.info(f"index.py | user_replica_set.py | spID={sp_id} fetched {cn_endpoint_info}")
         endpoint = cn_endpoint_info[1]
 
     return sp_factory_inst, endpoint

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -73,12 +73,12 @@ def user_state_update(self, update_task, session, user_factory_txs, block_number
 
             num_total_changes += processedEntries
 
-    logger.info(f"[users indexing] There are {num_total_changes} events processed.")
+    logger.info(f"index.py | users.py | There are {num_total_changes} events processed.")
 
     # for each record in user_events_lookup, invalidate the old record and add the new record
     # we do this after all processing has completed so the user record is atomic by block, not tx
     for user_id, value_obj in user_events_lookup.items():
-        logger.info(f"users.py | Adding {value_obj['user']}")
+        logger.info(f"index.py | users.py | Adding {value_obj['user']}")
         if value_obj["events"]:
             invalidate_old_user(session, user_id)
             session.add(value_obj["user"])
@@ -153,7 +153,10 @@ def parse_user_event(
         is_blacklisted = is_blacklisted_ipld(session, metadata_multihash)
         # If cid is in blacklist, do not update user
         if is_blacklisted:
-            logger.info(f"Encountered blacklisted CID {metadata_multihash} in indexing update user metadata multihash")
+            logger.info(
+                f"index.py | users.py | Encountered blacklisted CID:"
+                f"{metadata_multihash} in indexing update user metadata multihash"
+            )
             return None
         user_record.metadata_multihash = metadata_multihash
     elif event_type == user_event_types_lookup["update_name"]:
@@ -166,14 +169,20 @@ def parse_user_event(
         profile_photo_multihash = helpers.multihash_digest_to_cid(event_args._profilePhotoDigest)
         is_blacklisted = is_blacklisted_ipld(session, profile_photo_multihash)
         if is_blacklisted:
-            logger.info(f"Encountered blacklisted CID {profile_photo_multihash} in indexing update user profile photo")
+            logger.info(
+                f"index.py | users.py | Encountered blacklisted CID:"
+                f"{profile_photo_multihash} in indexing update user profile photo"
+            )
             return None
         user_record.profile_picture = profile_photo_multihash
     elif event_type == user_event_types_lookup["update_cover_photo"]:
         cover_photo_multihash = helpers.multihash_digest_to_cid(event_args._coverPhotoDigest)
         is_blacklisted = is_blacklisted_ipld(session, cover_photo_multihash)
         if is_blacklisted:
-            logger.info(f"Encountered blacklisted CID {cover_photo_multihash} in indexing update user cover photo")
+            logger.info(
+                f"index.py | users.py | Encountered blacklisted CID:"
+                f"{cover_photo_multihash} in indexing update user cover photo"
+            )
             return None
         user_record.cover_photo = cover_photo_multihash
     elif event_type == user_event_types_lookup["update_is_creator"]:
@@ -185,7 +194,7 @@ def parse_user_event(
         # legacy `creator_node_endpoint` changes
         # Reference user_replica_set.py for the updated indexing flow around this field
         replica_set_upgraded = user_replica_set_upgraded(user_record)
-        logger.info(f"users.py | {user_record.handle} Replica set upgraded: {replica_set_upgraded}")
+        logger.info(f"index.py | users.py | {user_record.handle} Replica set upgraded: {replica_set_upgraded}")
         if not replica_set_upgraded:
             user_record.creator_node_endpoint = event_args._creatorNodeEndpoint
 
@@ -246,14 +255,14 @@ def parse_user_event(
     # All incoming profile photos intended to be a directory
     # Any write to profile_picture field is replaced by profile_picture_sizes
     if user_record.profile_picture:
-        logger.info(f"users.py | Processing user profile_picture {user_record.profile_picture}")
+        logger.info(f"index.py | users.py | Processing user profile_picture {user_record.profile_picture}")
         user_record.profile_picture_sizes = user_record.profile_picture
         user_record.profile_picture = None
 
     # All incoming cover photos intended to be a directory
     # Any write to cover_photo field is replaced by cover_photo_sizes
     if user_record.cover_photo:
-        logger.info(f"users.py | Processing user cover photo {user_record.cover_photo}")
+        logger.info(f"index.py | users.py | Processing user cover photo {user_record.cover_photo}")
         user_record.cover_photo_sizes = user_record.cover_photo
         user_record.cover_photo = None
     return user_record
@@ -324,7 +333,7 @@ def update_user_associated_wallets(session, update_task, user_record, associated
         if is_updated_wallets:
             enqueue_balance_refresh(update_task.redis, [user_record.user_id])
     except Exception as e:
-        logger.error(f"Fatal updating user associated wallets while indexing {e}", exc_info=True)
+        logger.error(f"index.py | users.py | Fatal updating user associated wallets while indexing {e}", exc_info=True)
 
 
 def recover_user_id_hash(web3, user_id, signature):
@@ -342,7 +351,7 @@ def get_ipfs_metadata(update_task, user_record):
             user_metadata_format,
             user_record.creator_node_endpoint
         )
-        logger.info(f'users.py | {user_metadata}')
+        logger.info(f'index.py | users.py | {user_metadata}')
     return user_metadata
 
 # Determine whether this user has identity established on the UserReplicaSetManager contract


### PR DESCRIPTION
### Description
Add more logs to the indexing flow. This also allows us to benchmark the time taken by each stage.



### Tests
Ran this both locally and on stage and observed the logs 

```
{"levelno": 20, "level": "INFO", "msg": "index.py | update_task | 2440d900-8fc9-43ae-8c0b-3075467ecffe | Processing complete within session", "timestamp": "2021-04-16 00:17:25,958"}
{"levelno": 20, "level": "INFO", "msg": "Task update_discovery_provider[2440d900-8fc9-43ae-8c0b-3075467ecffe] succeeded in 0.24119906034320593s: None", "timestamp": "2021-04-16 00:17:25,958", "data": {"id": "2440d900-8fc9-43ae-8c0b-3075467ecffe", "name": "update_discovery_provider", "return_value": "None", "runtime": 0.24119906034320593}}
{"levelno": 20, "level": "INFO", "msg": "Received task: update_network_peers[719cecc4-ed32-4c46-bd1c-d52eab2c4521]  ", "timestamp": "2021-04-16 00:17:30,712"}
{"levelno": 20, "level": "INFO", "msg": "Received task: update_discovery_provider[65118dbe-8afe-47c9-b793-a733c1157633]  ", "timestamp": "2021-04-16 00:17:30,715"}
{"levelno": 20, "level": "INFO", "msg": "index.py | 65118dbe-8afe-47c9-b793-a733c1157633 | update_task | Acquired disc_prov_lock", "timestamp": "2021-04-16 00:17:30,755"}
{"levelno": 20, "level": "INFO", "msg": "index.py | get_latest_block | current=20408955 target=20408956", "timestamp": "2021-04-16 00:17:30,828"}
{"levelno": 20, "level": "INFO", "msg": "index.py | update_task | Intersect_blockhash : 0x13490ed10316b48d888df6b85f56c6e9bb5abaefc30f1d64a6a9fc5544214b48", "timestamp": "2021-04-16 00:17:30,896"}
{"levelno": 20, "level": "INFO", "msg": "index.py | index_blocks | 65118dbe-8afe-47c9-b793-a733c1157633 | block 20408956 - 1/1", "timestamp": "2021-04-16 00:17:30,897"}
{"levelno": 20, "level": "INFO", "msg": "index.py | TrackFactory contract addr: 0x465b78A7E3e549ac98953F78e697AAaEefEC53Fa tx from block - AttributeDict({'blockHash': HexBytes('0xc1c070dc718f36dbf4a422fb911efc4ebd0e1463e3bffb61884afd13d6313d6a'), 'blockNumber': 20408956, 'chainId': None, 'condition': None, 'creates': None, 'from': '0xaaaa90Fc2bfa70028D6b444BB9754066d9E2703b', 'gas': 163899, 'gasPrice': 10000000000, 'hash': HexBytes('0x64a55723a3bfce11d284829f84fa27ce9b63deac18b23791ccf7b64f47eeba13'), 'input': '0x549a712d0000000000000000000000000000000000000000000000000000000000000001485b7d925f0bc1306d3daf2969b45fc26971366a054c207e70968d395d3cd68500000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000020ddb2a7d7986b8a3b892ab07ccd3735b626ce830a3214639ca50a33c57ccfc41200000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000041d2c010fb9d4f8dc6eb855788b44e499031b3ea1904cd7fbc75f7b15890e6d30e5cee530c55dedf8b13ea2daf7385c4c6208833e97a00d008ced68e7d09603bb81c00000000000000000000000000000000000000000000000000000000000000', 'nonce': 369847, 'publicKey': HexBytes('0xc4d750e917746bc855de7a389c43c404d39c389d35da34c16ea9437fc46d3d3ceb4dbfcd6a928669a07e087398b944a4bb8154450bccb5e032500503ae4a7acb'), 'r': HexBytes('0x14545e1ba75e2356c3b15a3b44b75c9095dbab4e0b668c98449946f508089479'), 'raw': HexBytes('0xf901ae8305a4b78502540be4008302803b94465b78a7e3e549ac98953f78e697aaaeefec53fa80b90144549a712d0000000000000000000000000000000000000000000000000000000000000001485b7d925f0bc1306d3daf2969b45fc26971366a054c207e70968d395d3cd68500000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000020ddb2a7d7986b8a3b892ab07ccd3735b626ce830a3214639ca50a33c57ccfc41200000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000041d2c010fb9d4f8dc6eb855788b44e499031b3ea1904cd7fbc75f7b15890e6d30e5cee530c55dedf8b13ea2daf7385c4c6208833e97a00d008ced68e7d09603bb81c000000000000000000000000000000000000000000000000000000000000001ca014545e1ba75e2356c3b15a3b44b75c9095dbab4e0b668c98449946f508089479a005440e49c7a45e2fa11ea026a5353d672c800bf2ccb51f38394a83a13312fd23'), 's': HexBytes('0x05440e49c7a45e2fa11ea026a5353d672c800bf2ccb51f38394a83a13312fd23'), 'standardV': 1, 'to': '0x465b78A7E3e549ac98953F78e697AAaEefEC53Fa', 'transactionIndex': 0, 'v': 28, 'value': 0}), receipt - AttributeDict({'blockHash': HexBytes('0xc1c070dc718f36dbf4a422fb911efc4ebd0e1463e3bffb61884afd13d6313d6a'), 'blockNumber': 20408956, 'contractAddress': None, 'cumulativeGasUsed': 156094, 'from': '0xaaaa90Fc2bfa70028D6b444BB9754066d9E2703b', 'gasUsed': 156094, 'logs': [AttributeDict({'address': '0x465b78A7E3e549ac98953F78e697AAaEefEC53Fa', 'blockHash': HexBytes('0xc1c070dc718f36dbf4a422fb911efc4ebd0e1463e3bffb61884afd13d6313d6a'), 'blockNumber': 20408956, 'data': '0x00000000000000000000000000000000000000000000000000000000000032a20000000000000000000000000000000000000000000000000000000000000001485b7d925f0bc1306d3daf2969b45fc26971366a054c207e70968d395d3cd68500000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000020', 'logIndex': 0, 'removed': False, 'topics': [HexBytes('0x8e687115e7e80f8142cbe3e2ef071123ae6dfa4dcd1840207333058b678e2c60')], 'transactionHash': HexBytes('0x64a55723a3bfce11d284829f84fa27ce9b63deac18b23791ccf7b64f47eeba13'), 'transactionIndex': 0, 'transactionLogIndex': '0x0', 'type': 'mined'})], 'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000400200000000000000000000000000000000000000000000000000000000000000000000800000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000'), 'status': 1, 'to': '0x465b78A7E3e549ac98953F78e697AAaEefEC53Fa', 'transactionHash': HexBytes('0x64a55723a3bfce11d284829f84fa27ce9b63deac18b23791ccf7b64f47eeba13'), 'transactionIndex': 0})", "timestamp": "2021-04-16 00:17:30,934"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_state_update completed user_state_changed=False", "timestamp": "2021-04-16 00:17:30,934"}
{"levelno": 20, "level": "INFO", "msg": "index.py | tracks.py | track metadata ipld : QmTD6yhmJZWtR6Bt9RuAm4GCQFzZXCfnz4bEU3PPZifWZr", "timestamp": "2021-04-16 00:17:30,989"}
{"levelno": 30, "level": "WARNING", "msg": "IPFSCLIENT | get_metadata - QmTD6yhmJZWtR6Bt9RuAm4GCQFzZXCfnz4bEU3PPZifWZr", "timestamp": "2021-04-16 00:17:30,997"}
{"levelno": 20, "level": "INFO", "msg": "IPFSCLIENT | Retrieved QmTD6yhmJZWtR6Bt9RuAm4GCQFzZXCfnz4bEU3PPZifWZr from ipfs node", "timestamp": "2021-04-16 00:17:31,056"}
{"levelno": 20, "level": "INFO", "msg": "IPFSCLIENT | get_metadata $QmTD6yhmJZWtR6Bt9RuAm4GCQFzZXCfnz4bEU3PPZifWZr 0.06060338020324707 seconds                 | from ipfs:True |from gateway:False", "timestamp": "2021-04-16 00:17:31,059"}
{"levelno": 30, "level": "WARNING", "msg": "Validation: Setting the default value NULL for field stem_of of type ['object', 'null'] because of error: Instance {'stem_of': <sqlalchemy.sql.elements.Null object at 0x7fb4af4f2400>} is not proper. Errors: [\"<sqlalchemy.sql.elements.Null object at 0x7fb4af4f2400> is not of type 'object', 'null'\"]", "timestamp": "2021-04-16 00:17:31,078"}
{"levelno": 30, "level": "WARNING", "msg": "Validation: Setting the default value NULL for field remix_of of type ['object', 'null'] because of error: Instance {'remix_of': <sqlalchemy.sql.elements.Null object at 0x7fb4af4f2400>} is not proper. Errors: [\"<sqlalchemy.sql.elements.Null object at 0x7fb4af4f2400> is not of type 'object', 'null'\"]", "timestamp": "2021-04-16 00:17:31,080"}
{"levelno": 30, "level": "WARNING", "msg": "index.py | tracks.py | Processing track cover art Qmakv2dNjM74kVbk53JTsFzqazDSbcRzSgt3pn8eHLyBGw", "timestamp": "2021-04-16 00:17:31,087"}
{"levelno": 30, "level": "WARNING", "msg": "/usr/local/lib/python3.8/site-packages/web3/contract.py:1153: UserWarning: The log with transaction hash: b\"d\\xa5W#\\xa3\\xbf\\xce\\x11\\xd2\\x84\\x82\\x9f\\x84\\xfa'\\xce\\x9bc\\xde\\xac\\x18\\xb27\\x91\\xcc\\xf7\\xb6OG\\xee\\xba\\x13\" and logIndex: 0 encountered the following error during processing: MismatchedABI(The event signature did not match the provided ABI). It has been discarded.\n  warnings.warn(", "timestamp": "2021-04-16 00:17:31,092"}
{"levelno": 20, "level": "INFO", "msg": "index.py | tracks.py | [track indexing] There are 1 events processed.", "timestamp": "2021-04-16 00:17:31,093"}
{"levelno": 20, "level": "INFO", "msg": "index.py | tracks.py | Adding <Track(blockhash=0xc1c070dc718f36dbf4a422fb911efc4ebd0e1463e3bffb61884afd13d6313d6a,blocknumber=20408956,txhash=0x64a55723a3bfce11d284829f84fa27ce9b63deac18b23791ccf7b64f47eeba13,track_id=12962,is_current=True,is_delete=False,owner_id=1,route_id=dheeraj1/january,title=January,length=0,cover_art=None,cover_art_sizes=Qmakv2dNjM74kVbk53JTsFzqazDSbcRzSgt3pn8eHLyBGw,tags=None,genre=Experimental,mood=None,credits_splits=None,remix_of=NULL,create_date=None,release_date=Thu Apr 15 2021 20:17:05 GMT-0400,file_type=None,description=None,license=All rights reserved,isrc=None,iswc=None,track_segments=[{'multihash': 'QmaUotUZ7RejcSDXHRcbs4XewahJyd1GvcmDuu7PSv4LDz', 'duration': 6.016}, {'multihash': 'QmT2kuzVd1zBPjTn3tkWTHj8nZoUmfPmV8TD8jEmNnTTQP', 'duration': 5.994667}, {'multihash': 'QmUeBAwJTsSMY22v21JxupuurKJWxnqNomfLSRX1q5n9JJ', 'duration': 5.994667}, {'multihash': 'QmV3nsJyZtFVEsASuDzMyoaPiJsehd4c4uCfezbyjxAnFC', 'duration': 5.994667}, {'multihash': 'QmXXNSbm4hsTH2ZeC4QcS8BV1pjcAXKRjSLD2tRtfkbUWy', 'duration': 6.016}, {'multihash': 'QmUHNe57TFt7PDiqzZweXtbU83S4W5DiiecBhNDS8UnXdd', 'duration': 5.994667}, {'multihash': 'QmYM73wYAxYiQCAw2MvKZcHSF8cgac3Bw6gh5twrVhsQNW', 'duration': 5.994667}, {'multihash': 'QmZHUktrLSfMbMNJTXdfDRQUhL1Wcsjx7spRPFDtLwE62S', 'duration': 5.994667}, {'multihash': 'QmYhHciw3vSYaHYWyhJY941W8aG9NLoD9rKt7RC6c9XAXW', 'duration': 6.016}, {'multihash': 'QmdCUG8rvoLEnLs4kBS9gXb1AxAnFk3adFdYqCtTHzuhmR', 'duration': 5.994667}, {'multihash': 'Qmb3jLaX8ctsGcnDhUwZwhCJyEQZt8UbGV7is73dgn2kdM', 'duration': 5.994667}, {'multihash': 'QmP5onHXKSHDg8qpmYgvFY2qKb7Qk62MZveR4M9fSd5ZZj', 'duration': 5.994667}, {'multihash': 'QmXsQJbeq6FmVHHzNxuhVNWXPoirMTJ1AunZnHGYbHVnGN', 'duration': 6.016}, {'multihash': 'QmUNLjLRcMvsgXnNQRxrXqxQ397Nr1UeNJgb7fwuNEfq5c', 'duration': 5.994667}, {'multihash': 'QmVRz6ks4yLZjaR58Uhje6QwVbHkBiY54imaRFAdzq31q4', 'duration': 5.994667}, {'multihash': 'QmQYxNn3iARSM7rq1xcQfr5mCUNtyEMAnA6hyf5Zzs9YDa', 'duration': 5.994667}, {'multihash': 'QmNtgmJmEwdc4VkTjX5nVkaJpJdSZ1BekKxyQdcD3hxmqJ', 'duration': 6.016}, {'multihash': 'QmfHkA8TuC66FJy8Dq7bvJC4pbFzGo6EyZ1igbp591Bbxo', 'duration': 5.994667}, {'multihash': 'QmaecduTZPa9DkXTpBR7R6k9LPBH5LD5heoDuGwt5MFxYm', 'duration': 5.994667}, {'multihash': 'QmTYAStiaULSZXQx3dmcwq9F2qW9AafdkrNBiXmJWUY49r', 'duration': 5.994667}, {'multihash': 'QmNVnZAxdS1zrtXfhk2KSww7QqngP59UnhWpyJmzfrmBhf', 'duration': 0.028933}],metadata_multihash=QmTD6yhmJZWtR6Bt9RuAm4GCQFzZXCfnz4bEU3PPZifWZr,download={'is_downloadable': False, 'requires_follow': False, 'cid': None},updated_at=2021-04-16 00:17:30,created_at=2021-04-16 00:17:30,stem_of=NULL)>", "timestamp": "2021-04-16 00:17:31,093"}
{"levelno": 20, "level": "INFO", "msg": "index.py | track_state_update completed track_state_changed=True", "timestamp": "2021-04-16 00:17:31,103"}
{"levelno": 20, "level": "INFO", "msg": "index.py | social_feature_state_update completed social_feature_state_changed=False", "timestamp": "2021-04-16 00:17:31,103"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_replica_set_state_update completed user_replica_set_state_changed=False", "timestamp": "2021-04-16 00:17:31,104"}
{"levelno": 20, "level": "INFO", "msg": "index.py | playlist_state_update completed playlist_state_changed=False", "timestamp": "2021-04-16 00:17:31,104"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_library_state_update completed user_library_state_changed=0", "timestamp": "2021-04-16 00:17:31,104"}
{"levelno": 20, "level": "INFO", "msg": "index.py | session commmited to db", "timestamp": "2021-04-16 00:17:31,114"}
{"levelno": 20, "level": "INFO", "msg": "index.py | redis cache clean operations complete", "timestamp": "2021-04-16 00:17:31,115"}
{"levelno": 20, "level": "INFO", "msg": "index.py | update most recently processed block complete", "timestamp": "2021-04-16 00:17:31,119"}
{"levelno": 30, "level": "WARNING", "msg": "index.py | index_blocks | Indexed 1 blocks", "timestamp": "2021-04-16 00:17:31,119"}
{"levelno": 20, "level": "INFO", "msg": "index.py | update_task | 65118dbe-8afe-47c9-b793-a733c1157633 | Processing complete within session", "timestamp": "2021-04-16 00:17:31,119"}
{"levelno": 20, "level": "INFO", "msg": "Task update_discovery_provider[65118dbe-8afe-47c9-b793-a733c1157633] succeeded in 0.39132349006831646s: None", "timestamp": "2021-04-16 00:17:31,120", "data": {"id": "65118dbe-8afe-47c9-b793-a733c1157633", "name": "update_discovery_provider", "return_value": "None", "runtime": 0.39132349006831646}}
```

Edit - updated the state changed logs to include blocknumber
```
{"levelno": 20, "level": "INFO", "msg": "Task update_ipld_blacklist[6ed5fea3-01a6-4a62-a77d-37ec3cc541ce] succeeded in 0.09787690895609558s: None", "timestamp": "2021-04-16 19:19:47,436", "data": {"id": "6ed5fea3-01a6-4a62-a77d-37ec3cc541ce", "name": "update_ipld_blacklist", "return_value": "None", "runtime": 0.09787690895609558}}
{"levelno": 20, "level": "INFO", "msg": "index.py | index_blocks | bbd576c6-6442-4cf5-81e4-d3d9190fea72 | block 14130 - 1/1", "timestamp": "2021-04-16 19:19:47,462"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_state_update completed user_state_changed=False for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | track_state_update completed track_state_changed=False for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | social_feature_state_update completed social_feature_state_changed=False for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_replica_set_state_update completed user_replica_set_state_changed=False for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | playlist_state_update completed playlist_state_changed=False for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | user_library_state_update completed user_library_state_changed=0 for block=14130", "timestamp": "2021-04-16 19:19:47,469"}
{"levelno": 20, "level": "INFO", "msg": "index.py | session commmited to db", "timestamp": "2021-04-16 19:19:47,473"}
{"levelno": 20, "level": "INFO", "msg": "index.py | redis cache clean operations complete", "timestamp": "2021-04-16 19:19:47,473"}
{"levelno": 20, "level": "INFO", "msg": "index.py | update most recently processed block complete", "timestamp": "2021-04-16 19:19:47,473"}
{"levelno": 30, "level": "WARNING", "msg": "index.py | index_blocks | Indexed 1 blocks", "timestamp": "2021-04-16 19:19:47,474"}
```