### PR TITLE
Check if Solana Program is valid

### DIFF
--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -226,8 +226,10 @@ This is performed by simply slicing the tx_batches array and discarding the newe
 is found - these limiting parameters are defined as TX_SIGNATURES_MAX_BATCHES, TX_SIGNATURES_RESIZE_LENGTH
 '''
 def process_solana_plays(solana_client):
-    if not TRACK_LISTEN_PROGRAM:
-        logger.info("index_solana_plays.py | No program configured, exiting")
+    try:
+        base58.base58decode_check(TRACK_LISTEN_PROGRAM)
+    except ValueError:
+        logger.info("index_solana_plays.py | Invalid program configured, exiting")
         return
 
     db = index_solana_plays.db

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -227,7 +227,7 @@ is found - these limiting parameters are defined as TX_SIGNATURES_MAX_BATCHES, T
 '''
 def process_solana_plays(solana_client):
     try:
-        base58.base58decode_check(TRACK_LISTEN_PROGRAM)
+        base58.b58decode_check(TRACK_LISTEN_PROGRAM)
     except ValueError:
         logger.info("index_solana_plays.py | Invalid program configured, exiting")
         return

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -227,7 +227,7 @@ is found - these limiting parameters are defined as TX_SIGNATURES_MAX_BATCHES, T
 '''
 def process_solana_plays(solana_client):
     try:
-        base58.b58decode_check(TRACK_LISTEN_PROGRAM)
+        base58.b58decode(TRACK_LISTEN_PROGRAM)
     except ValueError:
         logger.info("index_solana_plays.py | Invalid program configured, exiting")
         return


### PR DESCRIPTION
### Description
Check if Solana Program for Track Listens is valid in Discovery Provider

This used to resolve to `"''"`, therefore checking if this is a valid value will resolve this issue.


### Tests
Tested on local deployment
