### PR TITLE
Snapback clock value retrieval bugfixes

### DIFF
--- a/creator-node/src/snapbackSM/secondarySyncHealthTracker.js
+++ b/creator-node/src/snapbackSM/secondarySyncHealthTracker.js
@@ -166,7 +166,7 @@ const Getters = {
       const pattern = Utils._getRedisKeyPattern(filters)
       return Utils._getMetricsMatchingPattern(pattern)
     } catch (e) {
-      logger.error(`secondarySyncHealthTracker - getSyncRequestOutcomeMetrics() Error || ${e.message}`)
+      logger.error(`SecondarySyncHealthTracker - getSyncRequestOutcomeMetrics() Error || ${e.message}`)
       return {}
     }
   }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -836,7 +836,7 @@ class SnapbackSM {
    *
    * Polls secondary for MaxSyncMonitoringDurationInMs
    */
-  async additionalSyncIsRequired (userWallet, primaryClockValue, secondaryUrl, syncType) {
+  async additionalSyncIsRequired (userWallet, primaryClockValue = -1, secondaryUrl, syncType) {
     const MaxExportClockValueRange = this.nodeConfig.get('maxExportClockValueRange')
     const logMsgString = `additionalSyncIsRequired (${syncType}): wallet ${userWallet} secondary ${secondaryUrl} primaryClock ${primaryClockValue}`
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -507,15 +507,14 @@ class SnapbackSM {
           return
         }
 
-        // Short-circuit on null wallet
-        if (!wallet) {
-          this.logError(`issueSyncRequests || Cannot process null wallet`)
-          return
-        }
-
         // Determine if secondary requires a sync by comparing clock values against primary (self)
-        const userPrimaryClockVal = userPrimaryClockValues[wallet] || -1
-        const userSecondaryClockVal = secondaryNodesToUserClockStatusesMap[secondary][wallet] || -1
+        // Default to -1 if null/undefined
+        const userPrimaryClockVal = (userPrimaryClockValues[wallet] == null) ? -1 : userPrimaryClockValues[wallet]
+        const userSecondaryClockVal = (
+          secondaryNodesToUserClockStatusesMap[secondary][wallet] == null
+            ? -1
+            : secondaryNodesToUserClockStatusesMap[secondary][wallet]
+        )
 
         if (userPrimaryClockVal > userSecondaryClockVal) {
           numSyncRequestsRequired += 1
@@ -932,8 +931,9 @@ class SnapbackSM {
      */
     this.syncDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint)
 
-    // primaryClockValue is used in additionalSyncIsRequired() call below
-    const primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet] || -1
+    // primaryClockValue is used in additionalSyncIsRequired() call below; default to -1 if null/undefined
+    let primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet]
+    primaryClockValue = (primaryClockValue == null) ? -1 : primaryClockValue
 
     this.log(`------------------Process SYNC | User ${userWallet} | Secondary: ${secondaryEndpoint} | Primary clock value ${primaryClockValue} | type: ${syncType} | jobID: ${id} ------------------`)
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -508,13 +508,8 @@ class SnapbackSM {
         }
 
         // Determine if secondary requires a sync by comparing clock values against primary (self)
-        // Default to -1 if null/undefined
-        const userPrimaryClockVal = (userPrimaryClockValues[wallet] == null) ? -1 : userPrimaryClockValues[wallet]
-        const userSecondaryClockVal = (
-          secondaryNodesToUserClockStatusesMap[secondary][wallet] == null
-            ? -1
-            : secondaryNodesToUserClockStatusesMap[secondary][wallet]
-        )
+        const userPrimaryClockVal = userPrimaryClockValues[wallet]
+        const userSecondaryClockVal = secondaryNodesToUserClockStatusesMap[secondary][wallet]
 
         if (userPrimaryClockVal > userSecondaryClockVal) {
           numSyncRequestsRequired += 1
@@ -931,9 +926,8 @@ class SnapbackSM {
      */
     this.syncDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint)
 
-    // primaryClockValue is used in additionalSyncIsRequired() call below; default to -1 if null/undefined
-    let primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet]
-    primaryClockValue = (primaryClockValue == null) ? -1 : primaryClockValue
+    // primaryClockValue is used in additionalSyncIsRequired() call below
+    const primaryClockValue = (await this.getUserPrimaryClockValues([userWallet]))[userWallet]
 
     this.log(`------------------Process SYNC | User ${userWallet} | Secondary: ${secondaryEndpoint} | Primary clock value ${primaryClockValue} | type: ${syncType} | jobID: ${id} ------------------`)
 


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Couple issues that are causing erroneous sync behavior:

**Problem:**
`getUserPrimaryClockValues()` does not return any clockval for a user with no data on current node. This is called in `processSyncOperation()`, after issuing a syncRequest to a secondary.
- This results in `Primary clock value undefined` log messages everywhere
- This undefined value is then passed to `additionalSyncIsRequired()` after issuing a syncRequest to secondary to determine whether the sync was successful and if an additional syncRequest is needed.
    - This results in the `primaryClock undefined` logmsgs everywhere
    - This is further problematic because the logic used to determine if the sync was successful is `secondaryClockValue >= primaryClockValue`, which is always `false` if `primaryClockValue = undefined`. This then means the function will always return `additionalSyncRequired = true` back to `processSyncOperation()` which will then re-enqueue the sync. This can lead to an infinite loop 🤦‍♂️
    - This is also problematic bc of this code in `additionalSyncIsRequired()`:
```
if (!additionalSyncRequired && !maxExportRangeExceeded) {
  await SecondarySyncHealthTracker.recordSuccess(secondaryUrl, userWallet, syncType)
} else {
  await SecondarySyncHealthTracker.recordFailure(secondaryUrl, userWallet, syncType)
}
```

  - Since `additionalSyncIsRequired() = true` always, we now always record the syncRequest to secondary as a failure, meaning we will end up marking secondaries as incorrectly unhealthy and cycling them out 🤦‍♂️

**Solution:**
- [x] make sure `getUserPrimaryClockValues()` returns -1 for any users with no DB state
- [ ] staging redis state is now corrupted with tons of incorrect SecondarySyncHealthTracker failure outcomes. Clear all of these **after releasing this change**

---
**Problem:**
`getUserPrimaryClockValues()` does not return any clockval for a user with no data on current node. This is called by `issueSyncRequests()` - it compares primaryClockVal against secondaryClockVal to determine if a sync is needed
- in theory this shouldn't be possible since `issueSyncRequests` would never be called with a nodeUSer that has no local state (`peerSetMAnager.getNodeUsers()` would never return such a user), but worth safeguarding against anyway
- the problematic code is:
```
// Determine if secondary requires a sync by comparing clock values against primary (this node)
const userPrimaryClockVal = userPrimaryClockValues[wallet]
const userSecondaryClockVal = secondaryNodesToUserClockStatusesMap[secondary][wallet]
const syncRequired = !userSecondaryClockVal || (userPrimaryClockVal > userSecondaryClockVal)
```

- if `userPrimaryClockVal` is undefined, `syncRequired` will be controlled solely by `userSecondaryClockVal`. This is not actually an issue since if primary clock val is undefined, it's actually -1 and we'd never want to issue a syncRequest anyway. so the behavior is correct, but for the wrong reason.

**Solution:**
- [x] make sure `getUserPrimaryClockValues()` returns -1 for any users with no DB state
---

TODO
- [x] evaluate prod state


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

Monitor logs of `primaryClock undefined` and `Primary clock value undefined`, as well as sync success rates