### PR TITLE
Undelegate bounds test

### DIFF
--- a/eth-contracts/test/delegateManager.test.js
+++ b/eth-contracts/test/delegateManager.test.js
@@ -2654,11 +2654,6 @@ contract('DelegateManager', async (accounts) => {
       // Confirm initial SP details
       const spDetails0 = await serviceProviderFactory.getServiceProviderDetails.call(stakerAccount)
       const totalStaked0 = await staking.totalStakedFor(stakerAccount)
-      console.log(totalStaked0.toString())
-      console.log(spDetails0.deployerStake.toString())
-      console.log(spDetails0.minAccountStake.toString())
-      console.log(spDetails0.maxAccountStake.toString())
-      console.log('\n')
 
       assert.isTrue(totalStaked0.eq(DEFAULT_AMOUNT), 'Expected totalStake == default amount')
       assert.isTrue(spDetails0.deployerStake.eq(DEFAULT_AMOUNT), 'Expected deployerStake == default amount')
@@ -2681,11 +2676,6 @@ contract('DelegateManager', async (accounts) => {
 
       const spDetails1 = await serviceProviderFactory.getServiceProviderDetails.call(stakerAccount)
       const totalStaked1 = await staking.totalStakedFor(stakerAccount)
-      console.log(totalStaked1.toString())
-      console.log(spDetails1.deployerStake.toString())
-      console.log(spDetails1.minAccountStake.toString())
-      console.log(spDetails1.maxAccountStake.toString())
-      console.log('\n')
 
       assert.isTrue(totalStaked1.eq(
         DEFAULT_AMOUNT.add(delegationAmount)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add a test to verify that an SP can return to valid bounds when a delegator undelegates.

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. New DelegateManager test
it('lets a service provider return to valid bounds when a delegator changes delegation')

This test currently fails due to the final assertion on validBounds
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
