### PR TITLE
Add WormholeClient and EthRewardsManager

### DIFF
--- a/eth-contracts/contract-config.js
+++ b/eth-contracts/contract-config.js
@@ -5,36 +5,48 @@ module.exports = {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   },
   'test_local': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   },
   'soliditycoverage': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   },
   'audius_private': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   },
   'staging': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   },
   'production': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
     guardianAddress: null,
-    wormholeAddress: null
+    wormholeAddress: null,
+    antiAbuseOracleAddress: null,
+    solanaRecipientAddress: null
   }
 }

--- a/eth-contracts/contract-config.js
+++ b/eth-contracts/contract-config.js
@@ -4,31 +4,37 @@ module.exports = {
   'development': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   },
   'test_local': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   },
   'soliditycoverage': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   },
   'audius_private': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   },
   'staging': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   },
   'production': {
     proxyDeployerAddress: null,
     proxyAdminAddress: null,
-    guardianAddress: null
+    guardianAddress: null,
+    wormholeAddress: null
   }
 }

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -38,19 +38,22 @@ contract EthRewardsManager is InitializableV2 {
     Wormhole internal wormhole;
     bytes32 internal recipient;
 
-    address public antiAbuseOracle;
+    address public antiAbuseOracleAddress;
 
     /**
      * @notice Function to initialize the contract
      * @param _tokenAddress - address of ERC20 token
      * @param _governanceAddress - address for Governance proxy contract
+     * @param _wormholeAddress - address for Wormhole contract
+     * @param _recipient - solana address of recipient
+     * @param _antiAbuseOracleAddress - address for antiAbuseOracleAddress
      */
     function initialize(
         address _tokenAddress,
         address _governanceAddress,
         address _wormholeAddress,
         bytes32 _recipient,
-        address _antiAbuseOracle
+        address _antiAbuseOracleAddress
     ) public initializer {
         require(Address.isContract(_tokenAddress), ERROR_TOKEN_NOT_CONTRACT);
         require(
@@ -60,7 +63,7 @@ contract EthRewardsManager is InitializableV2 {
         audiusToken = ERC20(_tokenAddress);
         wormhole = Wormhole(_wormholeAddress);
         recipient = _recipient;
-        antiAbuseOracle = _antiAbuseOracle;
+        antiAbuseOracleAddress = _antiAbuseOracleAddress;
         _updateGovernanceAddress(_governanceAddress);
         InitializableV2.initialize();
     }
@@ -82,7 +85,7 @@ contract EthRewardsManager is InitializableV2 {
      * @dev Only callable by Governance address
      * @param _recipient - address for new recipient
      */
-    function setRecipient(bytes32 _recipient) external {
+    function setRecipientAddress(bytes32 _recipient) external {
         _requireIsInitialized();
 
         require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
@@ -90,15 +93,15 @@ contract EthRewardsManager is InitializableV2 {
     }
 
     /**
-     * @notice Set the antiAbuseOracle address
+     * @notice Set antiAbuseOracleAddress
      * @dev Only callable by Governance address
-     * @param _antiAbuseOracle - address for new antiAbuseOracle
+     * @param _antiAbuseOracleAddress - value of new antiAbuseOracleAddress
      */
-    function setantiAbuseOracle(address _antiAbuseOracle) external {
+    function setAntiAbuseOracleAddress(address _antiAbuseOracleAddress) external {
         _requireIsInitialized();
 
         require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
-        antiAbuseOracle = _antiAbuseOracle;
+        antiAbuseOracleAddress = _antiAbuseOracleAddress;
     }
 
     /* External functions */
@@ -143,7 +146,7 @@ contract EthRewardsManager is InitializableV2 {
     }
 
     /// @notice Get the Governance address
-    function getRecipient() external view returns (bytes32) {
+    function getRecipientAddress() external view returns (bytes32) {
         _requireIsInitialized();
 
         return recipient;

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -151,7 +151,7 @@ contract EthRewardsManager is InitializableV2 {
     function _updateGovernanceAddress(address _governanceAddress) internal {
         require(
             Governance(_governanceAddress).isGovernanceAddress() == true,
-            "Staking: _governanceAddress is not a valid governance contract"
+            "EthRewardsManager: _governanceAddress is not a valid governance contract"
         );
         governanceAddress = _governanceAddress;
     }

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -45,7 +45,8 @@ contract EthRewardsManager is InitializableV2 {
         address _tokenAddress,
         address _governanceAddress,
         address _wormholeAddress,
-        bytes32 _recipient
+        bytes32 _recipient,
+        address _botOracle
     ) public initializer {
         require(Address.isContract(_tokenAddress), ERROR_TOKEN_NOT_CONTRACT);
         require(
@@ -55,6 +56,7 @@ contract EthRewardsManager is InitializableV2 {
         audiusToken = ERC20(_tokenAddress);
         wormhole = Wormhole(_wormholeAddress);
         recipient = _recipient;
+        botOracle = _botOracle;
         _updateGovernanceAddress(_governanceAddress);
         InitializableV2.initialize();
     }

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -113,8 +113,6 @@ contract EthRewardsManager is InitializableV2 {
     function transferToSolana(uint32 _nonce) external {
         _requireIsInitialized();
 
-        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
-
         uint256 balance = audiusToken.balanceOf(address(this));
         audiusToken.approve(address(wormhole), balance);
 

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -142,6 +142,13 @@ contract EthRewardsManager is InitializableV2 {
         return governanceAddress;
     }
 
+    /// @notice Get the Governance address
+    function getRecipient() external view returns (bytes32) {
+        _requireIsInitialized();
+
+        return recipient;
+    }
+
     // ========================================= Internal Functions =========================================
 
     /**

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -38,7 +38,7 @@ contract EthRewardsManager is InitializableV2 {
     Wormhole internal wormhole;
     bytes32 internal recipient;
 
-    address public botOracle;
+    address public antiAbuseOracle;
 
     /**
      * @notice Function to initialize the contract
@@ -50,7 +50,7 @@ contract EthRewardsManager is InitializableV2 {
         address _governanceAddress,
         address _wormholeAddress,
         bytes32 _recipient,
-        address _botOracle
+        address _antiAbuseOracle
     ) public initializer {
         require(Address.isContract(_tokenAddress), ERROR_TOKEN_NOT_CONTRACT);
         require(
@@ -60,7 +60,7 @@ contract EthRewardsManager is InitializableV2 {
         audiusToken = ERC20(_tokenAddress);
         wormhole = Wormhole(_wormholeAddress);
         recipient = _recipient;
-        botOracle = _botOracle;
+        antiAbuseOracle = _antiAbuseOracle;
         _updateGovernanceAddress(_governanceAddress);
         InitializableV2.initialize();
     }
@@ -90,15 +90,15 @@ contract EthRewardsManager is InitializableV2 {
     }
 
     /**
-     * @notice Set the botOracle address
+     * @notice Set the antiAbuseOracle address
      * @dev Only callable by Governance address
-     * @param _botOracle - address for new botOracle
+     * @param _antiAbuseOracle - address for new antiAbuseOracle
      */
-    function setBotOracle(address _botOracle) external {
+    function setantiAbuseOracle(address _antiAbuseOracle) external {
         _requireIsInitialized();
 
         require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
-        botOracle = _botOracle;
+        antiAbuseOracle = _antiAbuseOracle;
     }
 
     /* External functions */

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -1,0 +1,138 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/Address.sol";
+import "./InitializableV2.sol";
+import "./Governance.sol";
+
+interface Wormhole {
+    function lockAssets(
+        address asset,
+        uint256 amount,
+        bytes32 recipient,
+        uint8 target_chain,
+        uint32 nonce,
+        bool refund_dust
+    ) external;
+}
+
+contract EthRewardsManager is InitializableV2 {
+    using SafeERC20 for ERC20;
+
+    string private constant ERROR_TOKEN_NOT_CONTRACT =
+        "EthRewardsManager: token is not a contract";
+    string private constant ERROR_WORMHOLE_NOT_CONTRACT =
+        "EthRewardsManager: wormhole is not a contract";
+    string private constant ERROR_ONLY_GOVERNANCE =
+        "EthRewardsManager: Only governance";
+
+    address private governanceAddress;
+
+    /// @dev ERC-20 token that will be used to stake with
+    ERC20 internal audiusToken;
+    Wormhole internal wormhole;
+    bytes32 internal recipient;
+
+    /**
+     * @notice Function to initialize the contract
+     * @param _tokenAddress - address of ERC20 token
+     * @param _governanceAddress - address for Governance proxy contract
+     */
+    function initialize(
+        address _tokenAddress,
+        address _governanceAddress,
+        address _wormholeAddress,
+        bytes32 _recipient
+    ) public initializer {
+        require(Address.isContract(_tokenAddress), ERROR_TOKEN_NOT_CONTRACT);
+        require(
+            Address.isContract(_wormholeAddress),
+            ERROR_WORMHOLE_NOT_CONTRACT
+        );
+        audiusToken = ERC20(_tokenAddress);
+        wormhole = Wormhole(_wormholeAddress);
+        recipient = _recipient;
+        _updateGovernanceAddress(_governanceAddress);
+        InitializableV2.initialize();
+    }
+
+    /**
+     * @notice Set the Governance address
+     * @dev Only callable by Governance address
+     * @param _governanceAddress - address for new Governance contract
+     */
+    function setGovernanceAddress(address _governanceAddress) external {
+        _requireIsInitialized();
+
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+        _updateGovernanceAddress(_governanceAddress);
+    }
+
+    /**
+     * @notice Set the ClaimsManaager address
+     * @dev Only callable by Governance address
+     * @param _recipient - address for new recipient
+     */
+    function setRecipient(bytes32 _recipient) external {
+        _requireIsInitialized();
+
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+        recipient = _recipient;
+    }
+
+    /* External functions */
+
+    /**
+     * @notice Transfers to solana
+     * @param _nonce - nonce for wormhole
+     */
+    function transferToSolana(uint32 _nonce) external {
+        _requireIsInitialized();
+
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+
+        uint256 balance = audiusToken.balanceOf(address(this));
+        audiusToken.approve(address(wormhole), balance);
+
+        wormhole.lockAssets(
+            address(audiusToken),
+            balance,
+            recipient,
+            1,
+            _nonce,
+            true
+        );
+    }
+
+    /**
+     * @notice Get the token used by the contract
+     * @return The token used by the contract
+     */
+    function token() external view returns (address) {
+        _requireIsInitialized();
+
+        return address(audiusToken);
+    }
+
+    /// @notice Get the Governance address
+    function getGovernanceAddress() external view returns (address) {
+        _requireIsInitialized();
+
+        return governanceAddress;
+    }
+
+    // ========================================= Internal Functions =========================================
+
+    /**
+     * @notice Set the governance address after confirming contract identity
+     * @param _governanceAddress - Incoming governance address
+     */
+    function _updateGovernanceAddress(address _governanceAddress) internal {
+        require(
+            Governance(_governanceAddress).isGovernanceAddress() == true,
+            "Staking: _governanceAddress is not a valid governance contract"
+        );
+        governanceAddress = _governanceAddress;
+    }
+}

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -17,15 +17,19 @@ interface Wormhole {
     ) external;
 }
 
+
 contract EthRewardsManager is InitializableV2 {
     using SafeERC20 for ERC20;
 
-    string private constant ERROR_TOKEN_NOT_CONTRACT =
-        "EthRewardsManager: token is not a contract";
-    string private constant ERROR_WORMHOLE_NOT_CONTRACT =
-        "EthRewardsManager: wormhole is not a contract";
-    string private constant ERROR_ONLY_GOVERNANCE =
-        "EthRewardsManager: Only governance";
+    string private constant ERROR_TOKEN_NOT_CONTRACT = (
+        "EthRewardsManager: token is not a contract"
+    );
+    string private constant ERROR_WORMHOLE_NOT_CONTRACT = (
+        "EthRewardsManager: wormhole is not a contract"
+    );
+    string private constant ERROR_ONLY_GOVERNANCE = (
+        "EthRewardsManager: Only governance"
+    );
 
     address private governanceAddress;
 

--- a/eth-contracts/contracts/EthRewardsManager.sol
+++ b/eth-contracts/contracts/EthRewardsManager.sol
@@ -34,6 +34,8 @@ contract EthRewardsManager is InitializableV2 {
     Wormhole internal wormhole;
     bytes32 internal recipient;
 
+    address public botOracle;
+
     /**
      * @notice Function to initialize the contract
      * @param _tokenAddress - address of ERC20 token
@@ -70,7 +72,7 @@ contract EthRewardsManager is InitializableV2 {
     }
 
     /**
-     * @notice Set the ClaimsManaager address
+     * @notice Set the recipient address
      * @dev Only callable by Governance address
      * @param _recipient - address for new recipient
      */
@@ -79,6 +81,18 @@ contract EthRewardsManager is InitializableV2 {
 
         require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
         recipient = _recipient;
+    }
+
+    /**
+     * @notice Set the botOracle address
+     * @dev Only callable by Governance address
+     * @param _botOracle - address for new botOracle
+     */
+    function setBotOracle(address _botOracle) external {
+        _requireIsInitialized();
+
+        require(msg.sender == governanceAddress, ERROR_ONLY_GOVERNANCE);
+        botOracle = _botOracle;
     }
 
     /* External functions */

--- a/eth-contracts/contracts/WormholeClient.sol
+++ b/eth-contracts/contracts/WormholeClient.sol
@@ -113,7 +113,7 @@ contract WormholeClient is InitializableV2 {
         uint32 nonce = nonces[from]++;
 
         // solium-disable security/no-block-members
-        require(deadline >= block.timestamp, "AudiusToken: Deadline has expired");
+        require(deadline >= block.timestamp, "WormholeClient: Deadline has expired");
         bytes32 digest = keccak256(
             abi.encodePacked(
                 "\x19\x01",
@@ -136,7 +136,7 @@ contract WormholeClient is InitializableV2 {
         address recoveredAddress = ecrecover(digest, v, r, s);
         require(
             recoveredAddress != address(0) && recoveredAddress == from,
-            "AudiusToken: Invalid signature"
+            "WormholeClient: Invalid signature"
         );
 
         transferToken.safeTransferFrom(from, address(this), amount);

--- a/eth-contracts/contracts/WormholeClient.sol
+++ b/eth-contracts/contracts/WormholeClient.sol
@@ -1,0 +1,154 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/Address.sol";
+import "./InitializableV2.sol";
+
+
+interface Wormhole {
+    function lockAssets(
+        address asset,
+        uint256 amount,
+        bytes32 recipient,
+        uint8 target_chain,
+        uint32 nonce,
+        bool refund_dust
+    ) external;
+}
+
+
+contract WormholeClient is InitializableV2 {
+    using SafeERC20 for ERC20;
+
+    string private constant ERROR_TOKEN_NOT_CONTRACT = (
+        "WormholeClient: Transfer token is not a contract"
+    );
+
+    string private constant ERROR_WORMHOLE_NOT_CONTRACT = (
+        "WormholeClient: Wormhole is not a contract"
+    );
+
+    // for ERC20 approve transactions in compliance with EIP 2612:
+    // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2612.md
+    // code below, in constructor, and in permit function adapted from the audited reference Uniswap implementation:
+    // https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/UniswapV2ERC20.sol
+    bytes32 public DOMAIN_SEPARATOR;
+    // keccak256("LockAssets(address from,uint256 amount,bytes32 recipient,uint8 targetChain,uint32 nonce,bool refundDust,uint256 deadline)");
+
+    bytes32 public constant LOCK_ASSETS_TYPEHASH = (
+        0x32b9fa85e7487cf8e3430f4b773c7a862349025263595634cc74cb3036b9b130
+    );
+
+    mapping(address => uint32) public nonces;
+
+    /// @dev ERC-20 token that will be transfered
+    ERC20 internal transferToken;
+    Wormhole internal wormhole;
+
+    /**
+     * @notice Get the token used by the contract for transfer
+     * @return The token used by the contract for transfer
+     */
+    function token() external view returns (address) {
+        _requireIsInitialized();
+        return address(transferToken);
+    }
+
+    /**
+     * @notice Function to initialize the contract
+     * @param _tokenAddress - address of ERC20 token that will be transfered
+     * @param _wormholeAddress - address for Wormhole proxy contract
+     */
+    function initialize(address _tokenAddress, address _wormholeAddress)
+        public
+        initializer
+    {
+        require(Address.isContract(_tokenAddress), ERROR_TOKEN_NOT_CONTRACT);
+        require(
+            Address.isContract(_wormholeAddress),
+            ERROR_WORMHOLE_NOT_CONTRACT
+        );
+        transferToken = ERC20(_tokenAddress);
+        wormhole = Wormhole(_wormholeAddress);
+        InitializableV2.initialize();
+
+        // EIP712-compatible signature data
+        uint chainId;
+        // solium-disable security/no-inline-assembly
+        assembly {
+            chainId := chainid
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("AudiusWormholeClient")),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    /**
+     * @notice transfer `_amount` of tokens from sender to target account
+     * @param from - account to transfer from
+     * @param amount - amount of token to transfer
+     * @param recipient - foreign chain address of recipient
+     * @param targetChain -  id of the chain to transfer to
+     * @param refundDust - bool to refund dust
+     */
+    function lockAssets(
+        address from,
+        uint256 amount,
+        bytes32 recipient,
+        uint8 targetChain,
+        bool refundDust,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        uint32 nonce = nonces[from]++;
+
+        // solium-disable security/no-block-members
+        require(deadline >= block.timestamp, "AudiusToken: Deadline has expired");
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        LOCK_ASSETS_TYPEHASH,
+                        from,
+                        amount,
+                        recipient,
+                        targetChain,
+                        nonce,
+                        refundDust,
+                        deadline
+                    )
+                )
+            )
+        );
+
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(
+            recoveredAddress != address(0) && recoveredAddress == from,
+            "AudiusToken: Invalid signature"
+        );
+
+        transferToken.safeTransferFrom(from, address(this), amount);
+        transferToken.approve(address(wormhole), amount);
+
+        wormhole.lockAssets(
+            address(transferToken),
+            amount,
+            recipient,
+            targetChain,
+            nonce,
+            refundDust
+        );
+    }
+}

--- a/eth-contracts/contracts/test/MockWormhole.sol
+++ b/eth-contracts/contracts/test/MockWormhole.sol
@@ -1,0 +1,51 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol";
+
+
+contract MockWormhole {
+    using SafeERC20 for ERC20;
+
+    uint8 CHAIN_ID = 2;
+
+    event LogTokensLocked(
+        uint8 targetChain,
+        uint8 tokenChain,
+        uint8 tokenDecimals,
+        bytes32 indexed token,
+        bytes32 indexed sender,
+        bytes32 recipient,
+        uint256 amount,
+        uint32 nonce
+    );
+
+    constructor() public {}
+
+    function lockAssets(
+        address asset,
+        uint256 amount,
+        bytes32 recipient,
+        uint8 targetChain,
+        uint32 nonce,
+        bool refund_dust
+    ) public {
+        ERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
+
+        uint8 asset_chain = CHAIN_ID;
+        uint8 decimals = ERC20Detailed(asset).decimals();
+        bytes32 asset_address = bytes32(uint256(asset));
+
+        emit LogTokensLocked(
+            targetChain,
+            asset_chain,
+            decimals,
+            asset_address,
+            bytes32(uint256(msg.sender)),
+            recipient,
+            amount,
+            nonce
+        );
+    }
+}

--- a/eth-contracts/migrations/10_wormhole_client_migration.js
+++ b/eth-contracts/migrations/10_wormhole_client_migration.js
@@ -1,0 +1,46 @@
+const contractConfig = require('../contract-config.js')
+const _lib = require('../utils/lib')
+const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
+const WormholeClient = artifacts.require('WormholeClient')
+const Governance = artifacts.require('Governance')
+const MockWormhole = artifacts.require('MockWormhole') // TODO: remove this
+
+const wormholeClientProxyKey = web3.utils.utf8ToHex('WormholeClientProxy')
+
+module.exports = (deployer, network, accounts) => {
+  deployer.then(async () => {
+    const config = contractConfig[network]
+    const proxyAdminAddress = config.proxyAdminAddress || accounts[10]
+    const proxyDeployerAddress = config.proxyDeployerAddress || accounts[11]
+    const guardianAddress = config.guardianAddress || proxyDeployerAddress
+    // const wormholeAddress = config.wormholeAddress
+
+    const tokenAddress = process.env.tokenAddress
+    const governanceAddress = process.env.governanceAddress
+
+    const governance = await Governance.at(governanceAddress)
+
+    // Deploy WormholeClient logic and proxy contracts + register proxy
+    const mockWormhole = await deployer.deploy(MockWormhole, { from: proxyDeployerAddress }) // TODO: remove this
+    const wormholeClient0 = await deployer.deploy(WormholeClient, { from: proxyDeployerAddress })
+    const initializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [tokenAddress, mockWormhole.address]
+    )
+
+    const wormholeClientProxy = await deployer.deploy(
+      AudiusAdminUpgradeabilityProxy,
+      wormholeClient0.address,
+      governanceAddress,
+      initializeCallData,
+      { from: proxyDeployerAddress }
+    )
+
+    const wormholeClient = await WormholeClient.at(wormholeClientProxy.address)
+    _lib.registerContract(governance, wormholeClientProxyKey, wormholeClientProxy.address, guardianAddress)
+
+    // Set environment variable
+    process.env.wormholeClientAddress = wormholeClientProxy.address
+  })
+}

--- a/eth-contracts/migrations/10_wormhole_client_migration.js
+++ b/eth-contracts/migrations/10_wormhole_client_migration.js
@@ -3,8 +3,7 @@ const _lib = require('../utils/lib')
 const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
 const WormholeClient = artifacts.require('WormholeClient')
 const Governance = artifacts.require('Governance')
-const MockWormhole = artifacts.require('MockWormhole') // TODO: remove this
-
+const MockWormhole = artifacts.require('MockWormhole')
 const wormholeClientProxyKey = web3.utils.utf8ToHex('WormholeClientProxy')
 
 module.exports = (deployer, network, accounts) => {
@@ -13,20 +12,24 @@ module.exports = (deployer, network, accounts) => {
     const proxyAdminAddress = config.proxyAdminAddress || accounts[10]
     const proxyDeployerAddress = config.proxyDeployerAddress || accounts[11]
     const guardianAddress = config.guardianAddress || proxyDeployerAddress
-    // const wormholeAddress = config.wormholeAddress
+    let wormholeAddress = config.wormholeAddress
 
     const tokenAddress = process.env.tokenAddress
     const governanceAddress = process.env.governanceAddress
 
     const governance = await Governance.at(governanceAddress)
 
+    if (wormholeAddress === null) {
+      const mockWormhole = await deployer.deploy(MockWormhole, { from: proxyDeployerAddress })
+      wormholeAddress = mockWormhole.address
+    }
+
     // Deploy WormholeClient logic and proxy contracts + register proxy
-    const mockWormhole = await deployer.deploy(MockWormhole, { from: proxyDeployerAddress }) // TODO: remove this
     const wormholeClient0 = await deployer.deploy(WormholeClient, { from: proxyDeployerAddress })
     const initializeCallData = _lib.encodeCall(
       'initialize',
       ['address', 'address'],
-      [tokenAddress, mockWormhole.address]
+      [tokenAddress, wormholeAddress]
     )
 
     const wormholeClientProxy = await deployer.deploy(

--- a/eth-contracts/migrations/11_eth_rewards_manager_migration.js
+++ b/eth-contracts/migrations/11_eth_rewards_manager_migration.js
@@ -1,0 +1,46 @@
+const contractConfig = require('../contract-config.js')
+const _lib = require('../utils/lib')
+const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
+const EthRewardsManager = artifacts.require('EthRewardsManager')
+const Governance = artifacts.require('Governance')
+const MockWormhole = artifacts.require('MockWormhole') // TODO: remove this
+
+const ethRewardsManagerProxyKey = web3.utils.utf8ToHex('EthRewardsManagerProxy')
+
+module.exports = (deployer, network, accounts) => {
+  deployer.then(async () => {
+    const config = contractConfig[network]
+    const proxyAdminAddress = config.proxyAdminAddress || accounts[10]
+    const proxyDeployerAddress = config.proxyDeployerAddress || accounts[11]
+    const guardianAddress = config.guardianAddress || proxyDeployerAddress
+    // const wormholeAddress = config.wormholeAddress
+
+    const tokenAddress = process.env.tokenAddress
+    const governanceAddress = process.env.governanceAddress
+
+    const governance = await Governance.at(governanceAddress)
+
+    // Deploy EthRewardsManager logic and proxy contracts + register proxy
+    const mockWormhole = await deployer.deploy(MockWormhole, { from: proxyDeployerAddress }) // TODO: remove this
+    const ethRewardsManager0 = await deployer.deploy(EthRewardsManager, { from: proxyDeployerAddress })
+    const initializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address', 'address', 'bytes32', 'address'],
+      [tokenAddress, governanceAddress, mockWormhole.address, Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), accounts[13]]
+    )
+
+    const ethRewardsManagerProxy = await deployer.deploy(
+      AudiusAdminUpgradeabilityProxy,
+      ethRewardsManager0.address,
+      governanceAddress,
+      initializeCallData,
+      { from: proxyDeployerAddress }
+    )
+
+    const ethRewardsManager = await EthRewardsManager.at(ethRewardsManagerProxy.address)
+    _lib.registerContract(governance, ethRewardsManagerProxyKey, ethRewardsManagerProxy.address, guardianAddress)
+
+    // Set environment variable
+    process.env.ethRewardsManagerAddress = ethRewardsManagerProxy.address
+  })
+}

--- a/eth-contracts/test/ethRewardsManager.test.js
+++ b/eth-contracts/test/ethRewardsManager.test.js
@@ -70,6 +70,18 @@ contract('EthRewardsManager', async (accounts) => {
     await registry.addContract(ethRewardsManagerProxyKey, ethRewardsManagerProxy.address, { from: proxyDeployerAddress })
   })
 
+  it('botOracle', async () => {
+    await governance.guardianExecuteTransaction(
+      ethRewardsManagerProxyKey,
+      callValue0,
+      'setBotOracle(address)',
+      _lib.abiEncode(['address'], [accounts[10]]),
+      { from: guardianAddress }
+    )
+
+    assert.equal(await ethRewardsManagerProxy.botOracle(), accounts[10])
+  })
+
   it('transferToSolana', async () => {
     const amount = 100
 
@@ -86,5 +98,9 @@ contract('EthRewardsManager', async (accounts) => {
 
     assert.equal((await token.balanceOf(ethRewardsManagerProxy.address)).toNumber(), 0)
     assert.equal((await token.balanceOf(mockWormhole.address)).toNumber(), 100)
+  })
+
+  it('token', async () => {
+    assert.equal(await ethRewardsManagerProxy.token(), token.address)
   })
 })

--- a/eth-contracts/test/ethRewardsManager.test.js
+++ b/eth-contracts/test/ethRewardsManager.test.js
@@ -19,7 +19,7 @@ contract('EthRewardsManager', async (accounts) => {
   const [, proxyAdminAddress, proxyDeployerAddress, staker, newUpdateAddress] = accounts
   const tokenOwnerAddress = proxyDeployerAddress
   const guardianAddress = proxyDeployerAddress
-  const botOracle = proxyDeployerAddress
+  const antiAbuseOracle = proxyDeployerAddress
   const recipient = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
   const newRecipient = Buffer.from('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
 
@@ -57,7 +57,7 @@ contract('EthRewardsManager', async (accounts) => {
     const ethRewardsManagerInitializeCallData = _lib.encodeCall(
       'initialize',
       ['address', 'address', 'address', 'bytes32', 'address'],
-      [token.address, governance.address, mockWormhole.address, recipient, botOracle]
+      [token.address, governance.address, mockWormhole.address, recipient, antiAbuseOracle]
     )
     ethRewardsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       ethRewardsManager0.address,
@@ -84,7 +84,7 @@ contract('EthRewardsManager', async (accounts) => {
     )
 
     await _lib.assertRevert(
-      ethRewardsManagerProxy.setBotOracle(newGovernance.address, { from: accounts[7] }),
+      ethRewardsManagerProxy.setantiAbuseOracle(newGovernance.address, { from: accounts[7] }),
       'Only governance'
     )
 
@@ -110,21 +110,21 @@ contract('EthRewardsManager', async (accounts) => {
     assert.equal(await ethRewardsManagerProxy.getGovernanceAddress(), newGovernance.address)
   })
 
-  it('botOracle', async () => {
+  it('antiAbuseOracle', async () => {
     await _lib.assertRevert(
-      ethRewardsManagerProxy.setBotOracle(accounts[10], { from: accounts[7] }),
+      ethRewardsManagerProxy.setantiAbuseOracle(accounts[10], { from: accounts[7] }),
       'Only governance'
     )
 
     await governance.guardianExecuteTransaction(
       ethRewardsManagerProxyKey,
       callValue0,
-      'setBotOracle(address)',
+      'setantiAbuseOracle(address)',
       _lib.abiEncode(['address'], [accounts[10]]),
       { from: guardianAddress }
     )
 
-    assert.equal(await ethRewardsManagerProxy.botOracle(), accounts[10])
+    assert.equal(await ethRewardsManagerProxy.antiAbuseOracle(), accounts[10])
   })
 
   it('recipient', async () => {

--- a/eth-contracts/test/ethRewardsManager.test.js
+++ b/eth-contracts/test/ethRewardsManager.test.js
@@ -21,6 +21,7 @@ contract('EthRewardsManager', async (accounts) => {
   const guardianAddress = proxyDeployerAddress
   const botOracle = proxyDeployerAddress
   const recipient = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+  const newRecipient = Buffer.from('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
 
   const votingPeriod = 10
   const executionDelay = votingPeriod
@@ -124,6 +125,23 @@ contract('EthRewardsManager', async (accounts) => {
     )
 
     assert.equal(await ethRewardsManagerProxy.botOracle(), accounts[10])
+  })
+
+  it('recipient', async () => {
+    await _lib.assertRevert(
+      ethRewardsManagerProxy.setRecipient(newRecipient, { from: accounts[7] }),
+      'Only governance'
+    )
+
+    await governance.guardianExecuteTransaction(
+      ethRewardsManagerProxyKey,
+      callValue0,
+      'setRecipient(bytes32)',
+      _lib.abiEncode(['bytes32'], [newRecipient]),
+      { from: guardianAddress }
+    )
+
+    assert.equal(await ethRewardsManagerProxy.getRecipient(), `0x${newRecipient.toString('hex')}`)
   })
 
   it('transferToSolana', async () => {

--- a/eth-contracts/test/ethRewardsManager.test.js
+++ b/eth-contracts/test/ethRewardsManager.test.js
@@ -1,0 +1,90 @@
+import * as _lib from '../utils/lib.js'
+import * as _signatures from '../utils/signatures.js'
+
+const MockWormhole = artifacts.require('MockWormhole')
+const EthRewardsManager = artifacts.require('EthRewardsManager')
+const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
+
+const governanceKey = web3.utils.utf8ToHex('Governance')
+const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
+const ethRewardsManagerProxyKey = web3.utils.utf8ToHex('EthRewardsManagerProxy')
+
+const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
+const callValue0 = _lib.toBN(0)
+
+contract('EthRewardsManager', async (accounts) => {
+  let registry, governance, token, ethRewardsManager0, ethRewardsManagerProxy, ethRewardsManager
+  let mockWormhole
+
+  const [, proxyAdminAddress, proxyDeployerAddress, staker, newUpdateAddress] = accounts
+  const tokenOwnerAddress = proxyDeployerAddress
+  const guardianAddress = proxyDeployerAddress
+  const botOracle = proxyDeployerAddress
+  const recipient = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+
+  const votingPeriod = 10
+  const executionDelay = votingPeriod
+  const votingQuorumPercent = 10
+
+  beforeEach(async () => {
+    registry = await _lib.deployRegistry(artifacts, proxyAdminAddress, proxyDeployerAddress)
+    governance = await _lib.deployGovernance(
+      artifacts,
+      proxyAdminAddress,
+      proxyDeployerAddress,
+      registry,
+      votingPeriod,
+      executionDelay,
+      votingQuorumPercent,
+      guardianAddress
+    )
+
+    token = await _lib.deployToken(
+      artifacts,
+      proxyAdminAddress,
+      proxyDeployerAddress,
+      tokenOwnerAddress,
+      governance.address
+    )
+
+    // Register token
+    await registry.addContract(tokenRegKey, token.address, { from: proxyDeployerAddress })
+
+    mockWormhole = await MockWormhole.new()
+
+    ethRewardsManager0 = await EthRewardsManager.new({ from: proxyDeployerAddress })
+    const ethRewardsManagerInitializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address', 'address', 'bytes32', 'address'],
+      [token.address, governance.address, mockWormhole.address, recipient, botOracle]
+    )
+    ethRewardsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
+      ethRewardsManager0.address,
+      governance.address,
+      ethRewardsManagerInitializeCallData,
+      { from: proxyDeployerAddress }
+    )
+    ethRewardsManagerProxy = await EthRewardsManager.at(ethRewardsManagerProxy.address)
+
+    // Register ethRewardsManagerProxy
+    await registry.addContract(ethRewardsManagerProxyKey, ethRewardsManagerProxy.address, { from: proxyDeployerAddress })
+  })
+
+  it('transferToSolana', async () => {
+    const amount = 100
+
+    await token.transfer(ethRewardsManagerProxy.address, amount, { from: tokenOwnerAddress })
+    assert.equal((await token.balanceOf(ethRewardsManagerProxy.address)).toNumber(), amount)
+
+    await governance.guardianExecuteTransaction(
+      ethRewardsManagerProxyKey,
+      callValue0,
+      'transferToSolana(uint32)',
+      _lib.abiEncode(['uint32'], [1]),
+      { from: guardianAddress }
+    )
+
+    assert.equal((await token.balanceOf(ethRewardsManagerProxy.address)).toNumber(), 0)
+    assert.equal((await token.balanceOf(mockWormhole.address)).toNumber(), 100)
+  })
+})

--- a/eth-contracts/test/ethRewardsManager.test.js
+++ b/eth-contracts/test/ethRewardsManager.test.js
@@ -1,46 +1,68 @@
 import * as _lib from '../utils/lib.js'
-import * as _signatures from '../utils/signatures.js'
 const { time, expectEvent } = require('@openzeppelin/test-helpers')
 
+const MockDelegateManager = artifacts.require('MockDelegateManager')
+const MockStakingCaller = artifacts.require('MockStakingCaller')
 const MockWormhole = artifacts.require('MockWormhole')
 const EthRewardsManager = artifacts.require('EthRewardsManager')
+const Staking = artifacts.require('Staking')
 const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
+const ClaimsManager = artifacts.require('ClaimsManager')
 
+const stakingProxyKey = web3.utils.utf8ToHex('StakingProxy')
+const serviceProviderFactoryKey = web3.utils.utf8ToHex('ServiceProviderFactory')
+const delegateManagerKey = web3.utils.utf8ToHex('DelegateManager')
 const governanceKey = web3.utils.utf8ToHex('Governance')
+const claimsManagerProxyKey = web3.utils.utf8ToHex('ClaimsManagerProxy')
 const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
 const ethRewardsManagerProxyKey = web3.utils.utf8ToHex('EthRewardsManagerProxy')
 
+const RECURRING_COMMUNITY_FUNDING_AMOUNT = 120
 const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
+const VOTING_PERIOD = 10
+const EXECUTION_DELAY = VOTING_PERIOD
+const VOTING_QUORUM_PERCENT = 10
+
 const callValue0 = _lib.toBN(0)
 
 contract('EthRewardsManager', async (accounts) => {
-  let registry, governance, token, ethRewardsManager0, ethRewardsManagerProxy, ethRewardsManager
-  let mockWormhole
+  let token, registry, governance, staking, claimsManager, ethRewardsManager
+  let mockDelegateManager, mockStakingCaller, mockWormhole
 
+  // intentionally not using acct0 to make sure no TX accidentally succeeds without specifying sender
   const [, proxyAdminAddress, proxyDeployerAddress, staker, newUpdateAddress] = accounts
   const tokenOwnerAddress = proxyDeployerAddress
   const guardianAddress = proxyDeployerAddress
   const antiAbuseOracleAddress = proxyDeployerAddress
   const recipient = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
-  const newRecipient = Buffer.from('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
 
-  const votingPeriod = 10
-  const executionDelay = votingPeriod
-  const votingQuorumPercent = 10
+  const approveTransferAndStake = async (amount, staker) => {
+    // Transfer default tokens to
+    await token.transfer(staker, amount, { from: proxyDeployerAddress })
+    // Allow Staking app to move owner tokens
+    await token.approve(staking.address, amount, { from: staker })
+    // Stake tokens
+    await mockStakingCaller.stakeFor(staker, amount)
+  }
 
   beforeEach(async () => {
+    // Deploy registry
     registry = await _lib.deployRegistry(artifacts, proxyAdminAddress, proxyDeployerAddress)
+
+    // Deploy + register governance
     governance = await _lib.deployGovernance(
       artifacts,
       proxyAdminAddress,
       proxyDeployerAddress,
       registry,
-      votingPeriod,
-      executionDelay,
-      votingQuorumPercent,
+      VOTING_PERIOD,
+      EXECUTION_DELAY,
+      VOTING_QUORUM_PERCENT,
       guardianAddress
     )
+    await registry.addContract(governanceKey, governance.address, { from: proxyDeployerAddress })
 
+    // Deploy + register token
     token = await _lib.deployToken(
       artifacts,
       proxyAdminAddress,
@@ -48,28 +70,129 @@ contract('EthRewardsManager', async (accounts) => {
       tokenOwnerAddress,
       governance.address
     )
-
-    // Register token
     await registry.addContract(tokenRegKey, token.address, { from: proxyDeployerAddress })
 
+    // Deploy and register staking
+    const staking0 = await Staking.new({ from: proxyDeployerAddress })
+    const stakingInitializeData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [token.address, governance.address]
+    )
+    const stakingProxy = await AudiusAdminUpgradeabilityProxy.new(
+      staking0.address,
+      governance.address,
+      stakingInitializeData,
+      { from: proxyDeployerAddress }
+    )
+    await registry.addContract(stakingProxyKey, stakingProxy.address, { from: proxyDeployerAddress })
+    staking = await Staking.at(stakingProxy.address)
+
+    // Mock SP for test
+    mockStakingCaller = await MockStakingCaller.new()
+    await mockStakingCaller.initialize(stakingProxy.address, token.address)
+    await registry.addContract(serviceProviderFactoryKey, mockStakingCaller.address, { from: proxyDeployerAddress })
+
+    // Mock Wormhole for test
     mockWormhole = await MockWormhole.new()
 
-    ethRewardsManager0 = await EthRewardsManager.new({ from: proxyDeployerAddress })
+    // Deploy claimsManagerProxy
+    const claimsManager0 = await ClaimsManager.new({ from: proxyDeployerAddress })
+    const claimsInitializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [token.address, governance.address]
+    )
+    const claimsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
+      claimsManager0.address,
+      governance.address,
+      claimsInitializeCallData,
+      { from: proxyDeployerAddress }
+    )
+    claimsManager = await ClaimsManager.at(claimsManagerProxy.address)
+
+    // Register claimsManagerProxy
+    await registry.addContract(claimsManagerProxyKey, claimsManagerProxy.address, { from: proxyDeployerAddress })
+
+    // Deploy mock delegate manager with only function to forward processClaim call
+    mockDelegateManager = await MockDelegateManager.new()
+    await mockDelegateManager.initialize(claimsManagerProxy.address)
+    await registry.addContract(delegateManagerKey, mockDelegateManager.address, { from: proxyDeployerAddress })
+
+    // Deploy ethRewardsManagerProxy
+    const ethRewardsManager0 = await EthRewardsManager.new({ from: proxyDeployerAddress })
     const ethRewardsManagerInitializeCallData = _lib.encodeCall(
       'initialize',
       ['address', 'address', 'address', 'bytes32', 'address'],
       [token.address, governance.address, mockWormhole.address, recipient, antiAbuseOracleAddress]
     )
-    ethRewardsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
+    const ethRewardsManagerProxy = await AudiusAdminUpgradeabilityProxy.new(
       ethRewardsManager0.address,
       governance.address,
       ethRewardsManagerInitializeCallData,
       { from: proxyDeployerAddress }
     )
-    ethRewardsManagerProxy = await EthRewardsManager.at(ethRewardsManagerProxy.address)
+    ethRewardsManager = await EthRewardsManager.at(ethRewardsManagerProxy.address)
 
     // Register ethRewardsManagerProxy
     await registry.addContract(ethRewardsManagerProxyKey, ethRewardsManagerProxy.address, { from: proxyDeployerAddress })
+
+    // Register claimsManager contract as a minter, from the same address that deployed the contract
+    await governance.guardianExecuteTransaction(
+      tokenRegKey,
+      callValue0,
+      'addMinter(address)',
+      _lib.abiEncode(['address'], [claimsManager.address]),
+      { from: guardianAddress }
+    )
+
+    // ---- Configuring addresses
+    await _lib.configureGovernanceContractAddresses(
+      governance,
+      governanceKey,
+      guardianAddress,
+      stakingProxy.address,
+      mockStakingCaller.address,
+      mockDelegateManager.address
+    )
+
+    // ---- Set up staking contract permissions
+    await _lib.configureStakingContractAddresses(
+      governance,
+      guardianAddress,
+      stakingProxyKey,
+      staking,
+      mockStakingCaller.address,
+      claimsManagerProxy.address,
+      mockDelegateManager.address
+    )
+
+    // --- Set up claims manager contract permissions
+    await _lib.configureClaimsManagerContractAddresses(
+      governance,
+      guardianAddress,
+      claimsManagerProxyKey,
+      claimsManager,
+      staking.address,
+      mockStakingCaller.address,
+      mockDelegateManager.address
+    )
+
+    await governance.guardianExecuteTransaction(
+      claimsManagerProxyKey,
+      callValue0,
+      'updateRecurringCommunityFundingAmount(uint256)',
+      _lib.abiEncode(['uint256'], [RECURRING_COMMUNITY_FUNDING_AMOUNT]),
+      { from: guardianAddress }
+    )
+
+    await governance.guardianExecuteTransaction(
+      claimsManagerProxyKey,
+      callValue0,
+      'updateCommunityPoolAddress(address)',
+      _lib.abiEncode(['address'], [ethRewardsManagerProxy.address]),
+      { from: guardianAddress }
+    )
   })
 
   it('governanceAddress', async () => {
@@ -78,14 +201,14 @@ contract('EthRewardsManager', async (accounts) => {
       proxyAdminAddress,
       proxyDeployerAddress,
       registry,
-      votingPeriod,
-      executionDelay,
-      votingQuorumPercent,
+      VOTING_PERIOD,
+      EXECUTION_DELAY,
+      VOTING_QUORUM_PERCENT,
       guardianAddress
     )
 
     await _lib.assertRevert(
-      ethRewardsManagerProxy.setGovernanceAddress(newGovernance.address, { from: accounts[7] }),
+      ethRewardsManager.setGovernanceAddress(newGovernance.address, { from: accounts[7] }),
       'Only governance'
     )
 
@@ -108,12 +231,12 @@ contract('EthRewardsManager', async (accounts) => {
       { from: guardianAddress }
     )
 
-    assert.equal(await ethRewardsManagerProxy.getGovernanceAddress(), newGovernance.address)
+    assert.equal(await ethRewardsManager.getGovernanceAddress(), newGovernance.address)
   })
 
   it('antiAbuseOracleAddress', async () => {
     await _lib.assertRevert(
-      ethRewardsManagerProxy.setAntiAbuseOracleAddress(accounts[10], { from: accounts[7] }),
+      ethRewardsManager.setAntiAbuseOracleAddress(accounts[10], { from: accounts[7] }),
       'Only governance'
     )
 
@@ -125,12 +248,14 @@ contract('EthRewardsManager', async (accounts) => {
       { from: guardianAddress }
     )
 
-    assert.equal(await ethRewardsManagerProxy.antiAbuseOracleAddress(), accounts[10])
+    assert.equal(await ethRewardsManager.antiAbuseOracleAddress(), accounts[10])
   })
 
   it('recipient', async () => {
+    const newRecipient = Buffer.from('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
+
     await _lib.assertRevert(
-      ethRewardsManagerProxy.setRecipientAddress(newRecipient, { from: accounts[7] }),
+      ethRewardsManager.setRecipientAddress(newRecipient, { from: accounts[7] }),
       'Only governance'
     )
 
@@ -142,17 +267,17 @@ contract('EthRewardsManager', async (accounts) => {
       { from: guardianAddress }
     )
 
-    assert.equal(await ethRewardsManagerProxy.getRecipientAddress(), `0x${newRecipient.toString('hex')}`)
+    assert.equal(await ethRewardsManager.getRecipientAddress(), `0x${newRecipient.toString('hex')}`)
   })
 
   it('transferToSolana', async () => {
     const amount = 100
 
-    await token.transfer(ethRewardsManagerProxy.address, amount, { from: tokenOwnerAddress })
-    assert.equal((await token.balanceOf(ethRewardsManagerProxy.address)).toNumber(), amount)
+    await token.transfer(ethRewardsManager.address, amount, { from: tokenOwnerAddress })
+    assert.equal((await token.balanceOf(ethRewardsManager.address)).toNumber(), amount)
 
     await _lib.assertRevert(
-      ethRewardsManagerProxy.transferToSolana(1, { from: accounts[7] }),
+      ethRewardsManager.transferToSolana(1, { from: accounts[7] }),
       'Only governance'
     )
 
@@ -169,17 +294,54 @@ contract('EthRewardsManager', async (accounts) => {
       tokenChain: '2',
       tokenDecimals: await token.decimals(),
       token: web3.utils.padLeft(token.address, 64).toLowerCase(),
-      sender: web3.utils.padLeft(ethRewardsManagerProxy.address, 64).toLowerCase(),
+      sender: web3.utils.padLeft(ethRewardsManager.address, 64).toLowerCase(),
       recipient: `0x${recipient.toString('hex')}`,
       amount: amount.toString(),
       nonce: '1'
     })
 
-    assert.equal((await token.balanceOf(ethRewardsManagerProxy.address)).toNumber(), 0)
+    assert.equal((await token.balanceOf(ethRewardsManager.address)).toNumber(), 0)
     assert.equal((await token.balanceOf(mockWormhole.address)).toNumber(), 100)
   })
 
+  it('transferToSolana from claimsManager', async () => {
+    await approveTransferAndStake(DEFAULT_AMOUNT, staker)
+    let initiateTx = await claimsManager.initiateRound({ from: staker })
+
+    assert.equal(await token.balanceOf(ethRewardsManager.address), RECURRING_COMMUNITY_FUNDING_AMOUNT)
+
+    // Confirm events
+    await expectEvent.inTransaction(
+      initiateTx.tx,
+      ClaimsManager,
+      'CommunityRewardsTransferred',
+      {
+        _transferAddress: ethRewardsManager.address,
+        _amount: _lib.toBN(RECURRING_COMMUNITY_FUNDING_AMOUNT)
+      }
+    )
+
+    const transferToSolanaTx = await governance.guardianExecuteTransaction(
+      ethRewardsManagerProxyKey,
+      callValue0,
+      'transferToSolana(uint32)',
+      _lib.abiEncode(['uint32'], [1]),
+      { from: guardianAddress }
+    )
+
+    await expectEvent.inTransaction(transferToSolanaTx.tx, MockWormhole, 'LogTokensLocked', {
+      targetChain: '1',
+      tokenChain: '2',
+      tokenDecimals: await token.decimals(),
+      token: web3.utils.padLeft(token.address, 64).toLowerCase(),
+      sender: web3.utils.padLeft(ethRewardsManager.address, 64).toLowerCase(),
+      recipient: `0x${recipient.toString('hex')}`,
+      amount: RECURRING_COMMUNITY_FUNDING_AMOUNT.toString(),
+      nonce: '1'
+    })
+  })
+
   it('token', async () => {
-    assert.equal(await ethRewardsManagerProxy.token(), token.address)
+    assert.equal(await ethRewardsManager.token(), token.address)
   })
 })

--- a/eth-contracts/test/wormholeClient.test.js
+++ b/eth-contracts/test/wormholeClient.test.js
@@ -1,0 +1,115 @@
+import * as _lib from '../utils/lib.js'
+import * as _signatures from '../utils/signatures.js'
+
+const MockWormhole = artifacts.require('MockWormhole')
+const WormholeClient = artifacts.require('WormholeClient')
+const AudiusAdminUpgradeabilityProxy = artifacts.require('AudiusAdminUpgradeabilityProxy')
+
+const governanceKey = web3.utils.utf8ToHex('Governance')
+const tokenRegKey = web3.utils.utf8ToHex('TokenKey')
+const wormholeClientProxyKey = web3.utils.utf8ToHex('WormholeClientProxy')
+
+const DEFAULT_AMOUNT = _lib.audToWeiBN(120)
+
+contract('WormholeClient', async (accounts) => {
+  let registry, governance, token, wormholeClient0, wormholeClientProxy, wormholeClient
+  let mockWormhole
+
+  const [, proxyAdminAddress, proxyDeployerAddress, staker, newUpdateAddress] = accounts
+  const tokenOwnerAddress = proxyDeployerAddress
+  const guardianAddress = proxyDeployerAddress
+
+  const votingPeriod = 10
+  const executionDelay = votingPeriod
+  const votingQuorumPercent = 10
+
+  beforeEach(async () => {
+    registry = await _lib.deployRegistry(artifacts, proxyAdminAddress, proxyDeployerAddress)
+    governance = await _lib.deployGovernance(
+      artifacts,
+      proxyAdminAddress,
+      proxyDeployerAddress,
+      registry,
+      votingPeriod,
+      executionDelay,
+      votingQuorumPercent,
+      guardianAddress
+    )
+
+    token = await _lib.deployToken(
+      artifacts,
+      proxyAdminAddress,
+      proxyDeployerAddress,
+      tokenOwnerAddress,
+      governance.address
+    )
+
+    // Register token
+    await registry.addContract(tokenRegKey, token.address, { from: proxyDeployerAddress })
+
+    mockWormhole = await MockWormhole.new()
+
+    wormholeClient0 = await WormholeClient.new({ from: proxyDeployerAddress })
+    const wormholeClientInitializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [token.address, mockWormhole.address]
+    )
+    wormholeClientProxy = await AudiusAdminUpgradeabilityProxy.new(
+      wormholeClient0.address,
+      governance.address,
+      wormholeClientInitializeCallData,
+      { from: proxyDeployerAddress }
+    )
+    wormholeClient = await WormholeClient.at(wormholeClientProxy.address)
+
+    // Register claimsManagerProxy
+    await registry.addContract(wormholeClientProxyKey, wormholeClientProxy.address, { from: proxyDeployerAddress })
+  })
+
+  it('lock assets', async () => {
+    const amount = 100
+    const chainId = 1 // in ganache, the chain ID the token initializes with is always 1
+
+    const fromAcctPrivKey = Buffer.from('76195632b07afded1ae36f68635b6ff86791bd4579a27ca28ec7e539fed65c0e', 'hex')
+    const fromAcct = '0xaaa30A4bB636F15be970f571BcBe502005E9D66b'
+
+    const relayerAcct = accounts[6] // account that calls lockAssets
+
+    const recipient = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+
+    await token.transfer(fromAcct, amount, { from: tokenOwnerAddress })
+    await _lib.permit(token, fromAcct, fromAcctPrivKey, wormholeClient.address, amount, relayerAcct)
+
+    const nonce = (await wormholeClient.nonces(fromAcct)).toNumber()
+    const deadline = (await web3.eth.getBlock(await web3.eth.getBlockNumber())).timestamp + 25 // sufficiently far in future
+    const digest = _signatures.getLockAssetsDigest(
+      'AudiusWormholeClient',
+      wormholeClient.address,
+      chainId,
+      {
+        from: fromAcct,
+        amount: amount,
+        recipient,
+        targetChain: 1,
+        refundDust: true
+      },
+      nonce,
+      deadline
+    )
+    const result = _signatures.sign(digest, fromAcctPrivKey)
+
+    await wormholeClient.lockAssets(
+      fromAcct,
+      amount,
+      recipient,
+      1,
+      true,
+      deadline,
+      result.v,
+      result.r,
+      result.s,
+      { from: relayerAcct }
+    )
+  })
+})

--- a/eth-contracts/test/wormholeClient.test.js
+++ b/eth-contracts/test/wormholeClient.test.js
@@ -68,6 +68,40 @@ contract('WormholeClient', async (accounts) => {
     await registry.addContract(wormholeClientProxyKey, wormholeClientProxy.address, { from: proxyDeployerAddress })
   })
 
+  it('fails when token is not a contract, init test', async () => {
+    const wormholeClient1 = await WormholeClient.new({ from: proxyDeployerAddress })
+    const invalidWormholeClientInitializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [accounts[5], mockWormhole.address]
+    )
+    await _lib.assertRevert(
+      AudiusAdminUpgradeabilityProxy.new(
+        wormholeClient1.address,
+        governance.address,
+        invalidWormholeClientInitializeCallData,
+        { from: proxyDeployerAddress }
+      )
+    )
+  })
+
+  it('fails when wormhole is not a contract, init test', async () => {
+    const wormholeClient1 = await WormholeClient.new({ from: proxyDeployerAddress })
+    const invalidWormholeClientInitializeCallData = _lib.encodeCall(
+      'initialize',
+      ['address', 'address'],
+      [token.address, accounts[5]]
+    )
+    await _lib.assertRevert(
+      AudiusAdminUpgradeabilityProxy.new(
+        wormholeClient1.address,
+        governance.address,
+        invalidWormholeClientInitializeCallData,
+        { from: proxyDeployerAddress }
+      )
+    )
+  })
+
   it('token', async () => {
     assert.equal(await wormholeClient.token(), token.address)
   })

--- a/eth-contracts/test/wormholeClient.test.js
+++ b/eth-contracts/test/wormholeClient.test.js
@@ -1,5 +1,6 @@
 import * as _lib from '../utils/lib.js'
 import * as _signatures from '../utils/signatures.js'
+const { time, expectEvent } = require('@openzeppelin/test-helpers')
 
 const MockWormhole = artifacts.require('MockWormhole')
 const WormholeClient = artifacts.require('WormholeClient')
@@ -137,7 +138,7 @@ contract('WormholeClient', async (accounts) => {
       'Invalid signature'
     )
 
-    await wormholeClient.lockAssets(
+    const tx = await wormholeClient.lockAssets(
       fromAcct,
       amount,
       recipient,
@@ -149,5 +150,16 @@ contract('WormholeClient', async (accounts) => {
       workingResult.s,
       { from: relayerAcct }
     )
+
+    await expectEvent.inTransaction(tx.tx, MockWormhole, 'LogTokensLocked', {
+      targetChain: '1',
+      tokenChain: '2',
+      tokenDecimals: await token.decimals(),
+      token: web3.utils.padLeft(token.address, 64).toLowerCase(),
+      sender: web3.utils.padLeft(wormholeClient.address, 64).toLowerCase(),
+      recipient: `0x${recipient.toString('hex')}`,
+      amount: amount.toString(),
+      nonce: nonce.toString()
+    })
   })
 })

--- a/eth-contracts/utils/signatures.js
+++ b/eth-contracts/utils/signatures.js
@@ -11,6 +11,10 @@ export const PERMIT_TYPEHASH = keccak256(
   toUtf8Bytes('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)')
 )
 
+export const LOCKASSETS_TYPEHASH = keccak256(
+  toUtf8Bytes('LockAssets(address from,uint256 amount,bytes32 recipient,uint8 targetChain,uint32 nonce,bool refundDust,uint256 deadline)')
+)
+
 // Returns the EIP712 hash which should be signed by the user
 // in order to make a call to `permit`
 export function getPermitDigest(
@@ -33,6 +37,54 @@ export function getPermitDigest(
           defaultAbiCoder.encode(
             ['bytes32', 'address', 'address', 'uint256', 'uint256', 'uint256'],
             [PERMIT_TYPEHASH, approve.owner, approve.spender, approve.value, nonce, deadline]
+          )
+        ),
+      ]
+    )
+  )
+}
+
+// Returns the EIP712 hash which should be signed by the user
+// in order to make a call to `lockAssets`
+export function getLockAssetsDigest(
+  name,
+  address,
+  chainId,
+  lockAssets,
+  nonce,
+  deadline
+) {
+  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, chainId)
+
+  return keccak256(
+    solidityPack(
+      ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
+      [
+        '0x19',
+        '0x01',
+        DOMAIN_SEPARATOR,
+        keccak256(
+          defaultAbiCoder.encode(
+            [
+              'bytes32', 
+              'address',
+              'uint256',
+              'bytes32',
+              'uint8',
+              'uint32',
+              'bool',
+              'uint256',
+            ],
+            [
+              LOCKASSETS_TYPEHASH,
+            	lockAssets.from,
+            	lockAssets.amount,
+            	lockAssets.recipient,
+            	lockAssets.targetChain,
+            	nonce,
+            	lockAssets.refundDust,
+            	deadline,
+            ]
           )
         ),
       ]

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -38,7 +38,7 @@
       "echo 'Waiting for ganache to fully come online...'",
       "sleep 5",
       "echo 'Migrating eth contracts'",
-      "cd eth-contracts/; node_modules/.bin/truffle migrate"
+      "cd eth-contracts/; node_modules/.bin/truffle migrate --f 1 --to 9"
     ],
     "down": [
       "cd eth-contracts/; npm run ganache-q"


### PR DESCRIPTION
### Description
This PR adds a wormhole client contract that acts as an intermediary to act as a gas payer.

This PR also adds the EthRewardsManager contract to act as an intermediary ETH address to hold Audio before wormholing it to wAudio on Solana. This contract also stores the AntiAbuseOracle address that can be set via governance.

### Tests
Unit tests for both contracts. WormholeClient has been tested in production