### PR TITLE
Filter out solana plays

### DIFF
--- a/discovery-provider/src/tasks/index_plays.py
+++ b/discovery-provider/src/tasks/index_plays.py
@@ -34,6 +34,7 @@ def get_track_plays(self, db, lock):
         # more play counts from identity
         most_recent_play_date = (
             session.query(Play.updated_at)
+            .filter(Play.signature == None)
             .order_by(desc(Play.updated_at), desc(Play.id))
             .first()
         )


### PR DESCRIPTION
### Description
Fix indexing plays to filter out plays from solana.

### Tests
I tested locally: manually inserted plays with a signature and timestamp ahead of all other plays and this query filtered it out while indexing plays.

### How will this change be monitored?
