### PR TITLE
Prevent indexing from blocking

### DIFF
--- a/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
+++ b/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
@@ -1,7 +1,7 @@
 """add-skipped-transactions-table
 
 Revision ID: 7f4f44a8e880
-Revises: 6cf96b71cf3d
+Revises: 05e2eeb2bd03
 Create Date: 2021-05-24 20:14:46.963239
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '7f4f44a8e880'
-down_revision = '6cf96b71cf3d'
+down_revision = '05e2eeb2bd03'
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
+++ b/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.create_table('skipped_transactions',
-        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False, autoincrement=True),
         sa.Column('blocknumber', sa.Integer(), nullable=False),
         sa.Column('blockhash', sa.String(), nullable=False),
         sa.Column('transactionhash', sa.String(), nullable=False),

--- a/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
+++ b/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
@@ -21,7 +21,7 @@ def upgrade():
         sa.Column('id', sa.Integer(), primary_key=True, nullable=False, autoincrement=True),
         sa.Column('blocknumber', sa.Integer(), nullable=False),
         sa.Column('blockhash', sa.String(), nullable=False),
-        sa.Column('transactionhash', sa.String(), nullable=False),
+        sa.Column('txhash', sa.String(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False, default=sa.func.now()),
         sa.Column('updated_at', sa.DateTime(), nullable=False, default=sa.func.now(), onupdate=sa.func.now()),
         sa.PrimaryKeyConstraint('id')

--- a/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
+++ b/discovery-provider/alembic/versions/7f4f44a8e880_add_skipped_transactions_table.py
@@ -1,0 +1,32 @@
+"""add-skipped-transactions-table
+
+Revision ID: 7f4f44a8e880
+Revises: 6cf96b71cf3d
+Create Date: 2021-05-24 20:14:46.963239
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7f4f44a8e880'
+down_revision = '6cf96b71cf3d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('skipped_transactions',
+        sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+        sa.Column('blocknumber', sa.Integer(), nullable=False),
+        sa.Column('blockhash', sa.String(), nullable=False),
+        sa.Column('transactionhash', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False, default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, default=sa.func.now(), onupdate=sa.func.now()),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('skipped_transactions')

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -19,7 +19,8 @@ from flask_cors import CORS
 
 from src import exceptions
 from src import api_helpers
-from src.queries import queries, search, search_queries, health_check, notifications, block_confirmation
+from src.queries import queries, search, search_queries, health_check, notifications, \
+    block_confirmation, skipped_transactions
 from src.api.v1 import api as api_v1
 from src.utils import helpers
 from src.utils.multi_provider import MultiProvider
@@ -294,6 +295,7 @@ def configure_flask(test_config, app, mode="app"):
     app.register_blueprint(notifications.bp)
     app.register_blueprint(health_check.bp)
     app.register_blueprint(block_confirmation.bp)
+    app.register_blueprint(skipped_transactions.bp)
 
     app.register_blueprint(api_v1.bp)
     app.register_blueprint(api_v1.bp_full)

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -860,3 +860,22 @@ playlist_id={self.playlist_id},\
 is_album={self.is_album},\
 repost_count={self.repost_count},\
 save_count={self.save_count}>"
+
+class SkippedTransaction(Base):
+    __tablename__ = "skipped_transactions"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    blocknumber = Column(Integer, nullable=False)
+    blockhash = Column(String, nullable=False)
+    transactionhash = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+
+    def __repr__(self):
+        return f"<SkippedTransaction(\
+id={self.id},\
+blocknumber={self.blocknumber},\
+blockhash={self.blockhash},\
+transactionhash={self.transactionhash},\
+created_at={self.created_at},\
+updated_at={self.updated_at})>"

--- a/discovery-provider/src/models.py
+++ b/discovery-provider/src/models.py
@@ -867,7 +867,7 @@ class SkippedTransaction(Base):
     id = Column(Integer, primary_key=True, nullable=False)
     blocknumber = Column(Integer, nullable=False)
     blockhash = Column(String, nullable=False)
-    transactionhash = Column(String, nullable=False)
+    txhash = Column(String, nullable=False)
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
@@ -876,6 +876,6 @@ class SkippedTransaction(Base):
 id={self.id},\
 blocknumber={self.blocknumber},\
 blockhash={self.blockhash},\
-transactionhash={self.transactionhash},\
+txhash={self.txhash},\
 created_at={self.created_at},\
 updated_at={self.updated_at})>"

--- a/discovery-provider/src/queries/confirm_indexing_transaction_error.py
+++ b/discovery-provider/src/queries/confirm_indexing_transaction_error.py
@@ -5,12 +5,15 @@ from src.queries.get_skipped_transactions import set_indexing_error
 
 logger = logging.getLogger(__name__)
 
-'''
-Confirms that a transaction is causing an error indexing across the discovery nodes
-Gets all other discovery nodes and makes an api call to check the status of a transaction
-given a blocknumber, blockhash, and transactionhash
-'''
+# Percent of total discovery nodes needed to skip indexing a transaction
+INDEXING_FAILURE_CONSENSUS_PERCENT = 0.67
+
 def confirm_indexing_transaction_error(redis, blocknumber, blockhash, transactionhash, message):
+    """
+    Confirms that a transaction is causing an error indexing across the discovery nodes
+    Gets all other discovery nodes and makes an api call to check the status of a transaction
+    given a blocknumber, blockhash, and transactionhash
+    """
     all_other_nodes = get_all_other_nodes()
     num_other_nodes = len(all_other_nodes)
     num_transaction_failures = 0
@@ -28,6 +31,6 @@ def confirm_indexing_transaction_error(redis, blocknumber, blockhash, transactio
         except Exception as e:
             logger.error(e)
 
-    # Mark the redis indexing error w/ has_majority = true so that it skips this transaction
-    if num_other_nodes < (num_transaction_failures * 2):
+    # Mark the redis indexing error w/ has_consensus = true so that it skips this transaction
+    if num_transaction_failures >= num_other_nodes * INDEXING_FAILURE_CONSENSUS_PERCENT:
         set_indexing_error(redis, blocknumber, blockhash, transactionhash, message, True)

--- a/discovery-provider/src/queries/confirm_indexing_transaction_error.py
+++ b/discovery-provider/src/queries/confirm_indexing_transaction_error.py
@@ -1,0 +1,29 @@
+import logging
+import requests
+from src.tasks.index_metrics import get_all_other_nodes
+
+logger = logging.getLogger(__name__)
+
+'''
+Confirms that a transaction is causing an error indexing across the discovery nodes
+Gets all other discovery nodes and makes an api call to check the status of a transaction
+given a blocknumber, blockhash, and transactionhash
+'''
+def confirm_indexing_transaction_error(blocknumber, blockhash, transactionhash):
+    all_other_nodes = get_all_other_nodes()
+    num_other_nodes = len(all_other_nodes)
+    num_transaction_failures = 0
+    for node in all_other_nodes:
+        try:
+            endpoint = "{}/indexing/transaction_status?blocknumber={}&blockhash={}&transactionhash={}".format(
+                node, blocknumber, blockhash, transactionhash
+            )
+            response = requests.get(endpoint, timeout=10)
+            if response.status_code != 200:
+                raise Exception(f"Query to indexing transaction status endpoint {endpoint} \
+                    failed with status code {response.status_code}")
+            if response.json()['data'] == 'FAILED':
+                num_transaction_failures += 1
+        except Exception as e:
+            logger.error(e)
+    return {'num_failed': num_transaction_failures, 'total': num_other_nodes}

--- a/discovery-provider/src/queries/confirm_indexing_transaction_error.py
+++ b/discovery-provider/src/queries/confirm_indexing_transaction_error.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 from src.tasks.index_metrics import get_all_other_nodes
-from src.queries.get_skipped_transactions import setIndexingError
+from src.queries.get_skipped_transactions import set_indexing_error
 
 logger = logging.getLogger(__name__)
 
@@ -30,4 +30,4 @@ def confirm_indexing_transaction_error(redis, blocknumber, blockhash, transactio
 
     # Mark the redis indexing error w/ has_majority = true so that it skips this transaction
     if num_other_nodes < (num_transaction_failures * 2):
-        setIndexingError(redis, blocknumber, blockhash, transactionhash, message, True)
+        set_indexing_error(redis, blocknumber, blockhash, transactionhash, message, True)

--- a/discovery-provider/src/queries/confirm_indexing_transaction_error.py
+++ b/discovery-provider/src/queries/confirm_indexing_transaction_error.py
@@ -6,7 +6,7 @@ from src.queries.get_skipped_transactions import set_indexing_error
 logger = logging.getLogger(__name__)
 
 # Percent of total discovery nodes needed to skip indexing a transaction
-INDEXING_FAILURE_CONSENSUS_PERCENT = 0.67
+INDEXING_FAILURE_CONSENSUS_PERCENT = 1
 
 def confirm_indexing_transaction_error(redis, blocknumber, blockhash, transactionhash, message):
     """
@@ -32,5 +32,5 @@ def confirm_indexing_transaction_error(redis, blocknumber, blockhash, transactio
             logger.error(e)
 
     # Mark the redis indexing error w/ has_consensus = true so that it skips this transaction
-    if num_transaction_failures >= num_other_nodes * INDEXING_FAILURE_CONSENSUS_PERCENT:
+    if num_other_nodes >= 1 and num_transaction_failures >= num_other_nodes * INDEXING_FAILURE_CONSENSUS_PERCENT:
         set_indexing_error(redis, blocknumber, blockhash, transactionhash, message, True)

--- a/discovery-provider/src/queries/get_skipped_transactions.py
+++ b/discovery-provider/src/queries/get_skipped_transactions.py
@@ -1,0 +1,84 @@
+import redis
+from src.models import SkippedTransaction, Block
+from src.utils import helpers, db_session
+from src.utils.config import shared_config
+
+REDIS_URL = shared_config["redis"]["url"]
+REDIS = redis.Redis.from_url(url=REDIS_URL)
+
+indexing_error_key = 'indexing:error'
+
+# returns the recorded skipped transactions in the db during indexing
+# filters by blocknumber, blockhash, or transaction hash if they are not null
+def get_skipped_transactions(blocknumber, blockhash, transactionhash):
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        skipped_transactions_query = session.query(SkippedTransaction)
+        if blocknumber is not None:
+            skipped_transactions_query = skipped_transactions_query.filter(
+                SkippedTransaction.blocknumber == blocknumber
+            )
+        if blockhash is not None:
+            skipped_transactions_query = skipped_transactions_query.filter(
+                SkippedTransaction.blockhash == blockhash
+            )
+        if transactionhash is not None:
+            skipped_transactions_query = skipped_transactions_query.filter(
+                SkippedTransaction.transactionhash == transactionhash
+            )
+        skipped_transactions_results = skipped_transactions_query.all()
+        skipped_transactions_list = list(map(
+            helpers.model_to_dictionary,
+            skipped_transactions_results
+        ))
+        return skipped_transactions_list
+
+# returns the indexing transaction status
+# given a blocknumber, blockhash, and transaction
+# first checks whether there is an indexing error in entry
+# and whether the entry matches the given params
+# otherwise checks the database
+def get_transaction_status(blocknumber, blockhash, transactionhash):
+    indexing_error = REDIS.get(indexing_error_key)
+    # separating the conditions to reduce number of booleans in single condition (linting)
+    if indexing_error:
+        keys_exist = 'blocknumber' in indexing_error and \
+            'blockhash' in indexing_error and \
+            'transactionhash' in indexing_error
+        if keys_exist and \
+            indexing_error['blocknumber'] == blocknumber and \
+            indexing_error['blockhash'] == blockhash and \
+            indexing_error['transactionhash'] == transactionhash:
+            return 'FAILED'
+
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        skipped_transactions_results = session.query(SkippedTransaction).filter(
+            SkippedTransaction.blocknumber == blocknumber,
+            SkippedTransaction.blockhash == blockhash,
+            SkippedTransaction.transactionhash == transactionhash
+        ).all()
+        if len(skipped_transactions_results) > 1:
+            raise Exception(
+                "Expected no more than 1 row for skipped indexing transaction with \
+                blocknumber={}, blockhash={}, transactionhash={}".format(
+                    blocknumber, blockhash, transactionhash
+                )
+            )
+        if len(skipped_transactions_results) == 1:
+            return 'FAILED'
+
+        block_transaction_results = session.query(Block).filter(
+            Block.number == blocknumber,
+            Block.blockhash == blockhash
+        ).all()
+        if len(block_transaction_results) > 1:
+            raise Exception(
+                "Expected no more than 1 row for blocknumber={}, blockhash={}".format(
+                    blocknumber, blockhash
+                )
+            )
+        if len(block_transaction_results) == 1:
+            return 'PASSED'
+
+        return 'NOT_FOUND'

--- a/discovery-provider/src/queries/get_skipped_transactions.py
+++ b/discovery-provider/src/queries/get_skipped_transactions.py
@@ -92,7 +92,7 @@ def get_indexing_error(redis_instance):
     indexing_error = get_pickled_key(redis_instance, INDEXING_ERROR_KEY)
     return indexing_error
 
-def setIndexingError(redis_instance, blocknumber, blockhash, transactionhash, message, has_majority=False):
+def set_indexing_error(redis_instance, blocknumber, blockhash, transactionhash, message, has_majority=False):
     indexing_error = get_pickled_key(redis_instance, INDEXING_ERROR_KEY)
 
     if indexing_error is None or (
@@ -114,5 +114,5 @@ def setIndexingError(redis_instance, blocknumber, blockhash, transactionhash, me
         indexing_error['has_majority'] = has_majority
         pickle_and_set(redis_instance, INDEXING_ERROR_KEY, indexing_error)
 
-def clearIndexingError(redis_instance):
+def clear_indexing_error(redis_instance):
     redis_instance.delete(INDEXING_ERROR_KEY)

--- a/discovery-provider/src/queries/get_skipped_transactions.py
+++ b/discovery-provider/src/queries/get_skipped_transactions.py
@@ -45,7 +45,6 @@ def get_transaction_status(blocknumber, blockhash, txhash):
     """
     indexing_error = get_indexing_error(REDIS)
 
-    # separating the conditions to reduce number of booleans in single condition (linting)
     if indexing_error:
         blocknumber_match = 'blocknumber' in indexing_error and \
             indexing_error['blocknumber'] == blocknumber

--- a/discovery-provider/src/queries/get_skipped_transactions.py
+++ b/discovery-provider/src/queries/get_skipped_transactions.py
@@ -1,5 +1,5 @@
-import redis
 import logging
+import redis
 from src.models import SkippedTransaction, Block
 from src.utils import helpers, db_session
 from src.utils.config import shared_config
@@ -88,17 +88,17 @@ def get_transaction_status(blocknumber, blockhash, transactionhash):
         return 'NOT_FOUND'
 
 
-def getIndexingError(redis):
-    indexing_error = get_pickled_key(redis, INDEXING_ERROR_KEY)
+def getIndexingError(redis_instance):
+    indexing_error = get_pickled_key(redis_instance, INDEXING_ERROR_KEY)
     return indexing_error
 
-def setIndexingError(redis, blocknumber, blockhash, transactionhash, message, has_majority=False):
-    indexing_error = get_pickled_key(redis, INDEXING_ERROR_KEY)
+def setIndexingError(redis_instance, blocknumber, blockhash, transactionhash, message, has_majority=False):
+    indexing_error = get_pickled_key(redis_instance, INDEXING_ERROR_KEY)
 
     if indexing_error is None or (
-        indexing_error['blocknumber'] != blocknumber and
-        indexing_error['blockhash'] != blockhash and
-        indexing_error['transactionhash'] != transactionhash
+            indexing_error['blocknumber'] != blocknumber and
+            indexing_error['blockhash'] != blockhash and
+            indexing_error['transactionhash'] != transactionhash
     ):
         indexing_error = {
             'count': 1,
@@ -108,11 +108,11 @@ def setIndexingError(redis, blocknumber, blockhash, transactionhash, message, ha
             'message': message,
             'has_majority': has_majority
         }
-        pickle_and_set(redis, INDEXING_ERROR_KEY, indexing_error)
+        pickle_and_set(redis_instance, INDEXING_ERROR_KEY, indexing_error)
     else:
-        indexing_error['count'] +=1
+        indexing_error['count'] += 1
         indexing_error['has_majority'] = has_majority
-        pickle_and_set(redis, INDEXING_ERROR_KEY, indexing_error)
+        pickle_and_set(redis_instance, INDEXING_ERROR_KEY, indexing_error)
 
-def clearIndexingError(redis):
-    redis.delete(INDEXING_ERROR_KEY)
+def clearIndexingError(redis_instance):
+    redis_instance.delete(INDEXING_ERROR_KEY)

--- a/discovery-provider/src/queries/get_skipped_transactions.py
+++ b/discovery-provider/src/queries/get_skipped_transactions.py
@@ -42,7 +42,7 @@ def get_skipped_transactions(blocknumber, blockhash, transactionhash):
 # and whether the entry matches the given params
 # otherwise checks the database
 def get_transaction_status(blocknumber, blockhash, transactionhash):
-    indexing_error = getIndexingError(REDIS)
+    indexing_error = get_indexing_error(REDIS)
 
     # separating the conditions to reduce number of booleans in single condition (linting)
     if indexing_error:
@@ -88,7 +88,7 @@ def get_transaction_status(blocknumber, blockhash, transactionhash):
         return 'NOT_FOUND'
 
 
-def getIndexingError(redis_instance):
+def get_indexing_error(redis_instance):
     indexing_error = get_pickled_key(redis_instance, INDEXING_ERROR_KEY)
     return indexing_error
 

--- a/discovery-provider/src/queries/skipped_transactions.py
+++ b/discovery-provider/src/queries/skipped_transactions.py
@@ -1,0 +1,45 @@
+import logging
+from flask import Blueprint, request
+from src.queries.get_skipped_transactions import get_skipped_transactions, get_transaction_status
+from src.api_helpers import error_response, success_response
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("indexing", __name__)
+
+'''
+Returns skipped transactions during indexing
+Takes query params 'blocknumber', 'blockhash', and 'transactionhash'
+Filters by query params if they are not null
+'''
+@bp.route("/indexing/skipped_transactions", methods=["GET"])
+def check_skipped_transactions():
+    blocknumber = request.args.get("blocknumber", type=int)
+    blockhash = request.args.get("blockhash")
+    transactionhash = request.args.get("transactionhash")
+    skipped_transactions = get_skipped_transactions(
+        blocknumber, blockhash, transactionhash
+    )
+    return success_response(skipped_transactions)
+
+'''
+Returns whether a transaction 'PASSED' | 'FAILED' | 'NOT_FOUND'
+based on all 3 query params 'blocknumber', 'blockhash', and 'transactionhash'
+'''
+@bp.route("/indexing/transaction_status", methods=["GET"])
+def check_transaction_status():
+    blocknumber = request.args.get("blocknumber", type=int)
+    blockhash = request.args.get("blockhash")
+    transactionhash = request.args.get("transactionhash")
+    if blocknumber is None or blockhash is None or transactionhash is None:
+        return error_response(
+            f"Please pass in required query parameters 'blocknumber', 'blockhash', and 'transactionhash'",
+            400
+        )
+    try:
+        transaction_status = get_transaction_status(
+            blocknumber, blockhash, transactionhash
+        )
+    except Exception as e:
+        return error_response(e)
+    return success_response(transaction_status)

--- a/discovery-provider/src/queries/skipped_transactions.py
+++ b/discovery-provider/src/queries/skipped_transactions.py
@@ -7,13 +7,13 @@ logger = logging.getLogger(__name__)
 
 bp = Blueprint("indexing", __name__)
 
-'''
-Returns skipped transactions during indexing
-Takes query params 'blocknumber', 'blockhash', and 'transactionhash'
-Filters by query params if they are not null
-'''
 @bp.route("/indexing/skipped_transactions", methods=["GET"])
 def check_skipped_transactions():
+    """
+    Returns skipped transactions during indexing
+    Takes query params 'blocknumber', 'blockhash', and 'transactionhash'
+    Filters by query params if they are not null
+    """
     blocknumber = request.args.get("blocknumber", type=int)
     blockhash = request.args.get("blockhash")
     transactionhash = request.args.get("transactionhash")
@@ -22,12 +22,12 @@ def check_skipped_transactions():
     )
     return success_response(skipped_transactions)
 
-'''
-Returns whether a transaction 'PASSED' | 'FAILED' | 'NOT_FOUND'
-based on all 3 query params 'blocknumber', 'blockhash', and 'transactionhash'
-'''
 @bp.route("/indexing/transaction_status", methods=["GET"])
 def check_transaction_status():
+    """
+    Returns whether a transaction 'PASSED' | 'FAILED' | 'NOT_FOUND'
+    based on all 3 query params 'blocknumber', 'blockhash', and 'transactionhash'
+    """
     blocknumber = request.args.get("blocknumber", type=int)
     blockhash = request.args.get("blockhash")
     transactionhash = request.args.get("transactionhash")

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -17,7 +17,7 @@ from src.utils.redis_constants import latest_block_redis_key, \
 from src.utils.redis_cache import remove_cached_user_ids, \
     remove_cached_track_ids, remove_cached_playlist_ids
 from src.queries.get_skipped_transactions import get_indexing_error, \
-    setIndexingError, clearIndexingError
+    set_indexing_error, clear_indexing_error
 from src.queries.confirm_indexing_transaction_error import confirm_indexing_transaction_error
 from src.utils.indexing_errors import IndexingError
 
@@ -369,7 +369,7 @@ def index_blocks(self, db, blocks_list):
                 session.commit()
                 logger.info(f"index.py | session commmited to db for block=${block_number}")
                 if skip_tx_hash:
-                    clearIndexingError(redis)
+                    clear_indexing_error(redis)
                 if user_state_changed:
                     if user_ids:
                         remove_cached_user_ids(redis, user_ids)
@@ -388,7 +388,7 @@ def index_blocks(self, db, blocks_list):
                     f"index.py | Error in the indexing task at"
                     f" block={err.blocknumber} and hash={err.transactionhash}"
                 )
-                setIndexingError(redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
+                set_indexing_error(redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
                 confirm_indexing_transaction_error(
                     redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
                 raise

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -15,8 +15,7 @@ from src.utils.redis_constants import latest_block_redis_key, \
     latest_block_hash_redis_key, most_recent_indexed_block_hash_redis_key, \
     most_recent_indexed_block_redis_key
 from src.utils.redis_cache import remove_cached_user_ids, \
-    remove_cached_track_ids, remove_cached_playlist_ids, \
-    get_pickled_key
+    remove_cached_track_ids, remove_cached_playlist_ids
 from src.queries.get_skipped_transactions import getIndexingError, \
     setIndexingError, clearIndexingError
 from src.queries.confirm_indexing_transaction_error import confirm_indexing_transaction_error
@@ -319,7 +318,8 @@ def index_blocks(self, db, blocks_list):
 
                 social_feature_state_changed = ( # pylint: disable=W0612
                     social_feature_state_update(
-                        self, update_task, session, social_feature_factory_txs, block_number, block_timestamp, block_hash
+                        self, update_task, session, social_feature_factory_txs, block_number,
+                        block_timestamp, block_hash
                     )
                     > 0
                 )
@@ -384,9 +384,13 @@ def index_blocks(self, db, blocks_list):
                         remove_cached_playlist_ids(redis, playlist_ids)
                 logger.info(f"index.py | redis cache clean operations complete for block=${block_number}")
             except IndexingError as err:
-                logger.info(f"index.py | Error in the indexing task at block={err.blocknumber} and hash={err.transactionhash}")
+                logger.info(
+                    f"index.py | Error in the indexing task at"
+                    f" block={err.blocknumber} and hash={err.transactionhash}"
+                )
                 setIndexingError(redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
-                confirm_indexing_transaction_error(redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
+                confirm_indexing_transaction_error(
+                    redis, err.blocknumber, err.blockhash, err.transactionhash, err.message)
                 raise
         # add the block number of the most recently processed block to redis
         redis.set(most_recent_indexed_block_redis_key, block.number)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -16,7 +16,7 @@ from src.utils.redis_constants import latest_block_redis_key, \
     most_recent_indexed_block_redis_key
 from src.utils.redis_cache import remove_cached_user_ids, \
     remove_cached_track_ids, remove_cached_playlist_ids
-from src.queries.get_skipped_transactions import getIndexingError, \
+from src.queries.get_skipped_transactions import get_indexing_error, \
     setIndexingError, clearIndexingError
 from src.queries.confirm_indexing_transaction_error import confirm_indexing_transaction_error
 from src.utils.indexing_errors import IndexingError
@@ -171,7 +171,7 @@ def update_ursm_address(self):
 def get_skip_tx_hash(session, redis):
     """Fetch if there is a tx_hash to be skipped because of continuous errors
     """
-    indexing_error = getIndexingError(redis)
+    indexing_error = get_indexing_error(redis)
     if isinstance(indexing_error, dict) and 'has_majority' in indexing_error and indexing_error['has_majority']:
         skipped_tx = SkippedTransaction(
             blocknumber=indexing_error['blocknumber'],

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -12,13 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 def playlist_state_update(
-    self,
-    update_task,
-    session,
-    playlist_factory_txs,
-    block_number,
-    block_timestamp,
-    block_hash
+        self,
+        update_task,
+        session,
+        playlist_factory_txs,
+        block_number,
+        block_timestamp,
+        block_hash
 ):
     """Return int representing number of Playlist model state changes found in transaction."""
     num_total_changes = 0

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -6,12 +6,19 @@ from src.utils import helpers
 from src.models import Playlist
 from src.utils.playlist_event_constants import playlist_event_types_arr, playlist_event_types_lookup
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
+from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
 
 
 def playlist_state_update(
-        self, update_task, session, playlist_factory_txs, block_number, block_timestamp
+    self,
+    update_task,
+    session,
+    playlist_factory_txs,
+    block_number,
+    block_timestamp,
+    block_hash
 ):
     """Return int representing number of Playlist model state changes found in transaction."""
     num_total_changes = 0
@@ -35,34 +42,39 @@ def playlist_state_update(
             )().processReceipt(tx_receipt)
             processedEntries = 0 # if record does not get added, do not count towards num_total_changes
             for entry in playlist_events_tx:
-                playlist_id = entry["args"]._playlistId
-                playlist_ids.add(playlist_id)
+                try:
+                    playlist_id = entry["args"]._playlistId
+                    playlist_ids.add(playlist_id)
 
-                if playlist_id not in playlist_events_lookup:
-                    existing_playlist_entry = lookup_playlist_record(
-                        update_task, session, entry, block_number, txhash
+                    if playlist_id not in playlist_events_lookup:
+                        existing_playlist_entry = lookup_playlist_record(
+                            update_task, session, entry, block_number, txhash
+                        )
+                        playlist_events_lookup[playlist_id] = {
+                            "playlist": existing_playlist_entry,
+                            "events": [],
+                        }
+
+                    playlist_record = parse_playlist_event(
+                        self,
+                        update_task,
+                        entry,
+                        event_type,
+                        playlist_events_lookup[playlist_id]["playlist"],
+                        block_timestamp,
+                        session
                     )
-                    playlist_events_lookup[playlist_id] = {
-                        "playlist": existing_playlist_entry,
-                        "events": [],
-                    }
 
-                playlist_record = parse_playlist_event(
-                    self,
-                    update_task,
-                    entry,
-                    event_type,
-                    playlist_events_lookup[playlist_id]["playlist"],
-                    block_timestamp,
-                    session
-                )
+                    if playlist_record is not None:
+                        playlist_events_lookup[playlist_id]["events"].append(event_type)
+                        playlist_events_lookup[playlist_id]["playlist"] = playlist_record
+                        processedEntries += 1
+                except Exception as e:
+                    logger.info(f"Error in parse playlist transaction")
+                    blockhash = update_task.web3.toHex(block_hash)
+                    raise IndexingError('playlist', block_number, blockhash, txhash, str(e))
 
-                if playlist_record is not None:
-                    playlist_events_lookup[playlist_id]["events"].append(event_type)
-                    playlist_events_lookup[playlist_id]["playlist"] = playlist_record
-                    processedEntries += 1
-
-            num_total_changes += processedEntries
+                num_total_changes += processedEntries
 
     logger.info(f"index.py | playlists.py | There are {num_total_changes} events processed.")
 

--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -8,13 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 def social_feature_state_update(
-    self,
-    update_task,
-    session,
-    social_feature_factory_txs,
-    block_number,
-    block_timestamp,
-    block_hash
+        self,
+        update_task,
+        session,
+        social_feature_factory_txs,
+        block_number,
+        block_timestamp,
+        block_hash
 ):
     """Return int representing number of social feature related state changes in this transaction"""
 

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -2,11 +2,12 @@ import logging
 from datetime import datetime
 from src.app import contract_addresses
 from src.models import Playlist, SaveType, Save
+from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
 
 def user_library_state_update(
-        self, update_task, session, user_library_factory_txs, block_number, block_timestamp
+        self, update_task, session, user_library_factory_txs, block_number, block_timestamp, block_hash
 ):
     """Return int representing number of User Library model state changes found in transaction."""
 
@@ -24,49 +25,56 @@ def user_library_state_update(
     playlist_save_state_changes = {}
 
     for tx_receipt in user_library_factory_txs:
-        add_track_save(
-            self,
-            user_library_contract,
-            update_task,
-            session,
-            tx_receipt,
-            block_number,
-            block_datetime,
-            track_save_state_changes,
-        )
+        try:
+            add_track_save(
+                self,
+                user_library_contract,
+                update_task,
+                session,
+                tx_receipt,
+                block_number,
+                block_datetime,
+                track_save_state_changes,
+            )
 
-        add_playlist_save(
-            self,
-            user_library_contract,
-            update_task,
-            session,
-            tx_receipt,
-            block_number,
-            block_datetime,
-            playlist_save_state_changes,
-        )
+            add_playlist_save(
+                self,
+                user_library_contract,
+                update_task,
+                session,
+                tx_receipt,
+                block_number,
+                block_datetime,
+                playlist_save_state_changes,
+            )
 
-        delete_track_save(
-            self,
-            user_library_contract,
-            update_task,
-            session,
-            tx_receipt,
-            block_number,
-            block_datetime,
-            track_save_state_changes,
-        )
+            delete_track_save(
+                self,
+                user_library_contract,
+                update_task,
+                session,
+                tx_receipt,
+                block_number,
+                block_datetime,
+                track_save_state_changes,
+            )
 
-        delete_playlist_save(
-            self,
-            user_library_contract,
-            update_task,
-            session,
-            tx_receipt,
-            block_number,
-            block_datetime,
-            playlist_save_state_changes,
-        )
+            delete_playlist_save(
+                self,
+                user_library_contract,
+                update_task,
+                session,
+                tx_receipt,
+                block_number,
+                block_datetime,
+                playlist_save_state_changes,
+            )
+        except Exception as e:
+            logger.info(f"Error in user library transaction")
+            txhash = update_task.web3.toHex(tx_receipt.transactionHash)
+            blockhash = update_task.web3.toHex(block_hash)
+            raise IndexingError('user_library', block_number, blockhash, txhash, str(e))
+
 
     for user_id in track_save_state_changes:
         for track_id in track_save_state_changes[user_id]:

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -46,6 +46,7 @@ def user_replica_set_state_update(
     # Data format is {"cnode_sp_id": {"cnode_record", "events":[]}}
     cnode_events_lookup = {}
 
+    # pylint: disable=too-many-nested-blocks
     for tx_receipt in user_replica_set_mgr_txs:
         txhash = update_task.web3.toHex(tx_receipt.transactionHash)
         for event_type in user_replica_set_manager_event_types_arr:
@@ -67,7 +68,9 @@ def user_replica_set_state_update(
                     # first, get the user object from the db(if exists or create a new one)
                     # then set the lookup object for user_id with the appropriate props
                     if user_id and (user_id not in user_replica_set_events_lookup):
-                        ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
+                        ret_user = lookup_user_record(
+                            update_task, session, entry, block_number, block_timestamp, txhash
+                        )
                         user_replica_set_events_lookup[user_id] = {"user": ret_user, "events": []}
 
                     if cnode_sp_id and (cnode_sp_id not in cnode_events_lookup):

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -10,6 +10,7 @@ from src.utils.user_event_constants import (
     user_replica_set_manager_event_types_lookup
 )
 from src.utils.redis_cache import get_pickled_key, get_sp_id_key
+from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
 
@@ -50,69 +51,75 @@ def user_replica_set_state_update(
         for event_type in user_replica_set_manager_event_types_arr:
             user_events_tx = getattr(user_contract.events, event_type)().processReceipt(tx_receipt)
             for entry in user_events_tx:
-                args = entry["args"]
-                # Check if _userId is present
-                # If user id is found in the event args, update the local lookup object
-                user_id = args._userId if "_userId" in args else None
-                if user_id:
-                    user_ids.add(user_id)
+                try:
+                    args = entry["args"]
+                    # Check if _userId is present
+                    # If user id is found in the event args, update the local lookup object
+                    user_id = args._userId if "_userId" in args else None
+                    if user_id:
+                        user_ids.add(user_id)
 
-                # Check if cnodeId is present
-                # If cnode id is found in event args, update local lookup object
-                cnode_sp_id = args._cnodeSpId if "_cnodeSpId" in args else None
+                    # Check if cnodeId is present
+                    # If cnode id is found in event args, update local lookup object
+                    cnode_sp_id = args._cnodeSpId if "_cnodeSpId" in args else None
 
-                # if the user id is not in the lookup object, it hasn't been initialized yet
-                # first, get the user object from the db(if exists or create a new one)
-                # then set the lookup object for user_id with the appropriate props
-                if user_id and (user_id not in user_replica_set_events_lookup):
-                    ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
-                    user_replica_set_events_lookup[user_id] = {"user": ret_user, "events": []}
+                    # if the user id is not in the lookup object, it hasn't been initialized yet
+                    # first, get the user object from the db(if exists or create a new one)
+                    # then set the lookup object for user_id with the appropriate props
+                    if user_id and (user_id not in user_replica_set_events_lookup):
+                        ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
+                        user_replica_set_events_lookup[user_id] = {"user": ret_user, "events": []}
 
-                if cnode_sp_id and (cnode_sp_id not in cnode_events_lookup):
-                    ret_cnode = lookup_ursm_cnode(
-                        update_task,
-                        session,
-                        entry,
-                        block_number,
-                        block_timestamp,
-                        txhash
-                    )
-                    cnode_events_lookup[cnode_sp_id] = {"content_node": ret_cnode, "events": []}
+                    if cnode_sp_id and (cnode_sp_id not in cnode_events_lookup):
+                        ret_cnode = lookup_ursm_cnode(
+                            update_task,
+                            session,
+                            entry,
+                            block_number,
+                            block_timestamp,
+                            txhash
+                        )
+                        cnode_events_lookup[cnode_sp_id] = {"content_node": ret_cnode, "events": []}
 
-                # Add or update the value of the user record for this block in user_replica_set_events_lookup,
-                # ensuring that multiple events for a single user result in only 1 row insert operation
-                # (even if multiple operations are present)
-                if event_type == user_replica_set_manager_event_types_lookup['update_replica_set']:
-                    primary = args._primaryId
-                    secondaries = args._secondaryIds
-                    signer = args._signer
-                    user_record = user_replica_set_events_lookup[user_id]["user"]
-                    user_record.updated_at = datetime.utcfromtimestamp(block_timestamp)
-                    user_record.primary_id = primary
-                    user_record.secondary_ids = secondaries
-                    user_record.replica_set_update_signer = signer
+                    # Add or update the value of the user record for this block in user_replica_set_events_lookup,
+                    # ensuring that multiple events for a single user result in only 1 row insert operation
+                    # (even if multiple operations are present)
+                    if event_type == user_replica_set_manager_event_types_lookup['update_replica_set']:
+                        primary = args._primaryId
+                        secondaries = args._secondaryIds
+                        signer = args._signer
+                        user_record = user_replica_set_events_lookup[user_id]["user"]
+                        user_record.updated_at = datetime.utcfromtimestamp(block_timestamp)
+                        user_record.primary_id = primary
+                        user_record.secondary_ids = secondaries
+                        user_record.replica_set_update_signer = signer
 
-                    # Update cnode endpoint string reconstructed from sp ID
-                    creator_node_endpoint_str = get_endpoint_string_from_sp_ids(
-                        update_task,
-                        primary,
-                        secondaries,
-                        redis
-                    )
-                    user_record.creator_node_endpoint = creator_node_endpoint_str
-                    user_replica_set_events_lookup[user_id]["user"] = user_record
-                    user_replica_set_events_lookup[user_id]["events"].append(event_type)
-                # Process L2 Content Node operations
-                elif event_type == user_replica_set_manager_event_types_lookup['add_or_update_content_node']:
-                    cnode_record = parse_ursm_cnode_record(
-                        update_task,
-                        entry,
-                        cnode_events_lookup[cnode_sp_id]["content_node"]
-                    )
-                    if cnode_record is not None:
-                        cnode_events_lookup[cnode_sp_id]["content_node"] = cnode_record
-                        cnode_events_lookup[cnode_sp_id]["events"].append(event_type)
+                        # Update cnode endpoint string reconstructed from sp ID
+                        creator_node_endpoint_str = get_endpoint_string_from_sp_ids(
+                            update_task,
+                            primary,
+                            secondaries,
+                            redis
+                        )
+                        user_record.creator_node_endpoint = creator_node_endpoint_str
+                        user_replica_set_events_lookup[user_id]["user"] = user_record
+                        user_replica_set_events_lookup[user_id]["events"].append(event_type)
+                    # Process L2 Content Node operations
+                    elif event_type == user_replica_set_manager_event_types_lookup['add_or_update_content_node']:
+                        cnode_record = parse_ursm_cnode_record(
+                            update_task,
+                            entry,
+                            cnode_events_lookup[cnode_sp_id]["content_node"]
+                        )
+                        if cnode_record is not None:
+                            cnode_events_lookup[cnode_sp_id]["content_node"] = cnode_record
+                            cnode_events_lookup[cnode_sp_id]["events"].append(event_type)
+                except Exception as e:
+                    logger.info(f"Error in parse user replica set transaction")
+                    event_blockhash = update_task.web3.toHex(block_hash)
+                    raise IndexingError('user_replica_set', block_number, event_blockhash, txhash, str(e))
             num_user_replica_set_changes += len(user_events_tx)
+
     # for each record in user_replica_set_events_lookup, invalidate the old record and add the new record
     # we do this after all processing has completed so the user record is atomic by block, not tx
     for user_id, value_obj in user_replica_set_events_lookup.items():

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -10,6 +10,7 @@ from src.utils.user_event_constants import (
     user_replica_set_manager_event_types_lookup
 )
 from src.utils.redis_cache import get_pickled_key, get_sp_id_key
+from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ def user_replica_set_state_update(
         user_replica_set_mgr_txs,
         block_number,
         block_timestamp,
+        block_hash,
         redis
 ):
     """Return int representing number of User model state changes found in transaction and set of user_id values"""
@@ -49,70 +51,74 @@ def user_replica_set_state_update(
         for event_type in user_replica_set_manager_event_types_arr:
             user_events_tx = getattr(user_contract.events, event_type)().processReceipt(tx_receipt)
             for entry in user_events_tx:
-                args = entry["args"]
-                # Check if _userId is present
-                # If user id is found in the event args, update the local lookup object
-                user_id = args._userId if "_userId" in args else None
-                if user_id:
-                    user_ids.add(user_id)
+                try:
+                    args = entry["args"]
+                    # Check if _userId is present
+                    # If user id is found in the event args, update the local lookup object
+                    user_id = args._userId if "_userId" in args else None
+                    if user_id:
+                        user_ids.add(user_id)
 
-                # Check if cnodeId is present
-                # If cnode id is found in event args, update local lookup object
-                cnode_sp_id = args._cnodeSpId if "_cnodeSpId" in args else None
+                    # Check if cnodeId is present
+                    # If cnode id is found in event args, update local lookup object
+                    cnode_sp_id = args._cnodeSpId if "_cnodeSpId" in args else None
 
-                # if the user id is not in the lookup object, it hasn't been initialized yet
-                # first, get the user object from the db(if exists or create a new one)
-                # then set the lookup object for user_id with the appropriate props
-                if user_id and (user_id not in user_replica_set_events_lookup):
-                    ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
-                    user_replica_set_events_lookup[user_id] = {"user": ret_user, "events": []}
+                    # if the user id is not in the lookup object, it hasn't been initialized yet
+                    # first, get the user object from the db(if exists or create a new one)
+                    # then set the lookup object for user_id with the appropriate props
+                    if user_id and (user_id not in user_replica_set_events_lookup):
+                        ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
+                        user_replica_set_events_lookup[user_id] = {"user": ret_user, "events": []}
 
-                if cnode_sp_id and (cnode_sp_id not in cnode_events_lookup):
-                    ret_cnode = lookup_ursm_cnode(
-                        update_task,
-                        session,
-                        entry,
-                        block_number,
-                        block_timestamp,
-                        txhash
-                    )
-                    cnode_events_lookup[cnode_sp_id] = {"content_node": ret_cnode, "events": []}
+                    if cnode_sp_id and (cnode_sp_id not in cnode_events_lookup):
+                        ret_cnode = lookup_ursm_cnode(
+                            update_task,
+                            session,
+                            entry,
+                            block_number,
+                            block_timestamp,
+                            txhash
+                        )
+                        cnode_events_lookup[cnode_sp_id] = {"content_node": ret_cnode, "events": []}
 
-                # Add or update the value of the user record for this block in user_replica_set_events_lookup,
-                # ensuring that multiple events for a single user result in only 1 row insert operation
-                # (even if multiple operations are present)
-                if event_type == user_replica_set_manager_event_types_lookup['update_replica_set']:
-                    primary = args._primaryId
-                    secondaries = args._secondaryIds
-                    signer = args._signer
-                    user_record = user_replica_set_events_lookup[user_id]["user"]
-                    user_record.updated_at = datetime.utcfromtimestamp(block_timestamp)
-                    user_record.primary_id = primary
-                    user_record.secondary_ids = secondaries
-                    user_record.replica_set_update_signer = signer
+                    # Add or update the value of the user record for this block in user_replica_set_events_lookup,
+                    # ensuring that multiple events for a single user result in only 1 row insert operation
+                    # (even if multiple operations are present)
+                    if event_type == user_replica_set_manager_event_types_lookup['update_replica_set']:
+                        primary = args._primaryId
+                        secondaries = args._secondaryIds
+                        signer = args._signer
+                        user_record = user_replica_set_events_lookup[user_id]["user"]
+                        user_record.updated_at = datetime.utcfromtimestamp(block_timestamp)
+                        user_record.primary_id = primary
+                        user_record.secondary_ids = secondaries
+                        user_record.replica_set_update_signer = signer
 
-                    # Update cnode endpoint string reconstructed from sp ID
-                    creator_node_endpoint_str = get_endpoint_string_from_sp_ids(
-                        update_task,
-                        primary,
-                        secondaries,
-                        redis
-                    )
-                    user_record.creator_node_endpoint = creator_node_endpoint_str
-                    user_replica_set_events_lookup[user_id]["user"] = user_record
-                    user_replica_set_events_lookup[user_id]["events"].append(event_type)
-                # Process L2 Content Node operations
-                elif event_type == user_replica_set_manager_event_types_lookup['add_or_update_content_node']:
-                    cnode_record = parse_ursm_cnode_record(
-                        update_task,
-                        entry,
-                        cnode_events_lookup[cnode_sp_id]["content_node"]
-                    )
-                    if cnode_record is not None:
-                        cnode_events_lookup[cnode_sp_id]["content_node"] = cnode_record
-                        cnode_events_lookup[cnode_sp_id]["events"].append(event_type)
+                        # Update cnode endpoint string reconstructed from sp ID
+                        creator_node_endpoint_str = get_endpoint_string_from_sp_ids(
+                            update_task,
+                            primary,
+                            secondaries,
+                            redis
+                        )
+                        user_record.creator_node_endpoint = creator_node_endpoint_str
+                        user_replica_set_events_lookup[user_id]["user"] = user_record
+                        user_replica_set_events_lookup[user_id]["events"].append(event_type)
+                    # Process L2 Content Node operations
+                    elif event_type == user_replica_set_manager_event_types_lookup['add_or_update_content_node']:
+                        cnode_record = parse_ursm_cnode_record(
+                            update_task,
+                            entry,
+                            cnode_events_lookup[cnode_sp_id]["content_node"]
+                        )
+                        if cnode_record is not None:
+                            cnode_events_lookup[cnode_sp_id]["content_node"] = cnode_record
+                            cnode_events_lookup[cnode_sp_id]["events"].append(event_type)
+                except Exception as e:
+                    logger.info(f"Error in parse user replica set transaction")
+                    event_blockhash = update_task.web3.toHex(block_hash)
+                    raise IndexingError('user_replica_set', block_number, event_blockhash, txhash, str(e))
             num_user_replica_set_changes += len(user_events_tx)
-
     # for each record in user_replica_set_events_lookup, invalidate the old record and add the new record
     # we do this after all processing has completed so the user record is atomic by block, not tx
     for user_id, value_obj in user_replica_set_events_lookup.items():

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -50,7 +50,8 @@ def user_state_update(self, update_task, session, user_factory_txs, block_number
                     # first, get the user object from the db(if exists or create a new one)
                     # then set the lookup object for user_id with the appropriate props
                     if user_id not in user_events_lookup:
-                        ret_user = lookup_user_record(update_task, session, entry, block_number, block_timestamp, txhash)
+                        ret_user = lookup_user_record(
+                            update_task, session, entry, block_number, block_timestamp, txhash)
                         user_events_lookup[user_id] = {"user": ret_user, "events": []}
 
                     # Add or update the value of the user record for this block in user_events_lookup,

--- a/discovery-provider/src/utils/indexing_errors.py
+++ b/discovery-provider/src/utils/indexing_errors.py
@@ -5,14 +5,14 @@ class IndexingError(Exception):
         type -- One of 'user', 'user_replica_set', 'user_library', 'tracks', 'social_features', 'playlists'
         blocknumber -- block number of error
         blockhash -- block hash of error
-        transactionhash -- transaction hash of error
+        txhash -- transaction hash of error
         message -- error message
     """
 
-    def __init__(self, type, blocknumber, blockhash, transactionhash, message):
+    def __init__(self, type, blocknumber, blockhash, txhash, message):
         super(IndexingError, self).__init__(message)
         self.type = type
         self.blocknumber = blocknumber
         self.blockhash = blockhash
-        self.transactionhash = transactionhash
+        self.txhash = txhash
         self.message = message

--- a/discovery-provider/src/utils/indexing_errors.py
+++ b/discovery-provider/src/utils/indexing_errors.py
@@ -1,8 +1,4 @@
-class Error(Exception):
-    """Base class for exceptions in this module."""
-    pass
-
-class IndexingError(Error):
+class IndexingError(Exception):
     """Exception raised for errors in the indexing flow.
 
     Attributes:
@@ -14,6 +10,7 @@ class IndexingError(Error):
     """
 
     def __init__(self, type, blocknumber, blockhash, transactionhash, message):
+        super(IndexingError, self).__init__(message)
         self.type = type
         self.blocknumber = blocknumber
         self.blockhash = blockhash

--- a/discovery-provider/src/utils/indexing_errors.py
+++ b/discovery-provider/src/utils/indexing_errors.py
@@ -1,0 +1,21 @@
+class Error(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+class IndexingError(Error):
+    """Exception raised for errors in the indexing flow.
+
+    Attributes:
+        type -- One of 'user', 'user_replica_set', 'user_library', 'tracks', 'social_features', 'playlists'
+        blocknumber -- block number of error
+        blockhash -- block hash of error
+        transactionhash -- transaction hash of error
+        message -- error message
+    """
+
+    def __init__(self, type, blocknumber, blockhash, transactionhash, message):
+        self.type = type
+        self.blocknumber = blocknumber
+        self.blockhash = blockhash
+        self.transactionhash = transactionhash
+        self.message = message


### PR DESCRIPTION
### Description
Prevents indexing from stalling on an error if there is consensus from the Discovery Nodes
Link to [Notion Doc](https://www.notion.so/audiusproject/Prevent-Indexing-from-Stalling-dfde0e43d94e4f27812ec7ebee3512a4)

##### Flow:
* If there is an error while indexing, it raises a custom `IndexingError` exception. 
* If this custom exception is caught, set it in redis and check if other DP have also seen an error at this blocknumber, blockhash, transaction hash combination. 
* If the majority of discovery nodes have also seen this error (exposed via an endpoint), mark this tx to be skipped
* At the beginning of the indexing flow, if there is a tx to be skipped, filter it out from the transaction to be processed and insert it into the DB so we have a record of skipped tx

##### Changes:
* New DB Table `skipped_transactions` 
* New endpoints
  * `/indexing/skipped_transactions` which fetches all the skipped transactions
  *  `/indexing/transaction_status` which returns if a blocknumber, blockhash, txhash has failed, completed, or is not found
* Update to indexing flow to wrap in try except (for custom exception)
  * Sets a redis field on error to keep track of current until (until it is skipped and recorded in db)

### Tests
This was tested manually by spinning up 3 discovery nodes locally and writing in an error in the users, track, playlist, user_library, and social feature flow and then checking that it was stuck until a majority or nodes saw the error and that the transaction was skipped and recorded in the DB
