### PR TITLE
Change latest block number check

### DIFF
--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -35,7 +35,7 @@ run_unit_tests () {
 
 run_integration_tests () {
   echo Running integration tests...
-  ./node_modules/mocha/bin/mocha test/audiusUsers.test.js --timeout 30000 --exit
+  ./node_modules/mocha/bin/mocha test/*.test.js --timeout 30000 --exit
 }
 
 if [ "$1" == "standalone_creator" ]; then

--- a/creator-node/scripts/run-tests.sh
+++ b/creator-node/scripts/run-tests.sh
@@ -35,7 +35,7 @@ run_unit_tests () {
 
 run_integration_tests () {
   echo Running integration tests...
-  ./node_modules/mocha/bin/mocha test/*.test.js --timeout 30000 --exit
+  ./node_modules/mocha/bin/mocha test/audiusUsers.test.js --timeout 30000 --exit
 }
 
 if [ "$1" == "standalone_creator" ]; then

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -78,12 +78,6 @@ module.exports = function (app) {
     }
 
     const cnodeUser = req.session.cnodeUser
-    if (blockNumber === cnodeUser.latestBlockNumber) {
-      return successResponse({
-        message: `blockNumber ${blockNumber} already exists for user`
-      })
-    }
-
     if (blockNumber < cnodeUser.latestBlockNumber) {
       return errorResponseBadRequest(
         `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -77,11 +77,19 @@ module.exports = function (app) {
       return errorResponseBadRequest('Must include blockchainUserId, blockNumber, and metadataFileUUID.')
     }
 
-    // Error on outdated blocknumber.
     const cnodeUser = req.session.cnodeUser
-    if (!cnodeUser.latestBlockNumber || cnodeUser.latestBlockNumber >= blockNumber) {
-      return errorResponseBadRequest(`Invalid blockNumber param. Must be higher than previously processed blocknumber.`)
+    if (blockNumber === cnodeUser.latestBlockNumber) {
+      return successResponse({
+        message: `blockNumber ${blockNumber} already exists for user`
+      })
     }
+
+    if (blockNumber < cnodeUser.latestBlockNumber) {
+      return errorResponseBadRequest(
+        `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
+      )
+    }
+
     const cnodeUserUUID = req.session.cnodeUserUUID
 
     // Fetch metadataJSON for metadataFileUUID.

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -408,8 +408,10 @@ module.exports = function (app) {
 
     // Error on outdated blocknumber
     const cnodeUser = req.session.cnodeUser
-    if (!cnodeUser.latestBlockNumber || cnodeUser.latestBlockNumber > blockNumber) {
-      return errorResponseBadRequest(`Invalid blockNumber param. Must be higher than previously processed blocknumber.`)
+    if (blockNumber < cnodeUser.latestBlockNumber) {
+      return errorResponseBadRequest(
+        `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
+      )
     }
     const cnodeUserUUID = req.session.cnodeUserUUID
 

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -90,6 +90,73 @@ describe('test AudiusUsers with mocked IPFS', function () {
       .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(200)
   })
+
+  it('successfully completes Audius user creation when retrying an existing block number', async function () {
+    const metadata = { test: 'field1' }
+
+    ipfsMock.add.twice().withArgs(Buffer.from(JSON.stringify(metadata)))
+    ipfsMock.pin.add.once().withArgs('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    libsMock.User.getUsers.exactly(2)
+
+    const resp = await request(app)
+      .post('/audius_users/metadata')
+      .set('X-Session-ID', session.sessionToken)
+      .set('User-Id', session.userId)
+      .send({ metadata })
+      .expect(200)
+
+    if (resp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
+      throw new Error('invalid return data')
+    }
+
+    await request(app)
+      .post('/audius_users')
+      .set('X-Session-ID', session.sessionToken)
+      .set('User-Id', session.userId)
+      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .expect(200)
+
+    const res = await request(app)
+      .post('/audius_users')
+      .set('X-Session-ID', session.sessionToken)
+      .set('User-Id', session.userId)
+      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .expect(200)
+
+    assert.deepStrictEqual(res.body.data.message, 'blockNumber 10 already exists for user')
+  })
+
+  it('fails Audius user creation when too low of a block number is supplied', async function () {
+    const metadata = { test: 'field1' }
+
+    ipfsMock.add.twice().withArgs(Buffer.from(JSON.stringify(metadata)))
+    ipfsMock.pin.add.once().withArgs('QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6')
+    libsMock.User.getUsers.exactly(2)
+
+    const resp = await request(app)
+      .post('/audius_users/metadata')
+      .set('X-Session-ID', session.sessionToken)
+      .set('User-Id', session.userId)
+      .send({ metadata })
+      .expect(200)
+
+    if (resp.body.data.metadataMultihash !== 'QmYfSQCgCwhxwYcdEwCkFJHicDe6rzCAb7AtLz3GrHmuU6') {
+      throw new Error('invalid return data')
+    }
+
+    // Fast forward to block number 100
+    const cnodeUser = await models.CNodeUser.findOne({ where: { cnodeUserUUID: session.cnodeUserUUID } })
+    await cnodeUser.update({ latestBlockNumber: 100 })
+
+    await request(app)
+      .post('/audius_users')
+      .set('X-Session-ID', session.sessionToken)
+      .set('User-Id', session.userId)
+      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .expect(400, {
+        error: 'Invalid blockNumber param 10. Must be greater or equal to previously processed blocknumber 100.'
+      })
+  })
 })
 
 // Below block uses actual ipfsClient (unlike first describe block), hence
@@ -191,10 +258,6 @@ describe('Test AudiusUsers with real IPFS', function () {
     // check that the ipfs content matches what we expect
     const metadataBuffer = Buffer.from(JSON.stringify(metadata))
     assert.deepStrictEqual(metadataBuffer.compare(ipfsResp), 0)
-  })
-
-  it.skip('TODO - successfully completes Audius user creation (POST /audius_users/metadata -> POST /audius_users)', async function () {
-
   })
 
   it.skip('TODO - multiple uploads', async function () {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

When calling into the cnode, the client sends the maximum block number it sees across transactions as part of the user creation. https://github.com/AudiusProject/audius-protocol/blob/e8f0a4d8bf7f2d6fad80d5bdf4e67acc80089fdd/libs/src/api/user.js#L407

In cases where the client thinks it dropped the request to /audius_users, it would have written a block number to the cNodeUser table but then retry the same request with the same block number. This results in the sign up (or account action in general) failing from the client perspective even though it did not fail.

Also remove the case where we check for existence of latestBlock. It is default to -1 (https://github.com/AudiusProject/audius-protocol/commit/89c46fb08480ce9c420dc8f5e660c1cfb3edaba4#diff-c070549666690bfec3f3cfc9a5641aa6e3a741cfe7703e4facd0635b65a9ad01R19) and always truthy, so that check does nothing

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Added unit tests

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Staging + prod via create account success charts and the amount that we see latest block number sentry alert as well as the HEDGEHOG sign up alert (this is due to the entire flow being retried in a successful case)

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->