### PR TITLE
[ASI-628] Add retries to IPFS verification on CN image upload - fix maddog transient errors

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -44,7 +44,6 @@ const FILE_CACHE_EXPIRY_SECONDS = 5 * 60
 const BATCH_CID_ROUTE_LIMIT = 500
 const BATCH_CID_EXISTS_CONCURRENCY_LIMIT = 50
 const IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT = 5
-const IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUT_MS = 5000
 
 /**
  * Helper method to stream file from file system on creator node
@@ -368,7 +367,6 @@ const _dirCIDIPFSVerificationWithRetries = async function (req, resizeResp, dirC
   if (expectedDirCID !== dirCID) {
     if (retriesLeft > 0) {
       req.logger.error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. ${retriesLeft} retries remaining out of ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT}. Retrying...`)
-      await timeout(IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUT_MS)
       await _dirCIDIPFSVerificationWithRetries(req, resizeResp, dirCID, retriesLeft - 1)
     } else {
       throw new Error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. Failed after all ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT} retries.`)

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -44,7 +44,7 @@ const FILE_CACHE_EXPIRY_SECONDS = 5 * 60
 const BATCH_CID_ROUTE_LIMIT = 500
 const BATCH_CID_EXISTS_CONCURRENCY_LIMIT = 50
 const IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT = 5
-const IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUTMS = 5000
+const IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUT_MS = 5000
 
 /**
  * Helper method to stream file from file system on creator node
@@ -320,6 +320,60 @@ const getDirCID = async (req, res) => {
   }
 }
 
+/**
+ * Perform IPFS verification with retries
+ *
+ * Use retries because for some reason IPFS (very rarely) fails due to some non-deterministic error. Seems to be with the verification step; the files are correct.
+ * Wait fixed timeout between each retry, hopefully addresses IPFS non-deterministic errors
+ */
+ const _dirCIDIPFSVerificationWithRetries = async function (retriesLeft = IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT) {
+  // build ipfs add array
+  let ipfsAddArray = []
+  try {
+    await Promise.all(resizeResp.files.map(async function (file) {
+      const fileBuffer = await fs.readFile(file.storagePath)
+      ipfsAddArray.push({
+        path: file.sourceFile,
+        content: fileBuffer
+      })
+    }))
+  } catch (e) {
+    throw new Error(`Failed to build ipfs add array for dirCID ${dirCID} ${e}`)
+  }
+
+  // Re-compute dirCID from all image files to ensure it matches dirCID returned above
+  let ipfsAddRespArr
+  try {
+    const ipfsAddResp = await ipfs.add(
+      ipfsAddArray,
+      {
+        pin: false,
+        onlyHash: true,
+        timeout: 1000
+      }
+    )
+    ipfsAddRespArr = []
+    for await (const resp of ipfsAddResp) {
+      ipfsAddRespArr.push(resp)
+    }
+  } catch (e) {
+    // If ipfs.add op fails, log error and move on, since this is an ipfs error and not an image upload error
+    req.logger.info(`Error calling ipfs.add on dir to re-compute dirCID ${dirCID} ${e}`)
+  }
+
+  // Ensure actual and expected dirCIDs match
+  const expectedDirCID = ipfsAddRespArr[ipfsAddRespArr.length - 1].cid.toString()
+  if (expectedDirCID !== dirCID) {
+    if (retriesLeft > 0) {
+      req.logger.error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. ${retriesLeft} retries remaining out of ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT}. Retrying...`)
+      await timeout(IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUT_MS)
+      await _dirCIDIPFSVerificationWithRetries(retriesLeft - 1)
+    } else {
+      throw new Error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. Failed after all ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT} retries.`)
+    }
+  }
+}
+
 module.exports = function (app) {
   app.get('/track_content_status', handleResponse(async (req, res) => {
     const redisKey = constructProcessKey(PROCESS_NAMES.transcode, req.query.uuid)
@@ -385,61 +439,7 @@ module.exports = function (app) {
 
     const dirCID = resizeResp.dir.dirCID
 
-    /**
-     * Perform IPFS verification with retries
-     *
-     * Use retries because for some reason IPFS (very rarely) fails due to some non-deterministic error. Seems to be with the verification step; the files are correct.
-     * Wait fixed timeout between each retry, hopefully addresses IPFS non-deterministic errors
-     */
-    const ipfsVerificationWithRetries = async function (retriesLeft) {
-      // build ipfs add array
-      let ipfsAddArray = []
-      try {
-        await Promise.all(resizeResp.files.map(async function (file) {
-          const fileBuffer = await fs.readFile(file.storagePath)
-          ipfsAddArray.push({
-            path: file.sourceFile,
-            content: fileBuffer
-          })
-        }))
-      } catch (e) {
-        throw new Error(`Failed to build ipfs add array for dirCID ${dirCID} ${e}`)
-      }
-
-      // Re-compute dirCID from all image files to ensure it matches dirCID returned above
-      let ipfsAddRespArr
-      try {
-        const ipfsAddResp = await ipfs.add(
-          ipfsAddArray,
-          {
-            pin: false,
-            onlyHash: true,
-            timeout: 1000
-          }
-        )
-        ipfsAddRespArr = []
-        for await (const resp of ipfsAddResp) {
-          ipfsAddRespArr.push(resp)
-        }
-      } catch (e) {
-        // If ipfs.add op fails, log error and move on, since this is an ipfs error and not an image upload error
-        req.logger.info(`Error calling ipfs.add on dir to re-compute dirCID ${dirCID} ${e}`)
-      }
-
-      // Ensure actual and expected dirCIDs match
-      const expectedDirCID = ipfsAddRespArr[ipfsAddRespArr.length - 1].cid.toString()
-      if (expectedDirCID !== dirCID) {
-        if (retriesLeft > 0) {
-          req.logger.error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. ${retriesLeft} retries remaining out of ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT}. Retrying...`)
-          await timeout(IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_TIMEOUTMS)
-          await ipfsVerificationWithRetries(retriesLeft - 1)
-        } else {
-          throw new Error(`Image file validation failed - dirCIDs do not match for dirCID=${dirCID} expectedCID=${expectedDirCID}. Failed after all ${IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT} retries.`)
-        }
-      }
-    }
-
-    await ipfsVerificationWithRetries(IMAGE_UPLOAD_IPFS_VERIFICATION_RETRY_COUNT)
+    await _dirCIDIPFSVerificationWithRetries()
 
     // Record image file entries in DB
     const transaction = await models.sequelize.transaction()


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Moves IPFS verification step in image upload to a standalone function, and adds retries & logs to account for transient errors
Confirmed that dirCID validation errors are from ipfs verification, not original file upload. Retries always seem to fix the inconsistency

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Maddog tests cover this case

See changes in https://github.com/AudiusProject/audius-protocol/pull/1812

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->