### PR TITLE
Only check staged files for check-secrets hook

### DIFF
--- a/check_secrets.sh
+++ b/check_secrets.sh
@@ -15,4 +15,4 @@ git secrets --register-aws
 git secrets --add '.*[a-z0-9]*.rds.amazonaws.com:[0-9]*\/.*'
 
 # scan the repository
-git secrets --scan
+git secrets --scan --cached


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Reduce false positives by only scanning files to be included in the commit.

See also: https://github.com/awslabs/git-secrets/pull/13

Note: For CI and elsewhere, not sure if this would be sufficient as those changes wouldn't be staged.