### PR TITLE
Return transaction block hash and block number

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -112,7 +112,7 @@ class Account extends Base {
       ADD_USER: 'ADD_USER'
     }
     let phase = ''
-    let userId
+    let userId, blockHash, blockNumber
 
     try {
       this.REQUIRES(Services.CREATOR_NODE, Services.IDENTITY_SERVICE)
@@ -133,7 +133,10 @@ class Account extends Base {
 
       // Add user to chain
       phase = phases.ADD_USER
-      userId = await this.User.addUser(metadata)
+      const response = await this.User.addUser(metadata)
+      userId = response.userId
+      blockHash = response.blockHash
+      blockNumber = response.blockNumber
 
       // Assign replica set to user, updates creator_node_endpoint on chain, and then update metadata object on content node + chain (in this order)
       phase = phases.ADD_REPLICA_SET
@@ -145,8 +148,7 @@ class Account extends Base {
     } catch (e) {
       return { error: e.message, phase }
     }
-
-    return { userId, error: false }
+    return { blockHash, blockNumber, userId }
   }
 
   /**

--- a/libs/src/api/playlist.js
+++ b/libs/src/api/playlist.js
@@ -85,8 +85,13 @@ class Playlists extends Base {
     let createInitialIdsArray = trackIds.slice(0, maxInitialTracks)
     let postInitialIdsArray = trackIds.slice(maxInitialTracks)
     let playlistId
+    let receipt = {}
     try {
-      playlistId = await this.contracts.PlaylistFactoryClient.createPlaylist(userId, playlistName, isPrivate, isAlbum, createInitialIdsArray)
+      const response = await this.contracts.PlaylistFactoryClient.createPlaylist(
+        userId, playlistName, isPrivate, isAlbum, createInitialIdsArray
+      )
+      playlistId = response.playlistId
+      receipt = response.txReceipt
 
       // Add remaining tracks
       await Promise.all(postInitialIdsArray.map(trackId => {
@@ -95,13 +100,13 @@ class Playlists extends Base {
 
       // Order tracks
       if (postInitialIdsArray.length > 0) {
-        await this.contracts.PlaylistFactoryClient.orderPlaylistTracks(playlistId, trackIds)
+        receipt = await this.contracts.PlaylistFactoryClient.orderPlaylistTracks(playlistId, trackIds)
       }
     } catch (e) {
       console.error(e)
       return { playlistId, error: true }
     }
-    return { playlistId, error: false }
+    return { blockHash: receipt.blockHash, blockNumber: receipt.blockNumber, playlistId, error: false }
   }
 
   /**

--- a/libs/src/api/track.js
+++ b/libs/src/api/track.js
@@ -360,7 +360,7 @@ class Track extends Base {
         txReceipt.blockNumber,
         transcodedTrackUUID
       )
-      return { trackId, error: false }
+      return { blockHash: txReceipt.blockHash, blockNumber: txReceipt.blockNumber, trackId, error: false }
     } catch (e) {
       return {
         error: e.message,
@@ -520,7 +520,7 @@ class Track extends Base {
     )
     // Re-associate the track id with the new metadata
     await this.creatorNode.associateTrack(trackId, metadataFileUUID, txReceipt.blockNumber)
-    return trackId
+    return { blockHash: txReceipt.blockHash, blockNumber: txReceipt.blockNumber, trackId }
   }
 
   /**

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -640,6 +640,7 @@ class Users extends Base {
     if (addOps.length > 0) {
       // Execute update promises concurrently
       // TODO - what if one or more of these fails?
+      // sort transactions by blocknumber and return most recent transaction
       ops = await Promise.all(addOps)
       const sortedOpsDesc = ops.sort((op1, op2) => op1.txReceipt.blockNumber > op2.txReceipt.blockNumber)
       const latestTx = sortedOpsDesc[0].txReceipt
@@ -689,6 +690,7 @@ class Users extends Base {
 
     let ops; let latestBlockNumber = -Infinity; let latestBlockHash
     if (updateOps.length > 0) {
+      // sort transactions by blocknumber and return most recent transaction
       ops = await Promise.all(updateOps)
       const sortedOpsDesc = ops.sort((op1, op2) => op1.txReceipt.blockNumber > op2.txReceipt.blockNumber)
       const latestTx = sortedOpsDesc[0].txReceipt

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -393,7 +393,7 @@ class Users extends Base {
     const { txReceipt } = await this.contracts.UserFactoryClient.updateMultihash(userId, updatedMultihashDecoded.digest)
 
     // Write remaining metadata fields to chain
-    const { latestBlockHash, latestBlockNumber } = await this._updateUserOperations(
+    let { latestBlockHash, latestBlockNumber } = await this._updateUserOperations(
       newMetadata, oldMetadata, userId
     )
 
@@ -402,6 +402,11 @@ class Users extends Base {
 
     // Update libs instance with new user metadata object
     this.userStateManager.setCurrentUser({ ...oldMetadata, ...newMetadata })
+
+    if (!latestBlockHash || !latestBlockNumber) {
+      latestBlockHash = txReceipt.blockHash
+      latestBlockNumber = txReceipt.blockNumber
+    }
 
     return { blockHash: latestBlockHash, blockNumber: latestBlockNumber, userId }
   }

--- a/libs/src/services/dataContracts/playlistFactoryClient.js
+++ b/libs/src/services/dataContracts/playlistFactoryClient.js
@@ -44,7 +44,10 @@ class PlaylistFactoryClient extends ContractClient {
       this.contractRegistryKey,
       contractAddress
     )
-    return parseInt(tx.events.PlaylistCreated.returnValues._playlistId, 10)
+    return {
+      playlistId: parseInt(tx.events.PlaylistCreated.returnValues._playlistId, 10),
+      txReceipt: tx
+    }
   }
 
   async deletePlaylist (playlistId) {
@@ -66,7 +69,10 @@ class PlaylistFactoryClient extends ContractClient {
       this.contractRegistryKey,
       contractAddress
     )
-    return parseInt(tx.events.PlaylistDeleted.returnValues._playlistId, 10)
+    return {
+      playlistId: parseInt(tx.events.PlaylistDeleted.returnValues._playlistId, 10),
+      txReceipt: tx
+    }
   }
 
   async addPlaylistTrack (playlistId, addedTrackId) {

--- a/libs/tests/playlistClientTest.js
+++ b/libs/tests/playlistClientTest.js
@@ -57,7 +57,7 @@ it('should create album', async function () {
 
 it('should create and delete playlist', async function () {
   // create playlist
-  const playlistId = await audiusInstance.contracts.PlaylistFactoryClient.createPlaylist(
+  const { playlistId } = await audiusInstance.contracts.PlaylistFactoryClient.createPlaylist(
     playlistOwnerId,
     initialPlaylistName,
     initialIsPrivate,
@@ -65,7 +65,7 @@ it('should create and delete playlist', async function () {
     playlistTracks)
 
   // delete playlist + validate
-  const deletedPlaylistId = await audiusInstance.contracts.PlaylistFactoryClient.deletePlaylist(playlistId)
+  const { playlistId: deletedPlaylistId } = await audiusInstance.contracts.PlaylistFactoryClient.deletePlaylist(playlistId)
   assert.strictEqual(playlistId, deletedPlaylistId)
 })
 

--- a/libs/tests/socialFeatureClientTest.js
+++ b/libs/tests/socialFeatureClientTest.js
@@ -43,7 +43,7 @@ it('Should add + delete playlist repost', async function () {
   assert.ok(creatorId && Number.isInteger(creatorId), 'invalid creatorId')
 
   // add playlist
-  const playlistId = await audiusInstance.contracts.PlaylistFactoryClient.createPlaylist(
+  const { playlistId } = await audiusInstance.contracts.PlaylistFactoryClient.createPlaylist(
     creatorId,
     'initialPlaylistName',
     false,

--- a/mad-dog/src/tests/test_ipldBlacklist.js
+++ b/mad-dog/src/tests/test_ipldBlacklist.js
@@ -524,7 +524,7 @@ IpldBlacklistTest.updatePlaylistCoverPhoto = async ({
     // create playlist under userId
     const randomPlaylistName = genRandomString(8)
 
-    const playlistId = await executeOne(CREATOR_INDEX, libsWrapper => {
+    const { playlistId } = await executeOne(CREATOR_INDEX, libsWrapper => {
       return createPlaylist(
         libsWrapper,
         userId,
@@ -605,7 +605,7 @@ IpldBlacklistTest.updatePlaylistCoverPhotoNoMatch = async ({
 
     // create playlist under userId
     const randomPlaylistName = 'playlist_' + genRandomString(8)
-    const playlistId = await executeOne(CREATOR_INDEX, libsWrapper => {
+    const { playlistId } = await executeOne(CREATOR_INDEX, libsWrapper => {
       return createPlaylist(
         libsWrapper,
         userId,


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Return block hash and block number on some apis used by the client so that actions can be confirmed against indexed blocks' hashes and numbers.

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- updated unit tests and they're all passing
- tested dapp locally with this update and confirmations work

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

touches signup, upload, and many other flows. we want to make sure those still work as intended.