### PR TITLE
Add useHedgehogLocalStorage option

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "@audius/hedgehog": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@audius/hedgehog/-/hedgehog-1.0.8.tgz",
-      "integrity": "sha512-yBg9shxDlWF+cBPJO8ST1GkIMXwBMqT9IP7eMrknegMOvPK93dolHtba1I17Hxmtp8GmnYN0XXXWGWevPXaMtg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@audius/hedgehog/-/hedgehog-1.0.9.tgz",
+      "integrity": "sha512-VR9pPNVwtzmSNieSXhPk2WV3XUqLS210dglnPzKQGmFpXQHrrujWX6Pg5FZh4W6Z1PMeRyNa8VL1nMtKSqkXIw==",
       "requires": {
         "bip39": "^2.5.0",
         "browserify-cipher": "^1.0.1",
@@ -4398,17 +4398,17 @@
       }
     },
     "ethereumjs-wallet": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
-      "integrity": "sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
+      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
       "requires": {
         "aes-js": "^3.1.1",
         "bs58check": "^2.1.2",
+        "ethereum-cryptography": "^0.1.3",
         "ethereumjs-util": "^6.0.0",
-        "hdkey": "^1.1.0",
         "randombytes": "^2.0.6",
         "safe-buffer": "^5.1.2",
-        "scrypt.js": "^0.3.0",
+        "scryptsy": "^1.2.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
       }
@@ -5190,33 +5190,6 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
-        }
-      }
-    },
-    "hdkey": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
-      "integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
-      "requires": {
-        "bs58check": "^2.1.2",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
-      },
-      "dependencies": {
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
         }
       }
     },
@@ -7401,29 +7374,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.0.8"
-      }
-    },
     "scrypt-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
       "dev": true
-    },
-    "scrypt.js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
-      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
-      "requires": {
-        "scrypt": "^6.0.2",
-        "scryptsy": "^1.2.1"
-      }
     },
     "scryptsy": {
       "version": "1.2.1",

--- a/libs/package.json
+++ b/libs/package.json
@@ -18,7 +18,7 @@
     "lint-fix": "./node_modules/.bin/standard --fix"
   },
   "dependencies": {
-    "@audius/hedgehog": "1.0.8",
+    "@audius/hedgehog": "1.0.9",
     "@ethersproject/solidity": "5.0.5",
     "@solana/spl-token": "0.1.6",
     "@solana/web3.js": "1.20.0",

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -49,9 +49,10 @@ class AudiusLibs {
   /**
    * Configures an identity service wrapper
    * @param {string} url
+   * @param {boolean?} useHedgehogLocalStorage whether or not to read hedgehog entropy in local storage
    */
-  static configIdentityService (url) {
-    return { url }
+  static configIdentityService (url, useHedgehogLocalStorage = true) {
+    return { url, useHedgehogLocalStorage }
   }
 
   /**
@@ -282,7 +283,7 @@ class AudiusLibs {
     /** Identity Service */
     if (this.identityServiceConfig) {
       this.identityService = new IdentityService(this.identityServiceConfig.url, this.captcha)
-      this.hedgehog = new Hedgehog(this.identityService)
+      this.hedgehog = new Hedgehog(this.identityService, this.identityServiceConfig.useHedgehogLocalStorage)
     } else if (this.web3Config && !this.web3Config.useExternalWeb3) {
       throw new Error('Identity Service required for internal Web3')
     }

--- a/libs/src/services/hedgehog/index.js
+++ b/libs/src/services/hedgehog/index.js
@@ -10,7 +10,7 @@ class HedgehogWrapper {
   // Therefore, we need to define this.audiusServiceEndpoint, to satisfy all the deps of the
   // requestToAudiusService and make it execute correctly
 
-  constructor (identityService) {
+  constructor (identityService, useLocalStorage = true) {
     this.identityService = identityService
 
     this.getFn = async (obj) => {
@@ -25,7 +25,12 @@ class HedgehogWrapper {
       return this.identityService.setUserFn(obj)
     }
 
-    const hedgehog = new Hedgehog(this.getFn, this.setAuthFn, this.setUserFn)
+    const hedgehog = new Hedgehog(
+      this.getFn,
+      this.setAuthFn,
+      this.setUserFn,
+      useLocalStorage
+    )
 
     // we override the login function here because getFn needs both lookupKey and email
     // in identity service, but hedgehog only sends lookupKey


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Adds an option `useHedgehogLocalStorage` as a way to prevent libs from re-using hedgehog entropy stored in local storage. This allows parallelized libs initializations in the same runtime.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Locally with sauron
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
