### PR TITLE
Fix solana relay

### DIFF
--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -2,7 +2,7 @@ const express = require('express')
 const crypto = require('crypto')
 
 const config = require('../config')
-const { handleResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
+const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const { getFeePayer } = require('../solana-client')
 
 const solanaEndpoint = config.get('solanaEndpoint')

--- a/libs/src/services/solanaWeb3Manager/tokenAccount.js
+++ b/libs/src/services/solanaWeb3Manager/tokenAccount.js
@@ -125,7 +125,7 @@ async function createAssociatedTokenAccount ({
 
   const transactionData = {
     recentBlockhash: blockhash,
-    instruction: {
+    instructions: [{
       keys: accounts.map(account => {
         return {
           pubkey: account.pubkey.toString(),
@@ -135,7 +135,7 @@ async function createAssociatedTokenAccount ({
       }),
       programId: ASSOCIATED_TOKEN_PROGRAM_ID.toString(),
       data: Buffer.from([])
-    }
+    }]
   }
 
   const response = await identityService.solanaRelay(transactionData)

--- a/libs/src/services/solanaWeb3Manager/userBank.js
+++ b/libs/src/services/solanaWeb3Manager/userBank.js
@@ -156,7 +156,7 @@ const createUserBankFrom = async ({
 
   const transactionData = {
     recentBlockhash: blockhash,
-    instruction: {
+    instructions: [{
       keys: accounts.map(account => {
         return {
           pubkey: account.pubkey.toString(),
@@ -166,7 +166,7 @@ const createUserBankFrom = async ({
       }),
       programId: claimableTokenProgramKey.toString(),
       data: Buffer.from(serializedInstructionEnum)
-    }
+    }]
   }
 
   const response = await identityService.solanaRelay(transactionData)


### PR DESCRIPTION
### Description
Updates the solana relay endpoint to accept multiple instructions to include in a single transaction

Updates libs to use the new body params. 
Encodes secp instructions into the same format as well 

Closes AUD-835

### Tests
Ran a local client w/ linked libs and identity w/ prod solana config to test creating a user bank account and transferring waudio

### How will this change be monitored?
manually
