### PR TITLE
Fix indexing issue

### DIFF
--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -43,6 +43,7 @@ def validate_field_helper(field, value, model, field_type):
     # the fix is to replace those characters with empty with empty string
     # https://stackoverflow.com/questions/1347646/postgres-error-on-insert-error-invalid-byte-sequence-for-encoding-utf8-0x0
     if type(field_type) in (String, Text) and value:
+        value = value.encode("utf-8", "ignore").decode("utf-8", "ignore")
         value = value.replace("\x00", "")
 
     to_validate = {field: value}

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -383,9 +383,10 @@ def create_track_route_id(title, handle):
     Constructs a track's route_id from an unsanitized title and handle.
     Resulting route_ids are of the shape `<handle>/<sanitized_title>`.
     """
+    sanitized_title = title.encode("utf-8", "ignore").decode("utf-8", "ignore")
     # Strip out invalid character
     sanitized_title = re.sub(
-        r"!|%|#|\$|&|\'|\(|\)|&|\*|\+|,|\/|:|;|=|\?|@|\[|\]|\x00", "", title
+        r"!|%|#|\$|&|\'|\(|\)|&|\*|\+|,|\/|:|;|=|\?|@|\[|\]|\x00", "", sanitized_title
     )
 
     # Convert whitespaces to dashes
@@ -415,9 +416,12 @@ def create_track_slug(title, track_id, collision_id=0):
     Example:
     (Title="My Awesome Track!", collision_id=2) => "my-awesome-track-2"
     """
+    sanitized_title = title.encode("utf-8", "ignore").decode("utf-8", "ignore")
     # Strip out invalid character
     sanitized_title = re.sub(
-        r"!|%|#|\$|&|\'|\(|\)|&|\*|\+|,|\/|:|;|=|\?|@|\[|\]|\x00|\^|\.", "", title
+        r"!|%|#|\$|&|\'|\(|\)|&|\*|\+|,|\/|:|;|=|\?|@|\[|\]|\x00|\^|\.",
+        "",
+        sanitized_title,
     )
 
     # Convert whitespaces to dashes


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fixes an indexing issue caused by invalid utf8 character 
```
PUT error - {"levelno": 40, "level": "ERROR", "msg": "Task handler raised error: <MaybeEncodingError: Error sending result: ''(1, <ExceptionInfo: IndexingError(\"\\'utf-8\\' codec can\\'t encode character \\'\\\\\\\\ud835\\' in position 46: surrogates not allowed\")>, None)''. Reason: ''PicklingError(\"Can\\'t pickle <class \\'src.utils.indexing_errors.IndexingError\\'>: it\\'s not the same object as src.utils.indexing_errors.IndexingError\")''.>\nTraceback (most recent call last):\n  File \"/usr/lib/python3.8/site-packages/billiard/pool.py\", line 362, in workloop\n    put((READY, (job, i, result, inqW_fd)))\n  File \"/usr/lib/python3.8/site-packages/billiard/queues.py\", line 366, in put\n    self.send_payload(ForkingPickler.dumps(obj))\n  File \"/usr/lib/python3.8/site-packages/billiard/reduction.py\", line 56, in dumps\n    cls(buf, protocol).dump(obj)\nbilliard.pool.MaybeEncodingError: Error sending result: ''(1, <ExceptionInfo: IndexingError(\"\\'utf-8\\' codec can\\'t encode character \\'\\\\\\\\ud835\\' in position 46: surrogates not allowed\")>, None)''. Reason: ''PicklingError(\"Can\\'t pickle <class \\'src.utils.indexing_errors.IndexingError\\'>: it\\'s not the same object as src.utils.indexing_errors.IndexingError\")''.", "timestamp": "2021-08-31 05:57:29,774"}
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Sandbox node

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->