### PR TITLE
Adds indexing tests

### DIFF
--- a/discovery-provider/tests/index_helpers.py
+++ b/discovery-provider/tests/index_helpers.py
@@ -1,0 +1,23 @@
+# Helper methods for testing indexing
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+class IPFSClient:
+    def __init__(self, metadata_dict):
+      self.metadata_dict = metadata_dict
+
+    def get_metadata(self, multihash, format, endpoint):
+        return self.metadata_dict[multihash]
+
+class Web3:
+    def toHex(self, blockHash):
+        return '0x'
+
+class UpdateTask:
+    def __init__(self, ipfs_client, web3):
+      self.ipfs_client = ipfs_client
+      self.web3 = web3
+

--- a/discovery-provider/tests/index_helpers.py
+++ b/discovery-provider/tests/index_helpers.py
@@ -7,7 +7,7 @@ class AttrDict(dict):
 
 class IPFSClient:
     def __init__(self, metadata_dict):
-      self.metadata_dict = metadata_dict
+        self.metadata_dict = metadata_dict
 
     def get_metadata(self, multihash, format, endpoint):
         return self.metadata_dict[multihash]
@@ -18,6 +18,5 @@ class Web3:
 
 class UpdateTask:
     def __init__(self, ipfs_client, web3):
-      self.ipfs_client = ipfs_client
-      self.web3 = web3
-
+        self.ipfs_client = ipfs_client
+        self.web3 = web3

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -96,7 +96,7 @@ def test_index_playlist(app):
     """Tests that playlists are indexed correctly"""
     with app.app_context():
         db = get_db()
-    
+
     ipfs_client = IPFSClient({})
     web3 = Web3()
     update_task = UpdateTask(ipfs_client, web3)
@@ -108,7 +108,7 @@ def test_index_playlist(app):
         block_number = random.randint(1, 10000)
         block_timestamp = 1585336422
 
-        # Some sqlalchemy user instance
+        # Some sqlalchemy playlist instance
         playlist_record = lookup_playlist_record(
             update_task,
             session,

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -4,11 +4,7 @@ from src.tasks.playlists import parse_playlist_event, lookup_playlist_record
 from src.utils.db_session import get_db
 from src.utils.playlist_event_constants import playlist_event_types_lookup
 from src.utils import helpers
-
-class AttrDict(dict):
-    def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
-        self.__dict__ = self
+from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 
 # event_type: PlaylistCreated
 def get_playlist_created_event():
@@ -96,20 +92,14 @@ def get_playlist_deleted_event():
     })
     return event_type, AttrDict({"blockHash": "0x", "args": playlist_deleted_event})
 
-
-class Web3:
-    def toHex(self, blockHash):
-        return '0x'
-
-class UpdateTask:
-    web3 = Web3()
-
-update_task = UpdateTask()
-
 def test_index_playlist(app):
     """Tests that playlists are indexed correctly"""
     with app.app_context():
         db = get_db()
+    
+    ipfs_client = IPFSClient({})
+    web3 = Web3()
+    update_task = UpdateTask(ipfs_client, web3)
 
     with db.scoped_session() as session:
         # ================= Test playlist_created Event =================

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -1,6 +1,5 @@
 import random
-from datetime import datetime, timedelta
-from src.models import User
+from datetime import datetime
 from src.tasks.playlists import parse_playlist_event, lookup_playlist_record
 from src.utils.db_session import get_db
 from src.utils.playlist_event_constants import playlist_event_types_lookup
@@ -12,94 +11,95 @@ class AttrDict(dict):
         self.__dict__ = self
 
 # event_type: PlaylistCreated
-def playlist_created_event():
-  event_type = playlist_event_types_lookup['playlist_created']
-  playlist_created_event = AttrDict({
-    '_playlistId': 1,
-    '_playlistOwnerId': 1,
-    '_isPrivate': True,
-    '_isAlbum': False,
-    '_trackIds': [] # This is a list of numbers (track ids)
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_created_event })
+def get_playlist_created_event():
+    event_type = playlist_event_types_lookup['playlist_created']
+    playlist_created_event = AttrDict({
+        '_playlistId': 1,
+        '_playlistOwnerId': 1,
+        '_isPrivate': True,
+        '_isAlbum': False,
+        '_trackIds': [] # This is a list of numbers (track ids)
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_created_event})
 
 # event_type: PlaylistNameUpdated
-def playlist_name_updated_event():
-  event_type = playlist_event_types_lookup['playlist_name_updated']
-  playlist_name_updated_event = AttrDict({
-  '_playlistId': 1,
-  '_updatedPlaylistName': 'asdfg'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_name_updated_event })
+def get_playlist_name_updated_event():
+    event_type = playlist_event_types_lookup['playlist_name_updated']
+    playlist_name_updated_event = AttrDict({
+        '_playlistId': 1,
+        '_updatedPlaylistName': 'asdfg'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_name_updated_event})
 
 # event_type: PlaylistCoverPhotoUpdated
-def playlist_cover_photo_updated_event():
-  event_type = playlist_event_types_lookup['playlist_cover_photo_updated']
-  playlist_cover_photo_updated_event = AttrDict({
-  '_playlistId': 1,
-  '_playlistImageMultihashDigest': b'\xad\x8d\x1eeG\xf2\x12\xe3\x817\x7f\xb1A\xc6 M~\xfe\x03F\x98f\xab\xfa3\x17ib\xdcC>\xed'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_cover_photo_updated_event })
+def get_playlist_cover_photo_updated_event():
+    event_type = playlist_event_types_lookup['playlist_cover_photo_updated']
+    playlist_cover_photo_updated_event = AttrDict({
+        '_playlistId': 1,
+        '_playlistImageMultihashDigest':
+        b'\xad\x8d\x1eeG\xf2\x12\xe3\x817\x7f\xb1A\xc6 M~\xfe\x03F\x98f\xab\xfa3\x17ib\xdcC>\xed'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_cover_photo_updated_event})
 
 # event_type: PlaylistDescriptionUpdated
-def playlist_description_updated_event():
-  event_type = playlist_event_types_lookup['playlist_description_updated']
-  playlist_description_updated_event = AttrDict({
-    '_playlistId': 1,
-    '_playlistDescription': 'adf'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_description_updated_event })
+def get_playlist_description_updated_event():
+    event_type = playlist_event_types_lookup['playlist_description_updated']
+    playlist_description_updated_event = AttrDict({
+        '_playlistId': 1,
+        '_playlistDescription': 'adf'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_description_updated_event})
 
 
 # event_type: PlaylistTrackAdded
-def playlist_track_added_event(playlistId, addedTrackId):
-  event_type = playlist_event_types_lookup['playlist_track_added']
-  playlist_track_added_event = AttrDict({
-    '_playlistId': playlistId,
-    '_addedTrackId': addedTrackId
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_track_added_event })
+def get_playlist_track_added_event(playlistId, addedTrackId):
+    event_type = playlist_event_types_lookup['playlist_track_added']
+    playlist_track_added_event = AttrDict({
+        '_playlistId': playlistId,
+        '_addedTrackId': addedTrackId
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_track_added_event})
 
 # event_type: PlaylistTracksOrdered
-def playlist_tracks_ordered_event():
-  event_type = playlist_event_types_lookup['playlist_tracks_ordered']
-  playlist_tracks_ordered_event = AttrDict({
-    '_playlistId': 1,
-    '_orderedTrackIds': [2, 1]
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_tracks_ordered_event })
+def get_playlist_tracks_ordered_event():
+    event_type = playlist_event_types_lookup['playlist_tracks_ordered']
+    playlist_tracks_ordered_event = AttrDict({
+        '_playlistId': 1,
+        '_orderedTrackIds': [2, 1]
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_tracks_ordered_event})
 
 # event_type: PlaylistTrackDeleted
-def playlist_track_delete_event(playlistId, deletedTrackId, deletedTrackTimestamp):
-  event_type = playlist_event_types_lookup['playlist_track_deleted']
-  playlist_track_delete_event = AttrDict({
-    '_playlistId': playlistId,
-    '_deletedTrackId': deletedTrackId,
-    '_deletedTrackTimestamp': deletedTrackTimestamp
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_track_delete_event })
+def get_playlist_track_delete_event(playlistId, deletedTrackId, deletedTrackTimestamp):
+    event_type = playlist_event_types_lookup['playlist_track_deleted']
+    playlist_track_delete_event = AttrDict({
+        '_playlistId': playlistId,
+        '_deletedTrackId': deletedTrackId,
+        '_deletedTrackTimestamp': deletedTrackTimestamp
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_track_delete_event})
 
-  # event_type: PlaylistPrivacyUpdated
-def playlist_privacy_updated_event():
-  event_type = playlist_event_types_lookup['playlist_privacy_updated']
-  playlist_privacy_updated_event = AttrDict({
-    '_playlistId': 1,
-    '_updatedIsPrivate': False
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_privacy_updated_event })
+    # event_type: PlaylistPrivacyUpdated
+def get_playlist_privacy_updated_event():
+    event_type = playlist_event_types_lookup['playlist_privacy_updated']
+    playlist_privacy_updated_event = AttrDict({
+        '_playlistId': 1,
+        '_updatedIsPrivate': False
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_privacy_updated_event})
 
 # event_type: PlaylistDeleted
-def playlist_deleted_event():
-  event_type = playlist_event_types_lookup['playlist_deleted']
-  playlist_deleted_event = AttrDict({
-    '_playlistId': 1
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_deleted_event })
+def get_playlist_deleted_event():
+    event_type = playlist_event_types_lookup['playlist_deleted']
+    playlist_deleted_event = AttrDict({
+        '_playlistId': 1
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": playlist_deleted_event})
 
 
 class Web3:
-  def toHex(self, blockHash):
-    return '0x'
+    def toHex(self, blockHash):
+        return '0x'
 
 class UpdateTask:
     web3 = Web3()
@@ -107,203 +107,205 @@ class UpdateTask:
 update_task = UpdateTask()
 
 def test_index_playlist(app):
-  """Tests that playlists are indexed correctly"""
-  with app.app_context():
-    db = get_db()
+    """Tests that playlists are indexed correctly"""
+    with app.app_context():
+        db = get_db()
 
-  with db.scoped_session() as session:
-    # ================= Test playlist_created Event =================
-    event_type, entry = playlist_created_event()
+    with db.scoped_session() as session:
+        # ================= Test playlist_created Event =================
+        event_type, entry = get_playlist_created_event()
 
-    block_number = random.randint(1, 10000)
-    block_timestamp = 1585336422
+        block_number = random.randint(1, 10000)
+        block_timestamp = 1585336422
 
-    # Some sqlalchemy user instance
-    playlist_record = lookup_playlist_record(
-      update_task,
-      session,
-      entry,
-      block_number,
-      '0x' # txhash
-    )
-
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-
-    assert playlist_record.playlist_owner_id == entry.args._playlistOwnerId
-    assert playlist_record.is_private == entry.args._isPrivate
-    assert playlist_record.is_album == entry.args._isAlbum
-    block_datetime = datetime.utcfromtimestamp(block_timestamp)
-    block_integer_time = int(block_timestamp)
-
-    playlist_content_array = []
-    for track_id in entry.args._trackIds:
-        playlist_content_array.append(
-            {"track": track_id, "time": block_integer_time}
+        # Some sqlalchemy user instance
+        playlist_record = lookup_playlist_record(
+            update_task,
+            session,
+            entry,
+            block_number,
+            '0x' # txhash
         )
 
-    assert playlist_record.playlist_contents == {"track_ids": playlist_content_array}
-    assert playlist_record.created_at == block_datetime
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
 
-    # ================= Test playlist_name_updated Event =================
-    event_type, entry = playlist_name_updated_event()
+        assert playlist_record.playlist_owner_id == entry.args._playlistOwnerId
+        assert playlist_record.is_private == entry.args._isPrivate
+        assert playlist_record.is_album == entry.args._isAlbum
+        block_datetime = datetime.utcfromtimestamp(block_timestamp)
+        block_integer_time = int(block_timestamp)
 
-    assert playlist_record.playlist_name == None
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-    assert playlist_record.playlist_name == entry.args._updatedPlaylistName
+        playlist_content_array = []
+        for track_id in entry.args._trackIds:
+            playlist_content_array.append(
+                {"track": track_id, "time": block_integer_time}
+            )
 
-    # ================= Test playlist_cover_photo_updated Event =================
-    event_type, entry = playlist_cover_photo_updated_event()
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-    assert playlist_record.playlist_image_sizes_multihash == helpers.multihash_digest_to_cid(entry.args._playlistImageMultihashDigest)
-    assert playlist_record.playlist_image_multihash == None
+        assert playlist_record.playlist_contents == {"track_ids": playlist_content_array}
+        assert playlist_record.created_at == block_datetime
 
-    # ================= Test playlist_description_updated Event =================
-    event_type, entry = playlist_description_updated_event()
-    assert playlist_record.description == None
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-    assert playlist_record.description == entry.args._playlistDescription
+        # ================= Test playlist_name_updated Event =================
+        event_type, entry = get_playlist_name_updated_event()
 
-    # ================= Test playlist_privacy_updated Event =================
-    event_type, entry = playlist_privacy_updated_event()
-    assert playlist_record.is_private == True
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-    assert playlist_record.is_private == entry.args._updatedIsPrivate
+        assert playlist_record.playlist_name == None
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+        assert playlist_record.playlist_name == entry.args._updatedPlaylistName
 
-    # ================= Test playlist_track_added Event =================
-    event_type, entry = playlist_track_added_event(1, 1)
+        # ================= Test playlist_cover_photo_updated Event =================
+        event_type, entry = get_playlist_cover_photo_updated_event()
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+        assert playlist_record.playlist_image_sizes_multihash == (
+            helpers.multihash_digest_to_cid(entry.args._playlistImageMultihashDigest)
+        )
+        assert playlist_record.playlist_image_multihash == None
 
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        12, # block_timestamp,
-        session
-    )
-    
-    assert len(playlist_record.playlist_contents['track_ids']) == 1
-    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
-    assert last_playlist_content == { "track": entry.args._addedTrackId, "time":  12 }
+        # ================= Test playlist_description_updated Event =================
+        event_type, entry = get_playlist_description_updated_event()
+        assert playlist_record.description == None
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+        assert playlist_record.description == entry.args._playlistDescription
 
-    # ================= Test playlist_track_added with second track Event =================
-    event_type, entry = playlist_track_added_event(1, 2)
+        # ================= Test playlist_privacy_updated Event =================
+        event_type, entry = get_playlist_privacy_updated_event()
+        assert playlist_record.is_private == True
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+        assert playlist_record.is_private == entry.args._updatedIsPrivate
 
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        13, # block_timestamp,
-        session
-    )
-    
-    assert len(playlist_record.playlist_contents['track_ids']) == 2
-    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
-    assert last_playlist_content == { "track": entry.args._addedTrackId, "time":  13 }
+        # ================= Test playlist_track_added Event =================
+        event_type, entry = get_playlist_track_added_event(1, 1)
 
-    # ================= Test playlist_tracks_ordered Event =================
-    event_type, entry = playlist_tracks_ordered_event()
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            12, # block_timestamp,
+            session
+        )
 
-    assert playlist_record.playlist_contents['track_ids'] == [
-      { "track": 2, "time":  13 },
-      { "track": 1, "time":  12 }
-    ]
+        assert len(playlist_record.playlist_contents['track_ids']) == 1
+        last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+        assert last_playlist_content == {"track": entry.args._addedTrackId, "time": 12}
 
-    # ================= Test playlist_track_delete_event Event =================
-    event_type, entry = playlist_track_delete_event(1, 1, 12)
+        # ================= Test playlist_track_added with second track Event =================
+        event_type, entry = get_playlist_track_added_event(1, 2)
 
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            13, # block_timestamp,
+            session
+        )
 
-    assert len(playlist_record.playlist_contents['track_ids']) == 1
-    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
-    assert playlist_record.playlist_contents['track_ids'] == [{ "track": 2, "time":  13 }]
+        assert len(playlist_record.playlist_contents['track_ids']) == 2
+        last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+        assert last_playlist_content == {"track": entry.args._addedTrackId, "time": 13}
 
-    # ================= Test playlist_track_delete_event Event =================
-    # This should be a no-op
-    event_type, entry = playlist_track_delete_event(1, 1, 12)
+        # ================= Test playlist_tracks_ordered Event =================
+        event_type, entry = get_playlist_tracks_ordered_event()
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
 
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
+        assert playlist_record.playlist_contents['track_ids'] == [
+            {"track": 2, "time": 13},
+            {"track": 1, "time": 12}
+        ]
 
-    assert len(playlist_record.playlist_contents['track_ids']) == 1
-    assert playlist_record.playlist_contents['track_ids'] == [{ "track": 2, "time":  13 }]
+        # ================= Test playlist_track_delete_event Event =================
+        event_type, entry = get_playlist_track_delete_event(1, 1, 12)
 
-    # ================= Test playlist_deleted Event =================
-    event_type, entry = playlist_deleted_event()
-    assert playlist_record.is_delete == False
-    parse_playlist_event(
-        None, # self - not used
-        None, # update_task - not used
-        entry,
-        event_type,
-        playlist_record,
-        block_timestamp,
-        session
-    )
-    assert playlist_record.is_delete == True
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+
+        assert len(playlist_record.playlist_contents['track_ids']) == 1
+        last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+        assert playlist_record.playlist_contents['track_ids'] == [{"track": 2, "time": 13}]
+
+        # ================= Test playlist_track_delete_event Event =================
+        # This should be a no-op
+        event_type, entry = get_playlist_track_delete_event(1, 1, 12)
+
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+
+        assert len(playlist_record.playlist_contents['track_ids']) == 1
+        assert playlist_record.playlist_contents['track_ids'] == [{"track": 2, "time": 13}]
+
+        # ================= Test playlist_deleted Event =================
+        event_type, entry = get_playlist_deleted_event()
+        assert playlist_record.is_delete == False
+        parse_playlist_event(
+            None, # self - not used
+            None, # update_task - not used
+            entry,
+            event_type,
+            playlist_record,
+            block_timestamp,
+            session
+        )
+        assert playlist_record.is_delete == True

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -1,0 +1,309 @@
+import random
+from datetime import datetime, timedelta
+from src.models import User
+from src.tasks.playlists import parse_playlist_event, lookup_playlist_record
+from src.utils.db_session import get_db
+from src.utils.playlist_event_constants import playlist_event_types_lookup
+from src.utils import helpers
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+# event_type: PlaylistCreated
+def playlist_created_event():
+  event_type = playlist_event_types_lookup['playlist_created']
+  playlist_created_event = AttrDict({
+    '_playlistId': 1,
+    '_playlistOwnerId': 1,
+    '_isPrivate': True,
+    '_isAlbum': False,
+    '_trackIds': [] # This is a list of numbers (track ids)
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_created_event })
+
+# event_type: PlaylistNameUpdated
+def playlist_name_updated_event():
+  event_type = playlist_event_types_lookup['playlist_name_updated']
+  playlist_name_updated_event = AttrDict({
+  '_playlistId': 1,
+  '_updatedPlaylistName': 'asdfg'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_name_updated_event })
+
+# event_type: PlaylistCoverPhotoUpdated
+def playlist_cover_photo_updated_event():
+  event_type = playlist_event_types_lookup['playlist_cover_photo_updated']
+  playlist_cover_photo_updated_event = AttrDict({
+  '_playlistId': 1,
+  '_playlistImageMultihashDigest': b'\xad\x8d\x1eeG\xf2\x12\xe3\x817\x7f\xb1A\xc6 M~\xfe\x03F\x98f\xab\xfa3\x17ib\xdcC>\xed'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_cover_photo_updated_event })
+
+# event_type: PlaylistDescriptionUpdated
+def playlist_description_updated_event():
+  event_type = playlist_event_types_lookup['playlist_description_updated']
+  playlist_description_updated_event = AttrDict({
+    '_playlistId': 1,
+    '_playlistDescription': 'adf'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_description_updated_event })
+
+
+# event_type: PlaylistTrackAdded
+def playlist_track_added_event(playlistId, addedTrackId):
+  event_type = playlist_event_types_lookup['playlist_track_added']
+  playlist_track_added_event = AttrDict({
+    '_playlistId': playlistId,
+    '_addedTrackId': addedTrackId
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_track_added_event })
+
+# event_type: PlaylistTracksOrdered
+def playlist_tracks_ordered_event():
+  event_type = playlist_event_types_lookup['playlist_tracks_ordered']
+  playlist_tracks_ordered_event = AttrDict({
+    '_playlistId': 1,
+    '_orderedTrackIds': [2, 1]
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_tracks_ordered_event })
+
+# event_type: PlaylistTrackDeleted
+def playlist_track_delete_event(playlistId, deletedTrackId, deletedTrackTimestamp):
+  event_type = playlist_event_types_lookup['playlist_track_deleted']
+  playlist_track_delete_event = AttrDict({
+    '_playlistId': playlistId,
+    '_deletedTrackId': deletedTrackId,
+    '_deletedTrackTimestamp': deletedTrackTimestamp
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_track_delete_event })
+
+  # event_type: PlaylistPrivacyUpdated
+def playlist_privacy_updated_event():
+  event_type = playlist_event_types_lookup['playlist_privacy_updated']
+  playlist_privacy_updated_event = AttrDict({
+    '_playlistId': 1,
+    '_updatedIsPrivate': False
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_privacy_updated_event })
+
+# event_type: PlaylistDeleted
+def playlist_deleted_event():
+  event_type = playlist_event_types_lookup['playlist_deleted']
+  playlist_deleted_event = AttrDict({
+    '_playlistId': 1
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": playlist_deleted_event })
+
+
+class Web3:
+  def toHex(self, blockHash):
+    return '0x'
+
+class UpdateTask:
+    web3 = Web3()
+
+update_task = UpdateTask()
+
+def test_index_playlist(app):
+  """Tests that playlists are indexed correctly"""
+  with app.app_context():
+    db = get_db()
+
+  with db.scoped_session() as session:
+    # ================= Test playlist_created Event =================
+    event_type, entry = playlist_created_event()
+
+    block_number = random.randint(1, 10000)
+    block_timestamp = 1585336422
+
+    # Some sqlalchemy user instance
+    playlist_record = lookup_playlist_record(
+      update_task,
+      session,
+      entry,
+      block_number,
+      '0x' # txhash
+    )
+
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+
+    assert playlist_record.playlist_owner_id == entry.args._playlistOwnerId
+    assert playlist_record.is_private == entry.args._isPrivate
+    assert playlist_record.is_album == entry.args._isAlbum
+    block_datetime = datetime.utcfromtimestamp(block_timestamp)
+    block_integer_time = int(block_timestamp)
+
+    playlist_content_array = []
+    for track_id in entry.args._trackIds:
+        playlist_content_array.append(
+            {"track": track_id, "time": block_integer_time}
+        )
+
+    assert playlist_record.playlist_contents == {"track_ids": playlist_content_array}
+    assert playlist_record.created_at == block_datetime
+
+    # ================= Test playlist_name_updated Event =================
+    event_type, entry = playlist_name_updated_event()
+
+    assert playlist_record.playlist_name == None
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+    assert playlist_record.playlist_name == entry.args._updatedPlaylistName
+
+    # ================= Test playlist_cover_photo_updated Event =================
+    event_type, entry = playlist_cover_photo_updated_event()
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+    assert playlist_record.playlist_image_sizes_multihash == helpers.multihash_digest_to_cid(entry.args._playlistImageMultihashDigest)
+    assert playlist_record.playlist_image_multihash == None
+
+    # ================= Test playlist_description_updated Event =================
+    event_type, entry = playlist_description_updated_event()
+    assert playlist_record.description == None
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+    assert playlist_record.description == entry.args._playlistDescription
+
+    # ================= Test playlist_privacy_updated Event =================
+    event_type, entry = playlist_privacy_updated_event()
+    assert playlist_record.is_private == True
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+    assert playlist_record.is_private == entry.args._updatedIsPrivate
+
+    # ================= Test playlist_track_added Event =================
+    event_type, entry = playlist_track_added_event(1, 1)
+
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        12, # block_timestamp,
+        session
+    )
+    
+    assert len(playlist_record.playlist_contents['track_ids']) == 1
+    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+    assert last_playlist_content == { "track": entry.args._addedTrackId, "time":  12 }
+
+    # ================= Test playlist_track_added with second track Event =================
+    event_type, entry = playlist_track_added_event(1, 2)
+
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        13, # block_timestamp,
+        session
+    )
+    
+    assert len(playlist_record.playlist_contents['track_ids']) == 2
+    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+    assert last_playlist_content == { "track": entry.args._addedTrackId, "time":  13 }
+
+    # ================= Test playlist_tracks_ordered Event =================
+    event_type, entry = playlist_tracks_ordered_event()
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+
+    assert playlist_record.playlist_contents['track_ids'] == [
+      { "track": 2, "time":  13 },
+      { "track": 1, "time":  12 }
+    ]
+
+    # ================= Test playlist_track_delete_event Event =================
+    event_type, entry = playlist_track_delete_event(1, 1, 12)
+
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+
+    assert len(playlist_record.playlist_contents['track_ids']) == 1
+    last_playlist_content = playlist_record.playlist_contents['track_ids'][-1]
+    assert playlist_record.playlist_contents['track_ids'] == [{ "track": 2, "time":  13 }]
+
+    # ================= Test playlist_track_delete_event Event =================
+    # This should be a no-op
+    event_type, entry = playlist_track_delete_event(1, 1, 12)
+
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+
+    assert len(playlist_record.playlist_contents['track_ids']) == 1
+    assert playlist_record.playlist_contents['track_ids'] == [{ "track": 2, "time":  13 }]
+
+    # ================= Test playlist_deleted Event =================
+    event_type, entry = playlist_deleted_event()
+    assert playlist_record.is_delete == False
+    parse_playlist_event(
+        None, # self - not used
+        None, # update_task - not used
+        entry,
+        event_type,
+        playlist_record,
+        block_timestamp,
+        session
+    )
+    assert playlist_record.is_delete == True

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -1,10 +1,8 @@
 import random
-from datetime import datetime, timedelta
-from sqlalchemy.sql import null
-from src.models import Block, User, Track
+from datetime import datetime
+from src.models import Block, User
 from src.tasks.tracks import parse_track_event, lookup_track_record, track_event_types_lookup
 from src.utils.db_session import get_db
-from src.utils.user_event_constants import user_event_types_lookup
 
 class AttrDict(dict):
     def __init__(self, *args, **kwargs):
@@ -13,101 +11,102 @@ class AttrDict(dict):
 
 
 def get_new_track_event():
-  event_type = track_event_types_lookup['new_track']
-  new_track_event = AttrDict({
-    '_id': 1,
-    '_trackOwnerId': 1,
-    '_multihashDigest': b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg',
-    '_multihashHashFn': 18,
-    '_multihashSize': 32
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": new_track_event })
+    event_type = track_event_types_lookup['new_track']
+    new_track_event = AttrDict({
+        '_id': 1,
+        '_trackOwnerId': 1,
+        '_multihashDigest':
+            b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg',
+        '_multihashHashFn': 18,
+        '_multihashSize': 32
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": new_track_event})
 
 def get_update_track_event():
-  event_type = track_event_types_lookup['update_track']
-  update_track_event = AttrDict({
-    '_trackId': 1,
-    '_trackOwnerId': 1,
-    '_multihashDigest': b'\x93\x7f\xa2\xe6\xf0\xe5\xb5f\xca\x14(4m.B\xba3\xf8\xc8<|%*{\x11\xc1\xe2/\xd7\xee\xd7q',
-    '_multihashHashFn': 18,
-    '_multihashSize': 32
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_track_event })
+    event_type = track_event_types_lookup['update_track']
+    update_track_event = AttrDict({
+        '_trackId': 1,
+        '_trackOwnerId': 1,
+        '_multihashDigest': b'\x93\x7f\xa2\xe6\xf0\xe5\xb5f\xca\x14(4m.B\xba3\xf8\xc8<|%*{\x11\xc1\xe2/\xd7\xee\xd7q',
+        '_multihashHashFn': 18,
+        '_multihashSize': 32
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_track_event})
 
 def get_delete_track_event():
-  event_type = track_event_types_lookup['delete_track']
-  delete_track_event = AttrDict({
-    '_trackId': 1
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": delete_track_event })
+    event_type = track_event_types_lookup['delete_track']
+    delete_track_event = AttrDict({
+        '_trackId': 1
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": delete_track_event})
 
 
 class IPFSClient:
-  def get_metadata(self, multihash, format, endpoint):
-    return {
-      "owner_id": 1,
-      "title": "real magic bassy flip",
-      "length": None,
-      "cover_art": None,
-      "cover_art_sizes": "QmdxhDiRUC3zQEKqwnqksaSsSSeHiRghjwKzwoRvm77yaZ",
-      "tags": "realmagic,rickyreed,theroom",
-      "genre": "R&B/Soul",
-      "mood": "Empowering",
-      "credits_splits": None,
-      "created_at": "2020-07-11 08:22:15",
-      "create_date": None,
-      "updated_at": "2020-07-11 08:22:15",
-      "release_date": "Sat Jul 11 2020 01:19:58 GMT-0700",
-      "file_type": None,
-      "track_segments": [
-        {
-          "duration": 6.016,
-          "multihash": "QmabM5svgDgcRdQZaEKSMBCpSZrrYy2y87L8Dx8EQ3T2jp"
+    def get_metadata(self, multihash, format, endpoint):
+        return {
+            "owner_id": 1,
+            "title": "real magic bassy flip",
+            "length": None,
+            "cover_art": None,
+            "cover_art_sizes": "QmdxhDiRUC3zQEKqwnqksaSsSSeHiRghjwKzwoRvm77yaZ",
+            "tags": "realmagic,rickyreed,theroom",
+            "genre": "R&B/Soul",
+            "mood": "Empowering",
+            "credits_splits": None,
+            "created_at": "2020-07-11 08:22:15",
+            "create_date": None,
+            "updated_at": "2020-07-11 08:22:15",
+            "release_date": "Sat Jul 11 2020 01:19:58 GMT-0700",
+            "file_type": None,
+            "track_segments": [
+                {
+                    "duration": 6.016,
+                    "multihash": "QmabM5svgDgcRdQZaEKSMBCpSZrrYy2y87L8Dx8EQ3T2jp"
+                }
+            ],
+            "has_current_user_reposted": False,
+            "is_current": True,
+            "is_unlisted": False,
+            "field_visibility": {
+                "mood": True,
+                "tags": True,
+                "genre": True,
+                "share": True,
+                "play_count": True,
+                "remixes": True
+            },
+            "remix_of": {
+                "tracks": [
+                    {
+                        "parent_track_id": 75808
+                    }
+                ]
+            },
+            "repost_count": 12,
+            "save_count": 21,
+            "description": None,
+            "license": "All rights reserved",
+            "isrc": None,
+            "iswc": None,
+            "download": {
+                "cid": None,
+                "is_downloadable": False,
+                "requires_follow": False
+            },
+            "track_id": 77955,
+            "stem_of": None
         }
-      ],
-      "has_current_user_reposted": False,
-      "is_current": True,
-      "is_unlisted": False,
-      "field_visibility": {
-        "mood": True,
-        "tags": True,
-        "genre": True,
-        "share": True,
-        "play_count": True,
-        "remixes": True
-      },
-      "remix_of": {
-        "tracks": [
-          {
-            "parent_track_id": 75808
-          }
-        ]
-      },
-      "repost_count": 12,
-      "save_count": 21,
-      "description": None,
-      "license": "All rights reserved",
-      "isrc": None,
-      "iswc": None,
-      "download": {
-        "cid": None,
-        "is_downloadable": False,
-        "requires_follow": False
-      },
-      "track_id": 77955,
-      "stem_of": None
-    }
 
 
 class Web3:
-  def toHex(self, blockHash):
-    return '0x'
+    def toHex(self, blockHash):
+        return '0x'
 
 class UpdateTask:
     ipfs_client = IPFSClient()
     web3 = Web3()
 
-# ========================================== Start Tests ========================================== 
+# ========================================== Start Tests ==========================================
 def test_index_tracks(app):
     """Tests that tracks are indexed correctly"""
     with app.app_context():
@@ -124,13 +123,13 @@ def test_index_tracks(app):
 
         # Some sqlalchemy user instance
         track_record = lookup_track_record(
-          update_task,
-          session,
-          entry,
-          1, # event track id
-          block_number,
-          block_timestamp,
-          '0x' # txhash
+            update_task,
+            session,
+            entry,
+            1, # event track id
+            block_number,
+            block_timestamp,
+            '0x' # txhash
         )
 
         assert track_record.updated_at == None
@@ -141,11 +140,11 @@ def test_index_tracks(app):
         assert track_record.is_delete == False
 
         block_hash = f"0x{block_number}"
-        # Create track's owner user before 
+        # Create track's owner user before
         block = Block(
-          blockhash=block_hash,
-          number=block_number,
-          is_current=True
+            blockhash=block_hash,
+            number=block_number,
+            is_current=True
         )
         session.add(block)
         session.flush()
@@ -156,20 +155,21 @@ def test_index_tracks(app):
             handle='ray',
             blockhash=block_hash,
             blocknumber=block_number,
-            creator_node_endpoint='http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002',
+            creator_node_endpoint=
+            'http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002',
             created_at=datetime.utcfromtimestamp(block_timestamp),
             updated_at=datetime.utcfromtimestamp(block_timestamp)
         )
         session.add(track_owner)
 
         parse_track_event(
-          None, # self - not used
-          session,
-          update_task, # only need the ipfs client for get_metadata
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          track_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            session,
+            update_task, # only need the ipfs client for get_metadata
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            track_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # updated_at should be updated every parse_track_event
@@ -211,13 +211,13 @@ def test_index_tracks(app):
         event_type, entry = get_delete_track_event()
 
         parse_track_event(
-          None, # self - not used
-          session,
-          update_task, # only need the ipfs client for get_metadata
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          track_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            session,
+            update_task, # only need the ipfs client for get_metadata
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            track_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # updated_at should be updated every parse_track_event

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -1,0 +1,224 @@
+import random
+from datetime import datetime, timedelta
+from sqlalchemy.sql import null
+from src.models import Block, User, Track
+from src.tasks.tracks import parse_track_event, lookup_track_record, track_event_types_lookup
+from src.utils.db_session import get_db
+from src.utils.user_event_constants import user_event_types_lookup
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+
+def get_new_track_event():
+  event_type = track_event_types_lookup['new_track']
+  new_track_event = AttrDict({
+    '_id': 1,
+    '_trackOwnerId': 1,
+    '_multihashDigest': b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg',
+    '_multihashHashFn': 18,
+    '_multihashSize': 32
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": new_track_event })
+
+def get_update_track_event():
+  event_type = track_event_types_lookup['update_track']
+  update_track_event = AttrDict({
+    '_trackId': 1,
+    '_trackOwnerId': 1,
+    '_multihashDigest': b'\x93\x7f\xa2\xe6\xf0\xe5\xb5f\xca\x14(4m.B\xba3\xf8\xc8<|%*{\x11\xc1\xe2/\xd7\xee\xd7q',
+    '_multihashHashFn': 18,
+    '_multihashSize': 32
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_track_event })
+
+def get_delete_track_event():
+  event_type = track_event_types_lookup['delete_track']
+  delete_track_event = AttrDict({
+    '_trackId': 1
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": delete_track_event })
+
+
+class IPFSClient:
+  def get_metadata(self, multihash, format, endpoint):
+    return {
+      "owner_id": 1,
+      "title": "real magic bassy flip",
+      "length": None,
+      "cover_art": None,
+      "cover_art_sizes": "QmdxhDiRUC3zQEKqwnqksaSsSSeHiRghjwKzwoRvm77yaZ",
+      "tags": "realmagic,rickyreed,theroom",
+      "genre": "R&B/Soul",
+      "mood": "Empowering",
+      "credits_splits": None,
+      "created_at": "2020-07-11 08:22:15",
+      "create_date": None,
+      "updated_at": "2020-07-11 08:22:15",
+      "release_date": "Sat Jul 11 2020 01:19:58 GMT-0700",
+      "file_type": None,
+      "track_segments": [
+        {
+          "duration": 6.016,
+          "multihash": "QmabM5svgDgcRdQZaEKSMBCpSZrrYy2y87L8Dx8EQ3T2jp"
+        }
+      ],
+      "has_current_user_reposted": False,
+      "is_current": True,
+      "is_unlisted": False,
+      "field_visibility": {
+        "mood": True,
+        "tags": True,
+        "genre": True,
+        "share": True,
+        "play_count": True,
+        "remixes": True
+      },
+      "remix_of": {
+        "tracks": [
+          {
+            "parent_track_id": 75808
+          }
+        ]
+      },
+      "repost_count": 12,
+      "save_count": 21,
+      "description": None,
+      "license": "All rights reserved",
+      "isrc": None,
+      "iswc": None,
+      "download": {
+        "cid": None,
+        "is_downloadable": False,
+        "requires_follow": False
+      },
+      "track_id": 77955,
+      "stem_of": None
+    }
+
+
+class Web3:
+  def toHex(self, blockHash):
+    return '0x'
+
+class UpdateTask:
+    ipfs_client = IPFSClient()
+    web3 = Web3()
+
+# ========================================== Start Tests ========================================== 
+def test_index_tracks(app):
+    """Tests that tracks are indexed correctly"""
+    with app.app_context():
+        db = get_db()
+
+    update_task = UpdateTask()
+
+    with db.scoped_session() as session:
+        # ================== Test New Track Event ==================
+        event_type, entry = get_new_track_event()
+
+        block_number = random.randint(1, 10000)
+        block_timestamp = 1585336422
+
+        # Some sqlalchemy user instance
+        track_record = lookup_track_record(
+          update_task,
+          session,
+          entry,
+          1, # event track id
+          block_number,
+          block_timestamp,
+          '0x' # txhash
+        )
+
+        assert track_record.updated_at == None
+
+        # Fields set to defaults
+        assert track_record.created_at == None
+        assert track_record.owner_id == None
+        assert track_record.is_delete == False
+
+        block_hash = f"0x{block_number}"
+        # Create track's owner user before 
+        block = Block(
+          blockhash=block_hash,
+          number=block_number,
+          is_current=True
+        )
+        session.add(block)
+        session.flush()
+
+        track_owner = User(
+            is_current=True,
+            user_id=entry.args._trackOwnerId,
+            handle='ray',
+            blockhash=block_hash,
+            blocknumber=block_number,
+            creator_node_endpoint='http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002',
+            created_at=datetime.utcfromtimestamp(block_timestamp),
+            updated_at=datetime.utcfromtimestamp(block_timestamp)
+        )
+        session.add(track_owner)
+
+        parse_track_event(
+          None, # self - not used
+          session,
+          update_task, # only need the ipfs client for get_metadata
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          track_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # updated_at should be updated every parse_track_event
+        assert track_record.updated_at == datetime.utcfromtimestamp(block_timestamp)
+
+        # new_track updated fields
+        assert track_record.created_at == datetime.utcfromtimestamp(block_timestamp)
+        assert track_record.owner_id == entry.args._trackOwnerId
+        assert track_record.is_delete == False
+
+        track_metadata = update_task.ipfs_client.get_metadata('', '', '')
+
+        assert track_record.title == track_metadata["title"]
+        assert track_record.length == 0
+        assert track_record.cover_art == None
+        assert track_record.cover_art_sizes == track_metadata["cover_art_sizes"]
+        assert track_record.tags == track_metadata["tags"]
+        assert track_record.genre == track_metadata["genre"]
+        assert track_record.mood == track_metadata["mood"]
+        assert track_record.credits_splits == track_metadata["credits_splits"]
+        assert track_record.create_date == track_metadata["create_date"]
+        assert track_record.release_date == track_metadata["release_date"]
+        assert track_record.file_type == track_metadata["file_type"]
+        assert track_record.description == track_metadata["description"]
+        assert track_record.license == track_metadata["license"]
+        assert track_record.isrc == track_metadata["isrc"]
+        assert track_record.iswc == track_metadata["iswc"]
+        assert track_record.track_segments == track_metadata["track_segments"]
+        assert track_record.is_unlisted == track_metadata["is_unlisted"]
+        assert track_record.field_visibility == track_metadata["field_visibility"]
+        assert track_record.remix_of == track_metadata["remix_of"]
+        assert track_record.download == {
+            "is_downloadable": track_metadata["download"].get("is_downloadable") == True,
+            "requires_follow": track_metadata["download"].get("requires_follow") == True,
+            "cid": track_metadata["download"].get("cid", None),
+        }
+
+        # ================== Test Delete Track Event ==================
+        event_type, entry = get_delete_track_event()
+
+        parse_track_event(
+          None, # self - not used
+          session,
+          update_task, # only need the ipfs client for get_metadata
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          track_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # updated_at should be updated every parse_track_event
+        assert track_record.is_delete == True

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -36,7 +36,10 @@ def get_delete_track_event():
     })
     return event_type, AttrDict({"blockHash": "0x", "args": delete_track_event})
 
-multihash = helpers.multihash_digest_to_cid(b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg')
+multihash = helpers.multihash_digest_to_cid(
+    b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82' +
+    b'\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg'
+)
 ipfs_client = IPFSClient({
     multihash: {
         "owner_id": 1,
@@ -167,9 +170,12 @@ def test_index_tracks(app):
         assert track_record.created_at == datetime.utcfromtimestamp(block_timestamp)
         assert track_record.owner_id == entry.args._trackOwnerId
         assert track_record.is_delete == False
-        
-        multihash = helpers.multihash_digest_to_cid(b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg')
-        track_metadata = update_task.ipfs_client.get_metadata(multihash, '', '')
+
+        entry_multihash = helpers.multihash_digest_to_cid(
+            b'@\xfe\x1f\x02\xf3i%\xa5+\xec\x8dh\x82\xc5}' +
+            b'\x17\x91\xb9\xa1\x8dg j\xc0\xcd\x879K\x80\xf2\xdbg'
+        )
+        track_metadata = update_task.ipfs_client.get_metadata(entry_multihash, '', '')
 
         assert track_record.title == track_metadata["title"]
         assert track_record.length == 0

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from src.models import AssociatedWallet
 from src.tasks.users import lookup_user_record, parse_user_event
 from src.utils.db_session import get_db
@@ -11,119 +11,126 @@ class AttrDict(dict):
         self.__dict__ = self
 
 def get_add_user_event():
-  event_type = user_event_types_lookup['add_user']
-  add_user_event = AttrDict({
-    '_userId': 1,
-    '_handle': b'joe\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
-    '_wallet': '0x82Fc85A842c9922A9Db9091Cf6573754Cd2D0F14'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": add_user_event })
+    event_type = user_event_types_lookup['add_user']
+    add_user_event = AttrDict({
+        '_userId': 1,
+        '_handle': b'joe\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        '_wallet': '0x82Fc85A842c9922A9Db9091Cf6573754Cd2D0F14'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": add_user_event})
 
 def get_update_bio_event():
-  event_type = user_event_types_lookup['update_bio']
-  update_bio_event = AttrDict({
-    '_userId': 1,
-    '_bio': 'change description'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_bio_event })
+    event_type = user_event_types_lookup['update_bio']
+    update_bio_event = AttrDict({
+        '_userId': 1,
+        '_bio': 'change description'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_bio_event})
 
 def get_update_multihash_event():
-  event_type = user_event_types_lookup['update_multihash']
-  update_multihash_event = AttrDict({
-    '_userId': 1,
-    '_multihashDigest': b'\x94uU\x06@\xa2\x93\xf1$d:\xe8m|rj\x02y\x93\xdf\x9bf?\xe7h\xb3y\xa6\x19\x0c\x81\xb0'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_multihash_event })
+    event_type = user_event_types_lookup['update_multihash']
+    update_multihash_event = AttrDict({
+        '_userId': 1,
+        '_multihashDigest': b'\x94uU\x06@\xa2\x93\xf1$d:\xe8m|rj\x02y\x93\xdf\x9bf?\xe7h\xb3y\xa6\x19\x0c\x81\xb0'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_multihash_event})
 
 def get_update_location_event():
-  event_type = user_event_types_lookup['update_location']
-  update_location_event = AttrDict({
-    '_userId': 1,
-    '_location': b'location\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_location_event })
+    event_type = user_event_types_lookup['update_location']
+    update_location_event = AttrDict({
+        '_userId': 1,
+        '_location':
+        b'location\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_location_event})
 
 def get_update_profile_photo_event():
-  event_type = user_event_types_lookup['update_profile_photo']
-  update_profile_photo_event = AttrDict({
-    '_userId': 1,
-    '_profilePhotoDigest': b'\xc6\x0f\xc2@\x8f\xd1\xb7R\xbb\xe3\xf6\xc3\xa45\x19\x9d\xc6\x10g\x8dm\xe4\x15\x86|\x91\\r\xaa\x01\xab-'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_profile_photo_event })
+    event_type = user_event_types_lookup['update_profile_photo']
+    update_profile_photo_event = AttrDict({
+        '_userId': 1,
+        '_profilePhotoDigest':
+        b'\xc6\x0f\xc2@\x8f\xd1\xb7R\xbb\xe3\xf6\xc3\xa45\x19\x9d\xc6\x10g\x8dm\xe4\x15\x86|\x91\\r\xaa\x01\xab-'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_profile_photo_event})
 
 def get_update_cover_photo_event():
-  event_type = user_event_types_lookup['update_cover_photo']
-  update_cover_photo_event = AttrDict({
-    '_userId': 1,
-    '_coverPhotoDigest': b'C\x9a\r\xa5PO\x99\x8c\xdf;\x8cT\xdc\x18\xf5**\x80\x01\xe3j-\xd7\x11_\x84\xde%T\xd0\xcd\xc6'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_cover_photo_event })
+    event_type = user_event_types_lookup['update_cover_photo']
+    update_cover_photo_event = AttrDict({
+        '_userId': 1,
+        '_coverPhotoDigest':
+        b'C\x9a\r\xa5PO\x99\x8c\xdf;\x8cT\xdc\x18\xf5**\x80\x01\xe3j-\xd7\x11_\x84\xde%T\xd0\xcd\xc6'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_cover_photo_event})
 
 def get_update_name_event():
-  event_type = user_event_types_lookup['update_name']
-  update_name_event = AttrDict({
-    '_userId': 1,
-    '_name': b'joey\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_name_event })
+    event_type = user_event_types_lookup['update_name']
+    update_name_event = AttrDict({
+        '_userId': 1,
+        '_name':
+        b'joey\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' +
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_name_event})
 
 def get_update_is_creator_event():
-  event_type = user_event_types_lookup['update_is_creator']
-  update_is_creator_event = AttrDict({
-    '_userId': 1,
-    '_isCreator': True
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_is_creator_event })
+    event_type = user_event_types_lookup['update_is_creator']
+    update_is_creator_event = AttrDict({
+        '_userId': 1,
+        '_isCreator': True
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_is_creator_event})
 
 
 def get_update_creator_node_endpoint_event():
-  event_type = user_event_types_lookup['update_creator_node_endpoint']
-  update_creator_node_endpoint_event = AttrDict({
-    '_userId': 1,
-    '_creatorNodeEndpoint': 'http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002'
-  })
-  return event_type, AttrDict({ "blockHash": "0x", "args": update_creator_node_endpoint_event })
+    event_type = user_event_types_lookup['update_creator_node_endpoint']
+    update_creator_node_endpoint_event = AttrDict({
+        '_userId': 1,
+        '_creatorNodeEndpoint':
+        'http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002'
+    })
+    return event_type, AttrDict({"blockHash": "0x", "args": update_creator_node_endpoint_event})
 
 # 'update_is_verified': 'UpdateIsVerified',
 
 
 class IPFSClient:
     # TODO: make dynamic based on multihash, return different metadata
-  def get_metadata(self, multihash, format, endpoint):
-    return {
-      "is_creator": True,
-      "is_verified": False,
-      "name": "raymont",
-      "handle": "rayjacobson",
-      "profile_picture": None,
-      "profile_picture_sizes": "Qmdad2B9JPnJ9duZgfD5mVNDwKZUTNoqZp8xdDB9bmcewk",
-      "cover_photo": None,
-      "cover_photo_sizes": "QmQnJ8uXf886crAticzPGgrfqxq68kAxBXXcK73geFakUo",
-      "bio": "ðŸŒ\n;",
-      "location": "chik fil yay!",
-      "creator_node_endpoint": "https://creatornode2.audius.co,https://creatornode.audius.co,https://content-node.audius.co",
-      "associated_wallets": {
-        "0xEfFe2E2Dfc7945ED6Fd4C07c0B668589C52819BF": {
-          "signature": "0xdde72a90dad4a0027ca87630a2b5615240d9ad545f2fc50e24952a2b4f2c5af76c96b9e06df5801d3e3374e247b799ac3e6dfd22b4df117fe1d6190789c5bb781b"
-        },
-        "0x0aDd827a4d1ad41c4D4612B4f1Df84b9d9654782": {
-          "signature": "0xd13fc25e87dac94ba95af9e352111816aa25c1dc7ff48437660e2350a4f7a6f413011759fa6980ba5f55b0fc66d55122afd5497b5795992cf6749bbe06553abc1b"
+    def get_metadata(self, multihash, format, endpoint):
+        return {
+            "is_creator": True,
+            "is_verified": False,
+            "name": "raymont",
+            "handle": "rayjacobson",
+            "profile_picture": None,
+            "profile_picture_sizes": "Qmdad2B9JPnJ9duZgfD5mVNDwKZUTNoqZp8xdDB9bmcewk",
+            "cover_photo": None,
+            "cover_photo_sizes": "QmQnJ8uXf886crAticzPGgrfqxq68kAxBXXcK73geFakUo",
+            "bio": "ðŸŒ\n;",
+            "location": "chik fil yay!",
+            "creator_node_endpoint":
+            "https://creatornode2.audius.co,https://creatornode.audius.co,https://content-node.audius.co",
+            "associated_wallets": {
+                "0xEfFe2E2Dfc7945ED6Fd4C07c0B668589C52819BF": {
+                    "signature":
+                    "0xdde72a90dad4a0027ca87630a2b5615240d9ad545f2fc50e24952a2b4f2c5a" +
+                    "f76c96b9e06df5801d3e3374e247b799ac3e6dfd22b4df117fe1d6190789c5bb781b"
+                },
+                "0x0aDd827a4d1ad41c4D4612B4f1Df84b9d9654782": {
+                    "signature":
+                    "0xd13fc25e87dac94ba95af9e352111816aa25c1dc7ff48437660e2350a4f7a6f" +
+                    "413011759fa6980ba5f55b0fc66d55122afd5497b5795992cf6749bbe06553abc1b"
+                }
+            },
+            "collectibles": {
+                "73:::0x417cf58dc18edd17025689d13af2b85f403e130c": {},
+                "order": ["73:::0x417cf58dc18edd17025689d13af2b85f403e130c"]
+            },
+            "user_id": 1
         }
-      },
-      "collectibles": {
-        "73:::0x417cf58dc18edd17025689d13af2b85f403e130c": {
-          
-        },
-        "order": [
-          "73:::0x417cf58dc18edd17025689d13af2b85f403e130c"
-        ]
-      },
-      "user_id": 1
-      }
 
 class Web3:
-  def toHex(self, blockHash):
-    return '0x'
+    def toHex(self, blockHash):
+        return '0x'
 
 class UpdateTask:
     ipfs_client = IPFSClient()
@@ -146,12 +153,12 @@ def test_index_users(app):
 
         # Some sqlalchemy user instance
         user_record = lookup_user_record(
-          update_task,
-          session,
-          entry,
-          block_number,
-          block_timestamp,
-          '0x' # txhash
+            update_task,
+            session,
+            entry,
+            block_number,
+            block_timestamp,
+            '0x' # txhash
         )
 
         assert user_record.updated_at == None
@@ -162,16 +169,16 @@ def test_index_users(app):
         assert user_record.wallet == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # updated_at should be updated every parse_user_event
@@ -189,16 +196,16 @@ def test_index_users(app):
         assert user_record.handle != None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -207,20 +214,20 @@ def test_index_users(app):
         # ================== Test Update User Location Event ==================
         event_type, entry = get_update_location_event()
 
-        # `location` field is none by default 
+        # `location` field is none by default
         assert user_record.location == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -229,20 +236,20 @@ def test_index_users(app):
         # ================== Test Update User is Creator Event ==================
         event_type, entry = get_update_is_creator_event()
 
-        # `is_creator` field is none by default 
+        # `is_creator` field is none by default
         assert user_record.is_creator == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -251,20 +258,20 @@ def test_index_users(app):
         # ================== Test Update User Name Event ==================
         event_type, entry = get_update_name_event()
 
-        # `name` field is none by default 
+        # `name` field is none by default
         assert user_record.name == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -274,7 +281,7 @@ def test_index_users(app):
         # ================== Test Update User CNodes Event for legacy ==================
         event_type, entry = get_update_creator_node_endpoint_event()
 
-        # `creator_node_endpoint` field is none by default 
+        # `creator_node_endpoint` field is none by default
         assert user_record.creator_node_endpoint == None
 
         # Set primary id so that creator node endpoints is not set
@@ -282,16 +289,16 @@ def test_index_users(app):
         user_record.primary_id = 1
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -303,20 +310,20 @@ def test_index_users(app):
         # ================== Test Update User CNodes Event ==================
         event_type, entry = get_update_creator_node_endpoint_event()
 
-        # `creator_node_endpoint` field is none by default 
+        # `creator_node_endpoint` field is none by default
         assert user_record.creator_node_endpoint == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: handle, handle_lc, wallet
@@ -325,21 +332,21 @@ def test_index_users(app):
         # ================== Test Update User Porfile Photo Event ==================
         event_type, entry = get_update_profile_photo_event()
 
-        # `profile_picture` field is none by default 
+        # `profile_picture` field is none by default
         assert user_record.profile_picture == None
         assert user_record.profile_picture_sizes == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: profile_picture_sizes, profile_picture
@@ -349,21 +356,21 @@ def test_index_users(app):
         # ================== Test Update User Cover Photo Event ==================
         event_type, entry = get_update_cover_photo_event()
 
-        # `cover_photo` field is none by default 
+        # `cover_photo` field is none by default
         assert user_record.cover_photo == None
         assert user_record.cover_photo_sizes == None
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
 
         # add_user should be updated fields: cover_photo, cover_photo_sizes
@@ -374,16 +381,16 @@ def test_index_users(app):
         event_type, entry = get_update_multihash_event()
 
         parse_user_event(
-          None, # self - not used
-          None, # user_contract - not used
-          update_task, # only need the ipfs client for get_metadata
-          session,
-          None, # tx_receipt - not used
-          block_number, # not used
-          entry, # Contains the event args used for updating
-          event_type, # String that should one of user_event_types_lookup
-          user_record, # User ORM instance
-          block_timestamp # Used to update the user.updated_at field
+            None, # self - not used
+            None, # user_contract - not used
+            update_task, # only need the ipfs client for get_metadata
+            session,
+            None, # tx_receipt - not used
+            block_number, # not used
+            entry, # Contains the event args used for updating
+            event_type, # String that should one of user_event_types_lookup
+            user_record, # User ORM instance
+            block_timestamp # Used to update the user.updated_at field
         )
         ipfs_metadata = update_task.ipfs_client.get_metadata('', '', '')
 
@@ -398,9 +405,9 @@ def test_index_users(app):
 
         ipfs_associated_wallets = ipfs_metadata['associated_wallets']
         associated_wallets = session.query(AssociatedWallet).filter_by(
-          user_id=user_record.user_id,
-          is_current=True,
-          is_delete=False
+            user_id=user_record.user_id,
+            is_current=True,
+            is_delete=False
         ).all()
         for wallet in associated_wallets:
-          assert wallet in ipfs_associated_wallets
+            assert wallet in ipfs_associated_wallets

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -1,0 +1,406 @@
+from datetime import datetime, timedelta
+from src.models import AssociatedWallet
+from src.tasks.users import lookup_user_record, parse_user_event
+from src.utils.db_session import get_db
+from src.utils.user_event_constants import user_event_types_lookup
+from src.utils import helpers
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+def get_add_user_event():
+  event_type = user_event_types_lookup['add_user']
+  add_user_event = AttrDict({
+    '_userId': 1,
+    '_handle': b'joe\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    '_wallet': '0x82Fc85A842c9922A9Db9091Cf6573754Cd2D0F14'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": add_user_event })
+
+def get_update_bio_event():
+  event_type = user_event_types_lookup['update_bio']
+  update_bio_event = AttrDict({
+    '_userId': 1,
+    '_bio': 'change description'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_bio_event })
+
+def get_update_multihash_event():
+  event_type = user_event_types_lookup['update_multihash']
+  update_multihash_event = AttrDict({
+    '_userId': 1,
+    '_multihashDigest': b'\x94uU\x06@\xa2\x93\xf1$d:\xe8m|rj\x02y\x93\xdf\x9bf?\xe7h\xb3y\xa6\x19\x0c\x81\xb0'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_multihash_event })
+
+def get_update_location_event():
+  event_type = user_event_types_lookup['update_location']
+  update_location_event = AttrDict({
+    '_userId': 1,
+    '_location': b'location\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_location_event })
+
+def get_update_profile_photo_event():
+  event_type = user_event_types_lookup['update_profile_photo']
+  update_profile_photo_event = AttrDict({
+    '_userId': 1,
+    '_profilePhotoDigest': b'\xc6\x0f\xc2@\x8f\xd1\xb7R\xbb\xe3\xf6\xc3\xa45\x19\x9d\xc6\x10g\x8dm\xe4\x15\x86|\x91\\r\xaa\x01\xab-'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_profile_photo_event })
+
+def get_update_cover_photo_event():
+  event_type = user_event_types_lookup['update_cover_photo']
+  update_cover_photo_event = AttrDict({
+    '_userId': 1,
+    '_coverPhotoDigest': b'C\x9a\r\xa5PO\x99\x8c\xdf;\x8cT\xdc\x18\xf5**\x80\x01\xe3j-\xd7\x11_\x84\xde%T\xd0\xcd\xc6'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_cover_photo_event })
+
+def get_update_name_event():
+  event_type = user_event_types_lookup['update_name']
+  update_name_event = AttrDict({
+    '_userId': 1,
+    '_name': b'joey\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_name_event })
+
+def get_update_is_creator_event():
+  event_type = user_event_types_lookup['update_is_creator']
+  update_is_creator_event = AttrDict({
+    '_userId': 1,
+    '_isCreator': True
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_is_creator_event })
+
+
+def get_update_creator_node_endpoint_event():
+  event_type = user_event_types_lookup['update_creator_node_endpoint']
+  update_creator_node_endpoint_event = AttrDict({
+    '_userId': 1,
+    '_creatorNodeEndpoint': 'http://cn2_creator-node_1:4001,http://cn1_creator-node_1:4000,http://cn3_creator-node_1:4002'
+  })
+  return event_type, AttrDict({ "blockHash": "0x", "args": update_creator_node_endpoint_event })
+
+# 'update_is_verified': 'UpdateIsVerified',
+
+
+class IPFSClient:
+    # TODO: make dynamic based on multihash, return different metadata
+  def get_metadata(self, multihash, format, endpoint):
+    return {
+      "is_creator": True,
+      "is_verified": False,
+      "name": "raymont",
+      "handle": "rayjacobson",
+      "profile_picture": None,
+      "profile_picture_sizes": "Qmdad2B9JPnJ9duZgfD5mVNDwKZUTNoqZp8xdDB9bmcewk",
+      "cover_photo": None,
+      "cover_photo_sizes": "QmQnJ8uXf886crAticzPGgrfqxq68kAxBXXcK73geFakUo",
+      "bio": "ðŸŒ\n;",
+      "location": "chik fil yay!",
+      "creator_node_endpoint": "https://creatornode2.audius.co,https://creatornode.audius.co,https://content-node.audius.co",
+      "associated_wallets": {
+        "0xEfFe2E2Dfc7945ED6Fd4C07c0B668589C52819BF": {
+          "signature": "0xdde72a90dad4a0027ca87630a2b5615240d9ad545f2fc50e24952a2b4f2c5af76c96b9e06df5801d3e3374e247b799ac3e6dfd22b4df117fe1d6190789c5bb781b"
+        },
+        "0x0aDd827a4d1ad41c4D4612B4f1Df84b9d9654782": {
+          "signature": "0xd13fc25e87dac94ba95af9e352111816aa25c1dc7ff48437660e2350a4f7a6f413011759fa6980ba5f55b0fc66d55122afd5497b5795992cf6749bbe06553abc1b"
+        }
+      },
+      "collectibles": {
+        "73:::0x417cf58dc18edd17025689d13af2b85f403e130c": {
+          
+        },
+        "order": [
+          "73:::0x417cf58dc18edd17025689d13af2b85f403e130c"
+        ]
+      },
+      "user_id": 1
+      }
+
+class Web3:
+  def toHex(self, blockHash):
+    return '0x'
+
+class UpdateTask:
+    ipfs_client = IPFSClient()
+    web3 = Web3()
+
+
+def test_index_users(app):
+    """Tests that users are indexed correctly"""
+    with app.app_context():
+        db = get_db()
+
+    update_task = UpdateTask()
+
+    with db.scoped_session() as session:
+        # ================== Test Add User Event ==================
+        event_type, entry = get_add_user_event()
+
+        block_number = 1
+        block_timestamp = 1585336422
+
+        # Some sqlalchemy user instance
+        user_record = lookup_user_record(
+          update_task,
+          session,
+          entry,
+          block_number,
+          block_timestamp,
+          '0x' # txhash
+        )
+
+        assert user_record.updated_at == None
+
+        # Fields set to None by default
+        assert user_record.handle == None
+        assert user_record.handle_lc == None
+        assert user_record.wallet == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # updated_at should be updated every parse_user_event
+        assert user_record.updated_at == datetime.utcfromtimestamp(block_timestamp)
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.handle == helpers.bytes32_to_str(entry.args._handle)
+        assert user_record.handle_lc == helpers.bytes32_to_str(entry.args._handle).lower()
+        assert user_record.wallet == entry.args._wallet.lower()
+
+        # ================== Test Update User Bio Event ==================
+        event_type, entry = get_update_bio_event()
+
+        assert user_record.bio == None
+        assert user_record.handle != None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.bio == entry.args._bio
+
+        # ================== Test Update User Location Event ==================
+        event_type, entry = get_update_location_event()
+
+        # `location` field is none by default 
+        assert user_record.location == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.location == helpers.bytes32_to_str(entry.args._location)
+
+        # ================== Test Update User is Creator Event ==================
+        event_type, entry = get_update_is_creator_event()
+
+        # `is_creator` field is none by default 
+        assert user_record.is_creator == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.is_creator == entry.args._isCreator
+
+        # ================== Test Update User Name Event ==================
+        event_type, entry = get_update_name_event()
+
+        # `name` field is none by default 
+        assert user_record.name == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.name == helpers.bytes32_to_str(entry.args._name)
+
+
+        # ================== Test Update User CNodes Event for legacy ==================
+        event_type, entry = get_update_creator_node_endpoint_event()
+
+        # `creator_node_endpoint` field is none by default 
+        assert user_record.creator_node_endpoint == None
+
+        # Set primary id so that creator node endpoints is not set
+        assert user_record.primary_id == None
+        user_record.primary_id = 1
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.creator_node_endpoint == None
+
+        # Set primary id back to none
+        user_record.primary_id = None
+
+        # ================== Test Update User CNodes Event ==================
+        event_type, entry = get_update_creator_node_endpoint_event()
+
+        # `creator_node_endpoint` field is none by default 
+        assert user_record.creator_node_endpoint == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: handle, handle_lc, wallet
+        assert user_record.creator_node_endpoint == entry.args._creatorNodeEndpoint
+
+        # ================== Test Update User Porfile Photo Event ==================
+        event_type, entry = get_update_profile_photo_event()
+
+        # `profile_picture` field is none by default 
+        assert user_record.profile_picture == None
+        assert user_record.profile_picture_sizes == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: profile_picture_sizes, profile_picture
+        assert user_record.profile_picture_sizes == helpers.multihash_digest_to_cid(entry.args._profilePhotoDigest)
+        assert user_record.profile_picture == None
+
+        # ================== Test Update User Cover Photo Event ==================
+        event_type, entry = get_update_cover_photo_event()
+
+        # `cover_photo` field is none by default 
+        assert user_record.cover_photo == None
+        assert user_record.cover_photo_sizes == None
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+
+        # add_user should be updated fields: cover_photo, cover_photo_sizes
+        assert user_record.cover_photo == None
+        assert user_record.cover_photo_sizes == helpers.multihash_digest_to_cid(entry.args._coverPhotoDigest)
+
+        # ================== Test Update User Metadata Event ==================
+        event_type, entry = get_update_multihash_event()
+
+        parse_user_event(
+          None, # self - not used
+          None, # user_contract - not used
+          update_task, # only need the ipfs client for get_metadata
+          session,
+          None, # tx_receipt - not used
+          block_number, # not used
+          entry, # Contains the event args used for updating
+          event_type, # String that should one of user_event_types_lookup
+          user_record, # User ORM instance
+          block_timestamp # Used to update the user.updated_at field
+        )
+        ipfs_metadata = update_task.ipfs_client.get_metadata('', '', '')
+
+        assert user_record.profile_picture == ipfs_metadata["profile_picture"]
+        assert user_record.cover_photo == ipfs_metadata["cover_photo"]
+        assert user_record.bio == ipfs_metadata["bio"]
+        assert user_record.name == ipfs_metadata["name"]
+        assert user_record.location == ipfs_metadata["location"]
+        assert user_record.profile_picture_sizes == ipfs_metadata["profile_picture_sizes"]
+        assert user_record.cover_photo_sizes == ipfs_metadata["cover_photo_sizes"]
+        assert user_record.has_collectibles == True
+
+        ipfs_associated_wallets = ipfs_metadata['associated_wallets']
+        associated_wallets = session.query(AssociatedWallet).filter_by(
+          user_id=user_record.user_id,
+          is_current=True,
+          is_delete=False
+        ).all()
+        for wallet in associated_wallets:
+          assert wallet in ipfs_associated_wallets

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -87,7 +87,10 @@ def get_update_creator_node_endpoint_event():
     return event_type, AttrDict({"blockHash": "0x", "args": update_creator_node_endpoint_event})
 
 # 'update_is_verified': 'UpdateIsVerified',
-multihash = helpers.multihash_digest_to_cid(b'\x94uU\x06@\xa2\x93\xf1$d:\xe8m|rj\x02y\x93\xdf\x9bf?\xe7h\xb3y\xa6\x19\x0c\x81\xb0')
+multihash = helpers.multihash_digest_to_cid(
+    b'\x94uU\x06@\xa2\x93\xf1$d:\xe8m|rj\x02y' +
+    b'\x93\xdf\x9bf?\xe7h\xb3y\xa6\x19\x0c\x81\xb0'
+)
 
 ipfs_client = IPFSClient({
     multihash: {
@@ -379,9 +382,9 @@ def test_index_users(app):
             user_record, # User ORM instance
             block_timestamp # Used to update the user.updated_at field
         )
-        
-        multihash = helpers.multihash_digest_to_cid(entry.args._multihashDigest)
-        ipfs_metadata = update_task.ipfs_client.get_metadata(multihash, '', '')
+
+        entry_multihash = helpers.multihash_digest_to_cid(entry.args._multihashDigest)
+        ipfs_metadata = update_task.ipfs_client.get_metadata(entry_multihash, '', '')
 
         assert user_record.profile_picture == ipfs_metadata["profile_picture"]
         assert user_record.cover_photo == ipfs_metadata["cover_photo"]


### PR DESCRIPTION
### Description
Adds tests to indexing - specifically the functions `parse_playlist_event`, `parse_user_event` and `parse_track_event`

These tests mock out the blockchain events and the ipfs metadata to check that the correct transformations are applied in the parse event functions to the ORM instances of users, tracks and playlists. 

ie. for a `playlist_name_updated` event, check that the ORM instance of the playlist's name is updated after the parse_playlist_event function. 

I think this will be useful going forward to dev changes to the indexing flow w/ ipfs metadata w/out running the entire DP. 

A couple unrelated notes from writing these test:
* We should clean up the ipfs metadata, they are polluted w/ unnecessary data
* We should revisit the use of UPC codes - not set for playlists

There can def. be way more tests and edge cases to look at. 

### Tests
These are tests!
