### PR TITLE
[AUD-1045] [AUD-1047] Add is_deactivated to users

### DIFF
--- a/discovery-provider/alembic/versions/edccccc274a7_add_is_deactivated_to_users.py
+++ b/discovery-provider/alembic/versions/edccccc274a7_add_is_deactivated_to_users.py
@@ -1,7 +1,7 @@
 """Add is_deactivated to users
 
 Revision ID: edccccc274a7
-Revises: e2a8aea2e2e1
+Revises: 8bc5bac6711b
 Create Date: 2021-11-04 18:31:25.972519
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "edccccc274a7"
-down_revision = "e2a8aea2e2e1"
+down_revision = "8bc5bac6711b"
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/edccccc274a7_add_is_deactivated_to_users.py
+++ b/discovery-provider/alembic/versions/edccccc274a7_add_is_deactivated_to_users.py
@@ -1,4 +1,4 @@
-"""Add is_delete to users
+"""Add is_deactivated to users
 
 Revision ID: edccccc274a7
 Revises: e2a8aea2e2e1
@@ -19,9 +19,13 @@ depends_on = None
 def upgrade():
     op.add_column(
         "users",
-        sa.Column("is_deactivated", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column(
+            "is_deactivated", sa.Boolean(), server_default="false", nullable=False
+        ),
     )
-    op.create_index(op.f("ix_users_is_deactivated"), "users", ["is_deactivated"], unique=False)
+    op.create_index(
+        op.f("ix_users_is_deactivated"), "users", ["is_deactivated"], unique=False
+    )
 
 
 def downgrade():

--- a/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
+++ b/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
@@ -19,11 +19,11 @@ depends_on = None
 def upgrade():
     op.add_column(
         "users",
-        sa.Column("is_delete", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("is_deactivated", sa.Boolean(), server_default="false", nullable=False),
     )
-    op.create_index(op.f("ix_users_is_delete"), "users", ["is_delete"], unique=False)
+    op.create_index(op.f("ix_users_is_deactivated"), "users", ["is_deactivated"], unique=False)
 
 
 def downgrade():
-    op.drop_index(op.f("ix_users_is_delete"), table_name="users")
-    op.drop_column("users", "is_delete")
+    op.drop_index(op.f("ix_users_is_deactivated"), table_name="users")
+    op.drop_column("users", "is_deactivated")

--- a/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
+++ b/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
@@ -17,8 +17,13 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("users", sa.Column("is_delete", sa.Boolean(), nullable=False))
+    op.add_column(
+        "users",
+        sa.Column("is_delete", sa.Boolean(), server_default="false", nullable=False),
+    )
+    op.create_index(op.f("ix_users_is_delete"), "users", ["is_delete"], unique=False)
 
 
 def downgrade():
+    op.drop_index(op.f("ix_users_is_delete"), table_name="users")
     op.drop_column("users", "is_delete")

--- a/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
+++ b/discovery-provider/alembic/versions/edccccc274a7_add_is_delete_to_users.py
@@ -1,0 +1,24 @@
+"""Add is_delete to users
+
+Revision ID: edccccc274a7
+Revises: e2a8aea2e2e1
+Create Date: 2021-11-04 18:31:25.972519
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "edccccc274a7"
+down_revision = "e2a8aea2e2e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("is_delete", sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    op.drop_column("users", "is_delete")

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -38,6 +38,7 @@ user_model = ns.model(
         "profile_picture": fields.Nested(profile_picture, allow_null=True),
         "repost_count": fields.Integer(required=True),
         "track_count": fields.Integer(required=True),
+        "is_deactivated": fields.Boolean(required=True),
     },
 )
 

--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -206,7 +206,7 @@ class User(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
     playlist_library = Column(JSONB, nullable=True)
-    is_delete = Column(
+    is_deactivated = Column(
         Boolean, nullable=False, default=False, server_default="false", index=True
     )
 

--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -44,7 +44,11 @@ def configure_listener(class_, key_, inst):
     @event.listens_for(inst, "set", retval=True)
     def set_(target, value, oldvalue, initiator):
         column_type = getattr(target.__class__, inst.key).type
-        if type(column_type) in (String, Text, Unicode, UnicodeText) and value and isinstance(value, str):
+        if (
+            type(column_type) in (String, Text, Unicode, UnicodeText)
+            and value
+            and isinstance(value, str)
+        ):
             value = value.encode("utf-8", "ignore").decode("utf-8", "ignore")
             value = value.replace("\x00", "")
         return value
@@ -202,6 +206,7 @@ class User(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
     playlist_library = Column(JSONB, nullable=True)
+    is_delete = Column(Boolean, nullable=False, default=False)
 
     PrimaryKeyConstraint(is_current, user_id, blockhash, txhash)
 

--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -206,7 +206,9 @@ class User(Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
     playlist_library = Column(JSONB, nullable=True)
-    is_delete = Column(Boolean, nullable=False, default=False)
+    is_delete = Column(
+        Boolean, nullable=False, default=False, server_default="false", index=True
+    )
 
     PrimaryKeyConstraint(is_current, user_id, blockhash, txhash)
 

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -358,6 +358,9 @@ def parse_user_event(
             ):
                 user_record.playlist_library = ipfs_metadata["playlist_library"]
 
+            if "is_delete" in ipfs_metadata:
+                user_record.is_delete = ipfs_metadata["is_delete"]
+
             if "events" in ipfs_metadata and ipfs_metadata["events"]:
                 update_user_events(
                     session,

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -358,8 +358,8 @@ def parse_user_event(
             ):
                 user_record.playlist_library = ipfs_metadata["playlist_library"]
 
-            if "is_delete" in ipfs_metadata:
-                user_record.is_delete = ipfs_metadata["is_delete"]
+            if "is_deactivated" in ipfs_metadata:
+                user_record.is_deactivated = ipfs_metadata["is_deactivated"]
 
             if "events" in ipfs_metadata and ipfs_metadata["events"]:
                 update_user_events(

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -188,6 +188,7 @@ ipfs_client = IPFSClient(
                 "is_mobile_user": True,
             },
             "user_id": 1,
+            "is_delete": True,
         }
     }
 )
@@ -486,6 +487,9 @@ def test_index_users(bus_mock: mock.MagicMock, app):
         assert user_record.cover_photo_sizes == ipfs_metadata["cover_photo_sizes"]
         assert user_record.has_collectibles == True
         assert user_record.playlist_library == ipfs_metadata["playlist_library"]
+
+        # IPFS metadata sets is_delete to true to test deactivation
+        assert user_record.is_delete == True
 
         ipfs_associated_wallets = ipfs_metadata["associated_wallets"]
         associated_wallets = (

--- a/discovery-provider/tests/test_index_users.py
+++ b/discovery-provider/tests/test_index_users.py
@@ -188,7 +188,7 @@ ipfs_client = IPFSClient(
                 "is_mobile_user": True,
             },
             "user_id": 1,
-            "is_delete": True,
+            "is_deactivated": True,
         }
     }
 )
@@ -488,8 +488,7 @@ def test_index_users(bus_mock: mock.MagicMock, app):
         assert user_record.has_collectibles == True
         assert user_record.playlist_library == ipfs_metadata["playlist_library"]
 
-        # IPFS metadata sets is_delete to true to test deactivation
-        assert user_record.is_delete == True
+        assert user_record.is_deactivated == True
 
         ipfs_associated_wallets = ipfs_metadata["associated_wallets"]
         associated_wallets = (


### PR DESCRIPTION
### Description

AUD-1045 AUD-1047

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds a column `is_deactivated` to users to mark the user as deactivated, and indexes it off of IPFS metdata.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Updated index users test.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->