### PR TITLE
Improve Search Quality

### DIFF
--- a/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
+++ b/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
@@ -1,0 +1,209 @@
+"""search_quality_improvements
+
+Revision ID: 90021fba7f4a
+Revises: 5bcbe23f6c70
+Create Date: 2021-04-21 00:31:25.072811
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '90021fba7f4a'
+down_revision = '5bcbe23f6c70'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute('''
+    -- Update user lexeme matview to include user handles
+
+    DROP MATERIALIZED VIEW IF EXISTS user_lexeme_dict;
+    DROP INDEX IF EXISTS user_words_idx;
+
+    CREATE MATERIALIZED VIEW user_lexeme_dict as
+    SELECT * FROM (
+        SELECT
+            u.user_id,
+            lower(u.name) as user_name,
+            lower(u.handle) as handle,
+            a.follower_count as follower_count,
+            unnest(
+                tsvector_to_array(
+                    to_tsvector(
+                        'audius_ts_config',
+                        replace(COALESCE(u.name, ''), '&', 'and')
+                    ) ||
+                    to_tsvector(
+                        'audius_ts_config',
+                        COALESCE(u.handle, '')
+                    )
+                )
+            ) as word
+        FROM
+            users u
+        INNER JOIN aggregate_user a on a.user_id = u.user_id
+        WHERE u.is_current = true and 
+        u.user_id not in (
+			select u.user_id from users u
+			inner join
+				(
+					select distinct lower(u1.handle) as handle, u1.user_id from users u1
+					where u1.is_current = true and u1.is_verified = true
+				) as sq
+			on lower(u.name) = sq.handle and u.user_id != sq.user_id
+			where u.is_current = true
+		)
+        GROUP BY u.user_id, u.name, u.handle, a.follower_count
+    ) AS words;
+
+    CREATE INDEX user_words_idx ON user_lexeme_dict USING gin(word gin_trgm_ops);
+    CREATE INDEX user_handles_idx ON user_lexeme_dict(handle); 
+
+    -- Update tracks matview to:
+    --      lowercase track title
+    -- 	    add handle and name columns
+
+    DROP MATERIALIZED VIEW IF EXISTS track_lexeme_dict;
+    DROP INDEX IF EXISTS track_words_idx;
+
+    CREATE MATERIALIZED VIEW track_lexeme_dict as
+    SELECT * FROM (
+        SELECT
+            t.track_id,
+            t.owner_id as owner_id,
+            lower(t.title) as track_title,
+            lower(u.handle) as handle,
+            lower(u.name) as user_name,
+            a.repost_count as repost_count,
+            unnest(
+                tsvector_to_array(
+                    to_tsvector(
+                        'audius_ts_config',
+                        replace(COALESCE(t."title", ''), '&', 'and')
+                    )
+                )
+            ) as word
+        FROM
+            tracks t
+        INNER JOIN users u ON t.owner_id = u.user_id
+        INNER JOIN aggregate_track a on a.track_id = t.track_id
+        WHERE t.is_current = true AND t.is_unlisted = false AND t.is_delete = false AND t.stem_of IS NULL AND u.is_current = true and
+        u.user_id not in (
+			select u.user_id from users u
+			inner join
+				(
+					select distinct lower(u1.handle) as handle, u1.user_id from users u1
+					where u1.is_current = true and u1.is_verified = true
+				) as sq
+			on lower(u.name) = sq.handle and u.user_id != sq.user_id
+			where u.is_current = true
+		)
+        GROUP BY t.track_id, t.title, t.owner_id, u.handle, u.name, a.repost_count
+    ) AS words;
+
+    CREATE INDEX track_words_idx ON track_lexeme_dict USING gin(word gin_trgm_ops);
+    CREATE INDEX track_user_name_idx ON track_lexeme_dict USING gin(user_name gin_trgm_ops);
+    CREATE INDEX tracks_user_handle_idx ON track_lexeme_dict(handle);
+
+    -- Playlist + Album Matview:
+    --      Adds handles + user_names
+
+    DROP MATERIALIZED VIEW IF EXISTS playlist_lexeme_dict;
+    DROP MATERIALIZED VIEW IF EXISTS album_lexeme_dict;
+    DROP INDEX IF EXISTS playlist_words_idx;
+    DROP INDEX IF EXISTS album_words_idx;
+
+    CREATE MATERIALIZED VIEW playlist_lexeme_dict as
+    SELECT * FROM (
+        SELECT
+            p.playlist_id,
+            p.playlist_name,
+            p.playlist_owner_id as owner_id,
+            lower(u.handle) as handle,
+            lower(u.name) as user_name,
+            a.repost_count as repost_count,
+            unnest(
+                tsvector_to_array(
+                    to_tsvector(
+                        'audius_ts_config',
+                        replace(COALESCE(p.playlist_name, ''), '&', 'and')
+                    )
+                )
+            ) as word
+        FROM
+                playlists p
+        INNER JOIN users u ON p.playlist_owner_id = u.user_id
+        INNER JOIN aggregate_playlist a on a.playlist_id = p.playlist_id
+        WHERE
+                p.is_current = true and p.is_album = false and p.is_private = false and p.is_delete = false
+                and u.is_current = true and 
+                u.user_id not in (
+                    select u.user_id from users u
+                    inner join
+                        (
+                            select distinct lower(u1.handle) as handle, u1.user_id from users u1
+                            where u1.is_current = true and u1.is_verified = true
+                        ) as sq
+                    on lower(u.name) = sq.handle and u.user_id != sq.user_id
+                    where u.is_current = true
+                )
+        GROUP BY p.playlist_id, p.playlist_name, p.playlist_owner_id, u.handle, u.name, a.repost_count
+    ) AS words;
+
+
+    CREATE MATERIALIZED VIEW album_lexeme_dict as
+    SELECT * FROM (
+        SELECT
+            p.playlist_id,
+            p.playlist_name,
+            p.playlist_owner_id as owner_id,
+            lower(u.handle) as handle,
+            lower(u.name) as user_name,
+            a.repost_count as repost_count,
+            unnest(
+                tsvector_to_array(
+                    to_tsvector(
+                        'audius_ts_config',
+                        replace(COALESCE(p.playlist_name, ''), '&', 'and')
+                    )
+                )
+            ) as word
+        FROM
+                playlists p
+        INNER JOIN users u ON p.playlist_owner_id = u.user_id
+        INNER JOIN aggregate_playlist a on a.playlist_id = p.playlist_id
+        WHERE
+                p.is_current = true and p.is_album = true and p.is_private = false and p.is_delete = false
+                and u.is_current = true and
+                u.user_id not in (
+                    select u.user_id from users u
+                    inner join
+                        (
+                            select distinct lower(u1.handle) as handle, u1.user_id from users u1
+                            where u1.is_current = true and u1.is_verified = true
+                        ) as sq
+                    on lower(u.name) = sq.handle and u.user_id != sq.user_id
+                    where u.is_current = true
+                )
+        GROUP BY p.playlist_id, p.playlist_name, p.playlist_owner_id, u.handle, u.name, a.repost_count
+    ) AS words;
+
+    CREATE INDEX playlist_words_idx ON playlist_lexeme_dict USING gin(word gin_trgm_ops);
+    CREATE INDEX playlist_user_name_idx ON playlist_lexeme_dict USING gin(user_name gin_trgm_ops);
+    CREATE INDEX playlist_user_handle_idx ON playlist_lexeme_dict(handle);
+
+    CREATE INDEX album_words_idx ON album_lexeme_dict USING gin(word gin_trgm_ops);
+    CREATE INDEX album_user_name_idx ON album_lexeme_dict USING gin(user_name gin_trgm_ops);
+    CREATE INDEX album_user_handle_idx ON album_lexeme_dict(handle);
+    '''
+    )
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    pass
+    # ### end Alembic commands ###

--- a/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
+++ b/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
@@ -24,7 +24,7 @@ def upgrade():
     DROP INDEX IF EXISTS user_words_idx;
 
     CREATE MATERIALIZED VIEW user_lexeme_dict as
-    SELECT * FROM (
+    SELECT row_number() OVER (PARTITION BY true), * FROM (
         SELECT
             u.user_id,
             lower(u.name) as user_name,
@@ -61,12 +61,13 @@ def upgrade():
 
     CREATE INDEX user_words_idx ON user_lexeme_dict USING gin(word gin_trgm_ops);
     CREATE INDEX user_handles_idx ON user_lexeme_dict(handle); 
+    CREATE UNIQUE INDEX user_row_number_idx ON user_lexeme_dict(row_number);
 
     DROP MATERIALIZED VIEW IF EXISTS track_lexeme_dict;
     DROP INDEX IF EXISTS track_words_idx;
 
     CREATE MATERIALIZED VIEW track_lexeme_dict as
-    SELECT * FROM (
+    SELECT row_number() OVER (PARTITION BY true), * FROM (
         SELECT
             t.track_id,
             t.owner_id as owner_id,
@@ -103,6 +104,7 @@ def upgrade():
     CREATE INDEX track_words_idx ON track_lexeme_dict USING gin(word gin_trgm_ops);
     CREATE INDEX track_user_name_idx ON track_lexeme_dict USING gin(user_name gin_trgm_ops);
     CREATE INDEX tracks_user_handle_idx ON track_lexeme_dict(handle);
+    CREATE UNIQUE INDEX track_row_number_idx ON track_lexeme_dict(row_number);
 
     DROP MATERIALIZED VIEW IF EXISTS playlist_lexeme_dict;
     DROP MATERIALIZED VIEW IF EXISTS album_lexeme_dict;
@@ -110,7 +112,7 @@ def upgrade():
     DROP INDEX IF EXISTS album_words_idx;
 
     CREATE MATERIALIZED VIEW playlist_lexeme_dict as
-    SELECT * FROM (
+    SELECT row_number() OVER (PARTITION BY true), * FROM (
         SELECT
             p.playlist_id,
             lower(p.playlist_name) as playlist_name,
@@ -147,7 +149,7 @@ def upgrade():
     ) AS words;
 
     CREATE MATERIALIZED VIEW album_lexeme_dict as
-    SELECT * FROM (
+    SELECT row_number() OVER (PARTITION BY true), * FROM (
         SELECT
             p.playlist_id,
             lower(p.playlist_name) as playlist_name,
@@ -186,10 +188,12 @@ def upgrade():
     CREATE INDEX playlist_words_idx ON playlist_lexeme_dict USING gin(word gin_trgm_ops);
     CREATE INDEX playlist_user_name_idx ON playlist_lexeme_dict USING gin(user_name gin_trgm_ops);
     CREATE INDEX playlist_user_handle_idx ON playlist_lexeme_dict(handle);
+    CREATE UNIQUE INDEX playlist_row_number_idx ON playlist_lexeme_dict(row_number);
 
     CREATE INDEX album_words_idx ON album_lexeme_dict USING gin(word gin_trgm_ops);
     CREATE INDEX album_user_name_idx ON album_lexeme_dict USING gin(user_name gin_trgm_ops);
     CREATE INDEX album_user_handle_idx ON album_lexeme_dict(handle);
+    CREATE UNIQUE INDEX album_row_number_idx ON album_lexeme_dict(row_number);
     '''
     )
 

--- a/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
+++ b/discovery-provider/alembic/versions/90021fba7f4a_search_quality_improvements.py
@@ -121,7 +121,7 @@ def upgrade():
     SELECT * FROM (
         SELECT
             p.playlist_id,
-            p.playlist_name,
+            lower(p.playlist_name),
             p.playlist_owner_id as owner_id,
             lower(u.handle) as handle,
             lower(u.name) as user_name,
@@ -159,7 +159,7 @@ def upgrade():
     SELECT * FROM (
         SELECT
             p.playlist_id,
-            p.playlist_name,
+            lower(p.playlist_name),
             p.playlist_owner_id as owner_id,
             lower(u.handle) as handle,
             lower(u.name) as user_name,

--- a/discovery-provider/src/queries/get_ipfs_peer_info.py
+++ b/discovery-provider/src/queries/get_ipfs_peer_info.py
@@ -5,9 +5,9 @@ from src.utils.config import shared_config
 
 # Convert key to snake case
 pattern = re.compile(r'(?<!^)(?=[A-Z])')
-ipfs_client = IPFSClient(
-    shared_config["ipfs"]["host"], shared_config["ipfs"]["port"]
-)
+# ipfs_client = IPFSClient(
+#     shared_config["ipfs"]["host"], shared_config["ipfs"]["port"]
+# )
 
 def convert_to_snake_case(value):
     if value == 'ID':

--- a/discovery-provider/src/queries/get_ipfs_peer_info.py
+++ b/discovery-provider/src/queries/get_ipfs_peer_info.py
@@ -5,9 +5,9 @@ from src.utils.config import shared_config
 
 # Convert key to snake case
 pattern = re.compile(r'(?<!^)(?=[A-Z])')
-# ipfs_client = IPFSClient(
-#     shared_config["ipfs"]["host"], shared_config["ipfs"]["port"]
-# )
+ipfs_client = IPFSClient(
+    shared_config["ipfs"]["host"], shared_config["ipfs"]["port"]
+)
 
 def convert_to_snake_case(value):
     if value == 'ID':

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -238,28 +238,6 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
     return users
 
 
-def populate_user_follower_counts(session, user_ids, users):
-    """Gets user follower counts for an array of user_ids and corresponding users"""
-    follower_counts = (
-        session.query(
-            AggregateUser.user_id,
-            AggregateUser.follower_count
-        )
-        .filter(
-            AggregateUser.user_id.in_(user_ids)
-        )
-        .all()
-    )
-
-    follower_count_dict = {user_id: follower_count for (
-        user_id, follower_count) in follower_counts}
-    for user in users:
-        user_id = user["user_id"]
-        user[response_name_constants.follower_count] = follower_count_dict.get(
-            user_id, 0)
-    return users
-
-
 def get_track_play_count_dict(session, track_ids):
     if not track_ids:
         return {}
@@ -427,27 +405,6 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
         else:
             track[response_name_constants.remix_of] = None
 
-    return tracks
-
-
-def populate_track_repost_counts(session, track_ids, tracks):
-    """Gets track repost counts for an array of track_ids and corresponding tracks"""
-    repost_counts = (
-        session.query(
-            AggregateTrack.track_id,
-            AggregateTrack.repost_count
-        )
-        .filter(
-            AggregateTrack.track_id.in_(track_ids),
-        )
-        .all()
-    )
-    repost_count_dict = {track_id: repost_count for (
-        track_id, repost_count) in repost_counts}
-    for track in tracks:
-        track_id = track["track_id"]
-        track[response_name_constants.repost_count] = repost_count_dict.get(
-            track_id, 0)
     return tracks
 
 
@@ -719,21 +676,6 @@ def populate_playlist_metadata(session, playlist_ids, playlists, repost_types, s
             playlist_id, False)
 
     return playlists
-
-
-def populate_playlist_repost_counts(session, playlist_ids, playlists, repost_types):
-    """Gets playlist repost counts for an array of playlist_ids and corresponding playlists"""
-    # build dict of playlist id --> repost count
-    playlist_repost_counts = dict(get_repost_counts(
-        session, False, False, playlist_ids, repost_types))
-
-    for playlist in playlists:
-        playlist_id = playlist["playlist_id"]
-        playlist[response_name_constants.repost_count] = playlist_repost_counts.get(
-            playlist_id, 0)
-
-    return playlists
-
 
 def get_repost_counts_query(
         session,

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -1,18 +1,48 @@
 import logging
 
-trackTitleWeight = 0.7
-trackSimilarityWeight = 5
-trackUserNameWeight = 8
-trackRepostWeight = 10 # TODO: tune this
+# Global
 
-playlistRepostWeight = 0.2
-playlistUserNameWeight = 8
-
-userNameWeight = 0.7
-userFollowerWeight = 0.5
-playlistNameWeight = 0.7
-
+# Threshold for lexeme similarity, in [0, 1].
+# Lower values are slower and match more rows, higher values are quicker 
+# but may exclude viable candidates.
 minSearchSimilarity = 0.4
+
+# Tracks
+
+# Weight for query similarity against title
+trackTitleWeight = 0.7
+# Weight for query similarity to words in track title (summed)
+trackSimilarityWeight = 5
+# Weight for query similarity to track owner's username
+trackUserNameWeight = 8
+# Weight for track reposts.
+trackRepostWeight = 10
+track_title_exact_match_boost = 5
+track_handle_exact_match_boost = 20
+track_user_name_exact_match_boost = 5
+
+# Playlists
+
+# Weight for playlist reposts
+playlistRepostWeight = 0.2
+# Weight for similarity between query and playlist owner username
+playlistUserNameWeight = 8
+# Weight for similarity between query and playlist name
+playlistNameWeight = 0.7
+playlist_name_exact_match_boost = 5
+playlist_handle_exact_match_boost = 10
+playlist_user_name_exact_match_boost = 5
+
+# Users
+
+# Weight for similarity between query and user name
+userNameWeight = 0.7
+# Weight for user follower count (logged)
+userFollowerWeight = 0.5
+# Boost for exact handle match
+user_handle_exact_match_boost = 10
+
+
 
 
 logger = logging.getLogger(__name__)

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -1,9 +1,18 @@
 import logging
 
 trackTitleWeight = 0.7
+trackSimilarityWeight = 5
+trackUserNameWeight = 8
+trackRepostWeight = 10 # TODO: tune this
+
+playlistRepostWeight = 0.2
+playlistUserNameWeight = 8
+
 userNameWeight = 0.7
+userFollowerWeight = 0.5
 playlistNameWeight = 0.7
-minSearchSimilarity = 0.3
+
+minSearchSimilarity = 0.4
 
 
 logger = logging.getLogger(__name__)

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -17,7 +17,7 @@ search_similarity_weight = 5
 search_user_name_weight = 8
 # Weight for track reposts.
 search_repost_weight = 15
-search_title_exact_match_boost = 5
+search_title_exact_match_boost = 10
 search_handle_exact_match_boost = 15
 search_user_name_exact_match_boost = 5
 

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -3,7 +3,7 @@ import logging
 # Global
 
 # Threshold for lexeme similarity, in [0, 1].
-# Lower values are slower and match more rows, higher values are quicker 
+# Lower values are slower and match more rows, higher values are quicker
 # but may exclude viable candidates.
 min_search_similarity = 0.4
 

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -7,31 +7,19 @@ import logging
 # but may exclude viable candidates.
 min_search_similarity = 0.4
 
-# Tracks
+# Playlist and Track Search Weights
 
 # Weight for query similarity against title
-track_title_weight = 0.7
+search_title_weight = 2
 # Weight for query similarity to words in track title (summed)
-track_similarity_weight = 5
+search_similarity_weight = 5
 # Weight for query similarity to track owner's username
-track_user_name_weight = 8
+search_user_name_weight = 8
 # Weight for track reposts.
-track_repost_weight = 10
-track_title_exact_match_boost = 5
-track_handle_exact_match_boost = 20
-track_user_name_exact_match_boost = 5
-
-# Playlists
-
-# Weight for playlist reposts
-playlist_repost_weight = 20
-# Weight for similarity between query and playlist owner username
-playlist_user_name_weight = 8
-# Weight for similarity between query and playlist name
-playlist_name_weight = 2
-playlist_name_exact_match_boost = 5
-playlist_handle_exact_match_boost = 10
-playlist_user_name_exact_match_boost = 5
+search_repost_weight = 15
+search_title_exact_match_boost = 5
+search_handle_exact_match_boost = 15
+search_user_name_exact_match_boost = 5
 
 # Users
 
@@ -41,9 +29,6 @@ user_name_weight = 0.7
 user_follower_weight = 0.5
 # Boost for exact handle match
 user_handle_exact_match_boost = 10
-
-
-
 
 logger = logging.getLogger(__name__)
 

--- a/discovery-provider/src/queries/search_config.py
+++ b/discovery-provider/src/queries/search_config.py
@@ -5,18 +5,18 @@ import logging
 # Threshold for lexeme similarity, in [0, 1].
 # Lower values are slower and match more rows, higher values are quicker 
 # but may exclude viable candidates.
-minSearchSimilarity = 0.4
+min_search_similarity = 0.4
 
 # Tracks
 
 # Weight for query similarity against title
-trackTitleWeight = 0.7
+track_title_weight = 0.7
 # Weight for query similarity to words in track title (summed)
-trackSimilarityWeight = 5
+track_similarity_weight = 5
 # Weight for query similarity to track owner's username
-trackUserNameWeight = 8
+track_user_name_weight = 8
 # Weight for track reposts.
-trackRepostWeight = 10
+track_repost_weight = 10
 track_title_exact_match_boost = 5
 track_handle_exact_match_boost = 20
 track_user_name_exact_match_boost = 5
@@ -24,11 +24,11 @@ track_user_name_exact_match_boost = 5
 # Playlists
 
 # Weight for playlist reposts
-playlistRepostWeight = 0.2
+playlist_repost_weight = 20
 # Weight for similarity between query and playlist owner username
-playlistUserNameWeight = 8
+playlist_user_name_weight = 8
 # Weight for similarity between query and playlist name
-playlistNameWeight = 0.7
+playlist_name_weight = 2
 playlist_name_exact_match_boost = 5
 playlist_handle_exact_match_boost = 10
 playlist_user_name_exact_match_boost = 5
@@ -36,9 +36,9 @@ playlist_user_name_exact_match_boost = 5
 # Users
 
 # Weight for similarity between query and user name
-userNameWeight = 0.7
+user_name_weight = 0.7
 # Weight for user follower count (logged)
-userFollowerWeight = 0.5
+user_follower_weight = 0.5
 # Boost for exact handle match
 user_handle_exact_match_boost = 10
 
@@ -58,7 +58,7 @@ def set_search_similarity(cursor):
     """
     try:
         cursor.execute(
-            f"SET pg_trgm.similarity_threshold = {minSearchSimilarity}"
+            f"SET pg_trgm.similarity_threshold = {min_search_similarity}"
         )
     except Exception as e:
         logger.error(f"Unable to set similarity_threshold: {e}")

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -6,12 +6,12 @@ from flask import Blueprint, request
 import sqlalchemy
 
 from src import api_helpers, exceptions
-from src.queries.search_config import track_title_weight, user_name_weight, playlist_name_weight, track_similarity_weight, \
-    track_repost_weight, playlist_repost_weight, user_follower_weight, track_user_name_weight, playlist_user_name_weight, \
-    track_title_exact_match_boost, track_handle_exact_match_boost, track_user_name_exact_match_boost, \
-    user_handle_exact_match_boost, playlist_name_exact_match_boost, playlist_handle_exact_match_boost, \
-    playlist_user_name_exact_match_boost
-     
+from src.queries.search_config import track_title_weight, user_name_weight, playlist_name_weight, \
+    track_similarity_weight, track_repost_weight, playlist_repost_weight, user_follower_weight, \
+    track_user_name_weight, playlist_user_name_weight, track_title_exact_match_boost, \
+    track_handle_exact_match_boost, track_user_name_exact_match_boost, \
+    user_handle_exact_match_boost, playlist_name_exact_match_boost, \
+    playlist_handle_exact_match_boost, playlist_user_name_exact_match_boost
 from src.models import Track, RepostType, Save, SaveType, Follow
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
@@ -437,7 +437,7 @@ def track_search_query(
         f"""
         select track_id, b.balance, b.associated_wallets_balance from (
             select {'distinct on (owner_id)' if distinct_owner_id else ''} track_id, owner_id, total_score from (
-                select track_id, owner_id, 
+                select track_id, owner_id,
                     (
                         (:similarity_weight * sum(score)) +
                         (:title_weight * similarity(coalesce(title, ''), query)) +
@@ -516,8 +516,7 @@ def track_search_query(
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to track objects
-        for i in range(len(tracks)):
-            track = tracks[i]
+        for i, track in enumerate(tracks):
             user = users_dict[track["owner_id"]]
             # Add user balance
             balance = track_data[i][1]
@@ -592,8 +591,7 @@ def user_search_query(session, search_str, limit, offset, personalized, is_auto_
     users = get_unpopulated_users(session, user_ids)
 
     if is_auto_complete:
-        for i in range(len(users)):
-            user = users[i]
+        for i, user in enumerate(users):
             balance = user_info[i]['balance']
             associated_wallets_balance = user_info[i]['associated_wallets_balance']
             user[response_name_constants.balance] = balance
@@ -708,8 +706,7 @@ def playlist_search_query(
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to playlist objects
-        for i in range(len(playlists)):
-            playlist = playlists[i]
+        for i, playlist in enumerate(playlists):
             user = users_dict[playlist["playlist_owner_id"]]
             # Add user balance
             balance = playlist_data[i][1]

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -460,7 +460,7 @@ def track_search_query(
                         if only_downloadable
                         else ""
                     }
-                    where d."word" % :query or d."handle" = lower(:query) or d."user_name" % lower(:query)
+                    where (d."word" % :query or d."handle" = lower(:query) or d."user_name" % lower(:query))
                     {
                         "and s.save_type='track' and s.is_current=true and " +
                         "s.is_delete=false and s.user_id = :current_user_id"
@@ -476,7 +476,7 @@ def track_search_query(
                 group by track_id, title, query, user_name, handle, repost_count, owner_id
             ) as results2
             order by owner_id, total_score desc
-        ) as u join user_balances b on u.owner_id = b.user_id
+        ) as u left join user_balances b on u.owner_id = b.user_id
         order by total_score desc
         limit :limit
         offset :offset;
@@ -565,7 +565,7 @@ def user_search_query(session, search_str, limit, offset, personalized, is_auto_
             order by total_score desc, user_id asc
             limit :limit
             offset :offset
-        ) as u join user_balances b on u.user_id = b.user_id
+        ) as u left join user_balances b on u.user_id = b.user_id
         """
     )
 
@@ -654,7 +654,7 @@ def playlist_search_query(
                         if personalized and current_user_id
                         else ""
                     }
-                    where d."word" % :query or d."handle" = lower(:query) or d."user_name" % lower(:query)
+                    where (d."word" % :query or d."handle" = lower(:query) or d."user_name" % lower(:query))
                     {
                         "and s.save_type='" + save_type +
                         "' and s.is_current=true and s.is_delete=false and s.user_id=:current_user_id"
@@ -665,7 +665,7 @@ def playlist_search_query(
                 group by playlist_id, playlist_name, query, repost_count, user_name, handle, owner_id
             ) as results2
             order by owner_id, total_score desc
-        ) as p join user_balances b on p.owner_id = b.user_id
+        ) as p left join user_balances b on p.owner_id = b.user_id
         order by total_score desc
         limit :limit
         offset :offset;

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -6,7 +6,7 @@ from flask import Blueprint, request
 import sqlalchemy
 
 from src import api_helpers, exceptions
-from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight
+from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight, trackSimilarityWeight, trackRepostWeight, playlistRepostWeight, userFollowerWeight, trackUserNameWeight, playlistUserNameWeight
 from src.models import Track, RepostType, Save, SaveType, Follow
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
@@ -17,8 +17,7 @@ from src.queries.get_unpopulated_playlists import get_unpopulated_playlists
 from src.queries.search_track_tags import search_track_tags
 from src.queries.search_user_tags import search_user_tags
 from src.queries.query_helpers import get_current_user_id, get_users_by_id, get_users_ids, populate_user_metadata, \
-    populate_track_metadata, populate_playlist_metadata, get_pagination_vars, populate_playlist_repost_counts, \
-    populate_user_follower_counts, populate_track_repost_counts
+    populate_track_metadata, populate_playlist_metadata, get_pagination_vars
 
 logger = logging.getLogger(__name__)
 bp = Blueprint("search_tags", __name__)
@@ -47,24 +46,7 @@ def compare_users(user1, user2):
         return -1
     if user2["is_verified"] and not user1["is_verified"]:
         return 1
-    if "follower_count" in user1 and "follower_count" in user2:
-        return user2["follower_count"] - user1["follower_count"]
     return 0
-
-
-def compare_tracks(track1, track2):
-    """Comparison util for ordering track search results."""
-    if "repost_count" in track1 and "repost_count" in track2:
-        return track2["repost_count"] - track1["repost_count"]
-    return 0
-
-
-def compare_playlists(playlist1, playlist2):
-    """Comparison util for ordering playlist search results."""
-    if "repost_count" in playlist1 and "repost_count" in playlist2:
-        return playlist2["repost_count"] - playlist1["repost_count"]
-    return 0
-
 
 ######## ROUTES ########
 
@@ -447,62 +429,77 @@ def track_search_query(
     if personalized and not current_user_id:
         return []
 
+
     res = sqlalchemy.text(
         # pylint: disable=C0301
         f"""
-        select track_id from (
-            select
-                track_id,
-                (sum(score) + (:title_weight * similarity(coalesce(title, ''), query))) as total_score
-            from (
-                select
-                    d."track_id" as track_id, d."word" as word, similarity(d."word", :query) as score,
-                    d."track_title" as title, :query as query
-                from "track_lexeme_dict" d
-                {
-                    'inner join "saves" s on s.save_item_id = d.track_id'
-                    if personalized and current_user_id
-                    else ""
-                }
-                {
-                    'inner join "tracks" t on t.track_id = d.track_id'
-                    if only_downloadable
-                    else ""
-                }
-                where d."word" % :query
-                {
-                    "and s.save_type='track' and s.is_current=true and " +
-                    "s.is_delete=false and s.user_id = :current_user_id"
-                    if personalized and current_user_id
-                    else ""
-                }
-                {
-                    "and (t.download->>'is_downloadable')::boolean is True"
-                    if only_downloadable
-                    else ""
-                }
-            ) as results
-            group by track_id, title, query
-        ) as results2
-        order by total_score desc, track_id asc
+        select track_id, b.balance, b.associated_wallets_balance from (
+            select distinct on (owner_id) track_id, owner_id, total_score from (
+                select track_id, owner_id, 
+                    (
+                        (:similarity_weight * sum(score)) +
+                        (:title_weight * similarity(coalesce(title, ''), query)) +
+                        (:user_name_weight * similarity(coalesce(user_name, ''), query)) +
+                        (:repost_weight * log(case when (repost_count = 0) then 1 else repost_count end)) +
+                        (case when (lower(query) = coalesce(title, '')) then 5 else 0 end) +
+                        (case when (lower(query) = handle) then 20 else 0 end) +
+                        (case when (lower(query) = user_name) then 5 else 0 end)
+                    ) as total_score
+                from (
+                    select
+                        d."track_id" as track_id, d."word" as word, similarity(d."word", :query) as score,
+                        d."track_title" as title, :query as query, d."user_name" as user_name, d."handle" as handle,
+                        d."repost_count" as repost_count, d."owner_id" as owner_id
+                    from "track_lexeme_dict" d
+                    {
+                        'inner join "saves" s on s.save_item_id = d.track_id'
+                        if personalized and current_user_id
+                        else ""
+                    }
+                    {
+                        'inner join "tracks" t on t.track_id = d.track_id'
+                        if only_downloadable
+                        else ""
+                    }
+                    where (d."word" % :query or d."handle" = lower(:query)) or d."user_name" % lower(:query)
+                    {
+                        "and s.save_type='track' and s.is_current=true and " +
+                        "s.is_delete=false and s.user_id = :current_user_id"
+                        if personalized and current_user_id
+                        else ""
+                    }
+                    {
+                        "and (t.download->>'is_downloadable')::boolean is True"
+                        if only_downloadable
+                        else ""
+                    }
+                ) as results
+                group by track_id, title, query, user_name, handle, repost_count, owner_id
+            ) as results2
+            order by owner_id, total_score desc
+        ) as u join user_balances b on u.owner_id = b.user_id
+        order by total_score desc
         limit :limit
         offset :offset;
         """
     )
 
-    track_ids = session.execute(
+    track_data = session.execute(
         res,
         {
             "query": search_str,
             "limit": max(limit, MIN_SEARCH_LEXEME_LIMIT),
             "offset": offset,
             "title_weight": trackTitleWeight,
-            "current_user_id": current_user_id
+            "repost_weight": trackRepostWeight,
+            "similarity_weight": trackSimilarityWeight,
+            "current_user_id": current_user_id,
+            "user_name_weight": trackUserNameWeight
         },
     ).fetchall()
 
     # track_ids is list of tuples - simplify to 1-D list
-    track_ids = [i[0] for i in track_ids]
+    track_ids = [i[0] for i in track_data]
     tracks = get_unpopulated_tracks(session, track_ids, True)
 
     # TODO: Populate track metadata should be sped up to be able to be
@@ -514,9 +511,15 @@ def track_search_query(
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to track objects
-        for track in tracks:
-            track["user"] = users_dict[track["owner_id"]]
-        tracks = populate_track_repost_counts(session, track_ids, tracks)
+        for i in range(len(tracks)):
+            track = tracks[i]
+            user = users_dict[track["owner_id"]]
+            # Add user balance
+            balance = track_data[i][1]
+            associated_balance = track_data[i][2]
+            user[response_name_constants.balance] = balance
+            user[response_name_constants.associated_wallets_balance] = associated_balance
+            track["user"] = user
     else:
         # bundle peripheral info into track results
         tracks = populate_track_metadata(
@@ -528,9 +531,6 @@ def track_search_query(
         tracks_map[t["track_id"]] = t
     tracks = [tracks_map[track_id] for track_id in track_ids]
 
-    # Sort tracks by extra criteria for "best match"
-    tracks.sort(key=cmp_to_key(compare_tracks))
-
     return tracks[0:limit]
 
 
@@ -538,50 +538,68 @@ def user_search_query(session, search_str, limit, offset, personalized, is_auto_
     if personalized and not current_user_id:
         return []
 
+    # TODO: test whether we want the small similarity constant for handle (I think not)
+    # Add exact matches for usernames
+                # -- (0.3 * similarity(coalesce(handle, ''), query)) +
     res = sqlalchemy.text(
         f"""
-        select user_id from (
-            select user_id, (sum(score) + (:name_weight * similarity(coalesce(name, ''), query))) as total_score from (
-                select
-                    d."user_id" as user_id, d."word" as word, similarity(d."word", :query) as score,
-                    d."user_name" as name, :query as query
-                from "user_lexeme_dict" d
-                where d."word" % :query
-            ) as results
-            group by user_id, name, query
-        ) as results2
-        order by total_score desc, user_id asc
-        limit :limit
-        offset :offset;
+        select u.user_id, b.balance, b.associated_wallets_balance from (
+            select user_id from (
+                select user_id, (
+                    sum(score) +
+                    (:follower_weight * log(case when (follower_count = 0) then 1 else follower_count end)) + 
+                    (case when (handle=query) then 10 else 0 end) +
+                    (:name_weight * similarity(coalesce(name, ''), query))) as total_score from (
+                        select
+                                d."user_id" as user_id,
+                                d."word" as word,
+                                d."handle" as handle,
+                                similarity(d."word", :query) as score,
+                                d."user_name" as name,
+                                :query as query,
+                                d."follower_count" as follower_count
+                        from "user_lexeme_dict" d
+                        where 
+                            d."word" % :query OR
+                            d."handle" = :query
+                ) as results
+                group by user_id, name, query, handle, follower_count
+            ) as results2
+            order by total_score desc, user_id asc
+            limit :limit
+            offset :offset
+        ) as u join user_balances b on u.user_id = b.user_id
         """
     )
 
-    user_ids = session.execute(
+    user_info = session.execute(
         res,
         {
             "query": search_str,
             "limit": max(limit, MIN_SEARCH_LEXEME_LIMIT),
             "offset": offset,
             "name_weight": userNameWeight,
-            "current_user_id": current_user_id
+            "follower_weight": userFollowerWeight,
+            "current_user_id": current_user_id,
         },
     ).fetchall()
 
     # user_ids is list of tuples - simplify to 1-D list
-    user_ids = [i[0] for i in user_ids]
+    user_ids = [i[0] for i in user_info]
 
     users = get_unpopulated_users(session, user_ids)
 
-    # TODO: Populate user metadata should be sped up to be able to be
-    # used in search autocomplete as that'll give us better results.
     if is_auto_complete:
-        # get follower information to improve search ordering
-        users = populate_user_follower_counts(session, user_ids, users)
+        for i in range(len(users)):
+            user = users[i]
+            balance = user_info[i]['balance']
+            associated_wallets_balance = user_info[i]['associated_wallets_balance']
+            user[response_name_constants.balance] = balance
+            user[response_name_constants.associated_wallets_balance] = associated_wallets_balance
     else:
         # bundle peripheral info into user results
         users = populate_user_metadata(
             session, user_ids, users, current_user_id)
-
 
     # Preserve order from user_ids above
     user_map = {}
@@ -617,50 +635,64 @@ def playlist_search_query(
     res = sqlalchemy.text(
         # pylint: disable=C0301
         f"""
-        select playlist_id from (
-            select
-                playlist_id,
-                (sum(score) + (:name_weight * similarity(coalesce(playlist_name, ''), query))) as total_score
-            from (
-                select
-                    d."playlist_id" as playlist_id, d."word" as word, similarity(d."word", :query) as score,
-                    d."playlist_name" as playlist_name, :query as query
-                from "{table_name}" d
-                {
-                    'inner join "saves" s on s.save_item_id = d.playlist_id'
-                    if personalized and current_user_id
-                    else ""
-                }
-                where d."word" % :query
-                {
-                    "and s.save_type='" + save_type +
-                    "' and s.is_current=true and s.is_delete=false and s.user_id=:current_user_id"
-                    if personalized and current_user_id
-                    else ""
-                }
-            ) as results
-            group by playlist_id, playlist_name, query
-        ) as results2
-        order by total_score desc, playlist_id asc
+        select p.playlist_id, b.balance, b.associated_wallets_balance from (
+            select distinct on (owner_id) playlist_id, owner_id, total_score from (
+                select playlist_id, owner_id, (
+                    sum(score) +
+                    (:name_weight * similarity(coalesce(playlist_name, ''), query)) +
+                    (:user_name_weight * similarity(coalesce(user_name, ''), query)) +
+                    (:repost_weight * repost_count) +
+                    (case when (lower(query) = coalesce(playlist_name, '')) then 5 else 0 end) +
+                    (case when (lower(query) = handle) then 10 else 0 end) +
+                    (case when (lower(query) = user_name) then 5 else 0 end)
+                ) as total_score
+                from (
+                    select
+                        d."playlist_id" as playlist_id, d."word" as word, similarity(d."word", :query) as score,
+                        d."playlist_name" as playlist_name, :query as query, d."repost_count" as repost_count,
+                        d."handle" as handle, d."user_name" as user_name, d."owner_id" as owner_id
+                    from "{table_name}" d
+                    {
+                        'inner join "saves" s on s.save_item_id = d.playlist_id'
+                        if personalized and current_user_id
+                        else ""
+                    }
+                    where d."word" % :query or d."handle" = lower(:query) or d."user_name" % lower(:query)
+                    {
+                        "and s.save_type='" + save_type +
+                        "' and s.is_current=true and s.is_delete=false and s.user_id=:current_user_id"
+                        if personalized and current_user_id
+                        else ""
+                    }
+                ) as results
+                group by playlist_id, playlist_name, query, repost_count, user_name, handle, owner_id
+            ) as results2
+            order by owner_id, total_score desc
+        ) as p join user_balances b on p.owner_id = b.user_id
+        order by total_score desc
         limit :limit
         offset :offset;
         """
     )
 
-    playlist_ids = session.execute(
+    playlist_data = session.execute(
         res,
         {
             "query": search_str,
             "limit": max(limit, MIN_SEARCH_LEXEME_LIMIT),
             "offset": offset,
             "name_weight": playlistNameWeight,
-            "current_user_id": current_user_id
+            "repost_weight": playlistRepostWeight,
+            "current_user_id": current_user_id,
+            "user_name_weight": playlistUserNameWeight
         },
     ).fetchall()
 
     # playlist_ids is list of tuples - simplify to 1-D list
-    playlist_ids = [i[0] for i in playlist_ids]
+    playlist_ids = [i[0] for i in playlist_data]
     playlists = get_unpopulated_playlists(session, playlist_ids, True)
+    logger.warning("PLAYLISTS")
+    logger.warning(f"{len(playlists)} - {len(playlist_ids)}")
 
     # TODO: Populate playlist metadata should be sped up to be able to be
     # used in search autocomplete as that'll give us better results.
@@ -671,10 +703,16 @@ def playlist_search_query(
         users_dict = {user["user_id"]: user for user in users}
 
         # attach user objects to playlist objects
-        for playlist in playlists:
-            playlist["user"] = users_dict[playlist["playlist_owner_id"]]
+        for i in range(len(playlists)):
+            playlist = playlists[i]
+            user = users_dict[playlist["playlist_owner_id"]]
+            # Add user balance
+            balance = playlist_data[i][1]
+            associated_balance = playlist_data[i][2]
+            user[response_name_constants.balance] = balance
+            user[response_name_constants.associated_wallets_balance] = associated_balance
+            playlist["user"] = user
 
-        playlists = populate_playlist_repost_counts(session, playlist_ids, playlists, [repost_type])
     else:
         # bundle peripheral info into playlist results
         playlists = populate_playlist_metadata(
@@ -691,8 +729,5 @@ def playlist_search_query(
     for p in playlists:
         playlists_map[p["playlist_id"]] = p
     playlists = [playlists_map[playlist_id] for playlist_id in playlist_ids]
-
-    # Sort playlists by extra criteria for "best match"
-    playlists.sort(key=cmp_to_key(compare_playlists))
 
     return playlists[0:limit]

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -6,8 +6,8 @@ from flask import Blueprint, request
 import sqlalchemy
 
 from src import api_helpers, exceptions
-from src.queries.search_config import trackTitleWeight, userNameWeight, playlistNameWeight, trackSimilarityWeight, \
-    trackRepostWeight, playlistRepostWeight, userFollowerWeight, trackUserNameWeight, playlistUserNameWeight, \
+from src.queries.search_config import track_title_weight, user_name_weight, playlist_name_weight, track_similarity_weight, \
+    track_repost_weight, playlist_repost_weight, user_follower_weight, track_user_name_weight, playlist_user_name_weight, \
     track_title_exact_match_boost, track_handle_exact_match_boost, track_user_name_exact_match_boost, \
     user_handle_exact_match_boost, playlist_name_exact_match_boost, playlist_handle_exact_match_boost, \
     playlist_user_name_exact_match_boost
@@ -492,11 +492,11 @@ def track_search_query(
             "query": search_str,
             "limit": limit,
             "offset": offset,
-            "title_weight": trackTitleWeight,
-            "repost_weight": trackRepostWeight,
-            "similarity_weight": trackSimilarityWeight,
+            "title_weight": track_title_weight,
+            "repost_weight": track_repost_weight,
+            "similarity_weight": track_similarity_weight,
             "current_user_id": current_user_id,
-            "user_name_weight": trackUserNameWeight,
+            "user_name_weight": track_user_name_weight,
             "title_match_boost": track_title_exact_match_boost,
             "handle_match_boost": track_handle_exact_match_boost,
             "user_name_match_boost": track_user_name_exact_match_boost
@@ -579,8 +579,8 @@ def user_search_query(session, search_str, limit, offset, personalized, is_auto_
             "query": search_str,
             "limit": limit,
             "offset": offset,
-            "name_weight": userNameWeight,
-            "follower_weight": userFollowerWeight,
+            "name_weight": user_name_weight,
+            "follower_weight": user_follower_weight,
             "current_user_id": current_user_id,
             "handle_match_boost": user_handle_exact_match_boost
         },
@@ -685,10 +685,10 @@ def playlist_search_query(
             "query": search_str,
             "limit": limit,
             "offset": offset,
-            "name_weight": playlistNameWeight,
-            "repost_weight": playlistRepostWeight,
+            "name_weight": playlist_name_weight,
+            "repost_weight": playlist_repost_weight,
             "current_user_id": current_user_id,
-            "user_name_weight": playlistUserNameWeight,
+            "user_name_weight": playlist_user_name_weight,
             "name_match_boost": playlist_name_exact_match_boost,
             "handle_match_boost": playlist_handle_exact_match_boost,
             "user_name_match_boost": playlist_user_name_exact_match_boost

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -110,7 +110,7 @@ def test_gets_all_results(app):
         db = get_db()
     setup_search(db)
     with db.scoped_session() as session:
-        res = track_search_query(session, "the", 10, 0, False, False, None, False)
+        res = track_search_query(session, "the track", 10, 0, False, False, None, False)
         assert len(res) == 2
 
 def test_gets_downloadable_results(app):
@@ -119,5 +119,5 @@ def test_gets_downloadable_results(app):
         db = get_db()
     setup_search(db)
     with db.scoped_session() as session:
-        res = track_search_query(session, "the", 10, 0, False, False, None, True)
+        res = track_search_query(session, "the track", 10, 0, False, False, None, True)
         assert len(res) == 1

--- a/discovery-provider/tests/test_search.py
+++ b/discovery-provider/tests/test_search.py
@@ -49,7 +49,7 @@ def setup_search(db):
             track_id=2,
             is_current=True,
             is_delete=False,
-            owner_id=1,
+            owner_id=2,
             route_id='',
             track_segments=[],
             genre="",
@@ -88,6 +88,26 @@ def setup_search(db):
             wallet="",
             updated_at=now,
             created_at=now
+        ),
+        User(
+            blockhash=hex(2),
+            blocknumber=2,
+            user_id=2,
+            is_current=True,
+            handle="",
+            wallet="",
+            updated_at=now,
+            created_at=now
+        ),
+        User(
+            blockhash=hex(3),
+            blocknumber=3,
+            user_id=3,
+            is_current=True,
+            handle="",
+            wallet="",
+            updated_at=now,
+            created_at=now
         )
     ]
 
@@ -102,7 +122,8 @@ def setup_search(db):
             session.flush()
 
         # Refresh the lexeme matview
-        session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict")
+        session.execute("REFRESH MATERIALIZED VIEW aggregate_track;")
+        session.execute("REFRESH MATERIALIZED VIEW track_lexeme_dict;")
 
 def test_gets_all_results(app):
     """Tests we get all results, including downloaded"""


### PR DESCRIPTION
### Description

This PR improves search quality:

- Update matviews to include usernames and handles for tracks and playlists, and also fixes issues with terms not being lowercased.
- Search query itself now incorporates repost counts for tracks & playlists, follower_counts for users
- Includes tracks + playlists by a given artist if the query matches handle/username
- Boosts to scores for exact matches on username / handle
- Attaches user balances
- Filters out to a single artist for tracks/playlist autocomplete. Otherwise if you search for 'deadmau5' you only get deadmau5 tracks in autocomplete, etc

Perf seems roughly equal (I was benchmarking throughout dev), but I'm going to take another pass to make sure we have indices on everything we need, etc.

### Tests

Tested against prod search for a number of different cases. Live on my subdomain, putting it on our sandbox. 

