### PR TITLE
Add option to disable decision tree logging in CreatorNodeSelection

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -720,7 +720,8 @@ class SnapbackSM {
         // on a new replica set. Also, the sync check logic is coupled with a user state on the userStateManager.
         // There will be an explicit clock value check on the newly selected replica set nodes instead.
         const { services: healthyServicesMap } = await this.audiusLibs.ServiceProvider.autoSelectCreatorNodes({
-          performSyncCheck: false
+          performSyncCheck: false,
+          log: false
         })
 
         const healthyNodes = Object.keys(healthyServicesMap)

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -78,7 +78,8 @@ class ServiceProvider extends Base {
     whitelist = null,
     blacklist = null,
     performSyncCheck = true,
-    timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT
+    timeout = CONTENT_NODE_DEFAULT_SELECTION_TIMEOUT,
+    log = true
   }) {
     const creatorNodeSelection = new CreatorNodeSelection({
       creatorNode: this.creatorNode,
@@ -89,7 +90,7 @@ class ServiceProvider extends Base {
       timeout
     })
 
-    const { primary, secondaries, services } = await creatorNodeSelection.select(performSyncCheck)
+    const { primary, secondaries, services } = await creatorNodeSelection.select(performSyncCheck, log)
     return { primary, secondaries, services }
   }
 

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -59,7 +59,7 @@ class CreatorNodeSelection extends ServiceSelection {
    * 5. Select a primary and numberOfNodes-1 number of secondaries (most likely 2) from backups
    * @param {boolean?} performSyncCheck whether or not to check whether the nodes need syncs before selection
    */
-  async select (performSyncCheck = true) {
+  async select (performSyncCheck = true, log = true) {
     // Reset decision tree and backups
     this.decisionTree = []
     this.clearBackups()
@@ -91,7 +91,9 @@ class CreatorNodeSelection extends ServiceSelection {
       val: { primary, secondaries: secondaries.toString(), services: Object.keys(servicesMap).toString() }
     })
 
-    console.info('CreatorNodeSelection - final decision tree state', this.decisionTree)
+    if (log) {
+      console.info('CreatorNodeSelection - final decision tree state', this.decisionTree)
+    }
     return { primary, secondaries, services: servicesMap }
   }
 


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Creator node now calls `autoSelectCreatorNodes()` (see below code diff) on every snapback interval, and logging entire selection decision tree every time makes logs much harder to parse. Adds option to not log, but defaults to true to keep all behavior the same unless overridden.