### PR TITLE
Add monitor for user balance refresh

### DIFF
--- a/discovery-provider/src/queries/get_balances.py
+++ b/discovery-provider/src/queries/get_balances.py
@@ -78,10 +78,6 @@ def get_balances(session, redis, user_ids, is_verified_ids_set=None):
         } for user_id in needs_balance_set}
     result.update(no_balance_dict)
 
-    # Add new balances to DB
-    new_user_balances = [UserBalance(user_id=x, balance=0, associated_wallets_balance=0) for x in needs_balance_set]
-    session.add_all(new_user_balances)
-
     # Get old balances that need refresh
     needs_refresh = [user_balance.user_id for user_balance in query
                      if does_user_balance_need_refresh(user_balance, False)]

--- a/discovery-provider/src/queries/get_balances.py
+++ b/discovery-provider/src/queries/get_balances.py
@@ -73,8 +73,8 @@ def get_balances(session, redis, user_ids, is_verified_ids_set=None):
 
     # Add new balances to result set
     no_balance_dict = {user_id: {
-        "owner_wallet_balance": 0,
-        "associated_wallets_balance": 0
+        "owner_wallet_balance": '0',
+        "associated_wallets_balance": '0'
         } for user_id in needs_balance_set}
     result.update(no_balance_dict)
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -10,7 +10,7 @@ from src.utils.redis_constants import latest_block_redis_key, \
     latest_block_hash_redis_key, most_recent_indexed_block_hash_redis_key, most_recent_indexed_block_redis_key, \
     most_recent_indexed_ipld_block_redis_key, most_recent_indexed_ipld_block_hash_redis_key, \
     trending_tracks_last_completion_redis_key, trending_playlists_last_completion_redis_key, \
-    challenges_last_processed_event_redis_key
+    challenges_last_processed_event_redis_key, user_balances_refresh_last_completion_redis_key
 
 
 logger = logging.getLogger(__name__)
@@ -162,6 +162,7 @@ def get_health(args, use_redis_cache=True):
     trending_tracks_age_sec = get_elapsed_time_redis(redis, trending_tracks_last_completion_redis_key)
     trending_playlists_age_sec = get_elapsed_time_redis(redis, trending_playlists_last_completion_redis_key)
     challenge_events_age_sec = get_elapsed_time_redis(redis, challenges_last_processed_event_redis_key)
+    user_balances_age_sec = get_elapsed_time_redis(redis, user_balances_refresh_last_completion_redis_key)
 
     # Get system information monitor values
     sys_info = monitors.get_monitors([
@@ -189,6 +190,7 @@ def get_health(args, use_redis_cache=True):
         "trending_tracks_age_sec": trending_tracks_age_sec,
         "trending_playlists_age_sec": trending_playlists_age_sec,
         "challenge_last_event_age_sec": challenge_events_age_sec,
+        "user_balances_age_sec": user_balances_age_sec,
         "number_of_cpus": number_of_cpus,
         **sys_info
     }

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -232,8 +232,8 @@ def populate_user_metadata(session, user_ids, users, current_user_id, with_track
             user_id, False)
         user[response_name_constants.current_user_followee_follow_count] = current_user_followee_follow_count_dict.get(
             user_id, 0)
-        user[response_name_constants.balance] = user_balance.get("owner_wallet_balance", 0)
-        user[response_name_constants.associated_wallets_balance] = user_balance.get("associated_wallets_balance", 0)
+        user[response_name_constants.balance] = user_balance.get("owner_wallet_balance", '0')
+        user[response_name_constants.associated_wallets_balance] = user_balance.get("associated_wallets_balance", '0')
 
     return users
 

--- a/discovery-provider/src/tasks/cache_user_balance.py
+++ b/discovery-provider/src/tasks/cache_user_balance.py
@@ -5,6 +5,7 @@ from src.app import eth_abi_values
 from src.tasks.celery_app import celery
 from src.models import UserBalance, User, AssociatedWallet
 from src.queries.get_balances import does_user_balance_need_refresh, REDIS_PREFIX
+from src.utils.redis_constants import user_balances_refresh_last_completion_redis_key
 
 logger = logging.getLogger(__name__)
 audius_token_registry_key = bytes("Token", "utf-8")
@@ -216,6 +217,7 @@ def update_user_balances_task(self):
             refresh_user_ids(redis, db, token_inst, delegate_manager_inst, staking_inst, eth_web3)
 
             end_time = time.time()
+            redis.set(user_balances_refresh_last_completion_redis_key, int(end_time))
             logger.info(f"cache_user_balance.py | Finished cache_user_balance in {end_time - start_time} seconds")
         else:
             logger.info("cache_user_balance.py | Failed to acquire lock")

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -7,3 +7,4 @@ most_recent_indexed_ipld_block_hash_redis_key = 'most_recent_indexed_ipld_block_
 trending_tracks_last_completion_redis_key = 'trending:tracks:last-completion'
 trending_playlists_last_completion_redis_key = 'trending-playlists:last-completion'
 challenges_last_processed_event_redis_key = 'challenges:last-processed-event'
+user_balances_refresh_last_completion_redis_key = 'user_balances:last-completion'


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

* Adds a monitor to see the last time user balances were successfully refreshed
* Removes creation of UserBalance empty row in populate_user_metadata in favor of only doing so in celery task

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Ran discovery locally and hit /health_check
```
data: {
block_difference: 0,
challenge_last_event_age_sec: null,
database_connections: 16,
database_size: 12403203,
db: {
blockhash: "0x58ccf9eb91d49d8a74a75274b422203b38aea9e717a49a00564cc4df2fdf91c5",
number: 1369
},
filesystem_size: 103880232960,
filesystem_used: 39321374720,
git: "",
maximum_healthy_block_difference: 100,
number_of_cpus: 12,
received_bytes_per_sec: 7180.096771147346,
redis_total_memory: 16788414464,
service: "discovery-node",
total_memory: 16788414464,
transferred_bytes_per_sec: 7646.988504356561,
trending_playlists_age_sec: 1605,
trending_tracks_age_sec: 1134,
used_memory: 2946367488,
user_balances_age_sec: 29,
version: "0.3.38",
web: {
blockhash: "0x58ccf9eb91d49d8a74a75274b422203b38aea9e717a49a00564cc4df2fdf91c5",
blocknumber: 1369
}
},
```
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
