### PR TITLE
Add a max_overflow for queue pool

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -50,7 +50,7 @@ url_read_replica = postgresql+psycopg2://postgres@localhost/audius_discovery
 run_migrations = true
 engine_args_literal = {
     'pool_size': 20,
-    'max_overflow': 0,
+    'max_overflow': 10,
     'pool_recycle': 3600,
     'echo': False,
     'client_encoding': 'utf8',


### PR DESCRIPTION
### Description
Right now our max db queue pool size is 20 connections per pool instance. We've seen certain pools exceed this limit so add the ability for it to burst an extra 10 connections if necessary. https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Make an API request
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?
Check the logs for future QueuePool errors
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->