### PR TITLE
Use SP ID as the source of truth when issuing reconfigs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ jobs:
             docker ps
             export ipfsHost="localhost"
             export ipfsPort=6001
+            export snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
             npm run start test-ci verbose
 
   test-libs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,6 @@ jobs:
             docker ps
             export ipfsHost="localhost"
             export ipfsPort=6001
-            export snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
             npm run start test-ci verbose
 
   test-libs:

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -48,7 +48,7 @@ minimumDailySyncCount=5
 minimumRollingSyncCount=10
 minimumSuccessfulSyncCountPercentage=50
 secondaryUserSyncDailyFailureCountThreshold=2
-snapbackHighestReconfigMode=ONE_SECONDARY
+snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
 minimumSecondaryUserSyncSuccessPercent=50
 maxSyncMonitoringDurationInMs=10000 # 10sec
 

--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -47,8 +47,8 @@ snapbackModuloBase=3
 minimumDailySyncCount=5
 minimumRollingSyncCount=10
 minimumSuccessfulSyncCountPercentage=50
-secondaryUserSyncDailyFailureCountThreshold=2
 snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
+secondaryUserSyncDailyFailureCountThreshold=10
 minimumSecondaryUserSyncSuccessPercent=50
 maxSyncMonitoringDurationInMs=10000 # 10sec
 

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -138,7 +138,8 @@ class PeerSetManager {
    * @notice This function depends on a new discprov route and cannot be consumed until every discprov exposes that route
    *    It will throw if the route doesn't exist
    * @returns {Object[]} array of objects
-   *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
+   *  - Each object should have the schema { primary, secondary1, secondary2, user_id, wallet, primarySpID, secondary1SpID, secondary2SpID },
+   * and at the very least have the schema { primary, secondary1, secondary2, user_id, wallet }
    */
   async getAllNodeUsers () {
     // Fetch discovery node currently connected to libs as this can change
@@ -172,7 +173,8 @@ class PeerSetManager {
    * Retrieve users with this node as primary
    * Leaving this function in until all discovery providers update to new version and expose new `/users/content_node/all` route
    * @returns {Object[]} array of objects
-   *  - Each object has schema { primary, secondary1, secondary2, user_id, wallet }
+   *  - Each object should have the schema { primary, secondary1, secondary2, user_id, wallet, primarySpID, secondary1SpID, secondary2SpID }
+   * and at the very least have the schema { primary, secondary1, secondary2, user_id, wallet }
    */
   async getNodePrimaryUsers () {
     // Fetch discovery node currently connected to libs as this can change

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -499,7 +499,7 @@ class SnapbackSM {
         response.newPrimary = newPrimary
         response.newSecondary1 = currentHealthySecondary
         response.newSecondary2 = newReplicaNodes[0]
-        response.issueReconfig = this.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
+        response.issueReconfig = this.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
         response.reconfigType = RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
       } else {
         // If one secondary is unhealthy, select a new secondary
@@ -507,19 +507,19 @@ class SnapbackSM {
         response.newPrimary = primary
         response.newSecondary1 = currentHealthySecondary
         response.newSecondary2 = newReplicaNodes[0]
-        response.issueReconfig = this.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key)
+        response.issueReconfig = this.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key)
         response.reconfigType = RECONFIG_MODES.ONE_SECONDARY.key
       }
     } else if (unhealthyReplicasSet.size === 2) {
       if (unhealthyReplicasSet.has(primary)) {
         // If primary + secondary is unhealthy, use other healthy secondary as primary and 2 random secondaries
         response.newPrimary = !unhealthyReplicasSet.has(secondary1) ? secondary1 : secondary2
-        response.issueReconfig = this.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
+        response.issueReconfig = this.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
         response.reconfigType = RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
       } else {
         // If both secondaries are unhealthy, keep original primary and select two random secondaries
         response.newPrimary = primary
-        response.issueReconfig = this.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
+        response.issueReconfig = this.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
         response.reconfigType = RECONFIG_MODES.MULTIPLE_SECONDARIES.key
       }
       response.newSecondary1 = newReplicaNodes[0]
@@ -1273,7 +1273,12 @@ class SnapbackSM {
     throw new Error(`Secondary ${secondaryUrl} did not sync up to primary for user ${wallet} within ${timeoutMs}ms`)
   }
 
-  isReconfigModeEnabled (mode) {
+  /**
+   * Given the current snapback mode, determine if reconfig is enabled
+   * @param {string} mode current mode in snapback
+   * @returns boolean of whether or not reconfig is enabled
+   */
+  isReconfigEnabled (mode) {
     if (mode === RECONFIG_MODES.RECONFIG_DISABLED.key) return false
     return this.enabledReconfigModesSet.has(mode)
   }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -989,7 +989,7 @@ class SnapbackSM {
         // the self node
         replicaSetNodesToObserve = [{ endpoint: primary, spId: primarySpID }, ...replicaSetNodesToObserve]
         replicaSetNodesToObserve = replicaSetNodesToObserve.filter(entry => {
-          return !!(entry.endpoint && entry.spId) || entry.endpoint !== this.endpoint
+          return !!(entry.endpoint && entry.spId) && entry.endpoint !== this.endpoint
         })
 
         for (const replica of replicaSetNodesToObserve) {

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -979,13 +979,14 @@ class SnapbackSM {
 
     if (primary === this.endpoint) {
       // filter out false-y values to account for incomplete replica sets
-      replicaSetNodesToObserve = replicaSetNodesToObserve.filter(entry => entry.endpoint && entry.spId)
+      const secondariesInfo = replicaSetNodesToObserve.filter(entry => entry.endpoint && entry.spId)
+      const secondariesEndpoint = secondariesInfo.map(entry => entry.endpoint)
 
       /**
        * If either secondary is in `unhealthyPeers` list, add it to `unhealthyReplicas` list
        */
-      const userSecondarySyncMetrics = await this._computeUserSecondarySyncSuccessRates(nodeUser, [secondary1, secondary2])
-      for (const secondary of replicaSetNodesToObserve) {
+      const userSecondarySyncMetrics = await this._computeUserSecondarySyncSuccessRates(nodeUser, secondariesEndpoint)
+      for (const secondary of secondariesInfo) {
         const secUserSyncSuccessRate = userSecondarySyncMetrics[secondary.endpoint]['SuccessRate']
         if (secUserSyncSuccessRate < this.MinimumSecondaryUserSyncSuccessPercent ||
           unhealthyPeers.has(secondary.endpoint) ||

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -956,7 +956,7 @@ class SnapbackSM {
 
       if (primary === this.endpoint) {
         // filter out false-y values to account for incomplete replica sets
-        replicaSetNodesToObserve = replicaSetNodesToObserve.filter(entry => !!(entry.endpoint && entry.spId))
+        replicaSetNodesToObserve = replicaSetNodesToObserve.filter(entry => entry.endpoint && entry.spId)
 
         /**
          * If either secondary is in `unhealthyPeers` list, add it to `unhealthyReplicas` list
@@ -989,7 +989,7 @@ class SnapbackSM {
         // the self node
         replicaSetNodesToObserve = [{ endpoint: primary, spId: primarySpID }, ...replicaSetNodesToObserve]
         replicaSetNodesToObserve = replicaSetNodesToObserve.filter(entry => {
-          return !!(entry.endpoint && entry.spId) && entry.endpoint !== this.endpoint
+          return entry.endpoint && entry.spId && entry.endpoint !== this.endpoint
         })
 
         for (const replica of replicaSetNodesToObserve) {

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -201,10 +201,10 @@ describe('test SnapbackSM', function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.RECONFIG_DISABLED.key)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if the mode enabled does not cover the reconfig type, do not issue reconfig', async function () {
@@ -261,7 +261,7 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, false)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
   })
 
   it('[determineNewReplicaSet] if entire replica set is unhealthy, return falsy replica set', async function () {
@@ -341,8 +341,7 @@ describe('test SnapbackSM', function () {
     assert.strictEqual(newSecondary1, constants.secondary1Endpoint)
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
   })
 
   it('[determineNewReplicaSet] if both secondaries are unhealthy, return two new secondaries ', async function () {
@@ -397,9 +396,8 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if one primary is unhealthy, return a secondary promoted to primary, existing secondary1, and new secondary2', async function () {
@@ -457,10 +455,9 @@ describe('test SnapbackSM', function () {
     assert.strictEqual(newSecondary1, constants.secondary2Endpoint)
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if primary+secondary are unhealthy, return a secondary promoted to a primary, and 2 new secondaries', async function () {
@@ -517,10 +514,9 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[issueUpdateReplicaSetOp] if when `this.endpointToSPIdMap` is used and it does not have an spId for an endpoint, do not issue reconfig', async function () {
@@ -618,37 +614,33 @@ describe('test SnapbackSM', function () {
     let snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.ONE_SECONDARY.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.ONE_SECONDARY.key)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.RECONFIG_DISABLED.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.RECONFIG_DISABLED.key)
-    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[aggregateReconfigAndPotentialSyncOps] if the spIds are different from a re-registration event, add to reconfig arr', async function () {

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -792,7 +792,6 @@ describe('test SnapbackSM', function () {
 
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
 
-    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
     assert.strictEqual(potentialSyncRequests.length, 0)
   })
@@ -835,7 +834,6 @@ describe('test SnapbackSM', function () {
 
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
 
-    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://deregisteredCN.co')
     assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')
   })
@@ -878,7 +876,6 @@ describe('test SnapbackSM', function () {
 
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
 
-    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
     assert.strictEqual(potentialSyncRequests.length, 2)
     assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')
@@ -909,7 +906,6 @@ describe('test SnapbackSM', function () {
 
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
 
-    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
     assert.strictEqual(potentialSyncRequests.length, 0)
   })

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -646,18 +646,6 @@ describe('test SnapbackSM', function () {
   it('[aggregateReconfigAndPotentialSyncOps] if the self node is the secondary and a primary spId is different from what is on chain, issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          SuccessRate: 100
-        },
-        'http://cnWithSpId3.co': {
-          SuccessRate: 100
-        }
-      }
-    }
-
     // Mock that one of the nodes got reregistered from spId 3 to spId 4
     snapback.peerSetManager.endpointToSPIdMap = {
       'http://cnOriginallySpId3ReregisteredAsSpId4.co': 4,
@@ -780,18 +768,6 @@ describe('test SnapbackSM', function () {
   it('[aggregateReconfigAndPotentialSyncOps] if the self node (secondary) is the same as the SP with a different spId, do not issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          SuccessRate: 100
-        },
-        'http://cnOriginallySpId3ReregisteredAsSpId4.co': {
-          SuccessRate: 100
-        }
-      }
-    }
-
     // Mock that one of the nodes got reregistered from spId 3 to spId 4
     snapback.peerSetManager.endpointToSPIdMap = {
       'http://some_healthy_primary.co': 1,
@@ -911,18 +887,6 @@ describe('test SnapbackSM', function () {
 
   it('[aggregateReconfigAndPotentialSyncOps] if Discovery Node does not respond with replica set spIds, the spId is mismatched, and the self node is a secondary, do not issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
-
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          SuccessRate: 100
-        },
-        'http://cnOriginallySpId3ReregisteredAsSpId4.co': {
-          SuccessRate: 100
-        }
-      }
-    }
 
     // Mock that one of the nodes got reregistered from spId 3 to spId 4
     snapback.peerSetManager.endpointToSPIdMap = {

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -64,8 +64,6 @@ const healthCheckVerboseResponse = {
 
 const healthyNodes = [constants.healthyNode1Endpoint, constants.healthyNode2Endpoint, constants.healthyNode3Endpoint]
 
-// TODO: Update hardcoded strings in reconfig modes to the imported modes
-
 describe('test SnapbackSM', function () {
   let server
 
@@ -203,10 +201,10 @@ describe('test SnapbackSM', function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.RECONFIG_DISABLED.key)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if the mode enabled does not cover the reconfig type, do not issue reconfig', async function () {
@@ -263,7 +261,7 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, false)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
   })
 
   it('[determineNewReplicaSet] if entire replica set is unhealthy, return falsy replica set', async function () {
@@ -343,8 +341,8 @@ describe('test SnapbackSM', function () {
     assert.strictEqual(newSecondary1, constants.secondary1Endpoint)
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
   })
 
   it('[determineNewReplicaSet] if both secondaries are unhealthy, return two new secondaries ', async function () {
@@ -399,9 +397,9 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if one primary is unhealthy, return a secondary promoted to primary, existing secondary1, and new secondary2', async function () {
@@ -459,10 +457,10 @@ describe('test SnapbackSM', function () {
     assert.strictEqual(newSecondary1, constants.secondary2Endpoint)
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[determineNewReplicaSet] if primary+secondary are unhealthy, return a secondary promoted to a primary, and 2 new secondaries', async function () {
@@ -519,10 +517,10 @@ describe('test SnapbackSM', function () {
     assert.ok(healthyNodes.includes(newSecondary1))
     assert.ok(healthyNodes.includes(newSecondary2))
     assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
   })
 
   it('[issueUpdateReplicaSetOp] if when `this.endpointToSPIdMap` is used and it does not have an spId for an endpoint, do not issue reconfig', async function () {
@@ -620,36 +618,79 @@ describe('test SnapbackSM', function () {
     let snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.MULTIPLE_SECONDARIES.key)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.ONE_SECONDARY.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.ONE_SECONDARY.key)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
 
     nodeConfig.set('snapbackHighestReconfigMode', RECONFIG_MODES.RECONFIG_DISABLED.key)
     snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
     assert.strictEqual(snapback.highestEnabledReconfigMode, RECONFIG_MODES.RECONFIG_DISABLED.key)
-    assert.ok(snapback.enabledReconfigModesSet.has(RECONFIG_MODES.RECONFIG_DISABLED.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(!snapback.enabledReconfigModesSet.has(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    assert.ok(snapback.isReconfigModeEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    assert.ok(!snapback.isReconfigModeEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+  })
+
+  it('[aggregateReconfigAndPotentialSyncOps] if the spIds are different from a re-registration event, add to reconfig arr', async function () {
+    const snapback = new SnapbackSM(nodeConfig, getLibsMock())
+
+    // Mock these as very nodes that completed only successful syncs
+    snapback._computeUserSecondarySyncSuccessRates = async () => {
+      return {
+        'http://cnWithSpId2.co': {
+          SuccessRate: 100
+        },
+        'http://cnReregisteredAsSpId4.co': {
+          SuccessRate: 100
+        }
+      }
+    }
+
+    // Mock that one of the nodes got reregistered from spId 3 to spId 4
+    snapback.peerSetManager.endpointToSPIdMap = {
+      'http://cnWithSpId2.co': 2,
+      'http://cnReregisteredAsSpId4.co': 4
+    }
+
+    snapback.endpoint = 'http://some_healthy_primary.co'
+
+    const nodeUsers = [{
+      'user_id': 1,
+      'wallet': '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+      'primary': 'http://some_healthy_primary.co',
+      'secondary1': 'http://cnWithSpId2.co',
+      'secondary2': 'http://cnReregisteredAsSpId4.co',
+      'primarySpID': 1,
+      'secondary1SpID': 2,
+      'secondary2SpID': 3
+    }]
+
+    const unhealthyPeers = new Set()
+
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+
+    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
+    assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://cnReregisteredAsSpId4.co')
+    assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')
   })
 })

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -76,6 +76,9 @@ user_replica_set = ns.model(
         "primary": fields.String(required=False),
         "secondary1": fields.String(required=False),
         "secondary2": fields.String(required=False),
+        "primarySpID": fields.Integer(required=False),
+        "secondary1SpID": fields.Integer(required=False),
+        "secondary2SpID": fields.Integer(required=False),
     },
 )
 

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -707,7 +707,7 @@ class UsersByContentNode(Resource):
         """New route to call get_users_cnode with replica_type param (only consumed by content node)
         - Leaving `/users/creator_node` above untouched for backwards-compatibility
 
-        Response = array of objects of schema { user_id, wallet, primary, secondary1, secondary2 }
+        Response = array of objects of schema { user_id, wallet, primary, secondary1, secondary2, primarySpId, secondary1SpID, secondary2SpID }
         """
         args = users_by_content_node_route_parser.parse_args()
 

--- a/discovery-provider/src/queries/get_users_cnode.py
+++ b/discovery-provider/src/queries/get_users_cnode.py
@@ -36,13 +36,18 @@ def get_users_cnode(cnode_endpoint_string, replica_type=ReplicaType.PRIMARY):
                 "wallet",
                 ("creator_node_endpoints") [1] as "primary",
                 ("creator_node_endpoints") [2] as "secondary1",
-                ("creator_node_endpoints") [3] as "secondary2"
+                ("creator_node_endpoints") [3] as "secondary2",
+                "primary_id" as "primarySpID",
+                ("secondary_ids") [1] as "secondary1SpID",
+                ("secondary_ids") [2] as "secondary2SpID"
                 FROM
                 (
                     SELECT
                     "user_id",
                     "wallet",
-                    string_to_array("creator_node_endpoint", ',') as "creator_node_endpoints"
+                    string_to_array("creator_node_endpoint", ',') as "creator_node_endpoints",
+                    "primary_id",
+                    "secondary_ids"
                     FROM
                     "users"
                     WHERE

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -11,7 +11,7 @@ const {
   IpldBlacklistTest,
   userReplicaSetBlockSaturationTest,
   trackListenCountsTest,
-  userReplicaSetNodes
+  SnapbackReconfigTests
 } = require('./tests/')
 
 // Configuration.
@@ -256,16 +256,26 @@ async function main () {
         break
       }
       case 'test-ursm-nodes': {
-        const test = makeTest(
-          'userReplicaSetNodesTest',
-          userReplicaSetNodes,
+        const deregisterCNTest = makeTest(
+          'snapbackReconfigTestDeregisterCN',
+          SnapbackReconfigTests.deregisterCN,
           {
             numUsers: 8,
             numCreatorNodes: 10,
-            iterations: 3
+            iterations: 2
           }
         )
-        await testRunner([test])
+
+        const forceCNUnavailabilityTest = makeTest(
+          'snapbackReconfigTestForceCNUnavailability',
+          SnapbackReconfigTests.forceCNUnavailability,
+          {
+            numUsers: 8,
+            numCreatorNodes: 10,
+            iterations: 2
+          }
+        )
+        await testRunner([deregisterCNTest, forceCNUnavailabilityTest])
         break
       }
       case 'test-ci': {

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -321,13 +321,35 @@ async function main () {
           }
         )
 
+        const deregisterCNTest = makeTest(
+          'snapbackReconfigTestDeregisterCN',
+          SnapbackReconfigTests.deregisterCN,
+          {
+            numUsers: 2,
+            numCreatorNodes: DEFAULT_NUM_CREATOR_NODES,
+            iterations: 2
+          }
+        )
+
+        const forceCNUnavailabilityTest = makeTest(
+          'snapbackReconfigTestForceCNUnavailability',
+          SnapbackReconfigTests.forceCNUnavailability,
+          {
+            numUsers: 2,
+            numCreatorNodes: DEFAULT_NUM_CREATOR_NODES,
+            iterations: 2
+          }
+        )
+
         const tests = [
           coreIntegrationTests,
           snapbackTest,
           ...blacklistTests,
           ursmTest,
           ursmBlockSaturationTest,
-          trackListenCountTest
+          trackListenCountTest,
+          deregisterCNTest,
+          forceCNUnavailabilityTest
         ]
 
         await testRunner(tests)

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -326,7 +326,7 @@ async function main () {
           SnapbackReconfigTests.deregisterCN,
           {
             numUsers: 2,
-            numCreatorNodes: DEFAULT_NUM_CREATOR_NODES,
+            numCreatorNodes: 10,
             iterations: 2
           }
         )
@@ -336,7 +336,7 @@ async function main () {
           SnapbackReconfigTests.forceCNUnavailability,
           {
             numUsers: 2,
-            numCreatorNodes: DEFAULT_NUM_CREATOR_NODES,
+            numCreatorNodes: 10,
             iterations: 2
           }
         )

--- a/mad-dog/src/madDog.js
+++ b/mad-dog/src/madDog.js
@@ -62,7 +62,7 @@ class MadDog {
       // Kill original process
       this.netemProcess.kill()
       // Set packet loss to 0% aka revert back to normal
-      exec(`pumba netem --tc-image gaiadocker/iproute2 loss -p 0 containers ${this.netemProcessService}`)
+      exec(`pumba netem --tc-image gaiadocker/iproute2 -d ${this.networkDownDurationSec}s loss -p 0 containers ${this.netemProcessService}`)
     }
     if (this.pauseProcess) this.pauseProcess.kill()
   }

--- a/mad-dog/src/madDog.js
+++ b/mad-dog/src/madDog.js
@@ -17,7 +17,7 @@ const makeCreatorNodeName = num => `cn${num}_creator-node_1`
 // For now, this only takes down a single node
 // per test.
 class MadDog {
-  constructor({
+  constructor ({
     numCreatorNodes,
     downProbability = DOWN_PROBABILITY,
     pauseDurationSec = PAUSE_DURATION_SEC,
@@ -42,7 +42,7 @@ class MadDog {
    * Starts mad dog. Creates stormy network conditions
    * and randomly pauses down a single node over the course of the test.
    */
-  start(serviceName) {
+  start (serviceName) {
     logger.info('Starting 😡🐶')
     this._setNetworkConditions(serviceName)
     this.tickToken = setInterval(() => {
@@ -56,31 +56,37 @@ class MadDog {
     }, TICK_INTERVAL_SEC * 1000)
   }
 
-  stop() {
+  stop () {
     clearInterval(this.tickToken)
-    if (this.netemProcess) this.netemProcess.kill()
+    if (this.netemProcess) {
+      // Kill original process
+      this.netemProcess.kill()
+      // Set packet loss to 0% aka revert back to normal
+      exec(`pumba netem --tc-image gaiadocker/iproute2 loss -p 0 containers ${this.netemProcessService}`)
+    }
     if (this.pauseProcess) this.pauseProcess.kill()
   }
 
-  _setNetworkConditions(serviceName) {
+  _setNetworkConditions (serviceName) {
     const service = serviceName || _.sample(this.services)
     logger.info(
       `Setting ${this.packetLossPercent}% packet loss for service: ${service}`
     )
+    this.netemProcessService = service
     this.netemProcess = exec(`pumba netem --tc-image gaiadocker/iproute2 -d ${this.networkDownDurationSec}s loss -p ${this.packetLossPercent} containers ${service}`)
     this._setProcessLogs(this.netemProcess)
   }
 
-  _setProcessLogs(process) {
+  _setProcessLogs (process) {
     process.stdout.on('data', (data) => logger.info(`stdout: ${data}`))
     process.stderr.on('data', (data) => logger.error(`stderr: ${data}`))
     process.on('exit', (code) => {
-      logger.info(`child process exited with code ${code}`)
+      if (code) logger.info(`child process exited with code ${code}`)
       process = null
     })
   }
 
-  _pauseService(serviceName) {
+  _pauseService (serviceName) {
     const service = serviceName || _.sample(this.services)
     didPause = true
     logger.info(`Pausing service: [${service}]`)

--- a/mad-dog/src/madDog.js
+++ b/mad-dog/src/madDog.js
@@ -81,7 +81,7 @@ class MadDog {
     process.stdout.on('data', (data) => logger.info(`stdout: ${data}`))
     process.stderr.on('data', (data) => logger.error(`stderr: ${data}`))
     process.on('exit', (code) => {
-      if (code) logger.info(`child process exited with code ${code}`)
+      if (!isNaN(code)) logger.info(`child process exited with code ${code}`)
       process = null
     })
   }

--- a/mad-dog/src/madDog.js
+++ b/mad-dog/src/madDog.js
@@ -90,7 +90,7 @@ class MadDog {
     const service = serviceName || _.sample(this.services)
     didPause = true
     logger.info(`Pausing service: [${service}]`)
-    this.pauseProcess = exec(`pumba pause -d ${this.pauseDurationSec}s constainers ${service}`)
+    this.pauseProcess = exec(`pumba pause -d ${this.pauseDurationSec}s containers ${service}`)
     _setProcessLogs(this.pauseProcess)
     setTimeout(() => {
       logger.info(`Unpausing service: [${service}]`)

--- a/mad-dog/src/tests/index.js
+++ b/mad-dog/src/tests/index.js
@@ -5,7 +5,7 @@ const { userReplicaSetBlockSaturationTest } = require('./test_ursmBlockSaturatio
 const { userReplicaSetManagerTest } = require('./test_userReplicaSetManager.js')
 const { trackListenCountsTest } = require('./test_plays.js')
 
-const { userReplicaSetNodes } = require('./test_userReplicaSetNodes')
+const SnapbackReconfigTests = require('./test_userReplicaSetNodes')
 
 module.exports = {
   coreIntegration,
@@ -14,5 +14,5 @@ module.exports = {
   userReplicaSetManagerTest,
   userReplicaSetBlockSaturationTest,
   trackListenCountsTest,
-  userReplicaSetNodes
+  SnapbackReconfigTests
 }

--- a/mad-dog/src/tests/test_userReplicaSetManager.js
+++ b/mad-dog/src/tests/test_userReplicaSetManager.js
@@ -56,12 +56,12 @@ const verifyUserReplicaSetStatus = async (
     // Throw if mismatch between queried primaryID and assigned
     //    spID on chain for this endpoint
     if (primaryID !== primaryInfo.spID) {
-      throw new Error(`Mismatch spID values. Expected endpoint for ${primaryID}, found ${primaryInfo.spID}`)
+      throw new Error(`Mismatch spID values. Indexed value=${primaryID} chain value=${primaryInfo.spID}`)
     }
 
     // Throw if mismatch between primaryID from discovery-node and primaryID in UserReplicaSetManager
     if (primaryID !== parseInt(usrReplicaInfoFromContract.primaryId)) {
-      throw new Error(`Mismatch primaryID values. Expected ${primaryID}, found ${usrReplicaInfoFromContract.primaryId}`)
+      throw new Error(`Mismatch primaryID values. Indexed value=${primaryID} contract value=${usrReplicaInfoFromContract.primaryId}`)
     }
 
     logger.info(`userId: ${userId} Replica Set Info: ${primaryID}, ${usrQueryInfo.secondary_ids}`)

--- a/mad-dog/src/tests/test_userReplicaSetNodes/index.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/index.js
@@ -1,9 +1,10 @@
 const { addAndUpgradeUsers } = require('../../helpers.js')
 const verifyValidCNs = require('./verifyValidCN')
-// const deregisterRandomCreatorNode = require('./deregisterRandomCreatorNode.js')
+const deregisterRandomCreatorNode = require('./deregisterRandomCreatorNode.js')
 const stopRandomCreatorNode = require('./stopRandomCreatorNode.js')
 const setNumCreatorNodes = require('./setNumCreatorNodes.js')
 const { uploadTracksforUsers } = require('../../utils/uploadTracksForUsers')
+const { logger } = require('../../../../creator-node/src/logging.js')
 
 const MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET = 10
 const WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS = 20000
@@ -40,23 +41,41 @@ const userReplicaSetNodes = async ({
 
     // TODO: Implement spID as source of truth feature before uncommenting deregistration test code
 
-    // const deregisteredCreatorNodeId = await deregisterRandomCreatorNode(creatorNodeIDToInfoMapping)
-
-    // await new Promise(resolve => setTimeout(resolve, 10 * 1000))
-    // await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
+    const deregisteredCreatorNodeId = await deregisterRandomCreatorNode(creatorNodeIDToInfoMapping)
 
     // Create a MadDog instance, responsible for taking down 1 node
-    const {
-      madDog,
-      removedCreatorNodeId
-    } = await stopRandomCreatorNode(creatorNodeIDToInfoMapping)
-
     let attempts = 0
     let passed = false
     let error
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
       await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
       try {
+        await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
+        passed = true
+        break
+      } catch (e) {
+        error = e
+      }
+    }
+
+    if (!passed) {
+      return {
+        error: `[Deregistering] Error with verifying updated replica set: ${error.toString()}`
+      }
+    }
+
+    const {
+      madDog,
+      removedCreatorNodeId
+    } = await stopRandomCreatorNode(creatorNodeIDToInfoMapping)
+
+    error = null
+    attempts = 0
+    passed = false
+    while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
+      await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
+      try {
+        logger.info(`attempt ${attempts}`)
         await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
         break
@@ -67,7 +86,7 @@ const userReplicaSetNodes = async ({
 
     if (!passed) {
       return {
-        error: `Error with verifying updated replica set: ${error.toString()}`
+        error: `[Unavailability] Error with verifying updated replica set: ${error.toString()}`
       }
     }
 

--- a/mad-dog/src/tests/test_userReplicaSetNodes/index.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/index.js
@@ -4,9 +4,9 @@ const deregisterRandomCreatorNode = require('./deregisterRandomCreatorNode.js')
 const stopRandomCreatorNode = require('./stopRandomCreatorNode.js')
 const setNumCreatorNodes = require('./setNumCreatorNodes.js')
 const { uploadTracksforUsers } = require('../../utils/uploadTracksForUsers')
-const { logger } = require('../../../../creator-node/src/logging.js')
+const { logger } = require('../../logger')
 
-const MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET = 10
+const MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET = 20
 const WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS = 20000
 
 /**
@@ -50,6 +50,7 @@ const userReplicaSetNodes = async ({
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
       await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
       try {
+        console.log(`[CN Deregistering] attempts: ${attempts}`)
         await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
         break
@@ -75,7 +76,7 @@ const userReplicaSetNodes = async ({
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
       await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
       try {
-        logger.info(`attempt ${attempts}`)
+        logger.info(`[CN Unavailability] attempt ${attempts}`)
         await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
         break

--- a/mad-dog/src/tests/test_userReplicaSetNodes/index.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/index.js
@@ -5,6 +5,7 @@ const stopRandomCreatorNode = require('./stopRandomCreatorNode.js')
 const setNumCreatorNodes = require('./setNumCreatorNodes.js')
 const { uploadTracksforUsers } = require('../../utils/uploadTracksForUsers')
 const { logger } = require('../../logger')
+const { delay } = require('../../helpers')
 
 const MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET = 20
 const WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS = 20000
@@ -47,7 +48,7 @@ const deregisterCN = async ({
     let passed = false
     let error
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
-      await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
+      await delay(WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS)
       try {
         await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
@@ -102,7 +103,7 @@ const forceCNUnavailability = async ({
     let attempts = 0
     let passed = false
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
-      await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
+      await delay(WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS)
       try {
         await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true

--- a/mad-dog/src/tests/test_userReplicaSetNodes/index.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/index.js
@@ -34,6 +34,7 @@ const userReplicaSetNodes = async ({
   }
 
   for (let iteration = 0; iteration < iterations; iteration++) {
+    logger.info('[Snapback CN Deregistering] Start')
     creatorNodeIDToInfoMapping = await setNumCreatorNodes(numCreatorNodes, executeOne)
 
     // Upload tracks to users
@@ -50,7 +51,6 @@ const userReplicaSetNodes = async ({
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
       await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
       try {
-        console.log(`[CN Deregistering] attempts: ${attempts}`)
         await verifyValidCNs(executeOne, executeAll, deregisteredCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
         break
@@ -61,9 +61,13 @@ const userReplicaSetNodes = async ({
 
     if (!passed) {
       return {
-        error: `[Deregistering] Error with verifying updated replica set: ${error.toString()}`
+        error: `[Snapback CN Deregistering] Error with verifying updated replica set: ${error.toString()}`
       }
     }
+
+    logger.info('[Snapback CN Deregistering] SUCCESS!')
+
+    logger.info('[Snapback CN Unavailability] Start')
 
     const {
       madDog,
@@ -76,7 +80,6 @@ const userReplicaSetNodes = async ({
     while (attempts++ < MAX_ATTEMPTS_TO_VALIDATE_REPLICA_SET) {
       await new Promise(resolve => setTimeout(resolve, WAIT_INTERVAL_TO_UPDATE_REPLICA_SET_MS))
       try {
-        logger.info(`[CN Unavailability] attempt ${attempts}`)
         await verifyValidCNs(executeOne, executeAll, removedCreatorNodeId, walletIndexToUserIdMap, creatorNodeIDToInfoMapping)
         passed = true
         break
@@ -87,11 +90,13 @@ const userReplicaSetNodes = async ({
 
     if (!passed) {
       return {
-        error: `[Unavailability] Error with verifying updated replica set: ${error.toString()}`
+        error: `[Snapback CN Unavailability] Error with verifying updated replica set: ${error.toString()}`
       }
     }
 
     madDog.stop()
+
+    logger.info('[Snapback CN Unavailability] SUCCESS!')
   }
 }
 

--- a/mad-dog/src/tests/test_userReplicaSetNodes/verifyValidCN.js
+++ b/mad-dog/src/tests/test_userReplicaSetNodes/verifyValidCN.js
@@ -10,16 +10,16 @@ const { getUser } = ServiceCommands
 const verifyCreatorNodeRemoved = async (executeAll, removedCnId, walletIndexToUserIdMap) => {
   const userReplicaSets = await executeAll(async (libs, i) => {
     const userId = walletIndexToUserIdMap[i]
-    let usrQueryInfo = await getUser(libs, userId)
+    const usrQueryInfo = await getUser(libs, userId)
     // Deconstruct the comma separated value of enpdoint1,endoint2,endpoint3
-    let replicaCNIDs = usrQueryInfo.creator_node_endpoint
-      .split(",")
+    const replicaCNIDs = usrQueryInfo.creator_node_endpoint
+      .split(',')
       .map(getIDfromEndpoint)
     return { userId: replicaCNIDs }
   })
 
   const replicaSets = userReplicaSets.reduce((acc, urs) => ({ ...acc, ...urs }), {})
-  for (let userId in replicaSets) {
+  for (const userId in replicaSets) {
     const replicaIds = replicaSets[userId]
     if (replicaIds.some(cnId => cnId === removedCnId)) {
       throw new Error(`User ID: ${userId} has replica set: ${replicaIds}, but CN ${removedCnId} should be removed`)
@@ -48,17 +48,16 @@ const verifyUserReplicaSets = async (executeAll, walletIndexToUserIdMap, content
  * Checks that the user's creator nodes are all synced w/ the user's data
  * @param {Function} executeOne Wrapper lib fn
  * @param {Function} executeAll Wrapper libs fn
- * @param {number} removedCNId ID of the removed creator node  
- * @param {Object} walletIndexToUserIdMap wallet index to user id mapping 
- * @param {Object} contentNodeIDToInfoMapping creator node id to serice provider info 
+ * @param {number} removedCNId ID of the removed creator node
+ * @param {Object} walletIndexToUserIdMap wallet index to user id mapping
+ * @param {Object} contentNodeIDToInfoMapping creator node id to serice provider info
  */
 const verifyValidCNs = async (executeOne, executeAll, removedCNId, walletIndexToUserIdMap, contentNodeIDToInfoMapping) => {
-
   // Check Discovery for all user's replica set to ensure the cn is removed
   await verifyCreatorNodeRemoved(executeAll, removedCNId, walletIndexToUserIdMap)
 
-  // Cross reference Discovery w/ the replcia set manager contract to 
-  // check that they are consistent 
+  // Cross reference Discovery w/ the replcia set manager contract to
+  // check that they are consistent
   await verifyUserReplicaSets(executeAll, walletIndexToUserIdMap, contentNodeIDToInfoMapping)
 
   // Ensure that all primary and seondary clock values for all users are the same


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

**Context:** When a valid SP deregisters and then reregisters with the same endpoint, that SP gets reassigned a new spID. In snapback reconfig, the `creator_node_endpoint` field is the source of truth when it comes to determining whether or not a user needs a reconfig. However, in this scenario, a user needs a reconfig but does not get issued a reconfig because the endpoint has not changed. 

**This PR:** Makes the spID as the source of truth when issuing reconfigs where if the spID from what is on chain for the user does not match the endpoint and spID of what is registered on chain, then issue a reconfig. 

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

- ran the mad-dog test suite `npm run start test-ursm-nodes` 

Example output logs:
```
2021-08-03T21:51:53.060Z info: 	Running test [snapbackReconfigTestDeregisterCN]
// ... test logs
2021-08-03T23:11:41.953Z info: 	[Snapback CN Deregistering] SUCCESS!

2021-08-03T23:11:41.954Z info: 	Running test [snapbackReconfigTestForceCNUnavailability]
// ... test logs
2021-08-03T23:19:07.729Z info: 	[Snapback CN Unavailability] SUCCESS!
```

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Will be observing logs in loggly regarding snapback reconfig. 
