### PR TITLE
Revise defaults and add trending playlist mt

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -12,7 +12,7 @@ from .models.tracks import track
 from src.queries.search_queries import SearchKind, search
 from src.utils.redis_cache import cache, extract_key, use_redis_cache
 from src.utils.redis_metrics import record_metrics
-from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory, DEFAULT_TRENDING_VERSION
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory, DEFAULT_TRENDING_VERSIONS
 from src.trending_strategies.trending_type_and_version import TrendingType, TrendingVersion
 from src.queries.get_reposters_for_playlist import get_reposters_for_playlist
 from src.queries.get_savers_for_playlist import get_savers_for_playlist
@@ -275,7 +275,7 @@ trending_response = make_response("trending_playlists_response", ns, fields.List
 trending_parser = reqparse.RequestParser()
 trending_parser.add_argument('time', required=False)
 
-@ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.PLAYLISTS].name}, strict_slashes=False)
 @ns.route("/trending/<string:version>")
 class TrendingPlaylists(Resource):
     @record_metrics
@@ -324,7 +324,7 @@ full_trending_parser.add_argument('limit', required=False)
 full_trending_parser.add_argument('offset', required=False)
 full_trending_parser.add_argument('user_id', required=False)
 
-@full_ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@full_ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.PLAYLISTS].name}, strict_slashes=False)
 @full_ns.route("/trending/<string:version>")
 class FullTrendingPlaylists(Resource):
     @full_ns.expect(full_trending_parser)

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1,3 +1,4 @@
+from src.trending_strategies.ePWJD_trending_tracks_strategy import T
 from urllib.parse import urljoin
 import logging  # pylint: disable=C0302
 from flask import redirect
@@ -12,7 +13,7 @@ from src.api.v1.helpers import abort_not_found, decode_with_abort,  \
 from .models.tracks import track, track_full, stem_full, remixes_response as remixes_response_model
 from src.queries.search_queries import SearchKind, search
 from src.utils.redis_cache import cache, extract_key, use_redis_cache, get_trending_cache_key
-from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory, DEFAULT_TRENDING_VERSION
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory, DEFAULT_TRENDING_VERSIONS
 from src.trending_strategies.trending_type_and_version import TrendingType, TrendingVersion
 from flask.globals import request
 from src.utils.redis_metrics import record_metrics
@@ -229,7 +230,7 @@ class TrackSearchResult(Resource):
 # `get_trending_tracks.py`, which caches the scored tracks before they are populated (keyed by genre + time).
 # With this second cache, each user_id can reuse on the same cached list of tracks, and then populate them uniquely.
 
-@ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS].name}, strict_slashes=False)
 @ns.route("/trending/<string:version>")
 class Trending(Resource):
     @record_metrics
@@ -259,7 +260,7 @@ class Trending(Resource):
         trending_tracks = get_trending(args, strategy)
         return success_response(trending_tracks)
 
-@full_ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@full_ns.route("/trending", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS].name}, strict_slashes=False)
 @full_ns.route("/trending/<string:version>")
 class FullTrending(Resource):
     @record_metrics
@@ -280,7 +281,7 @@ underground_trending_parser.add_argument('limit', required=False)
 underground_trending_parser.add_argument('offset', required=False)
 underground_trending_parser.add_argument('user_id', required=False)
 
-@full_ns.route("/trending/underground", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@full_ns.route("/trending/underground", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.UNDERGROUND_TRACKS].name}, strict_slashes=False)
 @full_ns.route("/trending/underground/<string:version>")
 class FullUndergroundTrending(Resource):
     @record_metrics
@@ -303,7 +304,7 @@ recommended_track_parser.add_argument('limit', type=int, required=False)
 recommended_track_parser.add_argument('exclusion_list', type=int, action='append', required=False)
 recommended_track_parser.add_argument('time', required=False)
 
-@ns.route("/recommended", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@ns.route("/recommended", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS].name}, strict_slashes=False)
 @ns.route("/recommended/<string:version>")
 class RecommendedTrack(Resource):
     @record_metrics
@@ -339,7 +340,7 @@ class RecommendedTrack(Resource):
 full_recommended_track_parser = recommended_track_parser.copy()
 full_recommended_track_parser.add_argument('user_id', required=False)
 
-@full_ns.route("/recommended", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@full_ns.route("/recommended", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS].name}, strict_slashes=False)
 @full_ns.route("/recommended/<string:version>")
 class FullRecommendedTrack(Resource):
     @record_metrics
@@ -374,7 +375,7 @@ trending_ids_response = make_response(
     fields.Nested(trending_times_ids)
 )
 
-@full_ns.route("/trending/ids", defaults={"version": DEFAULT_TRENDING_VERSION.name}, strict_slashes=False)
+@full_ns.route("/trending/ids", defaults={"version": DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS].name}, strict_slashes=False)
 @full_ns.route("/trending/ids/<string:version>")
 class FullTrendingIds(Resource):
     @record_metrics

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1,4 +1,3 @@
-from src.trending_strategies.ePWJD_trending_tracks_strategy import T
 from urllib.parse import urljoin
 import logging  # pylint: disable=C0302
 from flask import redirect

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -1,17 +1,18 @@
+from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.db_session import get_db_read_replica
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import populate_track_metadata, \
     get_users_ids, get_users_by_id
 from src.tasks.generate_trending import generate_trending
 from src.utils.redis_cache import use_redis_cache
-from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSION
+from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
 
 TRENDING_LIMIT = 100
 TRENDING_TTL_SEC = 30 * 60
 
-def make_trending_cache_key(time_range, genre, version=DEFAULT_TRENDING_VERSION):
+def make_trending_cache_key(time_range, genre, version=DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]):
     """Makes a cache key resembling `generated-trending:week:electronic`"""
-    version_name = f":{version.name}" if version != DEFAULT_TRENDING_VERSION else ''
+    version_name = f":{version.name}" if version != DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS] else ''
     return f"generated-trending{version_name}:{time_range}:{(genre.lower() if genre else '')}"
 
 def generate_unpopulated_trending(session, genre, time_range, strategy, limit=TRENDING_LIMIT):

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import redis
 from sqlalchemy import func
 
+from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.db_session import get_db_read_replica
 from src.utils.redis_cache import use_redis_cache, get_trending_cache_key
 from src.models import Track, RepostType, Follow, SaveType, User, \
@@ -17,7 +18,7 @@ from src.api.v1.helpers import extend_track, format_offset, format_limit, \
 from src.queries.get_trending_tracks import make_trending_cache_key, TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.utils.redis_cache import get_pickled_key
 from src.utils.config import shared_config
-from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSION
+from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
 
 redis_url = shared_config["redis"]["url"]
 redis = redis.Redis.from_url(url=redis_url)
@@ -171,8 +172,8 @@ def get_scorable_track_data(session, redis_instance, strategy):
 
     return list(tracks_map.values())
 
-def make_underground_trending_cache_key(version=DEFAULT_TRENDING_VERSION):
-    version_name = f":{version.name}" if version != DEFAULT_TRENDING_VERSION else ''
+def make_underground_trending_cache_key(version=DEFAULT_TRENDING_VERSIONS[TrendingType.UNDERGROUND_TRACKS]):
+    version_name = f":{version.name}" if version != DEFAULT_TRENDING_VERSIONS[TrendingType.UNDERGROUND_TRACKS] else ''
     return f"{UNDERGROUND_TRENDING_CACHE_KEY}{version_name}"
 
 def make_get_unpopulated_tracks(session, redis_instance, strategy):

--- a/discovery-provider/src/trending_strategies/ePWJD_trending_playlists_strategy.py
+++ b/discovery-provider/src/trending_strategies/ePWJD_trending_playlists_strategy.py
@@ -10,4 +10,4 @@ class TrendingPlaylistsStrategyePWJD(BaseTrendingStrategy):
         return z(time, track)
 
     def get_score_params(self):
-        return {'zq': 1000, 'xf': True, 'pt': 0}
+        return {'zq': 1000, 'xf': True, 'pt': 0, 'mt': 3}

--- a/discovery-provider/src/trending_strategies/eYZmn_trending_playlists_strategy.py
+++ b/discovery-provider/src/trending_strategies/eYZmn_trending_playlists_strategy.py
@@ -10,4 +10,4 @@ class TrendingPlaylistsStrategyeYZmn(BaseTrendingStrategy):
         return z(time, track)
 
     def get_score_params(self):
-        return {'zq': 1000, 'xf': False, 'pt': 0}
+        return {'zq': 1000, 'xf': False, 'pt': 0, 'mt': 0}

--- a/discovery-provider/src/trending_strategies/trending_strategy_factory.py
+++ b/discovery-provider/src/trending_strategies/trending_strategy_factory.py
@@ -7,7 +7,11 @@ from src.trending_strategies.ePWJD_trending_tracks_strategy import TrendingTrack
 from src.trending_strategies.ePWJD_underground_trending_tracks_strategy import UndergroundTrendingTracksStrategyePWJD
 from src.trending_strategies.trending_type_and_version import TrendingType, TrendingVersion
 
-DEFAULT_TRENDING_VERSION = TrendingVersion.eYZmn
+DEFAULT_TRENDING_VERSIONS = {
+    TrendingType.TRACKS: TrendingVersion.eYZmn,
+    TrendingType.UNDERGROUND_TRACKS: TrendingVersion.eYZmn,
+    TrendingType.PLAYLISTS: TrendingVersion.eYZmn
+}
 class TrendingStrategyFactory:
     def __init__(self):
         self.strategies = {
@@ -25,7 +29,9 @@ class TrendingStrategyFactory:
             }
         }
 
-    def get_strategy(self, trending_type, version=DEFAULT_TRENDING_VERSION):
+    def get_strategy(self, trending_type, version=None):
+        if not version:
+            version = DEFAULT_TRENDING_VERSIONS[trending_type]
         return self.strategies[trending_type][version]
 
     def get_versions_for_type(self, trending_type):


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

- Add playlist mt to scorer
- Make unique defaults for each trending type


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Up stack locally against prod rds and test MT query, also this query works
```
select "playlist_id", "playlist_contents" from "playlists" where jsonb_array_length("playlist_contents"->'track_ids') > 20 limit 5
```
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
