### PR TITLE
Add script to globally call setup.js

### DIFF
--- a/service-commands/README.md
+++ b/service-commands/README.md
@@ -10,6 +10,7 @@ This API allows you to bring services up and down and control your local audius 
 - `export` the environment variable `PROTOCOL_DIR` to point to the cloned `protocol` repo.
 
   set this in your shell config (`.bashrc`), e.g. `export PROTOCOL_DIR=/Users/hareeshnagaraj/Development/audius-protocol`
+  Also add `export PATH=$HOME/.local/bin:$PATH` to your shell config.
 - Execute `npm install` in `<service-commands>` (audius-tooling/service-commands)
 - Run the `<service-commands>/scripts/hosts.js` script with `sudo node hosts.js add`. This script will add mappings to your `/etc/hosts` file.
 

--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -4,7 +4,7 @@
   "description": "Library for performing commands against services, including setup.",
   "main": "src/index.js",
   "scripts": {
-    "preinstall": "ln -f scripts/A ~/.local/bin"
+    "preinstall": "mkdir -p ~/.local/bin && ln -f scripts/A ~/.local/bin/A"
   },
   "dependencies": {
     "@audius/libs": "1.2.13",

--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Library for performing commands against services, including setup.",
   "main": "src/index.js",
+  "scripts": {
+    "preinstall": "ln -f scripts/A ~/.local/bin"
+  },
   "dependencies": {
     "@audius/libs": "1.2.13",
     "axios": "^0.19.2",

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd $PROTOCOL_DIR/service-commands
+node scripts/setup.js $@


### PR DESCRIPTION
### Description

This PR adds a script that can be moved to `~/.local/bin` or `~/bin` to call setup.js from a global context.

### Tests

```sh
A down
A up -nc 2
```

### How will this change be monitored?

NA
