### PR TITLE
Solana sendAndConfirmTransaction - Commitment level update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,8 +673,6 @@ workflows:
       - docker-build-and-push:
           name: build-identity-service
           repo: identity-service
-          requires:
-            - test-identity-service
 
       - docker-build-and-push:
           name: build-solana-programs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,6 +673,8 @@ workflows:
       - docker-build-and-push:
           name: build-identity-service
           repo: identity-service
+          requires:
+            - test-identity-service
 
       - docker-build-and-push:
           name: build-solana-programs

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -214,6 +214,7 @@ module.exports = function (app) {
 
     // Dedicated listen flow
     if (solanaListen) {
+      logger.info(`Sending Track listen transaction trackId=${trackId} userId=${userId}`)
       let solTxSignature = await solClient.createAndVerifyMessage(
         null,
         config.get('solanaSignerPrivateKey'),
@@ -221,7 +222,7 @@ module.exports = function (app) {
         trackId.toString(),
         'relay' // Static source value to indicate relayed listens
       )
-      logger.info(`Track listen tx submitted, ${solTxSignature} userId=${userId}, trackId=${trackId}`)
+      logger.info(`Track listen tx confirmed, ${solTxSignature} userId=${userId}, trackId=${trackId}`)
       return successResponse({
         solTxSignature
       })

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -3,8 +3,6 @@ const solanaWeb3 = require('@solana/web3.js')
 const keccak256 = require('keccak256')
 const secp256k1 = require('secp256k1')
 const borsh = require('borsh')
-const { logger } = require('./logging')
-
 
 const VALID_SIGNER = config.get('solanaValidSigner')
 const AUDIUS_ETH_REGISTRY_PROGRAM = config.get('solanaAudiusEthRegistryAddress') ? new solanaWeb3.PublicKey(
@@ -176,13 +174,12 @@ async function createAndVerifyMessage (
 
   let feePayerAccount = getFeePayer()
 
-  logger.info(`Sending transaction trackId=${trackId} userId=${userId}`)
   let signature = await solanaWeb3.sendAndConfirmTransaction(
     solanaConnection,
     transaction,
     [feePayerAccount],
     {
-      commitment: "confirmed"
+      commitment: 'confirmed'
     }
   )
 

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -3,6 +3,8 @@ const solanaWeb3 = require('@solana/web3.js')
 const keccak256 = require('keccak256')
 const secp256k1 = require('secp256k1')
 const borsh = require('borsh')
+const { logger } = require('./logging')
+
 
 const VALID_SIGNER = config.get('solanaValidSigner')
 const AUDIUS_ETH_REGISTRY_PROGRAM = config.get('solanaAudiusEthRegistryAddress') ? new solanaWeb3.PublicKey(
@@ -174,6 +176,7 @@ async function createAndVerifyMessage (
 
   let feePayerAccount = getFeePayer()
 
+  logger.info(`Sending transaction trackId=${trackId} userId=${userId}`)
   let signature = await solanaWeb3.sendAndConfirmTransaction(
     solanaConnection,
     transaction,

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -180,7 +180,10 @@ async function createAndVerifyMessage (
   let signature = await solanaWeb3.sendAndConfirmTransaction(
     solanaConnection,
     transaction,
-    [feePayerAccount]
+    [feePayerAccount],
+    {
+      commitment: "confirmed"
+    }
   )
 
   return signature


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Update the web3 commitment level for `sendAndConfirmTransaction` to `confirmed`. Source ref here: https://github.com/solana-labs/solana-web3.js/blob/16e50f5/src/connection.ts#L208

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Tested against mainnet solana in audius staging environment, observed 20-40s confirmation times with the default `max` Commitment value and between 2-5s with `confirmed`. Verified that this is a safe commitment level to guarantee tx propagation from Solana team as well.

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
