### PR TITLE
Add config for Pytest in VSCode

### DIFF
--- a/discovery-provider/.vscode/settings.json
+++ b/discovery-provider/.vscode/settings.json
@@ -13,5 +13,11 @@
   "editor.formatOnSave": true,
   "python.analysis.typeCheckingMode": "off",
   "python.languageServer": "Pylance",
-  "editor.tabSize": 4
+  "editor.tabSize": 4,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
Configures VSCode integration for testing Discovery Provider

Was tired of having this pending change in my working local so figured I'd merge it.