### PR TITLE
Fix bug with using this.moduloSlice

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -539,7 +539,7 @@ class SnapbackSM {
       stage: 'BEGIN processStateMachineOperation()',
       vals: {
         currentModuloSlice: this.currentModuloSlice,
-        moduloBase: this.ModuloBase
+        moduloBase: this.moduloBase
       },
       time: Date.now()
     }]
@@ -760,7 +760,7 @@ class SnapbackSM {
         stage: 'END processStateMachineOperation()',
         vals: {
           currentModuloSlice: this.currentModuloSlice,
-          moduloBase: this.ModuloBase,
+          moduloBase: this.moduloBase,
           numSyncRequestsEnqueued,
           numUpdateReplicaOpsIssued
         },
@@ -771,9 +771,9 @@ class SnapbackSM {
     } catch (e) {
       decisionTree.push({ stage: 'processStateMachineOperation Error', vals: e.message, time: Date.now() })
     } finally {
-      // Increment and adjust current slice by this.ModuloBase
+      // Increment and adjust current slice by this.moduloBase
       this.currentModuloSlice += 1
-      this.currentModuloSlice = this.currentModuloSlice % this.ModuloBase
+      this.currentModuloSlice = this.currentModuloSlice % this.moduloBase
 
       // Log decision tree
       try {


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

The member variable is `this.moduloSlice`. The 'M' should not be capitalized.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Current logs:
(not printing out `moduloBase` because the value is null at the moment)
```
 [{"stage":"BEGIN processStateMachineOperation()","vals":{"currentModuloSlice":1}
...
// next iteration
[{"stage":"BEGIN processStateMachineOperation()","vals":{"currentModuloSlice":null}
```

New logs:
```
[{"stage":"BEGIN processStateMachineOperation()","vals":{"currentModuloSlice":0,"moduloBase":2}
... 
// next iteration
[{"stage":"BEGIN processStateMachineOperation()","vals":{"currentModuloSlice":1,"moduloBase":2}
```

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

No monitoring necessary for this fix
