### PR TITLE
Support rewards challenge fields

### DIFF
--- a/discovery-provider/.gitignore
+++ b/discovery-provider/.gitignore
@@ -9,6 +9,9 @@ contracts.env
 # Python cache
 __pycache__/
 
+# Mypy cache
+.mypy_cache
+
 # Virtualenv generated info
 venv/
 

--- a/discovery-provider/.vscode/settings.json
+++ b/discovery-provider/.vscode/settings.json
@@ -10,7 +10,6 @@
   "python.pythonPath": "/usr/bin/python3",
   "python.formatting.provider": "black", // This gives us autoforatting
   "editor.formatOnSave": true,
-  "python.analysis.typeCheckingMode": "basic",
   "python.languageServer": "Pylance",
   "editor.tabSize": 4
 }

--- a/discovery-provider/alembic/versions/6cf091d52869_user_events.py
+++ b/discovery-provider/alembic/versions/6cf091d52869_user_events.py
@@ -1,0 +1,37 @@
+"""user_events
+
+Revision ID: 6cf091d52869
+Revises: 80271bf86c56
+Create Date: 2021-07-09 07:18:52.254180
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6cf091d52869'
+down_revision = '80271bf86c56'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_events",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("blockhash", sa.String(), nullable=False),
+        sa.Column("blocknumber", sa.Integer(), nullable=False),
+        sa.Column("is_current", sa.Boolean(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+
+        sa.Column("referrer", sa.Integer(), nullable=True),
+        sa.Column("is_mobile_user", sa.Boolean(), nullable=False, default=False),
+
+        sa.Index("user_id", "is_current"),
+        sa.PrimaryKeyConstraint("id")
+    )
+
+
+def downgrade():
+    op.drop_table("user_events")

--- a/discovery-provider/alembic/versions/6cf091d52869_user_events.py
+++ b/discovery-provider/alembic/versions/6cf091d52869_user_events.py
@@ -1,7 +1,7 @@
 """user_events
 
 Revision ID: 6cf091d52869
-Revises: 80271bf86c56
+Revises: 3f2ef631e338
 Create Date: 2021-07-09 07:18:52.254180
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '6cf091d52869'
-down_revision = '80271bf86c56'
+revision = "6cf091d52869"
+down_revision = "3f2ef631e338"
 branch_labels = None
 depends_on = None
 
@@ -24,12 +24,10 @@ def upgrade():
         sa.Column("blocknumber", sa.Integer(), nullable=False),
         sa.Column("is_current", sa.Boolean(), nullable=False),
         sa.Column("user_id", sa.Integer(), nullable=False),
-
         sa.Column("referrer", sa.Integer(), nullable=True),
         sa.Column("is_mobile_user", sa.Boolean(), nullable=False, default=False),
-
         sa.Index("user_id", "is_current"),
-        sa.PrimaryKeyConstraint("id")
+        sa.PrimaryKeyConstraint("id"),
     )
 
 

--- a/discovery-provider/mypy.ini
+++ b/discovery-provider/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = sqlmypy

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -1,3 +1,11 @@
+# Linting and type support
+pylint==2.9.3
+mypy==0.910
+sqlalchemy-stubs==0.4
+types-python-dateutil==0.1.4
+types-redis==3.5.4
+types-requests==2.25.0
+
 # web3 used to be 5.11.0 but due to a build issue in docker, downgraded to 5.8.0
 web3==5.8.0
 Flask==1.0.4
@@ -9,8 +17,6 @@ redis==3.2.0
 pytest==6.0.1
 SQLAlchemy-Utils==0.33.3
 chance==0.110
-pylint==2.9.3
-mypy==0.910
 ipfshttpclient==0.8.0a1
 pytest-cov==2.6.0
 pytest-dotenv==0.5.2
@@ -24,11 +30,8 @@ jsonformatter==0.3.0
 pytest-postgresql==2.4.1
 eventlet==0.28.0
 psutil==5.8.0
-types-python-dateutil==0.1.4
-types-redis==3.5.4
-types-requests==2.25.0
 
-# Below dependencies added during Solana integration
+# Solana support
 base58==2.1.0
 certifi==2020.12.5
 cffi==1.14.5

--- a/discovery-provider/src/models/__init__.py
+++ b/discovery-provider/src/models/__init__.py
@@ -47,6 +47,7 @@ from .models import (
     UserChallenge,
 )
 from .track_route import TrackRoute
+from .user_events import UserEvents
 
 __all__ = [
     "AggregateDailyAppNameMetrics",
@@ -96,4 +97,5 @@ __all__ = [
     "User",
     "UserBalance",
     "UserChallenge",
+    "UserEvents",
 ]

--- a/discovery-provider/src/models/user_events.py
+++ b/discovery-provider/src/models/user_events.py
@@ -1,0 +1,39 @@
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    ForeignKey
+)
+from .models import Base
+
+class UserEvents(Base):
+    """
+    User events track event metadata a user may produce as a part of their interaction
+    with the protocol over time, e.g. who was the user referred by? has the user signed in on a mobile app?
+
+    Events are stored as a separate table from Users as it is assumed that the table of events
+    will be fairly sparse as not all users will have produced all types of events.
+    While a JSONB column in the User table would be sufficient for many event types, in order to query
+    across all users that may or may not have produced a certain event, they are broken into separate fields.
+
+    Future events may wish to take on the shape of JSONB data within the UserEvents table itself.
+    """
+    __tablename__ = "user_events"
+    blockhash = Column(String, ForeignKey("blocks.blockhash"), nullable=False)
+    blocknumber = Column(Integer, ForeignKey("blocks.number"), nullable=False)
+    is_current = Column(Boolean, nullable=False)
+    id = Column(Integer, nullable=False, primary_key=True)
+    user_id = Column(Integer, nullable=False, index=True)
+
+    referrer = Column(Integer, nullable=True)
+    is_mobile_user = Column(Boolean, nullable=False, default=False)
+
+    def __repr__(self):
+        return f"<UserEvents(blockhash={self.blockhash},\
+blocknumber={self.blocknumber},\
+is_current={self.is_current},\
+id={self.id},\
+user_id={self.user_id},\
+referrer={self.referrer},\
+is_mobile_user={self.is_mobile_user})>"

--- a/discovery-provider/src/queries/get_attestation.py
+++ b/discovery-provider/src/queries/get_attestation.py
@@ -139,12 +139,12 @@ def get_attestation(
     )
     if not user_eth_address:
         raise Exception("Unexpectedly missing eth_address")
-    user_eth_address = str(user_eth_address[0])
+    user_address = str(user_eth_address[0])
 
     attestation = Attestation(
         amount=challenge.amount,
         oracle_address=oracle_address,
-        user_address=user_eth_address,
+        user_address=user_address,
         challenge_id=challenge.id,
         challenge_specifier=user_challenge.specifier,
     )

--- a/discovery-provider/src/queries/get_trending_playlists.py
+++ b/discovery-provider/src/queries/get_trending_playlists.py
@@ -1,8 +1,10 @@
 import logging  # pylint: disable=C0302
 from datetime import datetime
+from typing import cast
 from sqlalchemy import func, desc, Integer
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.sql.type_api import TypeEngine
 from src.models import Playlist, Save, SaveType, RepostType, Follow, AggregateUser
 from src.tasks.generate_trending import time_delta_map
 from src.trending_strategies.trending_type_and_version import TrendingType
@@ -34,7 +36,7 @@ from src.api.v1.helpers import (
 
 class jsonb_array_length(GenericFunction):  # pylint: disable=too-many-ancestors
     name = "jsonb_array_length"
-    type = Integer
+    type = cast(TypeEngine, Integer)
 
 
 @compiles(jsonb_array_length, "postgresql")

--- a/discovery-provider/src/queries/get_undisbursed_challenges.py
+++ b/discovery-provider/src/queries/get_undisbursed_challenges.py
@@ -8,7 +8,7 @@ class UndisbursedChallengeResponse(TypedDict):
     user_id: int
     specifier: str
     amount: str
-    completed_blocknumber: int
+    completed_blocknumber: Optional[int]
 
 
 def to_challenge_response(

--- a/discovery-provider/src/schemas/user_schema.json
+++ b/discovery-provider/src/schemas/user_schema.json
@@ -46,6 +46,9 @@
                 },
                 "playlist_library": {
                     "$ref": "#/definitions/PlaylistLibrary"
+                },
+                "events": {
+                    "$ref": "#/definitions/Events"
                 }
             },
             "required": [
@@ -186,6 +189,18 @@
                             }
                         ]
                     }
+                }
+            }
+        },
+        "Events": {
+            "type": ["object", "null"],
+            "default": null,
+            "properties": {
+                "referrer": {
+                    "type": "integer"
+                },
+                "is_mobile_user": {
+                    "type": "boolean"
                 }
             }
         }

--- a/discovery-provider/src/tasks/metadata.py
+++ b/discovery-provider/src/tasks/metadata.py
@@ -41,4 +41,5 @@ user_metadata_format = {
     "associated_wallets": None,
     "collectibles": None,
     "playlist_library": None,
+    "events": None,
 }

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -1,9 +1,8 @@
 import logging
 from datetime import datetime
-from typing import TypedDict, cast
+from typing import TypedDict
 from eth_account.messages import defunct_hash_message
 from sqlalchemy.orm.session import Session, make_transient
-from sqlalchemy.sql.schema import Column
 from src.app import contract_addresses
 from src.utils import helpers
 from src.models import User, UserEvents, AssociatedWallet

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -316,16 +316,12 @@ def parse_user_event(
             ):
                 user_record.playlist_library = ipfs_metadata["playlist_library"]
 
-            if (
-                "events" in ipfs_metadata
-                and ipfs_metadata["events"]
-            ):
+            if "events" in ipfs_metadata and ipfs_metadata["events"]:
                 update_user_events(
                     session,
                     user_record,
                     ipfs_metadata["events"],
                 )
-
 
     # All incoming profile photos intended to be a directory
     # Any write to profile_picture field is replaced by profile_picture_sizes
@@ -434,9 +430,7 @@ class UserEventsMetadata(TypedDict):
 
 
 def update_user_events(
-    session: Session,
-    user_record: User,
-    events: UserEventsMetadata
+    session: Session, user_record: User, events: UserEventsMetadata
 ) -> None:
     """Updates the user events table"""
     try:
@@ -445,9 +439,9 @@ def update_user_events(
             return
 
         # Mark existing UserEvents entries as not current
-        session.query(UserEvents).filter_by(user_id=user_record.user_id, is_current=True).update(
-            {"is_current": False}
-        )
+        session.query(UserEvents).filter_by(
+            user_id=user_record.user_id, is_current=True
+        ).update({"is_current": False})
 
         user_events = UserEvents(
             user_id=user_record.user_id,
@@ -456,10 +450,10 @@ def update_user_events(
             blockhash=user_record.blockhash,
         )
         for event, value in events.items():
-            if event == 'referrer':
-                user_events.referrer = cast(Column[int], value)
-            elif event == 'is_mobile_user':
-                user_events.is_mobile_user = cast(Column[bool], value)
+            if event == "referrer" and isinstance(value, int):
+                user_events.referrer = value
+            elif event == "is_mobile_user" and isinstance(value, bool):
+                user_events.is_mobile_user = value
         session.add(user_events)
 
     except Exception as e:

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from src.models import AssociatedWallet
+from src.models import AssociatedWallet, UserEvents
 from src.tasks.users import lookup_user_record, parse_user_event
 from src.utils.db_session import get_db
 from src.utils.user_event_constants import user_event_types_lookup
@@ -157,6 +157,10 @@ ipfs_client = IPFSClient(
                     {"type": "explore_playlist", "playlist_id": "feeling-lucky"},
                     {"type": "playlist", "playlist_id": 503},
                 ]
+            },
+            "events": {
+                "referrer": 2,
+                "is_mobile_user": True,
             },
             "user_id": 1,
         }
@@ -444,3 +448,11 @@ def test_index_users(app):
         )
         for wallet in associated_wallets:
             assert wallet in ipfs_associated_wallets
+
+        user_events = (
+            session.query(UserEvents)
+            .filter_by(user_id=user_record.user_id, is_current=True)
+            .first()
+        )
+        assert user_events.referrer == 2
+        assert user_events.is_mobile_user == True

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -20,7 +20,8 @@ const USER_PROPS = [
   'creator_node_endpoint',
   'associated_wallets',
   'collectibles',
-  'playlist_library'
+  'playlist_library',
+  'events'
 ]
 // User metadata fields that are required on the metadata object and only can have
 // non-null values

--- a/libs/src/services/schemaValidator/schemas/userSchema.json
+++ b/libs/src/services/schemaValidator/schemas/userSchema.json
@@ -46,6 +46,9 @@
                 },
                 "playlist_library": {
                     "$ref": "#/definitions/PlaylistLibrary"
+                },
+                "events": {
+                    "$ref": "#/definitions/Events"
                 }
             },
             "required": [
@@ -186,6 +189,18 @@
                             }
                         ]
                     }
+                }
+            }
+        },
+        "Events": {
+            "type": ["object", "null"],
+            "default": null,
+            "properties": {
+                "referrer": {
+                    "type": "integer"
+                },
+                "is_mobile_user": {
+                    "type": "boolean"
                 }
             }
         }


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add UserEvents table in discovery node to support indexing event fields off of user metadata.
Add support for two events, `referrer` and `is_mobile_user` to support rewards challenge types.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Unit test for indexing flow
2. Manually created account and forced referrer and is_mobile_user field updates
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

No immediate API impact, block diff on indexing would be the only thing to take note of as this gets released