### PR TITLE
Bump express rate limit to 5.3.0

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -4378,12 +4378,9 @@
       }
     },
     "express-rate-limit": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-3.5.3.tgz",
-      "integrity": "sha512-V6YEfLt5oNYKIJPBJQeE1xTM6JeeP/e4YXZGPgheo1nF4vtWHUFHmcNsOPxDa9VtIB1zOZ1j1DKScewVetw8Ow==",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.3.0.tgz",
+      "integrity": "sha512-qJhfEgCnmteSeZAeuOKQ2WEIFTX5ajrzE0xS6gCOBCoRQcU+xEzQmgYQQTpzCcqUAAzTEtu4YEih4pnLfvNtew=="
     },
     "ext": {
       "version": "1.4.0",
@@ -5849,9 +5846,9 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -11181,9 +11178,9 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "stream-to-it": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.3.tgz",
-      "integrity": "sha512-xaK9EjPtLox5rrC7YLSBXSanTtUJN/lzJlMFvy9VaROmnyvy0U/X6m2uMhXPJRn3g3M9uOSIzTszW7BPiWSg9w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
         "get-iterator": "^1.0.2"
       }

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -39,7 +39,7 @@
     "ethereumjs-wallet": "0.6.5",
     "exif-parser": "^0.1.12",
     "express": "^4.16.3",
-    "express-rate-limit": "^3.5.0",
+    "express-rate-limit": "5.3.0",
     "ffmpeg-static": "^2.7.0",
     "ffprobe-static": "^3.0.0",
     "form-data": "^3.0.1",

--- a/creator-node/src/reqLimiter.js
+++ b/creator-node/src/reqLimiter.js
@@ -124,7 +124,8 @@ const getRateLimiter = ({
   max,
   expiry,
   keyGenerator = req => req.ip,
-  skip
+  // Default to forcing rate limit by returning false
+  skip = () => { return false }
 }) => {
   return rateLimit({
     store: new RedisStore({


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

This PR's intention is to bump the express-rate-limit package to 5.3.0 (from our original version that is about 2 years old). This is so that we can use the `skip` field in this upcoming PR to [bypass rate limit if the requester is a valid sp](https://github.com/AudiusProject/audius-protocol/pull/1670)

[`skip` field fn doc](https://github.com/nfriedly/express-rate-limit#skip)

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- Ran all the content node unit tests with upgrade to make sure existing tests work 
