### PR TITLE
Remove old lookupKey if password was reset

### DIFF
--- a/identity-service/src/routes/authentication.js
+++ b/identity-service/src/routes/authentication.js
@@ -40,7 +40,7 @@ module.exports = function (app) {
           .then(function (auth) {
             const oldLookupKey = body.oldLookupKey
             if (oldLookupKey) {
-              await models.Authentication.destroy({ where: { lookupKey: oldLookupKey } }, { transaction: t })
+              return models.Authentication.destroy({ where: { lookupKey: oldLookupKey } }, { transaction: t })
             }
           })
         })


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

If the `oldLookupKey` is included in reset password, mark that lookup key as deleted so it can't be used to auth.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Manually tested on remote dev. Test cases:
- `oldLookupKey` present but non-existent: No deletion ✅ 
- `oldLookupKey` present and exists: Old record marked as deleted ✅ 
- `oldLookupKey` not present: No deletion ✅ 
- `oldLookupKey` and `lookupKey` are the same: Deletion is no-op, signup succeeds ✅ 

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->