### PR TITLE
Sol play query argument verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,8 @@ workflows:
       - docker-build-and-push:
           name: build-discovery-provider
           repo: discovery-provider
+          requires:
+            - test-discovery-provider
 
       - test-identity-service
       - docker-build-and-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,8 +666,6 @@ workflows:
       - docker-build-and-push:
           name: build-discovery-provider
           repo: discovery-provider
-          requires:
-            - test-discovery-provider
 
       - test-identity-service
       - docker-build-and-push:

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -1,5 +1,6 @@
 import logging
 from sqlalchemy import desc, func
+from src import exceptions
 from src.models import Play
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 # Get single play from table
 def get_sol_play(sol_tx_signature):
     if not sol_tx_signature:
-        raise Exception("Missing tx signature")
+        raise exceptions.ArgumentError("Missing tx signature")
 
     db = get_db_read_replica()
     sol_play = None

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -19,8 +19,10 @@ def get_sol_play(sol_tx_signature):
             )
         )
         query_results = base_query.first()
+        logger.error(query_results)
         if query_results:
             sol_play = helpers.model_to_dictionary(query_results)
+            logger.error(sol_play)
 
     return sol_play
 

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -9,6 +9,9 @@ logger = logging.getLogger(__name__)
 
 # Get single play from table
 def get_sol_play(sol_tx_signature):
+    if not sol_tx_signature:
+        raise Exception("Missing tx signature")
+
     db = get_db_read_replica()
     sol_play = None
     with db.scoped_session() as session:
@@ -19,10 +22,8 @@ def get_sol_play(sol_tx_signature):
             )
         )
         query_results = base_query.first()
-        logger.error(query_results)
         if query_results:
             sol_play = helpers.model_to_dictionary(query_results)
-            logger.error(sol_play)
 
     return sol_play
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Ensure sol_tx_signature argument is provided, preventing incorrect results from being returned - observed during staging rollout when queried with `tx=...` instead of `tx_sig=....`


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Manually verified on staging - proper argument error returned for
https://discoveryprovider3.staging.audius.co/get_sol_play?tx=2vnsEGPH8knEAxyZ8hovLqn3AcvGiapgd9d5gPzvUJJEfrqayAPKzExaqqKFQLox6HRMdTiJRH9VZ45FyD6UsFVK

vs

https://discoveryprovider3.staging.audius.co/get_sol_play?tx_sig=2vnsEGPH8knEAxyZ8hovLqn3AcvGiapgd9d5gPzvUJJEfrqayAPKzExaqqKFQLox6HRMdTiJRH9VZ45FyD6UsFVK

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
