### PR TITLE
Update trending to be on the block hr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,8 +704,8 @@ workflows:
       - docker-build-and-push:
           name: build-discovery-provider
           repo: discovery-provider
-          requires:
-            - test-discovery-provider
+          # requires:
+          #   - test-discovery-provider
 
       - test-identity-service:
           name: test-identity-service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,8 +704,8 @@ workflows:
       - docker-build-and-push:
           name: build-discovery-provider
           repo: discovery-provider
-          # requires:
-          #   - test-discovery-provider
+          requires:
+            - test-discovery-provider
 
       - test-identity-service:
           name: test-identity-service

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -422,7 +422,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "index_trending": {
                 "task": "index_trending",
-                "schedule": timedelta(seconds=60),
+                "schedule": timedelta(seconds=10),
             },
             "update_user_balances": {
                 "task": "update_user_balances",

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -422,7 +422,7 @@ def configure_celery(flask_app, celery, test_config=None):
             },
             "index_trending": {
                 "task": "index_trending",
-                "schedule": crontab(minute=15, hour="*"),
+                "schedule": timedelta(seconds=60),
             },
             "update_user_balances": {
                 "task": "update_user_balances",

--- a/discovery-provider/src/queries/get_trending_playlists.py
+++ b/discovery-provider/src/queries/get_trending_playlists.py
@@ -237,7 +237,7 @@ class GetTrendingPlaylistsArgs(TypedDict, total=False):
     offset: int
     limit: int
 
-def get_trending_playlists_session(
+def _get_trending_playlists_with_session(
     session: Session,
     args: GetTrendingPlaylistsArgs,
     strategy,
@@ -336,7 +336,7 @@ def get_trending_playlists(args: GetTrendingPlaylistsArgs, strategy):
     """Returns Trending Playlists. Checks Redis cache for unpopulated playlists."""
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        return get_trending_playlists_session(session, args, strategy)
+        return _get_trending_playlists_with_session(session, args, strategy)
 
 def get_full_trending_playlists(request, args, strategy):
     offset, limit = format_offset(args), format_limit(args, TRENDING_LIMIT)

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -98,9 +98,9 @@ def get_trending_tracks(args: GetTrendingTracksArgs, strategy: BaseTrendingStrat
     """Gets trending by getting the currently cached tracks and then populating them."""
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        return get_trending_tracks_session(session, args, strategy)
+        return _get_trending_tracks_with_session(session, args, strategy)
 
-def get_trending_tracks_session(session: Session, args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy):
+def _get_trending_tracks_with_session(session: Session, args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy):
     current_user_id, genre, time = (
         args.get("current_user_id"),
         args.get("genre"),

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -1,6 +1,9 @@
+from typing import Optional, TypedDict
 from sqlalchemy import desc
+from sqlalchemy.orm.session import Session
 
-from src.models import TrackTrendingScore, AggregateIntervalPlay
+from src.models import TrackTrendingScore
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.db_session import get_db_read_replica
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
@@ -51,43 +54,26 @@ def generate_unpopulated_trending(
 def generate_unpopulated_trending_from_mat_views(
     session, genre, time_range, strategy, limit=TRENDING_LIMIT
 ):
-    top_listen_tracks_subquery = session.query(AggregateIntervalPlay.track_id)
-    if genre:
-        top_listen_tracks_subquery = top_listen_tracks_subquery.filter(
-            AggregateIntervalPlay.genre == genre
-        )
-    if time_range == "week":
-        top_listen_tracks_subquery = top_listen_tracks_subquery.order_by(
-            desc(AggregateIntervalPlay.week_listen_counts)
-        )
-    elif time_range == "month":
-        top_listen_tracks_subquery = top_listen_tracks_subquery.order_by(
-            desc(AggregateIntervalPlay.month_listen_counts)
-        )
-    elif time_range == "year":
-        top_listen_tracks_subquery = top_listen_tracks_subquery.order_by(
-            desc(AggregateIntervalPlay.year_listen_counts)
-        )
 
-    score_params = strategy.get_score_params()
-    nm = score_params["nm"]
-
-    top_listen_tracks_subquery = top_listen_tracks_subquery.limit(limit * nm)
-
-    trending_track_ids_query = session.query(
-        TrackTrendingScore.track_id, TrackTrendingScore.score
-    ).filter(
-        TrackTrendingScore.type == strategy.trending_type.name,
-        TrackTrendingScore.version == strategy.version.name,
-        TrackTrendingScore.time_range == time_range,
-        TrackTrendingScore.track_id.in_(top_listen_tracks_subquery),
+    trending_track_ids_query = (
+        session.query(TrackTrendingScore.track_id, TrackTrendingScore.score)
+        .filter(
+            TrackTrendingScore.type == strategy.trending_type.name,
+            TrackTrendingScore.version == strategy.version.name,
+            TrackTrendingScore.time_range == time_range,
+        )
     )
 
+    if genre:
+        trending_track_ids_query = trending_track_ids_query.filter(TrackTrendingScore.genre == genre)
+
     trending_track_ids = (
-        trending_track_ids_query.order_by(desc(TrackTrendingScore.score))
+        trending_track_ids_query
+        .order_by(desc(TrackTrendingScore.score))
         .limit(limit)
         .all()
     )
+
     track_ids = [track_id[0] for track_id in trending_track_ids]
     tracks = get_unpopulated_tracks(session, track_ids)
     return (tracks, track_ids)
@@ -103,38 +89,46 @@ def make_generate_unpopulated_trending(session, genre, time_range, strategy):
     return wrapped
 
 
-def get_trending_tracks(args, strategy):
+class GetTrendingTracksArgs(TypedDict, total=False):
+    current_user_id: Optional[int]
+    genre: Optional[str]
+    time: str
+
+def get_trending_tracks(args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy):
     """Gets trending by getting the currently cached tracks and then populating them."""
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        current_user_id, genre, time = (
-            args.get("current_user_id"),
-            args.get("genre"),
-            args.get("time", "week"),
-        )
-        time_range = "week" if time not in ["week", "month", "year"] else time
-        key = make_trending_cache_key(time_range, genre, strategy.version)
+        return get_trending_tracks_session(session, args, strategy)
 
-        # Will try to hit cached trending from task, falling back
-        # to generating it here if necessary and storing it with no TTL
-        (tracks, track_ids) = use_redis_cache(
-            key,
-            None,
-            make_generate_unpopulated_trending(session, genre, time_range, strategy),
-        )
+def get_trending_tracks_session(session: Session, args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy):
+    current_user_id, genre, time = (
+        args.get("current_user_id"),
+        args.get("genre"),
+        args.get("time", "week"),
+    )
+    time_range = "week" if time not in ["week", "month", "year"] else time
+    key = make_trending_cache_key(time_range, genre, strategy.version)
 
-        # populate track metadata
-        tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
-        tracks_map = {track["track_id"]: track for track in tracks}
+    # Will try to hit cached trending from task, falling back
+    # to generating it here if necessary and storing it with no TTL
+    (tracks, track_ids) = use_redis_cache(
+        key,
+        None,
+        make_generate_unpopulated_trending(session, genre, time_range, strategy),
+    )
 
-        # Re-sort the populated tracks b/c it loses sort order in sql query
-        sorted_tracks = [tracks_map[track_id] for track_id in track_ids]
+    # populate track metadata
+    tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
+    tracks_map = {track["track_id"]: track for track in tracks}
 
-        if args.get("with_users", False):
-            user_id_list = get_users_ids(sorted_tracks)
-            users = get_users_by_id(session, user_id_list, current_user_id)
-            for track in sorted_tracks:
-                user = users[track["owner_id"]]
-                if user:
-                    track["user"] = user
-        return sorted_tracks
+    # Re-sort the populated tracks b/c it loses sort order in sql query
+    sorted_tracks = [tracks_map[track_id] for track_id in track_ids]
+
+    if args.get("with_users", False):
+        user_id_list = get_users_ids(sorted_tracks)
+        users = get_users_by_id(session, user_id_list, current_user_id)
+        for track in sorted_tracks:
+            user = users[track["owner_id"]]
+            if user:
+                track["user"] = user
+    return sorted_tracks

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -84,6 +84,10 @@ def make_generate_unpopulated_trending(session, genre, time_range, strategy):
     expects to be passed a function with no arguments."""
 
     def wrapped():
+        if strategy.use_mat_view:
+            return generate_unpopulated_trending_from_mat_views(
+                session, genre, time_range, strategy
+            )
         return generate_unpopulated_trending(session, genre, time_range, strategy)
 
     return wrapped

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -210,7 +210,7 @@ class GetUndergroundTrendingTrackcArgs(TypedDict, total=False):
     offset: int
     limit: int
 
-def _get_underground_trending_session(
+def _get_underground_trending_with_session(
     session: Session,
     args: GetUndergroundTrendingTrackcArgs,
     strategy,
@@ -248,7 +248,7 @@ def _get_underground_trending_session(
 def _get_underground_trending(args: GetUndergroundTrendingTrackcArgs, strategy):
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        return _get_underground_trending_session(session, args, strategy)
+        return _get_underground_trending_with_session(session, args, strategy)
 
 def get_underground_trending(request, args, strategy):
     offset, limit = format_offset(args), format_limit(args, TRENDING_LIMIT)

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -995,10 +995,10 @@ def get_genre_list(genre):
     return genre_list
 
 
-def get_users_by_id(session, user_ids, current_user_id=None):
+def get_users_by_id(session, user_ids, current_user_id=None, use_request_context=True):
     users = get_unpopulated_users(session, user_ids)
 
-    if not current_user_id:
+    if not current_user_id and use_request_context:
         current_user_id = get_current_user_id(required=False)
     # bundle peripheral info into user results
     populated_users = populate_user_metadata(session, user_ids, users, current_user_id)

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -13,7 +13,10 @@ from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
-from src.queries.get_underground_trending import GetUndergroundTrendingTrackcArgs, _get_underground_trending_with_session
+from src.queries.get_underground_trending import (
+    GetUndergroundTrendingTrackcArgs,
+    _get_underground_trending_with_session
+)
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 from src.utils.session_manager import SessionManager
 

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -7,13 +7,13 @@ from sqlalchemy.orm.session import Session
 
 from src.models import Block
 from src.tasks.celery_app import celery
-from src.queries.get_trending_tracks import get_trending_tracks_session
-from src.queries.get_trending_playlists import GetTrendingPlaylistsArgs, get_trending_playlists_session
+from src.queries.get_trending_tracks import _get_trending_tracks_with_session
+from src.queries.get_trending_playlists import GetTrendingPlaylistsArgs, _get_trending_playlists_with_session
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
-from src.queries.get_underground_trending import GetUndergroundTrendingTrackcArgs, _get_underground_trending_session
+from src.queries.get_underground_trending import GetUndergroundTrendingTrackcArgs, _get_underground_trending_with_session
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 from src.utils.session_manager import SessionManager
 
@@ -88,7 +88,7 @@ def enqueue_trending_challenges(
             strategy = trending_strategy_factory.get_strategy(
                 TrendingType.TRACKS, version
             )
-            top_tracks = get_trending_tracks_session(session, {"time": time_range}, strategy)
+            top_tracks = _get_trending_tracks_with_session(session, {"time": time_range}, strategy)
             top_tracks = top_tracks[:TRENDING_LIMIT]
             dispatch_trending_challenges(
                 challenge_bus,
@@ -108,7 +108,7 @@ def enqueue_trending_challenges(
                 TrendingType.UNDERGROUND_TRACKS, version
             )
             underground_args: GetUndergroundTrendingTrackcArgs = {"offset": 0, "limit":TRENDING_LIMIT}
-            top_tracks = _get_underground_trending_session(session, underground_args, strategy, False)
+            top_tracks = _get_underground_trending_with_session(session, underground_args, strategy, False)
 
             dispatch_trending_challenges(
                 challenge_bus,
@@ -131,7 +131,7 @@ def enqueue_trending_challenges(
                 "offset": 0,
                 "time": time_range
             }
-            trending_playlists = get_trending_playlists_session(session, playlists_args, strategy, False)
+            trending_playlists = _get_trending_playlists_with_session(session, playlists_args, strategy, False)
             for idx, playlist in enumerate(trending_playlists):
                 challenge_bus.dispatch(
                     ChallengeEvent.trending_playlist,

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -220,6 +220,12 @@ def get_should_update_trending(db: SessionManager, web3: Web3, redis: Redis) -> 
             return int(block_datetime.timestamp())
 
         duration_since_last_index = block_datetime - last_trending_datetime
+        logger.info(
+            f"index_trending.py | \
+            in compare, blk: {current_db_block[0]} current_timestamp: {current_timestamp}, duration_since_last_index: {duration_since_last_index}, \
+            block_datetime: {block_datetime}, last_trending_datetime: {last_trending_datetime}"
+        )
+
         if duration_since_last_index.total_seconds() > UPDATE_TRENDING_DURATION_DIFF_SEC:
             return int(block_datetime.timestamp())
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -222,7 +222,8 @@ def get_should_update_trending(db: SessionManager, web3: Web3, redis: Redis) -> 
         duration_since_last_index = block_datetime - last_trending_datetime
         logger.info(
             f"index_trending.py | \
-            in compare, blk: {current_db_block[0]} current_timestamp: {current_timestamp}, duration_since_last_index: {duration_since_last_index}, \
+            in compare, blk: {current_db_block[0]} current_timestamp: {current_timestamp}, \
+            duration_since_last_index: {duration_since_last_index}, \
             block_datetime: {block_datetime}, last_trending_datetime: {last_trending_datetime}"
         )
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -220,13 +220,6 @@ def get_should_update_trending(db: SessionManager, web3: Web3, redis: Redis) -> 
             return int(block_datetime.timestamp())
 
         duration_since_last_index = block_datetime - last_trending_datetime
-        logger.info(
-            f"index_trending.py | \
-            in compare, blk: {current_db_block[0]} current_timestamp: {current_timestamp}, \
-            duration_since_last_index: {duration_since_last_index}, \
-            block_datetime: {block_datetime}, last_trending_datetime: {last_trending_datetime}"
-        )
-
         if duration_since_last_index.total_seconds() >= UPDATE_TRENDING_DURATION_DIFF_SEC:
             return int(block_datetime.timestamp())
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -227,7 +227,7 @@ def get_should_update_trending(db: SessionManager, web3: Web3, redis: Redis) -> 
             block_datetime: {block_datetime}, last_trending_datetime: {last_trending_datetime}"
         )
 
-        if duration_since_last_index.total_seconds() > UPDATE_TRENDING_DURATION_DIFF_SEC:
+        if duration_since_last_index.total_seconds() >= UPDATE_TRENDING_DURATION_DIFF_SEC:
             return int(block_datetime.timestamp())
 
     return None

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date
+from datetime import datetime
 import logging
 import time
 from typing import List, Optional, Tuple

--- a/discovery-provider/tests/test_trending_challenge.py
+++ b/discovery-provider/tests/test_trending_challenge.py
@@ -105,9 +105,9 @@ def test_trending_challenge_job(app):
                 "description": "description",
                 "playlist_contents": {
                     "track_ids": [
-                        {"track": 1},
-                        {"track": 2},
-                        {"track": 3},
+                        {"track": 1, "time": 1},
+                        {"track": 2, "time": 2},
+                        {"track": 3, "time": 3},
                     ]
                 },
             },
@@ -118,9 +118,9 @@ def test_trending_challenge_job(app):
                 "description": "description",
                 "playlist_contents": {
                     "track_ids": [
-                        {"track": 1},
-                        {"track": 2},
-                        {"track": 3},
+                        {"track": 1, "time": 1},
+                        {"track": 2, "time": 2},
+                        {"track": 3, "time": 3},
                     ]
                 },
             },
@@ -132,9 +132,9 @@ def test_trending_challenge_job(app):
                 "description": "description",
                 "playlist_contents": {
                     "track_ids": [
-                        {"track": 1},
-                        {"track": 2},
-                        {"track": 3},
+                        {"track": 1, "time": 1},
+                        {"track": 2, "time": 2},
+                        {"track": 3, "time": 3},
                     ]
                 },
             },
@@ -145,9 +145,9 @@ def test_trending_challenge_job(app):
                 "description": "description",
                 "playlist_contents": {
                     "track_ids": [
-                        {"track": 1},
-                        {"track": 2},
-                        {"track": 3},
+                        {"track": 1, "time": 1},
+                        {"track": 2, "time": 2},
+                        {"track": 3, "time": 3},
                     ]
                 },
             },
@@ -158,9 +158,9 @@ def test_trending_challenge_job(app):
                 "description": "description",
                 "playlist_contents": {
                     "track_ids": [
-                        {"track": 1},
-                        {"track": 2},
-                        {"track": 3},
+                        {"track": 1, "time": 1},
+                        {"track": 2, "time": 2},
+                        {"track": 3, "time": 3},
                     ]
                 },
             },


### PR DESCRIPTION
### Description
**Updates index trending to be calculated every block hour** 
Block hour: Meaning taking the timestamp off the indexed block and checking to see if the hour has been increased from the previous index trending job

**Removes the 500 Net Multiplier for mat view trending ** 

**updates index trending rewards to pull off the cached trending instead of re-calculating* 

Closes AUD-1044

### Tests
Manually pointed against prod snap db and checked to see that the trending job was triggered on the new hr mark, that the mew view trending still worked without the new multiplier plays subquery, and that 


### How will this change be monitored?
