### PR TITLE
Add task to periodically run a db vacuum

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -339,10 +339,6 @@ def configure_celery(flask_app, celery, test_config=None):
                  "src.tasks.index_aggregate_views", "src.tasks.index_challenges"
                  ],
         beat_schedule={
-            "vacuum_db": {
-                "task": "vacuum_db",
-                "schedule": timedelta(days=1),
-            },
             "update_discovery_provider": {
                 "task": "update_discovery_provider",
                 "schedule": timedelta(seconds=indexing_interval_sec),
@@ -370,6 +366,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "update_materialized_views": {
                 "task": "update_materialized_views",
                 "schedule": timedelta(seconds=300)
+            },
+            "vacuum_db": {
+                "task": "vacuum_db",
+                "schedule": timedelta(days=1),
             },
             "update_network_peers": {
                 "task": "update_network_peers",

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -332,13 +332,17 @@ def configure_celery(flask_app, celery, test_config=None):
     celery.conf.update(
         imports=["src.tasks.index", "src.tasks.index_blacklist",
                  "src.tasks.index_plays", "src.tasks.index_metrics",
-                 "src.tasks.index_materialized_views",
+                 "src.tasks.index_materialized_views", "src.tasks.vacuum_db",
                  "src.tasks.index_network_peers", "src.tasks.index_trending",
                  "src.tasks.cache_user_balance", "src.monitors.monitoring_queue",
                  "src.tasks.cache_trending_playlists", "src.tasks.index_solana_plays",
                  "src.tasks.index_aggregate_views", "src.tasks.index_challenges"
                  ],
         beat_schedule={
+            "vacuum_db": {
+                "task": "vacuum_db",
+                "schedule": timedelta(days=1),
+            },
             "update_discovery_provider": {
                 "task": "update_discovery_provider",
                 "schedule": timedelta(seconds=indexing_interval_sec),

--- a/discovery-provider/src/tasks/vacuum_db.py
+++ b/discovery-provider/src/tasks/vacuum_db.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from src.tasks.celery_app import celery
 
 logger = logging.getLogger(__name__)

--- a/discovery-provider/src/tasks/vacuum_db.py
+++ b/discovery-provider/src/tasks/vacuum_db.py
@@ -20,7 +20,7 @@ def vacuum_db(self):
         if have_lock:
             engine = db._engine
             with engine.connect().execution_options(
-                isolation_level="AUTOCOMMIT"
+                    isolation_level="AUTOCOMMIT"
             ) as connection:
                 connection.execute("VACUUM ANALYZE")
         else:

--- a/discovery-provider/src/tasks/vacuum_db.py
+++ b/discovery-provider/src/tasks/vacuum_db.py
@@ -1,0 +1,31 @@
+import logging
+import time
+from src.tasks.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+
+@celery.task(name="vacuum_db", bind=True)
+def vacuum_db(self):
+    """Vacuum the db"""
+
+    db = vacuum_db.db
+    redis = vacuum_db.redis
+
+    have_lock = False
+    update_lock = redis.lock("vacuum_db", timeout=3600)
+
+    try:
+        have_lock = update_lock.acquire(blocking=False)
+
+        if have_lock:
+            with db.scoped_session() as session:
+                session.execute("VACUUM FULL")
+        else:
+            logger.info("vacuum_db.py | Failed to acquire lock")
+    except Exception as e:
+        logger.error("vacuum_db.py | Fatal error in main loop", exc_info=True)
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/vacuum_db.py
+++ b/discovery-provider/src/tasks/vacuum_db.py
@@ -20,7 +20,7 @@ def vacuum_db(self):
 
         if have_lock:
             with db.scoped_session() as session:
-                session.execute("VACUUM FULL ANALYZE")
+                session.execute("VACUUM ANALYZE")
         else:
             logger.info("vacuum_db.py | Failed to acquire lock")
     except Exception as e:

--- a/discovery-provider/src/tasks/vacuum_db.py
+++ b/discovery-provider/src/tasks/vacuum_db.py
@@ -20,7 +20,7 @@ def vacuum_db(self):
 
         if have_lock:
             with db.scoped_session() as session:
-                session.execute("VACUUM FULL")
+                session.execute("VACUUM FULL ANALYZE")
         else:
             logger.info("vacuum_db.py | Failed to acquire lock")
     except Exception as e:


### PR DESCRIPTION
### Description

This adds a new task to the discovery provider to run a vacuum analyze once every 24 hours.

### Tests

Tested locally to see vacuum job running. Pending stage / prod testing to observe CPU usage.
