### PR TITLE
Limit max number of blocks to revert + improve logging

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -371,14 +371,19 @@ def revert_blocks(self, db, revert_blocks_list):
     if num_revert_blocks == 0:
         return
 
+    logger.info(f"index.py | {self.request.id} | num_revert_blocks:{num_revert_blocks}")
+
+    if num_revert_blocks > 10000:
+        raise Exception('Unexpected revert, >10,0000 blocks')
+
     if num_revert_blocks > 500:
-        logger.error(f"index.py | {self.request.id} | Revert blocks list > 500:")
+        logger.error(f"index.py | {self.request.id} | Revert blocks list > 500")
         logger.error(revert_blocks_list)
         revert_blocks_list = revert_blocks_list[:500]
         logger.error(f"index.py | {self.request.id} | Sliced revert blocks list {revert_blocks_list}")
 
-    logger.error(f"index.py | {self.request.id} | Reverting {num_revert_blocks} blocks")
-    logger.error(revert_blocks_list)
+    logger.info(f"index.py | {self.request.id} | Reverting {num_revert_blocks} blocks")
+    logger.info(revert_blocks_list)
 
     with db.scoped_session() as session:
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -374,7 +374,8 @@ def revert_blocks(self, db, revert_blocks_list):
     if num_revert_blocks > 500:
         logger.error(f"index.py | {self.request.id} | Revert blocks list > 500:")
         logger.error(revert_blocks_list)
-        raise Exception('Unexpected revert, >0 blocks')
+        revert_blocks_list = revert_blocks_list[:500]
+        logger.error(f"index.py | {self.request.id} | Sliced revert blocks list {revert_blocks_list}")
 
     logger.error(f"index.py | {self.request.id} | Reverting {num_revert_blocks} blocks")
     logger.error(revert_blocks_list)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -431,8 +431,7 @@ def revert_blocks(self, db, revert_blocks_list):
                 session.query(AssociatedWallet).filter(AssociatedWallet.blockhash == revert_hash).all()
             )
 
-            # revert all of above transactions
-
+            # Revert all of above transactions
             for save_to_revert in revert_save_entries:
                 save_item_id = save_to_revert.save_item_id
                 save_user_id = save_to_revert.user_id


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_


In order to ensure any aberrant revert operations do not occur, this PR caps the maximum number of blocks that can be unwound. During POA hard fork revert validation we successfully reverted 3808 blocks. 

```
index.py | 4b9d7885-6f7f-40a2-996c-36800fd18353 | Reverting 3808 blocks
timestamp:2021-05-26 14:28:43,396
```

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


Production


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
