### PR TITLE
Fix copyright year where hardcoded to 2019

### DIFF
--- a/identity-service/src/notifications/emails/recovery.html
+++ b/identity-service/src/notifications/emails/recovery.html
@@ -131,7 +131,7 @@
       font-weight: 100;
       src: url(https://download.audius.co/fonts/Gilroy-Thin.ttf) format('truetype'), url(https://download.audius.co/fonts/Gilroy-Thin.otf) format('opentype')
     }
-    
+
   </style>
   <style type="text/css">
     html {
@@ -639,7 +639,7 @@
                       <p>Made with <span class='purple'>♥︎</span> in SF & LA</p>
                     </td>
                     <td>
-                      <p>&copy; 2019 Audius, Inc. All Rights Reserved.</p>
+                      <p>&copy; {{copyright_year}} Audius, Inc. All Rights Reserved.</p>
                     </td>
                   </tr>
                   <tr>

--- a/identity-service/src/notifications/renderEmail/Footer.js
+++ b/identity-service/src/notifications/renderEmail/Footer.js
@@ -61,6 +61,7 @@ var MadeWithLove = function MadeWithLove() {
 };
 
 var AllRightsReserved = function AllRightsReserved() {
+  var currentYear = new Date().getFullYear().toString();
   return _react["default"].createElement("div", {
     className: 'gilroy',
     style: {
@@ -68,7 +69,7 @@ var AllRightsReserved = function AllRightsReserved() {
       color: '#858199',
       fontSize: '14px'
     }
-  }, "\xA9 2019 Audius, Inc. All Rights Reserved.");
+  }, `\xA9 ${currentYear} Audius, Inc. All Rights Reserved.`);
 };
 
 var Unsubscribe = function Unsubscribe() {

--- a/identity-service/src/routes/recovery.js
+++ b/identity-service/src/routes/recovery.js
@@ -63,10 +63,11 @@ module.exports = function (app) {
       email: email
     }
     const recoveryLink = host + toQueryStr(recoveryParams)
-
+    const copyrightYear = new Date().getFullYear().toString()
     const context = {
       recovery_link: recoveryLink,
-      handle: handle
+      handle: handle,
+      copyright_year: copyrightYear
     }
     const recoveryHtml = recoveryTemplate(context)
 


### PR DESCRIPTION
### Description

Noticed in my email notifs that the copyright year said 2019 so wanted to open a quick fix to make year templating dynamic. Keepin' up w the times :) - will open a similar PR on the client-side as I originally noticed this happening on the Settings page.