### PR TITLE
Fix SecondarySyncHealthTracker math

### DIFF
--- a/creator-node/src/snapbackSM/secondarySyncHealthTracker.js
+++ b/creator-node/src/snapbackSM/secondarySyncHealthTracker.js
@@ -150,7 +150,7 @@ const Getters = {
     // For each secondary, compute and store successRate
     Object.keys(secondarySyncMetrics).forEach(secondary => {
       const { successCount, failureCount } = secondarySyncMetrics[secondary]
-      secondarySyncMetrics[secondary]['successRate'] = (failureCount === 0) ? 1 : (successCount / failureCount)
+      secondarySyncMetrics[secondary]['successRate'] = (failureCount === 0) ? 1 : (successCount / (successCount + failureCount))
     })
 
     return secondarySyncMetrics


### PR DESCRIPTION
Silly math error

This hasn't affected anything as Reconfig has been disabled, and it accidentally inflates successRates so it will only reduce # of reconfigs.

Will expect to see more reconfigs with this change, but they are disabled currently and we have a very low successRate threshold (50%) so its still very safe