### PR TITLE
Add reward manager transfer instruction indexing

### DIFF
--- a/discovery-provider/alembic/versions/badd3aab7e5e_add_rewards_manager_disbursement.py
+++ b/discovery-provider/alembic/versions/badd3aab7e5e_add_rewards_manager_disbursement.py
@@ -1,7 +1,7 @@
 """add-rewards-manager-disbursement
 
 Revision ID: badd3aab7e5e
-Revises: f64a484f1496
+Revises: 9562cf365cf4
 Create Date: 2021-08-05 13:50:52.864760
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "badd3aab7e5e"
-down_revision = "f64a484f1496"
+down_revision = "9562cf365cf4"
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/badd3aab7e5e_add_rewards_manager_disbursement.py
+++ b/discovery-provider/alembic/versions/badd3aab7e5e_add_rewards_manager_disbursement.py
@@ -1,0 +1,67 @@
+"""add-rewards-manager-disbursement
+
+Revision ID: badd3aab7e5e
+Revises: f64a484f1496
+Create Date: 2021-08-05 13:50:52.864760
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "badd3aab7e5e"
+down_revision = "f64a484f1496"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "challenge_disbursements_block_number_fkey",
+        "challenge_disbursements",
+        "foreignkey",
+    )
+    op.drop_column("challenge_disbursements", "block_number")
+    op.add_column(
+        "challenge_disbursements",
+        sa.Column("signature", sa.String(), nullable=False),
+    )
+    op.add_column(
+        "challenge_disbursements",
+        sa.Column("slot", sa.Integer(), nullable=False),
+    )
+
+    op.drop_column("challenge_disbursements", "amount")
+    op.add_column(
+        "challenge_disbursements",
+        sa.Column("amount", sa.String(), nullable=False),
+    )
+
+    op.create_index(
+        op.f("idx_challenge_disbursements_slot"),
+        "challenge_disbursements",
+        ["slot"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("idx_challenge_disbursements_slot"), table_name="challenge_disbursements"
+    )
+    op.drop_column("challenge_disbursements", "signature")
+    op.drop_column("challenge_disbursements", "slot")
+
+    op.add_column(
+        "challenge_disbursements",
+        sa.Column(
+            "block_number", sa.Integer(), sa.ForeignKey("blocks.number"), nullable=False
+        ),
+    )
+
+    op.drop_column("challenge_disbursements", "amount")
+    op.add_column(
+        "challenge_disbursements",
+        sa.Column("amount", sa.Integer(), nullable=False),
+    )

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -36,6 +36,7 @@ user_bank_program_address =
 waudio_program_address =
 waudio_mint_address =
 rewards_manager_program_address =
+rewards_manager_account = 
 rewards_manager_min_slot = 0
 
 [redis]

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -35,6 +35,8 @@ user_bank_min_slot = 0
 user_bank_program_address =
 waudio_program_address =
 waudio_mint_address =
+rewards_manager_program_address =
+rewards_manager_min_slot = 0
 
 [redis]
 url = redis://localhost:5379/0

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -363,6 +363,7 @@ def configure_celery(flask_app, celery, test_config=None):
             "src.tasks.index_user_bank",
             "src.tasks.index_eth",
             "src.tasks.index_oracles",
+            "src.tasks.index_rewards_manager",
         ],
         beat_schedule={
             "update_discovery_provider": {
@@ -448,6 +449,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "index_oracles": {
                 "task": "index_oracles",
                 "schedule": timedelta(minutes=5),
+            },
+            "index_rewards_manager": {
+                "task": "index_rewards_manager",
+                "schedule": timedelta(minutes=1),
             },
         },
         task_serializer="json",

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -452,7 +452,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "index_rewards_manager": {
                 "task": "index_rewards_manager",
-                "schedule": timedelta(minutes=1),
+                "schedule": timedelta(seconds=5),
             },
         },
         task_serializer="json",
@@ -485,6 +485,7 @@ def configure_celery(flask_app, celery, test_config=None):
     redis_inst.delete("user_bank_lock")
     redis_inst.delete("index_eth")
     redis_inst.delete("index_oracles")
+    redis_inst.delete("solana_rewards_manager")
     logger.info("Redis instance initialized!")
 
     # Initialize custom task context with database object

--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -1083,7 +1083,8 @@ class ChallengeDisbursement(Base):
     challenge_id = Column(String, ForeignKey("challenges.id"), nullable=False)
     user_id = Column(Integer, nullable=False)
     amount = Column(String, nullable=False)
-    block_number = Column(Integer, nullable=False)
+    signature = Column(String, nullable=False)
+    slot = Column(Integer, nullable=False)
     specifier = Column(String, nullable=False)
 
     PrimaryKeyConstraint(challenge_id, specifier)
@@ -1093,7 +1094,8 @@ class ChallengeDisbursement(Base):
 challenge_id={self.challenge_id},\
 user_id={self.user_id},\
 amount={self.amount},\
-block_number={self.block_number},\
+signature={self.signature},\
+slot={self.slot},\
 specifier={self.specifier})>"
 
 

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -1,0 +1,372 @@
+import concurrent.futures
+import logging
+import time
+from typing import Callable, Optional, List, Dict, TypedDict, Any
+from sqlalchemy.orm.session import Session
+from solana.rpc.api import Client
+from redis import Redis
+
+import base58
+from sqlalchemy import desc
+from src.models.models import User, UserChallenge
+from src.models import ChallengeDisbursement
+from src.tasks.celery_app import celery
+from src.utils.config import shared_config
+from src.utils.session_manager import SessionManager
+from src.utils.solana_indexing import (
+    get_sol_tx_info,
+    parse_instruction_data,
+    InstructionFormat,
+    SolanaInstructionType,
+    TransactionInfoResult,
+)
+
+logger = logging.getLogger(__name__)
+
+REWARDS_MANAGER_PROGRAM = shared_config["solana"]["rewards_manager_program_address"]
+MIN_SLOT = int(shared_config["solana"]["rewards_manager_min_slot"])
+
+# Maximum number of batches to process at once
+TX_SIGNATURES_MAX_BATCHES = 20
+
+# Last N entries present in tx_signatures array during processing
+TX_SIGNATURES_RESIZE_LENGTH = 10
+
+
+rewards_manager_transfer_instr: List[InstructionFormat] = [
+    {"name": "amount", "type": SolanaInstructionType.u64},
+    {"name": "id", "type": SolanaInstructionType.string},
+    {"name": "eth_recipient", "type": SolanaInstructionType.EthereumAddress},
+]
+
+
+class RewardsManagerTransfer(TypedDict):
+    amount: int
+    id: str
+    eth_recipient: str
+
+
+def parse_transfer_instruction_data(data: str) -> RewardsManagerTransfer:
+    """Parse Trasfer instruction data submitted to Audius Rewards Manager program
+
+    Instruction struct:
+    pub struct TransferArgs {
+        /// Amount to transfer
+        pub amount: u64,
+        /// ID generated on backend
+        pub id: String,
+        /// Recipient's Eth address
+        pub eth_recipient: EthereumAddress,
+    }
+
+    Decodes the data and parses each param into the correct type
+    """
+
+    return parse_instruction_data(data, rewards_manager_transfer_instr)
+
+
+def parse_transfer_instruction_id(transfer_id: str) -> List[str]:
+    """Parses the transfer instruction id into [challenge_id, specifier]
+    The id in the transfer instruction is formatted as "<CHALLENGE_ID>:<SPECIFIER>"
+    """
+    id_parts = transfer_id.split(":")
+    if len(id_parts) != 2:
+        raise Exception(
+            f"Unable to parse tranfer instruction id into challenge_id and specifier {transfer_id}"
+        )
+    return id_parts
+
+
+def process_sol_rewards_transfer_instruction(
+    session: Session, solana_client: Client, tx_sig: str
+):
+    """Fetches metadata for rewards tranfer transactions and creates Challege Disbursements
+
+    Fetches the transaction metadata from solana using the tx signature
+    Checks the metadata for a transfer instruction
+    Decodes and parses the transfer instruction metadata
+    Validates the metadata fields and inserts a ChallengeDisbursement DB entry
+    """
+    try:
+        tx_info = get_sol_tx_info(solana_client, tx_sig)
+        logger.info(f"index_rewards_manager.py | Got transaction: {tx_sig} | {tx_info}")
+        result: TransactionInfoResult = tx_info["result"]
+        meta = result["meta"]
+        if meta["err"]:
+            logger.info(
+                f"index_rewards_manager.py | Skipping error transaction from chain {tx_info}"
+            )
+            return
+        tx_message = result["transaction"]["message"]
+        instructions = tx_message["instructions"]
+        rewards_manager_program_index = tx_message["accountKeys"].index(
+            REWARDS_MANAGER_PROGRAM
+        )
+        has_transfer_instruction = any(
+            [log == "Program log: Instruction: Transfer" for log in meta["logMessages"]]
+        )
+        if has_transfer_instruction:
+            for instruction in instructions:
+                if instruction["programIdIndex"] == rewards_manager_program_index:
+                    logger.info(f"index_rewards_manager.py | instruction={tx_info}")
+                    transfer_instruction_data = parse_transfer_instruction_data(
+                        instruction["data"]
+                    )
+                    amount = transfer_instruction_data["amount"]
+                    eth_recipient = transfer_instruction_data["eth_recipient"]
+                    id = transfer_instruction_data["id"]
+                    challenge_id, specifier = parse_transfer_instruction_id(id)
+                    logger.info(
+                        f"index_rewards_manager.py | amount={amount} -- id={id} -- eth_recipient={eth_recipient}"
+                    )
+
+                    user_query = (
+                        session.query(User.user_id)
+                        .filter(User.wallet == eth_recipient)
+                        .first()
+                    )
+                    if user_query is None:
+                        raise Exception(
+                            f"No user found with eth address {eth_recipient}"
+                        )
+                    user_challenge = (
+                        session.query(UserChallenge.user_id)
+                        .filter(
+                            UserChallenge.challenge_id == challenge_id,
+                            UserChallenge.specifier == specifier,
+                        )
+                        .first()
+                    )
+                    if user_challenge is None:
+                        raise Exception(
+                            f"No user challenge found with challenge_id {challenge_id} and specifier {specifier}"
+                        )
+
+                    session.add(
+                        ChallengeDisbursement(
+                            challenge_id=challenge_id,
+                            user_id=user_query[0],
+                            specifier=specifier,
+                            amount=str(amount),
+                            slot=result["slot"],
+                            signature=tx_sig,
+                        )
+                    )
+    except Exception as e:
+        logger.error(
+            f"index_rewards_manager.py | Error processing {tx_sig}, {e}", exc_info=True
+        )
+        raise e
+
+
+def get_latest_reward_disbursment_slot(session: Session):
+    """Fetches the most recent slot for Challenge Disburements"""
+    latest_slot = None
+    highest_slot_query = (
+        session.query(ChallengeDisbursement.slot).order_by(
+            desc(ChallengeDisbursement.slot)
+        )
+    ).first()
+    # Can be None prior to first write operations
+    if highest_slot_query is not None:
+        latest_slot = highest_slot_query[0]
+
+    # If no slots have yet been recorded, assume all are valid
+    if latest_slot is None:
+        latest_slot = 0
+
+    logger.info(f"index_rewards_manager.py | returning {latest_slot} for highest slot")
+    return latest_slot
+
+
+def get_tx_in_db(session: Session, tx_sig: str) -> bool:
+    """Checks if the transaction signature already exists for Challenge Disburements"""
+    tx_sig_db_count = (
+        session.query(ChallengeDisbursement).filter(
+            ChallengeDisbursement.signature == tx_sig
+        )
+    ).count()
+    exists = tx_sig_db_count > 0
+    logger.info(f"index_rewards_manager.py | {tx_sig} exists={exists}")
+    return exists
+
+
+def get_transaction_signatures(
+    solana_client: Client,
+    db: SessionManager,
+    program: str,
+    get_latest_slot: Callable[[Session], int],
+    check_tx_exists: Callable[[Session, str], bool],
+    min_slot=None,
+):
+    """Fetches next batch of transaction signature offset from the previous latest processed slot
+
+    Fetches the latest processed slot for the rewards manager program
+    Iterates backwards from the current tx until an intersection is found with the latest processed slot
+    Returns the next set of transaction signature from the current offset slot to process
+    """
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures = []
+
+    last_tx_signature = None
+
+    # Loop exit condition
+    intersection_found = False
+
+    # Query for solana transactions until an intersection is found
+    with db.scoped_session() as session:
+        latest_processed_slot = get_latest_slot(session)
+        logger.info(f"index_rewards_manager.py | highest tx = {latest_processed_slot}")
+        while not intersection_found:
+            transactions_history = solana_client.get_confirmed_signature_for_address2(
+                program, before=last_tx_signature, limit=100
+            )
+
+            transactions_array = transactions_history["result"]
+            if not transactions_array:
+                intersection_found = True
+                logger.info(
+                    f"index_rewards_manager.py | No transactions found before {last_tx_signature}"
+                )
+            else:
+                # Current batch of transactions
+                transaction_signature_batch = []
+                for tx_info in transactions_array:
+                    tx_sig = tx_info["signature"]
+                    tx_slot = tx_info["slot"]
+                    logger.info(
+                        f"index_rewards_manager.py | Processing tx={tx_sig} | slot={tx_slot}"
+                    )
+                    if tx_info["slot"] > latest_processed_slot:
+                        transaction_signature_batch.append(tx_sig)
+                    elif tx_info["slot"] <= latest_processed_slot and (
+                        min_slot is None or tx_info["slot"] > min_slot
+                    ):
+                        # Check the tx signature for any txs in the latest batch,
+                        # and if not present in DB, add to processing
+                        logger.info(
+                            f"index_rewards_manager.py | Latest slot re-traversal\
+                            slot={tx_slot}, sig={tx_sig},\
+                            latest_processed_slot(db)={latest_processed_slot}"
+                        )
+                        exists = check_tx_exists(session, tx_sig)
+                        if exists:
+                            intersection_found = True
+                            break
+                        # Ensure this transaction is still processed
+                        transaction_signature_batch.append(tx_sig)
+
+                # Restart processing at the end of this transaction signature batch
+                last_tx = transactions_array[-1]
+                last_tx_signature = last_tx["signature"]
+
+                # Append batch of processed signatures
+                if transaction_signature_batch:
+                    transaction_signatures.append(transaction_signature_batch)
+
+                # Ensure processing does not grow unbounded
+                if len(transaction_signatures) > TX_SIGNATURES_MAX_BATCHES:
+                    prev_len = len(transaction_signatures)
+                    # Only take the oldest transaction from the transaction_signatures array
+                    # transaction_signatures is sorted from newest to oldest
+                    transaction_signatures = transaction_signatures[
+                        -TX_SIGNATURES_RESIZE_LENGTH:
+                    ]
+                    logger.info(
+                        f"index_rewards_manager.py | sliced tx_sigs from {prev_len} to {len(transaction_signatures)} entries"
+                    )
+
+    # Reverse batches aggregated so oldest transactions are processed first
+    transaction_signatures.reverse()
+    return transaction_signatures
+
+
+def process_transaction_signature(
+    solana_client: Client, db: SessionManager, transaction_signatures: List[str]
+):
+    """Concurrently processes the transactions to update the DB state for reward transfer instructions"""
+    for tx_sig_batch in transaction_signatures:
+        logger.info(f"index_rewards_manager.py | processing {tx_sig_batch}")
+        batch_start_time = time.time()
+        # Process each batch in parallel
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            with db.scoped_session() as session:
+                parse_sol_tx_futures = {
+                    executor.submit(
+                        process_sol_rewards_transfer_instruction,
+                        session,
+                        solana_client,
+                        tx_sig,
+                    ): tx_sig
+                    for tx_sig in tx_sig_batch
+                }
+                for future in concurrent.futures.as_completed(parse_sol_tx_futures):
+                    try:
+                        # No return value expected here so we just ensure all futures are resolved
+                        future.result()
+                    except Exception as exc:
+                        logger.error(f"index_rewards_manager.py | {exc}")
+                        raise exc
+
+        batch_end_time = time.time()
+        batch_duration = batch_end_time - batch_start_time
+        logger.info(
+            f"index_rewards_manager.py | processed batch {len(tx_sig_batch)} txs in {batch_duration}s"
+        )
+
+
+def process_solana_rewards_manager(solana_client: Client, db: SessionManager):
+    """Fetches the next set of reward manager transactions and updates the DB with Challenge Disbursements"""
+    try:
+        base58.b58decode(REWARDS_MANAGER_PROGRAM)
+    except ValueError:
+        logger.error(
+            f"index_rewards_manager.py"
+            f"Invalid Rewards Manager program ({REWARDS_MANAGER_PROGRAM}) configured, exiting."
+        )
+        return
+
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures = get_transaction_signatures(
+        solana_client,
+        db,
+        REWARDS_MANAGER_PROGRAM,
+        get_latest_reward_disbursment_slot,
+        get_tx_in_db,
+        MIN_SLOT,
+    )
+    logger.info(f"index_rewards_manager.py | {transaction_signatures}")
+
+    process_transaction_signature(solana_client, db, transaction_signatures)
+
+
+######## CELERY TASKS ########
+@celery.task(name="index_rewards_manager", bind=True)
+def index_rewards_manager(self):
+    redis = index_rewards_manager.redis
+    solana_client = index_rewards_manager.solana_client
+    db = index_rewards_manager.db
+
+    # Define lock acquired boolean
+    have_lock = False
+    # Max duration of lock is 4hrs or 14400 seconds
+    update_lock = redis.lock(
+        "solana_rewards_manager", blocking_timeout=25, timeout=14400
+    )
+
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info("index_rewards_manager.py | Acquired lock")
+            process_solana_rewards_manager(solana_client, db)
+        else:
+            logger.info("index_rewards_manager.py | Failed to acquire lock")
+    except Exception as e:
+        logger.error(
+            "index_rewards_manager.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -1,13 +1,12 @@
 import concurrent.futures
 import logging
 import time
-from typing import Callable, Optional, List, Dict, TypedDict, Any
+from typing import Callable, List, TypedDict
+from sqlalchemy import desc
 from sqlalchemy.orm.session import Session
 from solana.rpc.api import Client
-from redis import Redis
 
 import base58
-from sqlalchemy import desc
 from src.models.models import User, UserChallenge
 from src.models import ChallengeDisbursement
 from src.tasks.celery_app import celery
@@ -103,7 +102,7 @@ def process_sol_rewards_transfer_instruction(
             REWARDS_MANAGER_PROGRAM
         )
         has_transfer_instruction = any(
-            [log == "Program log: Instruction: Transfer" for log in meta["logMessages"]]
+            log == "Program log: Instruction: Transfer" for log in meta["logMessages"]
         )
         if has_transfer_instruction:
             for instruction in instructions:
@@ -273,7 +272,8 @@ def get_transaction_signatures(
                         -TX_SIGNATURES_RESIZE_LENGTH:
                     ]
                     logger.info(
-                        f"index_rewards_manager.py | sliced tx_sigs from {prev_len} to {len(transaction_signatures)} entries"
+                        f"index_rewards_manager.py | sliced tx_sigs from \
+                            {prev_len} to {len(transaction_signatures)} entries"
                     )
 
     # Reverse batches aggregated so oldest transactions are processed first

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -90,14 +90,15 @@ def parse_transfer_instruction_id(transfer_id: str) -> Optional[List[str]]:
     id_parts = transfer_id.split(":")
     if len(id_parts) != 2:
         logger.error(
-            f"index_rewards_manager.py | Unable to parse transfer instruction id into challenge_id and specifier {transfer_id}"
+            "index_rewards_manager.py | Unable to parse transfer instruction id"
+            f"into challenge_id and specifier {transfer_id}"
         )
         return None
     return id_parts
 
 
 def get_valid_instruction(
-    tx_message: TransactionMessage, meta: ResultMeta, tx_sig: str
+    tx_message: TransactionMessage, meta: ResultMeta
 ) -> Optional[TransactionMessageInstruction]:
     """Checks that the tx is valid
     checks for the transaction message for correct instruction log
@@ -163,7 +164,7 @@ def fetch_and_parse_sol_rewards_transfer_instruction(
             )
             return None
         tx_message = result["transaction"]["message"]
-        instruction = get_valid_instruction(tx_message, meta, tx_sig)
+        instruction = get_valid_instruction(tx_message, meta)
         if instruction is None:
             return None
         transfer_instruction_data = parse_transfer_instruction_data(instruction["data"])
@@ -193,7 +194,7 @@ def fetch_and_parse_sol_rewards_transfer_instruction(
 def process_batch_sol_rewards_transfer_instructions(
     session: Session, transfer_instructions: List[RewardTransferInstruction]
 ):
-    """Validates that the transfer instruction is consistent with DB and inserts a ChallengeDisbursement DB entries"""
+    """Validates that the transfer instruction is consistent with DB and inserts ChallengeDisbursement DB entries"""
     try:
         eth_recipients = [instr["eth_recipient"] for instr in transfer_instructions]
         users = (
@@ -220,7 +221,8 @@ def process_batch_sol_rewards_transfer_instructions(
             eth_recipient = transfer_instr["eth_recipient"]
             if specifier not in user_challenge_specifiers:
                 logger.error(
-                    f"index_rewards_manager.py | Challenge specifier {specifier} not found while processing disbursement"
+                    f"index_rewards_manager.py | Challenge specifier {specifier} not found"
+                    "while processing disbursement"
                 )
                 continue
             if eth_recipient not in users_map:

--- a/discovery-provider/src/utils/solana_indexing.py
+++ b/discovery-provider/src/utils/solana_indexing.py
@@ -121,7 +121,7 @@ def parse_instruction_data(data: str, instructionFormat: List[InstructionFormat]
             )
             start, end = last_end + type_len, last_end + type_len + instr_len
             decoded_value: bytes = decoded[start:end]
-            decoded_params[name] = str(decoded_value)
+            decoded_params[name] = str(decoded_value, "utf-8")
             last_end = end
         elif type == SolanaInstructionType.EthereumAddress:
             type_len = solanaInstructionSpace[type]

--- a/discovery-provider/src/utils/solana_indexing.py
+++ b/discovery-provider/src/utils/solana_indexing.py
@@ -1,0 +1,162 @@
+import enum
+import logging
+from typing import Optional, List, Dict, TypedDict, Any
+import base58
+from solana.rpc.api import Client
+
+logger = logging.getLogger(__name__)
+
+# ============== Solana Transaction Types ==============
+class TransactionMessageHeader(TypedDict):
+    numReadonlySignedAccounts: int  # num read only signed
+    numReadonlyUnsignedAccounts: int  # num read only unsigned
+    numRequiredSignatures: int  # num required signature
+
+
+class TransactionMessageInstruction(TypedDict):
+    accounts: List[int]  # list of solana accounts keys
+    data: str  # encoded tnstruction data
+    programIdIndex: int  # index of program in accounts
+
+
+class TransactionMessage(TypedDict):
+    accountKeys: List[str]
+    header: TransactionMessageHeader
+    instructions: List[TransactionMessageInstruction]
+    recentBlockhash: str
+
+
+class ResultTransction(TypedDict):
+    message: TransactionMessage
+    signatures: List[str]
+
+
+class MetaInnerInstructionData(TypedDict):
+    accounts: List[int]
+    data: str
+    programIdIndex: int
+
+
+class MetaInnerInstruction(TypedDict):
+    index: int
+    instruction: List[TransactionMessageInstruction]
+
+
+class UiTokenAmount(TypedDict):
+    amount: str
+    decimals: int
+    uiAmount: float
+    uiAmountString: str
+
+
+class TokenBalance(TypedDict):
+    accountIndex: int
+    mint: str
+    uiTokenAmount: UiTokenAmount
+
+
+class ResultMeta(TypedDict):
+    err: Optional[Any]
+    fee: int
+    innerInstructions: List[MetaInnerInstruction]
+    logMessages: List[str]
+    preBalances: List[int]
+    postBalances: List[int]
+    preTokenBalances: List[TokenBalance]
+    postTokenBalances: List[TokenBalance]
+    uiTokenAmount: UiTokenAmount
+    rewards: List[Any]
+    status: Any
+
+
+class TransactionInfoResult(TypedDict):
+    blockTime: int
+    meta: ResultMeta
+    slot: int
+    transaction: ResultTransction
+
+
+# ============== Solana Instruction Parsing Helpers ==============
+
+
+class SolanaInstructionType(str, enum.Enum):
+    u64 = "u64"
+    string = "string"
+    EthereumAddress = "EthereumAddress"
+    UnixTimestamp = "UnixTimestamp"
+
+
+solanaInstructionSpace = {
+    SolanaInstructionType.u64: 8,
+    SolanaInstructionType.string: 4,
+    SolanaInstructionType.EthereumAddress: 20,
+    SolanaInstructionType.UnixTimestamp: 8,
+}
+
+
+class InstructionFormat(TypedDict):
+    name: str
+    type: SolanaInstructionType
+
+
+def parse_instruction_data(data: str, instructionFormat: List[InstructionFormat]):
+    """Parses encoded instruction data into a dictionary based on instruction format"""
+    decoded = base58.b58decode(data)[1:]
+    last_end = 0
+    decoded_params: Dict = {}
+    for intr in instructionFormat:
+        name: str = intr["name"]
+        type: SolanaInstructionType = intr["type"]
+
+        if type == SolanaInstructionType.u64:
+            type_len = solanaInstructionSpace[type]
+            decoded_params[name] = int.from_bytes(
+                decoded[last_end : last_end + type_len], "little"
+            )
+            last_end = last_end + type_len
+        elif type == SolanaInstructionType.string:
+            type_len = solanaInstructionSpace[type]
+            instr_len = int.from_bytes(
+                decoded[last_end : last_end + type_len], "little"
+            )
+            start, end = last_end + type_len, last_end + type_len + instr_len
+            decoded_value: bytes = decoded[start:end]
+            decoded_params[name] = str(decoded_value)
+            last_end = end
+        elif type == SolanaInstructionType.EthereumAddress:
+            type_len = solanaInstructionSpace[type]
+            decoded_params[name] = hex(
+                int.from_bytes(decoded[last_end : last_end + type_len], "little")
+            )
+            last_end = last_end + type_len
+        elif type == SolanaInstructionType.UnixTimestamp:
+            type_len = solanaInstructionSpace[type]
+            decoded_params[name] = int.from_bytes(
+                decoded[last_end : last_end + type_len], "little"
+            )
+            last_end = last_end + type_len
+
+    return decoded_params
+
+
+# ============== Solana Fetch Transaction Info Helpers ==============
+
+
+def get_sol_tx_info(solana_client: Client, tx_sig: str, retries=5):
+    """Fetches a solana transaction by signature with retries
+
+    If not found, raise an exception
+    """
+    while retries > 0:
+        try:
+            tx_info = solana_client.get_confirmed_transaction(tx_sig)
+            if tx_info["result"] is not None:
+                return tx_info
+        except Exception as e:
+            logger.error(
+                f"get_sol_tx_info | Error fetching tx {tx_sig}, {e}",
+                exc_info=True,
+            )
+        retries -= 1
+        logger.error(f"get_sol_tx_info | Retrying tx fetch: {tx_sig}")
+    raise Exception(f"get_sol_tx_info | Failed to fetch {tx_sig}")

--- a/discovery-provider/src/utils/solana_indexing.py
+++ b/discovery-provider/src/utils/solana_indexing.py
@@ -105,8 +105,8 @@ def parse_instruction_data(data: str, instructionFormat: List[InstructionFormat]
     last_end = 0
     decoded_params: Dict = {}
     for intr in instructionFormat:
-        name: str = intr["name"]
-        type: SolanaInstructionType = intr["type"]
+        name = intr["name"]
+        type = intr["type"]
 
         if type == SolanaInstructionType.u64:
             type_len = solanaInstructionSpace[type]

--- a/discovery-provider/tests/test_get_challenges.py
+++ b/discovery-provider/tests/test_get_challenges.py
@@ -193,7 +193,8 @@ def setup_db(session):
             challenge_id="boolean_challenge_1",
             user_id=1,
             amount=5,
-            block_number=1,
+            signature='1',
+            slot=1,
             specifier="1",
         )
     ]

--- a/discovery-provider/tests/test_index_rewards_manager.py
+++ b/discovery-provider/tests/test_index_rewards_manager.py
@@ -1,5 +1,5 @@
-import pytest
 from unittest.mock import MagicMock
+import pytest
 import src
 from src.models import ChallengeDisbursement
 from src.tasks.index_rewards_manager import (
@@ -53,7 +53,9 @@ mock_tx_info = {
                     "instructions": [
                         {
                             "accounts": [0, 1, 6],
-                            "data": "6Tvirzk8jih7LmKk9jTesrZh8KkSo7qGfZJWP4yxBuegWSs3nE5RRNZkLVhGKKXB1ACu9Zhi7LcUV9bFUo27Y3A87jvC4FCRSJrCWZp3bYMBzJ2hyZXcVHLp3Pquzc8khJJJSQsPMm3KrBzxGjv93ZYbhrTh6XfLPJ",
+                            "data": "6Tvirzk8jih7LmKk9jTesrZh8KkSo7qGfZJWP4yxBuegWSs3nE5RRNZkLVhGKKXB1ACu9"
+                            + "Zhi7LcUV9bFUo27Y3A87jvC4FCRSJrCWZp3bYMBzJ2hyZXcVHLp3Pquzc8khJJJSQsPMm3KrBzxG"
+                            + "jv93ZYbhrTh6XfLPJ",
                             "programIdIndex": 9,
                         },
                         {"accounts": [1, 5, 6, 7], "data": "2", "programIdIndex": 8},
@@ -228,7 +230,9 @@ def get_sol_tx_info_mock(monkeypatch):
     return mock_get_sol_tx_info
 
 
-def test_process_sol_rewards_transfer_instruction(app, get_sol_tx_info_mock):
+def test_process_sol_rewards_transfer_instruction(
+    app, get_sol_tx_info_mock
+):  # pylint: disable=W0621
     get_sol_tx_info_mock.return_value = mock_tx_info
 
     with app.app_context():

--- a/discovery-provider/tests/test_index_rewards_manager.py
+++ b/discovery-provider/tests/test_index_rewards_manager.py
@@ -263,6 +263,11 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(
         ],
     }
 
+    with db.scoped_session() as session:
+        process_batch_sol_rewards_transfer_instructions(session, [parsed_tx])
+        disbursments = session.query(ChallengeDisbursement).all()
+        assert len(disbursments) == 0
+
     populate_mock_db(db, test_entries)
     with db.scoped_session() as session:
         process_batch_sol_rewards_transfer_instructions(session, [parsed_tx])
@@ -274,5 +279,3 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(
         assert disbursment.signature == "tx_sig_one"
         assert disbursment.slot == 72131741
         assert disbursment.specifier == "123456789"
-
-        # Check that the challenge disbursment is present

--- a/discovery-provider/tests/test_index_rewards_manager.py
+++ b/discovery-provider/tests/test_index_rewards_manager.py
@@ -1,0 +1,276 @@
+import pytest
+from unittest.mock import MagicMock
+import src
+from src.models import ChallengeDisbursement
+from src.tasks.index_rewards_manager import (
+    parse_transfer_instruction_data,
+    parse_transfer_instruction_id,
+    process_sol_rewards_transfer_instruction,
+)
+from src.utils.db_session import get_db
+from src.utils.config import shared_config
+from tests.utils import populate_mock_db
+
+REWARDS_MANAGER_PROGRAM = shared_config["solana"]["rewards_manager_program_address"]
+
+
+def test_decode_reward_manager_transfer_instruction():
+    transfer_data = "4uzJ5EwVTSPet22fnLDyB9JaEMWSqopW7F5PYKjf65j76BGhtMR5LXfv3twbV7Bq3CSH2iMRr7fNJzyijZ7"
+    decoded_data = parse_transfer_instruction_data(transfer_data)
+    assert decoded_data == {
+        "amount": 10000000000,
+        "id": "profile-completion:123456789",
+        "eth_recipient": "0x7698a57431399ab25c8567b4126a116035be0304",
+    }
+
+
+def test_parse_transfer_instruction_id():
+    transfer_id = "profile-completion:123456789"
+    parsed_id = parse_transfer_instruction_id(transfer_id)
+    assert parsed_id[0] == "profile-completion"
+    assert parsed_id[1] == "123456789"
+
+    # Throws an error on invalid transfer_id
+    with pytest.raises(Exception):
+        transfer_id = "profile-completion_123456789"
+        parsed_id = parse_transfer_instruction_id(transfer_id)
+
+    # Throws an error on invalid transfer_id
+    with pytest.raises(Exception):
+        transfer_id = "profile-completion:123456789:"
+        parsed_id = parse_transfer_instruction_id(transfer_id)
+
+
+mock_tx_info = {
+    "result": {
+        "blockTime": 1628015818,
+        "meta": {
+            "err": None,
+            "fee": 5000,
+            "innerInstructions": [
+                {
+                    "index": 0,
+                    "instructions": [
+                        {
+                            "accounts": [0, 1, 6],
+                            "data": "6Tvirzk8jih7LmKk9jTesrZh8KkSo7qGfZJWP4yxBuegWSs3nE5RRNZkLVhGKKXB1ACu9Zhi7LcUV9bFUo27Y3A87jvC4FCRSJrCWZp3bYMBzJ2hyZXcVHLp3Pquzc8khJJJSQsPMm3KrBzxGjv93ZYbhrTh6XfLPJ",
+                            "programIdIndex": 9,
+                        },
+                        {"accounts": [1, 5, 6, 7], "data": "2", "programIdIndex": 8},
+                    ],
+                },
+                {
+                    "index": 1,
+                    "instructions": [
+                        {
+                            "accounts": [3, 1, 11],
+                            "data": "3DcCptZte3oM",
+                            "programIdIndex": 8,
+                        },
+                        {
+                            "accounts": [0, 4],
+                            "data": "111112GJ1Cfr4Mnah1YBPDnXiJkkj9hCSapxB3jXmcS24qFS88K64heDkWFb6rEYjBj9rr",
+                            "programIdIndex": 9,
+                        },
+                    ],
+                },
+            ],
+            "logMessages": [
+                "Program G4pFwHLdYPHCjLkhHHdw9WmqXiY7FtcFd1npNVhihz5s invoke [1]",
+                "Program log: Instruction: CreateTokenAccount",
+                "Program 11111111111111111111111111111111 invoke [2]",
+                "Program 11111111111111111111111111111111 success",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+                "Program log: Instruction: InitializeAccount",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3920 of 178227 compute units",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+                "Program G4pFwHLdYPHCjLkhHHdw9WmqXiY7FtcFd1npNVhihz5s consumed 26357 of 200000 compute units",
+                "Program G4pFwHLdYPHCjLkhHHdw9WmqXiY7FtcFd1npNVhihz5s success",
+                f"Program {REWARDS_MANAGER_PROGRAM} invoke [1]",
+                "Program log: Instruction: Transfer",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+                "Program log: Instruction: Transfer",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3402 of 185013 compute units",
+                "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+                "Program 11111111111111111111111111111111 invoke [2]",
+                "Program 11111111111111111111111111111111 success",
+                f"Program {REWARDS_MANAGER_PROGRAM} consumed 31628 of 200000 compute units",
+                f"Program {REWARDS_MANAGER_PROGRAM} success",
+            ],
+            "postBalances": [
+                9325298880,
+                2039280,
+                0,
+                2039280,
+                890880,
+                1461600,
+                0,
+                1,
+                1130582400,
+                1,
+                1350240,
+                0,
+                1398960,
+                1141440,
+                1141440,
+            ],
+            "postTokenBalances": [
+                {
+                    "accountIndex": 1,
+                    "mint": "Hid8t4E7R6b6JCVHdiGcwYYq2s7gB9nfVjRZYr9YUTPp",
+                    "uiTokenAmount": {
+                        "amount": "10000000000",
+                        "decimals": 9,
+                        "uiAmount": 10.0,
+                        "uiAmountString": "10",
+                    },
+                },
+                {
+                    "accountIndex": 3,
+                    "mint": "Hid8t4E7R6b6JCVHdiGcwYYq2s7gB9nfVjRZYr9YUTPp",
+                    "uiTokenAmount": {
+                        "amount": "1009990000000000",
+                        "decimals": 9,
+                        "uiAmount": 1009990.0,
+                        "uiAmountString": "1009990",
+                    },
+                },
+            ],
+            "preBalances": [
+                9321260120,
+                0,
+                6973920,
+                2039280,
+                0,
+                1461600,
+                0,
+                1,
+                1130582400,
+                1,
+                1350240,
+                0,
+                1398960,
+                1141440,
+                1141440,
+            ],
+            "preTokenBalances": [
+                {
+                    "accountIndex": 3,
+                    "mint": "Hid8t4E7R6b6JCVHdiGcwYYq2s7gB9nfVjRZYr9YUTPp",
+                    "uiTokenAmount": {
+                        "amount": "1010000000000000",
+                        "decimals": 9,
+                        "uiAmount": 1010000.0,
+                        "uiAmountString": "1010000",
+                    },
+                }
+            ],
+            "rewards": [],
+            "status": {"Ok": None},
+        },
+        "slot": 72131741,
+        "transaction": {
+            "message": {
+                "accountKeys": [
+                    "2HYDf9XvHRKhquxK1z4ETJ8ywueZcqEazyFZdRfLqGcT",
+                    "54u7LVJhhbWaENGLzzgvTX72k9XSHSF3EhCcuvD9xMfk",
+                    "3zKGHtF9aNjevZ2DETXzTDWiN65Fkwv9oeiScAfSVh3H",
+                    "9ShGNjEm5repSKTkZMUXMj8cx31HAo363ovdm1AoLA8d",
+                    "EnoXtBihkkRwLbp6LTjRfSw8NjQMptV2mxTm1uB6z556",
+                    "Hid8t4E7R6b6JCVHdiGcwYYq2s7gB9nfVjRZYr9YUTPp",
+                    "6tz3kagxfjQrM2A5kbmnFQfSp4apcsP2pKaCw1SXMiPx",
+                    "SysvarRent111111111111111111111111111111111",
+                    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    "11111111111111111111111111111111",
+                    "3qvNmjbxmF9CDHzAEBvLSePRiMWtVcXPaRPiPtmrT29x",
+                    "7s74jBb2Qn9RJyzGMatKfCFJf118B9yM7Uiyk3YnofC7",
+                    "B5g2yyShAQeQSkTgAFyFN5UmNYWRnPAgvog6U2dazLkU",
+                    "G4pFwHLdYPHCjLkhHHdw9WmqXiY7FtcFd1npNVhihz5s",
+                    REWARDS_MANAGER_PROGRAM,
+                ],
+                "header": {
+                    "numReadonlySignedAccounts": 0,
+                    "numReadonlyUnsignedAccounts": 10,
+                    "numRequiredSignatures": 1,
+                },
+                "instructions": [
+                    {
+                        "accounts": [0, 5, 6, 1, 7, 8, 9],
+                        "data": "14F9hNTcPWcxgSuHDYnP8XmmvUvZ",
+                        "programIdIndex": 13,
+                    },
+                    {
+                        "accounts": [2, 10, 11, 3, 1, 4, 12, 0, 7, 8, 9],
+                        "data": "4uzJ5EwVTSPet22fnLDyB9JaEMWSqopW7F5PYKjf65j76BGhtMR5LXfv3twbV7Bq3CSH2iMRr7fNJzyijZ7",
+                        "programIdIndex": 14,
+                    },
+                ],
+                "recentBlockhash": "6yYGRT1rLjqH9fLK56uwEt5yYugntLrJwA3igJGzHrEA",
+            },
+            "signatures": [
+                "rnnNQ1N4eF4spVyAkgS1ef3KdW8uHb3J94aUAseMrJ3jE4mStoj8yMdYtAwzp9MpncYJrp8BcSPQNseHrqZDE1D"
+            ],
+        },
+    }
+}
+
+
+@pytest.fixture
+def get_sol_tx_info_mock(monkeypatch):
+    mock_get_sol_tx_info = MagicMock()
+
+    def get_sol_tx_info(client, signature):
+        return mock_get_sol_tx_info(client, signature)
+
+    monkeypatch.setattr(
+        src.tasks.index_rewards_manager, "get_sol_tx_info", get_sol_tx_info
+    )
+    return mock_get_sol_tx_info
+
+
+def test_process_sol_rewards_transfer_instruction(app, get_sol_tx_info_mock):
+    get_sol_tx_info_mock.return_value = mock_tx_info
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        with pytest.raises(Exception):
+            # Should Raise exeption for no matching user
+            process_sol_rewards_transfer_instruction(session, {}, "tx_sig_one")
+
+        # Insert block and user
+
+        with pytest.raises(Exception):
+            # Should Raise exeption for no matching user
+            process_sol_rewards_transfer_instruction(session, {}, "tx_sig_one")
+
+    test_entries = {
+        "users": [
+            {
+                "user_id": 1,
+                "handle": "piazza",
+                "wallet": "0x7698a57431399ab25c8567b4126a116035be0304",
+            },
+        ],
+        "user_challenges": [
+            {
+                "challenge_id": "profile-completion",
+                "user_id": 1,
+                "specifier": "123456789",
+            }
+        ],
+    }
+    populate_mock_db(db, test_entries)
+    with db.scoped_session() as session:
+        process_sol_rewards_transfer_instruction(session, {}, "tx_sig_one")
+        disbursments = session.query(ChallengeDisbursement).all()
+        assert len(disbursments) == 1
+        disbursment = disbursments[0]
+        assert disbursment.challenge_id == "profile-completion"
+        assert disbursment.user_id == 1
+        assert disbursment.signature == "tx_sig_one"
+        assert disbursment.slot == 72131741
+        assert disbursment.specifier == "123456789"
+
+        # Check that the challenge disbursment is present

--- a/discovery-provider/tests/utils.py
+++ b/discovery-provider/tests/utils.py
@@ -72,6 +72,9 @@ def populate_mock_db(db, entities):
         track_routes = entities.get("track_routes", [])
         remixes = entities.get("remixes", [])
         stems = entities.get("stems", [])
+        challenges = entities.get("challenges", [])
+        user_challenges = entities.get("user_challenges", [])
+
         num_blocks = max(len(tracks), len(users), len(follows))
 
         for i in range(num_blocks):
@@ -132,7 +135,7 @@ def populate_mock_db(db, entities):
         for i, user_meta in enumerate(users):
             user = models.User(
                 blockhash=hex(i),
-                blocknumber=1,
+                blocknumber=i,
                 user_id=user_meta.get("user_id", i),
                 is_current=True,
                 handle=user_meta.get("handle", i),
@@ -203,6 +206,7 @@ def populate_mock_db(db, entities):
                 collision_id=route_meta.get("collision_id", 0),
             )
             session.add(route)
+
         for i, remix_meta in enumerate(remixes):
             remix = models.Remix(
                 parent_track_id=remix_meta.get("parent_track_id", i),
@@ -215,3 +219,27 @@ def populate_mock_db(db, entities):
                 child_track_id=stems_meta.get("child_track_id", i + 1),
             )
             session.add(stem)
+
+        for i, challenge_meta in enumerate(challenges):
+            challenge = models.Challenge(
+                id=challenge_meta.get("id", ""),
+                type=challenge_meta.get("type", ""),
+                amount=challenge_meta.get("amount", ""),
+                active=challenge_meta.get("active", True),
+                step_count=challenge_meta.get("step_count", None),
+                starting_block=challenge_meta.get("starting_block", None),
+            )
+            session.add(challenge)
+        for i, user_challenge_meta in enumerate(user_challenges):
+            user_challenge = models.UserChallenge(
+                challenge_id=user_challenge_meta.get("challenge_id", ""),
+                user_id=user_challenge_meta.get("user_id", 1),
+                specifier=user_challenge_meta.get("specifier", ""),
+                is_complete=user_challenge_meta.get("is_complete", False),
+                completed_blocknumber=user_challenge_meta.get(
+                    "completed_blocknumber", 1
+                ),
+                current_step_count=user_challenge_meta.get("current_step_count", None),
+            )
+            session.add(user_challenge)
+        session.flush()


### PR DESCRIPTION
### Description
Adds Rewards Manger Transfer Instruction indexing to the Discovery Node service
* Updates the `challenge_disbursements` table
  * Removes the block_number col
  * Adds col for slot
  * Adds col for signature & index on signature
  * Updates amount col type from int to string
* Adds a new indexing job for rewards manager in the app
  * This jobs queries the solana program for transactions from the rewards manager program and inserts new ChallengeDisbursements into the DB
* Adds env vars to discovery
  * `rewards_manager_program_address` The address of the deployed solana program
  * `rewards_manager_min_slot` The min slot to start indexing from

Closes AUD-717

### Tests
Added a test for processing a mock solana transfer tx and validates that it inserts a challenge disbursement into the DB

### How will this change be monitored?
logs
