### PR TITLE
Improve Service Commands

### DIFF
--- a/service-commands/scripts/setup.js
+++ b/service-commands/scripts/setup.js
@@ -109,6 +109,16 @@ program
     'service instance number',
     SERVICE_INSTANCE_NUMBER.toString()
   )
+  .option(
+    '-nc, --num-cnodes <number>',
+    'number of creator nodes',
+    NUM_CREATOR_NODES.toString()
+  )
+  .option(
+    '-nd, --num-dn <number>',
+    'number of discovery nodes',
+    NUM_DISCOVERY_NODES.toString()
+  )
   .action(async (service, command, opts) => {
     try {
       if (!service || !command) {
@@ -118,6 +128,13 @@ program
 
       const serviceName = findService(service)
       const setupCommand = findCommand(command)
+
+      if (serviceName === Service.ALL && setupCommand == SetupCommand.UP) {
+        const numCreatorNodes = parseInt(opts.numCnodes)
+        const numDiscoveryNodes = parseInt(opts.numDn)
+        await allUp({ numCreatorNodes, numDiscoveryNodes })
+        return
+      }
 
       if (
         serviceName === Service.CREATOR_NODE ||

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -11,10 +11,10 @@
     "up": [
       "export DOCKER_CLIENT_TIMEOUT=360",
       "export COMPOSE_HTTP_TIMEOUT=360",
-      "docker network create -d bridge audius_dev"
+      "docker network create -d bridge audius_dev || true"
     ],
     "down": [
-      "docker network rm audius_dev"
+      "docker network rm audius_dev || true"
     ]
   },
   "contracts": {


### PR DESCRIPTION
### Description

- Allow service command `run all up`, to stay consistent with the structure of other commands
- On network creation step, don't fail if network already exists

### Tests

Tested locally
**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?
n/a
