### PR TITLE
Top Users API

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -683,7 +683,7 @@ top_users_response = make_full_response(
 class FullTopUsers(Resource):
     @full_ns.expect(top_users_response)
     @full_ns.doc(
-        id="""Get the Top Users""",
+        id="""Get the Top Users having at least one track by follower count""",
         params={"limit": "Limit", "offset": "Offset"},
         responses={200: "Success", 400: "Bad request", 500: "Server error"},
     )

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -1,4 +1,5 @@
 import logging
+from src.queries.get_top_users import get_top_users
 from src.queries.get_related_artists import get_related_artists
 from src.utils.helpers import encode_int_id
 from src.challenges.challenge_event_bus import setup_challenge_bus
@@ -666,6 +667,34 @@ class FullTopGenreUsers(Resource):
             get_top_genre_users_args["genre"] = args["genre"]
         top_users = get_top_genre_users(get_top_genre_users_args)
         users = list(map(extend_user, top_users["users"]))
+        return success_response(users)
+
+
+top_users_response_parser = reqparse.RequestParser()
+top_users_response_parser.add_argument("user_id", required=False)
+top_users_response_parser.add_argument("limit", required=False, type=int)
+top_users_response_parser.add_argument("offset", required=False, type=int)
+top_users_response = make_full_response(
+    "top_users_response", full_ns, fields.List(fields.Nested(user_model_full))
+)
+
+
+@full_ns.route("/top")
+class FullTopUsers(Resource):
+    @full_ns.expect(top_users_response)
+    @full_ns.doc(
+        id="""Get the Top Users""",
+        params={"limit": "Limit", "offset": "Offset"},
+        responses={200: "Success", 400: "Bad request", 500: "Server error"},
+    )
+    @full_ns.marshal_with(top_users_response)
+    @cache(ttl_sec=60 * 60 * 24)
+    def get(self):
+        args = top_users_response_parser.parse_args()
+        current_user_id = get_current_user_id(args)
+
+        top_users = get_top_users(current_user_id)
+        users = list(map(extend_user, top_users))
         return success_response(users)
 
 

--- a/discovery-provider/src/queries/get_related_artists.py
+++ b/discovery-provider/src/queries/get_related_artists.py
@@ -182,20 +182,6 @@ def _get_related_artists(session: Session, user_id: int, limit=100):
     return helpers.query_result_to_list(related_artists)
 
 
-def _get_top_artists(session: Session, limit=100):
-    """Gets the top artists by follows of all of Audius"""
-    top_artists = (
-        session.query(User)
-        .select_from(AggregateUser)
-        .join(User, User.user_id == AggregateUser.user_id)
-        .filter(AggregateUser.track_count > 0, User.is_current)
-        .order_by(desc(AggregateUser.follower_count), User.user_id)
-        .limit(limit)
-        .all()
-    )
-    return helpers.query_result_to_list(top_artists)
-
-
 @time_method
 def get_related_artists(user_id: int, current_user_id: int, limit: int = 100):
     db = get_db_read_replica()
@@ -212,8 +198,6 @@ def get_related_artists(user_id: int, current_user_id: int, limit: int = 100):
             and aggregate_user.follower_count >= MIN_FOLLOWER_REQUIREMENT
         ):
             users = _get_related_artists(session, user_id, limit)
-        else:
-            users = _get_top_artists(session, limit)
 
         user_ids = list(map(lambda user: user["user_id"], users))
         users = populate_user_metadata(session, user_ids, users, current_user_id)

--- a/discovery-provider/src/queries/get_top_users.py
+++ b/discovery-provider/src/queries/get_top_users.py
@@ -1,0 +1,25 @@
+from sqlalchemy.sql.expression import desc
+from src.models.models import AggregateUser, User
+from src.queries.query_helpers import helpers, paginate_query, populate_user_metadata
+from src.utils.db_session import get_db_read_replica
+
+
+def get_top_users(current_user_id):
+    """Gets the top users by follows of all of Audius"""
+    top_users = []
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        top_users = (
+            session.query(User)
+            .select_from(AggregateUser)
+            .join(User, User.user_id == AggregateUser.user_id)
+            .filter(AggregateUser.track_count > 0, User.is_current)
+            .order_by(desc(AggregateUser.follower_count), User.user_id)
+        )
+        top_users = paginate_query(top_users).all()
+        top_users = helpers.query_result_to_list(top_users)
+        user_ids = list(map(lambda user: user["user_id"], top_users))
+        top_users = populate_user_metadata(
+            session, user_ids, top_users, current_user_id
+        )
+    return top_users

--- a/discovery-provider/tests/test_get_related_artists.py
+++ b/discovery-provider/tests/test_get_related_artists.py
@@ -48,7 +48,9 @@ def test_calculate_related_artists_scores(app):
 
         # Check sampled (with large enough sample to get all rows for deterministic result)
         rows = _calculate_related_artists_scores(
-            session, 0, sample_size=200 + 50 + 100 + 40 + 5 + 500 + 200  # sum of all the follows
+            session,
+            0,
+            sample_size=200 + 50 + 100 + 40 + 5 + 500 + 200,  # sum of all the follows
         )
         assert rows[0].related_artist_user_id == 1 and math.isclose(
             rows[0].score, 50, abs_tol=0.001
@@ -116,20 +118,12 @@ def test_update_related_artist_scores_if_needed(app):
         assert result, "Calculate when the scores are stale"
 
 
-def test_get_related_artists_top_n(app):
-    """Tests that artists with too few followers get a generic list of top artists by follows"""
+def test_get_related_artists_too_few_followers(app):
+    """Tests that artists with too few followers get an empty list"""
     with app.app_context():
         db = get_db()
         populate_mock_db(db, entities)
         with db.scoped_session() as session:
             session.execute("REFRESH MATERIALIZED VIEW aggregate_user")
         artists = get_related_artists(1, None)
-        assert artists[0]["user_id"] == 5
-        assert (
-            artists[1]["user_id"] == 0
-        )  # 6 and 0 have the same number of follows, sort then by user_id
-        assert artists[2]["user_id"] == 6
-        assert artists[3]["user_id"] == 2
-        assert artists[4]["user_id"] == 1
-        assert artists[5]["user_id"] == 3
-        assert artists[6]["user_id"] == 4
+        assert len(artists) == 0


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds a new API to get the top creators on Audius (by follower count). Removes fallback to top artists for related artist API so that client can tell whether there's a calculation available or not.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Manually. Will be putting on stage/sandbox as well.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->