### PR TITLE
Add transcode queue insights into health check and integrate with service selection

### DIFF
--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -128,8 +128,8 @@ class TranscodingQueue {
       waiting,
       active
     ] = await Promise.all([
-      queue.getJobs(['waiting']),
-      queue.getJobs(['active'])
+      queue.getJobs(['waiting']).length,
+      queue.getJobs(['active']).length
     ])
 
     return {

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -128,13 +128,13 @@ class TranscodingQueue {
       waiting,
       active
     ] = await Promise.all([
-      queue.getJobs(['waiting']).length,
-      queue.getJobs(['active']).length
+      queue.getJobs(['waiting']),
+      queue.getJobs(['active'])
     ])
 
     return {
-      waiting,
-      active
+      waiting: waiting.length,
+      active: active.length
     }
   }
 }

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -78,6 +78,7 @@ class TranscodingQueue {
     this.logStatus = this.logStatus.bind(this)
     this.segment = this.segment.bind(this)
     this.transcode320 = this.transcode320.bind(this)
+    this.getTranscodeQueueJobs = this.getTranscodeQueueJobs.bind(this)
   }
 
   /**
@@ -119,6 +120,22 @@ class TranscodingQueue {
     )
     const result = await job.finished()
     return result
+  }
+
+  async getTranscodeQueueJobs () {
+    const queue = this.queue
+    const [
+      waiting,
+      active
+    ] = await Promise.all([
+      queue.getJobs(['waiting']),
+      queue.getJobs(['active'])
+    ])
+
+    return {
+      waiting,
+      active
+    }
   }
 }
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -19,7 +19,7 @@ const MIN_FILESYSTEM_SIZE = 1950000000000 // 1950 GB of file system storage
  * @param {string?} randomBytesToSign optional bytes string to be included in response object
  *    and used in signature generation
  */
-const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, numberOfCPUs, randomBytesToSign = null) => {
+const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs, randomBytesToSign = null) => {
   // System information
   const [
     totalMemory,
@@ -28,6 +28,8 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
     MONITORS.TOTAL_MEMORY,
     MONITORS.STORAGE_PATH_SIZE
   ])
+
+  const { active: transcodeActive, waiting: transcodeWaiting } = await getTranscodeQueueJobs()
 
   let response = {
     ...versionInfo,
@@ -40,7 +42,9 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
     isRegisteredOnURSM: config.get('isRegisteredOnURSM'),
     numberOfCPUs,
     totalMemory,
-    storagePathSize
+    storagePathSize,
+    transcodeActive,
+    transcodeWaiting
   }
 
   // If optional `randomBytesToSign` query param provided, node will include string in signed object

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -144,7 +144,6 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
   }
 
   const { active: transcodeActive, waiting: transcodeWaiting } = await getTranscodeQueueJobs()
-  console.log('transcodeActive', transcodeActive, transcodeWaiting)
 
   const response = {
     ...basicHealthCheck,
@@ -178,7 +177,6 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
     transcodeActive,
     transcodeWaiting
   }
-  console.log(response.transcodeActive, response.transcodeWaiting, 'respszz')
 
   return response
 }

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -19,7 +19,7 @@ const MIN_FILESYSTEM_SIZE = 1950000000000 // 1950 GB of file system storage
  * @param {string?} randomBytesToSign optional bytes string to be included in response object
  *    and used in signature generation
  */
-const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs, randomBytesToSign = null) => {
+const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, numberOfCPUs, randomBytesToSign = null) => {
   // System information
   const [
     totalMemory,
@@ -144,6 +144,7 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
   }
 
   const { active: transcodeActive, waiting: transcodeWaiting } = await getTranscodeQueueJobs()
+  console.log('transcodeActive', transcodeActive, transcodeWaiting)
 
   const response = {
     ...basicHealthCheck,
@@ -177,6 +178,7 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
     transcodeActive,
     transcodeWaiting
   }
+  console.log(response.transcodeActive, response.transcodeWaiting, 'respszz')
 
   return response
 }

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -87,8 +87,8 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
  * @param {function} getAggregateSyncData fn to get the latest daily sync count (success, fail, triggered)
  * @param {function} getLatestSyncData fn to get the timestamps of the most recent sync (success, fail)
  */
-const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, getMonitors, numberOfCPUs, getAggregateSyncData, getLatestSyncData) => {
-  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors, numberOfCPUs)
+const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs, getAggregateSyncData, getLatestSyncData) => {
+  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs)
 
   // Location information
   const country = config.get('serviceCountry')

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -84,7 +84,7 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
  * @param {function} getLatestSyncData fn to get the timestamps of the most recent sync (success, fail)
  */
 const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs, getAggregateSyncData, getLatestSyncData) => {
-  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors, numberOfCPUs, getTranscodeQueueJobs)
+  const basicHealthCheck = await healthCheck({ libs }, logger, sequelize, getMonitors, numberOfCPUs)
 
   // Location information
   const country = config.get('serviceCountry')

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -29,8 +29,6 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
     MONITORS.STORAGE_PATH_SIZE
   ])
 
-  const { active: transcodeActive, waiting: transcodeWaiting } = await getTranscodeQueueJobs()
-
   let response = {
     ...versionInfo,
     healthy: true,
@@ -42,9 +40,7 @@ const healthCheck = async ({ libs } = {}, logger, sequelize, getMonitors, number
     isRegisteredOnURSM: config.get('isRegisteredOnURSM'),
     numberOfCPUs,
     totalMemory,
-    storagePathSize,
-    transcodeActive,
-    transcodeWaiting
+    storagePathSize
   }
 
   // If optional `randomBytesToSign` query param provided, node will include string in signed object
@@ -147,6 +143,8 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
     currentSnapbackReconfigMode = snapbackSM.highestEnabledReconfigMode
   }
 
+  const { active: transcodeActive, waiting: transcodeWaiting } = await getTranscodeQueueJobs()
+
   const response = {
     ...basicHealthCheck,
     country,
@@ -175,7 +173,9 @@ const healthCheckVerbose = async ({ libs, snapbackSM } = {}, logger, sequelize, 
     currentSnapbackReconfigMode,
     manualSyncsDisabled,
     snapbackModuloBase,
-    snapbackJobInterval
+    snapbackJobInterval,
+    transcodeActive,
+    transcodeWaiting
   }
 
   return response

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -131,28 +131,6 @@ describe('Test Health Check', function () {
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
   })
-
-  it('Should return accurate transcode queue size', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
-
-    assert.deepStrictEqual(res, {
-      ...version,
-      service: 'content-node',
-      healthy: true,
-      git: undefined,
-      selectedDiscoveryProvider: 'none',
-      spID: config.get('spID'),
-      spOwnerWallet: config.get('spOwnerWallet'),
-      creatorNodeEndpoint: config.get('creatorNodeEndpoint'),
-      isRegisteredOnURSM: false,
-      meetsMinRequirements: false,
-      numberOfCPUs: 2,
-      storagePathSize: 62725623808,
-      totalMemory: 6237151232
-    })
-
-    assert.deepStrictEqual(res.meetsMinRequirements, false)
-  })
 })
 
 describe('Test Health Check Verbose', function () {

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -4,6 +4,7 @@ const { healthCheck, healthCheckVerbose } = require('./healthCheckComponentServi
 const version = require('../../../.version.json')
 const config = require('../../../src/config')
 const { MONITORS } = require('../../monitors/monitors')
+const { getTranscodeQueueJobs } = require('../../TranscodingQueue')
 
 const TEST_ENDPOINT = 'test_endpoint'
 
@@ -71,7 +72,7 @@ describe('Test Health Check', function () {
     config.set('creatorNodeEndpoint', 'http://test.endpoint')
     config.set('spID', 10)
 
-    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock, getMonitorsMock, 2)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock, getMonitorsMock, 2, getTranscodeQueueJobs)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -86,12 +87,14 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232
+      totalMemory: 6237151232,
+      transcodeActive: [],
+      transcodeWaiting: []
     })
   })
 
   it('Should handle no libs', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
+    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2, getTranscodeQueueJobs)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -106,12 +109,14 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232
+      totalMemory: 6237151232,
+      transcodeActive: [],
+      transcodeWaiting: []
     })
   })
 
   it('Should return "meetsMinRequirements" = false if system requirements arent met', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
+    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2, getTranscodeQueueJobs)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -126,7 +131,9 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232
+      totalMemory: 6237151232,
+      transcodeActive: [],
+      transcodeWaiting: []
     })
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
@@ -148,7 +155,7 @@ describe('Test Health Check Verbose', function () {
         highestEnabledReconfigMode: 'RECONFIG_DISABLED'
       }
     }
-    const res = await healthCheckVerbose(serviceRegistryMock, mockLogger, sequelizeMock, getMonitorsMock, 2)
+    const res = await healthCheckVerbose(serviceRegistryMock, mockLogger, sequelizeMock, getMonitorsMock, 2, getTranscodeQueueJobs)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -187,7 +194,9 @@ describe('Test Health Check Verbose', function () {
       currentSnapbackReconfigMode: 'RECONFIG_DISABLED',
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
-      snapbackJobInterval: 1000
+      snapbackJobInterval: 1000,
+      transcodeActive: [],
+      transcodeWaiting: []
     })
   })
 })

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -13,14 +13,6 @@ const libsMock = {
   }
 }
 
-const TranscodingQueueMock = (active = 0, waiting = 0) => {
-  return {
-    getTranscodeQueueJobs: async () => {
-      return { active, waiting }
-    }
-  }
-}
-
 const sequelizeMock = {
   'query': async () => Promise.resolve()
 }
@@ -79,7 +71,7 @@ describe('Test Health Check', function () {
     config.set('creatorNodeEndpoint', 'http://test.endpoint')
     config.set('spID', 10)
 
-    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock().getTranscodeQueueJobs)
+    const res = await healthCheck({ libs: libsMock }, mockLogger, sequelizeMock, getMonitorsMock, 2)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -94,14 +86,12 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232,
-      transcodeActive: 0,
-      transcodeWaiting: 0
+      totalMemory: 6237151232
     })
   })
 
   it('Should handle no libs', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock().getTranscodeQueueJobs)
+    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -116,14 +106,12 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232,
-      transcodeActive: 0,
-      transcodeWaiting: 0
+      totalMemory: 6237151232
     })
   })
 
   it('Should return "meetsMinRequirements" = false if system requirements arent met', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock().getTranscodeQueueJobs)
+    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -138,16 +126,14 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232,
-      transcodeActive: 0,
-      transcodeWaiting: 0
+      totalMemory: 6237151232
     })
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
   })
 
   it('Should return accurate transcode queue size', async function () {
-    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock(4, 0).getTranscodeQueueJobs)
+    const res = await healthCheck({}, mockLogger, sequelizeMock, getMonitorsMock, 2)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -162,9 +148,7 @@ describe('Test Health Check', function () {
       meetsMinRequirements: false,
       numberOfCPUs: 2,
       storagePathSize: 62725623808,
-      totalMemory: 6237151232,
-      transcodeActive: 4,
-      transcodeWaiting: 0
+      totalMemory: 6237151232
     })
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
@@ -186,7 +170,15 @@ describe('Test Health Check Verbose', function () {
         highestEnabledReconfigMode: 'RECONFIG_DISABLED'
       }
     }
-    const res = await healthCheckVerbose(serviceRegistryMock, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock().getTranscodeQueueJobs)
+    const TranscodingQueueMock = (active = 0, waiting = 0) => {
+      return {
+        getTranscodeQueueJobs: async () => {
+          return { active, waiting }
+        }
+      }
+    }
+
+    const res = await healthCheckVerbose(serviceRegistryMock, mockLogger, sequelizeMock, getMonitorsMock, 2, TranscodingQueueMock(4, 0).getTranscodeQueueJobs)
 
     assert.deepStrictEqual(res, {
       ...version,
@@ -226,7 +218,7 @@ describe('Test Health Check Verbose', function () {
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
       snapbackJobInterval: 1000,
-      transcodeActive: 0,
+      transcodeActive: 4,
       transcodeWaiting: 0
     })
   })

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -107,6 +107,7 @@ const healthCheckVerboseController = async (req) => {
     sequelize,
     getMonitors,
     numberOfCPUs,
+    TranscodingQueue.getTranscodeQueueJobs,
     getAggregateSyncData,
     getLatestSyncData
   )

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -7,6 +7,7 @@ const { serviceRegistry } = require('../../serviceRegistry')
 const { sequelize } = require('../../models')
 const { getMonitors } = require('../../monitors/monitors')
 const { getAggregateSyncData, getLatestSyncData } = require('../../snapbackSM/syncHistoryAggregator')
+const TranscodingQueue = require('../../TranscodingQueue')
 
 const { recoverWallet } = require('../../apiSigning')
 const { handleTrackContentUpload, removeTrackFolder } = require('../../fileManager')
@@ -57,7 +58,15 @@ const healthCheckController = async (req) => {
   let { randomBytesToSign } = req.query
 
   const logger = req.logger
-  const response = await healthCheck(serviceRegistry, logger, sequelize, getMonitors, numberOfCPUs, randomBytesToSign)
+  const response = await healthCheck(
+    serviceRegistry,
+    logger,
+    sequelize,
+    getMonitors,
+    numberOfCPUs,
+    TranscodingQueue.getTranscodeQueueJobs,
+    randomBytesToSign
+  )
   return successResponse(response)
 }
 

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -64,7 +64,6 @@ const healthCheckController = async (req) => {
     sequelize,
     getMonitors,
     numberOfCPUs,
-    TranscodingQueue.getTranscodeQueueJobs,
     randomBytesToSign
   )
   return successResponse(response)

--- a/libs/src/services/creatorNode/CreatorNodeSelection.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.js
@@ -268,7 +268,9 @@ class CreatorNodeSelection extends ServiceSelection {
               maxFileDescriptors: data.maxFileDescriptors,
               allocatedFileDescriptors: data.allocatedFileDescriptors,
               receivedBytesPerSec: data.receivedBytesPerSec,
-              transferredBytesPerSec: data.transferredBytesPerSec
+              transferredBytesPerSec: data.transferredBytesPerSec,
+              transcodeWaiting: data.transcodeWaiting,
+              transcodeActive: data.transcodeActive
             })
           } catch (e) {
             // Swallow errors -- this method should not throw generally

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -523,49 +523,4 @@ describe('test CreatorNodeSelection', () => {
     const healthyServices = [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2]
     healthyServices.map(service => assert(returnedHealthyServices.has(service)))
   })
-
-  it('correctly sorts healthy services by transcode queue size', async () => {
-    let healthCheckData = {
-      ...defaultHealthCheckData
-    }
-
-    const shouldBePrimary = 'https://noTranscodeTasks.audius.co'
-    nock(shouldBePrimary)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...healthCheckData, transcodeActive: 0, transcodeWaiting: 0 } })
-
-    const shouldBeSecondary1 = 'https://mostTranscodeTasks.audius.co'
-    nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...healthCheckData, transcodeActive: 8, transcodeWaiting: 0 } })
-
-    const shouldBeSecondary2 = 'https://mediumTranscodeTasks.audius.co'
-    nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
-      .reply(200, { data: { ...healthCheckData, transcodeActive: 4, transcodeWaiting: 0 } })
-
-    const cns = new CreatorNodeSelection({
-      creatorNode: mockCreatorNode,
-      numberOfNodes: 3,
-      ethContracts: mockEthContracts(
-        [shouldBeSecondary2, shouldBeSecondary1, shouldBePrimary],
-        '1.2.3'
-      ),
-      whitelist: null,
-      blacklist: null,
-      maxStorageUsedPercent: 50
-    })
-
-    const { primary, secondaries, services } = await cns.select()
-
-    assert(primary === shouldBePrimary)
-    assert(secondaries.length === 2)
-    assert(secondaries.includes(shouldBeSecondary1))
-    assert(secondaries.includes(shouldBeSecondary2))
-
-    const returnedHealthyServices = new Set(Object.keys(services))
-    assert(returnedHealthyServices.size === 3)
-    const healthyServices = [shouldBePrimary, shouldBeSecondary1, shouldBeSecondary2]
-    healthyServices.map(service => assert(returnedHealthyServices.has(service)))
-  })
 })

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.js
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.js
@@ -53,8 +53,7 @@ let defaultHealthCheckData = {
   'allocatedFileDescriptors': 2912,
   'receivedBytesPerSec': 776.7638177541248,
   'transferredBytesPerSec': 39888.88888888889,
-  'maxStorageUsedPercent': 95,
-  'numberOfCPUs': 8
+  'maxStorageUsedPercent': 95
 }
 
 describe('test CreatorNodeSelection', () => {

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -67,34 +67,6 @@ async function timeRequestsAndSortByVersion (requests, timeout = null) {
     if (semver.gt(a.response.data.data.version, b.response.data.data.version)) return -1
     if (semver.lt(a.response.data.data.version, b.response.data.data.version)) return 1
 
-    // Sort by content node transcode queue load
-    // defined as the ratio of (active + waiting transcodes) / (transcode slots, same as number of cpu cores)
-    // if either number of CPUs or transcode fields aren't defined in the health check, ratios default to 1
-    let numCPUsA = 1
-    let numCPUsB = 1
-    if (a.response.data.data && a.response.data.data.numberOfCPUs) {
-      numCPUsA = a.response.data.data.numberOfCPUs
-    }
-    if (b.response.data.data && b.response.data.data.numberOfCPUs) {
-      numCPUsB = b.response.data.data.numberOfCPUs
-    }
-
-    let transcodeCountA = numCPUsA
-    let transcodeCountB = numCPUsB
-    if (a.response.data.data && a.response.data.data.hasOwnProperty('transcodeActive') && a.response.data.data.hasOwnProperty('transcodeWaiting')) {
-      transcodeCountA = a.response.data.data.transcodeActive + a.response.data.data.transcodeWaiting
-    }
-    if (b.response.data.data && b.response.data.data.hasOwnProperty('transcodeActive') && b.response.data.data.hasOwnProperty('transcodeWaiting')) {
-      transcodeCountB = b.response.data.data.transcodeActive + b.response.data.data.transcodeWaiting
-    }
-
-    // lower is better, means less transcode queue utilization
-    // default ratio for transcode count and num cpus if node doesn't have one of those defined is 1
-    const healthRatioA = (transcodeCountA / numCPUsA)
-    const healthRatioB = (transcodeCountB / numCPUsB)
-    if (healthRatioA > healthRatioB) return 1
-    else if (healthRatioA < healthRatioB) return -1
-
     // If same version and transcode queue load, do a tie breaker on the response time
     return a.millis - b.millis
   })

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -62,9 +62,18 @@ async function timeRequestsAndSortByVersion (requests, timeout = null) {
     // If health check failed, send to back of timings
     if (!a.response) return 1
     if (!b.response) return -1
+
     // Sort by highest version
     if (semver.gt(a.response.data.data.version, b.response.data.data.version)) return -1
     if (semver.lt(a.response.data.data.version, b.response.data.data.version)) return 1
+
+    // Sort by content node transcode queue load
+    // defined as the ratio of (active + waiting transcodes) / (transcode slots, same as number of cpu cores)
+    const a_healthRatio = ((a.response.data.data.transcodeActive + a.response.data.data.transcodeWaiting) / a.response.data.data.numberOfCPUs)
+    const b_healthRatio = ((b.response.data.data.transcodeActive + b.response.data.data.transcodeWaiting) / b.response.data.data.numberOfCPUs)
+    if (a_healthRatio > b_healthRatio) return 1
+    else if (a_healthRatio < b_healthRatio) return -1
+
     // If same version, do a tie breaker on the response time
     return a.millis - b.millis
   })

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -74,7 +74,7 @@ async function timeRequestsAndSortByVersion (requests, timeout = null) {
     if (healthRatioA > healthRatioB) return 1
     else if (healthRatioA < healthRatioB) return -1
 
-    // If same version, do a tie breaker on the response time
+    // If same version and transcode queue load, do a tie breaker on the response time
     return a.millis - b.millis
   })
 }

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -69,10 +69,10 @@ async function timeRequestsAndSortByVersion (requests, timeout = null) {
 
     // Sort by content node transcode queue load
     // defined as the ratio of (active + waiting transcodes) / (transcode slots, same as number of cpu cores)
-    const a_healthRatio = ((a.response.data.data.transcodeActive + a.response.data.data.transcodeWaiting) / a.response.data.data.numberOfCPUs)
-    const b_healthRatio = ((b.response.data.data.transcodeActive + b.response.data.data.transcodeWaiting) / b.response.data.data.numberOfCPUs)
-    if (a_healthRatio > b_healthRatio) return 1
-    else if (a_healthRatio < b_healthRatio) return -1
+    const healthRatioA = ((a.response.data.data.transcodeActive + a.response.data.data.transcodeWaiting) / a.response.data.data.numberOfCPUs)
+    const healthRatioB = ((b.response.data.data.transcodeActive + b.response.data.data.transcodeWaiting) / b.response.data.data.numberOfCPUs)
+    if (healthRatioA > healthRatioB) return 1
+    else if (healthRatioA < healthRatioB) return -1
 
     // If same version, do a tie breaker on the response time
     return a.millis - b.millis


### PR DESCRIPTION
### Description

Add criteria in content node selection to sort healthy nodes by transcode queue utilization to better balance load across different content nodes
### Tests
Added unit tests, testing manually now.

### How will this change be monitored?
Amplitude has creator node selection graphs