### PR TITLE
Add track upload challenge

### DIFF
--- a/discovery-provider/src/challenges/challenge.py
+++ b/discovery-provider/src/challenges/challenge.py
@@ -230,7 +230,7 @@ class ChallengeManager:
         # Only add the new ones
         session.add_all(new_user_challenges)
 
-    def get_challenge_state(
+    def get_user_challenge_state(
         self, session: Session, specifiers: List[str]
     ) -> List[UserChallenge]:
         return fetch_user_challenges(session, self.challenge_id, specifiers)

--- a/discovery-provider/src/challenges/challenge_event.py
+++ b/discovery-provider/src/challenges/challenge_event.py
@@ -10,3 +10,4 @@ class ChallengeEvent(str, enum.Enum):
     follow = "follow"
     favorite = "favorite"
     track_listen = "track_listen"
+    track_upload = "track_upload"

--- a/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/discovery-provider/src/challenges/challenge_event_bus.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm.session import Session
 from src.utils.redis_connection import get_redis
 from src.challenges.profile_challenge import profile_challenge_manager
 from src.challenges.listen_streak_challenge import listen_streak_challenge_manager
+from src.challenges.track_upload_challenge import track_upload_challenge_manager
 from src.challenges.challenge_event import ChallengeEvent
 
 from collections import defaultdict
@@ -29,7 +30,7 @@ class ChallengeEventBus:
         self._managers = {}
 
     def register_listener(self, event: str, listener: ChallengeManager):
-        """Registers a listener (`ChallengeEventManager`) to listen for a particular event type."""
+        """Registers a listener (`ChallengeManager`) to listen for a particular event type."""
         self._listeners[event].append(listener)
         if not listener.challenge_id in self._managers:
             self._managers[listener.challenge_id] = listener
@@ -119,6 +120,8 @@ def setup_challenge_bus():
     bus.register_listener(ChallengeEvent.favorite, profile_challenge_manager)
     # listen_streak_challenge_manager listeners
     bus.register_listener(ChallengeEvent.track_listen, listen_streak_challenge_manager)
+    # track_upload_challenge_manager listeners
+    bus.register_listener(ChallengeEvent.track_upload, track_upload_challenge_manager)
 
     return bus
 

--- a/discovery-provider/src/challenges/challenges.json
+++ b/discovery-provider/src/challenges/challenges.json
@@ -12,5 +12,13 @@
 		"amount": "5",
 		"active": false,
 		"step_count": 7
+	},
+	{
+		"id": "track-upload",
+		"type": "numeric",
+		"amount": "5",
+		"active": true,
+		"step_count": 3,
+		"starting_block": 20000000
 	}
 ]

--- a/discovery-provider/src/challenges/challenges.json
+++ b/discovery-provider/src/challenges/challenges.json
@@ -17,7 +17,7 @@
 		"id": "track-upload",
 		"type": "numeric",
 		"amount": "5",
-		"active": true,
+		"active": false,
 		"step_count": 3,
 		"starting_block": 20000000
 	}

--- a/discovery-provider/src/challenges/create_new_challenges.py
+++ b/discovery-provider/src/challenges/create_new_challenges.py
@@ -25,7 +25,7 @@ def create_new_challenges(session):
     new_challenges = list(
         filter(lambda c: c.get("id") not in existing_ids, challenges_dicts)
     )
-    logger.info(f"Adding challenges: {challenges_dicts}")
+    logger.info(f"Adding challenges: {new_challenges}")
 
     # Add all the new challenges
     for challenge_dict in new_challenges:
@@ -49,3 +49,4 @@ def create_new_challenges(session):
         if existing:
             existing.active = challenge_dict["active"]
             existing.amount = challenge_dict["amount"]
+            existing.step_count = challenge_dict["step_count"]

--- a/discovery-provider/src/challenges/create_new_challenges.py
+++ b/discovery-provider/src/challenges/create_new_challenges.py
@@ -40,13 +40,14 @@ def create_new_challenges(session):
         challenges.append(challenge)
     session.add_all(challenges)
 
-    # Update any challenges whose active state / amount changed
+    # Update any challenges whose active state / amount / step count / starting block changed
     existing_challenge_map = {
         challenge.id: challenge for challenge in existing_challenges
     }
     for challenge_dict in challenges_dicts:
         existing = existing_challenge_map.get(challenge_dict["id"])
         if existing:
-            existing.active = challenge_dict["active"]
-            existing.amount = challenge_dict["amount"]
-            existing.step_count = challenge_dict["step_count"]
+            existing.active = challenge_dict.get("active")
+            existing.amount = challenge_dict.get("amount")
+            existing.step_count = challenge_dict.get("step_count")
+            existing.starting_block = challenge_dict.get("starting_block")

--- a/discovery-provider/src/challenges/listen_streak_challenge.py
+++ b/discovery-provider/src/challenges/listen_streak_challenge.py
@@ -23,6 +23,9 @@ class ListenStreakChallengeUpdater(ChallengeUpdater):
         event_metadatas: List[FullEventMetadata],
         starting_block: Optional[int],
     ):
+        if not step_count:
+            raise Exception("Expected a step count for listen streak challenge")
+
         user_ids = [user_challenge.user_id for user_challenge in user_challenges]
         partial_completions = get_listen_streak_challenges(session, user_ids)
         completion_map = {

--- a/discovery-provider/src/challenges/listen_streak_challenge.py
+++ b/discovery-provider/src/challenges/listen_streak_challenge.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy.orm.session import Session
 from src.challenges.challenge import (
@@ -7,7 +7,7 @@ from src.challenges.challenge import (
     ChallengeUpdater,
     FullEventMetadata,
 )
-from src.models.models import ListenStreakChallenge
+from src.models.models import ListenStreakChallenge, UserChallenge
 from src.challenges.challenge_event import ChallengeEvent
 
 
@@ -15,7 +15,13 @@ class ListenStreakChallengeUpdater(ChallengeUpdater):
     """Listening streak challenge"""
 
     def update_user_challenges(
-        self, session, event, user_challenges, step_count, event_metadatas
+        self,
+        session: Session,
+        event: str,
+        user_challenges: List[UserChallenge],
+        step_count: Optional[int],
+        event_metadatas: List[FullEventMetadata],
+        starting_block: Optional[int],
     ):
         user_ids = [user_challenge.user_id for user_challenge in user_challenges]
         partial_completions = get_listen_streak_challenges(session, user_ids)

--- a/discovery-provider/src/challenges/profile_challenge.py
+++ b/discovery-provider/src/challenges/profile_challenge.py
@@ -31,7 +31,15 @@ class ProfileChallengeUpdater(ChallengeUpdater):
     - favorites > threshold
     """
 
-    def update_user_challenges(self, session, event, user_challenges, step_count, event_metadatas):
+    def update_user_challenges(
+        self,
+        session,
+        event,
+        user_challenges,
+        step_count,
+        event_metadatas,
+        starting_block,
+    ):
 
         user_ids = [user_challenge.user_id for user_challenge in user_challenges]
         partial_completions = get_profile_completion_challenges(session, user_ids)
@@ -190,9 +198,3 @@ def get_user_dicts(session, user_ids):
         }
         for attr in res
     ]
-
-
-def get_aggregate_users(session, user_ids):
-    return (
-        session.query(AggregateUser).filter(AggregateUser.user_id.in_(user_ids)).all()
-    )

--- a/discovery-provider/src/challenges/profile_challenge.py
+++ b/discovery-provider/src/challenges/profile_challenge.py
@@ -1,9 +1,10 @@
 from collections import Counter
-from typing import List
+from typing import List, Optional
+from sqlalchemy.orm.session import Session
 from src.models import (
     ProfileCompletionChallenge,
+    UserChallenge,
     User,
-    AggregateUser,
     Repost,
     Follow,
     Save,
@@ -33,12 +34,12 @@ class ProfileChallengeUpdater(ChallengeUpdater):
 
     def update_user_challenges(
         self,
-        session,
-        event,
-        user_challenges,
-        step_count,
-        event_metadatas,
-        starting_block,
+        session: Session,
+        event: str,
+        user_challenges: List[UserChallenge],
+        step_count: Optional[int],
+        event_metadatas: List[FullEventMetadata],
+        starting_block: Optional[int],
     ):
 
         user_ids = [user_challenge.user_id for user_challenge in user_challenges]

--- a/discovery-provider/src/challenges/track_upload_challenge.py
+++ b/discovery-provider/src/challenges/track_upload_challenge.py
@@ -5,6 +5,7 @@ from src.models import Track, UserChallenge
 from src.challenges.challenge import (
     ChallengeManager,
     ChallengeUpdater,
+    FullEventMetadata,
 )
 
 
@@ -19,6 +20,7 @@ class TrackUploadChallengeUpdater(ChallengeUpdater):
         event: str,
         user_challenges: List[UserChallenge],
         step_count: Optional[int],
+        event_metadatas: List[FullEventMetadata],
         starting_block: Optional[int],
     ):
         if not starting_block:

--- a/discovery-provider/src/challenges/track_upload_challenge.py
+++ b/discovery-provider/src/challenges/track_upload_challenge.py
@@ -23,8 +23,10 @@ class TrackUploadChallengeUpdater(ChallengeUpdater):
         event_metadatas: List[FullEventMetadata],
         starting_block: Optional[int],
     ):
-        if not starting_block:
-            raise Exception("Expected a starting block for track upload challenge")
+        if not step_count or not starting_block:
+            raise Exception(
+                "Expected a step count and starting block for track upload challenge"
+            )
 
         num_tracks_per_user = self._get_num_track_uploads_by_user(
             session,

--- a/discovery-provider/src/challenges/track_upload_challenge.py
+++ b/discovery-provider/src/challenges/track_upload_challenge.py
@@ -1,0 +1,62 @@
+from collections import Counter
+from typing import List, Optional
+from sqlalchemy.orm.session import Session
+from src.models import Track, UserChallenge
+from src.challenges.challenge import (
+    ChallengeManager,
+    ChallengeUpdater,
+)
+
+
+class TrackUploadChallengeUpdater(ChallengeUpdater):
+    """Updates a track upload challenge.
+    Requires user to upload N (e.g. 3) songs to Audius to complete the challenge.
+    """
+
+    def update_user_challenges(
+        self,
+        session: Session,
+        event: str,
+        user_challenges: List[UserChallenge],
+        step_count: Optional[int],
+        starting_block: Optional[int],
+    ):
+        if not starting_block:
+            raise Exception("Expected a starting block for track upload challenge")
+
+        num_tracks_per_user = self._get_num_track_uploads_by_user(
+            session,
+            user_challenges,
+            starting_block,
+        )
+
+        # Update the user_challenges
+        for user_challenge in user_challenges:
+            # Update step count
+            user_challenge.current_step_count = num_tracks_per_user[
+                user_challenge.user_id
+            ]
+            # Update completion
+            user_challenge.is_complete = user_challenge.current_step_count == step_count
+
+    def _get_num_track_uploads_by_user(
+        self, session: Session, user_challenges: List[UserChallenge], block_number: int
+    ):
+        user_ids = [user_challenge.user_id for user_challenge in user_challenges]
+        tracks = (
+            session.query(Track)
+            .filter(
+                Track.owner_id.in_(user_ids),
+                Track.blocknumber >= block_number,
+                Track.is_current == True,
+                Track.is_delete == False,
+            )
+            .all()
+        )
+        num_tracks_per_user = Counter(map(lambda t: t.owner_id, tracks))
+        return num_tracks_per_user
+
+
+track_upload_challenge_manager = ChallengeManager(
+    "track-upload", TrackUploadChallengeUpdater()
+)

--- a/discovery-provider/tests/index_helpers.py
+++ b/discovery-provider/tests/index_helpers.py
@@ -1,3 +1,5 @@
+from src.challenges.challenge_event_bus import setup_challenge_bus
+
 # Helper methods for testing indexing
 
 
@@ -21,6 +23,7 @@ class Web3:
 
 
 class UpdateTask:
-    def __init__(self, ipfs_client, web3):
+    def __init__(self, ipfs_client, web3, challenge_event_bus=setup_challenge_bus()):
         self.ipfs_client = ipfs_client
         self.web3 = web3
+        self.challenge_event_bus = challenge_event_bus

--- a/discovery-provider/tests/index_helpers.py
+++ b/discovery-provider/tests/index_helpers.py
@@ -1,5 +1,3 @@
-from src.challenges.challenge_event_bus import setup_challenge_bus
-
 # Helper methods for testing indexing
 
 
@@ -23,7 +21,7 @@ class Web3:
 
 
 class UpdateTask:
-    def __init__(self, ipfs_client, web3, challenge_event_bus=setup_challenge_bus()):
+    def __init__(self, ipfs_client, web3, challenge_event_bus):
         self.ipfs_client = ipfs_client
         self.web3 = web3
         self.challenge_event_bus = challenge_event_bus

--- a/discovery-provider/tests/test_challenges.py
+++ b/discovery-provider/tests/test_challenges.py
@@ -254,7 +254,7 @@ def test_aggregates(app):
         bus.dispatch(session, TEST_EVENT, 100, 1, {"referred_id": 2})
         bus.dispatch(session, TEST_EVENT, 100, 1, {"referred_id": 3})
         bus.process_events(session)
-        state = agg_challenge.get_challenge_state(session, ["1-2", "1-3"])
+        state = agg_challenge.get_user_challenge_state(session, ["1-2", "1-3"])
         assert len(state) == 2
         # Also make sure the thing is incomplete
         res = get_challenges(1, False, session, bus)
@@ -265,7 +265,7 @@ def test_aggregates(app):
         bus.dispatch(session, TEST_EVENT, 100, 1, {"referred_id": 4})
         bus.dispatch(session, TEST_EVENT, 100, 1, {"referred_id": 4})
         bus.process_events(session)
-        state = agg_challenge.get_challenge_state(session, ["1-4"])
+        state = agg_challenge.get_user_challenge_state(session, ["1-4"])
         assert len(state) == 1
 
         # - If we've maxed the # of challenges, don't create any more

--- a/discovery-provider/tests/test_challenges.py
+++ b/discovery-provider/tests/test_challenges.py
@@ -89,7 +89,9 @@ def setup_challenges(app):
 
 
 class TestUpdater(ChallengeUpdater):
-    def update_user_challenges(self, session, event, user_challenges, step_count, event_metadatas):
+    def update_user_challenges(
+        self, session, event, user_challenges, step_count, event_metadatas, starting_block
+    ):
         for user_challenge in user_challenges:
             user_challenge.current_step_count += 1
             if user_challenge.current_step_count >= step_count:
@@ -215,6 +217,7 @@ class AggregateUpdater(ChallengeUpdater):
         user_challenges: List[UserChallenge],
         step_count,
         event_metadatas,
+        starting_block,
     ):
         pass
 

--- a/discovery-provider/tests/test_create_new_challenges.py
+++ b/discovery-provider/tests/test_create_new_challenges.py
@@ -17,6 +17,7 @@ def test_create_new_challenges(app):
             old_active = challenge.active
             old_amount = challenge.amount
             old_step_count = challenge.step_count
+            old_starting_block = challenge.starting_block
 
             # update challenge and give it different field values than what's in the json
             challenge.active = (
@@ -28,6 +29,9 @@ def test_create_new_challenges(app):
             challenge.step_count = (
                 challenge.step_count + 1
             )  # <<< different value than what's in the json
+            challenge.starting_block = (
+                challenge.starting_block + 1 if challenge.starting_block else 1
+            )  # <<< different value than what's in the json
             session.add(challenge)
 
             # make sure challenge is saved in db
@@ -37,6 +41,7 @@ def test_create_new_challenges(app):
             assert saved_challenge[0].active == challenge.active
             assert saved_challenge[0].amount == challenge.amount
             assert saved_challenge[0].step_count == challenge.step_count
+            assert saved_challenge[0].starting_block == challenge.starting_block
 
             # create new challenges / update existing challenges from challenges.json
             create_new_challenges(session)
@@ -48,3 +53,4 @@ def test_create_new_challenges(app):
             assert updated_challenge[0].active == old_active
             assert updated_challenge[0].amount == old_amount
             assert updated_challenge[0].step_count == old_step_count
+            assert updated_challenge[0].starting_block == old_starting_block

--- a/discovery-provider/tests/test_create_new_challenges.py
+++ b/discovery-provider/tests/test_create_new_challenges.py
@@ -1,0 +1,50 @@
+from src.utils.db_session import get_db
+from src.models import Challenge
+from src.challenges.create_new_challenges import create_new_challenges
+
+
+def test_create_new_challenges(app):
+    with app.app_context():
+        db = get_db()
+        with db.scoped_session() as session:
+            challenges = session.query(Challenge).all()
+            if not challenges:
+                return
+
+            challenge = challenges[0]
+            print("challenge is: ", challenge)
+            print("type is: ", type(challenge.amount))
+            old_active = challenge.active
+            old_amount = challenge.amount
+            old_step_count = challenge.step_count
+
+            # update challenge and give it different field values than what's in the json
+            challenge.active = (
+                not challenge.active
+            )  # <<< different value than what's in the json
+            challenge.amount = (
+                challenge.amount + "1"
+            )  # <<< different value than what's in the json
+            challenge.step_count = (
+                challenge.step_count + 1
+            )  # <<< different value than what's in the json
+            session.add(challenge)
+
+            # make sure challenge is saved in db
+            challenges = session.query(Challenge).all()
+            saved_challenge = list(filter(lambda c: c.id == challenge.id, challenges))
+            assert len(saved_challenge) == 1
+            assert saved_challenge[0].active == challenge.active
+            assert saved_challenge[0].amount == challenge.amount
+            assert saved_challenge[0].step_count == challenge.step_count
+
+            # create new challenges / update existing challenges from challenges.json
+            create_new_challenges(session)
+
+            # make sure existing challenge is updated to reflect what's in challenges.json
+            challenges = session.query(Challenge).all()
+            updated_challenge = list(filter(lambda c: c.id == challenge.id, challenges))
+            assert updated_challenge
+            assert updated_challenge[0].active == old_active
+            assert updated_challenge[0].amount == old_amount
+            assert updated_challenge[0].step_count == old_step_count

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -4,8 +4,8 @@ from src.tasks.playlists import parse_playlist_event, lookup_playlist_record
 from src.utils.db_session import get_db
 from src.utils.playlist_event_constants import playlist_event_types_lookup
 from src.utils import helpers
-from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 from src.challenges.challenge_event_bus import get_event_bus
+from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 
 # event_type: PlaylistCreated
 def get_playlist_created_event():

--- a/discovery-provider/tests/test_index_playlists.py
+++ b/discovery-provider/tests/test_index_playlists.py
@@ -5,6 +5,7 @@ from src.utils.db_session import get_db
 from src.utils.playlist_event_constants import playlist_event_types_lookup
 from src.utils import helpers
 from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
+from src.challenges.challenge_event_bus import get_event_bus
 
 # event_type: PlaylistCreated
 def get_playlist_created_event():
@@ -116,10 +117,10 @@ def test_index_playlist(app):
     """Tests that playlists are indexed correctly"""
     with app.app_context():
         db = get_db()
-
-    ipfs_client = IPFSClient({})
-    web3 = Web3()
-    update_task = UpdateTask(ipfs_client, web3)
+        ipfs_client = IPFSClient({})
+        web3 = Web3()
+        challenge_event_bus = get_event_bus()
+        update_task = UpdateTask(ipfs_client, web3, challenge_event_bus)
 
     with db.scoped_session() as session:
         # ================= Test playlist_created Event =================

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -11,6 +11,7 @@ from src.tasks.tracks import (
 from src.utils import helpers
 from src.utils.db_session import get_db
 from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
+from src.challenges.challenge_event_bus import get_event_bus
 
 
 def get_new_track_event():
@@ -179,8 +180,9 @@ def test_index_tracks(mock_index_task, app):
     """Tests that tracks are indexed correctly"""
     with app.app_context():
         db = get_db()
+        challenge_event_bus = get_event_bus()
+        update_task = UpdateTask(ipfs_client, web3, challenge_event_bus)
 
-    update_task = UpdateTask(ipfs_client, web3)
     pending_track_routes = []
 
     with db.scoped_session() as session:

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -10,8 +10,8 @@ from src.tasks.tracks import (
 )
 from src.utils import helpers
 from src.utils.db_session import get_db
-from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 from src.challenges.challenge_event_bus import get_event_bus
+from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 
 
 def get_new_track_event():

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -236,6 +236,7 @@ def test_index_tracks(mock_index_task, app):
             entry,  # Contains the event args used for updating
             event_type,  # String that should one of user_event_types_lookup
             track_record,  # User ORM instance
+            block_number,  # Used to forward to track uploads challenge
             block_timestamp,  # Used to update the user.updated_at field
             pending_track_routes,
         )
@@ -310,6 +311,7 @@ def test_index_tracks(mock_index_task, app):
             entry,
             event_type,
             track_record,
+            block_number,
             block_timestamp,
             pending_track_routes,
         )
@@ -379,6 +381,7 @@ def test_index_tracks(mock_index_task, app):
             entry,
             event_type,
             track_record_dupe,
+            block_number,
             block_timestamp,
             pending_track_routes,
         )
@@ -415,6 +418,7 @@ def test_index_tracks(mock_index_task, app):
             entry,
             event_type,
             track_record_dupe,
+            block_number,
             block_timestamp,
             pending_track_routes,
         )
@@ -479,6 +483,7 @@ def test_index_tracks(mock_index_task, app):
             entry,  # Contains the event args used for updating
             event_type,  # String that should one of user_event_types_lookup
             track_record,  # User ORM instance
+            block_number,  # Used to forward to track uploads challenge
             block_timestamp,  # Used to update the user.updated_at field
             pending_track_routes,
         )

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -4,8 +4,8 @@ from src.tasks.users import lookup_user_record, parse_user_event
 from src.utils.db_session import get_db
 from src.utils.user_event_constants import user_event_types_lookup
 from src.utils import helpers
-from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 from src.challenges.challenge_event_bus import get_event_bus
+from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
 
 
 def get_add_user_event():

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -5,6 +5,7 @@ from src.utils.db_session import get_db
 from src.utils.user_event_constants import user_event_types_lookup
 from src.utils import helpers
 from tests.index_helpers import AttrDict, IPFSClient, Web3, UpdateTask
+from src.challenges.challenge_event_bus import get_event_bus
 
 
 def get_add_user_event():
@@ -173,8 +174,8 @@ def test_index_users(app):
     """Tests that users are indexed correctly"""
     with app.app_context():
         db = get_db()
-
-    update_task = UpdateTask(ipfs_client, web3)
+        challenge_event_bus = get_event_bus()
+        update_task = UpdateTask(ipfs_client, web3, challenge_event_bus)
 
     with db.scoped_session() as session:
         # ================== Test Add User Event ==================

--- a/discovery-provider/tests/test_listen_streak_challenge.py
+++ b/discovery-provider/tests/test_listen_streak_challenge.py
@@ -75,16 +75,22 @@ def test_listen_streak_challenge(app):
 
         # Make sure plays increment the step count
         dispatch_play(0, session, bus)
-        state = listen_streak_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = listen_streak_challenge_manager.get_user_challenge_state(
+            session, ["1"]
+        )[0]
         assert state.current_step_count == 1 and not state.is_complete
 
         dispatch_play(1, session, bus)
-        state = listen_streak_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = listen_streak_challenge_manager.get_user_challenge_state(
+            session, ["1"]
+        )[0]
         assert state.current_step_count == 2 and not state.is_complete
 
         # Make sure the step count resets if the user missed a day
         dispatch_play(3, session, bus)
-        state = listen_streak_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = listen_streak_challenge_manager.get_user_challenge_state(
+            session, ["1"]
+        )[0]
         assert state.current_step_count == 1 and not state.is_complete
 
         # Add more plays to increment the step count
@@ -93,10 +99,14 @@ def test_listen_streak_challenge(app):
         dispatch_play(6, session, bus)
         dispatch_play(7, session, bus)
         dispatch_play(8, session, bus)
-        state = listen_streak_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = listen_streak_challenge_manager.get_user_challenge_state(
+            session, ["1"]
+        )[0]
         assert state.current_step_count == 6 and not state.is_complete
 
         # Make sure that is_complete is set when step count hits 7
         dispatch_play(9, session, bus)
-        state = listen_streak_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = listen_streak_challenge_manager.get_user_challenge_state(
+            session, ["1"]
+        )[0]
         assert state.current_step_count == 7 and state.is_complete == True

--- a/discovery-provider/tests/test_profile_completion_challenge.py
+++ b/discovery-provider/tests/test_profile_completion_challenge.py
@@ -50,7 +50,7 @@ def test_profile_completion_challenge(app):
         # Process dummy event just to get this thing initted
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
 
         # We should have completed a single step (name)
         assert state.current_step_count == 1 and not state.is_complete
@@ -70,7 +70,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.repost, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 2 and not state.is_complete
 
         # Do a save
@@ -89,7 +89,7 @@ def test_profile_completion_challenge(app):
         bus.dispatch(session, ChallengeEvent.favorite, 1, 1)
         bus.process_events(session)
         session.flush()
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 3 and not state.is_complete
 
         # Do 1 follow, then 5 total follows
@@ -107,7 +107,7 @@ def test_profile_completion_challenge(app):
         bus.dispatch(session, ChallengeEvent.follow, 1, 1)
         bus.process_events(session)
         session.flush()
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         # Assert 1 follow didn't do anything
         assert state.current_step_count == 3 and not state.is_complete
         follows = [
@@ -152,7 +152,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.follow, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 4 and not state.is_complete
 
         # profile_picture
@@ -162,7 +162,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 5 and not state.is_complete
 
         # profile description
@@ -172,7 +172,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 6 and not state.is_complete
 
         # Undo it, ensure that our count goes down
@@ -180,7 +180,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 5 and not state.is_complete
 
         # profile_cover_photo
@@ -190,7 +190,7 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 7 and state.is_complete == True
 
         # ensure that if we lose some data now that the thing is complete, we don't change the status of the challenge
@@ -198,5 +198,5 @@ def test_profile_completion_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.profile_update, 1, 1)
         bus.process_events(session)
-        state = profile_challenge_manager.get_challenge_state(session, ["1"])[0]
+        state = profile_challenge_manager.get_user_challenge_state(session, ["1"])[0]
         assert state.current_step_count == 7 and state.is_complete == True

--- a/discovery-provider/tests/test_track_upload_challenge.py
+++ b/discovery-provider/tests/test_track_upload_challenge.py
@@ -107,7 +107,7 @@ def test_track_upload_challenge(app):
         # Process dummy event at block number before this challenge is added
         bus.dispatch(session, ChallengeEvent.track_upload, 1, 1)
         bus.process_events(session)
-        user_challenges = track_upload_challenge_manager.get_challenge_state(
+        user_challenges = track_upload_challenge_manager.get_user_challenge_state(
             session, ["1"]
         )
 
@@ -118,7 +118,7 @@ def test_track_upload_challenge(app):
         session.add(track2)
         bus.dispatch(session, ChallengeEvent.track_upload, 20000000, 1)
         bus.process_events(session)
-        user_challenge = track_upload_challenge_manager.get_challenge_state(
+        user_challenge = track_upload_challenge_manager.get_user_challenge_state(
             session, ["1"]
         )[0]
 
@@ -132,7 +132,7 @@ def test_track_upload_challenge(app):
         session.add(track4)
         bus.dispatch(session, ChallengeEvent.track_upload, 20000001, 1)
         bus.process_events(session)
-        user_challenge = track_upload_challenge_manager.get_challenge_state(
+        user_challenge = track_upload_challenge_manager.get_user_challenge_state(
             session, ["1"]
         )[0]
 
@@ -147,7 +147,7 @@ def test_track_upload_challenge(app):
         session.flush()
         bus.dispatch(session, ChallengeEvent.track_upload, 3, 1)
         bus.process_events(session)
-        user_challenge = track_upload_challenge_manager.get_challenge_state(
+        user_challenge = track_upload_challenge_manager.get_user_challenge_state(
             session, ["1"]
         )[0]
 

--- a/discovery-provider/tests/test_track_upload_challenge.py
+++ b/discovery-provider/tests/test_track_upload_challenge.py
@@ -1,0 +1,156 @@
+from datetime import date, timedelta
+import redis
+from src.models import User, Block, Track
+from src.utils.db_session import get_db
+from src.challenges.track_upload_challenge import track_upload_challenge_manager
+from src.challenges.challenge_event_bus import ChallengeEventBus, ChallengeEvent
+from src.utils.config import shared_config
+
+REDIS_URL = shared_config["redis"]["url"]
+
+
+def test_track_upload_challenge(app):
+
+    redis_conn = redis.Redis.from_url(url=REDIS_URL)
+
+    # create user
+    with app.app_context():
+        db = get_db()
+
+    today = date.today()
+    block1 = Block(blockhash="0x1", number=1)
+    block2 = Block(blockhash="0x2", number=20000000)
+    block3 = Block(blockhash="0x3", number=20000001)
+    user = User(
+        blockhash="0x1",
+        blocknumber=1,
+        txhash="xyz",
+        user_id=1,
+        handle="TestHandle",
+        handle_lc="testhandle",
+        is_current=True,
+        created_at=today - timedelta(days=100),
+        updated_at=today - timedelta(days=100),
+    )
+    track1 = Track(
+        blockhash="0x1",
+        blocknumber=1,
+        txhash="xyz",
+        owner_id=1,
+        track_id=1,
+        route_id=1,
+        track_segments=[],
+        is_unlisted=False,
+        is_current=True,
+        is_delete=False,
+        created_at=today - timedelta(days=100),
+        updated_at=today - timedelta(days=100),
+    )
+    track2 = Track(
+        blockhash="0x2",
+        blocknumber=20000000,
+        txhash="yzx",
+        owner_id=1,
+        track_id=2,
+        route_id=2,
+        track_segments=[],
+        is_unlisted=False,
+        is_current=True,
+        is_delete=False,
+        created_at=today - timedelta(days=1),
+        updated_at=today - timedelta(days=1),
+    )
+    track3 = Track(
+        blockhash="0x3",
+        blocknumber=20000001,
+        txhash="zxy",
+        owner_id=1,
+        track_id=3,
+        route_id=3,
+        track_segments=[],
+        is_unlisted=False,
+        is_current=True,
+        is_delete=False,
+        created_at=today,
+        updated_at=today,
+    )
+    track4 = Track(
+        blockhash="0x3",
+        blocknumber=20000001,
+        txhash="abc",
+        owner_id=1,
+        track_id=4,
+        route_id=4,
+        track_segments=[],
+        is_unlisted=False,
+        is_current=True,
+        is_delete=False,
+        created_at=today,
+        updated_at=today,
+    )
+
+    with db.scoped_session() as session:
+        bus = ChallengeEventBus(redis_conn)
+
+        # Register events with the bus
+        bus.register_listener(
+            ChallengeEvent.track_upload, track_upload_challenge_manager
+        )
+
+        session.add(block1)
+        session.add(block2)
+        session.add(block3)
+        session.flush()
+        session.add(user)
+        session.add(track1)
+
+        # Process dummy event at block number before this challenge is added
+        bus.dispatch(session, ChallengeEvent.track_upload, 1, 1)
+        bus.process_events(session)
+        user_challenges = track_upload_challenge_manager.get_challenge_state(
+            session, ["1"]
+        )
+
+        # We should not have registered a count for this event
+        assert not user_challenges
+
+        # Process dummy event at block number when challenge is added
+        session.add(track2)
+        bus.dispatch(session, ChallengeEvent.track_upload, 20000000, 1)
+        bus.process_events(session)
+        user_challenge = track_upload_challenge_manager.get_challenge_state(
+            session, ["1"]
+        )[0]
+
+        # We should have completed a single step (one track upload)
+        assert user_challenge.current_step_count == 1
+        assert not user_challenge.is_complete
+
+        # Process two more dummy events to reach the step count (i.e. 3) for completion
+        session.add(track3)
+        bus.dispatch(session, ChallengeEvent.track_upload, 20000001, 1)
+        session.add(track4)
+        bus.dispatch(session, ChallengeEvent.track_upload, 20000001, 1)
+        bus.process_events(session)
+        user_challenge = track_upload_challenge_manager.get_challenge_state(
+            session, ["1"]
+        )[0]
+
+        # We should have completed the challenge
+        assert user_challenge.current_step_count == 3
+        assert user_challenge.is_complete
+
+        # ensure that if we lose some data now that the thing is complete, we don't change the status of the challenge
+        session.query(Track).filter(Track.owner_id == user.user_id).update(
+            {"is_delete": True}
+        )
+        session.flush()
+        bus.dispatch(session, ChallengeEvent.track_upload, 3, 1)
+        bus.process_events(session)
+        user_challenge = track_upload_challenge_manager.get_challenge_state(
+            session, ["1"]
+        )[0]
+
+        # The challenge should still be completed
+        assert user_challenge.current_step_count == 3
+        assert user_challenge.is_complete


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Add the challenge that handles N song uploads.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Added integration test that assumes the challenge starts from some block number, and events are dispatched at different block numbers and the user challenge state is verified.
Still have to confirm what's our wanted starting block number for this challenge.

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
