### PR TITLE
More verbose sync failure logs

### DIFF
--- a/creator-node/src/models/clockRecord.js
+++ b/creator-node/src/models/clockRecord.js
@@ -65,7 +65,7 @@ module.exports = (sequelize, DataTypes) => {
 
         // If not first clockRecord entry, clock value must be (previous.clock + 1)
         if (currentMaxClock && clock !== currentMaxClock + 1) {
-          return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeCreate currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
+          return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeCreate - currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
         }
       },
 
@@ -105,7 +105,7 @@ module.exports = (sequelize, DataTypes) => {
 
           // If not first clockRecord entry, clock value must be (previous.clock + 1)
           if (currentMaxClock && clock !== currentMaxClock + 1) {
-            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeBulkCreate currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
+            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeBulkCreate - currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
           }
 
           previousClock = clock
@@ -117,7 +117,7 @@ module.exports = (sequelize, DataTypes) => {
 
           // error if new clock is not previousClock + 1
           if (previousClock && clock !== previousClock + 1) {
-            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeCreate previousClock: ${previousClock}, clock: ${clock}`)
+            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeBulkCreate loop - previousClock: ${previousClock}, clock: ${clock}`)
           }
 
           previousClock = clock

--- a/creator-node/src/models/clockRecord.js
+++ b/creator-node/src/models/clockRecord.js
@@ -65,7 +65,7 @@ module.exports = (sequelize, DataTypes) => {
 
         // If not first clockRecord entry, clock value must be (previous.clock + 1)
         if (currentMaxClock && clock !== currentMaxClock + 1) {
-          return sequelize.Promise.reject('Can only insert contiguous clock values')
+          return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeCreate currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
         }
       },
 
@@ -105,7 +105,7 @@ module.exports = (sequelize, DataTypes) => {
 
           // If not first clockRecord entry, clock value must be (previous.clock + 1)
           if (currentMaxClock && clock !== currentMaxClock + 1) {
-            return sequelize.Promise.reject('Can only insert contiguous clock values')
+            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeBulkCreate currentMaxClock: ${currentMaxClock}, clock: ${clock}`)
           }
 
           previousClock = clock
@@ -117,7 +117,7 @@ module.exports = (sequelize, DataTypes) => {
 
           // error if new clock is not previousClock + 1
           if (previousClock && clock !== previousClock + 1) {
-            return sequelize.Promise.reject('Can only insert contiguous clock values')
+            return sequelize.Promise.reject(`Can only insert contiguous clock values. Inconsistency in beforeCreate previousClock: ${previousClock}, clock: ${clock}`)
           }
 
           previousClock = clock

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -417,7 +417,7 @@ describe('Test ClockRecord model', async function () {
         sourceTable: validSourceTable
       })
     } catch (e) {
-      assert.ok(e.message.contains('Can only insert contiguous clock values. Inconsistency in beforeCreate'))
+      assert.ok(e.message.includes('Can only insert contiguous clock values. Inconsistency in beforeCreate'))
     }
 
     // successfully create clockrecord with contiguous clock value
@@ -435,7 +435,7 @@ describe('Test ClockRecord model', async function () {
         { cnodeUserUUID, clock: 5, sourceTable: validSourceTable }
       ])
     } catch (e) {
-      assert.ok(e.message.contains('Can only insert contiguous clock values. Inconsistency in beforeBulkCreate'))
+      assert.ok(e.message.includes('Can only insert contiguous clock values. Inconsistency in beforeBulkCreate'))
     }
 
     // successfully bulk create multiple clock records

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -417,7 +417,7 @@ describe('Test ClockRecord model', async function () {
         sourceTable: validSourceTable
       })
     } catch (e) {
-      assert.ok(e.message.includes('Can only insert contiguous clock values. Inconsistency in beforeCreate'))
+      assert.ok(e.includes('Can only insert contiguous clock values. Inconsistency in beforeCreate'))
     }
 
     // successfully create clockrecord with contiguous clock value
@@ -435,7 +435,7 @@ describe('Test ClockRecord model', async function () {
         { cnodeUserUUID, clock: 5, sourceTable: validSourceTable }
       ])
     } catch (e) {
-      assert.ok(e.message.includes('Can only insert contiguous clock values. Inconsistency in beforeBulkCreate'))
+      assert.ok(e.includes('Can only insert contiguous clock values. Inconsistency in beforeBulkCreate'))
     }
 
     // successfully bulk create multiple clock records

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -417,7 +417,7 @@ describe('Test ClockRecord model', async function () {
         sourceTable: validSourceTable
       })
     } catch (e) {
-      assert.strictEqual(e, 'Can only insert contiguous clock values')
+      assert.ok(e.message.contains('Can only insert contiguous clock values'))
     }
 
     // successfully create clockrecord with contiguous clock value
@@ -435,7 +435,7 @@ describe('Test ClockRecord model', async function () {
         { cnodeUserUUID, clock: 5, sourceTable: validSourceTable }
       ])
     } catch (e) {
-      assert.strictEqual(e, 'Can only insert contiguous clock values')
+      assert.ok(e.message.contains('Can only insert contiguous clock values'))
     }
 
     // successfully bulk create multiple clock records

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -417,7 +417,7 @@ describe('Test ClockRecord model', async function () {
         sourceTable: validSourceTable
       })
     } catch (e) {
-      assert.ok(e.message.contains('Can only insert contiguous clock values'))
+      assert.ok(e.message.contains('Can only insert contiguous clock values. Inconsistency in beforeCreate'))
     }
 
     // successfully create clockrecord with contiguous clock value
@@ -435,7 +435,7 @@ describe('Test ClockRecord model', async function () {
         { cnodeUserUUID, clock: 5, sourceTable: validSourceTable }
       ])
     } catch (e) {
-      assert.ok(e.message.contains('Can only insert contiguous clock values'))
+      assert.ok(e.message.contains('Can only insert contiguous clock values. Inconsistency in beforeBulkCreate'))
     }
 
     // successfully bulk create multiple clock records


### PR DESCRIPTION
### Description
We're seeing a failure on production where we see an error message but it's difficult to see where it's happening since several functions have the same message. Also there's no info readily about the discrepancy either, so added that.



### Tests
Unit tests have been modified to use the new error message