### PR TITLE
[ASI-665] Check connxn before running DB migs

### DIFF
--- a/creator-node/src/index.js
+++ b/creator-node/src/index.js
@@ -17,14 +17,29 @@ const exitWithError = (...msg) => {
   process.exit(1)
 }
 
+const verifyDBConnection = async () => {
+  try {
+    logger.info('Verifying DB connection...')
+    await sequelize.authenticate() // runs SELECT 1+1 AS result to check db connection
+    logger.info('DB connected successfully!')
+  } catch (connectionError) {
+    exitWithError('Error connecting to DB:', connectionError)
+  }
+}
+
 const runDBMigrations = async () => {
   try {
     logger.info('Executing database migrations...')
     await runMigrations()
     logger.info('Migrations completed successfully')
-  } catch (err) {
-    exitWithError('Error in migrations: ', err)
+  } catch (migrationError) {
+    exitWithError('Error in migrations:', migrationError)
   }
+}
+
+const connectToDBAndRunMigrations = async () => {
+  await verifyDBConnection()
+  await runDBMigrations()
 }
 
 const getMode = () => {
@@ -61,11 +76,11 @@ const startApp = async () => {
   let appInfo
 
   if (mode === '--run-migrations') {
-    await runDBMigrations()
+    await connectToDBAndRunMigrations()
     process.exit(0)
   } else {
     if (mode === '--run-all') {
-      await runDBMigrations()
+      await connectToDBAndRunMigrations()
     }
 
     await logIpfsPeerIds()


### PR DESCRIPTION
* During Content Node startup, verify DB connection prior to running
  migrations in order to avoid situation where log says migrations
  are being run despite no DB connection, confusing devs.

See also:

[ASI-665][1]

[1]: https://linear.app/audius/issue/ASI-665

### Description

Info on `sequelize.authenticate()` API from [docs](https://sequelize.org/master/manual/getting-started.html):
```
Testing the connection
You can use the .authenticate() function to test if the connection is OK:

try {
  await sequelize.authenticate();
  console.log('Connection has been established successfully.');
} catch (error) {
  console.error('Unable to connect to the database:', error);
}

```
### Tests

N/A

### How will this change be monitored?

N/A
