### PR TITLE
Fix trending ids cache query

### DIFF
--- a/discovery-provider/src/queries/get_trending_ids.py
+++ b/discovery-provider/src/queries/get_trending_ids.py
@@ -1,4 +1,6 @@
 import logging
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
 from src.utils.redis_cache import extract_key, use_redis_cache
 from src.queries.get_trending import get_trending
 from src.queries.get_trending_tracks import TRENDING_TTL_SEC
@@ -9,7 +11,12 @@ request_cache_path = '/v1/full/tracks/trending'
 
 def get_time_trending(cache_args, time, limit, strategy):
     time_params = {**cache_args, 'time':time}
-    time_cache_key = extract_key(request_cache_path, time_params.items())
+
+    path = request_cache_path
+    if strategy.version != DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]:
+        path += f"/{strategy.version.value}"
+
+    time_cache_key = extract_key(path, time_params.items())
     time_trending = use_redis_cache(time_cache_key, TRENDING_TTL_SEC, lambda: get_trending(time_params, strategy))
     time_trending_track_ids = [{"track_id": track['track_id']} for track in time_trending]
     time_trending_track_ids = time_trending_track_ids[:limit]
@@ -23,6 +30,7 @@ def get_trending_ids(args, strategy):
         args: (dict) The args of the request
         args.limit: (number) The number of track ids to return
         args.genre: (string?) The genre to fetch the trending tracks for
+        strategy: (string?) The strategy to apply to compute trending
 
     Returns:
         trending_times_id: (dict) Dictionary containing the week/month/year trending track ids


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This relies on a hard-coded cache path, which doesn't account for the trending strategy

Follow-on to https://github.com/AudiusProject/audius-protocol/commit/21982a661aa2470a685caf1eb580c7ff50c1dab0


### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_


1. Ran discprov against snapshot, verified that both experiment cache keys are created
```
127.0.0.1:6379> keys API*
 "API_V1_ROUTE:/v1/full/tracks/trending:time=week"
 "API_V1_ROUTE:/v1/full/tracks/trending:time=month"
 "API_V1_ROUTE:/v1/full/tracks/trending:time=year"
 "API_V1_ROUTE:/v1/full/tracks/trending/ePWJD:time=year"
 "API_V1_ROUTE:/v1/full/tracks/trending/ePWJD:time=month"
 "API_V1_ROUTE:/v1/full/tracks/trending/ePWJD:time=week"

```
...


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
