### PR TITLE
Fix timestamp on notification

### DIFF
--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -196,7 +196,7 @@ const getCommonNotificationsFields = (notification) => ({
   isHidden: notification.isHidden,
   isRead: notification.isRead,
   isViewed: notification.isViewed,
-  timestamp: notification.timestamp
+  timestamp: notification.timestamp || notification.createdAt
 })
 
 const notificationResponseMap = {


### PR DESCRIPTION
### Description
Fix the timestamp on solana notifications. 
The solana notifications table does not have a timestamp field, but the notifications table does - which when returning notifications from identity to the client, the solana notifications' createdAt field needs to be changed to timestamp to match for consistency.

### Tests

### How will this change be monitored?
