### PR TITLE
Update ipfs monitors to use ipfs add wrapper

### DIFF
--- a/creator-node/src/monitors/ipfs.js
+++ b/creator-node/src/monitors/ipfs.js
@@ -1,5 +1,6 @@
 const { ipfs } = require('../ipfsClient')
 const { ipfsAddNonImages } = require('../ipfsAdd')
+const { logger } = require('../logging')
 
 /**
  * Performs a diagnostic test on IPFS operations to
@@ -30,9 +31,9 @@ const getIPFSReadWriteStatus = async () => {
     }
 
     const duration = Date.now() - start
-
     return JSON.stringify({ hash, duration })
   } catch (e) {
+    logger.error(`[getIPFSReadWriteStatus] Error - ${e.toString()}`)
     return null
   }
 }

--- a/creator-node/src/monitors/ipfs.js
+++ b/creator-node/src/monitors/ipfs.js
@@ -1,4 +1,4 @@
-const { ipfs } = require('../ipfsClient')
+const { ipfsLatest: ipfs } = require('../ipfsClient')
 
 /**
  * Performs a diagnostic test on IPFS operations to
@@ -13,7 +13,7 @@ const getIPFSReadWriteStatus = async () => {
     const content = Buffer.from(timestamp)
 
     // Add new buffer created from timestamp (without pin)
-    const results = await ipfs.add(content, { pin: false })
+    const results = await ipfs.add(content, { in: false })
     const hash = results[0].hash // "Qm...WW"
 
     // Retrieve and validate hash from local node

--- a/creator-node/src/monitors/ipfs.js
+++ b/creator-node/src/monitors/ipfs.js
@@ -13,7 +13,7 @@ const getIPFSReadWriteStatus = async () => {
     const content = Buffer.from(timestamp)
 
     // Add new buffer created from timestamp (without pin)
-    const results = await ipfs.add(content, { in: false })
+    const results = await ipfs.add(content, { pin: false })
     const hash = results[0].hash // "Qm...WW"
 
     // Retrieve and validate hash from local node

--- a/creator-node/src/monitors/ipfs.js
+++ b/creator-node/src/monitors/ipfs.js
@@ -1,10 +1,12 @@
-const { ipfsLatest: ipfs } = require('../ipfsClient')
+const { ipfs } = require('../ipfsClient')
+const { ipfsAddNonImages } = require('../ipfsAdd')
 
 /**
  * Performs a diagnostic test on IPFS operations to
  * confirm functionality:
  *   - Adds a file
- *   - Gets a file
+ *   - Retrieves the same file from ipfs via its content addressed hash
+ *
  */
 const getIPFSReadWriteStatus = async () => {
   try {
@@ -13,8 +15,12 @@ const getIPFSReadWriteStatus = async () => {
     const content = Buffer.from(timestamp)
 
     // Add new buffer created from timestamp (without pin)
-    const results = await ipfs.add(content, { pin: false })
-    const hash = results[0].hash // "Qm...WW"
+    const hash = await ipfsAddNonImages(
+      content,
+      { pin: false } /* ipfsConfig */,
+      {} /* logContext */,
+      true /* enableIPFSAdd */
+    )
 
     // Retrieve and validate hash from local node
     const ipfsResp = await ipfs.get(hash)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

With our recent PR to remove ipfs add from crit path, we should also update the monitors to use the ipfsLatest add function. This PR is to update the monitors ipfs api call.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Hitting /health_check/ipfs:
```
// 20211109115325
// http://cn1_creator-node_1:4000/health_check/ipfs

{
  "data": {
    "hash": "QmPuRGirFPy5VnzZWurf7yTvEEnU6cZmLDw68n1qJeeFUj",
    "duration": "166ms"
  },
  "signer": "0x943b965a0e62a615d69ac8d38ebd7dca5f995bf8",
  "timestamp": "2021-11-09T19:53:25.245Z",
  "signature": "0xb62f106e3994dbca625389b8ea9c6854d5d168390b88818429925d36f4310e720c5b90285f3dd6c6c847adc1deccec7d032df3c8069879c9f184e292dfa2203c1c"
}
```

### How will this change be monitored?

via the monitors 😉 

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->