### PR TITLE
Use psycopg2-binary instead of psycopg2 to avoid building from source

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -9,7 +9,7 @@ types-requests==2.25.0
 # web3 used to be 5.11.0 but due to a build issue in docker, downgraded to 5.8.0
 web3==5.8.0
 Flask==1.0.4
-psycopg2==2.8.5
+psycopg2-binary==2.8.5
 SQLAlchemy==1.2.5
 alembic==1.4.3
 celery[redis]==4.2.0


### PR DESCRIPTION
When attempting to run `test.sh`, ran into issues creating the binary needed for `psycopg2`, so use `psycopg2-binary` instead.