### PR TITLE
Exit on Discovery web server migration errors

### DIFF
--- a/discovery-provider/scripts/dev-server.sh
+++ b/discovery-provider/scripts/dev-server.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Audius Discovery Provider / Flask
 # Exports environment variables necessary for Flask app

--- a/discovery-provider/scripts/prod-server.sh
+++ b/discovery-provider/scripts/prod-server.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Audius Discovery Provider / Gunicorn
 


### PR DESCRIPTION
### Description
Currently the web server comes up regardless of the status of the commands run in the startup shell script. But if the migrations fail, we may not want the server to come up and we want to retry running the migrations. So I've added `set -e` so the script exits on any error, kube will restart and try to run the migrations again.

### Tests
Ran the discovery provider locally and caused alembic to exit with status 1 by adding exit(1) in the alembic/env.py file. Docker restarted the container in that case. However, when that was removed, the web server worked as intended.
