### PR TITLE
Fix: guard against forged sysvar instructions account in Claimable Tokens

### DIFF
--- a/solana-programs/audius_eth_registry/src/processor.rs
+++ b/solana-programs/audius_eth_registry/src/processor.rs
@@ -121,10 +121,6 @@ impl Processor {
     pub fn recover_secp_instructions(
         instruction_info: &AccountInfo,
     ) -> Result<Vec<(Instruction, u16)>, AudiusError> {
-        if !sysvar::instructions::check_id(&instruction_info.key) {
-            return Err(AudiusError::SignatureVerificationFailed.into());
-        }
-
         let mut v: Vec<(Instruction, u16)> = Vec::new();
         // Index of current instruction in tx
         let index = sysvar::instructions::load_current_index(&instruction_info.data.borrow());

--- a/solana-programs/claimable-tokens/program/src/processor.rs
+++ b/solana-programs/claimable-tokens/program/src/processor.rs
@@ -264,6 +264,10 @@ impl Processor {
         expected_signer: &EthereumAddress,
         expected_message: &[u8],
     ) -> ProgramResult {
+        if !sysvar::instructions::check_id(&instruction_info.key) {
+            return Err(ClaimableProgramError::Secp256InstructionLosing.into());
+        }
+
         let index = sysvar::instructions::load_current_index(&instruction_info.data.borrow());
 
         // instruction can't be first in transaction


### PR DESCRIPTION
### Description

- Fixes the previous commit, which implemented this fix incorrectly.

