### PR TITLE
Use master branch as parent branch on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,23 @@ orbs:
   kubernetes: circleci/kubernetes@0.3.0
   coveralls: coveralls/coveralls@1.0.6
   build-tools: circleci/build-tools@2.9.1
+commands:
+  diff-and-merge-with-master:
+    parameters:
+      service:
+        type: string
+    steps:
+      - unless:
+          condition:
+            or:
+              - equal: [ master, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: "^release.*$"
+                  value: << pipeline.git.branch >>
+          steps:
+            - run: ./diff.sh << parameters.service >> || (echo "no diff" && circleci-agent step halt)
+            - build-tools/merge-with-parent:
+                parent: master
 jobs:
   test-mad-dog-e2e:
     # https://circleci.com/docs/2.0/parallelism-faster-jobs/
@@ -24,7 +41,11 @@ jobs:
       - checkout
       - unless:
           condition:
-            equal: [ master, << pipeline.git.branch >> ]
+            or:
+              - equal: [ master, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: "^release.*$"
+                  value: << pipeline.git.branch >>
           steps:
             - build-tools/merge-with-parent:
                 parent: master
@@ -226,13 +247,8 @@ jobs:
       # - image: circleci/mongo:3.4.4
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh libs || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: libs
       - setup_remote_docker
 
       # Download and cache dependencies
@@ -293,13 +309,8 @@ jobs:
         command: ['--port=8555', '-a', '100', '-l', '8000000']
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh contracts || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: contracts
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -333,13 +344,8 @@ jobs:
         command: ['--port=8546', '-a', '50', '-l', '8000000']
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh eth-contracts || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: eth-contracts
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -383,13 +389,8 @@ jobs:
       - image: redis:5.0.4
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh creator-node || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: creator-node
       # Download and cache dependencies
       # - restore_cache:
       #     keys:
@@ -435,13 +436,8 @@ jobs:
         command: ['--port=8555', '-a', '100', '-l', '8000000']
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh discovery-provider || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: discovery-provider
       - restore_cache:
           keys:
             - disc-prov-1-{{ checksum "discovery-provider/requirements.txt" }}
@@ -504,13 +500,8 @@ jobs:
       - image: redis:5.0.4
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh identity-service || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: identity-service
       - setup_remote_docker
       # restores data-contracts
       - restore_cache:
@@ -553,13 +544,8 @@ jobs:
       - image: cimg/rust:1.53.0
     steps:
       - checkout
-      - unless:
-          condition:
-            equal: [ master, << pipeline.git.branch >> ]
-          steps:
-            - build-tools/merge-with-parent:
-                parent: master
-            - run: ./diff.sh solana-programs || (echo "no diff" && circleci-agent step halt)
+      - diff-and-merge-with-master:
+          service: solana-programs
 
       - run:
           name: Setup solana
@@ -641,7 +627,11 @@ jobs:
       - checkout
       - unless:
           condition:
-            equal: [ master, << pipeline.git.branch >> ]
+            or:
+              - equal: [ master, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: "^release.*$"
+                  value: << pipeline.git.branch >>
           steps:
             - build-tools/merge-with-parent:
                 parent: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
       - run:
           name: clone tooling and mad dog
           command: |
@@ -229,7 +230,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh libs || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
 
@@ -295,7 +297,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
       - restore_cache:
@@ -334,7 +337,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh eth-contracts || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
       - restore_cache:
@@ -383,7 +387,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh creator-node || (echo "no diff" && circleci-agent step halt)
       # Download and cache dependencies
       # - restore_cache:
@@ -434,7 +439,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh discovery-provider || (echo "no diff" && circleci-agent step halt)
       - restore_cache:
           keys:
@@ -502,7 +508,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh identity-service || (echo "no diff" && circleci-agent step halt)
       - setup_remote_docker
       # restores data-contracts
@@ -550,7 +557,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
             - run: ./diff.sh solana-programs || (echo "no diff" && circleci-agent step halt)
 
       - run:
@@ -635,7 +643,8 @@ jobs:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
-            - build-tools/merge-with-parent
+            - build-tools/merge-with-parent:
+                parent: master
       - setup_remote_docker:
           docker_layer_caching: true
       - run:


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

The command used by `merge-with-parent` fails to find the parent due to refs being too many. We only ever really want to merge with master, so hardcode master as the parent.

- Uses `master` as the parent for `merge-with-parent`
- Updates YAML to use reusable command instead of having the conditional logic every job
- Ignore `merge-with-parent` on release branches
- Run diff tool before merging

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->