### PR TITLE
Add challenge_last_event_age_sec to service monitor

### DIFF
--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -139,7 +139,8 @@ class DiscoveryProviderSelection extends ServiceSelection {
           totalStorage: data.data.filesystem_size,
           usedStorage: data.data.filesystem_used,
           receivedBytesPerSec: data.received_bytes_per_sec,
-          transferredBytesPerSec: data.transferred_bytes_per_sec
+          transferredBytesPerSec: data.transferred_bytes_per_sec,
+          challengeLastEventAgeSec: data.challenge_last_event_age_sec
         })
       } catch (e) {
         // Swallow errors -- this method should not throw generally


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Pipes out challenge_last_event_age_sec from discovery health checks so they are captured in client monitoring (on amplitude)

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Link libs + test on client
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Amplitude