### PR TITLE
Re-enable identity listens

### DIFF
--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -236,6 +236,7 @@ module.exports = function (app) {
     if (trackListenRecord && trackListenRecord[1]) {
       logger.info(`New track listen record inserted ${trackListenRecord}`)
     }
+    await models.TrackListenCount.increment('listens', { where: { hour: currentHour, trackId: req.params.id } })
 
     // Clients will send a randomly generated string UUID for anonymous users.
     // Those listened should NOT be recorded in the userTrackListen table


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Fixes unintended TrackListenCount removal from this PR
https://github.com/AudiusProject/audius-protocol/pull/1354/files#diff-0612108b9817539d4254443e06c6dd54414990511bed32c6573f94f1845f877fL219

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Test 1
2. Test 2
3. Test 3\
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
