### PR TITLE
Do not await md add ipfs

### DIFF
--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -35,7 +35,7 @@ module.exports = function (app) {
     // Save file from buffer to IPFS and disk
     let multihash, dstPath
     try {
-      const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer, true)
+      const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer)
       multihash = resp.multihash
       dstPath = resp.dstPath
     } catch (e) {

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -362,7 +362,7 @@ module.exports = function (app) {
     // Save file from buffer to IPFS and disk
     let multihash, dstPath
     try {
-      const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer, true)
+      const resp = await saveFileFromBufferToIPFSAndDisk(req, metadataBuffer)
       multihash = resp.multihash
       dstPath = resp.dstPath
     } catch (e) {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Originally, we waited on ipfs.add to complete for metadata content as discovery nodes directly fetch md content. however, this isn't necessary as at least there is a content node gateway fetch for content. plus our ipfs pods are not stable under load, and this flow is is very critical. 

This PR is to remove this await

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->