### PR TITLE
Dont print value since it can be very large

### DIFF
--- a/discovery-provider/src/monitors/monitoring_queue.py
+++ b/discovery-provider/src/monitors/monitoring_queue.py
@@ -27,7 +27,7 @@ def refresh(redis, db, monitor):
     # This allows any monitor to access the db and/or redis connection.
     value = monitor[monitor_names.func](db=db, redis=redis)
     logger.info(
-        f"monitoring_queue.py | Computed value for {monitor[monitor_names.name]} {value}"
+        f"monitoring_queue.py | Computed value for {monitor[monitor_names.name]}"
     )
 
     redis.set(key, value)


### PR DESCRIPTION
### Description
Right now the discovery logs get littered with 
```
"monitoring_queue.py | Computed value for slow_queries [{\"query\": \"SELECT tracks.blockhash AS tracks_blockhash, tracks.blocknumber AS tracks_blocknumber, tracks.txhash AS tracks_txhash, tracks.track_id AS tracks_track_id, tracks.is_current AS tracks_is_current, tracks.is_delete AS tracks_is_delete, tracks.owner_id AS tracks_owner_id, tracks.route_id AS tracks_route_id, tracks.title AS tracks_title, tracks.length AS tracks_length, tracks.cover_art AS tracks_cover_art, tracks.cover_art_sizes AS tracks_cover_art_sizes, tracks.tags AS tracks_tags, tracks.genre AS tracks_genre, tracks.mood AS tracks_mood, tracks.credits_splits AS tracks_credits_splits, tracks.remix_of AS tracks_remix_of, tracks.create_date AS tracks_create_date, tracks.release_date A...
```
This just prints "monitoring_queue.py | Computed value for slow_queries"
```
<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->