### PR TITLE
sol plays lock - delete on startup + max timeout

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -423,6 +423,7 @@ def configure_celery(flask_app, celery, test_config=None):
     redis_inst.delete("update_discovery_lock")
     redis_inst.delete("aggregate_metrics_lock")
     redis_inst.delete("synchronize_metrics_lock")
+    redis_inst.delete("solana_plays_lock")
     logger.info('Redis instance initialized!')
 
     # Initialize custom task context with database object

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -378,7 +378,7 @@ def index_solana_plays(self):
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("solana_plays_lock", blocking_timeout=25)
+    update_lock = redis.lock("solana_plays_lock", blocking_timeout=25, timeout=7200)
 
     try:
         # Attempt to acquire lock - do not block if unable to acquire

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -378,7 +378,8 @@ def index_solana_plays(self):
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("solana_plays_lock", blocking_timeout=25, timeout=7200)
+    # Max duration of lock is 4hrs or 14400 seconds
+    update_lock = redis.lock("solana_plays_lock", blocking_timeout=25, timeout=14400)
 
     try:
         # Attempt to acquire lock - do not block if unable to acquire


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Ensure the solana plays lock is cleared on startup _and_ has a maximum lifespan to ensure we do not get stuck 

https://audius-metadata-1.figment.io/get_sol_play?tx_sig=27Ab43HvsqKYnsqf7Nq7A4VREk4hYH57aqCesxfkYRgZ9Fdp1kEFryaZUkSWB56esAg3wQ6QgtBowjkhM8RJJiDP

vs.

https://discoveryprovider.audius.co/get_sol_play?tx_sig=27Ab43HvsqKYnsqf7Nq7A4VREk4hYH57aqCesxfkYRgZ9Fdp1kEFryaZUkSWB56esAg3wQ6QgtBowjkhM8RJJiDP

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Verified by restarting redis on production discovery provider 3 which was subject to the same constraints