### PR TITLE
[ASI-615] X-Prefix CN user-generated req headers

### DIFF
--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -44,8 +44,8 @@ function getRequestLoggingContext (req, requestID) {
     requestHostname: req.hostname,
     requestUrl: urlParts[0],
     requestQueryParams: urlParts.length > 1 ? urlParts[1] : undefined,
-    requestWallet: req.get('user-wallet-addr'),
-    requestBlockchainUserId: req.get('user-id')
+    requestWallet: req.get('audius-user-wallet-addr') || req.get('user-wallet-addr'),
+    requestBlockchainUserId: req.get('audius-user-id') || req.get('user-id')
   }
 }
 

--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -652,8 +652,8 @@ class CreatorNode {
 
       const user = this.userStateManager.getCurrentUser()
       if (user && user.wallet && user.user_id) {
-        axiosRequestObj.headers['User-Wallet-Addr'] = user.wallet
-        axiosRequestObj.headers['User-Id'] = user.user_id
+        axiosRequestObj.headers['Audius-User-Wallet-Addr'] = user.wallet
+        axiosRequestObj.headers['Audius-User-Id'] = user.user_id
       }
 
       const requestId = uuid()
@@ -752,9 +752,8 @@ class CreatorNode {
 
     const user = this.userStateManager.getCurrentUser()
     if (user && user.wallet && user.user_id) {
-      // TODO change to X-User-Wallet-Address and X-User-Id per convention
-      headers['User-Wallet-Addr'] = user.wallet
-      headers['User-Id'] = user.user_id
+      headers['Audius-User-Wallet-Addr'] = user.wallet
+      headers['Audius-User-Id'] = user.user_id
     }
 
     return { headers, formData }


### PR DESCRIPTION
Prefixes the User-Wallet-Addr and User-Id headers.

See also:

[ASI-615][1]

[1]: https://linear.app/audius/issue/ASI-615/change-cn-user-generated-req-headers-to-be-x-prefixed

### Description

Made this change since I wanted to test out git workflow/hygiene for this new org, but I'd like to understand better why this is a change that needs to be made. According to [docs](https://specs.openstack.org/openstack/api-wg/guidelines/headers.html) X-prefixed headers have been deprecated since RFC 6648, and further discouraged in RFC-7231 (see first paragraph of linked doc). 

### Tests
I didn't see any tests that asserted against headers for these requests but would be interested to learn where they would be written, if there is a need!

### How will this change be monitored?

Need more context around reason for change to understand potential impact.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->