### PR TITLE
AUD-844 Use session.flush() instead of manually tracking pending routes

### DIFF
--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -251,8 +251,8 @@ def add_old_style_route(session, track_record, track_metadata):
         new_track_route.txhash = track_record.txhash
         session.add(new_track_route)
 
-        # Commit this so it gets in before the new route creation
-        session.commit()
+        # Ensure the new route exists the next time we query
+        session.flush()
     else:
         logger.error(
             f"Cannot add 'old-style' track_route to Track={track_record}\
@@ -262,7 +262,7 @@ def add_old_style_route(session, track_record, track_metadata):
 
 @time_method
 def update_track_routes_table(session, track_record, track_metadata):
-    """Creates the route for the given track and commits it to the track_routes table"""
+    """Creates the route for the given track and flushes it to the track_routes table"""
 
     # Check if the title is staying the same, and if so, return early
     if track_record.title == track_metadata["title"]:
@@ -370,8 +370,8 @@ def update_track_routes_table(session, track_record, track_metadata):
     new_track_route.txhash = track_record.txhash
     session.add(new_track_route)
 
-    # Make sure to commit so we don't add the same route twice
-    session.commit()
+    # Make sure to flush so we don't add the same route twice
+    session.flush()
 
 
 def parse_track_event(
@@ -425,7 +425,7 @@ def parse_track_event(
             track_metadata_multihash, track_metadata_format, creator_node_endpoint
         )
 
-        # Note: These will commit the session
+        # Note: These will flush the session
         add_old_style_route(session, track_record, track_metadata)
         update_track_routes_table(session, track_record, track_metadata)
         track_record = populate_track_record_metadata(
@@ -487,7 +487,7 @@ def parse_track_event(
             upd_track_metadata_multihash, track_metadata_format, creator_node_endpoint
         )
 
-        # Note: These will commit the session
+        # Note: These will flush the session
         add_old_style_route(session, track_record, track_metadata)
         update_track_routes_table(session, track_record, track_metadata)
         track_record = populate_track_record_metadata(

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import time
 from datetime import datetime
-from typing import List, Set
+from typing import Optional, Set
 
 from sqlalchemy.orm.session import make_transient
 from sqlalchemy.sql import functions, null

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -186,8 +186,6 @@ def test_index_tracks(mock_index_task, app):
         web3 = Web3()
         update_task = UpdateTask(ipfs_client, web3, challenge_event_bus)
 
-    pending_track_routes = []
-
     with db.scoped_session() as session, challenge_event_bus.use_scoped_dispatch_queue():
         # ================== Test New Track Event ==================
         event_type, entry = get_new_track_event()
@@ -245,7 +243,6 @@ def test_index_tracks(mock_index_task, app):
             track_record,  # User ORM instance
             block_number,  # Used to forward to track uploads challenge
             block_timestamp,  # Used to update the user.updated_at field
-            pending_track_routes,
         )
 
         # updated_at should be updated every parse_track_event
@@ -322,7 +319,6 @@ def test_index_tracks(mock_index_task, app):
             track_record,
             block_number,
             block_timestamp,
-            pending_track_routes,
         )
 
         # Check that track routes are updated appropriately
@@ -392,7 +388,6 @@ def test_index_tracks(mock_index_task, app):
             track_record_dupe,
             block_number,
             block_timestamp,
-            pending_track_routes,
         )
 
         # Check that track routes are assigned appropriately
@@ -429,7 +424,6 @@ def test_index_tracks(mock_index_task, app):
             track_record_dupe,
             block_number,
             block_timestamp,
-            pending_track_routes,
         )
 
         # Check that track routes are assigned appropriately
@@ -454,11 +448,8 @@ def test_index_tracks(mock_index_task, app):
         )
         assert track_route
 
-        # Make sure the blocks are committed
-        session.commit()
-        pending_track_routes.clear()
         revert_blocks(mock_index_task, db, [second_block])
-        # Commit the revert
+
         session.commit()
 
         track_routes = session.query(TrackRoute).all()
@@ -494,7 +485,6 @@ def test_index_tracks(mock_index_task, app):
             track_record,  # User ORM instance
             block_number,  # Used to forward to track uploads challenge
             block_timestamp,  # Used to update the user.updated_at field
-            pending_track_routes,
         )
 
         # =================== Test track __repr___ ======================

--- a/discovery-provider/tests/test_index_tracks.py
+++ b/discovery-provider/tests/test_index_tracks.py
@@ -447,9 +447,10 @@ def test_index_tracks(mock_index_task, app):
             .all()
         )
         assert track_route
-
+        # Commit the new blocks
+        session.commit()
         revert_blocks(mock_index_task, db, [second_block])
-
+        # Commit the revert
         session.commit()
 
         track_routes = session.query(TrackRoute).all()


### PR DESCRIPTION
### Description

_What is the purpose of this PR? What is the current behavior? New behavior? Relevant links (e.g. Trello) and/or information pertaining to PR?_

Previously, a change went in to avoid using `session.commit()` by tracking additional routes to be appended separately and manually. This PR reverts that change after discovering that `session.flush()` does what we want: https://stackoverflow.com/questions/4201455/sqlalchemy-whats-the-difference-between-flush-and-commit

### Tests

_List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible.\
:exclamation: If this change impacts clients, make sure that you have tested the clients :exclamation:_

Existing unit tests

**:exclamation: Reminder :bulb::exclamation::**\
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label. **Add relevant labels as necessary.**

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
