### PR TITLE
Change ledger size limit in solana-test-validator

### DIFF
--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -52,7 +52,7 @@
    "port": 8899,
    "health_check_endpoint": "",
    "up": [
-      "docker run -d --name solana -p 8899:8899/tcp -p 8900-8902:8900-8902/tcp --network audius_dev --entrypoint='' solanalabs/solana:v1.7.1 sh -c 'solana-test-validator --gossip-host solana --limit-ledger-size 100000000'"
+      "docker run -d --name solana -p 8899:8899/tcp -p 8900-8902:8900-8902/tcp --network audius_dev --entrypoint='' solanalabs/solana:v1.7.1 sh -c 'solana-test-validator --gossip-host solana --limit-ledger-size 100000'"
    ],
     "down": [
       "docker container stop solana || true",


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Default for this param is 10K for solana test validator (as of 1.6.7)
https://github.com/solana-labs/solana/commit/7723673038d0d0c5ce4e36bbe33aacaa5cdfe998#diff-c78885c4ab56d12de3552ca82103e702f18335e878d592c9f46bc45152892260R42

It probably is helpful for to store more than 10K for our indexing purposes, but the value we had set would end up filling >200GB of space on device. 100K here should be between 400MB and 1.5GB, which is totally manageable.

Further diagnosis:

My machine crashed b/c of out of disk and upon inspecting the rocksdb instance (test-ledger) found at:
138G    /var/lib/docker/overlay2/85086cfd44949de3bcf09ab1202a986148ca5e53341f2d3f344a9b77dbd2bf27/diff/test-ledger/rocksdb

you can see it's using a lot of space 🦠 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran local stack

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Local dev

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->