### PR TITLE
Handle missing playlist track time

### DIFF
--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -208,12 +208,7 @@ def parse_playlist_event(
 
             playlist_content_array = []
             for track_id in event_args._orderedTrackIds:
-                if track_id not in intermediate_track_time_lookup_dict:
-                    logger.info(
-                        f"index.py | playlist.py | Track {track_id} not found, using track_time={block_integer_time}"
-                    )
-                    track_time = block_integer_time
-                else:
+                if track_id in intermediate_track_time_lookup_dict:
                     track_time_array_length = len(intermediate_track_time_lookup_dict[track_id])
                     if track_time_array_length > 1:
                         track_time = intermediate_track_time_lookup_dict[track_id].pop(0)
@@ -221,6 +216,11 @@ def parse_playlist_event(
                         track_time = intermediate_track_time_lookup_dict[track_id][0]
                     else:
                         track_time = block_integer_time
+                else:
+                    logger.info(
+                        f"index.py | playlist.py | Track {track_id} not found, using track_time={block_integer_time}"
+                    )
+                    track_time = block_integer_time
                 playlist_content_array.append({"track": track_id, "time": track_time})
 
             playlist_record.playlist_contents = {"track_ids": playlist_content_array}

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -208,13 +208,19 @@ def parse_playlist_event(
 
             playlist_content_array = []
             for track_id in event_args._orderedTrackIds:
-                track_time_array_length = len(intermediate_track_time_lookup_dict[track_id])
-                if track_time_array_length > 1:
-                    track_time = intermediate_track_time_lookup_dict[track_id].pop(0)
-                elif track_time_array_length == 1:
-                    track_time = intermediate_track_time_lookup_dict[track_id][0]
-                else:
+                if track_id not in intermediate_track_time_lookup_dict:
+                    logger.info(
+                        f"index.py | playlist.py | Track {track_id} not found, using track_time={block_integer_time}"
+                    )
                     track_time = block_integer_time
+                else:
+                    track_time_array_length = len(intermediate_track_time_lookup_dict[track_id])
+                    if track_time_array_length > 1:
+                        track_time = intermediate_track_time_lookup_dict[track_id].pop(0)
+                    elif track_time_array_length == 1:
+                        track_time = intermediate_track_time_lookup_dict[track_id][0]
+                    else:
+                        track_time = block_integer_time
                 playlist_content_array.append({"track": track_id, "time": track_time})
 
             playlist_record.playlist_contents = {"track_ids": playlist_content_array}


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Ensure that a missing `track_id` in the `intermediate_track_time_lookup_dict` does not halt indexing progress


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Verifying manually by creating a playlist / reordering - 1 track / reordering again


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
