### PR TITLE
Update web3 to 1.2.8 - Fixes COLLECTION_NO_ID

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -336,6 +336,187 @@
         }
       }
     },
+    "@ethersproject/abi": {
+      "version": "5.0.0-beta.153",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+      "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+      "requires": {
+        "@ethersproject/address": ">=5.0.0-beta.128",
+        "@ethersproject/bignumber": ">=5.0.0-beta.130",
+        "@ethersproject/bytes": ">=5.0.0-beta.129",
+        "@ethersproject/constants": ">=5.0.0-beta.128",
+        "@ethersproject/hash": ">=5.0.0-beta.128",
+        "@ethersproject/keccak256": ">=5.0.0-beta.127",
+        "@ethersproject/logger": ">=5.0.0-beta.129",
+        "@ethersproject/properties": ">=5.0.0-beta.131",
+        "@ethersproject/strings": ">=5.0.0-beta.130"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
+      "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
+      "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        }
+      }
+    },
     "@ethersproject/bignumber": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
@@ -362,6 +543,83 @@
         "@ethersproject/bignumber": "^5.0.7"
       }
     },
+    "@ethersproject/hash": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "@ethersproject/keccak256": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
@@ -383,6 +641,60 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
       "integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
     },
+    "@ethersproject/networks": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.1.tgz",
+      "integrity": "sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==",
+      "requires": {
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        }
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+      "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
+      "requires": {
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        }
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        }
+      }
+    },
     "@ethersproject/sha2": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
@@ -401,6 +713,39 @@
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
           }
+        }
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -424,6 +769,134 @@
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+      "requires": {
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+      "requires": {
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+          "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -2613,6 +3086,29 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "dependencies": {
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2627,6 +3123,11 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -2781,6 +3282,16 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "requires": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
       }
     },
     "content-type": {
@@ -3906,6 +4417,7 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
       "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+      "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -3922,17 +4434,20 @@
         "@types/node": {
           "version": "10.17.21",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==",
+          "dev": true
         },
         "aes-js": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true
         },
         "elliptic": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
           "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -3944,6 +4459,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -3952,17 +4468,20 @@
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
         }
       }
     },
@@ -5717,6 +6236,44 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
+      }
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -6856,7 +7413,8 @@
     "scrypt-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+      "dev": true
     },
     "scrypt.js": {
       "version": "0.3.0",
@@ -7828,6 +8386,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7844,23 +8407,50 @@
       }
     },
     "web3": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.7.tgz",
-      "integrity": "sha512-jAAJHMfUlTps+jH2li1ckDFEpPrEEriU/ubegSTGRl3KRdNhEqT93+3kd7FHJTn3NgjcyURo2+f7Da1YcZL8Mw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.8.tgz",
+      "integrity": "sha512-rXUn16VKxn2aIe9v0KX+bSm2JXdq/Vnj3lZ0Rub2Q5YUSycHdCBaDtJRukl/jB5ygAdyr5/cUwvJzhNDJSYsGw==",
       "requires": {
-        "web3-bzz": "1.2.7",
-        "web3-core": "1.2.7",
-        "web3-eth": "1.2.7",
-        "web3-eth-personal": "1.2.7",
-        "web3-net": "1.2.7",
-        "web3-shh": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-bzz": "1.2.8",
+        "web3-core": "1.2.8",
+        "web3-eth": "1.2.8",
+        "web3-eth-personal": "1.2.8",
+        "web3-net": "1.2.8",
+        "web3-shh": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-bzz": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.7.tgz",
-      "integrity": "sha512-iTIWBR+Z+Bn09WprtKm46LmyNOasg2lUn++AjXkBTB8UNxlUybxtza84yl2ETTZUs0zuFzdSSAEgbjhygG+9oA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.8.tgz",
+      "integrity": "sha512-jbi24/s2tT7FYuN+ktRvTa5em0GxhqcIYQ8FnD3Zb/ZoEPi+/7rH0Hh+WDol0pSZL+wdz/iM+Z2C9NE42z6EmQ==",
       "requires": {
         "@types/node": "^10.12.18",
         "got": "9.6.0",
@@ -7869,124 +8459,257 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         }
       }
     },
     "web3-core": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.7.tgz",
-      "integrity": "sha512-QA0MTae0gXcr3KHe3cQ4x56+Wh43ZKWfMwg1gfCc3NNxPRM1jJ8qudzyptCAUcxUGXWpDG8syLIn1APDz5J8BQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.8.tgz",
+      "integrity": "sha512-hvlYWyE1UcLoGa6qF1GoxGgi1quFsZOdwIUIVsAp+sp0plXp/Nqva2lAjJ+FFyWtVKbC7Zq+qwTJ4iP1aN0vTg==",
       "requires": {
         "@types/bn.js": "^4.11.4",
         "@types/node": "^12.6.1",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-core-requestmanager": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core-helpers": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-core-requestmanager": "1.2.8",
+        "web3-utils": "1.2.8"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.38",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
-          "integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA=="
+          "version": "12.20.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+          "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
         },
         "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.7.tgz",
-      "integrity": "sha512-bdU++9QATGeCetVrMp8pV97aQtVkN5oLBf/TWu/qumC6jK/YqrvLlBJLdwbz0QveU8zOSap6GCvJbqKvmmbV2A==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.8.tgz",
+      "integrity": "sha512-Wrl7ZPKn3Xyg0Hl5+shDnJcLP+EtTfThmQ1eCJLcg/BZqvLUR1SkOslNlhEojcYeBwhhymAKs8dfQbtYi+HMnw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-eth-iban": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.7.tgz",
-      "integrity": "sha512-e1TI0QUnByDMbQ8QHwnjxfjKw0LIgVRY4TYrlPijET9ebqUJU1HCayn/BHIMpV6LKyR1fQj9EldWyT64wZQXkg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.8.tgz",
+      "integrity": "sha512-69qbvOgx0Frw46dXvEKzYgtaPXpUaQAlQmczgb0ZUBHsEU2K7jTtFgBy6kVBgAwsXDvoZ99AX4SjpY2dTMwPkw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-promievent": "1.2.7",
-        "web3-core-subscriptions": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core-helpers": "1.2.8",
+        "web3-core-promievent": "1.2.8",
+        "web3-core-subscriptions": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.7.tgz",
-      "integrity": "sha512-jNmsM/czCeMGQqKKwM9/HZVTJVIF96hdMVNN/V9TGvp+EEE7vDhB4pUocDnc/QF9Z/5QFBCVmvNWttlRgZmU0A==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.8.tgz",
+      "integrity": "sha512-3EdRieaHpBVVhfGjoREQfdoCM3xC0WwWjXXzT6oTldotfYC38kwk/GW8c8txYiLP/KxhslAN1cJSlXNOJjKSog==",
       "requires": {
         "eventemitter3": "3.1.2"
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.7.tgz",
-      "integrity": "sha512-HJb/txjHixu1dxIebiZQKBoJCaNu4gsh7mq/uj6Z/w6tIHbybL90s/7ADyMED353yyJ2tDWtYJqeMVAR+KtdaA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.8.tgz",
+      "integrity": "sha512-bwc2ABG6yzgTy28fv4t59g+tf6+UmTRMoF8HqTeiNDffoMKP2akyKFZeu1oD2gE7j/7GA75TAUjwJ7pH9ek1MA==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.7",
-        "web3-providers-http": "1.2.7",
-        "web3-providers-ipc": "1.2.7",
-        "web3-providers-ws": "1.2.7"
+        "web3-core-helpers": "1.2.8",
+        "web3-providers-http": "1.2.8",
+        "web3-providers-ipc": "1.2.8",
+        "web3-providers-ws": "1.2.8"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.7.tgz",
-      "integrity": "sha512-W/CzQYOUawdMDvkgA/fmLsnG5aMpbjrs78LZMbc0MFXLpH3ofqAgO2by4QZrrTShUUTeWS0ZuEkFFL/iFrSObw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.8.tgz",
+      "integrity": "sha512-wmsRJ4ipwoF1mlOR+Oo8JdKigpkoVNQtqiRUuyQrTVhJx7GBuSaAIenpBYlkucC+RgByoGybR7Q3tTNJ6z/2tQ==",
       "requires": {
         "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.7"
+        "web3-core-helpers": "1.2.8"
       }
     },
     "web3-eth": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.7.tgz",
-      "integrity": "sha512-ljLd0oB4IjWkzFGVan4HkYhJXhSXgn9iaSaxdJixKGntZPgWMJfxeA+uLwTrlxrWzhvy4f+39WnT7wCh5e9TGg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.8.tgz",
+      "integrity": "sha512-CEnVIIR1zZQ9vQh/kPFAUbvbbHYkC84y15jdhRUDDGR6bs4FxO2NNWR2YDtNe038lrz747tZahsC9kEiGkJFZQ==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.2.7",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-core-subscriptions": "1.2.7",
-        "web3-eth-abi": "1.2.7",
-        "web3-eth-accounts": "1.2.7",
-        "web3-eth-contract": "1.2.7",
-        "web3-eth-ens": "1.2.7",
-        "web3-eth-iban": "1.2.7",
-        "web3-eth-personal": "1.2.7",
-        "web3-net": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-helpers": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-core-subscriptions": "1.2.8",
+        "web3-eth-abi": "1.2.8",
+        "web3-eth-accounts": "1.2.8",
+        "web3-eth-contract": "1.2.8",
+        "web3-eth-ens": "1.2.8",
+        "web3-eth-iban": "1.2.8",
+        "web3-eth-personal": "1.2.8",
+        "web3-net": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.7.tgz",
-      "integrity": "sha512-4FnlT1q+D0XBkxSMXlIb/eG337uQeMaUdtVQ4PZ3XzxqpcoDuMgXm4o+3NRxnWmr4AMm6QKjM+hcC7c0mBKcyg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.8.tgz",
+      "integrity": "sha512-OKp/maLdKHPpQxZhEd0HgnCJFQajsGe42WOG6SVftlgzyR8Jjv4KNm46TKvb3hv5OJTKZWU7nZIxkEG+fyI58w==",
       "requires": {
-        "ethers": "4.0.0-beta.3",
+        "@ethersproject/abi": "5.0.0-beta.153",
         "underscore": "1.9.1",
-        "web3-utils": "1.2.7"
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-accounts": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.7.tgz",
-      "integrity": "sha512-AE7QWi/iIQIjXwlAPtlMabm/OPFF0a1PhxT1EiTckpYNP8fYs6jW7lYxEtJPPJIKqfMjoi1xkEqTVR1YZQ88lg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.8.tgz",
+      "integrity": "sha512-QODqSD4SZN/1oWfvlvsuum6Ud9+2FUTW4VTPJh245YTewCpa0M5+Fzug3UTeUZNv88STwC//dV72zReITNh4ZQ==",
       "requires": {
         "@web3-js/scrypt-shim": "^0.1.0",
         "crypto-browserify": "3.12.0",
@@ -7995,10 +8718,10 @@
         "ethereumjs-tx": "^2.1.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.2.7",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-helpers": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-utils": "1.2.8"
       },
       "dependencies": {
         "eth-lib": {
@@ -8011,144 +8734,297 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.7.tgz",
-      "integrity": "sha512-uW23Y0iL7XroRNbf9fWZ1N6OYhEYTJX8gTuYASuRnpYrISN5QGiQML6pq/NCzqypR1bl5E0fuINZQSK/xefIVw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.8.tgz",
+      "integrity": "sha512-EWRLVhZksbzGAyHd7RaOsakjCJBA2BREWiJmBDlrxDBqw8HltXFzKdkRug/mwVNa5ZYMabKSRF/MMh0Sx06CFw==",
       "requires": {
         "@types/bn.js": "^4.11.4",
         "underscore": "1.9.1",
-        "web3-core": "1.2.7",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-core-promievent": "1.2.7",
-        "web3-core-subscriptions": "1.2.7",
-        "web3-eth-abi": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-helpers": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-core-promievent": "1.2.8",
+        "web3-core-subscriptions": "1.2.8",
+        "web3-eth-abi": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-ens": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.7.tgz",
-      "integrity": "sha512-SPRnvUNWQ0CnnTDBteGIJkvFWEizJcAHlVsrFLICwcwFZu+appjX1UOaoGu2h3GXWtc/XZlu7B451Gi+Os2cTg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.8.tgz",
+      "integrity": "sha512-zsFXY26BMGkihPkEO5qj9AEqyxPH4mclbzYs1dyrw7sHFmrUvhZc+jLGT9WyQGoujq37RN2l/tlOpCaFVVR8ng==",
       "requires": {
+        "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.2.7",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-promievent": "1.2.7",
-        "web3-eth-abi": "1.2.7",
-        "web3-eth-contract": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-helpers": "1.2.8",
+        "web3-core-promievent": "1.2.8",
+        "web3-eth-abi": "1.2.8",
+        "web3-eth-contract": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-iban": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.7.tgz",
-      "integrity": "sha512-2NrClz1PoQ3nSJBd+91ylCOVga9qbTxjRofq/oSCoHVAEvz3WZyttx9k5DC+0rWqwJF1h69ufFvdHAAlmN/4lg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.8.tgz",
+      "integrity": "sha512-xgPUOuDOQJYloUS334/wot6jvp6K8JBz8UvQ1tAxU9LO2v2DW+IDTJ5gQ6TdutTmzdDi97KdwhwnQwhQh5Z1PA==",
       "requires": {
         "bn.js": "4.11.8",
-        "web3-utils": "1.2.7"
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-personal": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.7.tgz",
-      "integrity": "sha512-2OAa1Spz0uB29dwCM8+1y0So7E47A4gKznjBEwXIYEcUIsvwT5X7ofFhC2XxyRpqlIWZSQAxRSSJFyupRRXzyw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.8.tgz",
+      "integrity": "sha512-sWhxF1cpF9pB1wMISrOSy/i8IB1NWtvoXT9dfkWtvByGf3JfC2DlnllLaA1f9ohyvxnR+QTgPKgOQDknmqDstw==",
       "requires": {
         "@types/node": "^12.6.1",
-        "web3-core": "1.2.7",
-        "web3-core-helpers": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-net": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-helpers": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-net": "1.2.8",
+        "web3-utils": "1.2.8"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.38",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
-          "integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA=="
+          "version": "12.20.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+          "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-net": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.7.tgz",
-      "integrity": "sha512-j9qeZrS1FNyCeA0BfdLojkxOZQz3FKa1DJI+Dw9fEVhZS68vLOFANu2RB96gR9BoPHo5+k5D3NsKOoxt1gw3Gg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.8.tgz",
+      "integrity": "sha512-Nsq6qgncvvThOjC+sQ+NfDH8L7jclQCFzLFYa9wsd5J6HJ6f5gJl/mv6rsZQX9iDEYDPKkDfyqHktynOBgKWMQ==",
       "requires": {
-        "web3-core": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-utils": "1.2.8"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+          "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-providers-http": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.7.tgz",
-      "integrity": "sha512-vazGx5onuH/zogrwkUaLFJwFcJ6CckP65VFSHoiV+GTQdkOqgoDIha7StKkslvDz4XJ2FuY/zOZHbtuOYeltXQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.8.tgz",
+      "integrity": "sha512-Esj4SpgabmBDOR4QD3qYapzwFYWHigcdgdjvt/VWT5/7TD10o52hr+Nsvp3/XV5AFrcCMdY+lzKFLVH24u0sww==",
       "requires": {
-        "web3-core-helpers": "1.2.7",
+        "web3-core-helpers": "1.2.8",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.7.tgz",
-      "integrity": "sha512-/zc0y724H2zbkV4UbGGMhsEiLfafjagIzfrsWZnyTZUlSB0OGRmmFm2EkLJAgtXrLiodaHHyXKM0vB8S24bxdA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.8.tgz",
+      "integrity": "sha512-ts3/UXCTRADPASdJ27vBVmcfM+lfG9QVBxGedY6+oNIo5EPxBUtsz94R32sfvFd6ofPsz6gOhK/M/ZKiJoi1sg==",
       "requires": {
         "oboe": "2.1.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.7"
+        "web3-core-helpers": "1.2.8"
       }
     },
     "web3-providers-ws": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.7.tgz",
-      "integrity": "sha512-b5XzqDpRkNVe6MFs5K6iqOEyjQikHtg3KuU2/ClCDV37hm0WN4xCRVMC0LwegulbDXZej3zT9+1CYzGaGFREzA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.8.tgz",
+      "integrity": "sha512-Gcm0n82wd/XVeGFGTx+v56UqyrV9EyB2r1QFaBx4mS+VHbW2MCOdiRbNDfoZQslflnCWl8oHsivJ8Tya9kqlTQ==",
       "requires": {
         "@web3-js/websocket": "^1.0.29",
         "eventemitter3": "^4.0.0",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.7"
+        "web3-core-helpers": "1.2.8"
       },
       "dependencies": {
         "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         }
       }
     },
     "web3-shh": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.7.tgz",
-      "integrity": "sha512-f6PAgcpG0ZAo98KqCmeHoDEx5qzm3d5plet18DkT4U6WIeYowKdec8vZaLPRR7c2XreXFJ2gQf45CB7oqR7U/w==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.8.tgz",
+      "integrity": "sha512-e29qKSfuZWDmxCG/uB48Nth6DCFFr2h2U+uI/fHEuhEjAEkBHopPNLc3ixrCTc6pqMocfJRPHJq/yET9PYN3oQ==",
       "requires": {
-        "web3-core": "1.2.7",
-        "web3-core-method": "1.2.7",
-        "web3-core-subscriptions": "1.2.7",
-        "web3-net": "1.2.7"
+        "web3-core": "1.2.8",
+        "web3-core-method": "1.2.8",
+        "web3-core-subscriptions": "1.2.8",
+        "web3-net": "1.2.8"
       }
     },
     "web3-utils": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7.tgz",
       "integrity": "sha512-FBh/CPJND+eiPeUF9KVbTyTZtXNWxPWtByBaWS6e2x4ACazPX711EeNaZaChIOGSLGe6se2n7kg6wnawe/MjuQ==",
+      "dev": true,
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
@@ -8164,6 +9040,7 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",

--- a/libs/package.json
+++ b/libs/package.json
@@ -40,7 +40,7 @@
     "secp256k1": "^4.0.2",
     "semver": "^6.3.0",
     "tus-js-client": "^2.3.0",
-    "web3": "1.2.7"
+    "web3": "1.2.8"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.6",

--- a/libs/tests/trackClientTest.js
+++ b/libs/tests/trackClientTest.js
@@ -17,7 +17,7 @@ before(async function () {
 })
 
 it('should call getTrack on invalid value and return empty', async function () {
-  let track = await audiusInstance.contracts.TrackFactoryClient.getTrack(-1)
+  let track = await audiusInstance.contracts.TrackFactoryClient.getTrack(0)
   assert.strictEqual(track.multihashDigest, helpers.constants['0x0'])
 })
 

--- a/libs/tests/userClientTest.js
+++ b/libs/tests/userClientTest.js
@@ -10,7 +10,7 @@ before(async function () {
 })
 
 it('should call getUser on invalid value and verify blockchain is empty', async function () {
-  let creator = await audiusInstance.contracts.UserFactoryClient.getUser(-1)
+  let creator = await audiusInstance.contracts.UserFactoryClient.getUser(0)
   assert.strictEqual(creator.wallet, '0x0000000000000000000000000000000000000000')
 })
 


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Emoji support on playlists/abi decoders was broken in web3 1.2.7. What I do not understand is how we operated on 1.2.7 for many months and this was not an issue.
Web3 Issue documentation: https://github.com/ChainSafe/web3.js/issues/3480

As per my comment on that issue, my only best guess here is that there was some transitive dependency in our lock file actually relies on some on-line resource or relies on something on-line during npm install (which is extremely scary to me) and that had a dependency upgrade somewhere. We observed this NO_ID issue begin in mid May and I have tried reverting the codebase back to that point in time and the issue is not resolved.

For the record. I do not support this change, but I don't have any alternatives, and we definitely want emoji support.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Created playlist
2. Created account 
3. Uploaded track
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

This PR touches crypto deps. It is always scary. Requires LOTS of QA.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
