### PR TITLE
Fix aggregate user follower count

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_user.py
+++ b/discovery-provider/src/tasks/index_aggregate_user.py
@@ -248,12 +248,6 @@ UPDATE_AGGREGATE_USER_QUERY = """
                 WHERE
                     f.is_current IS TRUE
                     AND f.is_delete IS FALSE
-                    AND f.follower_user_id IN (
-                        SELECT
-                            user_id
-                        FROM
-                            changed_users
-                    )
                 GROUP BY
                     f.followee_user_id
             ) user_follower ON user_follower.followee_user_id = u.user_id
@@ -266,12 +260,6 @@ UPDATE_AGGREGATE_USER_QUERY = """
                 WHERE
                     f.is_current IS TRUE
                     AND f.is_delete IS FALSE
-                    AND f.follower_user_id IN (
-                        SELECT
-                            user_id
-                        FROM
-                            changed_users
-                    )
                 GROUP BY
                     f.follower_user_id
             ) user_followee ON user_followee.follower_user_id = u.user_id


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->
Noticed this bug while testing stage. All aggregate_user values were correct initially but shortly after decremented to lower values. This is because we're filtering for changed_user in the follower column so the count only lasted when the users were considered new. In fact, we can probably remove all changed_users filtering besides the users table. This should have no effect on data correctness and negligible performance impact.  

### Tests
Ran against stage and follower count updated to correct values.

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->