### PR TITLE
Add trending challenges

### DIFF
--- a/discovery-provider/alembic/versions/7693ab16e2e1_create_trending_challenge.py
+++ b/discovery-provider/alembic/versions/7693ab16e2e1_create_trending_challenge.py
@@ -1,0 +1,43 @@
+"""create_trending_challenge
+
+Revision ID: 7693ab16e2e1
+Revises: 9562cf365cf4
+Create Date: 2021-08-12 12:54:57.042823
+
+"""
+from alembic import op
+from sqlalchemy.orm.session import Session
+import sqlalchemy as sa
+from src.challenges.create_new_challenges import create_new_challenges
+
+
+# revision identifiers, used by Alembic.
+revision = "7693ab16e2e1"
+down_revision = "9562cf365cf4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "trending_results",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.String()),
+        sa.Column("rank", sa.Integer(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("version", sa.String(), nullable=False),
+        sa.Column("week", sa.Date()),
+        sa.PrimaryKeyConstraint("rank", "type", "version", "week"),
+    )
+
+    # Create the challenges if needed
+    connection = op.get_bind()
+    session = Session(bind=connection)
+    allowed_challenge_types = set(["trending"])
+    create_new_challenges(session, allowed_challenge_types)
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    op.drop_table("trending_results")

--- a/discovery-provider/alembic/versions/7693ab16e2e1_create_trending_challenge.py
+++ b/discovery-provider/alembic/versions/7693ab16e2e1_create_trending_challenge.py
@@ -1,7 +1,7 @@
 """create_trending_challenge
 
 Revision ID: 7693ab16e2e1
-Revises: 9562cf365cf4
+Revises: 169519f975c2
 Create Date: 2021-08-12 12:54:57.042823
 
 """
@@ -13,7 +13,7 @@ from src.challenges.create_new_challenges import create_new_challenges
 
 # revision identifiers, used by Alembic.
 revision = "7693ab16e2e1"
-down_revision = "9562cf365cf4"
+down_revision = "169519f975c2"
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/80271bf86c56_modify_challenges_schema.py
+++ b/discovery-provider/alembic/versions/80271bf86c56_modify_challenges_schema.py
@@ -1,7 +1,7 @@
 """Modify challenges schema
 
 Revision ID: 80271bf86c56
-Revises: 436c10e54758
+Revises: 301b1e42dc4b
 Create Date: 2021-06-28 19:31:27.094479
 
 """

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -30,6 +30,7 @@ jsonformatter==0.3.0
 pytest-postgresql==2.4.1
 eventlet==0.28.0
 psutil==5.8.0
+pytz==2021.1
 
 # Solana support
 base58==2.1.0

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -5,6 +5,7 @@ sqlalchemy-stubs==0.4
 types-python-dateutil==0.1.4
 types-redis==3.5.4
 types-requests==2.25.0
+types-pytz==2021.1.2
 
 # web3 used to be 5.11.0 but due to a build issue in docker, downgraded to 5.8.0
 web3==5.8.0
@@ -46,3 +47,4 @@ six==1.15.0
 solana==0.9.2
 typing-extensions==3.7.4.3
 urllib3==1.26.3
+types-pytz

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -369,6 +369,7 @@ def configure_celery(flask_app, celery, test_config=None):
             "src.tasks.index_oracles",
             "src.tasks.index_rewards_manager",
             "src.tasks.index_related_artists",
+            "src.tasks.calculate_trending_challenges",
         ],
         beat_schedule={
             "update_discovery_provider": {
@@ -503,6 +504,7 @@ def configure_celery(flask_app, celery, test_config=None):
     redis_inst.delete("index_eth_lock")
     redis_inst.delete("index_oracles_lock")
     redis_inst.delete("solana_rewards_manager_lock")
+    redis_inst.delete("calculate_trending_challenges_lock")
     logger.info("Redis instance initialized!")
 
     # Initialize custom task context with database object

--- a/discovery-provider/src/challenges/challenge.py
+++ b/discovery-provider/src/challenges/challenge.py
@@ -223,28 +223,48 @@ class ChallengeManager:
                 self._create_new_user_challenge(
                     metadata["user_id"], metadata["specifier"]
                 )
-                for metadata in to_create_metadata
-            ]
-            # Do any other custom work needed after creating a challenge event
-            self._updater.on_after_challenge_creation(session, to_create_metadata)
+                .filter(
+                    UserChallenge.challenge_id == self.challenge_id,
+                    UserChallenge.user_id.in_(user_ids),
+                )
+                .group_by(UserChallenge.user_id)
+            ).all()
+            challenges_per_user = dict(all_user_challenges)
+            for new_metadata in new_challenge_metadata:
+                completion_count = challenges_per_user.get(new_metadata["user_id"], 0)
+                if self._step_count and completion_count >= self._step_count:
+                    continue
+                if not self._updater.should_create_new_challenge(
+                    event_type, new_metadata["user_id"], new_metadata["extra"]
+                ):
+                    continue
+                to_create_metadata.append(new_metadata)
+        else:
+            to_create_metadata = new_challenge_metadata
 
-            # Update all the challenges
+        new_user_challenges = [
+            self._create_new_user_challenge(metadata["user_id"], metadata["specifier"])
+            for metadata in to_create_metadata
+        ]
+        # Do any other custom work needed after creating a challenge event
+        self._updater.on_after_challenge_creation(session, to_create_metadata)
 
-            in_progress_challenges = [
-                challenge
-                for challenge in existing_user_challenges
-                if not challenge.is_complete
-            ]
-            to_update = in_progress_challenges + new_user_challenges
+        # Update all the challenges
+        in_progress_challenges = [
+            challenge
+            for challenge in existing_user_challenges
+            if not challenge.is_complete
+        ]
+        to_update = in_progress_challenges + new_user_challenges
 
-            self._updater.update_user_challenges(
-                session,
-                event_type,
-                to_update,
-                self._step_count,
-                events_with_specifiers,
-                self._starting_block,
-            )
+        self._updater.update_user_challenges(
+            session,
+            event_type,
+            to_update,
+            self._step_count,
+            events_with_specifiers,
+            self._starting_block,
+        )
 
             # Add block # to newly completed challenges
             for challenge in to_update:

--- a/discovery-provider/src/challenges/challenge_event.py
+++ b/discovery-provider/src/challenges/challenge_event.py
@@ -15,3 +15,6 @@ class ChallengeEvent(str, enum.Enum):
     referred_signup = "referred_signup"  # Fired for the new user
     connect_verified = "connect_verified"
     mobile_install = "mobile_install"
+    trending_track = "trending_track"
+    trending_underground = "trending_underground"
+    trending_playlist = "trending_playlist"

--- a/discovery-provider/src/challenges/challenges.json
+++ b/discovery-provider/src/challenges/challenges.json
@@ -45,5 +45,23 @@
 		"type": "boolean",
 		"amount": "10",
 		"active": false
+	},
+	{
+		"id": "trending-track",
+		"type": "trending",
+		"amount": "100",
+		"active": false
+	},
+	{
+		"id": "trending-underground-track",
+		"type": "trending",
+		"amount": "100",
+		"active": false
+	},
+	{
+		"id": "trending-playlist",
+		"type": "trending",
+		"amount": "100",
+		"active": false
 	}
 ]

--- a/discovery-provider/src/challenges/create_new_challenges.py
+++ b/discovery-provider/src/challenges/create_new_challenges.py
@@ -32,7 +32,7 @@ def create_new_challenges(session, allowed_challenge_types=[]):
         new_challenges = [
             challenge
             for challenge in new_challenges
-            if challenge.get("id") in allowed_challenge_types
+            if challenge.get("type") in allowed_challenge_types
         ]
     logger.info(f"Adding challenges: {new_challenges}")
 

--- a/discovery-provider/src/challenges/create_new_challenges.py
+++ b/discovery-provider/src/challenges/create_new_challenges.py
@@ -16,7 +16,7 @@ def get_challenges_dicts():
         return parsed
 
 
-def create_new_challenges(session):
+def create_new_challenges(session, allowed_challenge_types=[]):
     challenges_dicts = get_challenges_dicts()
     challenges = []
     existing_challenges = session.query(Challenge).all()
@@ -26,6 +26,14 @@ def create_new_challenges(session):
     new_challenges = list(
         filter(lambda c: c.get("id") not in existing_ids, challenges_dicts)
     )
+
+    # if allowed_challenge_typed defined, filter out non-type
+    if allowed_challenge_types:
+        new_challenges = [
+            challenge
+            for challenge in new_challenges
+            if challenge.get("id") in allowed_challenge_types
+        ]
     logger.info(f"Adding challenges: {new_challenges}")
 
     # Add all the new challenges

--- a/discovery-provider/src/challenges/create_new_challenges.py
+++ b/discovery-provider/src/challenges/create_new_challenges.py
@@ -16,7 +16,9 @@ def get_challenges_dicts():
         return parsed
 
 
-def create_new_challenges(session, allowed_challenge_types=[]):
+def create_new_challenges(session, allowed_challenge_types=None):
+    if not allowed_challenge_types:
+        allowed_challenge_types = []
     challenges_dicts = get_challenges_dicts()
     challenges = []
     existing_challenges = session.query(Challenge).all()

--- a/discovery-provider/src/challenges/trending_challenge.py
+++ b/discovery-provider/src/challenges/trending_challenge.py
@@ -1,28 +1,17 @@
 import logging
-from sqlalchemy import desc
-
-from src.models.trending_result import TrendingResult
 from typing import List, Optional, Tuple, Dict
 from datetime import date, datetime, timedelta
+from sqlalchemy.orm.session import Session
+from sqlalchemy import desc
 import pytz
-from sqlalchemy.orm.session import Session
-from src.models import (
-    UserChallenge,
-)
-from src.challenges.challenge import (
-    ChallengeManager,
-    ChallengeUpdater,
-    FullEventMetadata,
-)
 
-from typing import List, Optional
-from sqlalchemy.orm.session import Session
 from src.challenges.challenge import (
     ChallengeManager,
     ChallengeUpdater,
     FullEventMetadata,
 )
 from src.models.models import UserChallenge
+from src.models.trending_result import TrendingResult
 
 logger = logging.getLogger(__name__)
 

--- a/discovery-provider/src/challenges/trending_challenge.py
+++ b/discovery-provider/src/challenges/trending_challenge.py
@@ -1,0 +1,122 @@
+import logging
+from sqlalchemy import desc
+
+from src.models.trending_result import TrendingResult
+from typing import List, Literal, Optional, Union, Tuple
+from redis import Redis
+from datetime import date, datetime, timedelta
+import pytz
+from sqlalchemy.orm.session import Session
+from src.models import (
+    UserChallenge,
+)
+from src.challenges.challenge import (
+    ChallengeManager,
+    ChallengeUpdater,
+    FullEventMetadata,
+)
+
+from typing import List, Optional
+from sqlalchemy.orm.session import Session
+from src.challenges.challenge import (
+    ChallengeManager,
+    ChallengeUpdater,
+    FullEventMetadata,
+)
+from src.models.models import UserChallenge
+
+logger = logging.getLogger(__name__)
+
+
+class TrendingChallengeUpdater(ChallengeUpdater):
+    """Updates the trending track challenge."""
+
+    def update_user_challenges(
+        self,
+        session: Session,
+        event: str,
+        user_challenges: List[UserChallenge],
+        step_count: Optional[int],
+        event_metadatas: List[FullEventMetadata],
+        starting_block: Optional[int],
+    ):
+        # Update the user_challenges
+        for user_challenge in user_challenges:
+            # Update completion
+            user_challenge.is_complete = True
+
+    def on_after_challenge_creation(self, session, metadatas: List[FullEventMetadata]):
+        trending_results = [
+            TrendingResult(
+                user_id=metadata["extra"]["user_id"],
+                id=metadata["extra"]["id"],
+                rank=metadata["extra"]["rank"],
+                type=metadata["extra"]["type"],
+                version=metadata["extra"]["version"],
+                week=metadata["extra"]["week"],
+            )
+            for metadata in metadatas
+        ]
+        session.add_all(trending_results)
+
+
+trending_track_challenge_manager = ChallengeManager(
+    "trending-track", TrendingChallengeUpdater()
+)
+
+trending_underground_track_challenge_manager = ChallengeManager(
+    "trending-underground-track", TrendingChallengeUpdater()
+)
+
+trending_playlist_challenge_manager = ChallengeManager(
+    "trending-playlist", TrendingChallengeUpdater()
+)
+
+def is_dst(zonename):
+    """Checks if is daylight savings time
+    During daylight savings, the clock moves forward one hr
+    """
+    tz = pytz.timezone(zonename)
+    now = pytz.utc.localize(datetime.utcnow())
+    return now.astimezone(tz).dst() != timedelta(0)
+
+
+def get_is_valid_timestamp(dt: datetime):
+
+    isFriday = dt.weekday() == 4
+
+    # Check timestamp to be between 12pm and 1pm PT
+    add_hr = is_dst("America/Los_Angeles")
+    min = 19 if add_hr else 20
+    max = 20 if add_hr else 21
+
+    isWithinHourMargin = dt.hour >= min and dt.hour < max
+
+    return isFriday and isWithinHourMargin
+
+
+def should_trending_challenge_update(
+    session: Session, timestamp: int
+) -> Tuple[bool, Optional[date]]:
+    """Checks if the timestamp is after a week and there is no pending trending update"""
+
+    dt = datetime.fromtimestamp(timestamp)
+    is_valid_timestamp = get_is_valid_timestamp(dt)
+    if not is_valid_timestamp:
+        return (False, None)
+
+    # DB query for most recent db row of trending's date
+    # using that, figure out new date threshold -> next friday at noon
+    most_recent_user_challenge = (
+        session.query(TrendingResult.week).order_by(desc(TrendingResult.week)).first()
+    )
+
+    if most_recent_user_challenge is None:
+        # do somthing
+        return (True, dt.date())
+    week = most_recent_user_challenge[0]
+
+    if week == dt.date():
+        return (False, None)
+
+    return (True, dt.date())

--- a/discovery-provider/src/challenges/trending_challenge.py
+++ b/discovery-provider/src/challenges/trending_challenge.py
@@ -2,8 +2,7 @@ import logging
 from sqlalchemy import desc
 
 from src.models.trending_result import TrendingResult
-from typing import List, Literal, Optional, Union, Tuple
-from redis import Redis
+from typing import List, Optional, Tuple, Dict
 from datetime import date, datetime, timedelta
 import pytz
 from sqlalchemy.orm.session import Session
@@ -59,6 +58,9 @@ class TrendingChallengeUpdater(ChallengeUpdater):
         ]
         session.add_all(trending_results)
 
+    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+        return f"{extra['rank']}"
+
 
 trending_track_challenge_manager = ChallengeManager(
     "trending-track", TrendingChallengeUpdater()
@@ -71,6 +73,7 @@ trending_underground_track_challenge_manager = ChallengeManager(
 trending_playlist_challenge_manager = ChallengeManager(
     "trending-playlist", TrendingChallengeUpdater()
 )
+
 
 def is_dst(zonename):
     """Checks if is daylight savings time
@@ -98,7 +101,9 @@ def get_is_valid_timestamp(dt: datetime):
 def should_trending_challenge_update(
     session: Session, timestamp: int
 ) -> Tuple[bool, Optional[date]]:
-    """Checks if the timestamp is after a week and there is no pending trending update"""
+    """Checks if the timestamp is after a week and there is no pending trending update
+    Returns a tuple of boolean if the challenge should be updated, and if it's set to true, the date
+    """
 
     dt = datetime.fromtimestamp(timestamp)
     is_valid_timestamp = get_is_valid_timestamp(dt)

--- a/discovery-provider/src/models/__init__.py
+++ b/discovery-provider/src/models/__init__.py
@@ -51,6 +51,7 @@ from .track_route import TrackRoute
 from .user_bank import UserBankTransaction
 from .user_bank import UserBankAccount
 from .user_events import UserEvents
+from .trending_result import TrendingResult
 
 __all__ = [
     "AggregateDailyAppNameMetrics",
@@ -96,6 +97,7 @@ __all__ = [
     "TagTrackUserMatview",
     "Track",
     "TrackRoute",
+    "TrendingResult",
     "URSMContentNode",
     "User",
     "UserBalance",

--- a/discovery-provider/src/models/trending_result.py
+++ b/discovery-provider/src/models/trending_result.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, String, Date, PrimaryKeyConstraint
+from .models import Base
+
+
+class TrendingResult(Base):
+    """
+    Trending Reults track the top trending tracks/playlists each week to keep a record of the winners
+    for reference in the trending challenges
+    """
+
+    __tablename__ = "trending_results"
+    user_id = Column(Integer, nullable=False, index=True)
+    id = Column(Integer, nullable=False)
+    rank = Column(Integer, nullable=False)
+    type = Column(String, nullable=False)
+    version = Column(String, nullable=False)
+    week = Column(Date, nullable=False)
+    PrimaryKeyConstraint(rank, type, version, week)
+
+    def __repr__(self):
+        return f"<TrendingResult(\
+user_id={self.user_id},\
+id={self.id},\
+type={self.type},\
+version={self.version},\
+week={self.week},\
+)>"

--- a/discovery-provider/src/models/trending_result.py
+++ b/discovery-provider/src/models/trending_result.py
@@ -4,7 +4,7 @@ from .models import Base
 
 class TrendingResult(Base):
     """
-    Trending Reults track the top trending tracks/playlists each week to keep a record of the winners
+    Trending Results track the top trending tracks/playlists each week to keep a record of the winners
     for reference in the trending challenges
     """
 

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -40,7 +40,7 @@ def get_latest_blocknumber(session: Session, redis: Redis) -> Optional[int]:
     db_block_query = (
         session.query(Block.number).filter(Block.is_current == True).first()
     )
-    if not db_block_query:
+    if db_block_query is None:
         return None
     return db_block_query[0]
 
@@ -83,7 +83,7 @@ def enqueue_trending_challenges(
     with db.scoped_session() as session, challenge_bus.use_scoped_dispatch_queue():
 
         latest_blocknumber = get_latest_blocknumber(session, redis)
-        if not latest_blocknumber:
+        if latest_blocknumber is None:
             logger.error(
                 "calculate_trending_challenges.py | Unable to get latest block number"
             )

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -1,0 +1,179 @@
+import logging
+import time
+from redis import Redis
+from src.models import Block
+from src.tasks.celery_app import celery
+from src.queries.get_trending_tracks import (
+    make_trending_cache_key,
+    generate_unpopulated_trending,
+)
+from src.queries.get_trending_playlists import (
+    make_trending_cache_key as make_trending_cache_key_playlists,
+    make_get_unpopulated_playlists,
+)
+from src.utils.redis_cache import pickle_and_set
+from src.challenges.challenge_event import ChallengeEvent
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.queries.get_underground_trending import (
+    make_underground_trending_cache_key,
+    make_get_unpopulated_tracks,
+)
+from sqlalchemy.orm.session import Session
+from src.utils.redis_constants import most_recent_indexed_block_redis_key
+
+logger = logging.getLogger(__name__)
+time_ranges = ["week", "month", "year"]
+
+trending_strategy_factory = TrendingStrategyFactory()
+
+
+def get_latest_blocknumber(session: Session, redis: Redis) -> int:
+    # get latest db state from redis cache
+    latest_indexed_block_num = redis.get(most_recent_indexed_block_redis_key)
+    if latest_indexed_block_num is not None:
+        return int(latest_indexed_block_num)
+    db_block_query = (
+        session.query(Block.number).filter(Block.is_current == True).first()
+    )
+    return db_block_query[0]
+
+
+# The number of users to recieve the trending rewards
+TRENDING_LIMIT = 5
+
+
+def enqueue_trending_challenges(db, redis, challenge_bus, date):
+    logger.info(
+        "calculate_trending_challenges.py | Start calculating trending challenges"
+    )
+    update_start = time.time()
+    with db.scoped_session() as session:
+
+        latest_blocknumber = get_latest_blocknumber(session, redis)
+
+        trending_track_versions = trending_strategy_factory.get_versions_for_type(
+            TrendingType.TRACKS
+        ).keys()
+
+        genre = None
+        time_range = "week"
+
+        for version in trending_track_versions:
+            strategy = trending_strategy_factory.get_strategy(
+                TrendingType.TRACKS, version
+            )
+            res = generate_unpopulated_trending(session, genre, time_range, strategy)
+
+            key = make_trending_cache_key(time_range, genre, version)
+            pickle_and_set(redis, key, res)
+            top_tracks = res[0]
+            top_tracks = top_tracks[:TRENDING_LIMIT]
+            for idx, track in enumerate(top_tracks):
+                challenge_bus.dispatch(
+                    session,
+                    ChallengeEvent.trending_track,
+                    latest_blocknumber,
+                    track["owner_id"],
+                    {
+                        "id": track["track_id"],
+                        "user_id": track["owner_id"],
+                        "rank": idx + 1,
+                        "type": str(TrendingType.TRACKS),
+                        "version": str(version),
+                        "week": str(date),
+                    },
+                )
+
+        # Cache underground trending
+        underground_trending_versions = trending_strategy_factory.get_versions_for_type(
+            TrendingType.UNDERGROUND_TRACKS
+        ).keys()
+        for version in underground_trending_versions:
+            strategy = trending_strategy_factory.get_strategy(
+                TrendingType.UNDERGROUND_TRACKS, version
+            )
+            res = make_get_unpopulated_tracks(session, redis, strategy)()
+            key = make_underground_trending_cache_key(version)
+            pickle_and_set(redis, key, res)
+            top_underground_tracks = res[0]
+            top_underground_tracks = top_underground_tracks[:TRENDING_LIMIT]
+            for idx, track in enumerate(top_underground_tracks):
+                challenge_bus.dispatch(
+                    session,
+                    ChallengeEvent.trending_underground,
+                    latest_blocknumber,
+                    track["owner_id"],
+                    {
+                        "id": track["track_id"],
+                        "user_id": track["owner_id"],
+                        "rank": idx + 1,
+                        "type": str(TrendingType.UNDERGROUND_TRACKS),
+                        "version": str(version),
+                        "week": str(date),
+                    },
+                )
+
+        trending_playlist_versions = trending_strategy_factory.get_versions_for_type(
+            TrendingType.PLAYLISTS
+        ).keys()
+        for version in trending_playlist_versions:
+            strategy = trending_strategy_factory.get_strategy(
+                TrendingType.PLAYLISTS, version
+            )
+            key = make_trending_cache_key_playlists(time_range, strategy.version)
+            res = make_get_unpopulated_playlists(session, time_range, strategy)()
+            pickle_and_set(redis, key, res)
+            top_playlists = res[0]
+            top_playlists = top_playlists[:TRENDING_LIMIT]
+            for idx, playlist in enumerate(top_playlists):
+                challenge_bus.dispatch(
+                    session,
+                    ChallengeEvent.trending_playlist,
+                    latest_blocknumber,
+                    playlist["playlist_owner_id"],
+                    {
+                        "id": playlist["playlist_id"],
+                        "user_id": playlist["playlist_owner_id"],
+                        "rank": idx + 1,
+                        "type": str(TrendingType.PLAYLISTS),
+                        "version": str(version),
+                        "week": str(date),
+                    },
+                )
+
+    update_end = time.time()
+    update_total = update_end - update_start
+    logger.info(
+        f"calculate_trending_challenges.py | Finished calculating trending in {update_total} seconds"
+    )
+
+
+######## CELERY TASKS ########
+@celery.task(name="calculate_trending_challenges", bind=True)
+def calculate_trending_challenges_task(self, date=None):
+    """Caches all trending combination of time-range and genre (including no genre)."""
+    if date is None:
+        logger.error("calculate_trending_challenges.py | Must be called with a date")
+        return
+    db = calculate_trending_challenges_task.db
+    redis = calculate_trending_challenges_task.redis
+    challenge_bus = calculate_trending_challenges_task.challenge_event_bus
+    have_lock = False
+    update_lock = redis.lock("calculate_trending_challenges_lock", timeout=7200)
+    try:
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            enqueue_trending_challenges(db, redis, challenge_bus, date)
+        else:
+            logger.info(
+                "calculate_trending_challenges.py | Failed to acquire index trending lock"
+            )
+    except Exception as e:
+        logger.error(
+            "calculate_trending_challenges.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -1,6 +1,8 @@
 import logging
 import time
 from redis import Redis
+from sqlalchemy.orm.session import Session
+
 from src.models import Block
 from src.tasks.celery_app import celery
 from src.queries.get_trending_tracks import (
@@ -19,11 +21,9 @@ from src.queries.get_underground_trending import (
     make_underground_trending_cache_key,
     make_get_unpopulated_tracks,
 )
-from sqlalchemy.orm.session import Session
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 
 logger = logging.getLogger(__name__)
-time_ranges = ["week", "month", "year"]
 
 trending_strategy_factory = TrendingStrategyFactory()
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,13 +1,13 @@
 # pylint: disable=C0302
 import concurrent.futures
 import logging
-from src.challenges.trending_challenge import should_trending_challenge_update
-
 from sqlalchemy import func
+
 from src.app import contract_addresses
 from src.utils import helpers, multihash
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.challenges.challenge_event_bus import ChallengeEventBus
+from src.challenges.trending_challenge import should_trending_challenge_update
 from src.models import (
     AssociatedWallet,
     Block,
@@ -646,7 +646,7 @@ def index_blocks(self, db, blocks_list):
         try:
             # Check the last block's timestamp for updating the trending challenge
             [should_update, date] = should_trending_challenge_update(
-                redis, session, latest_block_timestamp
+                session, latest_block_timestamp
             )
             if should_update:
                 celery.send_task("calculate_trending_challenges", kwargs={"date": date})

--- a/discovery-provider/tests/test_connect_verified_challenge.py
+++ b/discovery-provider/tests/test_connect_verified_challenge.py
@@ -12,7 +12,7 @@ REDIS_URL = shared_config["redis"]["url"]
 logger = logging.getLogger(__name__)
 
 
-def test_listen_streak_challenge(app):
+def test_connect_verified_challenge(app):
     redis_conn = redis.Redis.from_url(url=REDIS_URL)
 
     with app.app_context():

--- a/discovery-provider/tests/test_trending_challenge.py
+++ b/discovery-provider/tests/test_trending_challenge.py
@@ -1,0 +1,283 @@
+import logging
+from datetime import date, datetime, timedelta
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.models.models import UserChallenge
+from src.models import TrendingResult, AggregatePlays
+from src.challenges.trending_challenge import should_trending_challenge_update
+import redis
+
+from src.models import User, Block
+from src.utils.db_session import get_db
+from src.challenges.trending_challenge import (
+    trending_track_challenge_manager,
+    trending_underground_track_challenge_manager,
+    trending_playlist_challenge_manager,
+)
+from src.challenges.challenge_event_bus import ChallengeEventBus, ChallengeEvent
+from src.utils.config import shared_config
+from src.tasks.calculate_trending_challenges import enqueue_trending_challenges
+from tests.utils import populate_mock_db
+
+REDIS_URL = shared_config["redis"]["url"]
+logger = logging.getLogger(__name__)
+
+"""
+def test_trending_challenge_should_update(app):
+    with app.app_context():
+        db = get_db()
+    redis_conn = redis.Redis.from_url(url=REDIS_URL)
+
+    with db.scoped_session() as session:
+
+        # ========== Test timestamp w/out trending result in DB ==========
+
+        # If the timestamp is outside of threshold and nothing in db
+        # Wrong time, wrong day
+        timestamp = 1629132028
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert not should_update
+
+        # Right time, wrong day
+        timestamp = 1629140400
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert not should_update
+
+        # wrong time, right day
+        timestamp = 1629489600
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert not should_update
+
+        # Within bounds
+        timestamp = 1629486000
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert should_update
+
+        # ========== Test working timestamp with trending result in DB ==========
+        session.add(
+            TrendingResult(
+                user_id=1,
+                rank=1,
+                id="1",
+                type="tracks",
+                version="ePWJD",
+                week="2021-08-20",
+            )
+        )
+        session.flush()
+
+        # Test same date as inserted trending result, so return false
+        timestamp = 1629486000
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert not should_update
+
+        # Test week after inserted trending result, so return true
+        timestamp = 1630090800
+        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        assert should_update
+
+"""
+
+
+def test_trending_challenge_job(app):
+    with app.app_context():
+        db = get_db()
+    redis_conn = redis.Redis.from_url(url=REDIS_URL)
+
+    test_entities = {
+        "tracks": [
+            {"track_id": 1, "owner_id": 1},
+            {"track_id": 2, "owner_id": 2},
+            {"track_id": 3, "owner_id": 3},
+            {"track_id": 4, "owner_id": 4},
+            {"track_id": 5, "owner_id": 5},
+            {"track_id": 6, "owner_id": 2},
+            {"track_id": 7, "owner_id": 3},
+            {"track_id": 8, "owner_id": 3},
+            {"track_id": 9, "is_unlisted": True, "owner_id": 3},
+            {"track_id": 11, "owner_id": 1},
+            {"track_id": 12, "owner_id": 2},
+            {"track_id": 13, "owner_id": 3},
+            {"track_id": 14, "owner_id": 4},
+            {"track_id": 15, "owner_id": 5},
+        ],
+        "playlists": [
+            {
+                "playlist_id": 1,
+                "playlist_owner_id": 1,
+                "playlist_contents": {
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                    ]
+                },
+            },
+            {
+                "playlist_id": 2,
+                "playlist_owner_id": 2,
+                "playlist_contents": {
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                    ]
+                },
+            },
+            {
+                "playlist_id": 3,
+                "is_album": True,
+                "playlist_owner_id": 3,
+                "playlist_contents": {
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                    ]
+                },
+            },
+            {
+                "playlist_id": 4,
+                "playlist_owner_id": 4,
+                "playlist_contents": {
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                    ]
+                },
+            },
+            {
+                "playlist_id": 5,
+                "playlist_owner_id": 5,
+                "playlist_contents": {
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                    ]
+                },
+            },
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user1"},
+            {"user_id": 2, "handle": "user2"},
+            {"user_id": 3, "handle": "user3"},
+            {"user_id": 4, "handle": "user4"},
+            {"user_id": 5, "handle": "user5"},
+        ],
+        "follows": [
+            {
+                "follower_user_id": 1,
+                "followee_user_id": 2,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 1,
+                "followee_user_id": 3,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 2,
+                "followee_user_id": 3,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 2,
+                "followee_user_id": 4,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 3,
+                "followee_user_id": 6,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 4,
+                "followee_user_id": 5,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 5,
+                "followee_user_id": 1,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+            {
+                "follower_user_id": 6,
+                "followee_user_id": 3,
+                "created_at": datetime.now() - timedelta(days=8),
+            },
+        ],
+        "reposts": [
+            {"repost_item_id": 1, "repost_type": "track", "user_id": 2},
+            {"repost_item_id": 1, "repost_type": "playlist", "user_id": 2},
+            {"repost_item_id": 3, "repost_type": "track", "user_id": 3},
+            {"repost_item_id": 1, "repost_type": "playlist", "user_id": 3},
+            {"repost_item_id": 4, "repost_type": "track", "user_id": 1},
+            {"repost_item_id": 5, "repost_type": "track", "user_id": 1},
+            {"repost_item_id": 6, "repost_type": "track", "user_id": 1},
+        ],
+        "saves": [
+            {"save_item_id": 1, "save_type": "track", "user_id": 2},
+            {"save_item_id": 1, "save_type": "track", "user_id": 3},
+            {"save_item_id": 4, "save_type": "track", "user_id": 1},
+            {"save_item_id": 5, "save_type": "track", "user_id": 1},
+            {"save_item_id": 6, "save_type": "track", "user_id": 1},
+            {"save_item_id": 1, "save_type": "playlist", "user_id": 4},
+            {"save_item_id": 2, "save_type": "playlist", "user_id": 3},
+            {"save_item_id": 3, "save_type": "playlist", "user_id": 2},
+            {"save_item_id": 4, "save_type": "playlist", "user_id": 1},
+            {"save_item_id": 5, "save_type": "playlist", "user_id": 2},
+        ],
+        "plays": [{"item_id": 1} for _ in range(55)]
+        + [{"item_id": 2} for _ in range(60)]
+        + [{"item_id": 3} for _ in range(70)]
+        + [{"item_id": 4} for _ in range(90)]
+        + [{"item_id": 5} for _ in range(80)]
+        + [{"item_id": 6} for _ in range(40)]
+        + [{"item_id": 11} for _ in range(200)]
+        + [{"item_id": 12} for _ in range(200)]
+        + [{"item_id": 13} for _ in range(200)]
+        + [{"item_id": 14} for _ in range(200)]
+        + [{"item_id": 15} for _ in range(200)],
+    }
+
+    populate_mock_db(db, test_entities)
+    bus = ChallengeEventBus(redis_conn)
+
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.trending_underground,
+        trending_underground_track_challenge_manager,
+    )
+    bus.register_listener(
+        ChallengeEvent.trending_track, trending_track_challenge_manager
+    )
+    bus.register_listener(
+        ChallengeEvent.trending_playlist, trending_playlist_challenge_manager
+    )
+
+    trending_date = date.fromisoformat("2021-08-20")
+
+    with db.scoped_session() as session:
+        session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+        session.execute("REFRESH MATERIALIZED VIEW aggregate_user")
+        session.commit()
+
+    enqueue_trending_challenges(db, redis_conn, bus, trending_date)
+
+    with db.scoped_session() as session:
+        bus.process_events(session)
+        session.flush()
+        trending_tracks = (
+            session.query(TrendingResult)
+            .filter(TrendingResult.type == str(TrendingType.TRACKS))
+            .all()
+        )
+        assert len(trending_tracks) == 5
+
+        trending_playlists = (
+            session.query(TrendingResult)
+            .filter(TrendingResult.type == str(TrendingType.PLAYLISTS))
+            .all()
+        )
+        assert len(trending_playlists) == 5

--- a/discovery-provider/tests/test_trending_challenge.py
+++ b/discovery-provider/tests/test_trending_challenge.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 def test_trending_challenge_should_update(app):
     with app.app_context():
         db = get_db()
-    redis_conn = redis.Redis.from_url(url=REDIS_URL)
 
     with db.scoped_session() as session:
 
@@ -34,22 +33,22 @@ def test_trending_challenge_should_update(app):
         # If the timestamp is outside of threshold and nothing in db
         # Wrong time, wrong day
         timestamp = 1629132028
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert not should_update
 
         # Right time, wrong day
         timestamp = 1629140400
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert not should_update
 
         # wrong time, right day
         timestamp = 1629489600
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert not should_update
 
         # Within bounds
         timestamp = 1629486000
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert should_update
 
         # ========== Test working timestamp with trending result in DB ==========
@@ -67,12 +66,12 @@ def test_trending_challenge_should_update(app):
 
         # Test same date as inserted trending result, so return false
         timestamp = 1629486000
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert not should_update
 
         # Test week after inserted trending result, so return true
         timestamp = 1630090800
-        should_update = should_trending_challenge_update(redis_conn, session, timestamp)
+        should_update, timestamp = should_trending_challenge_update(session, timestamp)
         assert should_update
 
 
@@ -102,6 +101,8 @@ def test_trending_challenge_job(app):
             {
                 "playlist_id": 1,
                 "playlist_owner_id": 1,
+                "playlist_name": "name",
+                "description": "description",
                 "playlist_contents": {
                     "track_ids": [
                         {"track": 1},
@@ -113,6 +114,8 @@ def test_trending_challenge_job(app):
             {
                 "playlist_id": 2,
                 "playlist_owner_id": 2,
+                "playlist_name": "name",
+                "description": "description",
                 "playlist_contents": {
                     "track_ids": [
                         {"track": 1},
@@ -125,6 +128,8 @@ def test_trending_challenge_job(app):
                 "playlist_id": 3,
                 "is_album": True,
                 "playlist_owner_id": 3,
+                "playlist_name": "name",
+                "description": "description",
                 "playlist_contents": {
                     "track_ids": [
                         {"track": 1},
@@ -136,6 +141,8 @@ def test_trending_challenge_job(app):
             {
                 "playlist_id": 4,
                 "playlist_owner_id": 4,
+                "playlist_name": "name",
+                "description": "description",
                 "playlist_contents": {
                     "track_ids": [
                         {"track": 1},
@@ -147,6 +154,8 @@ def test_trending_challenge_job(app):
             {
                 "playlist_id": 5,
                 "playlist_owner_id": 5,
+                "playlist_name": "name",
+                "description": "description",
                 "playlist_contents": {
                     "track_ids": [
                         {"track": 1},

--- a/discovery-provider/tests/test_trending_challenge.py
+++ b/discovery-provider/tests/test_trending_challenge.py
@@ -21,7 +21,7 @@ from tests.utils import populate_mock_db
 REDIS_URL = shared_config["redis"]["url"]
 logger = logging.getLogger(__name__)
 
-"""
+
 def test_trending_challenge_should_update(app):
     with app.app_context():
         db = get_db()
@@ -74,8 +74,6 @@ def test_trending_challenge_should_update(app):
         timestamp = 1630090800
         should_update = should_trending_challenge_update(redis_conn, session, timestamp)
         assert should_update
-
-"""
 
 
 def test_trending_challenge_job(app):

--- a/discovery-provider/tests/test_trending_challenge.py
+++ b/discovery-provider/tests/test_trending_challenge.py
@@ -277,7 +277,7 @@ def test_trending_challenge_job(app):
             or_(
                 Challenge.id == "trending-playlist",
                 Challenge.id == "trending-track",
-                Challenge.id == "trending-underground",
+                Challenge.id == "trending-underground-track",
             )
         ).update({"active": True})
         bus.process_events(session)

--- a/discovery-provider/tests/utils.py
+++ b/discovery-provider/tests/utils.py
@@ -75,7 +75,7 @@ def populate_mock_db(db, entities, block_offset=0):
         challenges = entities.get("challenges", [])
         user_challenges = entities.get("user_challenges", [])
 
-        num_blocks = max(len(tracks), len(users), len(follows))
+        num_blocks = max(len(tracks), len(users), len(follows), len(saves))
 
         for i in range(block_offset, block_offset + num_blocks):
             block = models.Block(

--- a/discovery-provider/tests/utils.py
+++ b/discovery-provider/tests/utils.py
@@ -76,16 +76,19 @@ def populate_mock_db(db, entities, block_offset=0):
         user_challenges = entities.get("user_challenges", [])
 
         num_blocks = max(len(tracks), len(users), len(follows), len(saves))
-
         for i in range(block_offset, block_offset + num_blocks):
-            block = models.Block(
-                blockhash=hex(i),
-                number=i,
-                parenthash="0x01",
-                is_current=(i == 0),
+            max_block = (
+                session.query(models.Block).filter(models.Block.number == i).first()
             )
-            session.add(block)
-            session.flush()
+            if not max_block:
+                block = models.Block(
+                    blockhash=hex(i),
+                    number=i,
+                    parenthash="0x01",
+                    is_current=(i == 0),
+                )
+                session.add(block)
+                session.flush()
 
         for i, track_meta in enumerate(tracks):
             track = models.Track(


### PR DESCRIPTION
### Description
Adds challenges `trending-track`, `trending-underground-track`, `trending-playlist`

**Summary**
* During discovery indexing of poa blocks, checks the block timestamp for Friday at noon PT
* If found, kicks off a job to recalculate trending tracks/ underground tracks/ and playlists
* This job creates DB records for the top 5 of each trending and creates associated user challenges

**Changes**
* Create a migration to create a Trending Results table that store the trending results
* Adds dependency `pytz` to get if in daylight saving time
* Adds 3 challenges

Notes:
* Because we are altering the `challenges.json` file, I had to update the migration to not re-create all challenges because there exists a migration to add challenge types that is after the first call to create challenges. 
* The part that alters indexing, is wrapped in a try except and should not cause indexing failure if erroring
* Calling the calculate trending task does not stall indexing. 
Closes AUD-714
 
### Tests
tests for the checking of timestamp to kick off the create trending user challenges
tests for checking that the calculate trending challenges creates the trending results records and user challenge records. 

### How will this change be monitored?
Logs