### PR TITLE
Convert challenge names in response

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict
 from src import api_helpers
 from src.utils.config import shared_config
 from hashids import Hashids
@@ -6,6 +7,7 @@ from flask_restx import fields, reqparse
 from datetime import datetime
 from .models.common import full_response
 from src.queries.get_challenges import ChallengeResponse
+from src.models import ChallengeType
 
 logger = logging.getLogger(__name__)
 
@@ -245,10 +247,18 @@ def extend_activity(item):
         }
     return None
 
+challenge_type_map: Dict[ChallengeType, str] = {
+    ChallengeType.boolean: 'boolean',
+    ChallengeType.numeric: 'numeric',
+    ChallengeType.aggregate: 'aggregate',
+    ChallengeType.trending: 'trending'
+}
+
 def extend_challenge_response(challenge: ChallengeResponse):
     user_id = encode_int_id(challenge["user_id"])
     new_challenge = challenge.copy()
     new_challenge["user_id"] = user_id
+    new_challenge["challenge_type"] = challenge_type_map[challenge["challenge_type"]]
     return new_challenge
 
 def abort_bad_path_param(param, namespace):


### PR DESCRIPTION
### Description

Fixes a bug where challenge names in the response would look like `ChallengeType.numeric` instead of just `numeric`

### Tests

Testing on stage


### How will this change be monitored?

n/a
