### PR TITLE
Fix CircleCI mad dog test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
           name: mad-dog repo init
           command: |
             cd mad-dog/
+            nvm install v10.16
             npm install
       - save_cache:
           name: Save mad-dog cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
             nvm use 10.16
             cd /home/circleci/project/service-commands/scripts/
             cd /home/circleci/project/libs/
+            npm rebuild
             npm link
             cd /home/circleci/project/service-commands/
             npm link

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
       - run:
           name: mad-dog repo init
           command: |
+            source ~/.bash_profile
             cd mad-dog/
             nvm install v10.16
             npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,6 @@ jobs:
             nvm use 10.16
             cd /home/circleci/project/service-commands/scripts/
             cd /home/circleci/project/libs/
-            npm rebuild
             npm link
             cd /home/circleci/project/service-commands/
             npm link


### PR DESCRIPTION
### Description
Add nvm install v10.16 to mad dog to make it consistent with all the other tasks and do an explicit `npm rebuild` in libs. 



### Tests
Tested on CircleCI. Successfully passed once, running again