### PR TITLE
Add wait for block indexing + misc changes

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -45,7 +45,7 @@ minimumDailySyncCount=5
 minimumRollingSyncCount=10
 minimumSuccessfulSyncCountPercentage=50
 snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
-secondaryUserSyncDailyFailureCountThreshold=10
+secondaryUserSyncDailyFailureCountThreshold=100
 minimumSecondaryUserSyncSuccessPercent=50
 minimumFailedSyncRequestsBeforeReconfig=5
 maxSyncMonitoringDurationInMs=10000 # 10sec
@@ -54,7 +54,7 @@ skippedCIDsRetryQueueJobIntervalMs=30000 # 30sec in ms
 
 # peerSetManager
 peerHealthCheckRequestTimeout=2000 # ms
-minimumStoragePathSize=10000000000 # bytes; 10gb
+minimumStoragePathSize=1000000000 # bytes; 1gb
 minimumMemoryAvailable=2000000000 # bytes; 2gb
 maxFileDescriptorsAllocatedPercentage=95
 maxNumberSecondsPrimaryRemainsUnhealthy=5

--- a/mad-dog/package.json
+++ b/mad-dog/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "🐶 Audius Protocol System Level Test Suite",
   "main": "src/index.js",
-   "scripts": {
+  "scripts": {
     "start": "node src/index.js --inspect",
     "link-deps": "npm link @audius/libs && npm link @audius/service-commands"
   },

--- a/mad-dog/src/emitter.js
+++ b/mad-dog/src/emitter.js
@@ -19,7 +19,7 @@ const Event = Object.freeze({
  */
 const tick = async (emitter, intervalSeconds, totalDurationSeconds) => {
   const token = setInterval(() => {
-    logger.info('Tick')
+    logger.info(`Tick at interval ${intervalSeconds * 1000}`)
     emitter.emit(Event.TICK)
   }, intervalSeconds * 1000)
 
@@ -83,7 +83,7 @@ class EmitterBasedTest {
   registerOnRequestListener (listener) {
     this.emitter.on(Event.REQUEST, request => {
       this.inFlightCount += 1
-      logger.info(`Handling request: [${request.type}]]`)
+      logger.info(`Handling request: [${request.type}]`)
       logger.info(`[${this.inFlightCount}] requests in flight.`)
       listener(request, this.emit)
     })

--- a/mad-dog/src/tests/test_integration.js
+++ b/mad-dog/src/tests/test_integration.js
@@ -114,7 +114,7 @@ module.exports = coreIntegration = async ({
           )
           res = new TrackUploadResponse(walletIndex, trackId, track)
         } catch (e) {
-          logger.warn(`Caught error [${e.message}] uploading track: [${track}]`)
+          logger.error(`Caught error [${e.message}] uploading track: [${JSON.stringify(track)}]\n${e.stack}`)
           res = new TrackUploadResponse(
             walletIndex,
             null,
@@ -277,9 +277,8 @@ module.exports = coreIntegration = async ({
   }
   const failedWallets = Object.values(failedUploads)
   if (failedWallets.length) {
-    logger.info({ failedWallets, failedUploads })
     const userIds = failedWallets.map(w => walletIdMap[w])
-    logger.warn(`Uploads failed for user IDs=[${userIds}]`)
+    logger.error(`Uploads failed for user IDs=[${userIds}]`)
   }
 
   // Switch user primary (above tests have already confirmed all secondaries have latest state)

--- a/service-commands/src/commands/tracks.js
+++ b/service-commands/src/commands/tracks.js
@@ -11,6 +11,9 @@ Track.uploadTrack = async (libs, trackMetadata, trackPath) => {
     trackMetadata
   })
 
+  // Wait for discovery node to index user
+  await libs.waitForLatestBlock()
+
   // Check that uploaded track is what we expect
   const uploadedTrackMetadata = await libs.getTrack(trackId)
 

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -122,7 +122,8 @@ function LibsWrapper (walletIndex = 0) {
       identityServiceConfig,
       creatorNodeConfig,
       isServer: true,
-      enableUserReplicaSetManagerContract: true
+      enableUserReplicaSetManagerContract: true,
+      useTrackContentPolling: true
     })
 
     try {
@@ -655,7 +656,7 @@ function LibsWrapper (walletIndex = 0) {
 
   /**
   * Wait for the discovery node to catch up to the latest block on chain up to a max
-  * indexing timeout of default 10000ms. Used to check IPLD block indexing.
+  * indexing timeout of default 10000ms.
   * @param {number} [maxIndexingTimeout=10000] max time indexing window
   */
   this.waitForLatestIPLDBlock = async (maxIndexingTimeout = MAX_INDEXING_TIMEOUT) => {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

**Context:** mad-dog was returning errors like 'No tracks returned' even though track uploads are successful. This is most likely due to the recent change in `ensurePrimaryMiddleware` where we do not wait for discovery to index replica set data, but instead call the URSM contract directly. 

mad-dog's `uploadTrack` method (1) uploads the track (2) grabs the track off of DN to see if what is uploaded is what we expect it to be. Without waiting on the discovery anymore, we potentially run into the issue where the indexing did not occur yet. Thus, failing the `uploadTrack` method. 

**Fix:** Wait for the block to be indexed before continuing with track upload.

**In this PR:**
- add indexing wait in uploadTrack method
- enable track polling in libs
- local dev env var updates
- misc comments/logs updates

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

- Fix mad-dog tests

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

- If mad-dog fails again, we will know

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->