### PR TITLE
Add a signer group config to discovery provider

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -29,6 +29,7 @@ eth_provider_url = http://audius_ganache_cli_eth_contracts:8545
 
 [solana]
 track_listen_count_address = ''
+signer_group_address = ''
 endpoint = ''
 
 [redis]

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -249,7 +249,10 @@ def process_solana_plays(solana_client):
     try:
         base58.b58decode(TRACK_LISTEN_PROGRAM)
     except ValueError:
-        logger.info(f"index_solana_plays.py | Invalid TrackListenCount program ({TRACK_LISTEN_PROGRAM}) configured, exiting.")
+        logger.info(
+            f"index_solana_plays.py"
+            f"Invalid TrackListenCount program ({TRACK_LISTEN_PROGRAM}) configured, exiting."
+        )
         return
 
     db = index_solana_plays.db

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -10,6 +10,7 @@ from src.tasks.celery_app import celery
 from src.utils.config import shared_config
 
 TRACK_LISTEN_PROGRAM = shared_config["solana"]["track_listen_count_address"]
+SIGNER_GROUP = shared_config["solana"]["signer_group_address"]
 SECP_PROGRAM = "KeccakSecp256k11111111111111111111111111111"
 
 # Maximum number of batches to process at once
@@ -84,14 +85,21 @@ def get_sol_tx_info(solana_client, tx_sig):
         retries -= 1
         logger.error(f"index_solana_plays.py | Retrying tx fetch: {tx_sig}")
 
+# Check for both SECP and SignerGroup
+# Ensures that a signature recovery was performed within the expected SignerGroup
+def is_valid_tx(account_keys):
+    if SECP_PROGRAM in account_keys and SIGNER_GROUP in account_keys:
+        return True
+    logger.error(f"index_solana_plays.py | Failed to find {SECP_PROGRAM} or {SIGNER_GROUP} in {account_keys}")
+    return False
+
 def parse_sol_play_transaction(session, solana_client, tx_sig):
     try:
         tx_info = get_sol_tx_info(solana_client, tx_sig)
         logger.info(
             f"index_solana_plays.py | Got transaction: {tx_sig} | {tx_info}"
         )
-        if SECP_PROGRAM in tx_info["result"]["transaction"]["message"][
-                "accountKeys"]:
+        if is_valid_tx(tx_info["result"]["transaction"]["message"]["accountKeys"]):
             audius_program_index = tx_info["result"]["transaction"]["message"][
                 "accountKeys"].index(TRACK_LISTEN_PROGRAM)
             for instruction in tx_info["result"]["transaction"]["message"][
@@ -241,7 +249,7 @@ def process_solana_plays(solana_client):
     try:
         base58.b58decode(TRACK_LISTEN_PROGRAM)
     except ValueError:
-        logger.info("index_solana_plays.py | Invalid program configured, exiting")
+        logger.info(f"index_solana_plays.py | Invalid TrackListenCount program ({TRACK_LISTEN_PROGRAM}) configured, exiting.")
         return
 
     db = index_solana_plays.db

--- a/discovery-provider/src/utils/config.py
+++ b/discovery-provider/src/utils/config.py
@@ -34,6 +34,7 @@ def env_config_update(config, section_name, key):
     env_var_name = f"audius_{env_var_base}"
     env_var_value = os.environ.get(env_var_name)
     env_var_exists = env_var_value != None
+    logger.error(f"{env_var_name} : Exists? {env_var_exists}")
     if env_var_exists:
         # Override any config values with environment variables if present
         # Variables are formatted as audius_<section_name>_<key>

--- a/libs/initScripts/configureLocalDiscProv.js
+++ b/libs/initScripts/configureLocalDiscProv.js
@@ -9,6 +9,7 @@ const solanaConfig = require('../../solana-programs/solana-program-config.json')
 const configureLocalDiscProv = async () => {
   let ethRegistryAddress = ethContractsMigrationOutput.registryAddress
   let solanaTrackListenCountAddress = solanaConfig.trackListenCountAddress
+  let signerGroup = solanaConfig.signerGroup
   let solanaEndpoint = solanaConfig.endpoint
   let envPath = path.join(process.cwd(), '../../', 'discovery-provider/compose/.env')
 
@@ -17,12 +18,13 @@ const configureLocalDiscProv = async () => {
     envPath,
     ethRegistryAddress,
     solanaTrackListenCountAddress,
-    solanaEndpoint
+    solanaEndpoint,
+    signerGroup
   )
 }
 
 // Write an update to the local discovery provider config .env file
-const _updateDiscoveryProviderEnvFile = async (readPath, writePath, ethRegistryAddress, solanaTrackListenCountAddress, solanaEndpoint) => {
+const _updateDiscoveryProviderEnvFile = async (readPath, writePath, ethRegistryAddress, solanaTrackListenCountAddress, solanaEndpoint, signerGroup) => {
   const fileStream = fs.createReadStream(readPath)
   const rl = readline.createInterface({
     input: fileStream,
@@ -32,9 +34,11 @@ const _updateDiscoveryProviderEnvFile = async (readPath, writePath, ethRegistryA
   let ethRegistryAddressFound = false
   let solanaTrackListenCountAddressFound = false
   let solanaEndpointFound = false
+  let signerGroupFound = false
   const ethRegistryAddressLine = `audius_eth_contracts_registry=${ethRegistryAddress}`
   const solanaTrackListenCountAddressLine = `audius_solana_track_listen_count_address=${solanaTrackListenCountAddress}`
   const solanaEndpointLine = `audius_solana_endpoint=${solanaEndpoint}`
+  const signerGroupLine = `audius_solana_signer_group_address=${signerGroup}`
   for await (const line of rl) {
     if (line.includes('audius_eth_contracts_registry')) {
       output.push(ethRegistryAddressLine)
@@ -45,6 +49,9 @@ const _updateDiscoveryProviderEnvFile = async (readPath, writePath, ethRegistryA
     } else if (line.includes('audius_solana_endpoint')) {
       output.push(solanaEndpointLine)
       solanaEndpointFound = true
+    } else if (line.includes('audius_signer_group_address')) {
+      output.push(signerGroupLine)
+      signerGroupFound = true
     } else {
       output.push(line)
     }
@@ -57,6 +64,9 @@ const _updateDiscoveryProviderEnvFile = async (readPath, writePath, ethRegistryA
   }
   if (!solanaEndpointFound) {
     output.push(solanaEndpointLine)
+  }
+  if (!signerGroupFound) {
+    output.push(signerGroupLine)
   }
   fs.writeFileSync(writePath, output.join('\n'))
   console.log(`Updated DISCOVERY PROVIDER ${writePath} audius_eth_contracts_registry=${ethRegistryAddress}`)


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Ensures only a signer group can be used at once in the discovery provider - since any party can create a `SignerGroup` and add `ValidSigners` we must check for the canonical group in the indexing layer

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

 Mad-dog existing tests cover this codepath

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
