### PR TITLE
Fix challenges user_id bug

### DIFF
--- a/creator-node/.gitignore
+++ b/creator-node/.gitignore
@@ -14,3 +14,4 @@ test_file_storage/
 coverage/
 .nyc_output/
 compose/env/commonEnv.sh
+file_storage/

--- a/discovery-provider/src/challenges/challenge.py
+++ b/discovery-provider/src/challenges/challenge.py
@@ -74,7 +74,7 @@ class ChallengeManager:
 
         # Create users that need challenges still
         existing_user_ids = {challenge.user_id for challenge in existing_user_challenges}
-        needs_challenge_ids = [id for id in user_ids if not id in existing_user_ids]
+        needs_challenge_ids = list({id for id in user_ids if not id in existing_user_ids})
         in_progress_challenges = [challenge for challenge in existing_user_challenges if not challenge.is_complete]
         new_user_challenges = self._create_new_challenges(needs_challenge_ids)
 

--- a/discovery-provider/tests/test_challenges.py
+++ b/discovery-provider/tests/test_challenges.py
@@ -118,6 +118,12 @@ def test_handle_event(app):
                 "user_id": 3,
                 "block_number": 100
             },
+            # Attempt to add id 6 twice to
+            # ensure that it doesn't cause a collision
+            {
+                "user_id": 6,
+                "block_number": 100
+            },
             {
                 "user_id": 6,
                 "block_number": 100


### PR DESCRIPTION
### Description

- There was a bug where if we processed a group of events with the same user_id, and no user_challenge yet existed for that user, we would attempt to create two user_challenges, violating a unique constraint. 


### Tests

Added test coverage

