### PR TITLE
Append to X-Forwarded-For header

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -42,19 +42,19 @@ http {
         location ~* ^/.*_check/?$ {
             proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location = /version {
             proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location /v1/metrics {
             proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location / {
@@ -100,7 +100,7 @@ http {
 
             proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }
 }


### PR DESCRIPTION
* OpenRESTY proxy append to X-Forwarded-For header instead of overwriting it
* related to dashboard metrics issue - flare #44.

### Description

See [docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#var_proxy_add_x_forwarded_for) 

### Testing
* Staging/remote dev