### PR TITLE
Manually vacuum search matviews on refresh

### DIFF
--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -4,6 +4,24 @@ from src.tasks.celery_app import celery
 
 logger = logging.getLogger(__name__)
 
+# Vacuum can't happen inside a db txn, so we have to acquire
+# a new connection and set it's isolation level to AUTOCOMMIT
+# as per: https://stackoverflow.com/questions/1017463/postgresql-how-to-run-vacuum-from-code-outside-transaction-block
+# (note that connections have their isolation level wiped before being returned
+# to the conn pool: https://docs.sqlalchemy.org/en/14/core/connections.html
+def vacuum_matviews(db):
+    logger.info(f"index_materialized_views.py | Beginning vacuum")
+    vacuum_start = time.time()
+
+    engine = db._engine
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        connection.execute("VACUUM ANALYZE track_lexeme_dict")
+        connection.execute("VACUUM ANALYZE user_lexeme_dict")
+        connection.execute("VACUUM ANALYZE playlist_lexeme_dict")
+        connection.execute("VACUUM ANALYZE album_lexeme_dict")
+
+    logger.info(f"index_materialized_views.py | vacuumed in {time.time() - vacuum_start} sec.")
+
 def update_views(self, db):
     with db.scoped_session() as session:
         start_time = time.time()
@@ -15,18 +33,11 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY aggregate_plays")
 
-        # Manually vacuum the search views
-        vacuum_start = time.time()
-        session.execute("VACUUM ANALYZE track_lexeme_dict")
-        session.execute("VACUUM ANALYZE user_lexeme_dict")
-        session.execute("VACUUM ANALYZE playlist_lexeme_dict")
-        session.execute("VACUUM ANALYZE album_lexeme_dict")
-        end = time.time()
+    vacuum_matviews(db)
 
-        logger.info(
-            f"index_materialized_views.py | Finished updating materialized views in: {end - start_time} sec. \
-              Vacuuming: {end - vacuum_start} sec."
-        )
+    logger.info(
+        f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time} sec."
+    )
 
 
 ######## CELERY TASKS ########
@@ -40,7 +51,7 @@ def update_materialized_views(self):
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("materialized_view_lock", timeout=60*5)
+    update_lock = redis.lock("materialized_view_lock", timeout=60*10)
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -14,8 +14,17 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY aggregate_plays")
+
+        # Manually vacuum the search views
+        vacuum_start = time.time()
+        session.execute("VACUUM ANALYZE track_lexeme_dict")
+        session.execute("VACUUM ANALYZE user_lexeme_dict")
+        session.execute("VACUUM ANALYZE playlist_lexeme_dict")
+        session.execute("VACUUM ANALYZE album_lexeme_dict")
+        end = time.time()
+
         logger.info(
-            f"index_materialized_views.py | Finished updating materialized views in: {time.time()-start_time} sec"
+            f"index_materialized_views.py | Finished updating materialized views in: {end - start_time} sec. Vacuuming: {end - vacuum_start} sec."
         )
 
 

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -24,7 +24,8 @@ def update_views(self, db):
         end = time.time()
 
         logger.info(
-            f"index_materialized_views.py | Finished updating materialized views in: {end - start_time} sec. Vacuuming: {end - vacuum_start} sec."
+            f"index_materialized_views.py | Finished updating materialized views in: {end - start_time} sec. \
+              Vacuuming: {end - vacuum_start} sec."
         )
 
 


### PR DESCRIPTION
### Description

With the latest matview changes, our search matviews (specifically the track_lexeme_dict) need manual vacuuming or they grow too large and search performance suffers tremendously. 

### Tests

Tested this against a slow DP on one of our sandbox VMs. 

