### PR TITLE
[ASI-632] Add Files_sourceFile_idx to speed up /tracks/download_status query

### DIFF
--- a/creator-node/sequelize/migrations/20210831162548-add-index-files-sourcefile.js
+++ b/creator-node/sequelize/migrations/20210831162548-add-index-files-sourcefile.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /**
  * Adds index on Files table ("sourceFile")
@@ -16,4 +16,4 @@ module.exports = {
       DROP INDEX IF EXISTS "Files_sourceFile_idx";
     `)
   }
-};
+}

--- a/creator-node/sequelize/migrations/20210831162548-add-index-files-sourcefile.js
+++ b/creator-node/sequelize/migrations/20210831162548-add-index-files-sourcefile.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Adds index on Files table ("sourceFile")
+ */
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "Files_sourceFile_idx" ON "Files" USING btree ("sourceFile");
+    `)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "Files_sourceFile_idx";
+    `)
+  }
+};


### PR DESCRIPTION
See linear card for details - https://linear.app/audius/issue/ASI-632/cn-tracksdownload-status-route-taking-way-too-long

`/tracks/download_status` route takes way longer than it should
There are 3 queries in this route (at most), and confirmed one of them takes several minutes because of a missing DB index.

This is the problematic query:
```
const copyFile = await models.File.findOne({ where: {
  type: 'copy320',
  sourceFile: segmentFile.sourceFile
} })

-- translates to
select * from "Files" where "type" = 'copy320' and "sourceFile" = '<sourceFile>';
```

Without index (performs sequential scan) - 300ms (this is on staging - prod is several min)
<img width="625" alt="Screen Shot 2021-08-31 at 12 36 03 PM" src="https://user-images.githubusercontent.com/3323835/131541779-aa95f75f-6c92-4a86-b055-6b458cf621ee.png">

With index (index scan) - .1ms
<img width="646" alt="Screen Shot 2021-08-31 at 12 36 34 PM" src="https://user-images.githubusercontent.com/3323835/131541843-997f83fd-cad4-448c-bc1d-0e4327e591b3.png">
