### PR TITLE
[ASI-722] DN Parallel metadata fetch

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -47,3 +47,6 @@ six==1.15.0
 solana==0.10.0
 typing-extensions==3.7.4.3
 urllib3==1.26.3
+
+# test
+pytest-mock==3.6.1

--- a/discovery-provider/src/models/test_base_model_validation.py
+++ b/discovery-provider/src/models/test_base_model_validation.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, String, Text, Integer
 from src.models.models import Base
 
 
-class TestModel(Base):
+class ModelTest(Base):
     __tablename__ = "fake"
     id = Column(Integer, primary_key=True)
     text_column = Column(Text)
@@ -10,7 +10,7 @@ class TestModel(Base):
 
 
 def test_validated_base():
-    my_model = TestModel(
+    my_model = ModelTest(
         string_column="κόσμε\uD800\x00",
         text_column="κόσμε\x00\uDF80\uDB7F\uDFFF",
     )

--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -9,7 +9,7 @@ import requests
 from src.utils.helpers import get_valid_multiaddr_from_id_json
 
 logger = logging.getLogger(__name__)
-
+new_block_timeout_seconds = 5
 
 class IPFSClient:
     """Helper class for Audius Discovery Provider + IPFS interaction"""
@@ -61,7 +61,7 @@ class IPFSClient:
             for get_metadata_future in concurrent.futures.as_completed(metadata_futures):
                 original_task = metadata_futures[get_metadata_future]
                 try:
-                    api_metadata = get_metadata_future.result(timeout=5)
+                    api_metadata = get_metadata_future.result(timeout=new_block_timeout_seconds)
                     retrieved = api_metadata != default_metadata_fields
                     if retrieved:
                         logger.info(f'IPFSCLIENT | retrieved metadata successfully, {api_metadata}, task: {original_task}')
@@ -122,7 +122,7 @@ class IPFSClient:
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             # Start the load operations and mark each future with its URL
             future_to_url = {
-                executor.submit(self.load_metadata_url, url, 5): url
+                executor.submit(self.load_metadata_url, url, new_block_timeout_seconds): url
                 for url in gateway_ipfs_urls
             }
             for future in concurrent.futures.as_completed(future_to_url):

--- a/discovery-provider/tests/test_ipfs_functionality.py
+++ b/discovery-provider/tests/test_ipfs_functionality.py
@@ -1,12 +1,55 @@
 import json
 import ipfshttpclient
 import pytest  # pylint: disable=unused-import
+import time
+from pytest_mock import mocker
 from chance import chance
 from src.utils.ipfs_lib import IPFSClient
 from src.utils.helpers import remove_test_file
 from src.tasks.metadata import track_metadata_format
 
 def test_ipfs(app):
+    def create_generic_metadata_object(track_metadata_format, json_file):
+        test_metadata_object = dict(track_metadata_format)
+        test_metadata_object["title"] = chance.name()
+        test_metadata_object["release_date"] = str(chance.date())
+        test_metadata_object["file_type"] = "mp3"
+        test_metadata_object["license"] = "HN"
+        with open(json_file, "w") as f:
+            json.dump(test_metadata_object, f)
+        return test_metadata_object
+
+    def add_metadata_object_to_ipfs_node(json_file, api):
+        json_res = api.add(json_file)
+        metadata_hash = json_res["Hash"]
+        return metadata_hash
+
+    def test_cleanup(json_file):
+        remove_test_file(json_file)
+
+    def confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata):
+        for key, val in test_metadata_object.items():
+            assert key in ipfs_metadata
+            assert val == ipfs_metadata[key]
+
+    def assert_metadata_retrieval_failure(track_metadata_format, json_file, ipfs_metadata, api):
+        with pytest.raises(Exception):
+            test_metadata_object = create_generic_metadata_object(track_metadata_format, json_file)
+            metadata_hash = add_metadata_object_to_ipfs_node(json_file, api)
+            ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
+            test_cleanup(json_file)
+
+
+    def assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api):
+        test_metadata_object = create_generic_metadata_object(track_metadata_format, json_file)
+        metadata_hash = add_metadata_object_to_ipfs_node(json_file, api)
+        ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
+        test_cleanup(json_file)
+        confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata)
+
+    def timeout_fetch():
+        time.sleep(10)
+
     json_file = "tests/res/test_ipfs.json"
     ipfs_peer_host = app.config["ipfs"]["host"]
     ipfs_peer_port = app.config["ipfs"]["port"]
@@ -14,27 +57,47 @@ def test_ipfs(app):
     # Instantiate IPFS client from src lib
     ipfsclient = IPFSClient(ipfs_peer_host, ipfs_peer_port)
 
-    remove_test_file(json_file)
+    test_cleanup(json_file)
     api = ipfshttpclient.connect(f"/dns/{ipfs_peer_host}/tcp/{ipfs_peer_port}/http")
+    assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
 
-    # Create generic metadata object w/above IPFS multihash
-    test_metadata_object = dict(track_metadata_format)
-    test_metadata_object["title"] = chance.name()
-    test_metadata_object["release_date"] = str(chance.date())
-    test_metadata_object["file_type"] = "mp3"
-    test_metadata_object["license"] = "HN"
-    with open(json_file, "w") as f:
-        json.dump(test_metadata_object, f)
+    ipfs_fetch = 'get_metadata_from_ipfs_node'
+    gateway_fetch = 'get_metadata_from_gateway'
 
-    # Add metadata object to ipfs node
-    json_res = api.add(json_file)
-    metadata_hash = json_res["Hash"]
+    def slow_return_metadata():
+        time.sleep(3)
+        return test_metadata_object
 
-    # Invoke audius-ipfs
-    ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
-    remove_test_file(json_file)
+    def return_metadata_immediately():
+        return test_metadata_object
 
-    # Confirm retrieved metadata object state
-    for key, val in test_metadata_object.items():
-        assert key in ipfs_metadata
-        assert val == ipfs_metadata[key]
+    def patch_ipfsclient_method(method_name, replacement_function):
+        mocker.patch.object(IPFSClient, method_name)
+        IPFSClient.get_metadata_from_gateway.side_effect = replacement_function
+
+    def test_ipfs_metadata_fetch_with_gateway_slow(mocker):
+        patch_ipfsclient_method(gateway_fetch, slow_return_metadata)
+        patch_ipfsclient_method(ipfs_fetch, return_metadata_immediately)
+        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+
+    def test_ipfs_metadata_fetch_with_ipfs_slow(mocker):
+        patch_ipfsclient_method(ipfs_fetch, slow_return_metadata)
+        patch_ipfsclient_method(gateway_fetch, return_metadata_immediately)
+        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+
+    def test_ipfs_metadata_fetch_with_ipfs_timeout(mocker):
+        patch_ipfsclient_method(ipfs_fetch, timeout_fetch)
+        patch_ipfsclient_method(gateway_fetch, return_metadata_immediately)
+        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+
+    def test_ipfs_metadata_fetch_with_gateway_timeout(mocker):
+        patch_ipfsclient_method(gateway_fetch, timeout_fetch)
+        patch_ipfsclient_method(ipfs_fetch, return_metadata_immediately)
+        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+
+    def test_ipfs_metadata_fetch_with_both_timeout(mocker):
+        patch_ipfsclient_method(ipfs_fetch, timeout_fetch)
+        patch_ipfsclient_method(gateway_fetch, timeout_fetch)
+        assert_metadata_retrieval_failure(track_metadata_format, json_file, ipfs_metadata, api)
+
+

--- a/discovery-provider/tests/test_ipfs_functionality.py
+++ b/discovery-provider/tests/test_ipfs_functionality.py
@@ -1,103 +1,108 @@
 import json
+import time
 import ipfshttpclient
 import pytest  # pylint: disable=unused-import
-import time
 from pytest_mock import mocker
 from chance import chance
 from src.utils.ipfs_lib import IPFSClient
-from src.utils.helpers import remove_test_file
+from src.utils.helpers import remove_test_file as test_cleanup
 from src.tasks.metadata import track_metadata_format
 
-def test_ipfs(app):
-    def create_generic_metadata_object(track_metadata_format, json_file):
-        test_metadata_object = dict(track_metadata_format)
-        test_metadata_object["title"] = chance.name()
-        test_metadata_object["release_date"] = str(chance.date())
-        test_metadata_object["file_type"] = "mp3"
-        test_metadata_object["license"] = "HN"
-        with open(json_file, "w") as f:
-            json.dump(test_metadata_object, f)
-        return test_metadata_object
+IPFS_FETCH = 'get_metadata_from_ipfs_node'
+GATEWAY_FETCH = 'get_metadata_from_gateway'
+JSON_FILE = "tests/res/test_ipfs.json"
+TEST_METADATA_OBJECT = create_generic_metadata_object(track_metadata_format, JSON_FILE)
 
-    def add_metadata_object_to_ipfs_node(json_file, api):
-        json_res = api.add(json_file)
-        metadata_hash = json_res["Hash"]
-        return metadata_hash
+# Helpers
+def create_generic_metadata_object(track_metadata_format, json_file):
+    test_metadata_object = dict(track_metadata_format)
+    test_metadata_object["title"] = chance.name()
+    test_metadata_object["release_date"] = str(chance.date())
+    test_metadata_object["file_type"] = "mp3"
+    test_metadata_object["license"] = "HN"
+    with open(json_file, "w") as f:
+        json.dump(test_metadata_object, f)
+    return test_metadata_object
 
-    def test_cleanup(json_file):
-        remove_test_file(json_file)
+def add_metadata_object_to_ipfs_node(json_file, api):
+    json_res = api.add(json_file)
+    metadata_hash = json_res["Hash"]
+    return metadata_hash
 
-    def confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata):
-        for key, val in test_metadata_object.items():
-            assert key in ipfs_metadata
-            assert val == ipfs_metadata[key]
+def confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata):
+    for key, val in test_metadata_object.items():
+        assert key in ipfs_metadata
+        assert val == ipfs_metadata[key]
 
-    def assert_metadata_retrieval_failure(track_metadata_format, json_file, ipfs_metadata, api):
-        with pytest.raises(Exception):
-            test_metadata_object = create_generic_metadata_object(track_metadata_format, json_file)
-            metadata_hash = add_metadata_object_to_ipfs_node(json_file, api)
-            ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
-            test_cleanup(json_file)
-
-
-    def assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api):
-        test_metadata_object = create_generic_metadata_object(track_metadata_format, json_file)
+def assert_metadata_retrieval_failure(track_metadata_format, json_file, api):
+    with pytest.raises(Exception):
         metadata_hash = add_metadata_object_to_ipfs_node(json_file, api)
-        ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
-        test_cleanup(json_file)
-        confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata)
+        ipfsclient.get_metadata(metadata_hash, track_metadata_format)
 
-    def timeout_fetch():
-        time.sleep(10)
+def assert_metadata_retrieval_success(track_metadata_format, json_file, api):
+    test_metadata_object = create_generic_metadata_object(track_metadata_format, json_file)
+    metadata_hash = add_metadata_object_to_ipfs_node(json_file, api)
+    ipfs_metadata = ipfsclient.get_metadata(metadata_hash, track_metadata_format)
+    confirm_retrieved_metadata_object_state(test_metadata_object, ipfs_metadata)
 
-    json_file = "tests/res/test_ipfs.json"
+def timeout_fetch():
+    time.sleep(10)
+
+def slow_return_metadata():
+    time.sleep(3)
+    return TEST_METADATA_OBJECT
+
+def return_metadata_immediately():
+    return TEST_METADATA_OBJECT
+
+def patch_ipfsclient_method(method_name, replacement_function):
+    mocker.patch.object(IPFSClient, method_name)
+    IPFSClient.get_metadata_from_gateway.side_effect = replacement_function
+
+def instantiate_client_and_return_api(app):
     ipfs_peer_host = app.config["ipfs"]["host"]
     ipfs_peer_port = app.config["ipfs"]["port"]
-
-    # Instantiate IPFS client from src lib
     ipfsclient = IPFSClient(ipfs_peer_host, ipfs_peer_port)
-
-    test_cleanup(json_file)
     api = ipfshttpclient.connect(f"/dns/{ipfs_peer_host}/tcp/{ipfs_peer_port}/http")
-    assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+    return api
 
-    ipfs_fetch = 'get_metadata_from_ipfs_node'
-    gateway_fetch = 'get_metadata_from_gateway'
+# Tests
+def test_base_case(app):
+    api = instantiate_client_and_return_api(app)
+    assert_metadata_retrieval_success(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)
 
-    def slow_return_metadata():
-        time.sleep(3)
-        return test_metadata_object
+def test_ipfs_metadata_fetch_with_gateway_slow(app, mocker):
+    api = instantiate_client_and_return_api(app)
+    patch_ipfsclient_method(GATEWAY_FETCH, slow_return_metadata)
+    patch_ipfsclient_method(IPFS_FETCH, return_metadata_immediately)
+    assert_metadata_retrieval_success(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)
 
-    def return_metadata_immediately():
-        return test_metadata_object
+def test_ipfs_metadata_fetch_with_ipfs_slow(app, mocker):
+    api = instantiate_client_and_return_api(app)
+    patch_ipfsclient_method(IPFS_FETCH, slow_return_metadata)
+    patch_ipfsclient_method(GATEWAY_FETCH, return_metadata_immediately)
+    assert_metadata_retrieval_success(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)
 
-    def patch_ipfsclient_method(method_name, replacement_function):
-        mocker.patch.object(IPFSClient, method_name)
-        IPFSClient.get_metadata_from_gateway.side_effect = replacement_function
+def test_ipfs_metadata_fetch_with_ipfs_timeout(app, mocker):
+    api = instantiate_client_and_return_api(app)
+    patch_ipfsclient_method(IPFS_FETCH, timeout_fetch)
+    patch_ipfsclient_method(GATEWAY_FETCH, return_metadata_immediately)
+    assert_metadata_retrieval_success(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)
 
-    def test_ipfs_metadata_fetch_with_gateway_slow(mocker):
-        patch_ipfsclient_method(gateway_fetch, slow_return_metadata)
-        patch_ipfsclient_method(ipfs_fetch, return_metadata_immediately)
-        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
+def test_ipfs_metadata_fetch_with_gateway_timeout(app, mocker):
+    api = instantiate_client_and_return_api(app)
+    patch_ipfsclient_method(GATEWAY_FETCH, timeout_fetch)
+    patch_ipfsclient_method(IPFS_FETCH, return_metadata_immediately)
+    assert_metadata_retrieval_success(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)
 
-    def test_ipfs_metadata_fetch_with_ipfs_slow(mocker):
-        patch_ipfsclient_method(ipfs_fetch, slow_return_metadata)
-        patch_ipfsclient_method(gateway_fetch, return_metadata_immediately)
-        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
-
-    def test_ipfs_metadata_fetch_with_ipfs_timeout(mocker):
-        patch_ipfsclient_method(ipfs_fetch, timeout_fetch)
-        patch_ipfsclient_method(gateway_fetch, return_metadata_immediately)
-        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
-
-    def test_ipfs_metadata_fetch_with_gateway_timeout(mocker):
-        patch_ipfsclient_method(gateway_fetch, timeout_fetch)
-        patch_ipfsclient_method(ipfs_fetch, return_metadata_immediately)
-        assert_metadata_retrieval_success(track_metadata_format, json_file, ipfs_metadata, api)
-
-    def test_ipfs_metadata_fetch_with_both_timeout(mocker):
-        patch_ipfsclient_method(ipfs_fetch, timeout_fetch)
-        patch_ipfsclient_method(gateway_fetch, timeout_fetch)
-        assert_metadata_retrieval_failure(track_metadata_format, json_file, ipfs_metadata, api)
-
-
+def test_ipfs_metadata_fetch_with_both_timeout(app, mocker):
+    api = instantiate_client_and_return_api(app)
+    patch_ipfsclient_method(IPFS_FETCH, timeout_fetch)
+    patch_ipfsclient_method(GATEWAY_FETCH, timeout_fetch)
+    assert_metadata_retrieval_failure(track_metadata_format, JSON_FILE, api)
+    test_cleanup(JSON_FILE)

--- a/discovery-provider/tests/test_ipfs_functionality.py
+++ b/discovery-provider/tests/test_ipfs_functionality.py
@@ -6,8 +6,6 @@ from src.utils.ipfs_lib import IPFSClient
 from src.utils.helpers import remove_test_file
 from src.tasks.metadata import track_metadata_format
 
-# Disabled temporarily, comment below line to enable test
-# @pytest.mark.skip(reason="enabled pending ipfs daemon functionality")
 def test_ipfs(app):
     json_file = "tests/res/test_ipfs.json"
     ipfs_peer_host = app.config["ipfs"]["host"]


### PR DESCRIPTION
Implements parallel processing for metadata fetch from IPFS /
CN gateway. The two requests are sent at once and race for the
first successful execution.

### Description

makes metadata fetch resolve faster when available from CN gateway, speeding up DN queries.

This is WIP - there are wrapper calls to this fn that say `get_ipfs_metadata` so maybe those will be renamed `get_metadata` to reflect that the response isn't always (or mostly) coming from IPFS. 

### Tests

Considering adding tests in [test_ipfs_functionality.py](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/tests/test_ipfs_functionality.py) but not sure which cases make sense to cover here. We are not responsible for the functionality of concurrent.futures so it doesn't make too much sense to me to mock/stub that out. Was thinking of adding a unit test to ensure that we log when both methods fail. 

Will test this manually on dev. 

### How will this change be monitored?

Will add logs that call out:
* when first attempted fetch fails
* how long fetch took (?)
* when both fetches fail 
