### PR TITLE
Update User Balances

### DIFF
--- a/discovery-provider/src/eth_indexing/event_scanner.py
+++ b/discovery-provider/src/eth_indexing/event_scanner.py
@@ -17,7 +17,7 @@ from eth_abi.codec import ABICodec
 
 from src.models.models import AssociatedWallet, EthBlock, User
 from src.utils.helpers import redis_set_and_dump, redis_get_or_restore
-from src.queries.get_balances import enqueue_balance_refresh
+from src.queries.get_balances import enqueue_immediate_balance_refresh
 
 
 logger = logging.getLogger(__name__)
@@ -186,7 +186,7 @@ class EventScanner:
                 .all()
             )
             user_ids = [user_id for [user_id] in result]
-            enqueue_balance_refresh(self.redis, user_ids)
+            enqueue_immediate_balance_refresh(self.redis, user_ids)
 
         # Return a pointer that allows us to look up this event later if needed
         return f"{block_number}-{txhash}-{log_index}"
@@ -388,7 +388,11 @@ def _retry_web3_call(  # type: ignore
 
 
 def _fetch_events_for_all_contracts(
-    web3, event_type, argument_filters: dict, from_block: BlockIdentifier, to_block: BlockIdentifier
+    web3,
+    event_type,
+    argument_filters: dict,
+    from_block: BlockIdentifier,
+    to_block: BlockIdentifier,
 ) -> Iterable:
     """Get events using eth_get_logs API.
 

--- a/discovery-provider/src/queries/get_balances.py
+++ b/discovery-provider/src/queries/get_balances.py
@@ -1,63 +1,62 @@
 import logging
 from datetime import datetime, timedelta
+from typing import List, Optional, Set
+from redis import Redis
+from sqlalchemy.orm.session import Session
 from src.models import UserBalance
 
 logger = logging.getLogger(__name__)
 
-# How stale of current_user or verified user balance we will tolerate before refreshing.
-BALANCE_REFRESH_SEC_PRIORITY_USER = 60
-
-# How stale of a non-zero user balance we tolerate before refreshing
-BALANCE_REFRESH_SEC_NONEMPTY_USER = 15 * 60
-
 # How stale of a zero user balance we tolerate before refreshing
-BALANCE_REFRESH_SEC_EMPTY_USER = 1 * 60 * 60
+BALANCE_REFRESH = 12 * 60 * 60
 
-REDIS_USER_BALANCE_REFRESH_KEY = "USER_BALANCE_REFRESH"
+LAZY_REFRESH_REDIS_PREFIX = "USER_BALANCE_REFRESH_LAZY"
+IMMEDIATE_REFRESH_REDIS_PREFIX = "USER_BALANCE_REFRESH_IMMEDIATE"
 
 
-def does_user_balance_need_refresh(user_balance, is_priority_user=True):
+def does_user_balance_need_refresh(user_balance: UserBalance) -> bool:
     """Returns whether a given user_balance needs update.
     Very heuristic-y:
         - If we've never updated before (new balance entry), update now
-        - If we're the current_user, update on the shortest interval
-        - If we're not the current user but we have some balance, update on medium interval
-        - If we're not the current user and we have no balance, update on slowest interval
+        - If the balance has not been updated in BALANCE_REFRESH seconds
     """
 
     if user_balance.updated_at == user_balance.created_at:
         return True
 
-    threshold = None
-    if is_priority_user:
-        threshold = BALANCE_REFRESH_SEC_PRIORITY_USER
-    elif (
-        int(user_balance.balance) > 0
-        or int(user_balance.associated_wallets_balance) > 0
-    ):
-        threshold = BALANCE_REFRESH_SEC_NONEMPTY_USER
-    else:
-        threshold = BALANCE_REFRESH_SEC_EMPTY_USER
-
-    delta = timedelta(seconds=threshold)
+    delta = timedelta(seconds=BALANCE_REFRESH)
     needs_refresh = user_balance.updated_at < (datetime.now() - delta)
     return needs_refresh
 
 
-def enqueue_balance_refresh(redis, user_ids):
+def enqueue_lazy_balance_refresh(redis: Redis, user_ids: List[int]):
     # unsafe to call redis.sadd w/ empty array
     if not user_ids:
         return
-    redis.sadd(REDIS_USER_BALANCE_REFRESH_KEY, *user_ids)
+    redis.sadd(LAZY_REFRESH_REDIS_PREFIX, *user_ids)
 
 
-def get_balances(session, user_ids):
+def enqueue_immediate_balance_refresh(redis: Redis, user_ids: List[int]):
+    # unsafe to call redis.sadd w/ empty array
+    if not user_ids:
+        return
+    redis.sadd(IMMEDIATE_REFRESH_REDIS_PREFIX, *user_ids)
+
+
+def get_balances(
+    session: Session,
+    redis: Redis,
+    user_ids: List[int],
+    is_verified_ids_set: Optional[Set[int]] = None,
+):
     """Gets user balances.
     Returns mapping { user_id: balance }
     Enqueues in Redis user balances requiring refresh.
     """
     # Find user balances
-    query = (session.query(UserBalance)).filter(UserBalance.user_id.in_(user_ids)).all()
+    query: List[UserBalance] = (
+        (session.query(UserBalance)).filter(UserBalance.user_id.in_(user_ids)).all()
+    )
 
     # Construct result dict from query result
     result = {
@@ -79,5 +78,21 @@ def get_balances(session, user_ids):
         for user_id in needs_balance_set
     }
     result.update(no_balance_dict)
+
+    # Get old balances that need refresh
+    needs_refresh = [
+        user_balance.user_id
+        for user_balance in query
+        if does_user_balance_need_refresh(user_balance)
+    ]
+
+    verified_ids_set = is_verified_ids_set if is_verified_ids_set else set()
+    # Enqueue new balances to Redis refresh queue
+    # 1. All users who need a new balance
+    # 2. All users who need a balance refresh
+    # 3. All verified users (priority)
+    enqueue_lazy_balance_refresh(
+        redis, list(needs_balance_set.union(verified_ids_set)) + needs_refresh
+    )
 
     return result

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -19,7 +19,10 @@ from src.utils.redis_constants import (
     user_balances_refresh_last_completion_redis_key,
     index_eth_last_completion_redis_key,
 )
-from src.queries.get_balances import REDIS_USER_BALANCE_REFRESH_KEY
+from src.queries.get_balances import (
+    LAZY_REFRESH_REDIS_PREFIX,
+    IMMEDIATE_REFRESH_REDIS_PREFIX,
+)
 from src.utils.helpers import redis_get_or_restore
 from src.eth_indexing.event_scanner import eth_indexing_last_scanned_block_key
 
@@ -200,8 +203,11 @@ def get_health(args, use_redis_cache=True):
     user_balances_age_sec = get_elapsed_time_redis(
         redis, user_balances_refresh_last_completion_redis_key
     )
-    num_users_in_balance_refresh_queue = len(
-        redis.smembers(REDIS_USER_BALANCE_REFRESH_KEY)
+    num_users_in_lazy_balance_refresh_queue = len(
+        redis.smembers(LAZY_REFRESH_REDIS_PREFIX)
+    )
+    num_users_in_immediate_balance_refresh_queue = len(
+        redis.smembers(IMMEDIATE_REFRESH_REDIS_PREFIX)
     )
     last_scanned_block_for_balance_refresh = redis_get_or_restore(
         redis, eth_indexing_last_scanned_block_key
@@ -243,7 +249,8 @@ def get_health(args, use_redis_cache=True):
         "trending_playlists_age_sec": trending_playlists_age_sec,
         "challenge_last_event_age_sec": challenge_events_age_sec,
         "user_balances_age_sec": user_balances_age_sec,
-        "num_users_in_balance_refresh_queue": num_users_in_balance_refresh_queue,
+        "num_users_in_lazy_balance_refresh_queue": num_users_in_lazy_balance_refresh_queue,
+        "num_users_in_immediate_balance_refresh_queue": num_users_in_immediate_balance_refresh_queue,
         "last_scanned_block_for_balance_refresh": last_scanned_block_for_balance_refresh,
         "index_eth_age_sec": index_eth_age_sec,
         "number_of_cpus": number_of_cpus,

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -23,7 +23,7 @@ from src.models import (
 )
 from src.utils import helpers, redis_connection
 from src.queries.get_unpopulated_users import get_unpopulated_users
-from src.queries.get_balances import get_balances
+from src.queries.get_balances import get_balances, enqueue_lazy_balance_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +111,10 @@ def parse_sort_param(base_query, model, whitelist_sort_params):
 def populate_user_metadata(
     session, user_ids, users, current_user_id, with_track_save_count=False
 ):
+    # Always enqueue balance refresh for current user
+    if current_user_id:
+        enqueue_lazy_balance_refresh(redis, [current_user_id])
+
     aggregate_user = (
         session.query(
             AggregateUser.user_id,
@@ -1188,8 +1192,10 @@ def decayed_score(score, created_at, peak=1000, nominal_timestamp=60 * 24 * 60 *
         where multipler is represented by:
         peak ^ 1 - min(time_ago / nominal_timestamp, 1)
     """
-    decay_exponent = 1 - func.least(seconds_ago(created_at) / nominal_timestamp, 1) # goes from 1 -> 0
-    decay_value = func.pow(peak, decay_exponent) / peak # decay slope value
+    decay_exponent = 1 - func.least(
+        seconds_ago(created_at) / nominal_timestamp, 1
+    )  # goes from 1 -> 0
+    decay_value = func.pow(peak, decay_exponent) / peak  # decay slope value
     return score * decay_value
 
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -210,7 +210,7 @@ def populate_user_metadata(
             current_user_followee_follow_counts
         )
 
-    balance_dict = get_balances(session, user_ids)
+    balance_dict = get_balances(session, redis, user_ids)
 
     for user in users:
         user_id = user["user_id"]

--- a/discovery-provider/src/tasks/cache_user_balance.py
+++ b/discovery-provider/src/tasks/cache_user_balance.py
@@ -1,12 +1,11 @@
 import logging
 import time
-import random
-from redis import Redis
 from typing import List, Set
-
-from src.utils.session_manager import SessionManager
+from redis import Redis
 from sqlalchemy.orm.session import Session
 from sqlalchemy import and_
+
+from src.utils.session_manager import SessionManager
 from src.app import eth_abi_values
 from src.tasks.celery_app import celery
 from src.models import UserBalance, User, AssociatedWallet

--- a/discovery-provider/src/tasks/cache_user_balance.py
+++ b/discovery-provider/src/tasks/cache_user_balance.py
@@ -191,12 +191,8 @@ def refresh_user_ids(
         )
         if lazy_refresh_user_ids:
             redis.srem(LAZY_REFRESH_REDIS_PREFIX, *lazy_refresh_user_ids)
-            # Add the count of the balances
-            redis.incrby(REDIS_ETH_BALANCE_COUNTER_KEY, len(lazy_refresh_user_ids))
         if immediate_refresh_user_ids:
             redis.srem(IMMEDIATE_REFRESH_REDIS_PREFIX, *immediate_refresh_user_ids)
-            # Add the count of the balances
-            redis.incrby(REDIS_ETH_BALANCE_COUNTER_KEY, len(immediate_refresh_user_ids))
 
 
 def get_token_address(eth_web3, shared_config):

--- a/discovery-provider/src/tasks/cache_user_balance.py
+++ b/discovery-provider/src/tasks/cache_user_balance.py
@@ -1,12 +1,19 @@
 import logging
 import time
+import random
+from redis import Redis
+from typing import List, Set
+
+from src.utils.session_manager import SessionManager
+from sqlalchemy.orm.session import Session
 from sqlalchemy import and_
 from src.app import eth_abi_values
 from src.tasks.celery_app import celery
 from src.models import UserBalance, User, AssociatedWallet
 from src.queries.get_balances import (
     does_user_balance_need_refresh,
-    REDIS_USER_BALANCE_REFRESH_KEY,
+    IMMEDIATE_REFRESH_REDIS_PREFIX,
+    LAZY_REFRESH_REDIS_PREFIX,
 )
 from src.utils.redis_constants import user_balances_refresh_last_completion_redis_key
 
@@ -16,6 +23,34 @@ audius_staking_registry_key = bytes("StakingProxy", "utf-8")
 audius_delegate_manager_registry_key = bytes("DelegateManager", "utf-8")
 
 REDIS_ETH_BALANCE_COUNTER_KEY = "USER_BALANCE_REFRESH_COUNT"
+
+
+def get_lazy_refresh_user_ids(redis: Redis, session: Session) -> List[int]:
+    redis_user_ids = redis.smembers(LAZY_REFRESH_REDIS_PREFIX)
+    user_ids = [int(user_id.decode()) for user_id in redis_user_ids]
+
+    user_balances = (
+        (session.query(UserBalance)).filter(UserBalance.user_id.in_(user_ids)).all()
+    )
+
+    # Balances from current user lookup may not be present in the db
+    not_present_set = set(user_ids) - {user.user_id for user in user_balances}
+
+    # Filter only user_balances that still need refresh
+    needs_refresh: Set[int] = {
+        user.user_id
+        for user in list(filter(does_user_balance_need_refresh, user_balances))
+    }
+    needs_refresh.update(not_present_set)
+
+    # return user id of needs_refresh
+    return list(needs_refresh)
+
+
+def get_immediate_refresh_user_ids(redis: Redis) -> List[int]:
+    redis_user_ids = redis.smembers(IMMEDIATE_REFRESH_REDIS_PREFIX)
+    return [int(user_id.decode()) for user_id in redis_user_ids]
+
 
 # *Explanation of user balance caching*
 # In an effort to minimize eth calls, we look up users embedded in track metadata once per user,
@@ -38,46 +73,45 @@ REDIS_ETH_BALANCE_COUNTER_KEY = "USER_BALANCE_REFRESH_COUNT"
 #
 #     enqueued User Ids in Redis that are *not* ready to be refreshed yet are left in the queue
 #     for later.
-
-
 def refresh_user_ids(
-    redis, db, token_contract, delegate_manager_contract, staking_contract, eth_web3
+    redis: Redis,
+    db: SessionManager,
+    token_contract,
+    delegate_manager_contract,
+    staking_contract,
+    eth_web3,
 ):
-    # List users in Redis set, balances decoded as strings
-    redis_user_ids = redis.smembers(REDIS_USER_BALANCE_REFRESH_KEY)
-    redis_user_ids = [int(user_id.decode()) for user_id in redis_user_ids]
-
-    if not redis_user_ids:
-        return
-
-    logger.info(
-        f"cache_user_balance.py | Starting refresh with {len(redis_user_ids)} user_ids: {redis_user_ids}"
-    )
-
     with db.scoped_session() as session:
-        query = (
-            (session.query(UserBalance))
-            .filter(UserBalance.user_id.in_(redis_user_ids))
-            .all()
+        lazy_refresh_user_ids = get_lazy_refresh_user_ids(redis, session)
+        immediate_refresh_user_ids = get_immediate_refresh_user_ids(redis)
+
+        logger.info(
+            f"cache_user_balance.py | Starting refresh with {len(lazy_refresh_user_ids)} "
+            f"lazy refresh user_ids: {lazy_refresh_user_ids} and {len(immediate_refresh_user_ids)} "
+            f"immediate refresh user_ids: {immediate_refresh_user_ids}"
+        )
+        all_user_ids = lazy_refresh_user_ids + immediate_refresh_user_ids
+        user_ids = list(set(all_user_ids))
+
+        existing_user_balances: List[UserBalance] = (
+            (session.query(UserBalance)).filter(UserBalance.user_id.in_(user_ids)).all()
         )
 
         # Balances from current user lookup may
         # not be present in the db, so make those
-        not_present_set = set(redis_user_ids) - {user.user_id for user in query}
+        not_present_set = set(all_user_ids) - {
+            user.user_id for user in existing_user_balances
+        }
         new_balances = [
-            UserBalance(user_id=user_id, balance=0, associated_wallets_balance=0)
+            UserBalance(user_id=user_id, balance="0", associated_wallets_balance="0")
             for user_id in not_present_set
         ]
         if new_balances:
             session.add_all(new_balances)
-            logger.info(f"cache_user_balance.py | adding new users: {not_present_set}")
 
-        # Filter only user_balances that still need refresh
-        needs_refresh = list(filter(does_user_balance_need_refresh, query))
-        needs_refresh += new_balances
-
-        # map user_id -> user_balance
-        needs_refresh_map = {user.user_id: user for user in needs_refresh}
+        user_balances = {
+            user.user_id: user for user in (existing_user_balances + new_balances)
+        }
 
         # Grab the users & associated_wallets we need to refresh
         user_query = (
@@ -91,7 +125,7 @@ def refresh_user_ids(
                 ),
             )
             .filter(
-                User.user_id.in_(needs_refresh_map.keys()),
+                User.user_id.in_(user_ids),
                 User.is_current == True,
             )
             .all()
@@ -110,7 +144,7 @@ def refresh_user_ids(
                     )
 
         logger.info(
-            f"cache_user_balance.py | fetching for {len(user_query)} users: {needs_refresh_map.keys()}"
+            f"cache_user_balance.py | fetching for {len(user_query)} users: {user_ids}"
         )
 
         # Fetch balances
@@ -140,9 +174,9 @@ def refresh_user_ids(
                         )
 
                 # update the balance on the user model
-                user_balance = needs_refresh_map[user_id]
+                user_balance = user_balances[user_id]
                 user_balance.balance = owner_wallet_balance
-                user_balance.associated_wallets_balance = associated_balance
+                user_balance.associated_wallets_balance = str(associated_balance)
 
             except Exception as e:
                 logger.error(
@@ -153,14 +187,17 @@ def refresh_user_ids(
         session.commit()
 
         # Remove the fetched balances from Redis set
-        to_remove = [user.user_id for user in needs_refresh]
         logger.info(
             f"cache_user_balance.py | Got balances for {len(user_query)} users, removing from Redis."
         )
-        if to_remove:
-            redis.srem(REDIS_USER_BALANCE_REFRESH_KEY, *to_remove)
+        if lazy_refresh_user_ids:
+            redis.srem(LAZY_REFRESH_REDIS_PREFIX, *lazy_refresh_user_ids)
             # Add the count of the balances
-            redis.incrby(REDIS_ETH_BALANCE_COUNTER_KEY, len(to_remove))
+            redis.incrby(REDIS_ETH_BALANCE_COUNTER_KEY, len(lazy_refresh_user_ids))
+        if immediate_refresh_user_ids:
+            redis.srem(IMMEDIATE_REFRESH_REDIS_PREFIX, *immediate_refresh_user_ids)
+            # Add the count of the balances
+            redis.incrby(REDIS_ETH_BALANCE_COUNTER_KEY, len(immediate_refresh_user_ids))
 
 
 def get_token_address(eth_web3, shared_config):

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -9,7 +9,7 @@ from src.models import User, UserEvents, AssociatedWallet
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.tasks.metadata import user_metadata_format
 from src.utils.user_event_constants import user_event_types_arr, user_event_types_lookup
-from src.queries.get_balances import enqueue_balance_refresh
+from src.queries.get_balances import enqueue_lazy_balance_refresh
 from src.utils.indexing_errors import IndexingError
 from src.challenges.challenge_event import ChallengeEvent
 
@@ -415,7 +415,7 @@ def update_user_associated_wallets(
 
         is_updated_wallets = set(previous_wallets) != added_associated_wallets
         if is_updated_wallets:
-            enqueue_balance_refresh(update_task.redis, [user_record.user_id])
+            enqueue_lazy_balance_refresh(update_task.redis, [user_record.user_id])
     except Exception as e:
         logger.error(
             f"index.py | users.py | Fatal updating user associated wallets while indexing {e}",

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -9,7 +9,7 @@ from src.models import User, UserEvents, AssociatedWallet
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.tasks.metadata import user_metadata_format
 from src.utils.user_event_constants import user_event_types_arr, user_event_types_lookup
-from src.queries.get_balances import enqueue_lazy_balance_refresh
+from src.queries.get_balances import enqueue_immediate_balance_refresh
 from src.utils.indexing_errors import IndexingError
 from src.challenges.challenge_event import ChallengeEvent
 
@@ -415,7 +415,7 @@ def update_user_associated_wallets(
 
         is_updated_wallets = set(previous_wallets) != added_associated_wallets
         if is_updated_wallets:
-            enqueue_lazy_balance_refresh(update_task.redis, [user_record.user_id])
+            enqueue_immediate_balance_refresh(update_task.redis, [user_record.user_id])
     except Exception as e:
         logger.error(
             f"index.py | users.py | Fatal updating user associated wallets while indexing {e}",


### PR DESCRIPTION
### Description
Updates the cache user balance job to add an immediate redis user id set for updating user's cached balances
Updates lazy refresh balance to 12 hrs instead of complicated heuristics 

### Tests
Manually ran and added user ids to the sets for immediate and lazy

### How will this change be monitored?
Manually w/ the logs
