### PR TITLE
Bump libs to 1.2.15

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

minor change where in CreatorNode.getClockValue() , you may pass in additional query string params of the signature and timestamp. this is used for our SP clock fetching to bypass SP rate limiting. 

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible._
- tested this feature in the [rate limit PR](https://github.com/AudiusProject/audius-protocol/pull/1670) 
