### PR TITLE
Add discovery whitelist in identity

### DIFF
--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -13,8 +13,12 @@ class AudiusLibsWrapper {
     const dataWeb3 = await AudiusLibs.Utils.configureWeb3(web3ProviderUrl, null, false)
     if (!dataWeb3) throw new Error('Web3 incorrectly configured')
 
+    const discoveryProviderWhitelist = config.get('discoveryProviderWhitelist')
+      ? new Set(config.get('discoveryProviderWhitelist').split(','))
+      : null
+
     let audiusInstance = new AudiusLibs({
-      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(),
+      discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(discoveryProviderWhitelist),
       ethWeb3Config: AudiusLibs.configEthWeb3(
         config.get('ethTokenAddress'),
         config.get('ethRegistryAddress'),

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -605,6 +605,12 @@ const config = convict({
     format: String,
     env: 'optimizelySdkKey',
     default: null
+  },
+  discoveryProviderWhitelist: {
+    doc: 'Whitelisted discovery providers to select from (comma-separated)',
+    format: String,
+    env: 'discoveryProviderWhitelist',
+    default: ''
   }
 })
 


### PR DESCRIPTION
### Description

We've never had a discovery whitelist env var in identity, adding to bring it to parity with content node.

### Tests
Tested on staging

### How will this change be monitored?
The selected discovery node is exposed via health check