### PR TITLE
Fix Solana Build - Dependency Update

### DIFF
--- a/solana-programs/Dockerfile
+++ b/solana-programs/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y jq curl build-essential libudev-dev libhidapi-dev pkg-config libssl-dev git python-is-python3 python3-pip && \
     pip3 install --no-cache-dir web3 && \
     curl -s --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    sh -c "$(curl -sSfL https://release.solana.com/v1.6.14/install)"
+    sh -c "$(curl -sSfL https://release.solana.com/v1.6.1/install)"
 
 ENV PATH="/root/.cargo/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
 

--- a/solana-programs/Dockerfile
+++ b/solana-programs/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y jq curl build-essential libudev-dev libhidapi-dev pkg-config libssl-dev git python-is-python3 python3-pip && \
     pip3 install --no-cache-dir web3 && \
     curl -s --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    sh -c "$(curl -sSfL https://release.solana.com/v1.6.1/install)"
+    sh -c "$(curl -sSfL https://release.solana.com/v1.6.14/install)"
 
 ENV PATH="/root/.cargo/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
 

--- a/solana-programs/audius_eth_registry/Cargo.toml
+++ b/solana-programs/audius_eth_registry/Cargo.toml
@@ -13,13 +13,14 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.7.0"
+solana-program = "1.7.4"
 thiserror = "1.0"
-borsh = "0.8.2"
+borsh = "0.9.0"
+borsh-derive = "0.9.0"
 
 [dev-dependencies]
-solana-program-test = "1.7.0"
-solana-sdk = "1.7.0"
+solana-program-test = "1.7.4"
+solana-sdk = "1.7.4"
 libsecp256k1 = { version = "0.3.5" }
 rand = { version = "0.8.3" }
 sha3 = { version = "0.9.1" }

--- a/solana-programs/audius_eth_registry/Cargo.toml
+++ b/solana-programs/audius_eth_registry/Cargo.toml
@@ -13,13 +13,13 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.6.4"
+solana-program = "1.7.0"
 thiserror = "1.0"
 borsh = "0.8.2"
 
 [dev-dependencies]
-solana-program-test = "1.6.4"
-solana-sdk = "1.6.4"
+solana-program-test = "1.7.0"
+solana-sdk = "1.7.0"
 libsecp256k1 = { version = "0.3.5" }
 rand = { version = "0.8.3" }
 sha3 = { version = "0.9.1" }

--- a/solana-programs/audius_eth_registry/src/lib.rs
+++ b/solana-programs/audius_eth_registry/src/lib.rs
@@ -16,4 +16,4 @@ pub mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("Eed4UXg3TqTkzbgT47WWMQtbzpxMUeHitt2jfAa6pmep");
+solana_program::declare_id!("5mpjDRgoRYRmSnAXZTfB2bBkbpwvRjobXUjb4WYjF225");

--- a/solana-programs/cli/Cargo.toml
+++ b/solana-programs/cli/Cargo.toml
@@ -14,12 +14,12 @@ solana-clap-utils = "1.6.4"
 solana-cli-config = "1.6.4"
 solana-client = "1.6.4"
 solana-logger = "1.6.4"
-solana-sdk = "1.5.14"
-solana-program = "1.5.14"
+solana-sdk = "1.7.4"
+solana-program = "1.7.4"
 hex = "0.4.2"
 libsecp256k1 = "0.3.5"
 sha3 = "0.9.1"
-borsh = "0.8.2"
+borsh = "0.9.0"
 audius_eth_registry = { path="../audius_eth_registry", features = [ "no-entrypoint" ] }
 
 [[bin]]

--- a/solana-programs/track_listen_count/Cargo.toml
+++ b/solana-programs/track_listen_count/Cargo.toml
@@ -14,7 +14,7 @@ num-traits = "0.2"
 num_enum = "0.5.1"
 solana-program = "1.7.0"
 thiserror = "1.0"
-borsh = "0.8.2"
+borsh = "0.9.0"
 audius_eth_registry = { path = "../audius_eth_registry", features = [ "no-entrypoint" ] }
 
 [dev-dependencies]

--- a/solana-programs/track_listen_count/Cargo.toml
+++ b/solana-programs/track_listen_count/Cargo.toml
@@ -12,14 +12,14 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.6.4"
+solana-program = "1.7.0"
 thiserror = "1.0"
 borsh = "0.8.2"
 audius_eth_registry = { path = "../audius_eth_registry", features = [ "no-entrypoint" ] }
 
 [dev-dependencies]
-solana-program-test = "1.6.4"
-solana-sdk = "1.6.4"
+solana-program-test = "1.7.0"
+solana-sdk = "1.7.0"
 libsecp256k1 = { version = "0.3.5" }
 rand = { version = "0.8.3" }
 sha3 = { version = "0.9.1" }

--- a/solana-programs/track_listen_count/Cargo.toml
+++ b/solana-programs/track_listen_count/Cargo.toml
@@ -12,14 +12,14 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.7.0"
+solana-program = "1.7.4"
 thiserror = "1.0"
 borsh = "0.9.0"
 audius_eth_registry = { path = "../audius_eth_registry", features = [ "no-entrypoint" ] }
 
 [dev-dependencies]
-solana-program-test = "1.7.0"
-solana-sdk = "1.7.0"
+solana-program-test = "1.7.4"
+solana-sdk = "1.7.4"
 libsecp256k1 = { version = "0.3.5" }
 rand = { version = "0.8.3" }
 sha3 = { version = "0.9.1" }

--- a/solana-programs/track_listen_count/src/lib.rs
+++ b/solana-programs/track_listen_count/src/lib.rs
@@ -15,4 +15,4 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("EjJosFkciC2GJK224yHiSG2QDeQ8cGuiVxH22e9dDoQj");
+solana_program::declare_id!("7K3UpbZViPnQDLn2DAM853B9J5GBxd1L1rLHy4KqSmWG");


### PR DESCRIPTION
### Description

Recently, builds have been failing with the following error:

```
Pubkey: BorshDeserialize` is not satisfied
```

This update bumps solana-program to 1.7.4 and borsh 0.9.0 in order to ensure successful builds.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Verified in CI, CLI query functionality confirmed against master as well. 

Will update staging with a new ValidSigner object prior to merge

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
