### PR TITLE
Bugfix for content node startup

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -2,8 +2,7 @@ const axios = require('axios')
 const convict = require('convict')
 const fs = require('fs')
 
-const { logger } = require('./logging')
-
+// can't import logger here due to possible circular dependency, use console
 
 // Custom boolean format used to ensure that empty string '' is evaluated as false
 // https://github.com/mozilla/node-convict/issues/380
@@ -637,7 +636,7 @@ const asyncConfig = async () => {
     if (!config.get('serviceLatitude')) config.set('serviceLatitude', lat)
     if (!config.get('serviceLongitude')) config.set('serviceLongitude', long)
   } catch (e) {
-    logger.error(`config.js:asyncConfig(): Failed to retrieve IP info || ${e.message}`)
+    console.error(`config.js:asyncConfig(): Failed to retrieve IP info || ${e.message}`)
   }
 }
 


### PR DESCRIPTION
### Description

Saw this running locally. Likely due to circular import
```
ubuntu@dm-remote-dev:~/audius-protocol/service-commands/scripts$ docker logs -f cn1_creator-node_1
Docker-compose-wait starting with configuration:
------------------------------------------------
 - Hosts to be waiting for: [cn1_creator-node-db_1:5432, cn1_creator-node-redis_1:6379]
 - Timeout before failure: 30 seconds 
 - Sleeping time before checking for hosts availability: 0 seconds
 - Sleeping time once all hosts are available: 0 seconds
------------------------------------------------
Checking availability of cn1_creator-node-db_1:5432
Host cn1_creator-node-db_1:5432 is now available
Checking availability of  cn1_creator-node-redis_1:6379
Host  cn1_creator-node-redis_1:6379 is now available
+ set -e
+ link_libs=false
+ '[' false '=' true ]
+ exec ./node_modules/.bin/nodemon src/index.js
+ ./node_modules/.bin/bunyan
[nodemon] 1.19.4
[nodemon] to restart at any time, enter `rs`
[nodemon] watching dir(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node src/index.js`
{}
/usr/src/app/src/logging.js:7
const logLevel = config.get('logLevel') || 'info'
                        ^
TypeError: config.get is not a function
    at Object.<anonymous> (/usr/src/app/src/logging.js:7:25)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/usr/src/app/src/config.js:5:20)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
[nodemon] app crashed - waiting for file changes before starting...
```

### Tests
Tested this locally