### PR TITLE
Skip diff script on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh libs || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
@@ -288,7 +289,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -329,7 +331,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh eth-contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -366,7 +369,7 @@ jobs:
   test-creator-node:
     docker:
       # specify the version you desire here
-      - image: circleci/node:14.16  
+      - image: circleci/node:14.16
       - image: ipfs/go-ipfs:release
       - image: circleci/postgres:11.1
         environment:
@@ -380,7 +383,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh creator-node || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -433,7 +437,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh discovery-provider || (echo "no diff" && circleci-agent step halt)
       - restore_cache:
@@ -503,7 +508,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh identity-service || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
@@ -553,7 +559,8 @@ jobs:
     steps:
       - checkout
       - unless:
-          condition: << parameters.force >>
+          condition:
+            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
           steps:
             - run: ./diff.sh solana-programs || (echo "no diff" && circleci-agent step halt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,15 +213,11 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/mongo:3.4.4
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh libs || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
@@ -282,15 +278,11 @@ jobs:
       - image: circleci/node:10.16.3
       - image: trufflesuite/ganache-cli:latest
         command: ['--port=8555', '-a', '100', '-l', '8000000']
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -324,15 +316,11 @@ jobs:
       - image: circleci/node:10.16.3
       - image: trufflesuite/ganache-cli:latest
         command: ['--port=8546', '-a', '50', '-l', '8000000']
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh eth-contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -376,15 +364,11 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: audius_creator_node_test
       - image: redis:5.0.4
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh creator-node || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
@@ -430,15 +414,11 @@ jobs:
       - image: redis:3.0-alpine
       - image: trufflesuite/ganache-cli:latest
         command: ['--port=8555', '-a', '100', '-l', '8000000']
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh discovery-provider || (echo "no diff" && circleci-agent step halt)
       - restore_cache:
@@ -501,15 +481,11 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: audius_identity_service_test
       - image: redis:5.0.4
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh identity-service || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
@@ -552,15 +528,11 @@ jobs:
     docker:
       # specify the version you desire here
       - image: cimg/rust:1.53.0
-    parameters:
-      force:
-        type: boolean
-        default: false
     steps:
       - checkout
       - unless:
           condition:
-            or: [equal: [ master, << pipeline.git.branch >> ], << parameters.force >>]
+            equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run: ./diff.sh solana-programs || (echo "no diff" && circleci-agent step halt)
 
@@ -729,25 +701,18 @@ workflows:
     jobs:
       - test-libs:
           name: test-libs-nightly
-          force: true
       - test-contracts:
           name: test-contracts-nightly
-          force: true
       - test-eth-contracts:
           name: test-eth-contracts-nightly
-          force: true
       - test-creator-node:
           name: test-creator-node-nightly
-          force: true
       - test-discovery-provider:
           name: test-discovery-provider-nightly
-          force: true
       - test-identity-service:
           name: test-identity-service-nightly
-          force: true
       - test-solana-programs:
           name: test-solana-programs-nightly
-          force: true
     triggers:
       - schedule:
           cron: '0 5 * * *'


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Changes CI to skip `./diff.sh` checks if the branch matches `master`, which fixes `test-build-and-push` workflow for the master branch, and also removes the need for the `force` parameter for nightlies

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->