### PR TITLE
AUD-949 Add index to slots on plays table

### DIFF
--- a/discovery-provider/alembic/versions/561ba1eca13a_add_slot_index.py
+++ b/discovery-provider/alembic/versions/561ba1eca13a_add_slot_index.py
@@ -1,0 +1,23 @@
+"""Add Slot Index
+
+Revision ID: 561ba1eca13a
+Revises: 7693ab16e2e1
+Create Date: 2021-09-20 21:06:07.682836
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "561ba1eca13a"
+down_revision = "7693ab16e2e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("ix_plays_slot"), "plays", ["slot"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_plays_slot"), table_name="plays")

--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -532,7 +532,7 @@ class Play(Base):
     user_id = Column(Integer, nullable=True, index=False)
     source = Column(String, nullable=True, index=False)
     play_item_id = Column(Integer, nullable=False, index=False)
-    slot = Column(Integer, nullable=True, index=False)
+    slot = Column(Integer, nullable=True, index=True)
     signature = Column(String, nullable=True, index=False)
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds an index to the plays table for `slot`

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran migration on local machine. Will test on sandbox too

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Will be checking the play check endpoint eg `/sol_play_check?max_drift=720` and seeing perf change

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->