### PR TITLE
Create captcha record only when captcha fields exist

### DIFF
--- a/identity-service/src/captchaMiddleware.js
+++ b/identity-service/src/captchaMiddleware.js
@@ -7,12 +7,14 @@ const verifyAndRecordCaptcha = async ({ token, walletAddress, url, logger, captc
     try {
       ({ score, ok, hostname } = await captcha.verify(token))
 
-      models.BotScores.create({
-        walletAddress,
-        recaptchaScore: score,
-        recaptchaContext: url,
-        recaptchaHostname: hostname
-      })
+      if ((score || (score === 0)) && hostname) {
+        models.BotScores.create({
+          walletAddress,
+          recaptchaScore: score,
+          recaptchaContext: url,
+          recaptchaHostname: hostname
+        })
+      }
     } catch (e) {
       logger.error(`CAPTCHA - Error with calculating or recording recaptcha score for wallet=${walletAddress}`, e)
     }

--- a/identity-service/src/captchaMiddleware.js
+++ b/identity-service/src/captchaMiddleware.js
@@ -7,7 +7,7 @@ const verifyAndRecordCaptcha = async ({ token, walletAddress, url, logger, captc
     try {
       ({ score, ok, hostname } = await captcha.verify(token))
 
-      if ((score || (score === 0)) && hostname) {
+      if (score !== undefined && score !== null && hostname) {
         models.BotScores.create({
           walletAddress,
           recaptchaScore: score,


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

The BotScores model does not allow null for recaptchaScore and recaptchaHostname, which could be null from the captcha.verify call. This change adds a condition to only create the db record when these values exist.


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Test 1
2. Test 2
3. Test 3\
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
