### PR TITLE
CircleCI Mad Dog - Increase no_input_timeout to prevent "context deadline exceeded" error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,8 @@ jobs:
 
       - run:
           name: execute
+          # https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
+          no_output_timeout: 30m
           command: |
             set -e
             export PROTOCOL_DIR=/home/circleci/project


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

We see frequent mad-dog CI failures due to "Too long with no output (exceeded 10m0s): context deadline exceeded" ([example](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/9955/workflows/c58c599d-1f8d-406a-adec-9ed802e07d63/jobs/82471)).

This is because:
> In CircleCI, a command will be killed if a certain period of time has passed with no output. By default, this is 10 minutes. This is designed to prevent errors in builds from hanging using a large number of credits unintentionally.
(from https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-)

[CI config reference](https://circleci.com/docs/2.0/configuration-reference/#run)

Attempts to minimize likelihood of these errors by increasing timeout from 10min to 30min.