### PR TITLE
[ASI-660] Fix SECP recovery potential vulnerability with struct 0 length check

### DIFF
--- a/solana-programs/audius_eth_registry/src/processor.rs
+++ b/solana-programs/audius_eth_registry/src/processor.rs
@@ -42,6 +42,9 @@ impl Processor {
         message: &[u8],
         secp_instruction_data: Vec<u8>,
     ) -> Result<(), AudiusError> {
+        if secp_instruction_data[0] != 1 {
+            return Err(AudiusError::SignatureVerificationFailed.into());
+        }
         let eth_address_offset = 12;
         let instruction_signer = secp_instruction_data
             [eth_address_offset..eth_address_offset + SecpSignatureOffsets::ETH_ADDRESS_SIZE]


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

* Explicitly ensure a single secp struct is present in signature recovery

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

* Existing tests pass, we have opted to avoid adding additional ones at this time

### How will this change be monitored?

* Will be validated w/an independent rollout, stage, then production manually
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->