### PR TITLE
Use v1 endpoint for getTracksByHandleAndSlug

### DIFF
--- a/libs/src/services/discoveryProvider/requests.js
+++ b/libs/src/services/discoveryProvider/requests.js
@@ -52,7 +52,7 @@ module.exports.getTracks = (limit = 100, offset = 0, idsArray = null, targetUser
 
 module.exports.getTracksByHandleAndSlug = (handle, slug) => {
   return {
-    endpoint: 'tracks',
+    endpoint: 'v1/tracks',
     method: 'get',
     queryParams: { handle, slug }
   }


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->
- #1994 
broke general admission because it removed the "slug" from being used in the `get_tracks` query, and only updated the `v1` API and not the `/tracks` route which GA was using via libs. This PR updates libs to use the `v1` API route.

https://github.com/AudiusProject/audius-protocol/pull/1994/files#diff-4f5be4cd18bbfa3ffa01d43ba8162607913282e86409c62c65d2e60074f9d9b2L27

**NOTE**: This is a breaking change as `v1/tracks` returns different fields than `/tracks`

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Verified against (a modified) GA locally. (modified GA changes: https://github.com/AudiusProject/general-admission/pull/77 )

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->