### PR TITLE
Remove double quotes

### DIFF
--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -97,7 +97,7 @@ function getLibsMock () {
     }
   }
   libsMock.ethContracts.ServiceProviderFactoryClient.getServiceProviderList = libsMock.ethContracts.getServiceProviderList
-  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': '"http://mock-cn1.audius.co,http://mock-cn2.audius.co,http://mock-cn3.audius.co"', 'blocknumber': 10, 'track_blocknumber': 10 }])
+  libsMock.User.getUsers.returns([{ 'creator_node_endpoint': 'http://mock-cn1.audius.co,http://mock-cn2.audius.co,http://mock-cn3.audius.co', 'blocknumber': 10, 'track_blocknumber': 10 }])
   libsMock.User.getUsers.atLeast(1)
 
   return libsMock


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

There was a bug in the content node tests were this double wrapping caused 400s in fetching the mock CIDs via the /ipfs/<cid> route. This PR is intended to resolve the 400s

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

We will monitor the content node tests for any future breakages.
<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->