### PR TITLE
Move query comment to beginning of statement

### DIFF
--- a/discovery-provider/src/utils/session_manager.py
+++ b/discovery-provider/src/utils/session_manager.py
@@ -34,7 +34,7 @@ class SessionManager:
         try to comment the caller's function name.
         """
         if "src" in conn.info:
-            statement = statement + " -- %s" % conn.info.pop("src")
+            statement = "-- %s \n" % conn.info.pop("src") + statement
 
         return statement, parameters
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Following up https://github.com/AudiusProject/audius-protocol/pull/1895. Moving query to beginning of statement to prevent truncated comment. Default stored query size is 1kb: https://postgresqlco.nf/doc/en/param/track_activity_query_size/. 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Local testing, confirmed comment was added to beginning of query.
```-- get_database_connection_info \nselect wait_event_type, wait_event, state, query, to_char(query_start, 'DD Mon YYYY HH:MI:SSPM')as \"query_start\" from pg_stat_activity where datname = current_database()```

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->