### PR TITLE
Fix Discovery Node lat/long error log

### DIFF
--- a/discovery-provider/src/utils/config.py
+++ b/discovery-provider/src/utils/config.py
@@ -133,4 +133,4 @@ try:
     shared_config["serviceLocation"]["serviceLongitude"] = longitude
 
 except (KeyError, RuntimeError) as e:
-    logger.error(f"""Failed to get latitude ({latitude}) and/or longitude ({longitude}): {e}""")
+    logger.error(f"""Failed to get latitude and/or longitude : {e}""")


### PR DESCRIPTION
### Description

Startup would fail if lat/long was undefined

### Tests

None

### How will this change be monitored?

n/a