### PR TITLE
Add max drift for challenges

### DIFF
--- a/discovery-provider/src/conftest.py
+++ b/discovery-provider/src/conftest.py
@@ -8,11 +8,12 @@ import fakeredis
 import src.utils.redis_connection
 import src.utils.web3_provider
 import src.utils.db_session
+from src.utils.session_manager import SessionManager
 
 # Test fixture to mock a postgres database using an in-memory alternative
 @pytest.fixture()
 def db_mock(monkeypatch):
-    db = src.utils.session_manager.SessionManager("sqlite://", {})
+    db = SessionManager("sqlite://", {})
 
     def get_db_read_replica():
         return db

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -275,17 +275,16 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         if error:
             return health_results, error
 
-    is_unhealthy = False
-
-    if enforce_block_diff and block_difference > healthy_block_diff:
-        is_unhealthy = True
-
-    if (
+    unhealthy_blocks = bool(
+        enforce_block_diff
+        and block_difference > healthy_block_diff
+    )
+    unhealthy_challenges = bool(
         challenge_events_age_max_drift
         and challenge_events_age_sec
         and challenge_events_age_sec > challenge_events_age_max_drift
-    ):
-        is_unhealthy = True
+    )
+    is_unhealthy = unhealthy_blocks or unhealthy_challenges
 
     return health_results, is_unhealthy
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from typing import Dict, Optional, Tuple, TypedDict
+from typing import Dict, Optional, Tuple, TypedDict, cast
 
 from src.models import Block, IPLDBlacklistBlock
 from src.monitors import monitors, monitor_names
@@ -146,7 +146,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
 
     verbose = args.get("verbose")
     enforce_block_diff = args.get("enforce_block_diff")
-    qs_healthy_block_diff = args.get("healthy_block_diff")
+    qs_healthy_block_diff = cast(Optional[int], args.get("healthy_block_diff"))
     challenge_events_age_max_drift = args.get("challenge_events_age_max_drift")
 
     # If healthy block diff is given in url and positive, override config value
@@ -263,9 +263,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         **sys_info,
     }
 
-    block_difference = abs(
-        health_results["web"]["blocknumber"] - health_results["db"]["number"]
-    )
+    block_difference = abs(latest_block_num - latest_indexed_block_num)
     health_results["block_difference"] = block_difference
     health_results["maximum_healthy_block_difference"] = default_healthy_block_diff
     health_results.update(disc_prov_version)

--- a/discovery-provider/src/queries/get_health_test.py
+++ b/discovery-provider/src/queries/get_health_test.py
@@ -1,4 +1,5 @@
 import os
+from time import time
 from unittest.mock import MagicMock
 from hexbytes import HexBytes
 from src.utils.redis_constants import (
@@ -383,7 +384,7 @@ def test_get_health_challenge_events_max_drift(web3_mock, redis_mock, db_mock):
     web3_mock.eth.getBlock = getBlock
 
     # Set up redis state
-    redis_mock.set(challenges_last_processed_event_redis_key, "50")
+    redis_mock.set(challenges_last_processed_event_redis_key, int(time() - 50))
 
     # Set up db state
     with db_mock.scoped_session() as session:
@@ -397,8 +398,8 @@ def test_get_health_challenge_events_max_drift(web3_mock, redis_mock, db_mock):
             )
         )
 
-    args = {"challenge_events_age_max_drift": 51}
+    args = {"challenge_events_age_max_drift": 49}
     health_results, error = get_health(args)
 
     assert error == True
-    assert health_results["challenge_last_event_age_sec"] == 50
+    assert health_results["challenge_last_event_age_sec"] < int(time() - 49)

--- a/discovery-provider/src/queries/get_health_test.py
+++ b/discovery-provider/src/queries/get_health_test.py
@@ -6,6 +6,7 @@ from src.utils.redis_constants import (
     latest_block_redis_key,
     most_recent_indexed_block_hash_redis_key,
     most_recent_indexed_block_redis_key,
+    challenges_last_processed_event_redis_key,
 )
 from src.models import Block
 from src.queries.get_health import get_health
@@ -368,3 +369,36 @@ def test_get_health_verbose(web3_mock, redis_mock, db_mock, get_monitors_mock):
     assert "maximum_healthy_block_difference" in health_results
     assert "version" in health_results
     assert "service" in health_results
+
+
+def test_get_health_challenge_events_max_drift(web3_mock, redis_mock, db_mock):
+    """Tests that the health check honors an unhealthy challenge events drift"""
+    # Set up web3 eth
+    def getBlock(_u1, _u2):  # unused
+        block = MagicMock()
+        block.number = 50
+        block.hash = HexBytes(b"\x50")
+        return block
+
+    web3_mock.eth.getBlock = getBlock
+
+    # Set up redis state
+    redis_mock.set(challenges_last_processed_event_redis_key, "50")
+
+    # Set up db state
+    with db_mock.scoped_session() as session:
+        Block.__table__.create(db_mock._engine)
+        session.add(
+            Block(
+                blockhash="0x01",
+                number=1,
+                parenthash="0x01",
+                is_current=True,
+            )
+        )
+
+    args = {"challenge_events_age_max_drift": 51}
+    health_results, error = get_health(args)
+
+    assert error == True
+    assert health_results["challenge_last_event_age_sec"] == 50


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add a max-drift arg to the health check for challenge event age so we can catch it with pingdom checks / automated scripts if necessary.

Additional PR to capture this same data in amplitude over time: https://github.com/AudiusProject/audius-protocol/pull/1677

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Unit test
2. Local stack
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Health check endpoint + maybe pingdom if we want the option
