### PR TITLE
Add redis key for notifications processor start and endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,58 +669,58 @@ workflows:
   # test, build and push all commits
   test-build-and-push:
     jobs:
-      - test-libs:
-          name: test-libs
-      - docker-build-and-push:
-          name: build-libs
-          repo: libs
-          requires:
-            - test-libs
+      # - test-libs:
+      #     name: test-libs
+      # - docker-build-and-push:
+      #     name: build-libs
+      #     repo: libs
+      #     requires:
+      #       - test-libs
 
-      - test-contracts:
-          name: test-contracts
-      - docker-build-and-push:
-          name: build-contracts
-          repo: contracts
-          requires:
-            - test-contracts
+      # - test-contracts:
+      #     name: test-contracts
+      # - docker-build-and-push:
+      #     name: build-contracts
+      #     repo: contracts
+      #     requires:
+      #       - test-contracts
 
-      - test-eth-contracts:
-          name: test-eth-contracts
-      - docker-build-and-push:
-          name: build-eth-contracts
-          repo: eth-contracts
-          requires:
-            - test-eth-contracts
+      # - test-eth-contracts:
+      #     name: test-eth-contracts
+      # - docker-build-and-push:
+      #     name: build-eth-contracts
+      #     repo: eth-contracts
+      #     requires:
+      #       - test-eth-contracts
 
-      - test-creator-node:
-          name: test-creator-node
-      - docker-build-and-push:
-          name: build-creator-node
-          repo: creator-node
-          requires:
-            - test-creator-node
+      # - test-creator-node:
+      #     name: test-creator-node
+      # - docker-build-and-push:
+      #     name: build-creator-node
+      #     repo: creator-node
+      #     requires:
+      #       - test-creator-node
 
-      - test-discovery-provider:
-          name: test-discovery-provider
-      - docker-build-and-push:
-          name: build-discovery-provider
-          repo: discovery-provider
-          requires:
-            - test-discovery-provider
+      # - test-discovery-provider:
+      #     name: test-discovery-provider
+      # - docker-build-and-push:
+      #     name: build-discovery-provider
+      #     repo: discovery-provider
+      #     requires:
+      #       - test-discovery-provider
 
       - test-identity-service:
           name: test-identity-service
       - docker-build-and-push:
           name: build-identity-service
           repo: identity-service
-          requires:
-            - test-identity-service
+          # requires:
+          #   - test-identity-service
 
-      - test-solana-programs:
-          name: test-solana-programs
+      # - test-solana-programs:
+      #     name: test-solana-programs
 
-      - test-mad-dog-e2e
+      # - test-mad-dog-e2e
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,58 +669,58 @@ workflows:
   # test, build and push all commits
   test-build-and-push:
     jobs:
-      # - test-libs:
-      #     name: test-libs
-      # - docker-build-and-push:
-      #     name: build-libs
-      #     repo: libs
-      #     requires:
-      #       - test-libs
+      - test-libs:
+          name: test-libs
+      - docker-build-and-push:
+          name: build-libs
+          repo: libs
+          requires:
+            - test-libs
 
-      # - test-contracts:
-      #     name: test-contracts
-      # - docker-build-and-push:
-      #     name: build-contracts
-      #     repo: contracts
-      #     requires:
-      #       - test-contracts
+      - test-contracts:
+          name: test-contracts
+      - docker-build-and-push:
+          name: build-contracts
+          repo: contracts
+          requires:
+            - test-contracts
 
-      # - test-eth-contracts:
-      #     name: test-eth-contracts
-      # - docker-build-and-push:
-      #     name: build-eth-contracts
-      #     repo: eth-contracts
-      #     requires:
-      #       - test-eth-contracts
+      - test-eth-contracts:
+          name: test-eth-contracts
+      - docker-build-and-push:
+          name: build-eth-contracts
+          repo: eth-contracts
+          requires:
+            - test-eth-contracts
 
-      # - test-creator-node:
-      #     name: test-creator-node
-      # - docker-build-and-push:
-      #     name: build-creator-node
-      #     repo: creator-node
-      #     requires:
-      #       - test-creator-node
+      - test-creator-node:
+          name: test-creator-node
+      - docker-build-and-push:
+          name: build-creator-node
+          repo: creator-node
+          requires:
+            - test-creator-node
 
-      # - test-discovery-provider:
-      #     name: test-discovery-provider
-      # - docker-build-and-push:
-      #     name: build-discovery-provider
-      #     repo: discovery-provider
-      #     requires:
-      #       - test-discovery-provider
+      - test-discovery-provider:
+          name: test-discovery-provider
+      - docker-build-and-push:
+          name: build-discovery-provider
+          repo: discovery-provider
+          requires:
+            - test-discovery-provider
 
       - test-identity-service:
           name: test-identity-service
       - docker-build-and-push:
           name: build-identity-service
           repo: identity-service
-          # requires:
-          #   - test-identity-service
+          requires:
+            - test-identity-service
 
-      # - test-solana-programs:
-      #     name: test-solana-programs
+      - test-solana-programs:
+          name: test-solana-programs
 
-      # - test-mad-dog-e2e
+      - test-mad-dog-e2e
 
   # test master at midnight daily
   test-nightly:

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -14,6 +14,7 @@ const audiusLibsWrapper = require('./audiusLibsInstance')
 const NotificationProcessor = require('./notifications/index.js')
 
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
+const { getShouldRunNotifications } = require('./notifications/utils')
 const { fetchAnnouncements } = require('./announcements')
 const { logger, loggingMiddleware } = require('./logging')
 const {
@@ -61,11 +62,14 @@ class App {
     // exclude these init's if running tests
     if (!config.get('isTestRun')) {
       const audiusInstance = await this.configureAudiusInstance()
-      await this.notificationProcessor.init(
-        audiusInstance,
-        this.express,
-        this.redisClient
-      )
+      const shouldRunNotifications = await getShouldRunNotifications(this.redisClient)
+      if (shouldRunNotifications) {
+        await this.notificationProcessor.init(
+          audiusInstance,
+          this.express,
+          this.redisClient
+        )
+      }
     }
 
     let server

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -82,6 +82,7 @@ class App {
     server.headersTimeout = config.get('headersTimeout')
 
     this.express.set('redis', this.redisClient)
+    this.express.set('notificationProcessor', this.notificationProcessor)
 
     try {
       await txRelay.fundRelayerIfEmpty()

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -617,6 +617,12 @@ const config = convict({
     format: String,
     env: 'discoveryProviderWhitelist',
     default: ''
+  },
+  podHostName: {
+    doc: 'The pod hostname',
+    format: String,
+    env: 'HOSTNAME',
+    default: ''
   }
 })
 

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -618,7 +618,7 @@ const config = convict({
     env: 'discoveryProviderWhitelist',
     default: ''
   },
-  podHostName: {
+  HOSTNAME: {
     doc: 'The pod hostname',
     format: String,
     env: 'HOSTNAME',

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -42,6 +42,7 @@ class NotificationProcessor {
   constructor ({
     errorHandler
   }) {
+    this.isInit = false
     this.notifQueue = new Bull(
       `notification-queue-${Date.now()}`,
       {
@@ -97,6 +98,7 @@ class NotificationProcessor {
    */
   async init (audiusLibs, expressApp, redis) {
     // Clear any pending notif jobs
+    this.isInit = true
     await this.notifQueue.empty()
     await this.emailQueue.empty()
     this.redis = redis

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -211,7 +211,7 @@ function decodeHashId (id) {
 const NOTIFICATIONS_POD_HOSTNAME = 'notifications-pod-hostname'
 async function getShouldRunNotifications (redis) {
   const notificationsPodHostname = await redis.get(NOTIFICATIONS_POD_HOSTNAME)
-  return config.HOSTNAME === notificationsPodHostname
+  return config.get('HOSTNAME') === notificationsPodHostname
 }
 
 module.exports = {

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -211,7 +211,7 @@ function decodeHashId (id) {
 const NOTIFICATIONS_POD_HOSTNAME = 'notifications-pod-hostname'
 async function getShouldRunNotifications (redis) {
   const notificationsPodHostname = await redis.get(NOTIFICATIONS_POD_HOSTNAME)
-  return config.podHostName === notificationsPodHostname
+  return config.HOSTNAME === notificationsPodHostname
 }
 
 module.exports = {

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -208,6 +208,12 @@ function decodeHashId (id) {
   return ids[0]
 }
 
+const NOTIFICATIONS_POD_HOSTNAME = 'notifications-pod-hostname'
+async function getShouldRunNotifications (redis) {
+  const notificationsPodHostname = await redis.get(NOTIFICATIONS_POD_HOSTNAME)
+  return config.podHostName === notificationsPodHostname
+}
+
 module.exports = {
   encodeHashId,
   decodeHashId,
@@ -216,5 +222,6 @@ module.exports = {
   calculateTrackListenMilestonesFromDiscovery,
   getHighestBlockNumber,
   getHighestSlot,
-  shouldNotifyUser
+  shouldNotifyUser,
+  getShouldRunNotifications
 }

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -700,7 +700,7 @@ module.exports = function (app) {
     const isProcessorRunning = app.get('notificationProcessor').isInit
     if (!isProcessorRunning && shouldRunNotifications) {
       req.logger.info(`Starting notification processor`)
-      await this.notificationProcessor.init(
+      await app.get('notificationProcessor').init(
         app.get('audiusLibs'),
         app,
         app.get('redis')

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -697,7 +697,7 @@ module.exports = function (app) {
   */
   app.post('/notifications/processor/start', handleResponse(async (req, res, next) => {
     const shouldRunNotifications = await getShouldRunNotifications(app.get('redis'))
-    const isProcessorRunning = app.notificationProcessor.isInit
+    const isProcessorRunning = app.get('notificationProcessor').isInit
     if (!isProcessorRunning && shouldRunNotifications) {
       req.logger.info(`Starting notification processor`)
       await this.notificationProcessor.init(

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -688,7 +688,7 @@ module.exports = function (app) {
   */
   app.get('/notifications/processor', handleResponse(async (req, res, next) => {
     const shouldRunNotifications = await getShouldRunNotifications(app.get('redis'))
-    const isProcessorRunning = app.notificationProcessor.isInit
+    const isProcessorRunning = app.get('notificationProcessor').isInit
     return successResponse({ isProcessorRunning, shouldRunNotifications })
   }))
 

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -7,6 +7,7 @@ const {
 const models = require('../models')
 const authMiddleware = require('../authMiddleware')
 const { fetchAnnouncements } = require('../announcements.js')
+const { getShouldRunNotifications } = require('../notifications/utils')
 
 const NotificationType = Object.freeze({
   Follow: 'Follow',
@@ -680,6 +681,33 @@ module.exports = function (app) {
       return subscribers
     }, initSubscribers)
     return successResponse({ users })
+  }))
+
+  /*
+   * Returns if the notifications processor is running
+  */
+  app.get('/notifications/processor', handleResponse(async (req, res, next) => {
+    const shouldRunNotifications = await getShouldRunNotifications(app.redisClient)
+    const isProcessorRunning = app.notificationProcessor.isInit
+    return successResponse({ isProcessorRunning, shouldRunNotifications })
+  }))
+
+  /*
+   * Starts the notifications processor if passing valid parameters
+  */
+  app.post('/notifications/processor/start', handleResponse(async (req, res, next) => {
+    const shouldRunNotifications = await getShouldRunNotifications(app.redisClient)
+    const isProcessorRunning = app.notificationProcessor.isInit
+    if (!isProcessorRunning && shouldRunNotifications) {
+      req.logger.info(`Starting notification processor`)
+      await this.notificationProcessor.init(
+        app.get('audiusLibs'),
+        app,
+        app.get('redis')
+      )
+      return successResponse({ didStart: true })
+    }
+    return successResponse({ didStart: false })
   }))
 }
 

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -687,7 +687,7 @@ module.exports = function (app) {
    * Returns if the notifications processor is running
   */
   app.get('/notifications/processor', handleResponse(async (req, res, next) => {
-    const shouldRunNotifications = await getShouldRunNotifications(app.redisClient)
+    const shouldRunNotifications = await getShouldRunNotifications(app.get('redis'))
     const isProcessorRunning = app.notificationProcessor.isInit
     return successResponse({ isProcessorRunning, shouldRunNotifications })
   }))
@@ -696,7 +696,7 @@ module.exports = function (app) {
    * Starts the notifications processor if passing valid parameters
   */
   app.post('/notifications/processor/start', handleResponse(async (req, res, next) => {
-    const shouldRunNotifications = await getShouldRunNotifications(app.redisClient)
+    const shouldRunNotifications = await getShouldRunNotifications(app.get('redis'))
     const isProcessorRunning = app.notificationProcessor.isInit
     if (!isProcessorRunning && shouldRunNotifications) {
       req.logger.info(`Starting notification processor`)


### PR DESCRIPTION
### Description
Only allow one identity service to run the notifications processor at a time by checking if the redis value matches the HOSTNAME env var, injected by kubernetes. 
NOTE: since the HOSTNAME changes every time, the process flow is manual to enable one pod's notifications
1.) Get the pod hostname
2.) Set the hostname in redis
3.) SSH into the pod and make a post request to the endpoint to enable the notifications processor

### Tests
Manually

### How will this change be monitored?
Manually
