### PR TITLE
Speed up remixables query by a lot

### DIFF
--- a/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/discovery-provider/src/queries/get_remixable_tracks.py
@@ -1,9 +1,13 @@
 from sqlalchemy import desc
-from src.models import Track, Stem
-from src.queries.query_helpers import create_save_repost_count_subquery, \
-    populate_track_metadata, add_users_to_tracks, decayed_score
+from src.models import Track, Stem, AggregateTrack
+from src.queries.query_helpers import (
+    populate_track_metadata,
+    add_users_to_tracks,
+    decayed_score,
+)
 from src.utils.db_session import get_db_read_replica
 from src.utils import helpers
+
 
 def get_remixable_tracks(args):
     """Gets a list of remixable tracks"""
@@ -15,36 +19,35 @@ def get_remixable_tracks(args):
         # Subquery to get current tracks that have stems
         remixable_tracks_subquery = (
             session.query(Track)
-                .join(Stem, Stem.parent_track_id == Track.track_id)
-                .filter(
-                    Track.is_current == True,
-                    Track.is_unlisted == False,
-                    Track.is_delete == False
-                )
-                .distinct(Track.track_id)
-                .subquery()
+            .join(Stem, Stem.parent_track_id == Track.track_id)
+            .filter(
+                Track.is_current == True,
+                Track.is_unlisted == False,
+                Track.is_delete == False,
+            )
+            .distinct(Track.track_id)
+            .subquery()
         )
 
-        count_subquery = create_save_repost_count_subquery(session, "track")
+        count_subquery = session.query(
+            AggregateTrack.track_id.label("id"),
+            (AggregateTrack.repost_count + AggregateTrack.save_count).label("count"),
+        ).subquery()
 
         query = (
             session.query(
                 remixable_tracks_subquery,
                 count_subquery.c["count"],
                 decayed_score(
-                    count_subquery.c["count"],
-                    remixable_tracks_subquery.c.created_at
-                ).label("score")
+                    count_subquery.c["count"], remixable_tracks_subquery.c.created_at
+                ).label("score"),
             )
             .select_from(remixable_tracks_subquery)
             .join(
                 count_subquery,
-                count_subquery.c["id"] == remixable_tracks_subquery.c.track_id
+                count_subquery.c["id"] == remixable_tracks_subquery.c.track_id,
             )
-            .order_by(
-                desc("score"),
-                desc(remixable_tracks_subquery.c.track_id)
-            )
+            .order_by(desc("score"), desc(remixable_tracks_subquery.c.track_id))
             .limit(limit)
         )
 


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Use aggregate_track for counting scores for remixables. This is *far* more performant. Query takes < 0.5s. There's an offline job here: https://github.com/AudiusProject/audius-protocol/blob/cefbc039c533797ae78584cd5f8c3dc1bbc3841b/discovery-provider/src/tasks/index_aggregate_views.py
that computes summed repost + save counts for all tracks.

The rest of explore should be refactored to use this, but since the playlists/albums and saves/reposts for playlists/albums is generally much smaller, it doesn't have as gnarly as a performance situation.

Sorry the diff here is a bit large -- autoformatting FTW though. The only change is the `count_subquery`

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Ran locally and exported the raw SQL and tested against prod data
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
