### PR TITLE
Fix reconfig mad dog tests

### DIFF
--- a/mad-dog/src/helpers.js
+++ b/mad-dog/src/helpers.js
@@ -323,6 +323,10 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 const ensureReplicaSetSyncIsConsistent = async ({ i, libs, executeOne }) => {
   let primary, secondary1, secondary2, primaryClockValue, secondary1ClockValue, secondary2ClockValue
   const userId = libs.userId
+
+  // Make sure replica set is updated before monitoring sync status
+  await executeOne(i, libsWrapper => libsWrapper.updateUserStateManagerToChainData(userId))
+
   let synced = false
   const startTime = Date.now()
   while (!synced && Date.now() - startTime <= MAX_SYNC_TIMEOUT) {

--- a/mad-dog/src/tests/test_userReplicaSetNodes/index.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/index.js
@@ -1,9 +1,12 @@
 const { addAndUpgradeUsers } = require('../../helpers.js')
 const verifyValidCNs = require('./verifyValidCN')
-const deregisterRandomCreatorNode = require('./deregisterRandomCreatorNode.js')
+// const deregisterRandomCreatorNode = require('./deregisterRandomCreatorNode.js')
 const stopRandomCreatorNode = require('./stopRandomCreatorNode.js')
 const setNumCreatorNodes = require('./setNumCreatorNodes.js')
 const { uploadTracksforUsers } = require('../../utils/uploadTracksForUsers')
+
+const MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET = 10
+const WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS = 20000
 
 /**
  * Tests that the user replica sets update when a node is deregistered or down
@@ -15,12 +18,10 @@ const userReplicaSetNodes = async ({
   executeAll,
   executeOne
 }) => {
-
   let creatorNodeIDToInfoMapping = {}
-
   let walletIndexToUserIdMap = {}
-  // Create users
-  // Initialize users
+
+  // Creates and initialize users if user does not exist. Else, uses existing users.
   try {
     walletIndexToUserIdMap = await addAndUpgradeUsers(
       numUsers,
@@ -31,26 +32,45 @@ const userReplicaSetNodes = async ({
     return { error: `Issue with creating and upgrading users: ${e}` }
   }
 
-
   for (let iteration = 0; iteration < iterations; iteration++) {
     creatorNodeIDToInfoMapping = await setNumCreatorNodes(numCreatorNodes, executeOne)
 
     // Upload tracks to users
     await uploadTracksforUsers({ executeAll, executeOne, walletIndexToUserIdMap })
 
-    const deregisteredCreatorNodeId = await deregisterRandomCreatorNode(creatorNodeIDToInfoMapping)
+    // TODO: Implement spID as source of truth feature before uncommenting deregistration test code
 
-    await new Promise(resolve => setTimeout(resolve, 10 * 1000))
-    await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
+    // const deregisteredCreatorNodeId = await deregisterRandomCreatorNode(creatorNodeIDToInfoMapping)
+
+    // await new Promise(resolve => setTimeout(resolve, 10 * 1000))
+    // await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
 
     // Create a MadDog instance, responsible for taking down 1 node
     const {
       madDog,
       removedCreatorNodeId
     } = await stopRandomCreatorNode(creatorNodeIDToInfoMapping)
-    await new Promise(resolve => setTimeout(resolve, 20 * 1000))
 
-    await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
+    let attempts = 0
+    let passed = false
+    let error
+    while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
+      await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
+      try {
+        await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
+        passed = true
+        break
+      } catch (e) {
+        error = e
+      }
+    }
+
+    if (!passed) {
+      return {
+        error: `Error with verifying updated replica set: ${error.toString()}`
+      }
+    }
+
     madDog.stop()
   }
 }

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -702,6 +702,15 @@ function LibsWrapper (walletIndex = 0) {
       url: '/ipld_block_check'
     })).data.data.db.number
   }
+
+  this.updateUserStateManagerToChainData = async (userId) => {
+    const users = await this.libsInstance.discoveryProvider.getUsers(1, 0, [userId])
+    if (!users || !users[0]) throw new Error(`[updateUserStateManagerToChainData] Cannot update user because no current record exists for user id ${userId}`)
+
+    const metadata = users[0]
+
+    this.libsInstance.userStateManager.setCurrentUser(metadata)
+  }
 }
 
 module.exports = { LibsWrapper, Utils }


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

The maddog reconfig test will bring down a randomly selected content node and then check to see if users with that node as part of their replica sets will be rolled off that node. 

This PR is to 
- fix the reconfig tests
- comment out test to deregister nodes

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- run the mad dog ursm test and confirm they pass

