### PR TITLE
Increase redis lock timeouts

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_views.py
+++ b/discovery-provider/src/tasks/index_aggregate_views.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 AGGREGATE_TRACK = "aggregate_track"
 AGGREGATE_PLAYLIST = "aggregate_playlist"
 
-DEFAULT_UPDATE_TIMEOUT = 60
+DEFAULT_UPDATE_TIMEOUT = 60 * 10  # 10 minutes
 
 
 def update_view(mat_view_name, db):

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -4,6 +4,8 @@ from src.tasks.celery_app import celery
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_UPDATE_TIMEOUT = 60 * 30  # 30 minutes
+
 # Vacuum can't happen inside a db txn, so we have to acquire
 # a new connection and set it's isolation level to AUTOCOMMIT
 # as per: https://stackoverflow.com/questions/1017463/postgresql-how-to-run-vacuum-from-code-outside-transaction-block
@@ -53,7 +55,7 @@ def update_materialized_views(self):
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("materialized_view_lock", timeout=60 * 10)
+    update_lock = redis.lock("materialized_view_lock", timeout=DEFAULT_UPDATE_TIMEOUT)
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)


### PR DESCRIPTION
### Description
Discovery nodes are sometimes seeing the redis lock for an operation expire and multiple instances of that query running in parallel. For example, figment metadata-2 on prod has 7 aggregate_track queries running concurrently. This PR increases the lock timeout to stop the vicious cycle of more queries -> more load, slower queries -> more queries get spun up and repeat.

<img width="1480" alt="https___audius-metadata-2_figment_io_health_check_verbose_true_and_Slack___eng-notifications___Audius" src="https://user-images.githubusercontent.com/295938/141156558-6085223b-d437-4ebe-b70d-be7da5753197.png">
<!-- What is the purpose of this PR
? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->