### PR TITLE
[AUD-896] Move aggregate plays to separate celery task to increase frequency

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -351,6 +351,7 @@ def configure_celery(flask_app, celery, test_config=None):
             "src.tasks.index_plays",
             "src.tasks.index_metrics",
             "src.tasks.index_materialized_views",
+            "src.tasks.index_aggregate_plays",
             "src.tasks.vacuum_db",
             "src.tasks.index_network_peers",
             "src.tasks.index_trending",
@@ -393,6 +394,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "update_materialized_views": {
                 "task": "update_materialized_views",
                 "schedule": timedelta(seconds=300),
+            },
+            "update_aggregate_plays": {
+                "task": "update_aggregate_plays",
+                "schedule": timedelta(seconds=15),
             },
             "vacuum_db": {
                 "task": "vacuum_db",

--- a/discovery-provider/src/tasks/index_aggregate_plays.py
+++ b/discovery-provider/src/tasks/index_aggregate_plays.py
@@ -1,0 +1,46 @@
+import logging
+import time
+from src.tasks.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+
+def update(self, db):
+    with db.scoped_session() as session:
+        start_time = time.time()
+        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY aggregate_plays")
+
+    logger.info(
+        f"index_aggregate_plays.py | Finished updating in: {time.time() - start_time} sec."
+    )
+
+
+######## CELERY TASKS ########
+@celery.task(name="update_aggregate_plays", bind=True)
+def update_aggregate_plays(self):
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/app.py
+    db = update_aggregate_plays.db
+    redis = update_aggregate_plays.redis
+    # Define lock acquired boolean
+    have_lock = False
+    # Define redis lock object
+    update_lock = redis.lock("index_aggregate_plays_lock", timeout=60 * 10)
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            update(self, db)
+        else:
+            logger.info(
+                "index_aggregate_plays.py | Failed to acquire update_aggregate_plays"
+            )
+    except Exception as e:
+        logger.error(
+            "index_aggregate_plays.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -34,7 +34,6 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY aggregate_plays")
 
     vacuum_matviews(db)
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Speed up frequency of aggregate play refresh.
Most play jobs finish in 8-10s

### Tests

Ran discovery stack locally and verified that aggregate plays job does indeed run ever 15s

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

In upcoming release canary

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->