### PR TITLE
Add peerSetManager and refactor

### DIFF
--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -1,0 +1,282 @@
+const axios = require('axios')
+
+const { logger } = require('../logging')
+
+// TODO: config var
+const PEER_HEALTH_CHECK_REQUEST_TIMEOUT = 2000
+
+class PeerSetManager {
+  constructor (discoveryProviderEndpoint, currentModuloSlice, creatorNodeEndpoint, moduloBase) {
+    this.currentModuloSlice = currentModuloSlice
+    this.discoveryProviderEndpoint = discoveryProviderEndpoint
+    this.creatorNodeEndpoint = creatorNodeEndpoint
+    this.moduloBase = moduloBase
+  }
+
+  log (msg) {
+    logger.info(`SnapbackSM:::PeerSetManager: ${msg}`)
+  }
+
+  logError (msg) {
+    logger.error(`SnapbackSM:::PeerSetManager ERROR: ${msg}`)
+  }
+
+  /**
+   * Retrieves node users, paritions it into a slice, computes the peer set of the node users,
+   * and performs a health check on the peer set.
+   * @param {Object[]} nodeUsers array of user info for those who have the current node as part of replica set.
+   * The structure is the discovery node response from route `v1/full/users/content_node/all`
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
+   * @returns the unhealthy peers in a Set
+   */
+  async getUnhealthyPeers (nodeUsers, decisionTree) {
+    // Compute content node peerset from nodeUsers (all nodes that are in a shared replica set with this node)
+    let peerSet = []
+    try {
+      peerSet = this.computeContentNodePeerSet(nodeUsers, decisionTree)
+    } catch (e) {
+      decisionTree.push({ stage: '4/ computeContentNodePeerSet() Error', vals: e.message, time: Date.now() })
+      throw new Error('getUnhealthyPeers():computeContentNodePeerSet() Error')
+    }
+
+    /**
+     * Determine health for every peer & build list of unhealthy peers
+     * TODO: change from sequential to chunked parallel
+     */
+    const unhealthyPeers = new Set()
+    try {
+      for await (const peer of peerSet) {
+        const peerIsHealthy = await this.determinePeerHealth(peer)
+        if (!peerIsHealthy) {
+          unhealthyPeers.add(peer)
+        }
+      }
+
+      decisionTree.push({
+        stage: '5/ determinePeerHealth() Success',
+        vals: {
+          unhealthyPeerSetLength: unhealthyPeers.size,
+          healthyPeerSetLength: peerSet.size - unhealthyPeers.size,
+          unhealthyPeers: Array.from(unhealthyPeers)
+        },
+        time: Date.now()
+      })
+    } catch (e) {
+      decisionTree.push({ stage: '5/ determinePeerHealth() Error', vals: e.message, time: Date.now() })
+      throw new Error('getUnhealthyPeers():determinePeerHealth() Error')
+    }
+
+    return unhealthyPeers
+  }
+
+  /**
+   * Wrapper method for retrieving all users on current node and slicing up a partition of it
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
+   * @returns a partition of the users that have this node as part of their replica sets
+   */
+  async getNodeUsersSlice (decisionTree) {
+    let nodeUsers = await this.getNodeUsers(decisionTree)
+    nodeUsers = this.sliceUsers(nodeUsers, decisionTree)
+
+    return nodeUsers
+  }
+
+  /**
+   * Retrieve list of all users which have this node as replica (primary or secondary) from discovery node
+   * Or retrieve primary users only if connected to old discprov
+   */
+  async getNodeUsers (decisionTree) {
+    let nodeUsers
+    try {
+      nodeUsers = await this._getNodeUsers(decisionTree)
+      decisionTree.push({ stage: '2/ getNodeUsers() Success', vals: { nodeUsersLength: nodeUsers.length }, time: Date.now() })
+    } catch (e) {
+      decisionTree.push({ stage: '2/ getNodeUsers() Error', vals: e.message, time: Date.now() })
+      throw new Error('getUnhealthyPeers():getNodeUsers() Error')
+    }
+
+    return nodeUsers
+  }
+
+  /**
+   * Wrapper function to handle backwards compatibility of getAllNodeUsers() and getNodePrimaryUsers()
+   * This only works if both functions have a consistent return format
+   */
+  async _getNodeUsers (decisionTree) {
+    let nodeUsers
+
+    try {
+      // Use new function to retrieve all node users
+      nodeUsers = await this.getAllNodeUsers(decisionTree)
+    } catch (e) {
+      // On failure, fallback to old function to retrieve all node primary users
+      nodeUsers = await this.getNodePrimaryUsers()
+    } finally {
+      // Ensure every object in response array contains all required fields
+      nodeUsers.forEach(nodeUser => {
+        const requiredFields = ['user_id', 'wallet', 'primary', 'secondary1', 'secondary2']
+        const responseFields = Object.keys(nodeUser)
+        const allRequiredFieldsPresent = requiredFields.every(requiredField => responseFields.includes(requiredField))
+        if (!allRequiredFieldsPresent) {
+          throw new Error('Unexpected response format during getAllNodeUsers() or getNodePrimaryUsers() call')
+        }
+      })
+    }
+
+    return nodeUsers
+  }
+
+  /**
+   * Retrieve users with this node as replica (primary or secondary)
+   *  - Makes single request to discovery node to retrieve all users
+   *
+   * @notice This function depends on a new discprov route and cannot be consumed until every discprov exposes that route
+   *    It will throw if the route doesn't exist
+   *
+   * @returns {Array} array of objects
+   *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
+   */
+  async getAllNodeUsers (decisionTree) {
+    // Fetch discovery node currently connected to libs as this can change
+    if (!this.discoveryProviderEndpoint) {
+      throw new Error('No discovery provider currently selected, exiting')
+    }
+
+    // Request all users that have this node as a replica (either primary or secondary)
+    const requestParams = {
+      method: 'get',
+      baseURL: this.discoveryProviderEndpoint,
+      url: `v1/full/users/content_node/all`,
+      params: {
+        creator_node_endpoint: this.creatorNodeEndpoint
+      }
+    }
+
+    // Will throw error on non-200 response
+    const resp = await axios(requestParams)
+    const allNodeUsers = resp.data.data
+
+    decisionTree.push({
+      stage: '2.A/ getNodeUsers():getAllNodeUsers() Success',
+      vals: { requestParams, numAllNodeUsers: allNodeUsers.length },
+      time: Date.now()
+    })
+
+    return allNodeUsers
+  }
+
+  /**
+   * Retrieve users with this node as primary
+   * Leaving this function in until all discovery providers update to new version and expose new `/users/content_node/all` route
+   *
+   * @returns {Array} array of objects
+   *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
+   */
+  async getNodePrimaryUsers (decisionTree) {
+    // Fetch discovery node currently connected to libs as this can change
+    if (!this.discoveryProviderEndpoint) {
+      throw new Error('No discovery provider currently selected, exiting')
+    }
+
+    const requestParams = {
+      method: 'get',
+      baseURL: this.discoveryProviderEndpoint,
+      url: `users/creator_node`,
+      params: {
+        creator_node_endpoint: this.creatorNodeEndpoint
+      }
+    }
+
+    // Will throw error on non-200 response
+    const resp = await axios(requestParams)
+    const nodePrimaryUsers = resp.data.data
+
+    decisionTree.push({
+      stage: '2.A/ getNodeUsers():getAllNodeUsers() Failure; fallback getNodePrimaryUsers() Success',
+      vals: { requestParams, numNodePrimaryUsers: nodePrimaryUsers.length },
+      time: Date.now()
+    })
+
+    return nodePrimaryUsers
+  }
+
+  /**
+   * Select chunk of users to process in this run
+   *  - User is selected if (user_id % this.moduloBase = currentModuloSlice)
+   *  - nodeUsers = array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   */
+  sliceUsers (nodeUsers, decisionTree) {
+    const filteredNodeUsers = nodeUsers.filter(nodeUser =>
+      nodeUser.user_id % this.moduloBase === this.currentModuloSlice
+    )
+
+    decisionTree.push({
+      stage: `3/ select nodeUsers modulo slice ${this.currentModuloSlice}`,
+      vals: { nodeUsersSubsetLength: nodeUsers.length, moduloBase: this.moduloBase, currentModuloSlice: this.currentModuloSlice },
+      time: Date.now()
+    })
+
+    return filteredNodeUsers
+  }
+
+  /**
+   * @param {Array} nodeUserInfoList array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @returns {Set} Set of content node endpoint strings
+   */
+  computeContentNodePeerSet (nodeUserInfoList, decisionTree) {
+    // Aggregate all nodes from user replica sets
+    let peerList = (
+      nodeUserInfoList.map(userInfo => userInfo.primary)
+        .concat(nodeUserInfoList.map(userInfo => userInfo.secondary1))
+        .concat(nodeUserInfoList.map(userInfo => userInfo.secondary2))
+    )
+
+    peerList = peerList.filter(Boolean) // filter out false-y values to account for incomplete replica sets
+      .filter(peer => peer !== this.creatorNodeEndpoint) // remove self from peerList
+
+    const peerSet = new Set(peerList) // convert to Set to get uniques
+
+    decisionTree.push({
+      stage: '4/ computeContentNodePeerSet() Success',
+      vals: { peerSetLength: peerSet.size },
+      time: Date.now()
+    })
+
+    return peerSet
+  }
+
+  /**
+   * Determines if a peer node is sufficiently healthy and able to process syncRequests
+   *
+   * Peer health criteria:
+   * - verbose health check returns 200 within timeout
+   *
+   * TODO - consider moving this pure function to libs
+   *
+   * @param {string} endpoint
+   * @returns {Boolean}
+   */
+  async determinePeerHealth (endpoint) {
+    let healthy = true
+
+    try {
+      // Axios request will throw on timeout or non-200 response
+      await axios({
+        baseURL: endpoint,
+        url: '/health_check/verbose',
+        method: 'get',
+        timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT
+      })
+    } catch (e) {
+      healthy = false
+    }
+
+    return healthy
+  }
+
+  setCurrentModuloSlice (index) {
+    this.currentModuloSlice = index
+  }
+}
+
+module.exports = PeerSetManager

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -24,8 +24,7 @@ class PeerSetManager {
   /**
    * Retrieves node users, paritions it into a slice, computes the peer set of the node users,
    * and performs a health check on the peer set.
-   * @param {Object[]} nodeUsers array of user info for those who have the current node as part of replica set.
-   * The structure is the discovery node response from route `v1/full/users/content_node/all`
+   * @param {Object[]} nodeUsers array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
    * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
    * @returns the unhealthy peers in a Set
    */
@@ -84,6 +83,7 @@ class PeerSetManager {
   /**
    * Retrieve list of all users which have this node as replica (primary or secondary) from discovery node
    * Or retrieve primary users only if connected to old discprov
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
    */
   async getNodeUsers (decisionTree) {
     let nodeUsers
@@ -101,6 +101,7 @@ class PeerSetManager {
   /**
    * Wrapper function to handle backwards compatibility of getAllNodeUsers() and getNodePrimaryUsers()
    * This only works if both functions have a consistent return format
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
    */
   async _getNodeUsers (decisionTree) {
     let nodeUsers
@@ -132,8 +133,8 @@ class PeerSetManager {
    *
    * @notice This function depends on a new discprov route and cannot be consumed until every discprov exposes that route
    *    It will throw if the route doesn't exist
-   *
-   * @returns {Array} array of objects
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
+   * @returns {Object[]} array of objects
    *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
    */
   async getAllNodeUsers (decisionTree) {
@@ -168,8 +169,8 @@ class PeerSetManager {
   /**
    * Retrieve users with this node as primary
    * Leaving this function in until all discovery providers update to new version and expose new `/users/content_node/all` route
-   *
-   * @returns {Array} array of objects
+    * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
+   * @returns {Object[]} array of objects
    *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
    */
   async getNodePrimaryUsers (decisionTree) {
@@ -203,7 +204,8 @@ class PeerSetManager {
   /**
    * Select chunk of users to process in this run
    *  - User is selected if (user_id % this.moduloBase = currentModuloSlice)
-   *  - nodeUsers = array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @param {Object[]} nodeUsers array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
    */
   sliceUsers (nodeUsers, decisionTree) {
     const filteredNodeUsers = nodeUsers.filter(nodeUser =>
@@ -220,7 +222,8 @@ class PeerSetManager {
   }
 
   /**
-   * @param {Array} nodeUserInfoList array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @param {Object[]} nodeUserInfoList array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @param {Object[]} decisionTree the decisions metadata in the form of an Object array
    * @returns {Set} Set of content node endpoint strings
    */
   computeContentNodePeerSet (nodeUserInfoList, decisionTree) {
@@ -251,7 +254,7 @@ class PeerSetManager {
    * Peer health criteria:
    * - verbose health check returns 200 within timeout
    *
-   * TODO - consider moving this pure function to libs
+   * TODO: - consider moving this pure function to libs
    *
    * @param {string} endpoint
    * @returns {Boolean}
@@ -274,6 +277,10 @@ class PeerSetManager {
     return healthy
   }
 
+  /**
+   * Setter method for `this.currentModuloSlice`
+   * @param {number} index new modulo slice
+   */
   setCurrentModuloSlice (index) {
     this.currentModuloSlice = index
   }

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -205,7 +205,7 @@ class PeerSetManager {
    * TODO: - consider moving this pure function to libs
    *
    * @param {string} endpoint
-   * @returns {Boolean}
+   * @returns {Object} the /health_check/verbose response
    */
   async determinePeerHealth (endpoint) {
     // Axios request will throw on timeout or non-200 response

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -6,11 +6,9 @@ const { logger } = require('../logging')
 const PEER_HEALTH_CHECK_REQUEST_TIMEOUT = 2000
 
 class PeerSetManager {
-  constructor (discoveryProviderEndpoint, currentModuloSlice, creatorNodeEndpoint, moduloBase) {
-    this.currentModuloSlice = currentModuloSlice
+  constructor ({ discoveryProviderEndpoint, creatorNodeEndpoint }) {
     this.discoveryProviderEndpoint = discoveryProviderEndpoint
     this.creatorNodeEndpoint = creatorNodeEndpoint
-    this.moduloBase = moduloBase
   }
 
   log (msg) {
@@ -166,12 +164,15 @@ class PeerSetManager {
 
   /**
    * Select chunk of users to process in this run
-   *  - User is selected if (user_id % this.moduloBase = currentModuloSlice)
-   * @param {Object[]} nodeUsers array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   *  - User is selected if (user_id % moduloBase = currentModuloSlice)
+   * @param {Object} param
+   * @param {Object[]} param.nodeUsers array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
+   * @param {number} param.moduluoBase
+   * @param {number} param.currentModuloSlice
    */
-  sliceUsers (nodeUsers) {
+  sliceUsers ({ nodeUsers, moduloBase, currentModuloSlice }) {
     return nodeUsers.filter(nodeUser =>
-      nodeUser.user_id % this.moduloBase === this.currentModuloSlice
+      nodeUser.user_id % moduloBase === currentModuloSlice
     )
   }
 
@@ -214,14 +215,6 @@ class PeerSetManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT
     })
-  }
-
-  /**
-   * Setter method for `this.currentModuloSlice`
-   * @param {number} index new modulo slice
-   */
-  setCurrentModuloSlice (index) {
-    this.currentModuloSlice = index
   }
 }
 

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -163,20 +163,6 @@ class PeerSetManager {
   }
 
   /**
-   * Select chunk of users to process in this run
-   *  - User is selected if (user_id % moduloBase = currentModuloSlice)
-   * @param {Object} param
-   * @param {Object[]} param.nodeUsers array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
-   * @param {number} param.moduluoBase
-   * @param {number} param.currentModuloSlice
-   */
-  sliceUsers ({ nodeUsers, moduloBase, currentModuloSlice }) {
-    return nodeUsers.filter(nodeUser =>
-      nodeUser.user_id % moduloBase === currentModuloSlice
-    )
-  }
-
-  /**
    * @param {Object[]} nodeUserInfoList array of objects of schema { primary, secondary1, secondary2, user_id, wallet }
    * @returns {Set} Set of content node endpoint strings
    */

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -422,7 +422,7 @@ class SnapbackSM {
 
       decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Success', vals: { nodeUsersLength: nodeUsers.length }, time: Date.now() })
     } catch (e) {
-      decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Error', vals: e.message, time: Date.now() })
+      decisionTree.push({ stage: 'getNodeUsers() or sliceUsers() Error', vals: e.message, time: Date.now() })
       throw new Error('processStateMachineOperation():getNodeUsers()/sliceUsers() Error')
     }
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -623,10 +623,10 @@ class SnapbackSM {
       this.log(`processStateMachineOperation(): Retrieved nodePrimaryUsers via new discprov route`)
 
       /**
-         * If getAllNodeUsers() call fails, CN is connected to old discprov that doesn't have the `/users/content_node/all` route
-         * Fallback to getNodePrimaryUsers(), which calls old discprov route `/users/creator_node`
-         * This route returns only users with this node as their primary
-         */
+       * If getAllNodeUsers() call fails, CN is connected to old discprov that doesn't have the `/users/content_node/all` route
+       * Fallback to getNodePrimaryUsers(), which calls old discprov route `/users/creator_node`
+       * This route returns only users with this node as their primary
+       */
     } catch (e) {
       nodePrimaryUsers = await this.getNodePrimaryUsers()
       this.log(`processStateMachineOperation(): Retrieved nodePrimaryUsers via legacy discprov route`)
@@ -644,9 +644,9 @@ class SnapbackSM {
     }
 
     /**
-       * Build map of content node to list of all users that need to be processed
-       * Determines user list by checking if user_id % moduloBase = currentModuloSlice
-       */
+     * Build map of content node to list of all users that need to be processed
+     * Determines user list by checking if user_id % moduloBase = currentModuloSlice
+     */
 
     // Generate list of wallets by node to query clock number
     // Structured as { nodeEndpoint: [wallet1, wallet2, ...] }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -415,8 +415,26 @@ class SnapbackSM {
       time: Date.now()
     }]
 
-    const nodeUsers = await this.peerSetManager.getNodeUsersSlice(decisionTree)
-    const unhealthyPeers = await this.peerSetManager.getUnhealthyPeers(nodeUsers, decisionTree)
+    let nodeUsers
+    try {
+      nodeUsers = await this.peerSetManager.getNodeUsers()
+      nodeUsers = this.peerSetManager.sliceUsers(nodeUsers)
+
+      decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Success', vals: { nodeUsersLength: nodeUsers.length }, time: Date.now() })
+    } catch (e) {
+      decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Error', vals: e.message, time: Date.now() })
+      throw new Error('processStateMachineOperation():getNodeUsers()/sliceUsers() Error')
+    }
+
+    let unhealthyPeers = await this.peerSetManager.getUnhealthyPeers(nodeUsers)
+    decisionTree.push({
+      stage: 'getUnhealthyPeers() Success',
+      vals: {
+        unhealthyPeerSetLength: unhealthyPeers.size,
+        unhealthyPeers: Array.from(unhealthyPeers)
+      },
+      time: Date.now()
+    })
 
     try {
       // Lists to aggregate all required ReplicaSetUpdate ops and potential SyncRequest ops

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -416,7 +416,7 @@ class SnapbackSM {
     }]
 
     const nodeUsers = await this.peerSetManager.getNodeUsersSlice(decisionTree)
-    const unhealthyPeers = this.peerSetManager.getUnhealthyPeers(nodeUsers, decisionTree)
+    const unhealthyPeers = await this.peerSetManager.getUnhealthyPeers(nodeUsers, decisionTree)
 
     try {
       // Lists to aggregate all required ReplicaSetUpdate ops and potential SyncRequest ops

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -588,6 +588,188 @@ class SnapbackSM {
   }
 
   /**
+   * DEPRECATED replaced by this.processStateMachineOperation()
+   */
+  async processStateMachineOperationOld () {
+    this.log(`------------------Process SnapbackSM Operation, slice ${this.currentModuloSlice}------------------`)
+
+    // Retrieve list of all users that have this node as primary
+    let nodePrimaryUsers
+    try {
+      // Returns all users that have this node in their replica set via discprov route `/users/content_node/all`
+      const nodeUsers = await this.getAllNodeUsers()
+
+      // Filter to subset of users that have this node as their primary
+      nodePrimaryUsers = nodeUsers.filter(nodeUser => nodeUser.primary === this.endpoint)
+
+      this.log(`processStateMachineOperation(): Retrieved nodePrimaryUsers via new discprov route`)
+
+      /**
+         * If getAllNodeUsers() call fails, CN is connected to old discprov that doesn't have the `/users/content_node/all` route
+         * Fallback to getNodePrimaryUsers(), which calls old discprov route `/users/creator_node`
+         * This route returns only users with this node as their primary
+         */
+    } catch (e) {
+      nodePrimaryUsers = await this.getNodePrimaryUsers()
+      this.log(`processStateMachineOperation(): Retrieved nodePrimaryUsers via legacy discprov route`)
+
+      // Ensure every object in response array contains required fields
+    } finally {
+      nodePrimaryUsers.forEach(nodePrimaryUser => {
+        const requiredFields = ['user_id', 'wallet', 'primary', 'secondary1', 'secondary2']
+        const responseFields = Object.keys(nodePrimaryUser)
+        const allRequiredFieldsPresent = requiredFields.every(requiredField => responseFields.includes(requiredField))
+        if (!allRequiredFieldsPresent) {
+          throw new Error('Unexpected response format during getAllNodeUsers() or getNodePrimaryUsers() call')
+        }
+      })
+    }
+
+    /**
+       * Build map of content node to list of all users that need to be processed
+       * Determines user list by checking if user_id % moduloBase = currentModuloSlice
+       */
+
+    // Generate list of wallets by node to query clock number
+    // Structured as { nodeEndpoint: [wallet1, wallet2, ...] }
+    let nodeVectorClockQueryList = {}
+
+    // Users actually selected to process
+    let usersToProcess = []
+
+    // Wallets being processed in this state machine operation
+    let wallets = []
+
+    nodePrimaryUsers.forEach(
+      (user) => {
+        // determine if user should be processed by checking if user_id % moduloBase = currentModuloSlice
+        const userId = user.user_id
+        const modResult = userId % ModuloBase
+        const shouldProcess = (modResult === this.currentModuloSlice)
+        if (!shouldProcess) {
+          return
+        }
+
+        // Add to list of currently processing users
+        usersToProcess.push(user)
+        const userWallet = user.wallet
+        wallets.push(userWallet)
+
+        // Conditionally asign secondary if present
+        const secondary1 = (user.secondary1) ? user.secondary1 : null
+        const secondary2 = (user.secondary2) ? user.secondary2 : null
+
+        // Initialize empty array for node in node-wallet map if needed
+        if (!nodeVectorClockQueryList[secondary1] && secondary1 != null) { nodeVectorClockQueryList[secondary1] = [] }
+        if (!nodeVectorClockQueryList[secondary2] && secondary2 != null) { nodeVectorClockQueryList[secondary2] = [] }
+
+        // Push wallet if necessary onto secondary wallet list
+        if (secondary1 != null) nodeVectorClockQueryList[secondary1].push(userWallet)
+        if (secondary2 != null) nodeVectorClockQueryList[secondary2].push(userWallet)
+      }
+    )
+
+    this.log(`Processing ${usersToProcess.length} users`)
+    // Cached primary clock values for currently processing user set
+    let primaryClockValues = await this.getUserPrimaryClockValues(wallets)
+    // Process nodeVectorClockQueryList and cache user clock values on each node
+    let secondaryNodesToProcess = Object.keys(nodeVectorClockQueryList)
+    let secondaryNodeUserClockStatus = {}
+    await Promise.all(
+      secondaryNodesToProcess.map(
+        async (node) => {
+          secondaryNodeUserClockStatus[node] = {}
+          let walletsToQuery = nodeVectorClockQueryList[node]
+          let requestParams = {
+            baseURL: node,
+            method: 'post',
+            url: '/users/batch_clock_status',
+            data: {
+              'walletPublicKeys': walletsToQuery
+            }
+          }
+          this.log(`Requesting ${walletsToQuery.length} users from ${node}`)
+          let { data: body } = await axios(requestParams)
+          let userClockStatusList = body.data.users
+          // Process returned clock values from this secondary node
+          userClockStatusList.map(
+            (entry) => {
+              try {
+                secondaryNodeUserClockStatus[node][entry.walletPublicKey] = entry.clock
+              } catch (e) {
+                this.log(`ERROR updating secondaryNodeUserClockStatus for ${entry.walletPublicKey} with ${entry.clock}`)
+                this.log(JSON.stringify(secondaryNodeUserClockStatus))
+                throw e
+              }
+            }
+          )
+        }
+      )
+    )
+    this.log(`Finished node user clock status querying, moving to sync calculation. Modulo slice ${this.currentModuloSlice}`)
+
+    // Issue syncs if necessary
+    // For each user in the initially returned nodePrimaryUsers,
+    //  compare local primary clock value to value from secondary retrieved in bulk above
+    let numSyncsIssued = 0
+    await Promise.all(
+      usersToProcess.map(
+        async (user) => {
+          try {
+            let userWallet = null
+            let secondary1 = null
+            let secondary2 = null
+
+            if (user.wallet) userWallet = user.wallet
+            if (user.secondary1) secondary1 = user.secondary1
+            if (user.secondary2) secondary2 = user.secondary2
+
+            let primaryClockValue = primaryClockValues[userWallet]
+            let secondary1ClockValue = secondary1 != null ? secondaryNodeUserClockStatus[secondary1][userWallet] : undefined
+            let secondary2ClockValue = secondary2 != null ? secondaryNodeUserClockStatus[secondary2][userWallet] : undefined
+            let secondary1SyncRequired = (secondary1ClockValue === undefined) ? true : (primaryClockValue > secondary1ClockValue)
+            let secondary2SyncRequired = (secondary2ClockValue === undefined) ? true : (primaryClockValue > secondary2ClockValue)
+            this.log(`${userWallet} primaryClock=${primaryClockValue}, (secondary1=${secondary1}, clock=${secondary1ClockValue} syncRequired=${secondary1SyncRequired}), (secondary2=${secondary2}, clock=${secondary2ClockValue}, syncRequired=${secondary2SyncRequired})`)
+
+            // Enqueue sync for secondary1 if required
+            if (secondary1SyncRequired && secondary1 != null) {
+              await this.enqueueSync({
+                userWallet,
+                secondaryEndpoint: secondary1,
+                primaryEndpoint: this.endpoint,
+                syncType: SyncType.Recurring
+              })
+
+              numSyncsIssued += 1
+            }
+
+            // Enqueue sync for secondary2 if required
+            if (secondary2SyncRequired && secondary2 != null) {
+              await this.enqueueSync({
+                userWallet,
+                secondaryEndpoint: secondary2,
+                primaryEndpoint: this.endpoint,
+                syncType: SyncType.Recurring
+              })
+
+              numSyncsIssued += 1
+            }
+          } catch (e) {
+            this.log(`Caught error for user ${user.wallet}, ${JSON.stringify(user)}, ${e.message}`)
+          }
+        }
+      )
+    )
+
+    // Increment and adjust current slice by ModuloBase
+    const previousModuloSlice = this.currentModuloSlice
+    this.currentModuloSlice += 1
+    this.currentModuloSlice = this.currentModuloSlice % ModuloBase
+
+    this.log(`------------------END Process SnapbackSM Operation || Issued ${numSyncsIssued} SyncRequest ops in slice ${previousModuloSlice} of ${ModuloBase}. Moving to slice ${this.currentModuloSlice} ------------------`)
+  }
+
+  /**
    * Monitor an ongoing sync operation for a given secondaryUrl and user wallet
    * Return boolean indicating if an additional sync is required
    *

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -408,7 +408,7 @@ class SnapbackSM {
   async processStateMachineOperation () {
     // Record all stages of this function along with associated information for use in logging
     let decisionTree = [{
-      stage: '1/ BEGIN processStateMachineOperation()',
+      stage: 'BEGIN processStateMachineOperation()',
       vals: {
         currentModuloSlice: this.currentModuloSlice
       },
@@ -458,7 +458,7 @@ class SnapbackSM {
         }
       }
       decisionTree.push({
-        stage: '6/ Build requiredUpdateReplicaSetOps and potentialSyncRequests arrays',
+        stage: 'Build requiredUpdateReplicaSetOps and potentialSyncRequests arrays',
         vals: {
           requiredUpdateReplicaSetOpsLength: requiredUpdateReplicaSetOps.length,
           potentialSyncRequestsLength: potentialSyncRequests.length
@@ -469,7 +469,7 @@ class SnapbackSM {
       // Build map of secondary node to secondary user wallets array
       const secondaryNodesToUserWalletsMap = this.buildSecondaryNodesToUserWalletsMap(potentialSyncRequests)
       decisionTree.push({
-        stage: '7/ buildSecondaryNodesToUserWalletsMap() Success',
+        stage: 'buildSecondaryNodesToUserWalletsMap() Success',
         vals: { numSecondaryNodes: Object.keys(secondaryNodesToUserWalletsMap).length },
         time: Date.now()
       })
@@ -481,13 +481,13 @@ class SnapbackSM {
           secondaryNodesToUserWalletsMap
         )
         decisionTree.push({
-          stage: '8/ retrieveClockStatusesForSecondaryUsersFromNodes() Success',
+          stage: 'retrieveClockStatusesForSecondaryUsersFromNodes() Success',
           vals: { },
           time: Date.now()
         })
       } catch (e) {
         decisionTree.push({
-          stage: '8/ retrieveClockStatusesForSecondaryUsersFromNodes() Error',
+          stage: 'retrieveClockStatusesForSecondaryUsersFromNodes() Error',
           vals: e.message,
           time: Date.now()
         })
@@ -507,7 +507,7 @@ class SnapbackSM {
         }
 
         decisionTree.push({
-          stage: '9/ issueSyncRequests() Success',
+          stage: 'issueSyncRequests() Success',
           vals: {
             numSyncRequestsRequired,
             numSyncRequestsIssued,
@@ -518,7 +518,7 @@ class SnapbackSM {
         })
       } catch (e) {
         decisionTree.push({
-          stage: '9/ issueSyncRequests() Error',
+          stage: 'issueSyncRequests() Error',
           vals: {
             numSyncRequestsRequired,
             numSyncRequestsIssued,
@@ -543,13 +543,13 @@ class SnapbackSM {
         }
         numUpdateReplicaOpsIssued = requiredUpdateReplicaSetOps.length
         decisionTree.push({
-          stage: '10/ issueUpdateReplicaSetOp() Success',
+          stage: 'issueUpdateReplicaSetOp() Success',
           vals: { numUpdateReplicaOpsIssued },
           time: Date.now()
         })
       } catch (e) {
         decisionTree.push({
-          stage: '10/ issueUpdateReplicaSetOp() Error',
+          stage: 'issueUpdateReplicaSetOp() Error',
           vals: e.message,
           time: Date.now()
         })
@@ -563,7 +563,7 @@ class SnapbackSM {
       this.peerSetManager.setCurrentModuloSlice(this.currentModuloSlice)
 
       decisionTree.push({
-        stage: '11/ END processStateMachineOperation()',
+        stage: 'END processStateMachineOperation()',
         vals: {
           currentModuloSlice: previousModuloSlice,
           nextModuloSlice: this.currentModuloSlice,

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -413,28 +413,28 @@ class SnapbackSM {
       time: Date.now()
     }]
 
-    let nodeUsers
     try {
-      nodeUsers = await this.peerSetManager.getNodeUsers()
-      nodeUsers = this.peerSetManager.sliceUsers({ nodeUsers, moduloBase: ModuloBase, currentModuloSlice: this.currentModuloSlice })
+      let nodeUsers
+      try {
+        nodeUsers = await this.peerSetManager.getNodeUsers()
+        nodeUsers = this.peerSetManager.sliceUsers({ nodeUsers, moduloBase: ModuloBase, currentModuloSlice: this.currentModuloSlice })
 
-      decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Success', vals: { nodeUsersLength: nodeUsers.length }, time: Date.now() })
-    } catch (e) {
-      decisionTree.push({ stage: 'getNodeUsers() or sliceUsers() Error', vals: e.message, time: Date.now() })
-      throw new Error(`processStateMachineOperation():getNodeUsers()/sliceUsers() Error: ${e.toString()}`)
-    }
+        decisionTree.push({ stage: 'getNodeUsers() and sliceUsers() Success', vals: { nodeUsersLength: nodeUsers.length }, time: Date.now() })
+      } catch (e) {
+        decisionTree.push({ stage: 'getNodeUsers() or sliceUsers() Error', vals: e.message, time: Date.now() })
+        throw new Error(`processStateMachineOperation():getNodeUsers()/sliceUsers() Error: ${e.toString()}`)
+      }
 
-    let unhealthyPeers = await this.peerSetManager.getUnhealthyPeers(nodeUsers)
-    decisionTree.push({
-      stage: 'getUnhealthyPeers() Success',
-      vals: {
-        unhealthyPeerSetLength: unhealthyPeers.size,
-        unhealthyPeers: Array.from(unhealthyPeers)
-      },
-      time: Date.now()
-    })
+      let unhealthyPeers = await this.peerSetManager.getUnhealthyPeers(nodeUsers)
+      decisionTree.push({
+        stage: 'getUnhealthyPeers() Success',
+        vals: {
+          unhealthyPeerSetLength: unhealthyPeers.size,
+          unhealthyPeers: Array.from(unhealthyPeers)
+        },
+        time: Date.now()
+      })
 
-    try {
       // Lists to aggregate all required ReplicaSetUpdate ops and potential SyncRequest ops
       const requiredUpdateReplicaSetOps = []
       const potentialSyncRequests = []


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

The `snapbackSM.js` file is very big. This PR's intentions is to break it down into classes with single responsibilities. 

**In this PR:**
- Create `PeerSetManager` class that given the users with the current node as part of their replica sets, determine the peer set and the peer set health
- Use `PeerSetManager` in the snapback class 
- Refactor + update comments as necessary


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- Ran mad-dog + CN tests to see if tests pass
- Uploaded a track and checked to see if clock values increased

before track upload:
```
(3) [{…}, {…}, {…}]
0: {type: "primary", endpoint: "http://cn1_creator-node_1:4000", clockValue: 2}
1: {type: "secondary", endpoint: "http://cn3_creator-node_1:4002", clockValue: 2}
2: {type: "secondary", endpoint: "http://cn4_creator-node_1:4003", clockValue: 2}
length: 3
```

after track upload:
```
(3) [{…}, {…}, {…}]
0: {type: "primary", endpoint: "http://cn1_creator-node_1:4000", clockValue: 42}
1: {type: "secondary", endpoint: "http://cn3_creator-node_1:4002", clockValue: 42}
2: {type: "secondary", endpoint: "http://cn4_creator-node_1:4003", clockValue: 42}
length: 3
```

- ran mad-dog test-ci and test-snapback modes with `snapbackDevModeEnabled` set to `true`, and `triggerSecondarySync` turned off (early return)