### PR TITLE
Bump libs to v1.2.11

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
### Description

Bump libs to v1.2.11

Includes:
#1639 Aud-754 tiktok oauth

### Tests

n/a

### How will this change be monitored?

Check that the new version is published to npm
