### PR TITLE
Add min delegation to identity

### DIFF
--- a/identity-service/sequelize/migrations/20210707144138-protocol-service-provider.js
+++ b/identity-service/sequelize/migrations/20210707144138-protocol-service-provider.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('ProtocolServiceProviders', {
+      wallet: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        primaryKey: true
+      },
+      minimumDelegationAmount: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.dropTable('ProtocolServiceProviders')
+  }
+};

--- a/identity-service/src/models/protocolServiceProvider.js
+++ b/identity-service/src/models/protocolServiceProvider.js
@@ -1,0 +1,24 @@
+'use strict'
+module.exports = (sequelize, DataTypes) => {
+  const ProtocolServiceProviders = sequelize.define('ProtocolServiceProviders', {
+    wallet: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true
+    },
+    minimumDelegationAmount: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    }
+  }, {})
+
+  return ProtocolServiceProviders
+}

--- a/identity-service/src/routes/protocol.js
+++ b/identity-service/src/routes/protocol.js
@@ -1,0 +1,80 @@
+const express = require('express')
+const { recoverPersonalSignature } = require('eth-sig-util')
+
+const {
+  handleResponse,
+  successResponse,
+  errorResponseBadRequest,
+  errorResponse: formatResponse,
+  sendResponse
+} = require("../apiHelpers")
+const models = require("../models")
+
+const protocolRouter = express.Router()
+
+protocolRouter.get('/:wallet/delegation/minimum', handleResponse(async (req, res, next) => {
+  const { wallet } = req.params
+
+  const serviceProvider = await models.ProtocolServiceProviders.findOne({
+    where: { wallet: wallet.toLowerCase() }
+  })
+
+  if (serviceProvider === null) {
+    return formatResponse(404, 'Minimum delegation amount not set')
+  }
+
+  return successResponse({
+    wallet,
+    minimumDelegationAmount: serviceProvider.minimumDelegationAmount
+  })
+}))
+
+async function serviceProviderAuthMiddleware (req, res, next) {
+  try {
+    const encodedDataMessage = req.get('Encoded-Data-Message')
+    const signature = req.get('Encoded-Data-Signature')
+
+    if (!encodedDataMessage) throw new Error('[Error]: Encoded data missing')
+    if (!signature) throw new Error('[Error]: Encoded data signature missing')
+
+    const wallet = recoverPersonalSignature({ data: encodedDataMessage, sig: signature })
+    req.authedWallet = wallet
+    next()
+  } catch (err) {
+    req.logger.warn(`${err}`)
+    const errorResponse = errorResponseBadRequest('[Error]: ')
+    return sendResponse(req, res, errorResponse)
+  }
+}
+
+protocolRouter.post('/:wallet/delegation/minimum', serviceProviderAuthMiddleware, handleResponse(async (req, res, next) => {
+  const { wallet } = req.params
+
+  if (wallet.toLowerCase() !== req.authedWallet.toLowerCase()) {
+    return errorResponseBadRequest(`[Error]: Not authenticated, unable to change minimun delegation`)
+  }
+
+  const { minimumDelegationAmount } = req.body
+  if (!minimumDelegationAmount || typeof minimumDelegationAmount !== 'string') {
+    return errorResponseBadRequest(`Bad Request: Must pass request body field 'minimumDelegationAmount' as string in wei`)
+  }
+
+  const isNumeric = /^\d+$/.test(minimumDelegationAmount)
+  if (!isNumeric) {
+    return errorResponseBadRequest(`Bad Request: 'minimumDelegationAmount' must be a string consisting of only numbers`)
+  }
+
+  await models.ProtocolServiceProviders.upsert(
+    { wallet, minimumDelegationAmount }
+  )
+
+  return successResponse({
+    wallet,
+    minimumDelegationAmount: minimumDelegationAmount
+  })
+
+}))
+
+module.exports = function (app) {
+  app.use('/protocol', protocolRouter)
+}

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -500,8 +500,8 @@ class Account extends Base {
     const signature = await this.ethWeb3Manager.sign(message)
     const wallet = this.ethWeb3Manager.getWalletAddress()
     return this.identityService.updateMinimumDelegationAmount(wallet, amount, {
-      [AuthHeaders.Message]: message,
-      [AuthHeaders.Signature]: signature
+      [AuthHeaders.MESSAGE]: message,
+      [AuthHeaders.SIGNATURE]: signature
     })
   }
 }

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -1,6 +1,7 @@
 const { Base, Services } = require('./base')
 const CreatorNodeService = require('../services/creatorNode/index')
 const Utils = require('../utils')
+const { AuthHeaders } = require('../constants')
 const {
   getPermitDigest, sign, getLockAssetsDigest
 } = require('../utils/signatures')
@@ -486,6 +487,22 @@ class Account extends Base {
   async sendTokens (owner, address, relayer, amount) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
     return this.ethContracts.AudiusTokenClient.transferFrom(owner, address, relayer, amount)
+  }
+
+  /**
+   * Updates the minimum delegation amount for a user in identity
+   * NOTE: Requests eth account signature
+   */
+  async updateMinimumDelegationAmount (amount) {
+    this.REQUIRES(Services.IDENTITY_SERVICE)
+    const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
+    const message = `Click sign to authenticate with identity service: ${unixTs}`
+    const signature = await this.ethWeb3Manager.sign(message)
+    const wallet = this.ethWeb3Manager.getWalletAddress()
+    return this.identityService.updateMinimumDelegationAmount(wallet, amount, {
+      [AuthHeaders.Message]: message,
+      [AuthHeaders.Signature]: signature
+    })
   }
 }
 

--- a/libs/src/constants.js
+++ b/libs/src/constants.js
@@ -1,1 +1,5 @@
 module.exports.CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY = '@audius/libs:found-user'
+module.exports.AuthHeaders = Object.freeze({
+  Message: 'Encoded-Data-Message',
+  Signature: 'Encoded-Data-Signature'
+})

--- a/libs/src/constants.js
+++ b/libs/src/constants.js
@@ -1,5 +1,5 @@
 module.exports.CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY = '@audius/libs:found-user'
 module.exports.AuthHeaders = Object.freeze({
-  Message: 'Encoded-Data-Message',
-  Signature: 'Encoded-Data-Signature'
+  MESSAGE: 'Encoded-Data-Message',
+  SIGNATURE: 'Encoded-Data-Signature',
 })

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -27,6 +27,14 @@ class EthWeb3Manager {
 
   getWalletAddress () { return this.ownerWallet.toLowerCase() }
 
+  /**
+   * Signs provided string data (should be timestamped).
+   * @param {string} data
+   */
+  async sign (data) {
+    return this.web3.eth.personal.sign(this.web3.utils.fromUtf8(data), this.getWalletAddress())
+  }
+
   async sendTransaction (
     contractMethod,
     contractAddress = null,

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -325,6 +325,22 @@ class IdentityService {
     })
   }
 
+  async getMinimumDelegationAmount (wallet) {
+    return this._makeRequest({
+      url: `/protocol/${wallet}/delegation/minimum`,
+      method: 'get'
+    })
+  }
+
+  async updateMinimumDelegationAmount (wallet, minimumDelegationAmount, signedData) {
+    return this._makeRequest({
+      url: `/protocol/${wallet}/delegation/minimum`,
+      method: 'post',
+      headers: signedData,
+      data: { minimumDelegationAmount }
+    })
+  }
+
   /* ------- INTERNAL FUNCTIONS ------- */
 
   async _makeRequest (axiosRequestObj) {


### PR DESCRIPTION
### Description
Adds min delegation to identity for the protocol dashboard
* New route to fetch min delegation per wallet
* New route to set min delegation - authed by signed message
* New table in identity to store wallet - min delegation 
* Libs binding for both routes

NOTE: need addition PR to bump libs after approval

### Tests
none - ran locally

### How will this change be monitored?
manually
