### PR TITLE
Bump libs to 1.2.23

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
### Description

Bump libs to take into account latest changes.

    Add libs functionality for E2E challenge attestation flow (#1887)

    * Working attestation methods

    * Handle attestation errors

    * Surface attestation error in response

    * Return response in all paths

    * Address PR comments

    Co-authored-by: Saliou Diallo <saliou@audius.co>

A       libs/src/api/challenge.js
M       libs/src/index.js