### PR TITLE
Increase aggregate user lock timeout

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_user.py
+++ b/discovery-provider/src/tasks/index_aggregate_user.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 # Names of the aggregate tables to update
 AGGREGATE_USER = "aggregate_user"
-DEFAULT_UPDATE_TIMEOUT = 60 * 5  # 5 minutes
+DEFAULT_UPDATE_TIMEOUT = 60 * 30  # 30 minutes
 REFRESH_COUNTER = 100
 
 ### UPDATE_AGGREGATE_USER_QUERY ###


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->
Increasing lock timeout to avoid blocking queries. Locks will be released at the end of indexing. 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->