### PR TITLE
Fix Identity local tests

### DIFF
--- a/identity-service/scripts/run-tests.sh
+++ b/identity-service/scripts/run-tests.sh
@@ -11,7 +11,7 @@ done
 
 PG_PORT=$POSTGRES_TEST_PORT
 if [ -z "${PG_PORT}" ]; then
-  PG_PORT=7432
+  PG_PORT=7433
 fi
 echo $PG_PORT
 
@@ -41,16 +41,16 @@ export solanaValidSigner=''
 # https://circleci.com/docs/2.0/building-docker-images/#separation-of-environments
 # So, if tests are run locally, run docker exec command. Else, run the psql command in the job.
 
-DB_CONTAINER='identity-db_1'
-DB_EXISTS=$(docker ps -q -f status=running -f name=^/${DB_CONTAINER}$)
-if [ ! "${DB_EXISTS}" ]; then
+DB_CONTAINER='identity-test-db_1'
+DB_EXISTS=$(docker ps -a -q -f status=running -f name=^/${DB_CONTAINER}$)
+if [ -z "${DB_EXISTS}" ]; then
   echo "DB Container doesn't exist"
   docker run -d --name $DB_CONTAINER -p 127.0.0.1:$PG_PORT:5432 postgres:11.1
   sleep 1
 fi
 
 REDIS_CONTAINER='identity_test_redis'
-REDIS_EXISTS=$(docker ps -q -f status=running -f name=^/${REDIS_CONTAINER}$)
+REDIS_EXISTS=$(docker ps -a -q -f status=running -f name=^/${REDIS_CONTAINER}$)
 if [ ! "${REDIS_EXISTS}" ]; then
   echo "Redis Container doesn't exist"
   docker run -d --name $REDIS_CONTAINER -p 127.0.0.1:$redisPort:6379 redis:5.0.4


### PR DESCRIPTION
### Description
If you attempt to run identity tests with your local system already set up, it throws an error with a container conflict. I've modified the port and the container name and port to not conflict with the existing containers. I've also fixed a bug where it wasn't correctly getting the boolean value for DB_EXISTS and REDIS_EXISTS because the -a was missing in docker ps.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Ran tests locally in identity
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->