### PR TITLE
Remove MAX_DISK_USAGE_PERCENT in favor of config var

### DIFF
--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -9,7 +9,6 @@ const {
 const DiskManager = require('../diskManager')
 
 const MAX_DB_CONNECTIONS = config.get('dbConnectionPoolMax')
-const MAX_DISK_USAGE_PERCENT = 90 // 90%
 
 module.exports = function (app) {
   /**
@@ -86,7 +85,7 @@ module.exports = function (app) {
    */
   app.get('/disk_check', handleResponse(async (req, res) => {
     const maxUsageBytes = parseInt(req.query.maxUsageBytes)
-    const maxUsagePercent = parseInt(req.query.maxUsagePercent) || MAX_DISK_USAGE_PERCENT
+    const maxUsagePercent = parseInt(req.query.maxUsagePercent) || config.get('maxStorageUsedPercent')
 
     const storagePath = DiskManager.getConfigStoragePath()
     const [ total, used ] = await getMonitors([


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Use config variable instead


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- Ran local cnode
```
{
data: {
available: "47.83 GB",
total: "70.62 GB",
usagePercent: "32%",
maxUsagePercent: "95%",
storagePath: "/file_storage"
},
signer: "0x4108697907b5bd30c7c7d90fb4577d1d200cb904",
timestamp: "2021-04-22T06:12:45.948Z",
signature: "0xb7260558a103e880fc178b182f7a9f9e2d873383f84d2ffbb78cc7b293a723951a18c42647bf3c4351ab3452e5e47c568fb0f843471fce3c870583845cd827b91b"
}
```

...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
