### PR TITLE
[ASI-614] libs CN login expires browser sessions weekly

### DIFF
--- a/libs/src/services/creatorNode/index.js
+++ b/libs/src/services/creatorNode/index.js
@@ -10,6 +10,7 @@ const SchemaValidator = require('../schemaValidator')
 const CHUNK_SIZE = 2000000 // 2MB
 const MAX_TRACK_TRANSCODE_TIMEOUT = 3600000 // 1 hour
 const POLL_STATUS_INTERVAL = 3000 // 3s
+const BROWSER_SESSION_REFRESH_TIMEOUT = 604800000 // 1 week
 
 // Currently only supports a single logged-in audius user
 class CreatorNode {
@@ -190,7 +191,7 @@ class CreatorNode {
         console.error(e.message)
       }
     }
-    this.connected = false
+    this.clearBrowserSession()
     this.creatorNodeEndpoint = creatorNodeEndpoint
     if (!this.lazyConnect) {
       await this.connect()
@@ -563,6 +564,18 @@ class CreatorNode {
       }
     }, false)
     this.authToken = resp.data.sessionToken
+
+    setTimeout(() => {
+      this.clearBrowserSession()
+    }, BROWSER_SESSION_REFRESH_TIMEOUT)
+  }
+
+  /**
+   * Clears authToken and connection to expire browser session.
+   */
+  clearBrowserSession () {
+    this.authToken = null
+    this.connected = false
   }
 
   async _logoutNodeUser () {
@@ -573,7 +586,6 @@ class CreatorNode {
       url: '/users/logout',
       method: 'post'
     }, false)
-    this.authToken = null
   }
 
   /**


### PR DESCRIPTION
* During login flow for cnode user we refresh the auth token every 7 days.
  This prevents the case where clients hold onto an expired session token
  for too long.

See also:

[ASI-614][1]

[1]: https://linear.app/audius/issue/ASI-614

### Description

Prereq for https://github.com/AudiusProject/audius-protocol/pull/1905 - prevents a case where clients with expired session tokens are left stranded without a refresh. 

### Tests

To be tested locally: on a client connected to local CN, expire the token on the server-side... does client refresh token? 

### How will this change be monitored?

N/A
