### PR TITLE
Fix phantom creator_node_endpoint not showing up

### DIFF
--- a/libs/src/api/file.js
+++ b/libs/src/api/file.js
@@ -30,6 +30,12 @@ const downloadURL = (url, filename) => {
 }
 
 class File extends Base {
+  constructor (user, ...args) {
+    super(...args)
+
+    this.User = user
+  }
+
   /**
    * Fetches a file from IPFS with a given CID. Public gateways are tried first, then
    * fallback to a specified gateway and then to the default gateway.
@@ -147,6 +153,10 @@ class File extends Base {
   async uploadImage (file, square) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.FILE_IS_VALID(file)
+
+    // Assign a creator_node_endpoint to the user if necessary
+    await this.User.assignReplicaSetIfNecessary()
+
     const resp = await this.creatorNode.uploadImage(file, square)
     return resp
   }

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -416,8 +416,11 @@ class Users extends Base {
    * This creates a record for that user on the connected creator node.
    * @param {string} existingEndpoint
    * @param {string} newCreatorNodeEndpoint comma delineated
+   * @param {boolean} setIsCreatorFlag flag to set is_current to true.
+   *  This is for users who are on UM to to get assigned a replica set without updating their
+   *  status to being a creator
    */
-  async upgradeToCreator (existingEndpoint, newCreatorNodeEndpoint) {
+  async upgradeToCreator (existingEndpoint, newCreatorNodeEndpoint, setIsCreatorFlag = true) {
     this.REQUIRES(Services.CREATOR_NODE)
 
     // Error if libs instance does not already have existing user state
@@ -439,7 +442,9 @@ class Users extends Base {
 
     // Populate metadata with required fields - wallet, is_creator, creator_node_endpoint
     newMetadata.wallet = this.web3Manager.getWalletAddress()
-    newMetadata.is_creator = true
+    if (setIsCreatorFlag) {
+      newMetadata.is_creator = true
+    }
 
     let updateEndpointTxBlockNumber = null
 

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -419,11 +419,8 @@ class Users extends Base {
    * This creates a record for that user on the connected creator node.
    * @param {string} existingEndpoint
    * @param {string} newCreatorNodeEndpoint comma delineated
-   * @param {boolean} setIsCreatorFlag flag to set is_current to true.
-   *  This is for users who are on UM to to get assigned a replica set without updating their
-   *  status to being a creator
    */
-  async upgradeToCreator (existingEndpoint, newCreatorNodeEndpoint, setIsCreatorFlag = true) {
+  async upgradeToCreator (existingEndpoint, newCreatorNodeEndpoint) {
     this.REQUIRES(Services.CREATOR_NODE)
 
     // Error if libs instance does not already have existing user state
@@ -445,9 +442,7 @@ class Users extends Base {
 
     // Populate metadata with required fields - wallet, is_creator, creator_node_endpoint
     newMetadata.wallet = this.web3Manager.getWalletAddress()
-    if (setIsCreatorFlag) {
-      newMetadata.is_creator = true
-    }
+    newMetadata.is_creator = true
 
     let updateEndpointTxBlockNumber = null
 

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -605,11 +605,7 @@ class Users extends Base {
   }
 
   /**
-   * If a user's creator_node_endpoint is null:
-   * 1. Generate a replica set
-   * 2. Use the `upgradeToCreator` method to
-   *    - Update the replica set
-   *    - Sync user data over from UM if any
+   * If a user's creator_node_endpoint is null, assign a replica set.
    * Used during the sanity check and in uploadImage() in files.js
    */
   async assignReplicaSetIfNecessary () {
@@ -621,10 +617,7 @@ class Users extends Base {
 
     // Generate a replica set and assign to user
     try {
-      const { primary, secondaries } = await this.ServiceProvider.autoSelectCreatorNodes({})
-      const contentNodeEndpoint = CreatorNode.buildEndpoint(primary, secondaries)
-      const currentEndpoint = this.userStateManager.getCurrentUser().creator_node_endpoint
-      await this.upgradeToCreator(currentEndpoint, contentNodeEndpoint, false)
+      await this.assignReplicaSet({ userId: user.user_id })
     } catch (e) {
       throw new Error(`assignReplicaSetIfNecessary error - ${e.toString()}`)
     }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -342,7 +342,7 @@ class AudiusLibs {
     this.Account = new Account(this.User, ...services)
     this.Track = new Track(...services)
     this.Playlist = new Playlist(...services)
-    this.File = new File(...services)
+    this.File = new File(this.User, ...services)
   }
 }
 

--- a/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
+++ b/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
@@ -12,7 +12,7 @@ const assignReplicaSetIfNecessary = async (libs) => {
     const { primary, secondaries } = await libs.ServiceProvider.autoSelectCreatorNodes({})
     const contentNodeEndpoint = CreatorNode.buildEndpoint(primary, secondaries)
     const currentEndpoint = libs.userStateManager.getCurrentUser().creator_node_endpoint
-    await libs.User.upgradeToCreator(currentEndpoint, contentNodeEndpoint)
+    await libs.User.upgradeToCreator(currentEndpoint, contentNodeEndpoint, false)
   } catch (e) {
     // If for some reason this fails, log error and allow user to continue
     console.error(`assignReplicaSetIfNecessary error - ${e.toString()}`)

--- a/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
+++ b/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
@@ -1,0 +1,22 @@
+const CreatorNode = require('../services/creatorNode/index')
+
+const assignReplicaSetIfNecessary = async (libs) => {
+  const user = libs.userStateManager.getCurrentUser()
+
+  // If no user is logged in, or a creator node endpoint is already assigned,
+  // skip this call
+  if (!user || user.creator_node_endpoint) return
+
+  // Generate a replica set and assign to user
+  try {
+    const { primary, secondaries } = await libs.ServiceProvider.autoSelectCreatorNodes({})
+    const contentNodeEndpoint = CreatorNode.buildEndpoint(primary, secondaries)
+    const currentEndpoint = libs.userStateManager.getCurrentUser().creator_node_endpoint
+    await libs.User.upgradeToCreator(currentEndpoint, contentNodeEndpoint)
+  } catch (e) {
+    // If for some reason this fails, log error and allow user to continue
+    console.error(`assignReplicaSetIfNecessary error - ${e.toString()}`)
+  }
+}
+
+module.exports = assignReplicaSetIfNecessary

--- a/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
+++ b/libs/src/sanityChecks/assignReplicaSetIfNecessary.js
@@ -1,21 +1,9 @@
-const CreatorNode = require('../services/creatorNode/index')
-
 const assignReplicaSetIfNecessary = async (libs) => {
-  const user = libs.userStateManager.getCurrentUser()
-
-  // If no user is logged in, or a creator node endpoint is already assigned,
-  // skip this call
-  if (!user || user.creator_node_endpoint) return
-
-  // Generate a replica set and assign to user
   try {
-    const { primary, secondaries } = await libs.ServiceProvider.autoSelectCreatorNodes({})
-    const contentNodeEndpoint = CreatorNode.buildEndpoint(primary, secondaries)
-    const currentEndpoint = libs.userStateManager.getCurrentUser().creator_node_endpoint
-    await libs.User.upgradeToCreator(currentEndpoint, contentNodeEndpoint, false)
+    await libs.User.assignReplicaSetIfNecessary()
   } catch (e) {
-    // If for some reason this fails, log error and allow user to continue
-    console.error(`assignReplicaSetIfNecessary error - ${e.toString()}`)
+    // If sanity check fails, do not block main thread and log error
+    console.error(e.message)
   }
 }
 

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -26,6 +26,10 @@ class SanityChecks {
     await recoveryEmail(this.libs)
     await assignReplicaSetIfNecessary(this.libs)
   }
+
+  async assignReplicaSet (libs) {
+    await assignReplicaSetIfNecessary(libs)
+  }
 }
 
 module.exports = SanityChecks

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -21,10 +21,10 @@ class SanityChecks {
     await isCreator(this.libs)
     await sanitizeNodes(this.libs)
     await addSecondaries(this.libs)
+    await assignReplicaSetIfNecessary(this.libs)
     await syncNodes(this.libs)
     if (!this.options.skipRollover) await rolloverNodes(this.libs, creatorNodeWhitelist)
     await recoveryEmail(this.libs)
-    await assignReplicaSetIfNecessary(this.libs)
   }
 }
 

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -26,10 +26,6 @@ class SanityChecks {
     await recoveryEmail(this.libs)
     await assignReplicaSetIfNecessary(this.libs)
   }
-
-  async assignReplicaSet (libs) {
-    await assignReplicaSetIfNecessary(libs)
-  }
 }
 
 module.exports = SanityChecks

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -4,6 +4,7 @@ const addSecondaries = require('./addSecondaries')
 const syncNodes = require('./syncNodes')
 const rolloverNodes = require('./rolloverNodes')
 const recoveryEmail = require('./needsRecoveryEmail')
+const assignReplicaSetIfNecessary = require('./assignReplicaSetIfNecessary')
 
 // Checks to run at startup to ensure a user is in a good state.
 class SanityChecks {
@@ -23,6 +24,7 @@ class SanityChecks {
     await syncNodes(this.libs)
     if (!this.options.skipRollover) await rolloverNodes(this.libs, creatorNodeWhitelist)
     await recoveryEmail(this.libs)
+    await assignReplicaSetIfNecessary(this.libs)
   }
 }
 


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Context: If the signup flow does not fully finish, the replica set may not be assigned to a user. 

PR Goal: Add replica set to users on sanity check or photo upload

Details:
- add `assignReplicaSetIfNecessary()` method that checks if a user has the creator_node_endpoint field, and if not, generates and assign them one
- intercept file upload method with `assignReplicaSetIfNecessary()`
- modifies the original `upgradeToCreator()` method to take an additional flag called `setIsCreatorFlag = true` 
   - users who do not have CNE are not creators. we want the functionality in `upgradeToCreator()` without setting the `is_creator` flag to `true`

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Test scenarios

1. Sanity check
    - signup ⇒ assignReplicaSet() forced fail ⇒ loads error page ⇒ presses "try again" ⇒ sanity check runs ⇒ assigns replica set to user ⇒ upload cp/pp ⇒ photos are uploaded
2. File upload
    - signup ⇒ assignReplicaSet() forced fail ⇒ loads error page ⇒ presses "try again" ⇒ sanity check runs ⇒ sanity check forced fail ⇒ goes to profile ⇒ uploads profile picture ⇒ assignReplicaSetIfNecessary() triggered ⇒ succeeds ⇒ photo is uploaded
    - signup ⇒ assignReplicaSet() forced fail ⇒ loads error page ⇒ presses "try again" ⇒ sanity check runs ⇒ sanity check forced fail ⇒ goes to profile ⇒ uploads cover picture ⇒ assignReplicaSetIfNecessary() triggered ⇒ succeeds ⇒ photo is uploaded
3. `assignReplicaSetIfNecessary()` just fails
    - photos do not get uploaded
