### PR TITLE
Fixes for provisioning remote dev stack

### DIFF
--- a/service-commands/README.md
+++ b/service-commands/README.md
@@ -30,7 +30,7 @@ node scripts/setup.js run init-repos up
 
 **Bringing up all services:**
 - In `<service-commands>/scripts/`, run `node setup.js up` to bring all services up.
-- `-nc, --num-cnodes <number>`, by default set to 4. Adjusts the number of creator nodes initialized within the system. 
+- `-nc, --num-cnodes <number>`, by default set to 4. Adjusts the number of creator nodes initialized within the system.
 
 ```
 node setup.js up
@@ -50,7 +50,25 @@ For a breakdown of how the `up` operation brings up the entire system, reference
 
 All commands to the system are structured as a combination of `service` and `command` - the mapping is stored in [service-commands.json](src/commands/service-commands.json). Any of these service + command combinations are accessible to you through the `node setup.js run` entrypoint detailed below.
 
+### Provisioning a brand-new dev box!
+You can provision a brand-new dev instance with:
+* dependencies and tooling installed
+* Docker images cached
+* at commit hashes/branches of your choosing for protocol + client!
 
+```bash
+  $ A setup remote-dev --fast <instance-name> [--protocol-git-ref <branch-name-or-commit-hash>] [--client-git-ref <branch-name-or-commit-hash>] [--up]
+```
+
+Note that you will need to manually confirm the instance creation as well as ssh connection upon startup. Once you've confirmed the ssh connection, that's it -- you can walk away and make a pie and wait for your dev environment to finish provisioning!
+
+Here's an example of how to provision a gcloud instance called `pietocol-team` at protocol branch `cj-quickfix` and client git hash `7cf17667972d4c5d6bc25d08ce1f626c37f9abb7` and make sure to run `A up` right after setting up the box:
+
+```bash
+  $ A setup remote-dev --fast pietocol-team --protocol-git-ref cj-quickfix --client-git-ref 7cf17667972d4c5d6bc25d08ce1f626c37f9abb7 --up
+```
+
+Don't forget to delete your instance once you're finished using it with `gcloud compute instances delete <instance-name>`.
 
 ### Bringing up services locally
 Individual service commands can be executed with: `node setup.js run <service> [command]`

--- a/service-commands/package-lock.json
+++ b/service-commands/package-lock.json
@@ -3755,9 +3755,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._baseiteratee": {
       "version": "4.7.0",

--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -8,17 +8,18 @@
   },
   "dependencies": {
     "@audius/libs": "1.2.19",
+    "@solana/web3.js": "1.20.0",
     "axios": "^0.19.2",
+    "borsh": "^0.4.0",
     "colors": "^1.4.0",
     "commander": "^6.0.0",
     "convict": "^5.2.0",
     "dotenv": "^8.2.0",
     "ffmpeg-static": "^4.2.7",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.0",
     "untildify": "^4.0.0",
-    "web3": "^1.2.7",
-    "@solana/web3.js": "1.20.0",
-    "borsh": "^0.4.0"
+    "web3": "^1.2.7"
   },
   "devDependencies": {
     "eslint": "^7.2.0",

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -255,9 +255,12 @@ def setup(name, azure, service, config, user):
             ]
         )
     elif service == "remote-dev":
+        node_version = '14.18.1'
+        python_version = '3.9'
         subprocess.run(
             [
                 "ssh",
+                "-o StrictHostKeyChecking=no", # auto-ssh in for setup
                 host,
                 (
                     "sudo apt update && "
@@ -266,17 +269,19 @@ def setup(name, azure, service, config, user):
                     "sudo sudo add-apt-repository 'deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable' && "
                     "sudo add-apt-repository ppa:deadsnakes/ppa &&" # python3.9 installation
                     "sudo apt update && "
-                    "sudo apt install -y docker-ce python3.9 && "
+                    f"sudo apt install -y docker-ce python{python_version} && "
                     "sudo usermod -aG docker $USER && "
                     'sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && '
                     "sudo chmod +x /usr/local/bin/docker-compose && "
                     "sudo chown $USER /etc/hosts && "
                     "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash && "
                     "echo 'export PROTOCOL_DIR=$HOME/audius-protocol' >> ~/.profile && "
+                    f"echo 'nvm use {node_version}' >> ~/.profile && "
+                    "echo 'export AUDIUS_REMOTE_DEV_HOST=$(curl -sfL -H \"Metadata-Flavor: Google\" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)' >> ~/.profile && "
                     "source ~/.nvm/nvm.sh && "
                     "source ~/.profile && "
                     "source ~/.bashrc && "
-                    "nvm install v14.18.1 && "
+                    f"nvm install v{node_version} && "
                     "git clone https://github.com/AudiusProject/audius-protocol.git; "
                     "git clone https://github.com/AudiusProject/audius-client.git; "
                     "cd audius-protocol/service-commands && "

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -5,44 +5,74 @@ import sys
 import subprocess
 import argparse
 
+def get_gcloud_project_and_account():
+    project = (
+        subprocess.run(
+            [
+                "gcloud",
+                "config",
+                "get-value",
+                "project",
+            ],
+            capture_output=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
 
-def create_instance(name, azure, image_project, image_family, size, machine_type):
+    account = (
+        subprocess.run(
+            [
+                "gcloud",
+                "config",
+                "list",
+                "account",
+                "--format",
+                "value(core.account)",
+            ],
+            capture_output=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+    return {
+        'project': project,
+        'account': account
+    }
+
+def get_gcloud_instance_ip(instance_name):
+    ip = (
+        subprocess.run(
+            [
+                "gcloud",
+                "compute",
+                "instances",
+                "describe",
+                instance_name,
+                "--format",
+                "get(networkInterfaces[0].accessConfigs[0].natIP)",
+            ],
+            capture_output=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
+    return ip
+
+def create_instance(name, azure, image_project, image_family, size, machine_type, use_image, image_name):
     if not azure:
-        project = (
-            subprocess.run(
-                [
-                    "gcloud",
-                    "config",
-                    "get-value",
-                    "project",
-                ],
-                capture_output=True,
-            )
-            .stdout.decode()
-            .strip()
-        )
-
-        account = (
-            subprocess.run(
-                [
-                    "gcloud",
-                    "config",
-                    "list",
-                    "account",
-                    "--format",
-                    "value(core.account)",
-                ],
-                capture_output=True,
-            )
-            .stdout.decode()
-            .strip()
-        )
-
-        print("Project:", project)
-        print("Account:", account)
-
+        gcloud_account_details = get_gcloud_project_and_account()
+        print("Project:", gcloud_account_details['project'])
+        print("Account:", gcloud_account_details['account'])
         if input("Confirm account and project? [y/N]").lower() != "y":
             return
+        if use_image:
+            image_family_or_image_flag = "--image"
+            image_family_or_image_value = image_name
+        else:
+            image_family_or_image_flag = "--image-family"
+            image_family_or_image_value = image_family
 
         subprocess.run(
             [
@@ -53,8 +83,8 @@ def create_instance(name, azure, image_project, image_family, size, machine_type
                 name,
                 "--image-project",
                 image_project,
-                "--image-family",
-                image_family,
+                image_family_or_image_flag,
+                image_family_or_image_value,
                 "--boot-disk-size",
                 size,
                 "--machine-type",
@@ -62,22 +92,7 @@ def create_instance(name, azure, image_project, image_family, size, machine_type
             ]
         )
 
-        ip = (
-            subprocess.run(
-                [
-                    "gcloud",
-                    "compute",
-                    "instances",
-                    "describe",
-                    name,
-                    "--format",
-                    "get(networkInterfaces[0].accessConfigs[0].natIP)",
-                ],
-                capture_output=True,
-            )
-            .stdout.decode()
-            .strip()
-        )
+        ip = get_gcloud_instance_ip(name)
         print("IP address:", ip)
     else:
         subprocess.run(
@@ -156,7 +171,7 @@ def create_instance(name, azure, image_project, image_family, size, machine_type
     return ip
 
 
-def setup(name, azure, service, config, user):
+def setup(name, azure, service, config, user, fast, up_stack_upon_provision, protocol_git_ref, client_git_ref):
     if not azure:
         proc = subprocess.run(
             [
@@ -190,14 +205,24 @@ def setup(name, azure, service, config, user):
 
     ip = proc.stdout.decode().strip()
     if proc.returncode != 0:
-        input(f"Creating new instance '{name}'. Press Enter to continue...")
+        input(f"Creating new instance '{name}' from prebaked image: {fast}. Press Enter to continue...")
+        use_image = False
+        image_name = ""
+        image_project = "ubuntu-os-cloud"
+        if fast:
+            use_image = True
+            image_name = "audius-dev-poc"
+            image_project = "audius-infrastructure"
+
         ip = create_instance(
             name,
             azure,
-            "ubuntu-os-cloud",
+            image_project,
             "ubuntu-2004-lts",
             "256",
             "n2-custom-12-24576",
+            use_image,
+            image_name
         )
 
     host = f"{user}@{ip}"
@@ -255,21 +280,34 @@ def setup(name, azure, service, config, user):
             ]
         )
     elif service == "remote-dev":
-        subprocess.run(
-            [
-                "ssh",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
-                "-o",
-                "StrictHostKeyChecking=no", # auto-ssh in for setup - why isn't this working?
-                host,
-                (
-                    "git clone --branch cj-set-py-node-version-dev https://github.com/AudiusProject/audius-protocol.git &&"
-                    "cd audius-protocol &&"
-                    "yes | bash service-commands/scripts/provision-dev-env.sh"
-                ),
-            ]
-        )
+        if fast:
+            subprocess.run(
+                [
+                    "ssh",
+                    host,
+                    (
+                        f"cd ~/audius-protocol && git fetch origin && git checkout {protocol_git_ref} &&"
+                        f"cd ~/audius-client && git fetch origin && git checkout {client_git_ref}"
+                    )
+                ],
+            )
+            if up_stack_upon_provision:
+                up_command = "exec $SHELL -l; A up"
+                subprocess.run(
+                    f'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -t {host} {up_command}',
+                    shell=True
+                )
+        else:
+            subprocess.run(
+                [
+                    "ssh",
+                    host,
+                    (
+                        "git clone https://github.com/AudiusProject/audius-protocol.git &&"
+                        "yes | bash audius-protocol/service-commands/scripts/provision-dev-env.sh"
+                    ),
+                ]
+            )
 
         if input("Configure local /etc/hosts? [y/N]").lower() == "y":
             subprocess.run(
@@ -357,6 +395,30 @@ def main():
     )
 
     parser_setup.add_argument(
+        "--fast",
+        action="store_true",
+        help="Use prebaked dev image when provisioning",
+    )
+
+    parser_setup.add_argument(
+        "--up",
+        action="store_true",
+        help="Provision a local dev stack right after creating instance",
+    )
+
+    parser_setup.add_argument(
+        "--protocol-git-ref",
+        default="master",
+        help="audius-protocol branch name or commit hash to check out when provisioning",
+    )
+
+    parser_setup.add_argument(
+        "--client-git-ref",
+        default="master",
+        help="audius-client branch name or commit hash to check out when provisioning",
+    )
+
+    parser_setup.add_argument(
         "--user",
         default="ubuntu",
         help="user to login as",
@@ -383,10 +445,20 @@ def main():
                 args.image_project,
                 args.image_family,
                 args.size,
-                args.machine_type,
+                args.machine_type
             )
         elif args.operation == "setup":
-            setup(args.name, args.azure, args.service, args.config, args.user)
+            setup(
+                args.name,
+                args.azure,
+                args.service,
+                args.config,
+                args.user,
+                args.fast,
+                args.up,
+                args.protocol_git_ref,
+                args.client_git_ref
+            )
     except argparse.ArgumentError:
         subprocess.run(
             [

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -264,8 +264,9 @@ def setup(name, azure, service, config, user):
                     "sudo apt install -y apt-transport-https ca-certificates curl software-properties-common build-essential python-is-python2 python3-pip git-secrets && "
                     "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - && "
                     "sudo sudo add-apt-repository 'deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable' && "
+                    "sudo add-apt-repository ppa:deadsnakes/ppa &&" # python3.9 installation
                     "sudo apt update && "
-                    "sudo apt install -y docker-ce && "
+                    "sudo apt install -y docker-ce python3.9 && "
                     "sudo usermod -aG docker $USER && "
                     'sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && '
                     "sudo chmod +x /usr/local/bin/docker-compose && "
@@ -275,7 +276,7 @@ def setup(name, azure, service, config, user):
                     "source ~/.nvm/nvm.sh && "
                     "source ~/.profile && "
                     "source ~/.bashrc && "
-                    "nvm install 10.23.0 && "
+                    "nvm install v14.18.1 && "
                     "git clone https://github.com/AudiusProject/audius-protocol.git; "
                     "git clone https://github.com/AudiusProject/audius-client.git; "
                     "cd audius-protocol/service-commands && "

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -255,41 +255,18 @@ def setup(name, azure, service, config, user):
             ]
         )
     elif service == "remote-dev":
-        node_version = '14.18.1'
-        python_version = '3.9'
         subprocess.run(
             [
                 "ssh",
-                "-o StrictHostKeyChecking=no", # auto-ssh in for setup
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no", # auto-ssh in for setup - why isn't this working?
                 host,
                 (
-                    "sudo apt update && "
-                    "sudo apt install -y apt-transport-https ca-certificates curl software-properties-common build-essential python-is-python2 python3-pip git-secrets && "
-                    "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - && "
-                    "sudo sudo add-apt-repository 'deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable' && "
-                    "sudo add-apt-repository ppa:deadsnakes/ppa &&" # python3.9 installation
-                    "sudo apt update && "
-                    f"sudo apt install -y docker-ce python{python_version} && "
-                    "sudo usermod -aG docker $USER && "
-                    'sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && '
-                    "sudo chmod +x /usr/local/bin/docker-compose && "
-                    "sudo chown $USER /etc/hosts && "
-                    "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash && "
-                    "echo 'export PROTOCOL_DIR=$HOME/audius-protocol' >> ~/.profile && "
-                    f"echo 'nvm use {node_version}' >> ~/.profile && "
-                    "echo 'export AUDIUS_REMOTE_DEV_HOST=$(curl -sfL -H \"Metadata-Flavor: Google\" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)' >> ~/.profile && "
-                    "source ~/.nvm/nvm.sh && "
-                    "source ~/.profile && "
-                    "source ~/.bashrc && "
-                    f"nvm install v{node_version} && "
-                    "git clone https://github.com/AudiusProject/audius-protocol.git; "
-                    "git clone https://github.com/AudiusProject/audius-client.git; "
-                    "cd audius-protocol/service-commands && "
-                    "npm install && "
-                    "node scripts/hosts.js add && "
-                    "node scripts/setup.js run init-repos up && "
-                    "echo 'Rebooting machine...' && "
-                    "reboot"
+                    "git clone --branch cj-set-py-node-version-dev https://github.com/AudiusProject/audius-protocol.git &&"
+                    "cd audius-protocol &&"
+                    "yes | bash service-commands/scripts/provision-dev-env.sh"
                 ),
             ]
         )

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -288,13 +288,6 @@ def setup(name, azure, service, config, user):
                     "npm install && "
                     "node scripts/hosts.js add && "
                     "node scripts/setup.js run init-repos up && "
-                    "cd ../libs && "
-                    "npm link && "
-                    "cd ../service-commands && "
-                    "npm link @audius/libs && "
-                    "cd ~/audius-client && "
-                    "npm install && "
-                    "npm link @audius/libs && "
                     "echo 'Rebooting machine...' && "
                     "reboot"
                 ),

--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -1,5 +1,4 @@
-set -e
-set -x
+set -ex
 
 # setup root
 cd $PROTOCOL_DIR/
@@ -44,7 +43,7 @@ npm install
 # setup identity service
 cd $PROTOCOL_DIR/
 cd identity-service/
-npm install --dev
+npm install --also=dev
 
 wait
 

--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -62,5 +62,6 @@ cd $PROTOCOL_DIR/
 cd ..
 if [ -d "audius-client" ]; then
     cd audius-client
+    npm install
     npm link @audius/libs
 fi

--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -3,27 +3,29 @@ set -x
 
 # setup root
 cd $PROTOCOL_DIR/
-npm install &
+npm install
 
 # setup service commands
 cd $PROTOCOL_DIR/
 cd service-commands/
-npm install &
+npm install
+npm link
 
 # setup mad dog
 cd $PROTOCOL_DIR/
 cd mad-dog/
-npm install &
+npm install
+npm link @audius/service-commands
 
 # setup contracts
 cd $PROTOCOL_DIR/
 cd contracts/
-npm install &
+npm install
 
 # setup eth contracts
 cd $PROTOCOL_DIR/
 cd eth-contracts/
-npm install &
+npm install
 
 # no discovery provider setup needed
 # 'pip install' is performed through Docker for development
@@ -32,18 +34,17 @@ npm install &
 # setup creator node
 cd $PROTOCOL_DIR/
 cd creator-node/
-npm install &
-npm install & #why does it not work without this?
+npm install
 
 # setup libs
 cd $PROTOCOL_DIR/
 cd libs/
-npm install &
+npm install
 
 # setup identity service
 cd $PROTOCOL_DIR/
 cd identity-service/
-npm install --dev &
+npm install --dev
 
 wait
 

--- a/service-commands/scripts/provision-dev-env.sh
+++ b/service-commands/scripts/provision-dev-env.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -x
+
+export NODE_VERSION="v14.18.1"
+export PYTHON_VERSION="3.9"
+export NVM_VERSION="v0.35.3"
+export DOCKER_COMPOSE_VERSION="1.27.4"
+
+sudo apt update
+sudo apt install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    build-essential \
+    python-is-python2 \
+    python3-pip \
+    git-secrets \
+    jq
+
+# python setup
+sudo add-apt-repository ppa:deadsnakes/ppa # python3.9 installation
+sudo apt install -y "python$PYTHON_VERSION"
+
+# docker setup
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository 'deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable'
+sudo apt update
+sudo apt install -y docker-ce
+sudo usermod -aG docker $USER
+sudo curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+# prevent docker logs from eating all memory
+sudo sh -c "cat >/etc/docker/daemon.json" <<EOF
+{
+    "log-driver": "json-file",
+    "log-opts": {
+        "max-size": "10m",
+        "max-file": "3"
+    }
+}
+EOF
+
+sudo chown $USER /etc/hosts
+
+# install nvm and node
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+nvm install $NODE_VERSION
+
+# profile setup
+echo "nvm use $NODE_VERSION" >> ~/.profile
+echo 'export PROTOCOL_DIR=$HOME/audius-protocol' >> ~/.profile
+echo 'export AUDIUS_REMOTE_DEV_HOST=$(curl -sfL -H \"Metadata-Flavor: Google\" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)' >> ~/.profile
+source ~/.profile
+source ~/.bashrc
+
+# audius repos setup
+git clone https://github.com/AudiusProject/audius-client.git;
+cd $PROTOCOL_DIR/service-commands
+npm install
+node scripts/hosts.js add
+node scripts/setup.js run init-repos up
+echo 'Rebooting machine...'
+reboot

--- a/service-commands/scripts/provision-dev-env.sh
+++ b/service-commands/scripts/provision-dev-env.sh
@@ -58,7 +58,7 @@ source ~/.profile
 source ~/.bashrc
 
 # audius repos setup
-git clone https://github.com/AudiusProject/audius-client.git;
+git clone https://github.com/AudiusProject/audius-client.git
 cd $PROTOCOL_DIR/service-commands
 npm install
 node scripts/hosts.js add


### PR DESCRIPTION
Sets node version to v14.18.1 and Python to 3.9 so you can `A up` directly after provisioning a box.

### Description

Found this because I'm trying to double-fist dev stacks to troubleshoot seed CLI and discrete volume mounting at once, and ran into some hurdles while using `A setup remote-dev` to provision my parallel stack. Fixing these versioning issues makes it more plug-and-play, and hopefully paves the path to baking a machine image that can be used for even easier developer environment vending. 