### PR TITLE
Listen Milestone

### DIFF
--- a/discovery-provider/alembic/versions/8bc5bac6711b_add_milestone.py
+++ b/discovery-provider/alembic/versions/8bc5bac6711b_add_milestone.py
@@ -1,0 +1,74 @@
+"""add milestone
+
+Revision ID: 8bc5bac6711b
+Revises: e2a8aea2e2e1
+Create Date: 2021-10-20 15:28:46.113178
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8bc5bac6711b'
+down_revision = 'e2a8aea2e2e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "milestones",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("threshold", sa.Integer(), nullable=False),
+        sa.Column("blocknumber", sa.Integer(), nullable=True),
+        sa.Column("slot", sa.Integer(), nullable=True),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Index("name", "id"),
+        sa.PrimaryKeyConstraint(
+            "id", "name", "threshold"
+        )
+    )
+    # Backfill Milestone for existsing listen milestones
+    connection = op.get_bind()
+    connection.execute(
+    """
+    INSERT INTO milestones (
+        id,
+        name,
+        threshold,
+        blocknumber,
+        slot,
+        timestamp
+    )
+    SELECT
+        play_item_id as id,
+        'LISTEN_COUNT' as name,
+        CASE
+            WHEN count BETWEEN 10 AND 24 THEN 10
+            WHEN count BETWEEN 25 AND 49 THEN 25
+            WHEN count BETWEEN 50 AND 99 THEN 50
+            WHEN count BETWEEN 100 AND 499 THEN 100
+            WHEN count BETWEEN 500 AND 999 THEN 500
+            WHEN count BETWEEN 1000 AND 4999 THEN 1000
+            WHEN count BETWEEN 5000 AND 9999 THEN 5000
+            WHEN count BETWEEN 10000 AND 1999 THEN 10000
+            WHEN count BETWEEN 20000 AND 4999 THEN 20000
+            WHEN count BETWEEN 50000 AND 99999 THEN 50000
+            WHEN count BETWEEN 100000 AND 999999 THEN 100000
+            WHEN count >= 1000000 THEN 1000000
+        END AS threshold,
+        0 as blocknumber,
+        0 as slot,
+        now() as timestamp
+    FROM
+        aggregate_plays
+    WHERE
+        count >= 10;
+    """
+    )
+
+
+def downgrade():
+    op.drop_table("milestones")

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -378,6 +378,7 @@ def configure_celery(flask_app, celery, test_config=None):
             "src.tasks.index_rewards_manager",
             "src.tasks.index_related_artists",
             "src.tasks.calculate_trending_challenges",
+            "src.tasks.index_listen_count_milestones",
         ],
         beat_schedule={
             "update_discovery_provider": {
@@ -475,6 +476,10 @@ def configure_celery(flask_app, celery, test_config=None):
             "index_related_artists": {
                 "task": "index_related_artists",
                 "schedule": timedelta(seconds=60),
+            },
+            "index_listen_count_milestones": {
+                "task": "index_listen_count_milestones",
+                "schedule": timedelta(seconds=5),
             },
         },
         task_serializer="json",

--- a/discovery-provider/src/models/__init__.py
+++ b/discovery-provider/src/models/__init__.py
@@ -56,6 +56,7 @@ from .reward_manager import RewardManagerTransaction
 from .aggregate_interval_play import AggregateIntervalPlay
 from .trending_param import TrendingParam
 from .track_trending_score import TrackTrendingScore
+from .milestone import Milestone
 
 __all__ = [
     "AggregateDailyAppNameMetrics",
@@ -83,6 +84,7 @@ __all__ = [
     "ChallengeType",
     "Follow",
     "IPLDBlacklistBlock",
+    "Milestone",
     "Play",
     "Playlist",
     "ProfileCompletionChallenge",

--- a/discovery-provider/src/models/milestone.py
+++ b/discovery-provider/src/models/milestone.py
@@ -1,0 +1,29 @@
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    PrimaryKeyConstraint,
+)
+from .models import Base
+
+class Milestone(Base):
+    __tablename__ = "milestones"
+
+    id = Column(Integer, nullable=False)
+    name = Column(String, nullable=False)
+    threshold = Column(Integer, nullable=False)
+    blocknumber = Column(Integer, nullable=True)
+    slot = Column(Integer, nullable=True)
+    timestamp = Column(DateTime, nullable=False)
+    PrimaryKeyConstraint(id, name, threshold)
+
+    def __repr__(self):
+        return f"<Milestone(\
+id={self.id},\
+name={self.name},\
+threshold={self.threshold},\
+blocknumber={self.blocknumber},\
+slot={self.slot},\
+timestamp={self.timestamp},\
+)>"

--- a/discovery-provider/src/queries/get_health_test.py
+++ b/discovery-provider/src/queries/get_health_test.py
@@ -11,7 +11,11 @@ from src.utils.redis_constants import (
     challenges_last_processed_event_redis_key,
     latest_sol_play_db_tx_key,
     latest_sol_play_program_tx_key,
-    latest_legacy_play_db_key
+    latest_legacy_play_db_key,
+    latest_sol_rewards_manager_program_tx_key,
+    latest_sol_rewards_manager_db_tx_key,
+    latest_sol_user_bank_program_tx_key,
+    latest_sol_user_bank_db_tx_key
 )
 from src.models import Block
 from src.queries.get_health import get_health
@@ -23,11 +27,9 @@ def cache_play_health_vars(redis_mock):
     redis_mock.set(
         latest_sol_play_db_tx_key,
         json.dumps({
-            "user_id": 0,
-            "track_id": 1,
-            "created_at": 1635477758,
+            "timestamp": 1635477758,
             "slot": 12,
-            "tx_sig": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK"
+            "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK"
         })
     )
     # Set latest legacy
@@ -38,6 +40,42 @@ def cache_play_health_vars(redis_mock):
     # Set latest chain tx
     redis_mock.set(
         latest_sol_play_program_tx_key,
+        json.dumps({
+            "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK",
+            "slot": 15,
+            "timestamp":1635477758
+        })
+    )
+    # Set latest chain tx
+    redis_mock.set(
+        latest_sol_rewards_manager_program_tx_key,
+        json.dumps({
+            "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK",
+            "slot": 15,
+            "timestamp":1635477758
+        })
+    )
+    # Set latest chain tx
+    redis_mock.set(
+        latest_sol_rewards_manager_db_tx_key,
+        json.dumps({
+            "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK",
+            "slot": 15,
+            "timestamp":1635477758
+        })
+    )
+    # Set latest chain tx
+    redis_mock.set(
+        latest_sol_user_bank_program_tx_key,
+        json.dumps({
+            "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK",
+            "slot": 15,
+            "timestamp":1635477758
+        })
+    )
+    # Set latest chain tx
+    redis_mock.set(
+        latest_sol_user_bank_db_tx_key,
         json.dumps({
             "signature": "5SD9fJhsuMKb1dnJtKszoLLHGve5qmubTvfJX6eLQKRT71XWXkAGXw5faj2uJPhqngzT2V4zucocGiyXYXYMv7QK",
             "slot": 15,
@@ -79,7 +117,7 @@ def test_get_health(web3_mock, redis_mock, db_mock):
     assert health_results["db"]["number"] == 1
     assert health_results["db"]["blockhash"] == "0x01"
     assert health_results["block_difference"] == 1
-    assert health_results["plays"]["solana"]["slot_diff"] == 3
+    assert health_results["plays"]["tx_info"]["slot_diff"] == 3
 
     assert "maximum_healthy_block_difference" in health_results
     assert "version" in health_results

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -1,14 +1,15 @@
 import logging
 from datetime import datetime
-from typing import Optional, TypedDict
+from typing import Optional, List, Dict
+from redis import Redis
 from sqlalchemy import desc, func
 from src import exceptions
 from src.models import Play
 from src.utils import helpers
+from src.utils.cache_solana_program import CachedProgramTxInfo, get_cache_latest_sol_program_tx, get_latest_sol_db_tx
 from src.utils.db_session import get_db_read_replica
 from src.queries.query_helpers import get_track_play_counts
 from src.utils.redis_constants import latest_sol_play_program_tx_key, latest_sol_play_db_tx_key
-from src.utils.helpers import redis_get_json_cached_key_or_restore
 from src.tasks.index_solana_plays import cache_latest_sol_play_db_tx
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def get_sol_play(sol_tx_signature):
     return sol_play
 
 # Get last x sol specific plays
-def get_latest_sol_plays(limit=10):
+def get_latest_sol_plays(limit=10) -> Optional[List[Dict]]:
     db = get_db_read_replica()
 
     # Cap max returned db entries
@@ -70,61 +71,45 @@ def get_track_listen_milestones(limit=100):
 
     return track_id_play_counts
 
-class CachedDBListenTxInfo(TypedDict):
-    # User ID for listen
-    user_id: Optional[int]
-    # Track ID for listen
-    track_id: int
-    # UTC timestamp this was created at
-    created_at: int
-    # Source of tx submission (should only be 'relay')
-    source: str
-    # Slot in which tx was processed
-    slot: int
-    # Signature of transaction
-    tx_sig: str
-
 # Retrieve the latest stored value in database for sol plays
 # Cached during processing of plays
-def get_latest_cached_sol_play_db(redis) -> CachedDBListenTxInfo:
-    latest_sol_play_db = redis_get_json_cached_key_or_restore(redis, latest_sol_play_db_tx_key)
+def get_latest_cached_sol_play_db(redis) -> CachedProgramTxInfo:
+    latest_sol_play_db = get_cache_latest_sol_program_tx(redis, latest_sol_play_db_tx_key)
     plays_from_db = None
     if not latest_sol_play_db:
         # If nothing found in cache, pull from db
         plays_from_db = get_latest_sol_plays(1)
-        latest_sol_play_db = plays_from_db[0] if plays_from_db else None
-        # If found, re-cache value to avoid repeated DB hits
-        if latest_sol_play_db:
-            cache_latest_sol_play_db_tx(redis, latest_sol_play_db)
+        latest_sol_play = plays_from_db[0] if plays_from_db else None
+        if latest_sol_play:
+            latest_sol_play_db = {
+                "signature": latest_sol_play.get("signature"),
+                "slot": latest_sol_play.get("slot"),
+                "timestamp": int(latest_sol_play.get("created_at").timestamp())
+            }
+            # If found, re-cache value to avoid repeated DB hits
+            if latest_sol_play_db:
+                cache_latest_sol_play_db_tx(redis, latest_sol_play_db)
     return latest_sol_play_db
-
-class CachedProgramTxInfo(TypedDict):
-    # Signature of latest transaction that has been processed
-    signature: str
-    # Slot corresponding to tx signature
-    slot: int
-    # Block time of latest transaction on chain
-    timestamp: int
 
 def get_latest_cached_sol_play_program_tx(redis) -> CachedProgramTxInfo:
     # Latest play tx from chain
-    latest_sol_play_program_tx = redis_get_json_cached_key_or_restore(redis, latest_sol_play_program_tx_key)
+    latest_sol_play_program_tx = get_latest_sol_db_tx(redis, latest_sol_play_program_tx_key)
     return latest_sol_play_program_tx
 
 # Retrieve sol plays health object
-def get_sol_play_health_info(redis, current_time_utc):
+def get_sol_play_health_info(redis: Redis, current_time_utc: datetime):
     # Query latest plays information
     # Latest play tx committed to DB
     latest_sol_play_db = get_latest_cached_sol_play_db(redis)
 
     # Latest play tx from chain
-    latest_sol_play_program_tx = get_latest_cached_sol_play_program_tx(redis)
-    time_diff = -1
+    latest_sol_play_program_tx = get_latest_sol_db_tx(redis, latest_sol_play_program_tx_key)
+    time_diff = -1.0
     slot_diff = -1
 
     if latest_sol_play_db and latest_sol_play_program_tx:
         slot_diff = latest_sol_play_program_tx["slot"] - latest_sol_play_db["slot"]
-        last_created_at_time = datetime.utcfromtimestamp(latest_sol_play_db["created_at"])
+        last_created_at_time = datetime.utcfromtimestamp(latest_sol_play_db["timestamp"])
         time_diff = (current_time_utc - last_created_at_time).total_seconds()
 
     return_val = {
@@ -137,14 +122,14 @@ def get_sol_play_health_info(redis, current_time_utc):
     }
     return return_val
 
-def get_latest_sol_play_check_info(redis, limit):
+def get_latest_sol_play_check_info(redis: Redis, limit: int):
     response = {}
     # Latest play information from chain
-    latest_sol_play_program_tx = redis_get_json_cached_key_or_restore(
+    latest_sol_play_program_tx = get_latest_sol_db_tx(
         redis,
         latest_sol_play_program_tx_key
     )
-    latest_sol_play_db_tx = redis_get_json_cached_key_or_restore(
+    latest_sol_play_db_tx = get_cache_latest_sol_program_tx(
         redis,
         latest_sol_play_db_tx_key
     )

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, TypedDict
 from redis import Redis
 from sqlalchemy import desc, func
 from src import exceptions
@@ -29,8 +29,18 @@ def get_sol_play(sol_tx_signature):
 
     return sol_play
 
+class PlayDict(TypedDict):
+    id: int
+    user_id: int
+    source: Optional[str]
+    play_item_id: int
+    slot: Optional[int]
+    signature: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
 # Get last x sol specific plays
-def get_latest_sol_plays(limit=10) -> Optional[List[Dict]]:
+def get_latest_sol_plays(limit=10) -> Optional[List[PlayDict]]:
     db = get_db_read_replica()
 
     # Cap max returned db entries
@@ -84,7 +94,7 @@ def get_latest_cached_sol_play_db(redis) -> CachedProgramTxInfo:
             latest_sol_play_db = {
                 "signature": latest_sol_play.get("signature"),
                 "slot": latest_sol_play.get("slot"),
-                "timestamp": int(latest_sol_play.get("created_at").timestamp())
+                "timestamp": int(latest_sol_play["created_at"].timestamp())
             }
             # If found, re-cache value to avoid repeated DB hits
             if latest_sol_play_db:

--- a/discovery-provider/src/queries/get_sol_plays.py
+++ b/discovery-provider/src/queries/get_sol_plays.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Optional, List, Dict, TypedDict
+from typing import Optional, List, TypedDict
 from redis import Redis
 from sqlalchemy import desc, func
 from src import exceptions

--- a/discovery-provider/src/queries/get_sol_rewards_manager.py
+++ b/discovery-provider/src/queries/get_sol_rewards_manager.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from typing import Optional, Dict
 from redis import Redis
@@ -10,9 +9,6 @@ from src.utils.cache_solana_program import CachedProgramTxInfo, get_cache_latest
 from src.utils.db_session import get_db_read_replica
 from src.utils.redis_constants import latest_sol_rewards_manager_db_tx_key
 from src.utils import helpers
-
-logger = logging.getLogger(__name__)
-
 
 # Get last sol rewards manager transaction in the db
 def get_latest_sol_rewards_manager() -> Optional[Dict]:

--- a/discovery-provider/src/queries/get_sol_rewards_manager.py
+++ b/discovery-provider/src/queries/get_sol_rewards_manager.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import datetime
+from typing import Optional, Dict
+from redis import Redis
+from sqlalchemy import desc
+from src.models import RewardManagerTransaction
+from src.queries.get_sol_user_bank import get_sol_tx_health_info
+from src.tasks.index_rewards_manager import cache_latest_sol_rewards_manager_db_tx
+from src.utils.cache_solana_program import CachedProgramTxInfo, get_cache_latest_sol_program_tx, get_latest_sol_db_tx
+from src.utils.db_session import get_db_read_replica
+from src.utils.redis_constants import latest_sol_rewards_manager_db_tx_key
+from src.utils import helpers
+
+logger = logging.getLogger(__name__)
+
+
+# Get last sol rewards manager transaction in the db
+def get_latest_sol_rewards_manager() -> Optional[Dict]:
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        rewards_manager_tx = (
+            session.query(RewardManagerTransaction)
+            .order_by(desc(RewardManagerTransaction.slot))
+            .first()
+        )
+        if rewards_manager_tx:
+            return helpers.model_to_dictionary(rewards_manager_tx)
+    return None
+
+# Retrieve the latest stored value in database for rewards manager
+# Cached during processing
+def get_latest_cached_sol_rewards_manager_db(redis: Redis) -> Optional[CachedProgramTxInfo]:
+    latest_sol_rewards_manager_db = get_cache_latest_sol_program_tx(redis, latest_sol_rewards_manager_db_tx_key)
+    if not latest_sol_rewards_manager_db:
+        # If nothing found in cache, pull from db
+        rewards_manager_tx = get_latest_sol_rewards_manager()
+        if rewards_manager_tx:
+            latest_sol_rewards_manager = {
+                "signature": rewards_manager_tx["signature"],
+                "slot": rewards_manager_tx["slot"],
+                "timestamp": int(rewards_manager_tx["created_at"].timestamp())
+            }
+            # If found, re-cache value to avoid repeated DB hits
+            cache_latest_sol_rewards_manager_db_tx(redis, latest_sol_rewards_manager)
+
+    return latest_sol_rewards_manager_db
+
+def get_latest_cached_sol_rewards_manager_program_tx(redis) -> CachedProgramTxInfo:
+    # Latest rewards_manager tx from chain
+    latest_sol_rewards_manager_program_tx = get_latest_sol_db_tx(redis, latest_sol_rewards_manager_db_tx_key)
+    return latest_sol_rewards_manager_program_tx
+
+def get_sol_rewards_manager_health_info(redis: Redis, current_time_utc: datetime):
+    db_cache = get_latest_cached_sol_rewards_manager_db(redis)
+    tx_cache = get_latest_cached_sol_rewards_manager_program_tx(redis)
+    return get_sol_tx_health_info(current_time_utc, db_cache, tx_cache)

--- a/discovery-provider/src/queries/get_sol_user_bank.py
+++ b/discovery-provider/src/queries/get_sol_user_bank.py
@@ -1,0 +1,89 @@
+import logging
+from datetime import datetime
+from typing import Optional, TypedDict, Dict
+from redis import Redis
+from sqlalchemy import desc
+from src.models import UserBankTransaction
+from src.tasks.index_user_bank import cache_latest_sol_user_bank_db_tx
+from src.utils.cache_solana_program import CachedProgramTxInfo, get_cache_latest_sol_program_tx, get_latest_sol_db_tx
+from src.utils.db_session import get_db_read_replica
+from src.utils.redis_constants import latest_sol_user_bank_db_tx_key
+from src.utils import helpers
+
+logger = logging.getLogger(__name__)
+
+
+# Get last user_bank sol tx
+def get_latest_sol_user_bank() -> Optional[Dict]:
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        user_bank_tx = (
+            session.query(UserBankTransaction)
+            .order_by(desc(UserBankTransaction.slot))
+            .first()
+        )
+        if user_bank_tx:
+            return helpers.model_to_dictionary(user_bank_tx)
+    return None
+
+# Retrieve the latest stored value in database for sol plays
+# Cached during processing
+def get_latest_cached_sol_user_bank_db(redis: Redis) -> Optional[CachedProgramTxInfo]:
+    latest_sol_user_bank_db = get_cache_latest_sol_program_tx(redis, latest_sol_user_bank_db_tx_key)
+    if not latest_sol_user_bank_db:
+        # If nothing found in cache, pull from db
+        user_bank = get_latest_sol_user_bank()
+        if user_bank:
+            latest_sol_user_bank_db = {
+                "signature": user_bank["signature"],
+                "slot": user_bank["slot"],
+                "timestamp": int(user_bank["created_at"].timestamp())
+            }
+            # If found, re-cache value to avoid repeated DB hits
+            if latest_sol_user_bank_db:
+                cache_latest_sol_user_bank_db_tx(redis, latest_sol_user_bank_db)
+
+    return latest_sol_user_bank_db
+
+def get_latest_cached_sol_user_bank_program_tx(redis) -> CachedProgramTxInfo:
+    # Latest user_bank tx from chain
+    latest_sol_user_bank_program_tx = get_latest_sol_db_tx(redis, latest_sol_user_bank_db_tx_key)
+    return latest_sol_user_bank_program_tx
+
+def get_sol_user_bank_health_info(redis: Redis, current_time_utc: datetime):
+    db_cache = get_latest_cached_sol_user_bank_db(redis)
+    tx_cache = get_latest_cached_sol_user_bank_program_tx(redis)
+    return get_sol_tx_health_info(current_time_utc, db_cache, tx_cache)
+
+class SolTxHealthTxInfo(TypedDict):
+    chain_tx: Optional[CachedProgramTxInfo]
+    db_tx: Optional[CachedProgramTxInfo]
+
+class SolTxHealthInfo(TypedDict):
+    slot_diff: int
+    tx_info: SolTxHealthTxInfo
+    time_diff: float
+
+# Retrieve sol plays health object
+def get_sol_tx_health_info(
+    current_time_utc: datetime,
+    db_cache: Optional[CachedProgramTxInfo],
+    tx_cache: Optional[CachedProgramTxInfo]
+) -> SolTxHealthInfo:
+    time_diff = -1.0
+    slot_diff = -1
+
+    if db_cache and tx_cache:
+        slot_diff = tx_cache["slot"] - db_cache["slot"]
+        last_created_at_time = datetime.utcfromtimestamp(db_cache["timestamp"])
+        time_diff = (current_time_utc - last_created_at_time).total_seconds()
+
+    return_val: SolTxHealthInfo = {
+        "slot_diff": slot_diff,
+        "tx_info": {
+            "chain_tx": tx_cache,
+            "db_tx": db_cache,
+        },
+        "time_diff": time_diff,
+    }
+    return return_val

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -1,9 +1,9 @@
 import logging  # pylint: disable=C0302
 import functools as ft
 from datetime import date, datetime, timedelta
+from typing import Tuple, List
 from flask import Blueprint, request
 from sqlalchemy import desc
-from typing import Tuple, TypedDict, List, Optional, Dict, Set
 
 from src import api_helpers
 from src.models import (
@@ -18,7 +18,6 @@ from src.models import (
     Remix,
     AggregateUser,
     ChallengeDisbursement,
-    RewardManagerTransaction,
 )
 from src.models.milestone import Milestone
 from src.queries import response_name_constants as const
@@ -926,13 +925,13 @@ def solana_notifications():
     # TODO: This needs to be updated when more notification types are added to the solana notifications queue
     # Need to write a system to keep track of the proper latest slot to index based on all of the applicable table
     with db.scoped_session() as session:
-        current_slot_query_result = (
-            session.query(RewardManagerTransaction.slot)
-            .order_by(
-                desc(RewardManagerTransaction.slot)
-            )
-            .first()
-        )
+        # current_slot_query_result = (
+        #     session.query(RewardManagerTransaction.slot)
+        #     .order_by(
+        #         desc(RewardManagerTransaction.slot)
+        #     )
+        #     .first()
+        # )
         milestone_slot_query_result = (
             session.query(Milestone.slot)
             .order_by(

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -899,24 +899,18 @@ def notifications():
 
 
 def get_max_slot(redis: Redis):
-    logger.error("GET MAX CLOST")
     max_slot = 0
 
     listen_milestone_slot = redis.get(PROCESSED_LISTEN_MILESTONE)
-    logger.error(listen_milestone_slot)
     if listen_milestone_slot:
         max_slot = int(listen_milestone_slot)
-    logger.error(max_slot)
 
     rewards_manager_db_cache = get_latest_cached_sol_rewards_manager_db(redis)
     tx_cache = get_latest_cached_sol_rewards_manager_program_tx(redis)
-    logger.error(rewards_manager_db_cache)
-    logger.error(tx_cache)
 
     if tx_cache and rewards_manager_db_cache:
         if tx_cache["slot"] != rewards_manager_db_cache["slot"]:
             max_slot = min(rewards_manager_db_cache["slot"], max_slot)
-    logger.error(max_slot)
 
     return max_slot
 

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -101,6 +101,7 @@ notification_playlist_update_users = "playlist_update_users"
 # solana notification metadata
 solana_notification_type = "type"
 solana_notification_type_challenge_reward = "ChallengeReward"
+solana_notification_type_listen_milestone = "MilestoneListen"
 
 solana_notification_slot = "slot"
 solana_notification_timestamp = "timestamp"
@@ -108,6 +109,7 @@ solana_notification_initiator = "initiator"
 solana_notification_metadata = "metadata"
 
 solana_notification_challenge_id = "challenge_id"
+solana_notification_threshold = "threshold"
 
 # Trending
 owner_follower_count = "owner_follower_count"

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -88,16 +88,16 @@ class SolanaClientManager:
                 except Exception as e:
                     logger.error(
                         f"solana_client_manager.py | get_confirmed_signature_for_address2 | \
-                            Error fetching tx {tx_sig} from endpoint {endpoint}, {e}",
+                            Error fetching account {account} from endpoint {endpoint}, {e}",
                         exc_info=True,
                     )
                 num_retries -= 1
                 time.sleep(DELAY_SECONDS)
                 logger.error(
-                    f"solana_client_manager.py | get_confirmed_signature_for_address2 | Retrying tx fetch: {tx_sig} with endpoint {endpoint}"
+                    f"solana_client_manager.py | get_confirmed_signature_for_address2 | Retrying account fetch: {account} with endpoint {endpoint}"
                 )
             raise Exception(
-                f"solana_client_manager.py | get_confirmed_signature_for_address2 | Failed to fetch {tx_sig} with endpoint {endpoint}"
+                f"solana_client_manager.py | get_confirmed_signature_for_address2 | Failed to fetch account {account} with endpoint {endpoint}"
             )
 
         return _try_all_with_timeout(

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 from solana.account import Account
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
+from src.solana.solana_transaction_types import ConfirmedSignatureForAddressResponse
 from src.utils.config import shared_config
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ class SolanaClientManager:
             while num_retries > 0:
                 try:
                     logger.info(f"solana_client_manager.py | handle_get_confirmed_signature_for_address2 | Fetching {before} {endpoint}")
-                    transactions = client.get_confirmed_signature_for_address2(account, before, limit)
+                    transactions: ConfirmedSignatureForAddressResponse = client.get_confirmed_signature_for_address2(account, before, limit)
                     logger.info(f"solana_client_manager.py | handle_get_confirmed_signature_for_address2 | Finished fetching {before} {endpoint}")
                     return transactions
                 except Exception as e:

--- a/discovery-provider/src/solana/solana_transaction_types.py
+++ b/discovery-provider/src/solana/solana_transaction_types.py
@@ -71,3 +71,16 @@ class TransactionInfoResult(TypedDict):
     meta: ResultMeta
     slot: int
     transaction: ResultTransction
+
+class ConfirmedSignatureForAddressResult(TypedDict):
+    err: Any
+    memo: Any
+    signature: str
+    slot: int
+    blockTime: int
+    confirmationStatus: str
+
+class ConfirmedSignatureForAddressResponse(TypedDict):
+    jsonrpc: str
+    result: List[ConfirmedSignatureForAddressResult]
+    id: int

--- a/discovery-provider/src/tasks/index_listen_count_milestones.py
+++ b/discovery-provider/src/tasks/index_listen_count_milestones.py
@@ -1,0 +1,151 @@
+from datetime import datetime
+import logging
+import time
+from typing import List, Optional
+from redis import Redis
+from sqlalchemy import func
+
+from src.models import Milestone
+from src.models.models import AggregatePlays
+from src.tasks.celery_app import celery
+from src.utils.session_manager import SessionManager
+from src.utils.redis_cache import get_json_cached_key
+
+logger = logging.getLogger(__name__)
+
+CURRENT_PLAY_INDEXING = 'CURRENT_PLAY_INDEXING'
+PROCESSED_LISTEN_MILESTONE = 'PROCESSED_LISTEN_MILESTONE'
+TRACK_LISTEN_IDS = 'TRACK_LISTEN_IDS'
+
+LISTEN_COUNT_MILESTONE = 'LISTEN_COUNT'
+milestone_threshold = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000]
+next_threshold = { prev: next for prev, next in zip(milestone_threshold[:-1], milestone_threshold[1:]) }
+
+
+def get_next_track_milestone(play_count: int, prev_milestone: Optional[int]=None):
+    """
+    Gets the next hightest milstone threshold avaiable given the play count, 
+    if past the last threshold or given an invalid previous milestone, will return None
+    """
+    next_milestone = milestone_threshold[0]
+    if prev_milestone:
+        if prev_milestone in next_threshold:
+            next_milestone = next_threshold[prev_milestone]
+        else:
+            # track is past the last milestone, so return none and stop
+            return None
+    
+    # If play counts have not passed the next threshold, return None
+    if play_count < next_milestone:
+        return None
+
+    # If play counts have pasted the next milestone threshold, continue to compare against higher thresholds
+    next_next_milestone = next_threshold[next_milestone] if next_milestone in next_threshold else None
+    while next_next_milestone and play_count >= next_next_milestone:
+        next_milestone = next_next_milestone
+        next_next_milestone = next_threshold[next_milestone] if next_milestone in next_threshold else None
+
+    return next_milestone
+
+def get_track_listen_ids(redis) -> List[int]:
+    check_track_ids: List[bytes] = list(redis.smembers(TRACK_LISTEN_IDS))
+    return [int(track_id.decode()) for track_id in check_track_ids]
+
+
+def index_listen_count_milestones(db: SessionManager, redis: Redis):
+    logger.info(
+        "index_listen_count_milestones.py | Start calculating listen count milestones"
+    )
+    job_start = time.time()
+    with db.scoped_session() as session:
+        current_play_indexing = get_json_cached_key(redis, CURRENT_PLAY_INDEXING)
+        if not current_play_indexing or current_play_indexing['slot'] is None:
+            return
+
+        check_track_ids = get_track_listen_ids(redis)
+
+        # Pull off current play indexed slot number from redis
+        # Pull off track ids to check from redis
+        existing_milestone = (
+            session.query(
+                Milestone.id,
+                func.max(Milestone.threshold)
+            )
+            .filter(
+                Milestone.name == LISTEN_COUNT_MILESTONE,
+                Milestone.id.in_(check_track_ids)
+            )
+            .group_by(Milestone.id)
+            .all()
+        )
+
+        aggregate_play_counts = (
+            session.query(
+                AggregatePlays.play_item_id,
+                AggregatePlays.count,
+            )
+            .filter(
+                AggregatePlays.play_item_id.in_(check_track_ids)
+            ).all()
+        )
+
+        milestones = {track_id: threshold for track_id, threshold in existing_milestone}
+        play_counts = {track_id: plays for track_id, plays in aggregate_play_counts}
+
+        # Bulk fetch track's next milestone threshold
+        listen_milestones = []
+        for track_id in check_track_ids:
+            current_milestone = None
+            if track_id in milestones:
+                current_milestone = milestones[track_id]
+            next_milestone_threshold = get_next_track_milestone(play_counts[track_id], current_milestone)
+            if next_milestone_threshold:
+                listen_milestones.append(Milestone(
+                    id=track_id,
+                    threshold=next_milestone_threshold,
+                    name=LISTEN_COUNT_MILESTONE,
+                    slot=current_play_indexing['slot'],
+                    timestamp=datetime.utcfromtimestamp(int(current_play_indexing['timestamp']))
+                ))
+
+        if listen_milestones:
+            session.bulk_save_objects(listen_milestones)
+
+        redis.set(PROCESSED_LISTEN_MILESTONE, current_play_indexing['slot'])
+        if check_track_ids:
+            redis.srem(TRACK_LISTEN_IDS, *check_track_ids)
+
+
+    job_end = time.time()
+    job_total = job_end - job_start
+    logger.info(
+        f"index_listen_count_milestones.py | Finished calculating trending in {job_total} seconds",
+        extra={"job": "index_listen_count_milestones", "total_time": job_total},
+    )
+
+
+######## CELERY TASKS ########
+@celery.task(name="index_listen_count_milestones", bind=True)
+def index_listen_count_milestones_task(self):
+    """Caches all trending combination of time-range and genre (including no genre)."""
+    db = index_listen_count_milestones_task.db
+    redis = index_listen_count_milestones_task.redis
+    have_lock = False
+    # Max timeout is 60 sec * 10 min
+    update_lock = redis.lock("index_listen_count_milestones_lock", timeout=600)
+    try:
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            index_listen_count_milestones(db, redis)
+        else:
+            logger.info(
+                "index_listen_count_milestones.py | Failed to acquire index trending lock"
+            )
+    except Exception as e:
+        logger.error(
+            "index_listen_count_milestones.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_listen_count_milestones.py
+++ b/discovery-provider/src/tasks/index_listen_count_milestones.py
@@ -19,12 +19,12 @@ TRACK_LISTEN_IDS = 'TRACK_LISTEN_IDS'
 
 LISTEN_COUNT_MILESTONE = 'LISTEN_COUNT'
 milestone_threshold = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000]
-next_threshold = { prev: next for prev, next in zip(milestone_threshold[:-1], milestone_threshold[1:]) }
+next_threshold = dict(zip(milestone_threshold[:-1], milestone_threshold[1:]))
 
 
 def get_next_track_milestone(play_count: int, prev_milestone: Optional[int]=None):
     """
-    Gets the next hightest milstone threshold avaiable given the play count, 
+    Gets the next hightest milstone threshold avaiable given the play count,
     if past the last threshold or given an invalid previous milestone, will return None
     """
     next_milestone = milestone_threshold[0]
@@ -34,7 +34,7 @@ def get_next_track_milestone(play_count: int, prev_milestone: Optional[int]=None
         else:
             # track is past the last milestone, so return none and stop
             return None
-    
+
     # If play counts have not passed the next threshold, return None
     if play_count < next_milestone:
         return None
@@ -89,8 +89,8 @@ def index_listen_count_milestones(db: SessionManager, redis: Redis):
             ).all()
         )
 
-        milestones = {track_id: threshold for track_id, threshold in existing_milestone}
-        play_counts = {track_id: plays for track_id, plays in aggregate_play_counts}
+        milestones = dict(existing_milestone)
+        play_counts = dict(aggregate_play_counts)
 
         # Bulk fetch track's next milestone threshold
         listen_milestones = []

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -568,8 +568,14 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis):
             last_tx_sig = transaction_signatures[-1][-1]
             tx_info = solana_client_manager.get_sol_tx_info(last_tx_sig)
             tx_result = tx_info["result"]
-            set_json_cached_key(redis, CURRENT_PLAY_INDEXING, { 'slot': tx_result["slot"], 'timestamp': tx_result["blockTime"] })
-            slot = tx_result["slot"]
+            set_json_cached_key(
+                redis,
+                CURRENT_PLAY_INDEXING,
+                {
+                    'slot': tx_result["slot"],
+                    'timestamp': tx_result["blockTime"]
+                }
+            )
     except Exception as e:
         logger.error("index_solana_plays.py | Unable to set redis current play indexing", exc_info=True)
         raise e

--- a/discovery-provider/src/utils/cache_solana_program.py
+++ b/discovery-provider/src/utils/cache_solana_program.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Optional, TypedDict
+from redis import Redis
+
+from src.solana.solana_client_manager import SolanaClientManager
+from src.solana.solana_transaction_types import ConfirmedSignatureForAddressResult
+from src.utils.helpers import redis_get_json_cached_key_or_restore, redis_set_json_and_dump
+
+logger = logging.getLogger(__name__)
+
+class CachedProgramTxInfo(TypedDict):
+    # Signature of latest transaction that has been processed
+    signature: str
+    # Slot corresponding to tx signature
+    slot: int
+    # Block time of latest transaction on chain
+    timestamp: int
+
+# Cache the latest value committed to DB in redis
+# Used for quick retrieval in health check
+def cache_latest_sol_db_tx(redis: Redis, cache_key: str, latest_tx: CachedProgramTxInfo):
+    try:
+        redis_set_json_and_dump(
+            redis,
+            cache_key,
+            latest_tx
+        )
+    except Exception as e:
+        logger.error(
+            f"cache_solana_program.py | Failed to cache key {cache_key} latest processed transaction {latest_tx}, {e}"
+        )
+        raise e
+
+def get_latest_sol_db_tx(redis: Redis, cahce_key: str):
+    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(redis, cahce_key)
+    return latest_sol_db
+
+# Function that ensures we always cache the latest known transaction in redis
+# Performed outside of lock acquisition
+# Ensures a lock held for a long time (usually during catchup scenarios)
+#   does not prevent a refresh of latest known transaction
+def fetch_and_cache_latest_program_tx_redis(
+    solana_client_manager: SolanaClientManager,
+    redis: Redis,
+    program: str,
+    cache_key: str
+):
+    transactions_history = (
+        solana_client_manager.get_confirmed_signature_for_address2(
+            program, before=None, limit=1
+        )
+    )
+    transactions_array = transactions_history["result"]
+    if transactions_array:
+        # Cache latest transaction from chain
+        cache_latest_sol_play_program_tx(redis, program, cache_key, transactions_array[0])
+
+# Cache the latest chain tx value in redis
+# Represents most recently seen value from the sol program
+def cache_latest_sol_play_program_tx(
+    redis: Redis,
+    program: str,
+    cache_key: str,
+    tx: ConfirmedSignatureForAddressResult
+):
+    try:
+        sig = tx["signature"]
+        slot = tx["slot"]
+        timestamp = tx["blockTime"]
+        redis_set_json_and_dump(
+            redis,
+            cache_key,
+            {
+                "signature": sig,
+                "slot": slot,
+                "timestamp": timestamp
+            }
+        )
+    except Exception as e:
+        logger.error(
+            f"cache_solana_program.py |Failed to cache sol program {program} latest transaction {tx}, {e}"
+        )
+        raise e
+
+def get_cache_latest_sol_program_tx(redis: Redis, cahce_key: str):
+    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(redis, cahce_key)
+    return latest_sol_db

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -11,7 +11,15 @@ trending_tracks_last_completion_redis_key = "trending:tracks:last-completion"
 trending_playlists_last_completion_redis_key = "trending-playlists:last-completion"
 challenges_last_processed_event_redis_key = "challenges:last-processed-event"
 user_balances_refresh_last_completion_redis_key = "user_balances:last-completion"
-latest_sol_play_program_tx_key = "latest_sol_play_program_tx_key"
-latest_sol_play_db_tx_key = "latest_sol_play_db_tx_key"
 latest_legacy_play_db_key = "latest_legacy_play_db_key"
 index_eth_last_completion_redis_key = "index_eth:last-completion"
+
+# Solana latest program keys
+latest_sol_play_program_tx_key = "latest_sol_program_tx:play:confirmed"
+latest_sol_play_db_tx_key = "latest_sol_program_tx:play:db"
+
+latest_sol_rewards_manager_program_tx_key = "latest_sol_program_tx:rewards_manager:confirmed"
+latest_sol_rewards_manager_db_tx_key = "latest_sol_program_tx:rewards_manager:db"
+
+latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:confirmed"
+latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -15,11 +15,11 @@ latest_legacy_play_db_key = "latest_legacy_play_db_key"
 index_eth_last_completion_redis_key = "index_eth:last-completion"
 
 # Solana latest program keys
-latest_sol_play_program_tx_key = "latest_sol_program_tx:play:confirmed"
+latest_sol_play_program_tx_key = "latest_sol_program_tx:play:chain"
 latest_sol_play_db_tx_key = "latest_sol_program_tx:play:db"
 
-latest_sol_rewards_manager_program_tx_key = "latest_sol_program_tx:rewards_manager:confirmed"
+latest_sol_rewards_manager_program_tx_key = "latest_sol_program_tx:rewards_manager:chain"
 latest_sol_rewards_manager_db_tx_key = "latest_sol_program_tx:rewards_manager:db"
 
-latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:confirmed"
+latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:chain"
 latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"

--- a/discovery-provider/tests/test_index_listen_count_milestone.py
+++ b/discovery-provider/tests/test_index_listen_count_milestone.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+import redis
+from src.tasks.index_listen_count_milestones import (
+    CURRENT_PLAY_INDEXING,
+    TRACK_LISTEN_IDS,
+    index_listen_count_milestones,
+    get_next_track_milestone
+)
+from src.utils.db_session import get_db
+from src.models import (
+    Milestone,
+)
+from src.utils.config import shared_config
+from src.utils.redis_cache import get_json_cached_key, set_json_cached_key
+
+from tests.utils import populate_mock_db
+
+REDIS_URL = shared_config["redis"]["url"]
+DEFAULT_EVENT = ""
+
+def test_get_next_track_milestone():
+    next_milestone = get_next_track_milestone(8)
+    assert next_milestone == None
+
+    next_milestone = get_next_track_milestone(10)
+    assert next_milestone == 10
+
+    next_milestone = get_next_track_milestone(520)
+    assert next_milestone == 500
+
+    # Test get next milestone with prev milestone defined
+    next_milestone = get_next_track_milestone(12, 10)
+    assert next_milestone == None
+
+    next_milestone = get_next_track_milestone(28, 10)
+    assert next_milestone == 25
+
+    next_milestone = get_next_track_milestone(50, 10)
+    assert next_milestone == 50
+
+    next_milestone = get_next_track_milestone(520, 10)
+    assert next_milestone == 500
+
+    next_milestone = get_next_track_milestone(1000100, 100000)
+    assert next_milestone == 1000000
+
+    next_milestone = get_next_track_milestone(1000100, 1000000)
+    assert next_milestone == None
+
+
+track_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+def test_listen_count_milestone_processing(app):
+    redis_conn = redis.Redis.from_url(url=REDIS_URL)
+    set_json_cached_key(redis_conn, CURRENT_PLAY_INDEXING, { 'slot': 12, 'timestamp': 1634836054 })
+    with app.app_context():
+        db = get_db()
+
+        test_entities = {
+            "plays": [{"item_id": 1} for _ in range(8)]
+            + [{"item_id": 2} for _ in range(10)] # milestone 10
+            + [{"item_id": 3} for _ in range(11)] # milestone 10
+            + [{"item_id": 4} for _ in range(12)] # milestone 10
+            + [{"item_id": 5} for _ in range(25)] # milestone 25
+            + [{"item_id": 6} for _ in range(27)] # milestone 25
+            + [{"item_id": 7} for _ in range(40)] # milestone 25
+            + [{"item_id": 8} for _ in range(80)] # milestone 50
+            + [{"item_id": 9} for _ in range(111)] # milestone 100
+            + [{"item_id": 10} for _ in range(25)] # milestone 25
+        }
+        populate_mock_db(db, test_entities)
+
+        with db.scoped_session() as session:
+            session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+
+        redis_conn.sadd(TRACK_LISTEN_IDS, *track_ids)
+
+        index_listen_count_milestones(db, redis_conn)
+        with db.scoped_session() as session:
+            milestones = session.query(Milestone).all()
+            assert len(milestones) == 9
+            sorted_milestones = sorted(milestones, key=lambda m: m.id)
+            sorted_milestones = [(milestone.id, milestone.threshold, milestone.slot, milestone.timestamp) for milestone in sorted_milestones] 
+
+            assert sorted_milestones == [
+                (2, 10, 12, datetime.fromtimestamp(1634836054)),
+                (3, 10, 12, datetime.fromtimestamp(1634836054)),
+                (4, 10, 12, datetime.fromtimestamp(1634836054)),
+                (5, 25, 12, datetime.fromtimestamp(1634836054)),
+                (6, 25, 12, datetime.fromtimestamp(1634836054)),
+                (7, 25, 12, datetime.fromtimestamp(1634836054)),
+                (8, 50, 12, datetime.fromtimestamp(1634836054)),
+                (9, 100, 12, datetime.fromtimestamp(1634836054)),
+                (10, 25, 12, datetime.fromtimestamp(1634836054)),
+            ]
+
+        # Add the same track and process to check that no new milesetones are created
+        redis_conn.sadd(TRACK_LISTEN_IDS, *track_ids)
+        index_listen_count_milestones(db, redis_conn)
+        with db.scoped_session() as session:
+            milestones = session.query(Milestone).all()
+            assert len(milestones) == 9
+
+        test_entities = {
+            "plays": [{"item_id": 1, "id": 1000+i} for i in range(3)] # 3 + 8 = 11 new
+            + [{"item_id": 2, "id": 1200+i} for i in range(100)] # 10 + 100 = 110 new
+            + [{"item_id": 3, "id": 1400+i} for i in range(10)] # 10 + 11 = 21 not new
+            + [{"item_id": 4, "id": 1600+i} for i in range(1000)] # 1000 + 12 = 1012 new
+            + [{"item_id": 8, "id": 3000+i} for i in range(19)] # 19 + 80 = 99 not new
+            + [{"item_id": 9, "id": 9000+i} for i in range(5000)] # 5000 + 111 = 5111 new
+        }
+        populate_mock_db(db, test_entities)
+        with db.scoped_session() as session:
+            session.execute("REFRESH MATERIALIZED VIEW aggregate_plays")
+
+        # Add the same track and process to check that no new milesetones are created
+        redis_conn.sadd(TRACK_LISTEN_IDS, *track_ids)
+        set_json_cached_key(redis_conn, CURRENT_PLAY_INDEXING, { 'slot': 14, 'timestamp': 1634836056 })
+        index_listen_count_milestones(db, redis_conn)
+
+        with db.scoped_session() as session:
+            milestones = session.query(Milestone).filter(Milestone.slot==14).all()
+            assert len(milestones) == 4
+            sorted_milestones = sorted(milestones, key=lambda m: m.id)
+            sorted_milestones = [(milestone.id, milestone.threshold) for milestone in sorted_milestones] 
+
+            assert sorted_milestones == [
+                (1, 10),
+                (2, 100),
+                (4, 1000),
+                (9, 5000)
+            ]

--- a/discovery-provider/tests/test_index_listen_count_milestone.py
+++ b/discovery-provider/tests/test_index_listen_count_milestone.py
@@ -11,7 +11,7 @@ from src.models import (
     Milestone,
 )
 from src.utils.config import shared_config
-from src.utils.redis_cache import get_json_cached_key, set_json_cached_key
+from src.utils.redis_cache import set_json_cached_key
 
 from tests.utils import populate_mock_db
 
@@ -80,7 +80,12 @@ def test_listen_count_milestone_processing(app):
             milestones = session.query(Milestone).all()
             assert len(milestones) == 9
             sorted_milestones = sorted(milestones, key=lambda m: m.id)
-            sorted_milestones = [(milestone.id, milestone.threshold, milestone.slot, milestone.timestamp) for milestone in sorted_milestones] 
+            sorted_milestones = [(
+                milestone.id,
+                milestone.threshold,
+                milestone.slot,
+                milestone.timestamp
+            ) for milestone in sorted_milestones]
 
             assert sorted_milestones == [
                 (2, 10, 12, datetime.fromtimestamp(1634836054)),
@@ -122,7 +127,7 @@ def test_listen_count_milestone_processing(app):
             milestones = session.query(Milestone).filter(Milestone.slot==14).all()
             assert len(milestones) == 4
             sorted_milestones = sorted(milestones, key=lambda m: m.id)
-            sorted_milestones = [(milestone.id, milestone.threshold) for milestone in sorted_milestones] 
+            sorted_milestones = [(milestone.id, milestone.threshold) for milestone in sorted_milestones]
 
             assert sorted_milestones == [
                 (1, 10),

--- a/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
+++ b/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
@@ -1,14 +1,14 @@
 'use strict'
 const models = require('../../src/models')
 
+/**
+ * Adds enum value `MilestoneListen` to the solana notifications table, column "type"
+ */
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.query("ALTER TYPE \"enum_SolanaNotifications_type\" ADD VALUE 'MilestoneListen'")
   },
   down: (queryInterface, Sequelize) => {
-    /**
-     * Remove 'TrendingTrack' from enum 'enum_Notifications_type'
-     */
     const tableName = 'SolanaNotifications'
     const columnName = 'type'
     const enumName = 'enum_SolanaNotifications_type'

--- a/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
+++ b/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
@@ -1,0 +1,46 @@
+'use strict';
+const models = require('../../src/models')
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query("ALTER TYPE \"enum_SolanaNotifications_type\" ADD VALUE 'MilestoneListen'")
+  },
+  down: (queryInterface, Sequelize) => {
+    /**
+     * Remove 'TrendingTrack' from enum 'enum_Notifications_type'
+     */
+     const tableName = 'SolanaNotifications'
+     const columnName = 'type'
+     const enumName = 'enum_SolanaNotifications_type'
+     const newEnumName = `enum_SolanaNotifications_type_new`
+     const prevValues = [ 'ChallengeReward']
+ 
+     return queryInterface.sequelize.transaction(async (transaction) => {
+       await models.Notification.destroy({
+         where: { type: { [models.Sequelize.Op.in]: ['MilestoneListen'] } },
+         transaction
+       })
+ 
+       await queryInterface.sequelize.query(`
+           CREATE TYPE "${newEnumName}"
+             AS ENUM ('${prevValues.join('\', \'')}')
+         `, { transaction })
+       // Change column type to the new ENUM TYPE
+       await queryInterface.sequelize.query(`
+         ALTER TABLE "${tableName}"
+           ALTER COLUMN ${columnName}
+             TYPE "${newEnumName}"
+             USING ("${columnName}"::text::"${newEnumName}")
+       `, { transaction })
+       // Drop old ENUM
+       await queryInterface.sequelize.query(`
+         DROP TYPE "${enumName}"
+       `, { transaction })
+       // Rename new ENUM name
+       await queryInterface.sequelize.query(`
+         ALTER TYPE "${newEnumName}"
+           RENAME TO "${enumName}"
+       `, { transaction })
+     })
+  }
+};

--- a/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
+++ b/identity-service/sequelize/migrations/20211025184306-solana-notification-type.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 const models = require('../../src/models')
 
 module.exports = {
@@ -9,38 +9,38 @@ module.exports = {
     /**
      * Remove 'TrendingTrack' from enum 'enum_Notifications_type'
      */
-     const tableName = 'SolanaNotifications'
-     const columnName = 'type'
-     const enumName = 'enum_SolanaNotifications_type'
-     const newEnumName = `enum_SolanaNotifications_type_new`
-     const prevValues = [ 'ChallengeReward']
- 
-     return queryInterface.sequelize.transaction(async (transaction) => {
-       await models.Notification.destroy({
-         where: { type: { [models.Sequelize.Op.in]: ['MilestoneListen'] } },
-         transaction
-       })
- 
-       await queryInterface.sequelize.query(`
-           CREATE TYPE "${newEnumName}"
-             AS ENUM ('${prevValues.join('\', \'')}')
-         `, { transaction })
-       // Change column type to the new ENUM TYPE
-       await queryInterface.sequelize.query(`
-         ALTER TABLE "${tableName}"
-           ALTER COLUMN ${columnName}
-             TYPE "${newEnumName}"
-             USING ("${columnName}"::text::"${newEnumName}")
-       `, { transaction })
-       // Drop old ENUM
-       await queryInterface.sequelize.query(`
-         DROP TYPE "${enumName}"
-       `, { transaction })
-       // Rename new ENUM name
-       await queryInterface.sequelize.query(`
-         ALTER TYPE "${newEnumName}"
-           RENAME TO "${enumName}"
-       `, { transaction })
-     })
+    const tableName = 'SolanaNotifications'
+    const columnName = 'type'
+    const enumName = 'enum_SolanaNotifications_type'
+    const newEnumName = `enum_SolanaNotifications_type_new`
+    const prevValues = ['ChallengeReward']
+
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await models.Notification.destroy({
+        where: { type: { [models.Sequelize.Op.in]: ['MilestoneListen'] } },
+        transaction
+      })
+
+      await queryInterface.sequelize.query(`
+        CREATE TYPE "${newEnumName}"
+          AS ENUM ('${prevValues.join('\', \'')}')
+        `, { transaction })
+      // Change column type to the new ENUM TYPE
+      await queryInterface.sequelize.query(`
+        ALTER TABLE "${tableName}"
+        ALTER COLUMN ${columnName}
+          TYPE "${newEnumName}"
+          USING ("${columnName}"::text::"${newEnumName}")
+      `, { transaction })
+      // Drop old ENUM
+      await queryInterface.sequelize.query(`
+        DROP TYPE "${enumName}"
+      `, { transaction })
+      // Rename new ENUM name
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "${newEnumName}"
+        RENAME TO "${enumName}"
+      `, { transaction })
+    })
   }
-};
+}

--- a/identity-service/src/models/solanaNotification.js
+++ b/identity-service/src/models/solanaNotification.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     type: {
       type: DataTypes.ENUM({
-        values: ['ChallengeReward']
+        values: ['ChallengeReward', 'MilestoneListen']
       }),
       allowNull: false
     },

--- a/identity-service/src/notifications/formatNotificationMetadata.js
+++ b/identity-service/src/notifications/formatNotificationMetadata.js
@@ -208,10 +208,10 @@ const notificationResponseMap = {
     return formatChallengeReward(notification, metadata)
   },
   [NotificationType.Announcement]: formatAnnouncement,
-  [NotificationType.MilestoneRepost]: formatMilestone('Repost'),
-  [NotificationType.MilestoneFavorite]: formatMilestone('Favorite'),
-  [NotificationType.MilestoneListen]: formatMilestone('Listen'),
-  [NotificationType.MilestoneFollow]: formatMilestone('Follow')
+  [NotificationType.MilestoneRepost]: formatMilestone('repost'),
+  [NotificationType.MilestoneFavorite]: formatMilestone('favorite'),
+  [NotificationType.MilestoneListen]: formatMilestone('listen'),
+  [NotificationType.MilestoneFollow]: formatMilestone('follow')
 }
 
 const NewFavoriteTitle = 'New Favorite'
@@ -266,6 +266,7 @@ const notificationResponseTitleMap = {
   [NotificationType.CreateTrack]: () => NewSubscriptionUpdateTitle,
   [NotificationType.CreateAlbum]: () => NewSubscriptionUpdateTitle,
   [NotificationType.CreatePlaylist]: () => NewSubscriptionUpdateTitle,
+  [NotificationType.MilestoneListen]: () => NewMilestoneTitle,
   [NotificationType.Milestone]: () => NewMilestoneTitle,
   [NotificationType.TrendingTrack]: () => TrendingTrackTitle,
   [NotificationType.RemixCreate]: () => RemixCreateTitle,
@@ -301,9 +302,9 @@ const pushNotificationMessagesMap = {
   [notificationTypes.Milestone] (notification) {
     if (notification.entity) {
       const entity = notification.entity.type.toLowerCase()
-      return `Your ${entity} ${notification.entity.name} has reached over ${notification.value} ${notification.achievement}s`
+      return `Your ${entity} ${notification.entity.name} has reached over ${notification.value.toLocaleString()} ${notification.achievement}s`
     } else {
-      return `You have reached over ${notification.value} Followers `
+      return `You have reached over ${notification.value.toLocaleString()} Followers `
     }
   },
   [notificationTypes.Create.base] (notification) {

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -186,7 +186,7 @@ class NotificationProcessor {
         await this.redis.set(NOTIFICATION_SOLANA_JOB_LAST_SUCCESS_KEY, new Date().toISOString())
 
         // Restart job with updated starting slot
-        await this.notifQueue.add({
+        await this.solanaNotifQueue.add({
           type: solanaNotificationJobType,
           minSlot: maxSlot
         }, {
@@ -197,7 +197,7 @@ class NotificationProcessor {
         logger.error(`Restarting due to error indexing notifications : ${e}`)
         this.errorHandler(e)
         // Restart job with same starting slot
-        await this.notifQueue.add({
+        await this.solanaNotifQueue.add({
           type: solanaNotificationJobType,
           minSlot: minSlot
         }, {
@@ -392,11 +392,11 @@ class NotificationProcessor {
     const tx = await models.sequelize.transaction()
     try {
       // Insert the solana notifications into the DB
-      await processNotifications(notifications, tx)
+      const processedNotifications = await processNotifications(notifications, tx)
       logger.info(`${logLabel} - processNotifications complete`)
 
       // Fetch additional metadata from DP, query for the user's notification settings, and send push notifications (mobile/browser)
-      await sendNotifications(audiusLibs, notifications, tx)
+      await sendNotifications(audiusLibs, processedNotifications, tx)
       logger.info(`${logLabel} - sendNotifications complete`)
 
       // Commit

--- a/identity-service/src/notifications/milestoneProcessing.js
+++ b/identity-service/src/notifications/milestoneProcessing.js
@@ -39,9 +39,6 @@ async function indexMilestones (milestones, owners, metadata, listenCounts, audi
 
   // Index favorite milestones
   await updateFavoriteMilestones(milestones.favorite_counts, owners, blocknumber, timestamp, audiusLibs, tx)
-
-  // Index listens
-  // await updateTrackListenMilestones(listenCounts, blocknumber, timestamp, audiusLibs, tx)
 }
 
 /**

--- a/identity-service/src/notifications/processNotifications/challengeRewardNotification.js
+++ b/identity-service/src/notifications/processNotifications/challengeRewardNotification.js
@@ -17,7 +17,7 @@ async function processChallengeRewardNotifications (notifications, tx) {
     // Create/Find a Notification and NotificationAction for this event
     // NOTE: ChallengeReward Notifications do NOT stack. A new notification is created for each
     const slot = notification.slot
-    const [notificationObj] = await models.SolanaNotifications.findOrCreate({
+    const [notificationObj] = await models.SolanaNotification.findOrCreate({
       where: {
         slot,
         type: notificationTypes.ChallengeReward,
@@ -37,6 +37,7 @@ async function processChallengeRewardNotifications (notifications, tx) {
       transaction: tx
     })
   }
+  return notifications
 }
 
 module.exports = processChallengeRewardNotifications

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -33,6 +33,7 @@ const getNotifType = (entityType) => {
  * @param {*} tx The DB transcation to attach to DB requests
  */
 async function processCreateNotifications (notifications, tx) {
+  const validNotifications = []
   for (const notification of notifications) {
     const blocknumber = notification.blocknumber
     const timestamp = Date.parse(notification.timestamp.slice(0, -2))
@@ -51,7 +52,7 @@ async function processCreateNotifications (notifications, tx) {
     })
 
     // No operation if no users subscribe to this creator
-    if (subscribers.length === 0) return
+    if (subscribers.length === 0) continue
 
     // The notification entity id is the uploader id for tracks
     // Each track will added to the notification actions table
@@ -142,7 +143,9 @@ async function processCreateNotifications (notifications, tx) {
         }
       }
     }
+    validNotifications.push(notification)
   }
+  return validNotifications
 }
 
 module.exports = processCreateNotifications

--- a/identity-service/src/notifications/processNotifications/favoriteNotification.js
+++ b/identity-service/src/notifications/processNotifications/favoriteNotification.js
@@ -112,6 +112,7 @@ async function processFavoriteNotifications (notifications, tx) {
       }
     }
   }
+  return notifications
 }
 
 module.exports = processFavoriteNotifications

--- a/identity-service/src/notifications/processNotifications/followNotification.js
+++ b/identity-service/src/notifications/processNotifications/followNotification.js
@@ -88,6 +88,7 @@ async function processFollowNotifications (notifications, tx) {
       }
     }
   }
+  return notifications
 }
 
 module.exports = processFollowNotifications

--- a/identity-service/src/notifications/processNotifications/index.js
+++ b/identity-service/src/notifications/processNotifications/index.js
@@ -9,6 +9,7 @@ const processRemixCosignNotifications = require('./remixCosignNotification')
 const processCreateNotifications = require('./createNotification')
 const processPlaylistUpdateNotifications = require('./playlistUpdateNotification')
 const processChallengeRewardNotifications = require('./challengeRewardNotification')
+const processMilestoneListenNotifications = require('./milestoneListenNotification')
 
 // Mapping of Notification type to processing function.
 const notificationMapping = {
@@ -19,7 +20,8 @@ const notificationMapping = {
   [notificationTypes.RemixCosign]: processRemixCosignNotifications,
   [notificationTypes.Create.base]: processCreateNotifications,
   [notificationTypes.PlaylistUpdate]: processPlaylistUpdateNotifications,
-  [notificationTypes.ChallengeReward]: processChallengeRewardNotifications
+  [notificationTypes.ChallengeReward]: processChallengeRewardNotifications,
+  [notificationTypes.MilestoneListen]: processMilestoneListenNotifications,
 }
 
 /**
@@ -39,15 +41,17 @@ async function processNotifications (notifications, tx) {
   }, {})
 
   // Process notification types in parallel
-  return Promise.all(Object.entries(notificationCategories).map(([notifType, notifications]) => {
+  const processedNotifications = await Promise.all(Object.entries(notificationCategories).map(([notifType, notifications]) => {
     const processType = notificationMapping[notifType]
     if (processType) {
       logger.debug(`Processing: ${notifications.length} notifications of type ${notifType}`)
       return processType(notifications, tx)
     } else {
       logger.error('processNotifications - no handler defined for notification type', notifType)
+      return []
     }
   }))
+  return processedNotifications.flat()
 }
 
 module.exports = processNotifications

--- a/identity-service/src/notifications/processNotifications/index.js
+++ b/identity-service/src/notifications/processNotifications/index.js
@@ -21,7 +21,7 @@ const notificationMapping = {
   [notificationTypes.Create.base]: processCreateNotifications,
   [notificationTypes.PlaylistUpdate]: processPlaylistUpdateNotifications,
   [notificationTypes.ChallengeReward]: processChallengeRewardNotifications,
-  [notificationTypes.MilestoneListen]: processMilestoneListenNotifications,
+  [notificationTypes.MilestoneListen]: processMilestoneListenNotifications
 }
 
 /**

--- a/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
+++ b/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
@@ -6,8 +6,7 @@ const {
 } = require('../constants')
 
 /**
- * Batch process favorite notifications, creating a notification (if prev unread) and notification action
- * for the owner of the favorited track/playlist/album
+ * Batch process milestone listen notifications
  * @param {Array<Object>} notifications
  * @param {*} tx The DB transaction to attach to DB requests
  */
@@ -37,11 +36,6 @@ async function processMilestoneListenNotifications (notifications, tx) {
       transaction: tx
     })
     if (existingMilestoneQuery.length === 0) {
-      // MilestoneListen/Favorite/Repost
-      // userId=user achieving milestone
-      // entityId=Entity reaching milestone, one of track/collection
-      // actionEntityType=Entity achieving milestone, can be track/collection
-      // actionEntityId=Milestone achieved
       let createMilestoneTx = await models.SolanaNotification.create({
         userId: trackOwnerId,
         type: notificationTypes.MilestoneListen,

--- a/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
+++ b/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
@@ -1,4 +1,3 @@
-const { logger } = require('../../logging')
 const models = require('../../models')
 const {
   notificationTypes,
@@ -17,7 +16,7 @@ async function processMilestoneListenNotifications (notifications, tx) {
     const trackId = notification.metadata.entity_id
     const threshold = notification.metadata.threshold
     const slot = notification.slot
-  
+
     // Check for existing milestone
     let existingMilestoneQuery = await models.SolanaNotification.findAll({
       where: {
@@ -52,13 +51,10 @@ async function processMilestoneListenNotifications (notifications, tx) {
         },
         transaction: tx
       })
-
       validNotifications.push(notification)
     }
- 
   }
   return validNotifications
-
 }
 
 module.exports = processMilestoneListenNotifications

--- a/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
+++ b/identity-service/src/notifications/processNotifications/milestoneListenNotification.js
@@ -1,0 +1,70 @@
+const { logger } = require('../../logging')
+const models = require('../../models')
+const {
+  notificationTypes,
+  actionEntityTypes
+} = require('../constants')
+
+/**
+ * Batch process favorite notifications, creating a notification (if prev unread) and notification action
+ * for the owner of the favorited track/playlist/album
+ * @param {Array<Object>} notifications
+ * @param {*} tx The DB transaction to attach to DB requests
+ */
+async function processMilestoneListenNotifications (notifications, tx) {
+  const validNotifications = []
+  for (const notification of notifications) {
+    const trackOwnerId = notification.initiator
+    const trackId = notification.metadata.entity_id
+    const threshold = notification.metadata.threshold
+    const slot = notification.slot
+  
+    // Check for existing milestone
+    let existingMilestoneQuery = await models.SolanaNotification.findAll({
+      where: {
+        userId: trackOwnerId,
+        type: notificationTypes.MilestoneListen,
+        entityId: trackId
+      },
+      include: [{
+        model: models.SolanaNotificationAction,
+        as: 'actions',
+        where: {
+          actionEntityType: actionEntityTypes.Track,
+          actionEntityId: threshold
+        }
+      }],
+      transaction: tx
+    })
+    if (existingMilestoneQuery.length === 0) {
+      // MilestoneListen/Favorite/Repost
+      // userId=user achieving milestone
+      // entityId=Entity reaching milestone, one of track/collection
+      // actionEntityType=Entity achieving milestone, can be track/collection
+      // actionEntityId=Milestone achieved
+      let createMilestoneTx = await models.SolanaNotification.create({
+        userId: trackOwnerId,
+        type: notificationTypes.MilestoneListen,
+        entityId: trackId,
+        slot
+      }, { transaction: tx })
+      let notificationId = createMilestoneTx.id
+      await models.SolanaNotificationAction.findOrCreate({
+        where: {
+          notificationId,
+          actionEntityType: actionEntityTypes.Track,
+          actionEntityId: threshold,
+          slot
+        },
+        transaction: tx
+      })
+
+      validNotifications.push(notification)
+    }
+ 
+  }
+  return validNotifications
+
+}
+
+module.exports = processMilestoneListenNotifications

--- a/identity-service/src/notifications/processNotifications/playlistUpdateNotification.js
+++ b/identity-service/src/notifications/processNotifications/playlistUpdateNotification.js
@@ -90,6 +90,7 @@ async function processPlaylistUpdateNotifications (notifications, tx) {
   })
 
   await Promise.all(newPlaylistUpdatePromises)
+  return notifications
 }
 
 module.exports = processPlaylistUpdateNotifications

--- a/identity-service/src/notifications/processNotifications/remixCosignNotification.js
+++ b/identity-service/src/notifications/processNotifications/remixCosignNotification.js
@@ -8,11 +8,12 @@ const {
 } = require('../constants')
 
 /**
- * Process cosign notifications, note that a unique cosign event is created only once time.
+ * Process cosign notifications, note that a unique cosign event is created only once.
  * @param {Array<Object>} notifications
  * @param {*} tx The DB transaction to attach to DB requests
  */
 async function processCosignNotifications (notifications, tx) {
+  const validNotifications = []
   for (const notification of notifications) {
     const {
       entity_id: childTrackId,
@@ -38,8 +39,9 @@ async function processCosignNotifications (notifications, tx) {
       transaction: tx
     })
 
-    // If this track is already cosigned, ignore
-    if (cosignNotifications.length > 0) return false
+    // If this track is already cosigned, ignore this notification
+    if (cosignNotifications.length > 0) continue
+
     const blocknumber = notification.blocknumber
     const timestamp = Date.parse(notification.timestamp.slice(0, -2))
     const momentTimestamp = moment(timestamp)
@@ -62,7 +64,9 @@ async function processCosignNotifications (notifications, tx) {
       actionEntityId: parentTrackUserId,
       blocknumber
     }, { transaction: tx })
+    validNotifications.push(notiifcation)
   }
+  return validNotifications
 }
 
 module.exports = processCosignNotifications

--- a/identity-service/src/notifications/processNotifications/remixCosignNotification.js
+++ b/identity-service/src/notifications/processNotifications/remixCosignNotification.js
@@ -64,7 +64,7 @@ async function processCosignNotifications (notifications, tx) {
       actionEntityId: parentTrackUserId,
       blocknumber
     }, { transaction: tx })
-    validNotifications.push(notiifcation)
+    validNotifications.push(notification)
   }
   return validNotifications
 }

--- a/identity-service/src/notifications/processNotifications/remixCreateNotification.js
+++ b/identity-service/src/notifications/processNotifications/remixCreateNotification.js
@@ -48,6 +48,7 @@ async function processRemixCreateNotifications (notifications, tx) {
       transaction: tx
     })
   }
+  return notifications
 }
 
 module.exports = processRemixCreateNotifications

--- a/identity-service/src/notifications/processNotifications/repostNotification.js
+++ b/identity-service/src/notifications/processNotifications/repostNotification.js
@@ -112,6 +112,7 @@ async function processBaseRepostNotifications (notifications, tx) {
       }
     }
   }
+  return notifications
 }
 
 module.exports = processBaseRepostNotifications

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -198,7 +198,7 @@ async function formatNotifications (notifications, notificationSettings, tx) {
         }
         formattedNotifications.push(formattedListenMilstoneNotification)
         userIds.add(formattedListenMilstoneNotification.initiator)
-        }
+      }
     }
 
     // Handle the 'create' notification type, track/album/playlist

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -146,7 +146,7 @@ async function formatNotifications (notifications, notificationSettings, tx) {
       }
     }
 
-    // Handle the 'favorite' notification type, track/album/playlist
+    // Handle the remix cosign notification type
     if (notif.type === notificationTypes.RemixCosign) {
       const formattedRemixCosign = {
         ...notif,
@@ -180,6 +180,25 @@ async function formatNotifications (notifications, notificationSettings, tx) {
       }
       formattedNotifications.push(formattedRewardNotification)
       userIds.add(formattedRewardNotification.initiator)
+    }
+
+    // Handle 'listen milestone' notification type
+    if (notif.type === notificationTypes.MilestoneListen) {
+      let notificationTarget = notif.initiator
+      const shouldNotify = shouldNotifyUser(notificationTarget, 'milestonesAndAchievements', notificationSettings)
+      if (shouldNotify.mobile || shouldNotify.browser) {
+        const formattedListenMilstoneNotification = {
+          ...notif,
+          entityId: notif.metadata.entity_id,
+          type: notificationTypes.MilestoneListen,
+          actions: [{
+            actionEntityType: actionEntityTypes.Track,
+            actionEntityId: notif.metadata.threshold
+          }]
+        }
+        formattedNotifications.push(formattedListenMilstoneNotification)
+        userIds.add(formattedListenMilstoneNotification.initiator)
+        }
     }
 
     // Handle the 'create' notification type, track/album/playlist

--- a/identity-service/src/notifications/sendNotifications/index.js
+++ b/identity-service/src/notifications/sendNotifications/index.js
@@ -17,6 +17,7 @@ function getUserIdsToNotify (notifications) {
       case notificationTypes.RemixCreate:
         return userIds.concat(notification.metadata.remix_parent_track_user_id)
       case notificationTypes.ChallengeReward:
+      case notificationTypes.MilestoneListen:
         return userIds.concat(notification.initiator)
       default:
         return userIds

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -32,11 +32,17 @@ const getPublishNotifBaseType = (notification) => {
       return notificationTypes.Create.base
     case notificationTypes.ChallengeReward:
       return notificationTypes.ChallengeReward
-  }
+    case notificationTypes.MilestoneListen:
+    case notificationTypes.MilestoneFavorite:
+    case notificationTypes.MilestoneFollow:
+    case notificationTypes.MilestoneRepost:
+      return notificationTypes.Milestone
+    }
 }
 
 const solanaNotificationBaseTypes = [
-  notificationTypes.ChallengeReward
+  notificationTypes.ChallengeReward,
+  notificationTypes.MilestoneListen
 ]
 
 // Gets the userId that a notification should be sent to based off the notification's base type
@@ -48,6 +54,7 @@ const getPublishUserId = (notif, baseType) => {
   else if (baseType === notificationTypes.RemixCosign) return notif.metadata.entity_owner_id
   else if (baseType === notificationTypes.Create.base) return notif.subscriberId
   else if (baseType === notificationTypes.ChallengeReward) return notif.initiator
+  else if (baseType === notificationTypes.Milestone) return notif.initiator
 }
 
 // Notification types that always get send a notification, regardless of settings
@@ -63,7 +70,8 @@ const mapNotificationBaseTypeToSettings = {
   [notificationTypes.Follow]: 'followers',
   [notificationTypes.Repost.base]: 'reposts',
   [notificationTypes.Favorite.base]: 'favorites',
-  [notificationTypes.RemixCreate]: 'remixes'
+  [notificationTypes.RemixCreate]: 'remixes',
+  [notificationTypes.Milestone]: 'milestonesAndAchievements'
 }
 
 /**
@@ -80,8 +88,8 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
   const userSettings = userNotificationSettings[userId]
   const types = []
   const settingKey = mapNotificationBaseTypeToSettings[baseNotificationType]
-  if (userSettings.mobile && userSettings.mobile[settingKey]) types.push(deviceType.Mobile)
-  if (userSettings.browser && userSettings.browser[settingKey]) types.push(deviceType.Browser)
+  if (userSettings?.mobile && userSettings.mobile[settingKey]) types.push(deviceType.Mobile)
+  if (userSettings?.browser && userSettings.browser[settingKey]) types.push(deviceType.Browser)
   return types
 }
 
@@ -106,7 +114,7 @@ const publishNotifications = async (notifications, metadata, userNotificationSet
     const userId = getPublishUserId(notification, publishNotifType)
     const types = getPublishTypes(userId, publishNotifType, userNotificationSettings)
 
-    if (solanaNotificationBaseTypes.includes(publishNotifType)) {
+    if (solanaNotificationBaseTypes.includes(notification.type)) {
       await publishSolanaNotification(msg, userId, tx, true, title, types)
     } else {
       await publish(msg, userId, tx, true, title, types)

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -37,7 +37,7 @@ const getPublishNotifBaseType = (notification) => {
     case notificationTypes.MilestoneFollow:
     case notificationTypes.MilestoneRepost:
       return notificationTypes.Milestone
-    }
+  }
 }
 
 const solanaNotificationBaseTypes = [
@@ -88,8 +88,8 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
   const userSettings = userNotificationSettings[userId]
   const types = []
   const settingKey = mapNotificationBaseTypeToSettings[baseNotificationType]
-  if (userSettings?.mobile && userSettings.mobile[settingKey]) types.push(deviceType.Mobile)
-  if (userSettings?.browser && userSettings.browser[settingKey]) types.push(deviceType.Browser)
+  if (userSettings && userSettings.mobile && userSettings.mobile[settingKey]) types.push(deviceType.Mobile)
+  if (userSettings && userSettings.browser && userSettings.browser[settingKey]) types.push(deviceType.Browser)
   return types
 }
 

--- a/identity-service/test/processNotifications/remixCosignNotification.js
+++ b/identity-service/test/processNotifications/remixCosignNotification.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const models = require('../../src/models')
-const processFavoriteNotifications = require('../../src/notifications/processNotifications/remixCosignNotification')
+const processRemixCosignNotifications = require('../../src/notifications/processNotifications/remixCosignNotification')
 const { clearDatabase, runMigrations } = require('../lib/app')
 
 /**
@@ -57,7 +57,7 @@ describe('Test Remix Cosign Notification', function () {
   it('should insert rows into notifications and notifications actions tables', async function () {
     // ======================================= Process initial Notifications =======================================
     const tx1 = await models.sequelize.transaction()
-    await processFavoriteNotifications(initialNotifications, tx1)
+    await processRemixCosignNotifications(initialNotifications, tx1)
     await tx1.commit()
 
     // ======================================= Run checks against the Notifications =======================================
@@ -85,7 +85,7 @@ describe('Test Remix Cosign Notification', function () {
 
     // ======================================= Process additional notifications =======================================
     const tx2 = await models.sequelize.transaction()
-    await processFavoriteNotifications(additionalNotifications, tx2)
+    await processRemixCosignNotifications(additionalNotifications, tx2)
     await tx2.commit()
 
     // No additional notifications should be created

--- a/identity-service/test/processNotifications/remixCreateNotification.js
+++ b/identity-service/test/processNotifications/remixCreateNotification.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const models = require('../../src/models')
-const processFavoriteNotifications = require('../../src/notifications/processNotifications/remixCreateNotification')
+const processRemixCreateNotifications = require('../../src/notifications/processNotifications/remixCreateNotification')
 
 const { clearDatabase, runMigrations } = require('../lib/app')
 
@@ -64,7 +64,7 @@ describe('Test Remix Create Notification', function () {
   it('should insert rows into notifications and notifications actions tables', async function () {
     // ======================================= Process initial Notifications =======================================
     const tx1 = await models.sequelize.transaction()
-    await processFavoriteNotifications(initialNotifications, tx1)
+    await processRemixCreateNotifications(initialNotifications, tx1)
     await tx1.commit()
 
     // ======================================= Run checks against the Notifications =======================================
@@ -89,7 +89,7 @@ describe('Test Remix Create Notification', function () {
 
     // ======================================= Process additional notifications =======================================
     const tx2 = await models.sequelize.transaction()
-    await processFavoriteNotifications(additionalNotifications, tx2)
+    await processRemixCreateNotifications(additionalNotifications, tx2)
     await tx2.commit()
 
     // User 40 should have 3 notifications


### PR DESCRIPTION
### Description
Fixes the listen milestone notifications. The new flow is as follows:
* While processing listens in discovery, send listened track ids to a new job to check for milestone completion
* In job, pull off track ids from redis, and if track passed milestone, write row to milestone DB table in discovery
* Update the `/notifications/solana` endpoint in discovery to also return listen milestone notifications
* Update identity to process the listen milestone notifications from that endpoint - store in db and send push notifs
* Update identity /notifications endpoints used by the clients to handle notifications triggered from solana

#### Discovery Changes
* Adds migration
  * Creates `milestone` DB table to store milestone notifications
  * Backfills listen milestones
* Updates the index_solana_plays flow to write track_ids to redis along with the current slot & timestamp
* Creates a new index_listen_count_milestones job to check if tracks have passed a milestone and write to db
* Updates the /notifications/solana endpoint to return listen milestones

#### Identity Changes
* Adds migration to update solana milestone type to include listen milestone
* Updates the process notifications to handle listen milestone
* Updates the /notifications endpoint to serve solana notifications and mark them as read/viewed
* Fixes the solana milestone indexing to add correct job at end of queue

### Tests
Discovery tests written to check that milestone processing works as expected. 
Manually ran e2e test and verified discovery milestones created correctly and identity milestones created correctly and logs for sending out mobile notifications as well as viewing the listen milestone notification in the client 

### How will this change be monitored?
Via the logs from discovery and identity


Closes AUD-994