### PR TITLE
Re-enable TikTok CSRF check and allow custom redirect url

### DIFF
--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -16,6 +16,7 @@ module.exports = function (app) {
   app.get(
     '/tiktok',
     handleResponse(async (req, res, next) => {
+      const { redirectUrl } = req.query
       const csrfState = Math.random().toString(36).substring(7)
       res.cookie('csrfState', csrfState, { maxAge: 60000 })
 
@@ -24,7 +25,7 @@ module.exports = function (app) {
       url += `?client_key=${config.get('tikTokAPIKey')}`
       url += '&scope=user.info.basic,share.sound.create'
       url += '&response_type=code'
-      url += `&redirect_uri=${config.get('tikTokAuthOrigin')}`
+      url += `&redirect_uri=${redirectUrl || config.get('tikTokAuthOrigin')}`
       url += '&state=' + csrfState
 
       res.redirect(url)

--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -1,12 +1,12 @@
 const axios = require('axios')
 const cors = require('cors')
 
-const { errorResponseBadRequest } = require('./apiHelpers')
 const config = require('../config.js')
 
 const {
   handleResponse,
-  successResponse
+  successResponse,
+  errorResponseBadRequest
 } = require('../apiHelpers')
 
 /**

--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -41,12 +41,12 @@ module.exports = function (app) {
     '/tiktok/access_token',
     cors(accessTokenCorsOptions),
     handleResponse(async (req, res, next) => {
-      const { code } = req.body
+      const { code, state } = req.body;
+      const { csrfState } = req.cookies;
 
-      // NOTE: sk - temporarily disabling csrf check for go live
-      // if (!state || !csrfState || state !== csrfState) {
-      //   return errorResponseBadRequest('Invalid state')
-      // }
+      if (!state || !csrfState || state !== csrfState) {
+        return errorResponseBadRequest("Invalid state");
+      }
 
       let urlAccessToken = 'https://open-api.tiktok.com/oauth/access_token/'
       urlAccessToken += '?client_key=' + config.get('tikTokAPIKey')

--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -1,5 +1,7 @@
 const axios = require('axios')
 const cors = require('cors')
+
+const { errorResponseBadRequest } = require('./apiHelpers')
 const config = require('../config.js')
 
 const {
@@ -42,11 +44,11 @@ module.exports = function (app) {
     '/tiktok/access_token',
     cors(accessTokenCorsOptions),
     handleResponse(async (req, res, next) => {
-      const { code, state } = req.body;
-      const { csrfState } = req.cookies;
+      const { code, state } = req.body
+      const { csrfState } = req.cookies
 
       if (!state || !csrfState || state !== csrfState) {
-        return errorResponseBadRequest("Invalid state");
+        return errorResponseBadRequest('Invalid state')
       }
 
       let urlAccessToken = 'https://open-api.tiktok.com/oauth/access_token/'


### PR DESCRIPTION
### Description

This PR:
* Re-enables the TikTok auth CSRF check that was disabled due to some cookie issues on iOS. A fix exists now for iOS
* Adds a redirectUrl param to the `/tiktok` route on identity. This is to allow for testing against prod on a non-prod client

### Tests

Manual

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
