### PR TITLE
Fix get_remixable_tracks to eagerly load users

### DIFF
--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -323,7 +323,8 @@ class Track(Base):
             f"updated_at={self.updated_at},"
             f"created_at={self.created_at},"
             f"stem_of={self.stem_of},"
-            f"permalink={self.permalink}"
+            f"permalink={self.permalink},"
+            f"user={self.user}"
             ")>"
         )
 

--- a/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/discovery-provider/src/queries/get_remixable_tracks.py
@@ -42,10 +42,7 @@ def get_remixable_tracks(args):
                     "score"
                 ),
             )
-            .join(
-                remixable_tracks_subquery,
-                remixable_tracks_subquery.c.track_id == Track.track_id,
-            )
+            .select_entity_from(remixable_tracks_subquery)
             .join(
                 count_subquery,
                 count_subquery.c["id"] == Track.track_id,

--- a/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/discovery-provider/src/queries/get_remixable_tracks.py
@@ -38,16 +38,19 @@ def get_remixable_tracks(args):
             session.query(
                 Track,
                 count_subquery.c["count"],
-                decayed_score(
-                    count_subquery.c["count"], remixable_tracks_subquery.c.created_at
-                ).label("score"),
+                decayed_score(count_subquery.c["count"], Track.created_at).label(
+                    "score"
+                ),
             )
-            .select_from(remixable_tracks_subquery)
+            .join(
+                remixable_tracks_subquery,
+                remixable_tracks_subquery.c.track_id == Track.track_id,
+            )
             .join(
                 count_subquery,
-                count_subquery.c["id"] == remixable_tracks_subquery.c.track_id,
+                count_subquery.c["id"] == Track.track_id,
             )
-            .order_by(desc("score"), desc(remixable_tracks_subquery.c.track_id))
+            .order_by(desc("score"), desc(Track.track_id))
             .limit(limit)
         )
 

--- a/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/discovery-provider/src/queries/get_remixable_tracks.py
@@ -36,7 +36,7 @@ def get_remixable_tracks(args):
 
         query = (
             session.query(
-                remixable_tracks_subquery,
+                Track,
                 count_subquery.c["count"],
                 decayed_score(
                     count_subquery.c["count"], remixable_tracks_subquery.c.created_at
@@ -55,9 +55,9 @@ def get_remixable_tracks(args):
 
         tracks = []
         for result in results:
-            track = result[0:-2]
+            track = result[0]
             score = result[-1]
-            track = helpers.tuple_to_model_dictionary(track, Track)
+            track = helpers.model_to_dictionary(track)
             track["score"] = score
             tracks.append(track)
 
@@ -68,5 +68,11 @@ def get_remixable_tracks(args):
 
         if args.get("with_users", False):
             add_users_to_tracks(session, tracks, current_user_id)
+        else:
+            # Remove the user from the tracks
+            tracks = [
+                {key: val for key, val in dict.items() if key != "user"}
+                for dict in tracks
+            ]
 
     return tracks

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -1276,12 +1276,16 @@ def add_users_to_tracks(session, tracks, current_user_id=None):
     Returns: None
     """
     user_ids = get_users_ids(tracks)
-    users = list(map(lambda t: t["user"][0], tracks))
+    users = []
+    if tracks and len(tracks) > 0 and tracks[0].get("user"):
+        users = list(map(lambda t: t["user"][0], tracks))
+    else:
+        # This shouldn't happen - all tracks should come preloaded with their owners per the relationship
+        users = get_unpopulated_users(session, user_ids)
+        logger.warning("add_users_to_tracks() called but tracks have no users")
     set_users_in_cache(users)
     # bundle peripheral info into user results
-    populated_users = populate_user_metadata(
-        session, user_ids, users, current_user_id
-    )
+    populated_users = populate_user_metadata(session, user_ids, users, current_user_id)
     user_map = {}
     for user in populated_users:
         user_map[user["user_id"]] = user

--- a/discovery-provider/tests/test_get_tracks.py
+++ b/discovery-provider/tests/test_get_tracks.py
@@ -1,15 +1,7 @@
 from datetime import datetime
-from src.queries.get_remixable_tracks import get_remixable_tracks
-from src.utils import helpers
 
-from sqlalchemy import desc
-from src.models import AggregateTrack, Stem, Track
+from src.queries.get_remixable_tracks import get_remixable_tracks
 from src.queries.get_tracks import _get_tracks
-from src.queries.query_helpers import (
-    add_users_to_tracks,
-    decayed_score,
-    populate_track_metadata,
-)
 from src.utils.db_session import get_db
 
 from tests.utils import populate_mock_db
@@ -210,4 +202,3 @@ def test_get_remixable_tracks(app):
         tracks = get_remixable_tracks({"with_users": True})
         assert len(tracks) == 2
         assert tracks[0]["user"]
-        print(tracks)

--- a/discovery-provider/tests/test_get_tracks.py
+++ b/discovery-provider/tests/test_get_tracks.py
@@ -1,7 +1,17 @@
 from datetime import datetime
+from src.queries.get_remixable_tracks import get_remixable_tracks
+from src.utils import helpers
 
+from sqlalchemy import desc
+from src.models import AggregateTrack, Stem, Track
 from src.queries.get_tracks import _get_tracks
+from src.queries.query_helpers import (
+    add_users_to_tracks,
+    decayed_score,
+    populate_track_metadata,
+)
 from src.utils.db_session import get_db
+
 from tests.utils import populate_mock_db
 
 
@@ -171,3 +181,33 @@ def test_get_track_by_handle_slug(app):
                 {"user_id": 4, "id": [9], "offset": 0, "limit": 10},
             )
             assert len(tracks) == 0
+
+
+def test_get_remixable_tracks(app):
+
+    with app.app_context():
+        db = get_db()
+
+        populate_tracks(db)
+        populate_mock_db(
+            db,
+            {
+                "remixes": [
+                    {"parent_track_id": 9, "child_track_id": 1},
+                    {"parent_track_id": 8, "child_track_id": 1},
+                ],
+                "stems": [
+                    {"parent_track_id": 7, "child_track_id": 1},
+                    {"parent_track_id": 6, "child_track_id": 1},
+                ],
+                "saves": [{"user_id": 4, "save_item_id": 1}],
+                "reposts": [{"user_id": 4, "repost_item_id": 1}],
+            },
+        )
+
+        with db.scoped_session() as session:
+            session.execute("REFRESH MATERIALIZED VIEW aggregate_track")
+        tracks = get_remixable_tracks({"with_users": True})
+        assert len(tracks) == 2
+        assert tracks[0]["user"]
+        print(tracks)

--- a/discovery-provider/tests/utils.py
+++ b/discovery-provider/tests/utils.py
@@ -70,6 +70,8 @@ def populate_mock_db(db, entities):
         reposts = entities.get("reposts", [])
         saves = entities.get("saves", [])
         track_routes = entities.get("track_routes", [])
+        remixes = entities.get("remixes", [])
+        stems = entities.get("stems", [])
         num_blocks = max(len(tracks), len(users), len(follows))
 
         for i in range(num_blocks):
@@ -201,3 +203,15 @@ def populate_mock_db(db, entities):
                 collision_id=route_meta.get("collision_id", 0),
             )
             session.add(route)
+        for i, remix_meta in enumerate(remixes):
+            remix = models.Remix(
+                parent_track_id=remix_meta.get("parent_track_id", i),
+                child_track_id=remix_meta.get("child_track_id", i + 1),
+            )
+            session.add(remix)
+        for i, stems_meta in enumerate(stems):
+            stem = models.Stem(
+                parent_track_id=stems_meta.get("parent_track_id", i),
+                child_track_id=stems_meta.get("child_track_id", i + 1),
+            )
+            session.add(stem)


### PR DESCRIPTION
- Make `get_remixable_tracks` pull in `Track` models so that the relationship gets loaded
- Adds test to ensure that `get_remixable_tracks` pulls in the right number of tracks and that those tracks have users
- Adds failsafe in helper if the tracks don't have users (tested with the prior version of `get_remixable_tracks`)
