### PR TITLE
Update get karma to use aggregate user

### DIFF
--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-lines
 import logging
-from sqlalchemy import func, desc, text, Integer, and_, bindparam
+from sqlalchemy import func, desc, text, Integer, and_, bindparam, cast
 
 from flask import request
 
@@ -829,10 +829,12 @@ def get_karma(session, ids, time=None, is_playlist=False, xf=False):
         ).subquery()
 
     query = (
-        session.query(saves_and_reposts.c.item_id, func.count(Follow.followee_user_id))
+        session.query(
+            saves_and_reposts.c.item_id,
+            cast(func.sum(AggregateUser.follower_count), Integer),
+        )
         .select_from(saves_and_reposts)
-        .join(Follow, saves_and_reposts.c.user_id == Follow.followee_user_id)
-        .filter(Follow.is_current == True, Follow.is_delete == False)
+        .join(AggregateUser, saves_and_reposts.c.user_id == AggregateUser.user_id)
         .group_by(saves_and_reposts.c.item_id)
     )
 


### PR DESCRIPTION
### Description
Updates the query in `get_karma` to use aggregate_user to count the user's followers instead of counting the individual rows in the follows table. 

Running the job against a prod snapshot took ~50 minutes to finish
With the change to use aggregate_user, it took ~10 minutes

Note: the aggregate_user mat view is updated about every minute and trending is calculated on an hourly basis. 

### Tests
I ran the discovery provider locally and ensured that no errors were output while running the. 
I printed out the previous and updated sql queries and ensure they returned the same results (after running refresh aggregate_user mat view)

### How will this change be monitored?
manually

Closes AUD-942