### PR TITLE
Revert gateway switch

### DIFF
--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -44,25 +44,25 @@ class IPFSClient:
         retrieved_from_gateway = False
         start_time = time.time()
 
-        # First try to retrieve from gateways.
+        # First try to retrieve from local ipfs node.
         try:
-            api_metadata = self.get_metadata_from_gateway(
-                multihash, metadata_format, user_replica_set
-            )
-            retrieved_from_gateway = api_metadata != metadata_format
+            api_metadata = self.get_metadata_from_ipfs_node(multihash, metadata_format)
+            retrieved_from_local_node = api_metadata != metadata_format
         except Exception:
             logger.error(
-                f"Failed to retrieve CID from gateway, {multihash}", exc_info=True
+                f"Failed to retrieve CID from local node, {multihash}", exc_info=True
             )
 
-        # Else, try to retrieve from local ipfs node.
-        if not retrieved_from_gateway:
+        # Else, try to retrieve from gateways.
+        if not retrieved_from_local_node:
             try:
-                api_metadata = self.get_metadata_from_ipfs_node(multihash, metadata_format)
-                retrieved_from_local_node = api_metadata != metadata_format
+                api_metadata = self.get_metadata_from_gateway(
+                    multihash, metadata_format, user_replica_set
+                )
+                retrieved_from_gateway = api_metadata != metadata_format
             except Exception:
                 logger.error(
-                    f"Failed to retrieve CID from local node, {multihash}", exc_info=True
+                    f"Failed to retrieve CID from gateway, {multihash}", exc_info=True
                 )
 
         retrieved_metadata = retrieved_from_gateway or retrieved_from_local_node


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

After observing some logs, it looks like ipfs fetching is faster than content node gateway fetching. this pr is to revert the switch

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->