### PR TITLE
Clear redis keys on init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,12 @@ jobs:
             - eth-contracts/node_modules
           key: v1-eth-contracts-{{ checksum "eth-contracts/package-lock.json" }}
 
-      # content node
-      # - restore_cache:
-      #     name: Restore content-node cache
-      #     keys:
-      #       - v1-content-node-{{ checksum "creator-node/package-lock.json" }}
-      #       - v1-content-node-
+      content node
+      - restore_cache:
+          name: Restore content-node cache
+          keys:
+            - v1-content-node-{{ checksum "creator-node/package-lock.json" }}
+            - v1-content-node-
       - run:
           name: content-node repo init
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ jobs:
           key: v1-eth-contracts-{{ checksum "eth-contracts/package-lock.json" }}
 
       # content node
-      - restore_cache:
-          name: Restore content-node cache
-          keys:
-            - v1-content-node-{{ checksum "creator-node/package-lock.json" }}
-            - v1-content-node-
+      # - restore_cache:
+      #     name: Restore content-node cache
+      #     keys:
+      #       - v1-content-node-{{ checksum "creator-node/package-lock.json" }}
+      #       - v1-content-node-
       - run:
           name: content-node repo init
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             - eth-contracts/node_modules
           key: v1-eth-contracts-{{ checksum "eth-contracts/package-lock.json" }}
 
-      content node
+      # content node
       - restore_cache:
           name: Restore content-node cache
           keys:

--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -18,6 +18,9 @@ class BlacklistManager {
 
   static async init () {
     try {
+      // clear existing redis keys
+      await this.deleteRedisKeys()
+
       const contentToBlacklist = await this.getTrackAndUserIdsToBlacklist()
       await this.fetchCIDsAndAddToRedis(contentToBlacklist)
       this.initialized = true
@@ -331,6 +334,13 @@ class BlacklistManager {
   // Retrieves all track ids in redis
   static async getAllTrackIds () {
     return redis.smembers(REDIS_SET_BLACKLIST_TRACKID_KEY)
+  }
+
+  // Delete all existing redis keys
+  static async deleteRedisKeys () {
+    await redis.del(this.getRedisTrackIdKey())
+    await redis.del(this.getRedisUserIdKey())
+    await redis.del(this.getRedisSegmentCIDKey())
   }
 }
 

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -97,7 +97,7 @@
   },
   "discovery-provider": {
     "protocol": "http",
-    "host": "dn1_web-server",
+    "host": "dn1_web-server_1",
     "port": 5000,
     "up": [
       "cd libs/initScripts; node configureLocalDiscProv.js",

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -97,7 +97,7 @@
   },
   "discovery-provider": {
     "protocol": "http",
-    "host": "audius-disc-prov_web-server_1",
+    "host": "dn1_web-server",
     "port": 5000,
     "up": [
       "cd libs/initScripts; node configureLocalDiscProv.js",

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -6,7 +6,7 @@ const CreatorNode = require('@audius/libs/src/services/creatorNode')
 const Utils = require('@audius/libs/src/utils')
 const config = require('../config/config')
 
-const DISCOVERY_NODE_ENDPOINT = 'http://audius-disc-prov_web-server_1:5000'
+const DISCOVERY_NODE_ENDPOINT = 'http://dn1_web-server_1:5000'
 const MAX_INDEXING_TIMEOUT = 10000
 
 /**

--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -491,7 +491,7 @@ const allUp = async ({ numCreatorNodes = 4, numDiscoveryNodes = 1  }) => {
     [Service.INIT_TOKEN_VERSIONS, SetupCommand.UP],
     ...discoveryNodesCommands,
     [Service.USER_METADATA_NODE, SetupCommand.UNSET_SHELL_ENV],
-    [Service.USER_METADATA_NODE, SetupCommand.UP_UM],
+    [Service.USER_METADATA_NODE, SetupCommand.UP_UM, { ...options, waitSec: 10 }],
     [Service.USER_METADATA_NODE, SetupCommand.HEALTH_CHECK],
     ...creatorNodeCommands,
     [Service.IDENTITY_SERVICE, SetupCommand.UP],


### PR DESCRIPTION
### Description
There's 3 bug fixes here:
1. Sometimes the redis data can be stale and we have stuff in redis that shouldn't be there anymore. This cleans redis so we force a clean slate to init into
2. Fix mad dog local runs because we hardcoded the discovery node to select and the naming model changed
3. Give UM more time to come up in service commands



### Tests
Tested locally