### PR TITLE
Remove blocking ipfs.id call on each export request

### DIFF
--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -4,6 +4,8 @@ const config = require('../config')
 const { getIPFSPeerId } = require('../utils')
 
 module.exports = function (app) {
+  let ipfsIDObj
+
   /**
    * Exports all db data (not files) associated with walletPublicKey[] as JSON.
    * Returns IPFS node ID object, so importing nodes can peer manually for optimized file transfer.
@@ -131,7 +133,10 @@ module.exports = function (app) {
 
       // Expose ipfs node's peer ID.
       const ipfs = req.app.get('ipfsAPI')
-      const ipfsIDObj = await getIPFSPeerId(ipfs)
+
+      if (!ipfsIDObj) {
+        ipfsIDObj = await getIPFSPeerId(ipfs)
+      }
 
       req.logger.info(`Successful export for wallets ${walletPublicKeys} to source endpoint ${sourceEndpoint || '(not provided)'} for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${Date.now() - start} ms`)
       return successResponse({ cnodeUsers: cnodeUsersDict, ipfsIDObj })

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -4,8 +4,6 @@ const config = require('../config')
 const { getIPFSPeerId } = require('../utils')
 
 module.exports = function (app) {
-  let ipfsIDObj
-
   /**
    * Exports all db data (not files) associated with walletPublicKey[] as JSON.
    * Returns IPFS node ID object, so importing nodes can peer manually for optimized file transfer.
@@ -133,10 +131,7 @@ module.exports = function (app) {
 
       // Expose ipfs node's peer ID.
       const ipfs = req.app.get('ipfsAPI')
-
-      if (!ipfsIDObj) {
-        ipfsIDObj = await getIPFSPeerId(ipfs)
-      }
+      const ipfsIDObj = await getIPFSPeerId(ipfs)
 
       req.logger.info(`Successful export for wallets ${walletPublicKeys} to source endpoint ${sourceEndpoint || '(not provided)'} for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${Date.now() - start} ms`)
       return successResponse({ cnodeUsers: cnodeUsersDict, ipfsIDObj })

--- a/creator-node/src/services/sync/processSync.js
+++ b/creator-node/src/services/sync/processSync.js
@@ -106,7 +106,7 @@ async function processSync (serviceRegistry, walletPublicKeys, creatorNodeEndpoi
 
     try {
       // Attempt to connect directly to target CNode's IPFS node.
-      await _initBootstrapAndRefreshPeers(serviceRegistry, logger, body.data.ipfsIDObj.addresses, redisKey)
+      _initBootstrapAndRefreshPeers(serviceRegistry, logger, body.data.ipfsIDObj.addresses, redisKey)
       logger.info(redisKey, 'IPFS Nodes connected + data export received')
     } catch (e) {
       // if there's an error peering to an IPFS node, do not stop execution

--- a/creator-node/src/services/sync/processSync.js
+++ b/creator-node/src/services/sync/processSync.js
@@ -105,7 +105,8 @@ async function processSync (serviceRegistry, walletPublicKeys, creatorNodeEndpoi
     logger.info(redisKey, `Successful export from ${creatorNodeEndpoint} for wallets ${walletPublicKeys} and requested min clock ${localMaxClockVal + 1}`)
 
     try {
-      // Attempt to connect directly to target CNode's IPFS node.
+      // Attempt to connect directly to target CNode's IPFS node
+      // async function runs in the background
       _initBootstrapAndRefreshPeers(serviceRegistry, logger, body.data.ipfsIDObj.addresses, redisKey)
       logger.info(redisKey, 'IPFS Nodes connected + data export received')
     } catch (e) {

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -17,6 +17,9 @@ const { generateTimestampAndSignature } = require('./apiSigning')
 const readFile = promisify(fs.readFile)
 
 const THIRTY_MINUTES_IN_SECONDS = 60 * 30
+const TEN_MINUTES_IN_SECONDS = 60 * 10
+
+let ipfsIDObj
 
 class Utils {
   static verifySignature (data, sig) {
@@ -79,8 +82,12 @@ async function getIPFSPeerId (ipfs) {
   // the IPFS pod. Command is:
   // ipfs config --json Addresses.Announce '["/ip4/<public ip>/tcp/<public port>"]'
   // the public port is the port mapped to IPFS' port 4001
-
-  let ipfsIDObj = await ipfs.id()
+  if (!ipfsIDObj) {
+    ipfsIDObj = await ipfs.id()
+    setInterval(async () => {
+      ipfsIDObj = await ipfs.id()
+    }, TEN_MINUTES_IN_SECONDS * 1000)
+  }
 
   return ipfsIDObj
 }


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Change `ipfs.id()` calls to only compute at startup and at an interval rather than each export request.

Allow `initBootstrapAndRefreshPeers` to run in the background.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Test 1
2. Test 2
3. Test 3\

Used logs to verify `ipfs.id()` is only called on first export request and at an interval. Verified id is unchanged in export response.

Not sure how to test `initBootstrapAndRefreshPeers`.
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
