### PR TITLE
Expose sync history in verbose health check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -75,7 +75,9 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     maxFileDescriptors,
     allocatedFileDescriptors,
     receivedBytesPerSec,
-    transferredBytesPerSec
+    transferredBytesPerSec,
+    rollingSyncSuccessCount,
+    rollingSyncFailCount
   ] = await getMonitors([
     MONITORS.DATABASE_CONNECTIONS,
     MONITORS.DATABASE_SIZE,
@@ -87,7 +89,9 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     MONITORS.MAX_FILE_DESCRIPTORS,
     MONITORS.ALLOCATED_FILE_DESCRIPTORS,
     MONITORS.RECEIVED_BYTES_PER_SEC,
-    MONITORS.TRANSFERRED_BYTES_PER_SEC
+    MONITORS.TRANSFERRED_BYTES_PER_SEC,
+    MONITORS.ROLLING_SYNC_SUCCESS_COUNT,
+    MONITORS.ROLLING_SYNC_FAIL_COUNT
   ])
 
   const response = {
@@ -107,7 +111,9 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     receivedBytesPerSec,
     transferredBytesPerSec,
     maxStorageUsedPercent,
-    numberOfCPUs
+    numberOfCPUs,
+    rollingSyncSuccessCount,
+    rollingSyncFailCount
   }
 
   return response

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -78,8 +78,12 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     allocatedFileDescriptors,
     receivedBytesPerSec,
     transferredBytesPerSec,
-    rollingSyncSuccessCount,
-    rollingSyncFailCount
+    thirtyDayRollingSyncSuccessCount,
+    thirtyDayRollingSyncFailCount,
+    dailySyncSuccessCount,
+    dailySyncFailCount,
+    latestSyncSuccessTimestamp,
+    latestSyncFailTimestamp
   ] = await getMonitors([
     MONITORS.DATABASE_CONNECTIONS,
     MONITORS.DATABASE_SIZE,
@@ -92,12 +96,13 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     MONITORS.ALLOCATED_FILE_DESCRIPTORS,
     MONITORS.RECEIVED_BYTES_PER_SEC,
     MONITORS.TRANSFERRED_BYTES_PER_SEC,
-    MONITORS.ROLLING_SYNC_SUCCESS_COUNT,
-    MONITORS.ROLLING_SYNC_FAIL_COUNT
+    MONITORS.THIRTY_DAY_ROLLING_SYNC_SUCCESS_COUNT,
+    MONITORS.THIRTY_DAY_ROLLING_SYNC_FAIL_COUNT,
+    MONITORS.DAILY_SYNC_SUCCESS_COUNT,
+    MONITORS.DAILY_SYNC_FAIL_COUNT,
+    MONITORS.LATEST_SYNC_SUCCESS_TIMESTAMP,
+    MONITORS.LATEST_SYNC_FAIL_TIMESTAMP
   ])
-
-  const latestDailySyncCount = await getAggregateSyncData()
-  const latestDailySyncTimestamps = await getLatestSyncData()
 
   const response = {
     ...basicHealthCheck,
@@ -118,12 +123,12 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     maxStorageUsedPercent,
     numberOfCPUs,
     // Rolling window days dependent on value set in monitor's sync history file
-    rollingSyncSuccessCount,
-    rollingSyncFailCount,
-    latestDailySyncSuccessCount: latestDailySyncCount.success,
-    latestDailySyncFailCount: latestDailySyncCount.fail,
-    latestDailySyncSuccessTimestamp: latestDailySyncTimestamps.success,
-    latestDailySyncFailTImestamp: latestDailySyncTimestamps.fail
+    thirtyDayRollingSyncSuccessCount,
+    thirtyDayRollingSyncFailCount,
+    dailySyncSuccessCount,
+    dailySyncFailCount,
+    latestSyncSuccessTimestamp,
+    latestSyncFailTimestamp
   }
 
   return response

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -44,6 +44,18 @@ const getMonitorsMock = async (monitors) => {
         return 776.7638177541248
       case MONITORS.TRANSFERRED_BYTES_PER_SEC.name:
         return 269500
+      case MONITORS.THIRTY_DAY_ROLLING_SYNC_SUCCESS_COUNT.name:
+        return 50
+      case MONITORS.THIRTY_DAY_ROLLING_SYNC_FAIL_COUNT.name:
+        return 10
+      case MONITORS.DAILY_SYNC_SUCCESS_COUNT.name:
+        return 5
+      case MONITORS.DAILY_SYNC_FAIL_COUNT.name:
+        return 0
+      case MONITORS.LATEST_SYNC_SUCCESS_TIMESTAMP.name:
+        return '2021-06-08T21:29:34.231Z'
+      case MONITORS.LATEST_SYNC_FAIL_TIMESTAMP.name:
+        return ''
       default:
         return null
     }
@@ -126,7 +138,13 @@ describe('Test Health Check Verbose', function () {
       receivedBytesPerSec: 776.7638177541248,
       transferredBytesPerSec: 269500,
       maxStorageUsedPercent: 95,
-      numberOfCPUs: 2
+      numberOfCPUs: 2,
+      thirtyDayRollingSyncSuccessCount: 50,
+      thirtyDayRollingSyncFailCount: 10,
+      dailySyncSuccessCount: 5,
+      dailySyncFailCount: 0,
+      latestSyncSuccessTimestamp: '2021-06-08T21:29:34.231Z',
+      latestSyncFailTimestamp: ''
     })
   })
 })

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -6,6 +6,7 @@ const { syncHealthCheck } = require('./syncHealthCheckComponentService')
 const { serviceRegistry } = require('../../serviceRegistry')
 const { sequelize } = require('../../models')
 const { getMonitors } = require('../../monitors/monitors')
+const { getAggregateSyncData, getLatestSyncData } = require('../../snapbackSM/syncHistoryAggregator')
 
 const { recoverWallet } = require('../../apiSigning')
 const { handleTrackContentUpload, removeTrackFolder } = require('../../fileManager')
@@ -96,7 +97,9 @@ const healthCheckVerboseController = async (req) => {
     logger,
     sequelize,
     getMonitors,
-    numberOfCPUs
+    numberOfCPUs,
+    getAggregateSyncData,
+    getLatestSyncData
   )
 
   return successResponse({

--- a/creator-node/src/monitors/monitors.js
+++ b/creator-node/src/monitors/monitors.js
@@ -26,8 +26,12 @@ const {
   getIPFSReadWriteStatus
 } = require('./ipfs')
 const {
-  getRollingSyncSuccessCount,
-  getRollingSyncFailCount
+  get30DayRollingSyncSuccessCount,
+  get30DayRollingSyncFailCount,
+  getDailySyncSuccessCount,
+  getDailySyncFailCount,
+  getLatestSyncSuccessTimestamp,
+  getLatestSyncFailTimestamp
 } = require('./syncHistory')
 const redis = require('../redis')
 
@@ -166,9 +170,9 @@ const IPFS_READ_WRITE_STATUS = {
 // The rolling window count of successful syncs
 // The window is for 30 days
 // Keep the rolling window count ttl to 1 hour (refreshes every hour)
-const ROLLING_SYNC_SUCCESS_COUNT = {
+const THIRTY_DAY_ROLLING_SYNC_SUCCESS_COUNT = {
   name: 'rollingSyncSuccessCount',
-  func: getRollingSyncSuccessCount,
+  func: get30DayRollingSyncSuccessCount,
   ttl: 60 /* mins */ * 60 /* s */,
   type: 'int'
 }
@@ -176,11 +180,47 @@ const ROLLING_SYNC_SUCCESS_COUNT = {
 // The rolling window count of failed syncs
 // The window is for 30 days
 // Keep the rolling window count ttl to 1 hour (refreshes every hour)
-const ROLLING_SYNC_FAIL_COUNT = {
+const THIRTY_DAY_ROLLING_SYNC_FAIL_COUNT = {
   name: 'rollingSyncFailCount',
-  func: getRollingSyncFailCount,
+  func: get30DayRollingSyncFailCount,
   ttl: 60 /* mins */ * 60 /* s */,
   type: 'int'
+}
+
+// The daily count of successful syncs
+// Set ttl to every 5 minutes
+const DAILY_SYNC_SUCCESS_COUNT = {
+  name: 'dailySyncSuccessCount',
+  func: getDailySyncSuccessCount,
+  ttl: 5 /* mins */ * 60 /* s */,
+  type: 'int'
+}
+
+// The daily count of successful syncs
+// Set ttl freshness to every 5 minutes
+const DAILY_SYNC_FAIL_COUNT = {
+  name: 'dailySyncFailCount',
+  func: getDailySyncFailCount,
+  ttl: 5 /* mins */ * 60 /* s */,
+  type: 'int'
+}
+
+// The timestamp of the latest succesful sync
+// Set ttl freshness to every 5 minutes
+const LATEST_SYNC_SUCCESS_TIMESTAMP = {
+  name: 'latestSyncSuccessTimestamp',
+  func: getLatestSyncSuccessTimestamp,
+  ttl: 5 /* mins */ * 60 /* s */,
+  type: 'string'
+}
+
+// The timestamp of the latest failed sync
+// Set ttl freshness to every 5 minutes
+const LATEST_SYNC_FAIL_TIMESTAMP = {
+  name: 'latestSyncFailTimestamp',
+  func: getLatestSyncFailTimestamp,
+  ttl: 5 /* mins */ * 60 /* s */,
+  type: 'string'
 }
 
 const MONITORS = {
@@ -204,8 +244,12 @@ const MONITORS = {
   REDIS_USED_MEMORY,
   REDIS_TOTAL_MEMORY,
   IPFS_READ_WRITE_STATUS,
-  ROLLING_SYNC_SUCCESS_COUNT,
-  ROLLING_SYNC_FAIL_COUNT
+  THIRTY_DAY_ROLLING_SYNC_SUCCESS_COUNT,
+  THIRTY_DAY_ROLLING_SYNC_FAIL_COUNT,
+  DAILY_SYNC_SUCCESS_COUNT,
+  DAILY_SYNC_FAIL_COUNT,
+  LATEST_SYNC_SUCCESS_TIMESTAMP,
+  LATEST_SYNC_FAIL_TIMESTAMP
 }
 
 const getMonitorRedisKey = (monitor) => `${MONITORING_REDIS_PREFIX}:${monitor.name}`

--- a/creator-node/src/monitors/monitors.js
+++ b/creator-node/src/monitors/monitors.js
@@ -25,6 +25,10 @@ const {
 const {
   getIPFSReadWriteStatus
 } = require('./ipfs')
+const {
+  getRollingSyncSuccessCount,
+  getRollingSyncFailCount
+} = require('./syncHistory')
 const redis = require('../redis')
 
 // Prefix used to key each monitored value in redis
@@ -159,6 +163,26 @@ const IPFS_READ_WRITE_STATUS = {
   type: 'json'
 }
 
+// The rolling window count of successful syncs
+// The window is for 30 days
+// Keep the rolling window count ttl to 1 day (refreshes daily)
+const ROLLING_SYNC_SUCCESS_COUNT = {
+  name: 'rollingSyncSuccessCount',
+  func: getRollingSyncSuccessCount,
+  ttl: 24 /* hours */ * 60 /* mins */ * 60 /* s */,
+  type: 'int'
+}
+
+// The rolling window count of failed syncs
+// The window is for 30 days
+// Keep the rolling window count ttl to 1 day (refreshes daily)
+const ROLLING_SYNC_FAIL_COUNT = {
+  name: 'rollingSyncFailCount',
+  func: getRollingSyncFailCount,
+  ttl: 24 /* hours */ * 60 /* mins */ * 60 /* s */,
+  type: 'int'
+}
+
 const MONITORS = {
   DATABASE_LIVENESS,
   DATABASE_SIZE,
@@ -179,7 +203,9 @@ const MONITORS = {
   REDIS_NUM_KEYS,
   REDIS_USED_MEMORY,
   REDIS_TOTAL_MEMORY,
-  IPFS_READ_WRITE_STATUS
+  IPFS_READ_WRITE_STATUS,
+  ROLLING_SYNC_SUCCESS_COUNT,
+  ROLLING_SYNC_FAIL_COUNT
 }
 
 const getMonitorRedisKey = (monitor) => `${MONITORING_REDIS_PREFIX}:${monitor.name}`

--- a/creator-node/src/monitors/monitors.js
+++ b/creator-node/src/monitors/monitors.js
@@ -165,21 +165,21 @@ const IPFS_READ_WRITE_STATUS = {
 
 // The rolling window count of successful syncs
 // The window is for 30 days
-// Keep the rolling window count ttl to 1 day (refreshes daily)
+// Keep the rolling window count ttl to 1 hour (refreshes every hour)
 const ROLLING_SYNC_SUCCESS_COUNT = {
   name: 'rollingSyncSuccessCount',
   func: getRollingSyncSuccessCount,
-  ttl: 24 /* hours */ * 60 /* mins */ * 60 /* s */,
+  ttl: 60 /* mins */ * 60 /* s */,
   type: 'int'
 }
 
 // The rolling window count of failed syncs
 // The window is for 30 days
-// Keep the rolling window count ttl to 1 day (refreshes daily)
+// Keep the rolling window count ttl to 1 hour (refreshes every hour)
 const ROLLING_SYNC_FAIL_COUNT = {
   name: 'rollingSyncFailCount',
   func: getRollingSyncFailCount,
-  ttl: 24 /* hours */ * 60 /* mins */ * 60 /* s */,
+  ttl: 60 /* mins */ * 60 /* s */,
   type: 'int'
 }
 

--- a/creator-node/src/monitors/syncHistory.js
+++ b/creator-node/src/monitors/syncHistory.js
@@ -1,14 +1,11 @@
 const redisClient = require('../redis')
 const SyncHistoryAggregator = require('../snapbackSM/syncHistoryAggregator')
 
-// The window to determine the aggregate sync history count
-const ROLLING_WINDOW = 30 // days
-
-const getRollingSyncSuccessCount = async () => {
+const get30DayRollingSyncSuccessCount = async () => {
   // Get the start and end dates of the rolling window
   const today = new Date()
   const rollingWindowStartDate = new Date(
-    today.setDate(today.getDate() - ROLLING_WINDOW)
+    today.setDate(today.getDate() - 30)
   )
   const rollingWindowEndDate = new Date()
 
@@ -16,7 +13,7 @@ const getRollingSyncSuccessCount = async () => {
   let rollingSyncSuccessCount = 0
   let date = rollingWindowStartDate
 
-  while (date <= rollingWindowEndDate) {
+  while (date <= rollingWindowEndDate) { // eslint-disable-line no-unmodified-loop-condition
     const redisDateKeySuffix = date.toISOString().split('T')[0] // ex.: "2021-05-04"
     const { success: syncSuccessCountKey } = SyncHistoryAggregator.getAggregateSyncKeys(redisDateKeySuffix)
 
@@ -30,11 +27,11 @@ const getRollingSyncSuccessCount = async () => {
   return rollingSyncSuccessCount
 }
 
-const getRollingSyncFailCount = async () => {
+const get30DayRollingSyncFailCount = async () => {
   // Get the start and end dates of the rolling window
   const today = new Date()
   const rollingWindowStartDate = new Date(
-    today.setDate(today.getDate() - ROLLING_WINDOW)
+    today.setDate(today.getDate() - 30)
   )
   const rollingWindowEndDate = new Date()
 
@@ -42,7 +39,7 @@ const getRollingSyncFailCount = async () => {
   let rollingSyncFailCount = 0
   let date = rollingWindowStartDate
 
-  while (date <= rollingWindowEndDate) {
+  while (date <= rollingWindowEndDate) { // eslint-disable-line no-unmodified-loop-condition
     const redisDateKeySuffix = date.toISOString().split('T')[0] // ex.: "2021-05-04"
     const { fail: syncFailCountKey } = SyncHistoryAggregator.getAggregateSyncKeys(redisDateKeySuffix)
 
@@ -56,6 +53,26 @@ const getRollingSyncFailCount = async () => {
   return rollingSyncFailCount
 }
 
+const getDailySyncSuccessCount = async () => {
+  const { success } = await SyncHistoryAggregator.getAggregateSyncData()
+  return success
+}
+
+const getDailySyncFailCount = async () => {
+  const { fail } = await SyncHistoryAggregator.getAggregateSyncData()
+  return fail
+}
+
+const getLatestSyncSuccessTimestamp = async () => {
+  const { success } = await SyncHistoryAggregator.getLatestSyncData()
+  return success
+}
+
+const getLatestSyncFailTimestamp = async () => {
+  const { fail } = await SyncHistoryAggregator.getLatestSyncData()
+  return fail
+}
+
 /**
  * Get sync count given key param
  * @param {string} key redis key for sync success or fail count
@@ -67,7 +84,10 @@ const getSyncCount = async key => {
 }
 
 module.exports = {
-  getRollingSyncSuccessCount,
-  getRollingSyncFailCount,
-  ROLLING_WINDOW
+  get30DayRollingSyncSuccessCount,
+  get30DayRollingSyncFailCount,
+  getDailySyncSuccessCount,
+  getDailySyncFailCount,
+  getLatestSyncSuccessTimestamp,
+  getLatestSyncFailTimestamp
 }

--- a/creator-node/src/monitors/syncHistory.js
+++ b/creator-node/src/monitors/syncHistory.js
@@ -68,5 +68,6 @@ const getSyncCount = async key => {
 
 module.exports = {
   getRollingSyncSuccessCount,
-  getRollingSyncFailCount
+  getRollingSyncFailCount,
+  ROLLING_WINDOW
 }

--- a/creator-node/src/monitors/syncHistory.js
+++ b/creator-node/src/monitors/syncHistory.js
@@ -1,0 +1,72 @@
+const redisClient = require('../redis')
+const SyncHistoryAggregator = require('../snapbackSM/syncHistoryAggregator')
+
+// The window to determine the aggregate sync history count
+const ROLLING_WINDOW = 30 // days
+
+const getRollingSyncSuccessCount = async () => {
+  // Get the start and end dates of the rolling window
+  const today = new Date()
+  const rollingWindowStartDate = new Date(
+    today.setDate(today.getDate() - ROLLING_WINDOW)
+  )
+  const rollingWindowEndDate = new Date()
+
+  // Get the success count from the date within the rolling window range
+  let rollingSyncSuccessCount = 0
+  let date = rollingWindowStartDate
+
+  while (date <= rollingWindowEndDate) {
+    const redisDateKeySuffix = date.toISOString().split('T')[0] // ex.: "2021-05-04"
+    const { success: syncSuccessCountKey } = SyncHistoryAggregator.getAggregateSyncKeys(redisDateKeySuffix)
+
+    const syncSuccessCount = await getSyncCount(syncSuccessCountKey)
+    rollingSyncSuccessCount += syncSuccessCount
+
+    // Set the date to the next day
+    date.setDate(date.getDate() + 1)
+  }
+
+  return rollingSyncSuccessCount
+}
+
+const getRollingSyncFailCount = async () => {
+  // Get the start and end dates of the rolling window
+  const today = new Date()
+  const rollingWindowStartDate = new Date(
+    today.setDate(today.getDate() - ROLLING_WINDOW)
+  )
+  const rollingWindowEndDate = new Date()
+
+  // Get the fail count from the date within the rolling window range
+  let rollingSyncFailCount = 0
+  let date = rollingWindowStartDate
+
+  while (date <= rollingWindowEndDate) {
+    const redisDateKeySuffix = date.toISOString().split('T')[0] // ex.: "2021-05-04"
+    const { fail: syncFailCountKey } = SyncHistoryAggregator.getAggregateSyncKeys(redisDateKeySuffix)
+
+    const syncFailCount = await getSyncCount(syncFailCountKey)
+    rollingSyncFailCount += syncFailCount
+
+    // Set the date to the next day
+    date.setDate(date.getDate() + 1)
+  }
+
+  return rollingSyncFailCount
+}
+
+/**
+ * Get sync count given key param
+ * @param {string} key redis key for sync success or fail count
+ * @returns the number of successful or failed sync attempts or 0
+ */
+const getSyncCount = async key => {
+  let syncCount = await redisClient.get(key)
+  return parseInt(syncCount) || 0
+}
+
+module.exports = {
+  getRollingSyncSuccessCount,
+  getRollingSyncFailCount
+}

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -207,22 +207,6 @@ module.exports = function (app) {
     return successResponse()
   }))
 
-  /**
-   * Returns sync history.
-   * `aggregateSyncData` - the number of succesful, failed, and triggered syncs for the current day
-   * `latestSyncData` - the date of the most recent successful and failed sync. will be `null` if no sync occurred with that state
-   *
-   * Structure:
-   *  aggregateSyncData = {triggered: <number>, success: <number>, fail: <number>}
-   *  latestSyncData = {success: <MM:DD:YYYYTHH:MM:SS:ssss>, fail: <MM:DD:YYYYTHH:MM:SS:ssss>}
-   */
-  app.get('/sync_history', handleResponse(async (req, res) => {
-    const aggregateSyncData = await SyncHistoryAggregator.getAggregateSyncData(req.logContext)
-    const latestSyncData = await SyncHistoryAggregator.getLatestSyncData(req.logContext)
-
-    return successResponse({ aggregateSyncData, latestSyncData })
-  }))
-
   /** Checks if node sync is in progress for wallet. */
   app.get('/sync_status/:walletPublicKey', handleResponse(async (req, res) => {
     const walletPublicKey = req.params.walletPublicKey

--- a/creator-node/src/snapbackSM/syncHistoryAggregator.js
+++ b/creator-node/src/snapbackSM/syncHistoryAggregator.js
@@ -99,11 +99,11 @@ class SyncHistoryAggregator {
   /**
    * Returns the aggregate sync data of the current day's number of successful, failed,
    * and triggered syncs
-   * @param {Object} logContext the log context off of the Express req object
+   * @param {Object?} logContext the log context off of the Express req object
    * @returns an object of the current day's aggregate sync count like
    *    {triggered: <natural number>, success: <natural number>, fail: <natural number>}
    */
-  static async getAggregateSyncData (logContext) {
+  static async getAggregateSyncData (logContext = {}) {
     const logger = genericLogger.child(logContext)
     let currentAggregateData = {
       success: 0,
@@ -134,11 +134,11 @@ class SyncHistoryAggregator {
   /**
    * Returns the date of the latest successful and failed sync. Will be `null` if a sync with those
    * states have not been triggered.
-   * @param {Object} logContext the log context off of the Express req object
+   * @param {Object?} logContext the log context off of the Express req object
    * @returns an object of the current day's aggregate sync count like
    *     {success: <YYYY-MM-DDTHH:MM:SS:sssZ>, fail: <YYYY-MM-DDTHH:MM:SS:sssZ>}
    */
-  static async getLatestSyncData (logContext) {
+  static async getLatestSyncData (logContext = {}) {
     const logger = genericLogger.child(logContext)
     let currentLatestSyncData = {
       success: null,
@@ -162,10 +162,11 @@ class SyncHistoryAggregator {
 
   /**
    * Retrieves the redis keys used for storing aggregate sync counts
+   * @param {string?} date string with the structure YYYY-MM-DD. defaulted to today's date
    * @returns an object of the `success` and `fail` redis keys for the aggregate sync count
    */
-  static getAggregateSyncKeys () {
-    const prefix = `aggregateSync:::${new Date().toISOString().split('T')[0]}`
+  static getAggregateSyncKeys (date = new Date().toISOString().split('T')[0]) {
+    const prefix = `aggregateSync:::${date}`
 
     // ex: aggregateSync:::2021-06-01:::success
     return {
@@ -176,10 +177,11 @@ class SyncHistoryAggregator {
 
   /**
    * Retreives the redis keys used for storing latest sync dates
+   * @param {string?} date string with the structure YYYY-MM-DD. defaulted to today's date
    * @returns an object of the `succes` and `fail` redis keys for the latest sync dates
    */
-  static getLatestSyncKeys () {
-    const prefix = `latestSync:::${new Date().toISOString().split('T')[0]}`
+  static getLatestSyncKeys (date = new Date().toISOString().split('T')[0]) {
+    const prefix = `latestSync:::${date}`
 
     // ex: latestSync:::2021-06-01:::success
     return {


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Context: We will need the sync history data exposed somewhere to calculate peer health. This PR is to expose sync history details in the manner of:
- the current day's sync count
- the current day's timestamp of the latest successful and failed sync (if any)
- the rolling window of 30 days sync count (set to refresh every hour)

This PR also:
- removes the `/sync_history` route as it is not used
- refactoring code to implement core goal of PR

TODO:
- [x] Address PR comments
- [x] Address lint issues
- [x] Update unit tests for health check


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- hit the `/health_check/verbose` route to see results
```
// 20210608144413
// http://cn3_creator-node_1:4002/health_check/verbose

{
  "data": {
    "version": "0.3.36",
    "service": "content-node",
    "healthy": true,
    "git": "",
    "selectedDiscoveryProvider": "http://audius-disc-prov_web-server_1:5000",
    "creatorNodeEndpoint": "http://cn3_creator-node_1:4002",
    "spID": 3,
    "spOwnerWallet": "0x42f28aa6169c8901d0fcc6aa265db9082de04ca3",
    "isRegisteredOnURSM": true,
    "country": "US",
    "latitude": "41.2619",
    "longitude": "-95.8608",
    "databaseConnections": 5,
    "databaseSize": 8809471,
    "totalMemory": 25219547136,
    "usedMemory": 13833035776,
    "usedTCPMemory": 184,
    "storagePathSize": 259975987200,
    "storagePathUsed": 41439989760,
    "maxFileDescriptors": 9223372036854776000,
    "allocatedFileDescriptors": 8512,
    "receivedBytesPerSec": null,
    "transferredBytesPerSec": 381388.88888888893,
    "maxStorageUsedPercent": 95,
    "numberOfCPUs": 12,
    "thirtyDayRollingSyncSuccessCount": 3,
    "thirtyDayRollingSyncFailCount": 0,
    "dailySyncSuccessCount": 3,
    "dailySyncFailCount": 0,
    "latestSyncSuccessTimestamp": "2021-06-08T21:29:34.231Z",
    "latestSyncFailTimestamp": ""
  },
  "signer": "0x42f28aa6169c8901d0fcc6aa265db9082de04ca3",
  "timestamp": "2021-06-08T21:44:13.467Z",
  "signature": "0x349777a6fa174b5e572d058dd7222a5f3b04c528eaa39a85c590b74dfa99de64356b1e56b6bdff88d81be36c5ede2ea9c60eb96e2ce291e9ce7fea484006a7471c"
}
```
