### PR TITLE
Update aggregate_user filtering for performance and consistency

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_user.py
+++ b/discovery-provider/src/tasks/index_aggregate_user.py
@@ -248,7 +248,7 @@ UPDATE_AGGREGATE_USER_QUERY = """
                 WHERE
                     f.is_current IS TRUE
                     AND f.is_delete IS FALSE
-                    AND f.followee_user_id IN (
+                    AND f.followee_user_id IN ( -- to calculate follower count for changed users, changed user id must match followee user id
                         SELECT
                             user_id
                         FROM


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adding these filters back because I noticed a small performance difference if all filters were removed. I had assumed the single filter on the users would be equivalent but I noticed a ~.2 second difference. Data correctness is equivalent. 

The only difference from [the original change](https://github.com/AudiusProject/audius-protocol/pull/1963
) is the filter for follower_count now considers any followee ID that is a changed users. Previously filtering for follower IDs as changed_users would correctly calculate new follows but would revert to an incorrect value when those followers weren't considered changed anymore.

Related PRs
https://github.com/AudiusProject/audius-protocol/pull/2001


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran against stage 2 and validated counts.


### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->