### PR TITLE
 Add getTracksByHandleAndSlug API to libs

### DIFF
--- a/libs/src/api/track.js
+++ b/libs/src/api/track.js
@@ -79,6 +79,16 @@ class Track extends Base {
   }
 
   /**
+   * Gets tracks by their slug and owner handle
+   * @param {string} handle the owner's handle
+   * @param {string} slug the track's slug, including collision identifiers
+   */
+  async getTracksByHandleAndSlug (handle, slug) {
+    this.REQUIRES(Services.DISCOVERY_PROVIDER)
+    return this.discoveryProvider.getTracksByHandleAndSlug(handle, slug)
+  }
+
+  /**
    * @typedef {Object} getTracksIdentifier
    * @property {string} handle
    * @property {number} id

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -143,6 +143,16 @@ class DiscoveryProvider {
   }
 
   /**
+   * Gets a particular track by its creator's handle and the track's URL slug
+   * @param {string} handle the handle of the owner of the track
+   * @param {string} slug the URL slug of the track, generally the title urlized
+   * @returns {Object} the requested track's metadata
+   */
+  async getTracksByHandleAndSlug (handle, slug) {
+    return this._makeRequest(Requests.getTracksByHandleAndSlug(handle, slug))
+  }
+
+  /**
    * @typedef {Object} getTracksIdentifier
    * @property {string} handle
    * @property {number} id

--- a/libs/src/services/discoveryProvider/requests.js
+++ b/libs/src/services/discoveryProvider/requests.js
@@ -50,6 +50,14 @@ module.exports.getTracks = (limit = 100, offset = 0, idsArray = null, targetUser
   return req
 }
 
+module.exports.getTracksByHandleAndSlug = (handle, slug) => {
+  return {
+    endpoint: 'tracks',
+    method: 'get',
+    queryParams: { handle, slug }
+  }
+}
+
 module.exports.getTracksIncludingUnlisted = (identifiers, withUsers = false) => {
   let req = {
     endpoint: 'tracks_including_unlisted',


### PR DESCRIPTION
Adds the new API to get tracks by their owner's handle and the track's slug to libs, which is required for GA to call the new API.