### PR TITLE
Fix OpenResty pass through for checks

### DIFF
--- a/discovery-provider/scripts/gen_nginx_conf.py
+++ b/discovery-provider/scripts/gen_nginx_conf.py
@@ -27,7 +27,7 @@ http {
     server {
         listen 5000;
 
-        location = /health_check {
+        location ~* .*_(check|version) {
             proxy_pass http://127.0.0.1:3000;
         }
 


### PR DESCRIPTION
### Description

This PR proxy passes all check related endpoints through OpenResty

### Tests

Tested on Staging

### How will this change be monitored?

Will monitor on prod


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->