### PR TITLE
Use verbose health check resp to determine peer health

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -40,9 +40,11 @@ WAIT_HOSTS=
 enableRehydrate=true
 
 peerHealthCheckRequestTimeout=2000
+# bytes
 minimumStoragePathSize=100000000000
+# bytes
 minimumMemoryAvailable=6000000000
 maxFileDescriptorsAllocatedPercentage=95
-minimumDailySyncCount=50
-minimumRollingSyncCount=5000
+minimumDailySyncCount=5
+minimumRollingSyncCount=10
 minimumSuccessfulSyncCountPercentage=50

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -40,9 +40,9 @@ WAIT_HOSTS=
 enableRehydrate=true
 
 peerHealthCheckRequestTimeout=2000
-# bytes
+# bytes; 100gb
 minimumStoragePathSize=100000000000
-# bytes
+# bytes; 6gb 
 minimumMemoryAvailable=6000000000
 maxFileDescriptorsAllocatedPercentage=95
 minimumDailySyncCount=5

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -38,3 +38,11 @@ creatorNodeIsDebug=true
 
 WAIT_HOSTS=
 enableRehydrate=true
+
+peerHealthCheckRequestTimeout=2000
+minimumStoragePathSize=100000000000
+minimumMemoryAvailable=6000000000
+maxFileDescriptorsAllocatedPercentage=95
+minimumDailySyncCount=50
+minimumRollingSyncCount=5000
+minimumSuccessfulSyncCountPercentage=50

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -40,10 +40,10 @@ WAIT_HOSTS=
 enableRehydrate=true
 
 peerHealthCheckRequestTimeout=2000
-# bytes; 100gb
-minimumStoragePathSize=100000000000
-# bytes; 6gb 
-minimumMemoryAvailable=6000000000
+# bytes; 10gb
+minimumStoragePathSize=10000000000
+# bytes; 2gb 
+minimumMemoryAvailable=2000000000
 maxFileDescriptorsAllocatedPercentage=95
 minimumDailySyncCount=5
 minimumRollingSyncCount=10

--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -100,10 +100,10 @@ export creatorNodeEndpoint="http://localhost:5000"
 export spOwnerWallet="0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25"
 
 # Setting peerSetManager env vars
-# bytes; 100gb
-export minimumStoragePathSize=100000000000
-# bytes; 6gb 
-export minimumMemoryAvailable=6000000000
+# bytes; 10gb
+export minimumStoragePathSize=10000000000
+# bytes; 2gb 
+export minimumMemoryAvailable=2000000000
 export maxFileDescriptorsAllocatedPercentage=95
 export minimumDailySyncCount=50
 export minimumRollingSyncCount=5000

--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -105,8 +105,8 @@ export minimumStoragePathSize=10000000000
 # bytes; 2gb 
 export minimumMemoryAvailable=2000000000
 export maxFileDescriptorsAllocatedPercentage=95
-export minimumDailySyncCount=50
-export minimumRollingSyncCount=5000
+export minimumDailySyncCount=5
+export minimumRollingSyncCount=10
 export minimumSuccessfulSyncCountPercentage=50
 
 # tests

--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -99,6 +99,16 @@ export delegatePrivateKey="0xdb527e4d4a2412a443c17e1666764d3bba43e89e61129a35f9a
 export creatorNodeEndpoint="http://localhost:5000"
 export spOwnerWallet="0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25"
 
+# Setting peerSetManager env vars
+# bytes; 100gb
+export minimumStoragePathSize=100000000000
+# bytes; 6gb 
+export minimumMemoryAvailable=6000000000
+export maxFileDescriptorsAllocatedPercentage=95
+export minimumDailySyncCount=50
+export minimumRollingSyncCount=5000
+export minimumSuccessfulSyncCountPercentage=50
+
 # tests
 run_unit_tests
 run_integration_tests

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -104,9 +104,6 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     MONITORS.LATEST_SYNC_FAIL_TIMESTAMP
   ])
 
-  const latestDailySyncCount = await getAggregateSyncData()
-  const latestDailySyncTimestamps = await getLatestSyncData()
-
   const response = {
     ...basicHealthCheck,
     country,

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -104,6 +104,9 @@ const healthCheckVerbose = async ({ libs } = {}, logger, sequelize, getMonitors,
     MONITORS.LATEST_SYNC_FAIL_TIMESTAMP
   ])
 
+  const latestDailySyncCount = await getAggregateSyncData()
+  const latestDailySyncTimestamps = await getLatestSyncData()
+
   const response = {
     ...basicHealthCheck,
     country,

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -482,6 +482,50 @@ const config = convict({
     format: 'nat',
     env: 'maxRecurringRequestSyncJobConcurrency',
     default: 5
+  },
+
+  // peerSetManager configs
+  peerHealthCheckRequestTimeout: {
+    doc: 'Timeout [ms] for checking health check route',
+    format: 'nat',
+    env: 'peerHealthCheckRequestTimeout',
+    default: 2000
+  },
+  minimumStoragePathSize: {
+    doc: 'Minimum storage size [bytes] on node to be a viable option in peer set',
+    format: 'nat',
+    env: 'minimumStoragePathSize',
+    default: 100000000000
+  },
+  minimumMemoryAvailable: {
+    doc: 'Minimum memory available [bytes] on node to be a viable option in peer set',
+    format: 'nat',
+    env: 'minimumMemoryAvailable',
+    default: 6000000000
+  },
+  maxFileDescriptorsAllocatedPercentage: {
+    doc: 'Max file descriptors allocated percentage on node to be a viable option in peer set',
+    format: 'nat',
+    env: 'maxFileDescriptorsAllocatedPercentage',
+    default: 95
+  },
+  minimumDailySyncCount: {
+    doc: 'Minimum count of daily syncs that need to have occurred to consider daily sync history',
+    format: 'nat',
+    env: 'minimumDailySyncCount',
+    default: 50
+  },
+  minimumRollingSyncCount: {
+    doc: 'Minimum count of rolling syncs that need to have occurred to consider rolling sync history',
+    format: 'nat',
+    env: 'minimumRollingSyncCount',
+    default: 5000
+  },
+  minimumSuccessfulSyncCountPercentage: {
+    doc: 'Minimum percentage of failed syncs to be considered unhealthy',
+    format: 'nat',
+    env: 'minimumSuccessfulSyncCountPercentage',
+    default: 50
   }
 
   // unsupported options at the moment

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -492,16 +492,16 @@ const config = convict({
     default: 2000
   },
   minimumStoragePathSize: {
-    doc: 'Minimum storage size [bytes] on node to be a viable option in peer set',
+    doc: 'Minimum storage size [bytes] on node to be a viable option in peer set; 100gb',
     format: 'nat',
     env: 'minimumStoragePathSize',
     default: 100000000000
   },
   minimumMemoryAvailable: {
-    doc: 'Minimum memory available [bytes] on node to be a viable option in peer set',
+    doc: 'Minimum memory available [bytes] on node to be a viable option in peer set; 2gb',
     format: 'nat',
     env: 'minimumMemoryAvailable',
-    default: 6000000000
+    default: 2000000000
   },
   maxFileDescriptorsAllocatedPercentage: {
     doc: 'Max file descriptors allocated percentage on node to be a viable option in peer set',
@@ -525,7 +525,8 @@ const config = convict({
     doc: 'Minimum percentage of failed syncs to be considered unhealthy',
     format: 'nat',
     env: 'minimumSuccessfulSyncCountPercentage',
-    default: 50
+    // TODO: Update to higher percentage when higher threshold of syncs are passing
+    default: 0
   }
 
   // unsupported options at the moment

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -3,8 +3,6 @@ const { handleResponse, successResponse, errorResponse, errorResponseServerError
 const config = require('../config')
 const { getIPFSPeerId } = require('../utils')
 
-const SyncHistoryAggregator = require('../snapbackSM/syncHistoryAggregator')
-
 module.exports = function (app) {
   /**
    * Exports all db data (not files) associated with walletPublicKey[] as JSON.
@@ -142,22 +140,6 @@ module.exports = function (app) {
       await transaction.rollback()
       return errorResponseServerError(e.message)
     }
-  }))
-
-  /**
-   * Returns sync history.
-   * `aggregateSyncData` - the number of succesful, failed, and triggered syncs for the current day
-   * `latestSyncData` - the date of the most recent successful and failed sync. will be `null` if no sync occurred with that state
-   *
-   * Structure:
-   *  aggregateSyncData = {triggered: <number>, success: <number>, fail: <number>}
-   *  latestSyncData = {success: <MM:DD:YYYYTHH:MM:SS:ssss>, fail: <MM:DD:YYYYTHH:MM:SS:ssss>}
-   */
-  app.get('/sync_history', handleResponse(async (req, res) => {
-    const aggregateSyncData = await SyncHistoryAggregator.getAggregateSyncData(req.logContext)
-    const latestSyncData = await SyncHistoryAggregator.getLatestSyncData(req.logContext)
-
-    return successResponse({ aggregateSyncData, latestSyncData })
   }))
 
   /** Checks if node sync is in progress for wallet. */

--- a/creator-node/test/peerSetManager.test.js
+++ b/creator-node/test/peerSetManager.test.js
@@ -65,7 +65,7 @@ describe('test peerSetManager()', () => {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
       assert.fail('Should not have passed without meeting minimum storage requirements')
     } catch (e) {
-      // Swallow error
+      assert.ok(e.message.includes('storage'))
     }
   })
 
@@ -91,7 +91,7 @@ describe('test peerSetManager()', () => {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
       assert.fail('Should not have passed without meeting minimum memory requirements')
     } catch (e) {
-      // Swallow error
+      assert.ok(e.message.includes('memory'))
     }
   })
 
@@ -115,7 +115,7 @@ describe('test peerSetManager()', () => {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
       assert.fail('Should not have passed when surpassing file descriptors open threshold')
     } catch (e) {
-      // Swallow error
+      assert.ok(e.message.includes('file descriptors'))
     }
   })
 
@@ -142,12 +142,13 @@ describe('test peerSetManager()', () => {
     }
 
     verboseHealthCheckResp.dailySyncSuccessCount = 5
-    verboseHealthCheckResp.dailySyncFailCount = 30
+    verboseHealthCheckResp.dailySyncFailCount = 55
 
     try {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
-    } catch (e) {
       assert.fail('Should not have passed when fail count percentage is greater than success count')
+    } catch (e) {
+      assert.ok(e.message.includes('sync data'))
     }
   })
 
@@ -180,7 +181,7 @@ describe('test peerSetManager()', () => {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
       assert.fail('Should not have passed when fail count percentage is greater than success count')
     } catch (e) {
-      // Swallow error
+      assert.ok(e.message.includes('sync data'))
     }
   })
 

--- a/creator-node/test/peerSetManager.test.js
+++ b/creator-node/test/peerSetManager.test.js
@@ -132,8 +132,8 @@ describe('test peerSetManager()', () => {
       assert.fail('Should not have considered latest sync history if vars are not present')
     }
 
-    verboseHealthCheckResp.dailySyncSuccessCount = 5
-    verboseHealthCheckResp.dailySyncFailCount = 10
+    verboseHealthCheckResp.dailySyncSuccessCount = 2
+    verboseHealthCheckResp.dailySyncFailCount = 1
 
     try {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)
@@ -166,7 +166,7 @@ describe('test peerSetManager()', () => {
     }
 
     verboseHealthCheckResp.thirtyDayRollingSyncSuccessCount = 5
-    verboseHealthCheckResp.thirtyDayRollingSyncFailCount = 10
+    verboseHealthCheckResp.thirtyDayRollingSyncFailCount = 1
 
     try {
       peerSetManager.determinePeerHealth(verboseHealthCheckResp)

--- a/creator-node/test/peerSetManager.test.js
+++ b/creator-node/test/peerSetManager.test.js
@@ -1,0 +1,194 @@
+const assert = require('assert')
+
+const PeerSetManager = require('../src/snapbackSM/peerSetManager')
+
+describe('test peerSetManager()', () => {
+  const peerSetManager = new PeerSetManager({
+    discoveryProviderEndpoint: 'https://discovery_endpoint.audius.co',
+    creatorNodeEndpoint: 'https://content_node_endpoint.audius.co'
+  })
+
+  const baseVerboseHealthCheckResp = {
+    version: '0.3.37',
+    service: 'content-node',
+    healthy: true,
+    git: '',
+    selectedDiscoveryProvider: 'http://audius-disc-prov_web-server_1:5000',
+    creatorNodeEndpoint: 'http://cn1_creator-node_1:4000',
+    spID: 1,
+    spOwnerWallet: '0xf7316fe994bb92556dcfd998038618ce1227aeea',
+    sRegisteredOnURSM: true,
+    country: 'US',
+    latitude: '41.2619',
+    longitude: '-95.8608',
+    databaseConnections: 5,
+    databaseSize: 8956927,
+    usedTCPMemory: 166,
+    receivedBytesPerSec: 756.3444159135626,
+    transferredBytesPerSec: 186363.63636363638,
+    maxStorageUsedPercent: 95,
+    numberOfCPUs: 12,
+    latestSyncSuccessTimestamp: '2021-06-08T21:29:34.231Z',
+    latestSyncFailTimestamp: '',
+
+    // Fields to consider in this test
+    thirtyDayRollingSyncSuccessCount: 50,
+    thirtyDayRollingSyncFailCount: 10,
+    dailySyncSuccessCount: 5,
+    dailySyncFailCount: 0,
+    totalMemory: 25219547136,
+    usedMemory: 16559153152,
+    maxFileDescriptors: 9223372036854776000,
+    allocatedFileDescriptors: 15456,
+    storagePathSize: 259975987200,
+    storagePathUsed: 59253436416
+  }
+
+  it('should throw error if storage path vars are improper', () => {
+    let verboseHealthCheckResp = {
+      ...baseVerboseHealthCheckResp
+    }
+    delete verboseHealthCheckResp.storagePathSize
+    delete verboseHealthCheckResp.storagePathUsed
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered storage criteria if vars are not present')
+    }
+
+    // In bytes
+    verboseHealthCheckResp.storagePathSize = 200000000000
+    verboseHealthCheckResp.storagePathUsed = 190000000000
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+      assert.fail('Should not have passed without meeting minimum storage requirements')
+    } catch (e) {
+      // Swallow error
+    }
+  })
+
+  it('should throw error if memory vars are improper', () => {
+    let verboseHealthCheckResp = {
+      ...baseVerboseHealthCheckResp
+    }
+    delete verboseHealthCheckResp.usedMemory
+    delete verboseHealthCheckResp.totalMemory
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      // Swallow error
+      assert.fail('Should not have considered memory criteria if vars are not present')
+    }
+
+    // In bytes
+    verboseHealthCheckResp.usedMemory = 6000000001
+    verboseHealthCheckResp.totalMemory = 12000000000
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+      assert.fail('Should not have passed without meeting minimum memory requirements')
+    } catch (e) {
+      // Swallow error
+    }
+  })
+
+  it('should throw error if the file descriptors are improper', () => {
+    let verboseHealthCheckResp = {
+      ...baseVerboseHealthCheckResp
+    }
+    delete verboseHealthCheckResp.allocatedFileDescriptors
+    delete verboseHealthCheckResp.maxFileDescriptors
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered file descriptors if vars are not present')
+    }
+
+    verboseHealthCheckResp.allocatedFileDescriptors = 1000
+    verboseHealthCheckResp.maxFileDescriptors = 1001
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+      assert.fail('Should not have passed when surpassing file descriptors open threshold')
+    } catch (e) {
+      // Swallow error
+    }
+  })
+
+  it('should throw error if latest sync history vars are improper', () => {
+    let verboseHealthCheckResp = {
+      ...baseVerboseHealthCheckResp
+    }
+    delete verboseHealthCheckResp.dailySyncSuccessCount
+    delete verboseHealthCheckResp.dailySyncFailCount
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered latest sync history if vars are not present')
+    }
+
+    verboseHealthCheckResp.dailySyncSuccessCount = 5
+    verboseHealthCheckResp.dailySyncFailCount = 10
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered latest sync history if mininum count not met')
+    }
+
+    verboseHealthCheckResp.dailySyncSuccessCount = 5
+    verboseHealthCheckResp.dailySyncFailCount = 30
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have passed when fail count percentage is greater than success count')
+    }
+  })
+
+  it('should throw error if rolling sync history vars are improper', () => {
+    let verboseHealthCheckResp = {
+      ...baseVerboseHealthCheckResp
+    }
+    delete verboseHealthCheckResp.thirtyDayRollingSyncSuccessCount
+    delete verboseHealthCheckResp.thirtyDayRollingSyncFailCount
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered rolling sync history if vars are not present')
+    }
+
+    verboseHealthCheckResp.thirtyDayRollingSyncSuccessCount = 5
+    verboseHealthCheckResp.thirtyDayRollingSyncFailCount = 10
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+    } catch (e) {
+      assert.fail('Should not have considered rolling sync history if mininum count not met')
+    }
+
+    verboseHealthCheckResp.thirtyDayRollingSyncSuccessCount = 1
+    verboseHealthCheckResp.thirtyDayRollingSyncFailCount = 5000
+
+    try {
+      peerSetManager.determinePeerHealth(verboseHealthCheckResp)
+      assert.fail('Should not have passed when fail count percentage is greater than success count')
+    } catch (e) {
+      // Swallow error
+    }
+  })
+
+  it('should pass if verbose health check resp is proper', () => {
+    try {
+      peerSetManager.determinePeerHealth(baseVerboseHealthCheckResp)
+    } catch (e) {
+      assert.fail(`Should have succeeded: ${e.toString()}`)
+    }
+  })
+})


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Extension of https://github.com/AudiusProject/audius-protocol/pull/1544 but with a cleaned up history + refactoring + tests

### Tests

Added unit tests where if 
- certain fields are not present
- certain fields do not meet the requirements
- certain fields are all proper

pass or fail the test

Also checked to make sure that the env vars are respected in the config by logging out the values in a test route:
```
[2021-06-15T21:43:13.591Z]  INFO: audius_creator_node/959 on df291ca40f68:  (requestID=JokQWMLVj, requestMethod=GET, requestHostname=35.184.108.176, requestUrl=/vicky, PEER_HEALTH_CHECK_REQUEST_TIMEOUT=2000, MINIMUM_DAILY_SYNC_COUNT=5, MINIMUM_MEMORY_AVAILABLE=6000000000, MINIMUM_ROLLING_SYNC_COUNT=10, MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE=0.5, MAX_FILE_DESCRIPTORS_ALLOCATED_PERCENTAGE=0.95, MINIMUM_STORAGE_PATH_SIZE=100000000000)
```
