### PR TITLE
Reduce aggregate user full refresh frequency

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_user.py
+++ b/discovery-provider/src/tasks/index_aggregate_user.py
@@ -10,7 +10,10 @@ logger = logging.getLogger(__name__)
 # Names of the aggregate tables to update
 AGGREGATE_USER = "aggregate_user"
 DEFAULT_UPDATE_TIMEOUT = 60 * 30  # 30 minutes
-REFRESH_COUNTER = 100
+
+# every ~10000 updates, refresh the entire table
+# at 30 secs interval, this should happen ~twice a day
+REFRESH_COUNTER = 1000
 
 ### UPDATE_AGGREGATE_USER_QUERY ###
 # Get a lower bound blocknumber to check for new entity counts for a user

--- a/discovery-provider/src/tasks/index_aggregate_user.py
+++ b/discovery-provider/src/tasks/index_aggregate_user.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 AGGREGATE_USER = "aggregate_user"
 DEFAULT_UPDATE_TIMEOUT = 60 * 30  # 30 minutes
 
-# every ~10000 updates, refresh the entire table
+# every ~1000 updates, refresh the entire table
 # at 30 secs interval, this should happen ~twice a day
 REFRESH_COUNTER = 1000
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

The full refreshes that happen once every ~100 updates for aggregate_user seems to block other queries. For now, we can reduce the frequency to prevent this. Next we'll separate the truncate from the update transaction and do a drop/replace.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->