### PR TITLE
Parallelize redis and db calls in clock status

### DIFF
--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -168,7 +168,7 @@ module.exports = function (app) {
 
     const returnSkipInfo = !!req.query.returnSkipInfo
 
-    const response = {}
+    let response = {}
 
     async function fetchClockValueFromDb () {
       // Fetch clock value from DB


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Parallelize redis and db calls.

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

1. Hit users/clock_status/<non existent wallet>?returnSkipInfo=true and confirmed response has clockValue `-1` and syncInProgress `false`.
   ...

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
