### PR TITLE
[AUD-1084] Don't filter deleted so that we can get tombstones on the client

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -181,9 +181,7 @@ class TrackByRoute(Resource):
         if slug and handle:
             routes_parsed.append({"handle": handle, "slug": slug})
 
-        tracks = get_tracks(
-            {"routes": routes_parsed, "with_users": True, "filter_deleted": True}
-        )
+        tracks = get_tracks({"routes": routes_parsed, "with_users": True})
         if not tracks:
             if handle and slug:
                 abort_not_found(f"{handle}/{slug}", ns)
@@ -255,7 +253,6 @@ class FullTrackByRoute(Resource):
             {
                 "routes": routes_parsed,
                 "with_users": True,
-                "filter_deleted": True,
                 "current_user_id": current_user_id,
             }
         )


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Tombstones weren't working in the client because the track endpoint for routes is filtering deleted tracks.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested manually against local client

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->