### PR TITLE
Create and use an in-memory list of records to be added

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -18,7 +18,7 @@ from src.models import (
     UserEvents,
 )
 from src.tasks.celery_app import celery
-from src.tasks.tracks import track_state_update
+from src.tasks.tracks import reset_pending_updates, track_state_update
 from src.tasks.users import user_state_update  # pylint: disable=E0611,E0001
 from src.tasks.social_features import social_feature_state_update
 from src.tasks.playlists import playlist_state_update
@@ -484,6 +484,7 @@ def index_blocks(self, db, blocks_list):
 
                 track_lexeme_state_changed = user_state_changed or track_state_changed
                 session.commit()
+                reset_pending_updates()
                 logger.info(
                     f"index.py | session commmited to db for block=${block_number}"
                 )

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -18,7 +18,7 @@ from src.models import (
     UserEvents,
 )
 from src.tasks.celery_app import celery
-from src.tasks.tracks import reset_pending_updates, track_state_update
+from src.tasks.tracks import track_state_update
 from src.tasks.users import user_state_update  # pylint: disable=E0611,E0001
 from src.tasks.social_features import social_feature_state_update
 from src.tasks.playlists import playlist_state_update
@@ -484,7 +484,6 @@ def index_blocks(self, db, blocks_list):
 
                 track_lexeme_state_changed = user_state_changed or track_state_changed
                 session.commit()
-                reset_pending_updates()
                 logger.info(
                     f"index.py | session commmited to db for block=${block_number}"
                 )

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -181,6 +181,7 @@ def test_index_tracks(mock_index_task, app):
         db = get_db()
 
     update_task = UpdateTask(ipfs_client, web3)
+    pending_track_routes = []
 
     with db.scoped_session() as session:
         # ================== Test New Track Event ==================
@@ -236,6 +237,7 @@ def test_index_tracks(mock_index_task, app):
             event_type,  # String that should one of user_event_types_lookup
             track_record,  # User ORM instance
             block_timestamp,  # Used to update the user.updated_at field
+            pending_track_routes,
         )
 
         # updated_at should be updated every parse_track_event
@@ -302,7 +304,14 @@ def test_index_tracks(mock_index_task, app):
 
         event_type, entry = get_update_track_event()
         parse_track_event(
-            None, session, update_task, entry, event_type, track_record, block_timestamp
+            None,
+            session,
+            update_task,
+            entry,
+            event_type,
+            track_record,
+            block_timestamp,
+            pending_track_routes,
         )
 
         # Check that track routes are updated appropriately
@@ -371,6 +380,7 @@ def test_index_tracks(mock_index_task, app):
             event_type,
             track_record_dupe,
             block_timestamp,
+            pending_track_routes,
         )
 
         # Check that track routes are assigned appropriately
@@ -406,6 +416,7 @@ def test_index_tracks(mock_index_task, app):
             event_type,
             track_record_dupe,
             block_timestamp,
+            pending_track_routes,
         )
 
         # Check that track routes are assigned appropriately
@@ -432,6 +443,7 @@ def test_index_tracks(mock_index_task, app):
 
         # Make sure the blocks are committed
         session.commit()
+        pending_track_routes.clear()
         revert_blocks(mock_index_task, db, [second_block])
         # Commit the revert
         session.commit()
@@ -468,6 +480,7 @@ def test_index_tracks(mock_index_task, app):
             event_type,  # String that should one of user_event_types_lookup
             track_record,  # User ORM instance
             block_timestamp,  # Used to update the user.updated_at field
+            pending_track_routes,
         )
 
         # updated_at should be updated every parse_track_event

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -430,8 +430,10 @@ def test_index_tracks(mock_index_task, app):
         )
         assert track_route
 
+        # Make sure the blocks are committed
+        session.commit()
         revert_blocks(mock_index_task, db, [second_block])
-
+        # Commit the revert
         session.commit()
 
         track_routes = session.query(TrackRoute).all()


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Removes the `session.commit()` from the `TrackRoutes` indexing so that we don't end up with partial block state. Uses an in memory cache of what we plan to add to the DB to ensure we don't get constraint errors on dupes.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Covered by existing tests.

   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
