### PR TITLE
Add directory key to tus filestore

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -60,7 +60,12 @@ const getFileName = (req) => {
 
 const server = new tus.Server()
 server.datastore = new tus.FileStore({
-  path: tmpTrackArtifactsPath, // has to be a path that exists
+  // Has to be a path that exists
+  path: tmpTrackArtifactsPath,
+  // In the tus-node-server example, they set the file path using the 'path' key. However, in their package,
+  // doing so strips off any forward slashes. The 'directory' key overrides any 'path' specified, so use
+  // this key instead.
+  directory: tmpTrackArtifactsPath,
   namingFunction: getFileName
 })
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Using `tus-node-server` FileStore failed because the `path` key strips off the beginning forward slash, causing the cnode to think that the path does not exist when it does. Override that by adding the path to the `directory` key too.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

On startup:
1. Deleted the tmp file storage path
2. Restarted the cnode
3. Checked to see if any error logs popped up

On track upload:
1. Uploaded a track to ensure track can still be uploaded 
