### PR TITLE
Include unlisted tracks in get tracks by handle and slug endpoint

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -161,6 +161,7 @@ class TrackBySlug(Resource):
                 "filter_deleted": True,
                 "limit": 1,
                 "offset": 0,
+                "include_unlisted": True,
             }
         )
         if not tracks:
@@ -221,6 +222,7 @@ class FullTrackBySlug(Resource):
                 "limit": 1,
                 "offset": 0,
                 "current_user_id": current_user_id,
+                "include_unlisted": True,
             }
         )
         if not tracks:

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -161,7 +161,6 @@ class TrackBySlug(Resource):
                 "filter_deleted": True,
                 "limit": 1,
                 "offset": 0,
-                "include_unlisted": True,
             }
         )
         if not tracks:
@@ -222,7 +221,6 @@ class FullTrackBySlug(Resource):
                 "limit": 1,
                 "offset": 0,
                 "current_user_id": current_user_id,
-                "include_unlisted": True,
             }
         )
         if not tracks:

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -34,12 +34,7 @@ def _get_tracks(session, args):
         ).filter(TrackRoute.slug == slug)
 
     # Only return unlisted tracks if slug and user_id are present
-    if (
-        not "include_unlisted" in args
-        or not args.get("include_unlisted")
-        or not "slug" in args
-        or not "user_id" in args
-    ):
+    if not "slug" in args or not "user_id" in args:
         base_query.filter(Track.is_unlisted == False)
 
     # Conditionally process an array of tracks

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -23,9 +23,7 @@ redis = redis_connection.get_redis()
 def _get_tracks(session, args):
     # Create initial query
     base_query = session.query(Track)
-    base_query = base_query.filter(
-        Track.is_current == True, Track.is_unlisted == False, Track.stem_of == None
-    )
+    base_query = base_query.filter(Track.is_current == True, Track.stem_of == None)
 
     # Note that if slug is included, we should only get one track
     # The user ID filter should also be included
@@ -34,6 +32,15 @@ def _get_tracks(session, args):
         base_query = base_query.join(
             TrackRoute, TrackRoute.track_id == Track.track_id
         ).filter(TrackRoute.slug == slug)
+
+    # Only return unlisted tracks if slug and user_id are present
+    if (
+        not "include_unlisted" in args
+        or not args.get("include_unlisted")
+        or not "slug" in args
+        or not "user_id" in args
+    ):
+        base_query.filter(Track.is_unlisted == False)
 
     # Conditionally process an array of tracks
     if "id" in args:

--- a/discovery-provider/tests/test_get_tracks.py
+++ b/discovery-provider/tests/test_get_tracks.py
@@ -51,6 +51,13 @@ def populate_tracks(db):
                 "release_date": "garbage-should-not-parse",
                 "created_at": datetime(2018, 5, 20),
             },
+            {
+                "track_id": 9,
+                "owner_id": 4,
+                "release_date": "Wed Dec 25 2019 12:00:00 GMT-0800",
+                "created_at": datetime(2018, 5, 20),
+                "is_unlisted": True,
+            },
         ],
         "track_routes": [
             {"slug": "track-1", "owner_id": 1287289},
@@ -69,6 +76,11 @@ def populate_tracks(db):
                 "slug": "track-2",
                 "owner_id": 4,
                 "track_id": 8,
+            },
+            {
+                "slug": "hidden-track",
+                "owner_id": 4,
+                "track_id": 9,
             },
         ],
         "users": [
@@ -138,3 +150,17 @@ def test_get_track_by_handle_slug(app):
             assert len(tracks) == 1
             assert tracks[0]["owner_id"] == 4
             assert tracks[0]["slug"] == "track-1"
+
+            # Get an unlisted track
+            tracks = _get_tracks(
+                session,
+                {
+                    "user_id": 4,
+                    "slug": "hidden-track",
+                    "offset": 0,
+                    "limit": 10,
+                },
+            )
+            assert len(tracks) == 1
+            assert tracks[0]["owner_id"] == 4
+            assert tracks[0]["slug"] == "hidden-track"


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Getting a track by handle/slug should include unlisted tracks

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Added a test and manually tested with the client changes I have ongoing

   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
