### PR TITLE
Await selectFromBackups

### DIFF
--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -119,7 +119,7 @@ class ServiceSelection {
       this.decisionTree.push({ stage: DECISION_TREE_STATE.NO_SERVICES_LEFT_TO_TRY })
       if (this.getBackupsSize() > 0) {
         // Some backup exists
-        const backup = this.selectFromBackups()
+        const backup = await this.selectFromBackups()
         this.decisionTree.push({ stage: DECISION_TREE_STATE.SELECTED_FROM_BACKUP, val: backup })
         return backup
       } else {


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

selecting a disc prov result looks like this if selecting from a backup:
```
Selected discprov https://discoveryprovider2.staging.audius.co [ { stage: 'Check Short Circuit', val: null },
  { stage: 'Get All Services',
    val:
     [ 'https://discoveryprovider2.staging.audius.co',
       'https://discoveryprovider3.staging.audius.co',
       'https://discoveryprovider.staging.audius.co' ] },
  { stage: 'Filter Out Known Unhealthy', val: [] },
  { stage: 'Get Selection Round', val: [] },
  { stage: 'No Services Left To Try' },
  { stage: 'Selected From Backup',
    val: Promise { 'https://discoveryprovider2.staging.audius.co' } } ]
```

this PR is to await the selectFromBackup() call. 

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Test 1
2. Test 2
3. Test 3\
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
