### PR TITLE
Resumable and chunked track upload

### DIFF
--- a/creator-node/compose/docker-compose.yml
+++ b/creator-node/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - '${CREATOR_NODE_HOST_PORT}:${CREATOR_NODE_HOST_PORT}'
     volumes:
-      - file_storage:/file_storage
+      - ../file_storage:/file_storage
       - ..:/usr/src/app
       # Prevent hiding node_modules on container with host volume
       # From https://github.com/barrysteyn/node-scrypt/issues/148

--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -674,6 +674,66 @@
         "@ethersproject/strings": "^5.0.8"
       }
     },
+    "@google-cloud/common": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
+      "requires": {
+        "array-uniq": "^1.0.3",
+        "arrify": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.1",
+        "google-auto-auth": "^0.10.0",
+        "is": "^3.2.0",
+        "log-driver": "1.2.7",
+        "methmeth": "^1.1.0",
+        "modelo": "^4.2.0",
+        "request": "^2.79.0",
+        "retry-request": "^3.0.0",
+        "split-array-stream": "^1.0.0",
+        "stream-events": "^1.0.1",
+        "string-format-obj": "^1.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "@google-cloud/storage": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.7.0.tgz",
+      "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
+      "requires": {
+        "@google-cloud/common": "^0.17.0",
+        "arrify": "^1.0.0",
+        "async": "^2.0.1",
+        "compressible": "^2.0.12",
+        "concat-stream": "^1.5.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.0",
+        "gcs-resumable-upload": "^0.10.2",
+        "hash-stream-validation": "^0.2.1",
+        "is": "^3.0.1",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "once": "^1.3.1",
+        "pumpify": "^1.5.1",
+        "request": "^2.85.0",
+        "safe-buffer": "^5.1.1",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "through2": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1186,6 +1246,14 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
     },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -1351,6 +1419,11 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -1457,6 +1530,11 @@
         }
       }
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
     "asmcrypto.js": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
@@ -1547,6 +1625,53 @@
       "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
       "requires": {
         "array-filter": "^1.0.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.900.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.900.0.tgz",
+      "integrity": "sha512-MtLsmuE5z0F3+lEdybh8j8cThIN+VK0qF8Len83gpOaK5pj4D9aJNS95Tb7xZ0/3yqGzugk/+nRv9xXQq/Fkfg==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
       }
     },
     "aws-sign2": {
@@ -2092,6 +2217,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2389,8 +2519,7 @@
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2685,6 +2814,21 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.47.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+          "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2715,7 +2859,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-      "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -2729,7 +2872,6 @@
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
           "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -2879,7 +3021,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -2962,11 +3103,15 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
       "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
+    "crypto-rand": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypto-rand/-/crypto-rand-0.0.2.tgz",
+      "integrity": "sha1-Hn3CMQLhiRo+6zQPtwrElYCzLt0="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "d": {
       "version": "1.0.1",
@@ -3262,7 +3407,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -3301,6 +3445,17 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3308,6 +3463,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "editorconfig": {
@@ -3380,6 +3543,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "err-code": {
       "version": "1.1.2",
@@ -3585,6 +3753,14 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "es6-symbol": {
       "version": "3.1.2",
@@ -4205,6 +4381,11 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -5492,6 +5673,50 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
       "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
     },
+    "gaxios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
+      "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
+      "requires": {
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
+        "retry-axios": "0.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        }
+      }
+    },
+    "gcs-resumable-upload": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.2.tgz",
+      "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
+      "requires": {
+        "configstore": "^3.1.2",
+        "google-auto-auth": "^0.10.0",
+        "pumpify": "^1.4.0",
+        "request": "^2.85.0",
+        "stream-events": "^1.0.3"
+      }
+    },
     "generic-pool": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
@@ -5633,6 +5858,63 @@
         "define-properties": "^1.1.3"
       }
     },
+    "google-auth-library": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
+      "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
+      "requires": {
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.6.3",
+        "gtoken": "^2.3.0",
+        "jws": "^3.1.5",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.3",
+        "retry-axios": "^0.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        }
+      }
+    },
+    "google-auto-auth": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
+      "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
+      "requires": {
+        "async": "^2.3.0",
+        "gcp-metadata": "^0.6.1",
+        "google-auth-library": "^1.3.1",
+        "request": "^2.79.0"
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.4.tgz",
+      "integrity": "sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==",
+      "requires": {
+        "node-forge": "^0.8.0",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -5684,6 +5966,30 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.3.tgz",
+      "integrity": "sha512-EaB49bu/TCoNeQjhCYKI/CurooBKkGxIqFHsWABW0b25fobBYVTMe84A8EBVVZhl8emiUdNypil9huMOTmyAnw==",
+      "requires": {
+        "gaxios": "^1.0.4",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5818,6 +6124,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "hash-stream-validation": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
+      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
+    },
     "hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -5920,6 +6231,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
       }
     },
     "iconv-lite": {
@@ -6813,6 +7133,11 @@
         }
       }
     },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -7077,8 +7402,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
       "version": "1.0.1",
@@ -7152,6 +7476,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -7654,6 +7983,11 @@
         "regenerator-runtime": "^0.13.3"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "jpeg-js": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.6.tgz",
@@ -7818,6 +8152,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.1.0.tgz",
       "integrity": "sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g=="
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "keccak": {
       "version": "1.4.0",
@@ -8004,11 +8357,21 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
       "version": "4.2.0",
@@ -8039,7 +8402,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -8081,7 +8443,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       },
@@ -8089,8 +8450,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -8167,6 +8527,11 @@
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
         }
       }
+    },
+    "methmeth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
+      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk="
     },
     "methods": {
       "version": "1.1.2",
@@ -8376,6 +8741,11 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
       "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
+    },
+    "modelo": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",
+      "integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA=="
     },
     "module-not-found-error": {
       "version": "1.0.1",
@@ -10142,8 +10512,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
@@ -10208,6 +10577,27 @@
         "once": "^1.3.1"
       }
     },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -10234,6 +10624,11 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10628,6 +11023,20 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    },
+    "retry-request": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
+      "integrity": "sha512-WIiGp37XXDC6e7ku3LFoi7LCL/Gs9luGeeqvbPRb+Zl6OQMw4RCRfSaW+aLfE6lhz1R941UavE6Svl3Dm5xGIQ==",
+      "requires": {
+        "request": "^2.81.0",
+        "through2": "^2.0.0"
       }
     },
     "rimraf": {
@@ -11034,8 +11443,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "signed-varint": {
       "version": "2.0.1",
@@ -11099,6 +11507,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -11321,6 +11734,15 @@
         "through": "2"
       }
     },
+    "split-array-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
+      "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
+      "requires": {
+        "async": "^2.4.0",
+        "is-stream-ended": "^0.1.0"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11418,6 +11840,19 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "stream-to-it": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
@@ -11444,6 +11879,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-format-obj": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
+      "integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
     },
     "string-width": {
       "version": "2.1.1",
@@ -11657,6 +12097,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -11857,6 +12302,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -11975,6 +12429,18 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "tus-node-server": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.3.2.tgz",
+      "integrity": "sha512-Jl/x3eUNPZ+0x4c9DoJEyOe96xf3d+A8MuSKEagxhPXaEL1dwTpilllePfRrMF5JIGYWRvaiFtRf02m9o8nv+g==",
+      "requires": {
+        "@google-cloud/storage": "1.7.0",
+        "aws-sdk": "^2.224.1",
+        "configstore": "^3.1.2",
+        "crypto-rand": "0.0.2",
+        "debug": "^3.1.0"
       }
     },
     "tweetnacl": {
@@ -12112,7 +12578,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
@@ -12209,6 +12674,22 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -12928,8 +13409,7 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xhr": {
       "version": "2.5.0",
@@ -13028,8 +13508,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "13.3.0",

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -55,6 +55,7 @@
     "sequelize": "^4.41.2",
     "shortid": "^2.2.14",
     "systeminformation": "^5.0.2",
+    "tus-node-server": "^0.3.2",
     "umzug": "^2.2.0",
     "uuid": "3.3.2"
   },

--- a/creator-node/src/FileProcessingQueue.js
+++ b/creator-node/src/FileProcessingQueue.js
@@ -41,7 +41,7 @@ class FileProcessingQueue {
         const response = await this.monitorProgress(PROCESS_NAMES.transcode, transcodeFn, transcodeParams)
         done(null, { response })
       } catch (e) {
-        this.logError(transcodeParams.logContext, `Could not process taskType=${PROCESS_NAMES.transcode} uuid=${transcodeParams.logContext}: ${e.toString()}`)
+        this.logError(transcodeParams.logContext, `Could not process taskType=${PROCESS_NAMES.transcode} uuid=${transcodeParams.logContext.requestID}: ${e.toString()}`)
         done(e.message)
       }
     })

--- a/creator-node/src/FileProcessingQueue.js
+++ b/creator-node/src/FileProcessingQueue.js
@@ -42,7 +42,7 @@ class FileProcessingQueue {
         done(null, { response })
       } catch (e) {
         this.logError(transcodeParams.logContext, `Could not process taskType=${PROCESS_NAMES.transcode} uuid=${transcodeParams.logContext.requestID}: ${e.toString()}`)
-        done(e.message)
+        done(e.toString())
       }
     })
   }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -442,34 +442,18 @@ const trackFileUpload = multer({
 })
 
 const handleTrackContentUpload = (req, res, next) => {
-  // If this condition is met, use the multer package to handle track upload
-  if (req.headers['use-resumable-track-upload'] === 'false') {
-    trackFileUpload.single('file')(req, res, (err) => {
-      if (err) {
-        if (err.code === 'LIMIT_FILE_SIZE') {
-          req.fileSizeError = err
-        } else if (err instanceof multer.MulterError) {
-          req.logger.error(`Multer error: ${err}`)
-        } else {
-          req.logger.error(`Content upload error: ${err}`)
-        }
+  trackFileUpload.single('file')(req, res, (err) => {
+    if (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        req.fileSizeError = err
+      } else if (err instanceof multer.MulterError) {
+        req.logger.error(`Multer error: ${err}`)
+      } else {
+        req.logger.error(`Content upload error: ${err}`)
       }
-      next()
-    })
-  } else {
-    // Else, use the tus-node-server (resumable upload) package to handle track upload
+    }
     next()
-  }
-}
-
-// File has already been uploaded. Take the file metadata and set it in the req obj.
-const handleTrackContentTranscode = (req, res, next) => {
-  const { filename, filedir } = req.headers
-  req.fileName = filename
-  req.fileDir = filedir
-  req.file = { destination: filedir }
-
-  next()
+  })
 }
 
 function getFileExtension (fileName) {
@@ -549,6 +533,5 @@ module.exports = {
   handleTrackContentUpload,
   hasEnoughStorageSpace,
   checkFile,
-  getFileExtension,
-  handleTrackContentTranscode
+  getFileExtension
 }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -463,7 +463,7 @@ function getFileExtension (fileName) {
 
 /**
  * Checks the file type. Throws an error if not accepted.
- * @param {Object} req express request object
+ * @param {Object} logger the logger instance from the express request object
  * @param {Object} param
  * @param {string} param.fileName the file name
  * @param {string} param.fileMimeType the file type

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -4,7 +4,6 @@ const multer = require('multer')
 const getUuid = require('uuid/v4')
 const axios = require('axios')
 const promiseAny = require('promise.any')
-const tus = require('tus-node-server')
 
 const config = require('./config')
 const Utils = require('./utils')
@@ -16,8 +15,6 @@ const MAX_MEMORY_FILE_SIZE = parseInt(config.get('maxMemoryFileSizeBytes')) // D
 
 const ALLOWED_UPLOAD_FILE_EXTENSIONS = config.get('allowedUploadFileExtensions') // default set in config.json
 const AUDIO_MIME_TYPE_REGEX = /audio\/(.*)/
-
-const server = new tus.Server()
 
 /**
  * Adds file to IPFS then saves file to disk under /multihash name

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -433,7 +433,7 @@ const trackFileUpload = multer({
   limits: { fileSize: MAX_AUDIO_FILE_SIZE },
   fileFilter: function (req, file, cb) {
     try {
-      checkFileType(req, { fileName: file.originalname, fileMimeType: file.mimetype })
+      checkFileType(req.logger, { fileName: file.originalname, fileMimeType: file.mimetype })
       cb(null, true)
     } catch (e) {
       req.fileFilterError = e.message

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -34,7 +34,7 @@ const ImageProcessingQueue = require('../ImageProcessingQueue')
 const RehydrateIpfsQueue = require('../RehydrateIpfsQueue')
 const DBManager = require('../dbManager')
 const DiskManager = require('../diskManager')
-const { constructProcessKey } = require('../FileProcessingQueue')
+const { constructProcessKey, PROCESS_NAMES } = require('../FileProcessingQueue')
 
 const { promisify } = require('util')
 
@@ -319,8 +319,8 @@ const getDirCID = async (req, res) => {
 }
 
 module.exports = function (app) {
-  app.get('/task_status', handleResponse(async (req, res) => {
-    const redisKey = constructProcessKey(req.query.taskType, req.query.uuid)
+  app.get('/track_content_status', handleResponse(async (req, res) => {
+    const redisKey = constructProcessKey(PROCESS_NAMES.transcode, req.query.uuid)
     const value = await redisClient.get(redisKey) || '{}'
 
     return successResponse(JSON.parse(value))

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -319,7 +319,7 @@ const getDirCID = async (req, res) => {
 }
 
 module.exports = function (app) {
-  app.get('/track_content_status', handleResponse(async (req, res) => {
+  app.get('/task_status', handleResponse(async (req, res) => {
     const redisKey = constructProcessKey(req.query.taskType, req.query.uuid)
     const value = await redisClient.get(redisKey) || '{}'
 

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -87,6 +87,7 @@ module.exports = function (app) {
   })
 
   // Route that handles the resumable upload HEAD and PATCH requests.
+  app.all(resumableUploadRoute, authMiddleware, ensurePrimaryMiddleware, ensureStorageMiddleware, syncLockMiddleware, async function (req, res, next) {
     try {
     const urlArr = req.originalUrl.split('/')
     const fileDir = (urlArr.slice(0, urlArr.length - 1)).join('/')

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -148,6 +148,19 @@ module.exports = function (app) {
    * @dev - Prune upload artifacts after successful and failed uploads. Make call without awaiting, and let async queue clean up.
    */
   app.post('/track_content', authMiddleware, ensurePrimaryMiddleware, ensureStorageMiddleware, syncLockMiddleware, handleTrackContentUpload, handleResponseWithHeartbeat(async (req, res) => {
+    if (req.fileSizeError) {
+      // Prune upload artifacts
+      removeTrackFolder(req, req.fileDir)
+
+      return errorResponseBadRequest(req.fileSizeError)
+    }
+    if (req.fileFilterError) {
+      // Prune upload artifacts
+      removeTrackFolder(req, req.fileDir)
+
+      return errorResponseBadRequest(req.fileFilterError)
+    }
+
     const routeTimeStart = Date.now()
     let codeBlockTimeStart
     const cnodeUserUUID = req.session.cnodeUserUUID

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -2503,6 +2503,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha1-9N9nQAg+VwOjGBEQwrEFUfAD2oY=",
+      "requires": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
+      }
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2678,6 +2687,11 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
       "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
+    "custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha1-PPY5FIemYppiR+sMoM4ACBt+Nho="
     },
     "d": {
       "version": "1.0.1",
@@ -4850,6 +4864,11 @@
         "is-object": "^1.0.1"
       }
     },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -5014,6 +5033,46 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha1-NKm1VDVycnw9sueO2uPA6eZr0QI=",
+      "requires": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8="
+    },
+    "lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+      "requires": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha1-lBvPDmQmbl/B1m/tCmlZVExXaCQ=",
+      "requires": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -5031,6 +5090,20 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
+    "lodash.uniqby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+      "integrity": "sha1-o6F7v2LutiQPSRhG6XwcTipeHiE=",
+      "requires": {
+        "lodash._baseiteratee": "~4.7.0",
+        "lodash._baseuniq": "~4.6.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5956,6 +6029,22 @@
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
+    "proper-lockfile": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+      "integrity": "sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+        }
+      }
+    },
     "proper-url-join": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/proper-url-join/-/proper-url-join-1.2.0.tgz",
@@ -6019,6 +6108,11 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -6186,6 +6280,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.17.0",
@@ -7084,6 +7183,32 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "tus-js-client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.3.0.tgz",
+      "integrity": "sha512-I4cSwm6N5qxqCmBqenvutwSHe9ntf81lLrtf6BmLpG2v4wTl89atCQKqGgqvkodE6Lx+iKIjMbaXmfvStTg01g==",
+      "requires": {
+        "buffer-from": "^0.1.1",
+        "combine-errors": "^3.0.3",
+        "is-stream": "^2.0.0",
+        "js-base64": "^2.6.1",
+        "lodash.throttle": "^4.1.1",
+        "proper-lockfile": "^2.0.1",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -7184,6 +7309,15 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -33,6 +33,7 @@
     "node-localstorage": "^1.3.1",
     "proper-url-join": "^1.2.0",
     "semver": "^6.3.0",
+    "tus-js-client": "^2.3.0",
     "web3": "1.2.7"
   },
   "devDependencies": {

--- a/libs/src/api/track.js
+++ b/libs/src/api/track.js
@@ -21,11 +21,8 @@ const TRACK_REQUIRED_PROPS = [
 ]
 
 class Track extends Base {
-  constructor (useTrackContentPolling, ...args) {
+  constructor (...args) {
     super(...args)
-
-    this.useTrackContentPolling = useTrackContentPolling
-
     this.getTracks = this.getTracks.bind(this)
     this.getTracksIncludingUnlisted = this.getTracksIncludingUnlisted.bind(this)
     this.getUnlistedTracks = this.getUnlistedTracks.bind(this)
@@ -337,8 +334,7 @@ class Track extends Base {
         trackFile,
         coverArtFile,
         metadata,
-        onProgress,
-        this.useTrackContentPolling
+        onProgress
       )
 
       phase = phases.ADDING_TRACK
@@ -402,7 +398,8 @@ class Track extends Base {
         trackFile,
         coverArtFile,
         metadata,
-        onProgress)
+        onProgress
+      )
     }, {
     // Retry function 3x
     // 1st retry delay = 500ms, 2nd = 1500ms, 3rd...nth retry = 4000 ms (capped)

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -211,7 +211,6 @@ class AudiusLibs {
     this.Playlist = null
     this.File = null
 
-    console.log('libs index.js -- what is useTrackContentPolling useResumableTrackUpload', useTrackContentPolling, useResumableTrackUpload)
     this.useTrackContentPolling = useTrackContentPolling
     this.useResumableTrackUpload = useResumableTrackUpload
 

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -175,7 +175,8 @@ class AudiusLibs {
     captchaConfig,
     isServer,
     isDebug = false,
-    useTrackContentPolling = false
+    useTrackContentPolling = false,
+    useResumableTrackUpload = false
   }) {
     // set version
     this.version = packageJSON.version
@@ -210,7 +211,9 @@ class AudiusLibs {
     this.Playlist = null
     this.File = null
 
+    console.log('libs index.js -- what is useTrackContentPolling useResumableTrackUpload', useTrackContentPolling, useResumableTrackUpload)
     this.useTrackContentPolling = useTrackContentPolling
+    this.useResumableTrackUpload = useResumableTrackUpload
 
     // Schemas
     const schemaValidator = new SchemaValidator()
@@ -308,7 +311,9 @@ class AudiusLibs {
         this.schemas,
         this.creatorNodeConfig.passList,
         this.creatorNodeConfig.blockList,
-        this.creatorNodeConfig.monitoringCallbacks
+        this.creatorNodeConfig.monitoringCallbacks,
+        this.useTrackContentPolling,
+        this.useResumableTrackUpload
       )
       await this.creatorNode.init()
     }
@@ -336,7 +341,7 @@ class AudiusLibs {
     this.ServiceProvider = new ServiceProvider(...services)
     this.User = new User(this.ServiceProvider, ...services)
     this.Account = new Account(this.User, ...services)
-    this.Track = new Track(this.useTrackContentPolling, ...services)
+    this.Track = new Track(...services)
     this.Playlist = new Playlist(...services)
     this.File = new File(...services)
   }

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -761,7 +761,7 @@ class CreatorNode {
     } else {
       console.log(url, file, requestId)
       try {
-        const uuid = await this.startResumableUpload(file, url, headers, onProgress)
+        const { uuid, fileName, fileDir } = await this.startResumableUpload(file, url, headers, onProgress)
 
         return { data: { uuid } }
       } catch (e) {
@@ -786,11 +786,11 @@ class CreatorNode {
           filetype: file.type,
           userId: this.userStateManager.getCurrentUser().user_id
         },
-        headers,
+        headers: { ...headers, filesize: file.size, filetype: file.type },
         // An optional integer representing the size of the file in bytes
         uploadSize: file.size,
         // Maximum size of PATCH request body in bytes
-        chunkSize: 1000,
+        chunkSize: 1000000,
         removeFingerprintOnSuccess: true,
         // Adds a request ID to (v4 uuid) to X-Request-ID header
         // addRequestId: true,
@@ -816,7 +816,16 @@ class CreatorNode {
           console.log('whati sthe upload response', upload)
 
           // resolve(upload._req.getHeaders('X-Request-ID'))
-          resolve(headers['X-Request-ID'])
+
+          const urlArr = upload.url.split('/')
+          const fileName = urlArr.slice(urlArr.length - 1)[0]
+          const fileDir = '/' + urlArr.slice(3, urlArr.length - 1).join('/')
+
+          resolve({
+            uuid: headers['X-Request-ID'],
+            fileName,
+            fileDir
+          })
         },
         fingerprint: function (file, options) {
           console.log('hello what is these things', file, options)

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -377,10 +377,10 @@ class CreatorNode {
   }
 
   async pollProcessingStatus (taskType, uuid) {
-    const route = this.creatorNodeEndpoint + '/task_status'
+    const route = this.creatorNodeEndpoint + '/track_content_status'
     const start = Date.now()
     while (Date.now() - start < MAX_TRACK_TRANSCODE_TIMEOUT) {
-      const { status, resp } = await this.getProcessingStatus(taskType, uuid)
+      const { status, resp } = await this.getTrackContentProcessingStatus(uuid)
       // Should have a body structure of:
       //   { transcodedTrackCID, transcodedTrackUUID, track_segments, source_file }
       if (status && status === 'DONE') return resp
@@ -395,15 +395,13 @@ class CreatorNode {
 
   /**
    * Gets the task progress given the task type and uuid associated with the task
-   * @param {string} taskType
-   * @param {string} uuid
+   * @param {string} uuid the uuid of the track transcoding task
    * @returns the status, and the success or failed response if the task is complete
    */
-  async getProcessingStatus (taskType, uuid) {
+  async getTrackContentProcessingStatus (uuid) {
     const { data: body } = await this._makeRequest({
-      url: '/task_status',
+      url: '/track_content_status',
       params: {
-        taskType,
         uuid
       },
       method: 'get'

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -793,7 +793,6 @@ class CreatorNode {
 
   // https://github.com/tus/tus-js-client/blob/master/docs/api.md
   async startResumableUpload (file, url, headers, onProgress) {
-    const randomFileName = uuid()
     return new Promise((resolve, reject) => {
       const upload = new tus.Upload(file, {
         // Endpoint is the upload creation URL from your tus server

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -371,7 +371,7 @@ class CreatorNode {
       if (status && status === 'DONE') return resp
       if (status && status === 'FAILED') await this._handleErrorHelper(new Error(`Transcode failed: uuid=${uuid}, error=${resp}`), `/track_content_async`, uuid)
 
-      // Check the transcode status every 5s
+      // Check the transcode status every 3s
       await wait(POLL_STATUS_INTERVAL)
     }
 

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -804,7 +804,7 @@ class CreatorNode {
     })
 
     if (this.isServer) {
-      headers = formData.getHeaders()
+      headers = { ...headers, ...formData.getHeaders() }
     }
     headers['X-Session-ID'] = this.authToken
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

**Context:** Currently, when a user uploads a track, the entire file is uploaded. In conjunction with a bad network, the user will have to trouble uploading the track. This can cause frustration.

**Purpose:** This PR is to implement track upload chunking and resumable upload. More details are listed in the upload track design doc

**In this PR:**
-  abstracting file filter check in `fileManager.js` to two methods called `checkFileType()` and `checkFileSize()`
- creating a middleware called `checkFileMiddleware()` that uses the ^ methods
- rename `/track_content_status` route to `/task_status`
- add a route called `/track_content_upload` for chunking and resumable upload logic
- pass new flags `useTrackContentPolling` and `useResumableTrackUpload` into libs CN instance
- refactor `uploadTrackAudio()` to handle 3 different scenarios:  
   - resumable upload + polling track transcode response
   - uploading the entire file + polling track transcode response
   - uploading the entire file + waiting for the track transcode response (original flow)
- add tus-client-js logic into libs for chunking and resumable upload in method `startResumableUpload()` 

A high level flow chart of upload flow:
![IMG_D5042EEEDC09-1](https://user-images.githubusercontent.com/60366641/117894048-61b0f380-b270-11eb-8c59-6e80e62e5aa3.jpeg)

TODO:
- [x] Address any comments on PR review
- [x] Fix unit tests
- [ ] Merge

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- [x]  Track upload works with flag conditions
    - [x]  resumable = T, polling = T
    - [x]  resumable = T, polling = F (same behavior as ^)
    - [x]  resumable = F, polling = F (OG)
    - [x]  resumable = F, poling = T
- [x]  Track upload succeeds with 3MB track
- [x]  Track upload succeeds with 200MB track
    - [x]  single upload works
    - [x]  refresh + upload again resumes from where it was left off at
- [x]  Track upload succeeds with multiple tracks (album)
- [x]  Track upload succeeds with uploads on multiple tabs
    - album, short track, long track on 3 different tabs
- [x]  Track upload succeeds with fast network
    - [x]  big track
    - [x]  small track
- [x]  Track upload succeeds with slow network (3G slow on console)
    - [x]  big track
    - [x]  small track
- POST 
    - [x]  Dapp handles track content upload middleware failing
        - dapp ugly stack trace page shows with POST route failing

        ```bash
        {"error":"i failed in middleware"}
        ```

    - [x]  Dapp handles track content upload logic before tus middleware failing
        - dapp ugly stack trace page shows with POST route failing 6x

        ```bash
        {"error":"Error: i failed in creating directories"}
        ```

    - [x]  Dapp handles track content upload logic during tus middleware failing
        - dapp ugly stack trace page shows with POST route failing 6x

        ```bash
        Something went wrong with that request
        ENOENT: no such file or directory, open 'file_storage/files/tmp_track_artifacts/0cfe7b7d-a5d6-46a9-a2cc-98d36e2ec2db/d402b1a8-e263-47b4-9a78-9dae0655a4b1.mp3'
        ```

- HEAD/PATCH
    - [x]  Dapp handles tmp file dir route middleware failing
        - dapp shows heavy load page then nasty stack page

        ```bash
        Server returned error: [423] [Cannot change state of wallet 0xcddd53a34b2f06dac19b59f4187880f0d91d30dc. Node sync currently in progress.] for request: [7e615cd0-0c3f-4956-94fb-a2acda892f93, 7e615cd0-0c3f-4956-94fb-a2acda892f93]
        ```

    - [x]  Dapp handles tmp file dir route before tus middleware failing
        - dapp retries the patch and head a few times (progress bar kinda goes brazzy; back and forth progress)
        - dapp shows heavy load page then nasty stack page

        ```bash
        {"error":"Error: i failed before the tus logic patch"} 
        ```

    - [x]  Dapp handles tmp file dir route during tus middleware failing
        - manually deleted the file

        ```bash
        PATCH 410 GONE 
        The file for this url no longer exists
        ```
