### PR TITLE
Switch metadata gateway fetch from ipfs to replica set gateway

### DIFF
--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -52,7 +52,7 @@ class IPFSClient:
             retrieved_from_gateway = api_metadata != metadata_format
         except Exception:
             logger.error(
-                f"Failed to retrieve CID from local node, {multihash}", exc_info=True
+                f"Failed to retrieve CID from gateway, {multihash}", exc_info=True
             )
 
         # Else, try to retrieve from local ipfs node.
@@ -62,7 +62,7 @@ class IPFSClient:
                 retrieved_from_local_node = api_metadata != metadata_format
             except Exception:
                 logger.error(
-                    f"Failed to retrieve CID from gateway, {multihash}", exc_info=True
+                    f"Failed to retrieve CID from local node, {multihash}", exc_info=True
                 )
 
         retrieved_metadata = retrieved_from_gateway or retrieved_from_local_node


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

In order to gradually remove our dependency on ipfs, we will prioritize fetching from content node gateways first. This PR is to first fetch rom the content node gateways, and then the ipfs gateway if the first fetch fails.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

This reordering should not impact protocol usability.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

We should keep check of the ipfs fetch logs in discovery to see:
1. if there are any performance impacts with this change -- this will effectively shoot 3 requests (possibly >3 in the future) to the content nodes in the replica set VS 1 to the ipfs gateway. but, with the additional caching and more powerful boxes content node sps are on, this change should not be impactful.
2. if content nodes fail to retrieve the content

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->