### PR TITLE
Make ownerWallet an optional param

### DIFF
--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -138,7 +138,7 @@ class AudiusLibs {
    * @param {string} tokenAddress
    * @param {string} registryAddress
    * @param {string | Web3 | Array<string>} providers web3 provider endpoint(s)
-   * @param {string} ownerWallet
+   * @param {string?} ownerWallet optional owner wallet to establish who we are sending transactions on behalf of
    * @param {string?} claimDistributionContractAddress
    * @param {string?} wormholeContractAddress
    */
@@ -291,7 +291,8 @@ class AudiusLibs {
     if (this.ethWeb3Config) {
       this.ethWeb3Manager = new EthWeb3Manager(
         this.ethWeb3Config,
-        this.identityService
+        this.identityService,
+        this.hedgehog
       )
     }
     if (this.web3Config) {

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -9,23 +9,36 @@ const GANACHE_GAS_PRICE = 39062500000 // ganache gas price is extremely high, so
 
 /** Singleton state-manager for Audius Eth Contracts */
 class EthWeb3Manager {
-  constructor (web3Config, identityService) {
+  constructor (web3Config, identityService, hedgehog) {
     if (!web3Config) throw new Error('web3Config object not passed in')
     if (!web3Config.providers) throw new Error('missing web3Config property: providers')
-    if (!web3Config.ownerWallet) throw new Error('missing web3Config property: ownerWallet')
 
     // MultiProvider implements a web3 provider with fallback.
     const provider = new MultiProvider(web3Config.providers)
 
     this.web3Config = web3Config
-    this.identityService = identityService
     this.web3 = new Web3(provider)
-    this.ownerWallet = web3Config.ownerWallet
+    this.identityService = identityService
+    this.hedgehog = hedgehog
+
+    if (this.web3Config.ownerWallet) {
+      this.ownerWallet = this.web3Config.ownerWallet
+    } else {
+      const storedWallet = this.hedgehog.getWallet()
+      if (storedWallet) {
+        this.ownerWallet = storedWallet
+      }
+    }
   }
 
   getWeb3 () { return this.web3 }
 
-  getWalletAddress () { return this.ownerWallet.toLowerCase() }
+  getWalletAddress () {
+    if (this.ownerWallet) {
+      return this.ownerWallet.toLowerCase()
+    }
+    throw new Error('Owner wallet not set')
+  }
 
   /**
    * Signs provided string data (should be timestamped).


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

`ownerWallet` is an necessary param for eth init here. Leaving in the existing config for backwards compat, but it's not strictly necessary. It's more important that from the eth manager persp. we're using the user's hedgehog wallet.

Current requirement for ownerWallet doesn't really make any sense for consumers of libs

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Linked libs & ran client against production and sent $AUDIO
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
