### PR TITLE
Add endpoint to save hCaptcha verification

### DIFF
--- a/identity-service/compose/.env
+++ b/identity-service/compose/.env
@@ -56,3 +56,4 @@ WAIT_HOSTS=identity-db:5432,identity-redis:6379
 
 captchaScoreSecret=captcha_score_secret
 recaptchaServiceKey=
+hCaptchaSecret=

--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -62,6 +62,7 @@
   "headersTimeout": 60000,
   "captchaScoreSecret": "captcha_score_secret",
   "recaptchaServiceKey": "",
+  "hCaptchaSecret": "",
   "solanaFeePayerWallet": "[]",
   "sentryDSN": "",
   "solanaEndpoint": "https://api.mainnet-beta.solana.com",

--- a/identity-service/package-lock.json
+++ b/identity-service/package-lock.json
@@ -5941,6 +5941,11 @@
       "resolved": "https://registry.npmjs.org/hashids/-/hashids-2.2.8.tgz",
       "integrity": "sha512-OI6rsk/OqyX60nBsqxnNl3R7CDv9eMOgxzipshZwXE6cUcBcEyHf8rNDlWVdQJZK3TEynILYybCsNUEQfJsdLA=="
     },
+    "hcaptcha": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/hcaptcha/-/hcaptcha-0.1.0.tgz",
+      "integrity": "sha512-mVRkhNcOuP7QJO50nYdu3vS+uaOg6Ku2HpMy50C2EckjB9DlnwX24iePi912IXuVIq5L8ukjISG4Ea6MimZ5+w=="
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",

--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -40,6 +40,7 @@
     "express-rate-limit": "^3.4.0",
     "handlebars": "^4.4.3",
     "hashids": "^2.2.2",
+    "hcaptcha": "^0.1.0",
     "ioredis": "^4.9.0",
     "keccak256": "^1.0.2",
     "mailgun-js": "^0.22.0",

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -522,6 +522,12 @@ const config = convict({
     env: 'recaptchaServiceKey',
     default: ''
   },
+  hCaptchaSecret: {
+    doc: 'The secret for hCaptcha account verification',
+    format: String,
+    env: 'hCaptchaSecret',
+    default: ''
+  },
   cognitoAPISecret: {
     doc: 'API Secret for Congnito',
     format: String,

--- a/identity-service/src/routes/captcha.js
+++ b/identity-service/src/routes/captcha.js
@@ -1,8 +1,11 @@
 const config = require('../config')
-const { handleResponse, successResponse, errorResponseForbidden } = require('../apiHelpers')
+const { handleResponse, successResponse, errorResponseForbidden, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
 const models = require('../models')
 const { QueryTypes } = require('sequelize')
 const userHandleMiddleware = require('../userHandleMiddleware')
+const authMiddleware = require('../authMiddleware')
+const { verify } = require('hcaptcha')
+const HCAPTCHA_SECRET = config.get('hCaptchaSecret')
 
 module.exports = function (app) {
   app.get('/scores', userHandleMiddleware, handleResponse(async req => {
@@ -25,5 +28,43 @@ module.exports = function (app) {
     )
 
     return successResponse(recaptchaEntries)
+  }))
+
+  app.post('/score', authMiddleware, handleResponse(async req => {
+    const user = req.user
+    const token = req.body.token
+
+    if (!token) {
+      return errorResponseBadRequest('Please provide hCaptcha token.')
+    }
+
+    try {
+      const { success, hostname } = await verify(HCAPTCHA_SECRET, token)
+
+      if (!success) {
+        return errorResponseServerError('hCaptcha Verification failed.')
+      }
+
+      // save hCaptcha score for user in BotScores
+      await models.BotScores.create({
+        walletAddress: user.walletAddress,
+        // hCaptcha scores represent risk scores
+        // the score values go from 0 to 1
+        // the higher the score the worse it is
+        // e.g. 0 is 'safe' and 1 is 'bot'
+        // given we are using the free publisher tier of hCaptcha, we only get the binary success/fail and no score value
+        // therefore we use the score of 1 to denote that verification was ok and remain consistent with our other scores
+        recaptchaScore: 1,
+        // the recaptcha context is very important because that's how we know whether
+        // the score is from hCaptcha, meaning 0 is best
+        // or if it's from our other recpatcha scores, where 1 is best
+        recaptchaContext: 'hCaptcha',
+        recaptchaHostname: hostname
+      })
+      return successResponse({})
+    } catch (err) {
+      console.error(err)
+      return errorResponseServerError(err.message)
+    }
   }))
 }


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add endpoint to save hCaptcha verification

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. With Postman making the post request with the right request body
2. With audius-client running locally and have the hCaptcha verify button make a request to identity


**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
