### PR TITLE
Fix eth contracts up service command

### DIFF
--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -35,8 +35,7 @@
   "eth-contracts": {
     "path": "eth-contracts",
     "up": [
-      "cd eth-contracts/",
-      "rm -rf build",
+      "cd eth-contracts/; rm -rf build",
       "docker run --name audius_ganache_cli_eth_contracts -d -p 8546:8545 --network=audius_dev trufflesuite/ganache-cli:v6.9.1 -h 0.0.0.0 --acctKeys eth-contracts-ganache-accounts.json -a 100 -l 8000000",
       "echo 'Waiting for ganache to fully come online...'",
       "sleep 5",


### PR DESCRIPTION
Fixes https://github.com/AudiusProject/audius-protocol/pull/1928. 

Each discrete command in [`service-commands.json`](https://github.com/AudiusProject/audius-protocol/blob/f57af4110471597e1e3bc2e8dfc0bd527a921c50/service-commands/src/commands/service-commands.json#L39) is prepended with `CD_PROTOCOL_DIR_COMMAND` (see [ref](https://github.com/AudiusProject/audius-protocol/blob/f57af4110471597e1e3bc2e8dfc0bd527a921c50/service-commands/src/setup.js#L49)) so the `rm -rf build` dir was removing `$PROTOCOL_DIR/build`, not `$PROTOCOL_DIR/eth-contracts/build`. This fixes the command so that it removes the build dir in the correct directory. 