### PR TITLE
[Snapback Bug fixes] Fix snapback modulo incrementing + Remove Snapback short-circuit on issueSyncRequests errors

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -531,6 +531,7 @@ class SnapbackSM {
         numSyncRequestsIssued = resp.numSyncRequestsIssued
         syncRequestErrors = resp.syncRequestErrors
 
+        // Error if > 50% syncRequests fail
         if (syncRequestErrors.length > numSyncRequestsIssued) {
           throw new Error()
         }
@@ -556,7 +557,6 @@ class SnapbackSM {
           },
           time: Date.now()
         })
-        throw new Error('processStateMachineOperation():issueSyncRequests() Error')
       }
 
       /**

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -533,7 +533,7 @@ class SnapbackSM {
 
         // Error if > 50% syncRequests fail
         if (syncRequestErrors.length > numSyncRequestsIssued) {
-          throw new Error()
+          throw new Error('More than 50% of SyncRequests failed')
         }
 
         decisionTree.push({
@@ -550,6 +550,7 @@ class SnapbackSM {
         decisionTree.push({
           stage: 'issueSyncRequests() Error',
           vals: {
+            error: e.message,
             numSyncRequestsRequired,
             numSyncRequestsIssued,
             numSyncRequestErrors: (syncRequestErrors ? syncRequestErrors.length : null),


### PR DESCRIPTION
### Description
_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

1) I realized in current format, modulo incrementing is done inside the try block, meaning any errors that throw above it would exit before the modulo slice is incremented - we are susceptible to infinite looping and hanging on a broken user state as a result. this is almost definitely my fault, but simple fix
2) Per vicky's callout, snapback currently short circuits if > 50% of syncRequests fail on the issueSyncRequests step. This means it skips over the `issueUpdateReplicaSetOps` step for no reason, so changed code to no longer short circuit and continue through snapback logic.

### Tests
_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**
