### PR TITLE
Add max_overflow connections

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -50,7 +50,7 @@ url_read_replica = postgresql+psycopg2://postgres@localhost/audius_discovery
 run_migrations = true
 engine_args_literal = {
     'pool_size': 20,
-    'max_overflow': 0,
+    'max_overflow': 10,
     'pool_recycle': 3600,
     'echo': False,
     'client_encoding': 'utf8',


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

We sometimes see QueuePool timeout and run out of connections. This adds max_overflow connections (default is 10) which will be instantiated when pool_size has run out then cleaned up after use.  

(20 pool_size + 10 max_overflow) * (16 gunicorn workers) = 480 connections.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?
`sqlalchemy.exc.TimeoutError: QueuePool limit of size` logs.

https://analytics.amplitude.com/audius/chart/ma21km1?source=redirect%3A+chart+saved

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->