### PR TITLE
Update listen streak challenge id to use hyphen

### DIFF
--- a/discovery-provider/src/challenges/challenges.json
+++ b/discovery-provider/src/challenges/challenges.json
@@ -7,7 +7,7 @@
 		"step_count": 7
 	},
 	{
-		"id": "listen_streak",
+		"id": "listen-streak",
 		"type": "numeric",
 		"amount": "5",
 		"active": false,

--- a/discovery-provider/src/challenges/listen_streak_challenge.py
+++ b/discovery-provider/src/challenges/listen_streak_challenge.py
@@ -74,7 +74,7 @@ class ListenStreakChallengeUpdater(ChallengeUpdater):
 
 
 listen_streak_challenge_manager = ChallengeManager(
-    "listen_streak", ListenStreakChallengeUpdater()
+    "listen-streak", ListenStreakChallengeUpdater()
 )
 
 # Accessors


### PR DESCRIPTION
### Description

Updating the listen streak challenge id to use a hyphen for consistency and better specifiers
