### PR TITLE
Fix email download separate job and skip no notifs

### DIFF
--- a/identity-service/src/notifications/constants.js
+++ b/identity-service/src/notifications/constants.js
@@ -45,6 +45,7 @@ const notificationJobType = 'notificationProcessJob'
 const solanaNotificationJobType = 'solanaNotificationProcessJob'
 const announcementJobType = 'pushAnnouncementsJob'
 const unreadEmailJobType = 'unreadEmailJob'
+const downloadEmailJobType = 'downloadEmailJobType'
 
 const deviceType = Object.freeze({
   Mobile: 'mobile',
@@ -60,5 +61,6 @@ module.exports = {
   solanaNotificationJobType,
   announcementJobType,
   unreadEmailJobType,
+  downloadEmailJobType,
   deviceType
 }

--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -99,8 +99,15 @@ async function getEmailNotifications (audius, userId, announcements = [], fromTi
     })
 
     const finalUserNotifications = userNotifications.slice(0, limit)
-    // Explicitly fetch image thumbnails
+
+    if (userNotifications.length === 0) {
+      return [{}, 0]
+    }
+
+    const fethNotificationsTime = Date.now()
     const metadata = await fetchNotificationMetadata(audius, [userId], finalUserNotifications, true)
+    const fetchDataDuration = (Date.now() - fethNotificationsTime) / 1000
+    logger.info({ job: 'fetchNotificationMetdata', durationn: fetchDataDuration }, `fetchNotificationMetdata | get metadata ${fetchDataDuration} sec`)
     const notificationsEmailProps = formatNotificationProps(finalUserNotifications, metadata)
     return [notificationsEmailProps, notificationCount + unreadAnnouncementCount]
   } catch (err) {
@@ -115,7 +122,6 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
   let fetchTrackRemixParents = []
 
   for (let notification of notifications) {
-    logger.debug('fetchNotificationMetadata.js#notification', notification)
     switch (notification.type) {
       case NotificationType.Follow: {
         userIdsToFetch.push(
@@ -130,9 +136,7 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
           ...notification.actions
             .map(({ actionEntityId }) => actionEntityId).slice(0, USER_FETCH_LIMIT)
         )
-        logger.debug('fetchNotificationMetadata.js#about to push notification.entityId onto tracks', notification.entityId)
         trackIdsToFetch.push(notification.entityId)
-        logger.debug('fetchNotificationMetadata.js#pushed notification.entityId onto tracks', notification.entityId, trackIdsToFetch)
         break
       }
       case NotificationType.FavoritePlaylist:
@@ -193,12 +197,15 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
   }
 
   const uniqueTrackIds = [...new Set(trackIdsToFetch)]
-  logger.debug('fetchNotificationMetadata.js#uniqueTrackIds', uniqueTrackIds)
+
   let tracks = await audius.Track.getTracks(
     /** limit */ uniqueTrackIds.length,
     /** offset */ 0,
     /** idsArray */ uniqueTrackIds
   )
+  if (!Array.isArray(tracks)) {
+    logger.error(`fetchNotificationnMetadata | Unable to fetch track ids ${uniqueTrackIds.join('')}`)
+  }
 
   const trackMap = tracks.reduce((tm, track) => {
     tm[track.track_id] = track
@@ -221,31 +228,41 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
       /** offset */ 0,
       /** idsArray */ uniqueParentTrackIds
     )
+    if (!Array.isArray(parentTracks)) {
+      logger.error(`fetchNotificationnMetadata | Unable to fetch parent track ids ${uniqueParentTrackIds.join('')}`)
+    }
+
     parentTracks.forEach(track => {
       trackMap[track.track_id] = track
     })
   }
 
   const uniqueCollectionIds = [...new Set(collectionIdsToFetch)]
-  logger.debug('fetchNotificationMetadata.js#uniqueCollectionIds', uniqueCollectionIds)
   const collections = await audius.Playlist.getPlaylists(
     /** limit */ uniqueCollectionIds.length,
     /** offset */ 0,
     /** idsArray */ uniqueCollectionIds
   )
 
+  if (!Array.isArray(collections)) {
+    logger.error(`fetchNotificationnMetadata | Unable to fetch collection ids ${uniqueCollectionIds.join('')}`)
+  }
+
   userIdsToFetch.push(
     ...tracks.map(({ owner_id: id }) => id),
     ...collections.map(({ playlist_owner_id: id }) => id)
   )
   const uniqueUserIds = [...new Set(userIdsToFetch)]
-  logger.debug('fetchNotificationMetadata.js#uniqueUserIds', uniqueUserIds)
 
   let users = await audius.User.getUsers(
     /** limit */ uniqueUserIds.length,
     /** offset */ 0,
     /** idsArray */ uniqueUserIds
   )
+
+  if (!Array.isArray(users)) {
+    logger.error(`fetchNotificationnMetadata | Unable to fetch user ids ${uniqueUserIds.join('')}`)
+  }
 
   // Fetch all the social handles and attach to the users - For twitter sharing
   const socialHandles = await models.SocialHandles.findAll({

--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -98,11 +98,11 @@ async function getEmailNotifications (audius, userId, announcements = [], fromTi
       }
     })
 
-    const finalUserNotifications = userNotifications.slice(0, limit)
-
     if (userNotifications.length === 0) {
       return [{}, 0]
     }
+
+    const finalUserNotifications = userNotifications.slice(0, limit)
 
     const fethNotificationsTime = Date.now()
     const metadata = await fetchNotificationMetadata(audius, [userId], finalUserNotifications, true)
@@ -204,7 +204,7 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
     /** idsArray */ uniqueTrackIds
   )
   if (!Array.isArray(tracks)) {
-    logger.error(`fetchNotificationnMetadata | Unable to fetch track ids ${uniqueTrackIds.join('')}`)
+    logger.error(`fetchNotificationMetadata | Unable to fetch track ids ${uniqueTrackIds.join('')}`)
   }
 
   const trackMap = tracks.reduce((tm, track) => {
@@ -229,7 +229,7 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
       /** idsArray */ uniqueParentTrackIds
     )
     if (!Array.isArray(parentTracks)) {
-      logger.error(`fetchNotificationnMetadata | Unable to fetch parent track ids ${uniqueParentTrackIds.join('')}`)
+      logger.error(`fetchNotificationMetadata | Unable to fetch parent track ids ${uniqueParentTrackIds.join('')}`)
     }
 
     parentTracks.forEach(track => {
@@ -245,7 +245,7 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
   )
 
   if (!Array.isArray(collections)) {
-    logger.error(`fetchNotificationnMetadata | Unable to fetch collection ids ${uniqueCollectionIds.join('')}`)
+    logger.error(`fetchNotificationMetadata | Unable to fetch collection ids ${uniqueCollectionIds.join('')}`)
   }
 
   userIdsToFetch.push(
@@ -261,7 +261,7 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
   )
 
   if (!Array.isArray(users)) {
-    logger.error(`fetchNotificationnMetadata | Unable to fetch user ids ${uniqueUserIds.join('')}`)
+    logger.error(`fetchNotificationMetadata | Unable to fetch user ids ${uniqueUserIds.join('')}`)
   }
 
   // Fetch all the social handles and attach to the users - For twitter sharing

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -30,7 +30,7 @@ const audiusLibsWrapper = require('../audiusLibsInstance')
 
 const NOTIFICATION_INTERVAL_SEC = 3 * 1000
 const NOTIFICATION_SOLANA_INTERVAL_SEC = 3 * 1000
-const NOTIFICATION_EMAILS_INTERVAL_SEC = 20 * 1000
+const NOTIFICATION_EMAILS_INTERVAL_SEC = 10 * 60 * 1000
 const NOTIFICATION_ANNOUNCEMENTS_INTERVAL_SEC = 30 * 1000
 
 const NOTIFICATION_JOB_LAST_SUCCESS_KEY = 'notifications:last-success'
@@ -85,15 +85,15 @@ class NotificationProcessor {
         },
         defaultJobOptions
       })
-      this.downloadEmailQueue = new Bull(
-        `download-email-queue-${Date.now()}`,
-        {
-          redis: {
-            port: config.get('redisPort'),
-            host: config.get('redisHost')
-          },
-          defaultJobOptions
-        })
+    this.downloadEmailQueue = new Bull(
+      `download-email-queue-${Date.now()}`,
+      {
+        redis: {
+          port: config.get('redisPort'),
+          host: config.get('redisHost')
+        },
+        defaultJobOptions
+      })
     if (errorHandler) {
       this.errorHandler = errorHandler
     } else {

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -240,8 +240,6 @@ class NotificationProcessor {
         logger.error(`processEmailNotifications - Problem with processing emails: ${e}`)
         this.errorHandler(e)
       }
-      // Wait 10 minutes before re-running the job
-      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_EMAILS_INTERVAL_SEC))
       await this.emailQueue.add({ type: unreadEmailJobType }, { jobId: `${unreadEmailJobType}:${Date.now()}` })
       done(error)
     })
@@ -258,8 +256,6 @@ class NotificationProcessor {
         logger.error(`processDownloadEmails - Problem with processing emails: ${e}`)
         this.errorHandler(e)
       }
-      // Wait 10 minutes before re-running the job
-      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_EMAILS_INTERVAL_SEC))
       await this.downloadEmailQueue.add({ type: downloadEmailJobType }, { jobId: `${downloadEmailJobType}:${Date.now()}` })
       done(error)
     })

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -14,7 +14,13 @@ const {
 const { processEmailNotifications } = require('./sendNotificationEmails')
 const { processDownloadAppEmail } = require('./sendDownloadAppEmails')
 const { pushAnnouncementNotifications } = require('./pushAnnouncementNotifications')
-const { notificationJobType, solanaNotificationJobType, announcementJobType, unreadEmailJobType } = require('./constants')
+const {
+  notificationJobType,
+  solanaNotificationJobType,
+  announcementJobType,
+  unreadEmailJobType,
+  downloadEmailJobType
+} = require('./constants')
 const { drainPublishedMessages, drainPublishedSolanaMessages } = require('./notificationQueue')
 const emailCachePath = './emailCache'
 const processNotifications = require('./processNotifications/index.js')
@@ -24,13 +30,14 @@ const audiusLibsWrapper = require('../audiusLibsInstance')
 
 const NOTIFICATION_INTERVAL_SEC = 3 * 1000
 const NOTIFICATION_SOLANA_INTERVAL_SEC = 3 * 1000
-const NOTIFICATION_EMAILS_INTERVAL_SEC = 10 * 60 * 1000
+const NOTIFICATION_EMAILS_INTERVAL_SEC = 20 * 1000
 const NOTIFICATION_ANNOUNCEMENTS_INTERVAL_SEC = 30 * 1000
 
 const NOTIFICATION_JOB_LAST_SUCCESS_KEY = 'notifications:last-success'
 const NOTIFICATION_SOLANA_JOB_LAST_SUCCESS_KEY = 'notifications:solana:last-success'
 const NOTIFICATION_EMAILS_JOB_LAST_SUCCESS_KEY = 'notifications:emails:last-success'
 const NOTIFICATION_ANNOUNCEMENTS_JOB_LAST_SUCCESS_KEY = 'notifications:announcements:last-success'
+const NOTIFICATION_DOWNLOAD_EMAIL_JOB_LAST_SUCCESS_KEY = 'notifications:download-emails:last-success'
 
 // Reference Bull Docs: https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue
 const defaultJobOptions = {
@@ -78,6 +85,15 @@ class NotificationProcessor {
         },
         defaultJobOptions
       })
+      this.downloadEmailQueue = new Bull(
+        `download-email-queue-${Date.now()}`,
+        {
+          redis: {
+            port: config.get('redisPort'),
+            host: config.get('redisHost')
+          },
+          defaultJobOptions
+        })
     if (errorHandler) {
       this.errorHandler = errorHandler
     } else {
@@ -99,6 +115,7 @@ class NotificationProcessor {
     // Clear any pending notif jobs
     await this.notifQueue.empty()
     await this.emailQueue.empty()
+    await this.downloadEmailQueue.empty()
     this.redis = redis
     this.mg = expressApp.get('mailgun')
 
@@ -217,7 +234,6 @@ class NotificationProcessor {
       let error = null
       try {
         await processEmailNotifications(expressApp, audiusLibs)
-        await processDownloadAppEmail(expressApp, audiusLibs)
         await this.redis.set(NOTIFICATION_EMAILS_JOB_LAST_SUCCESS_KEY, new Date().toISOString())
       } catch (e) {
         error = e
@@ -227,6 +243,24 @@ class NotificationProcessor {
       // Wait 10 minutes before re-running the job
       await new Promise(resolve => setTimeout(resolve, NOTIFICATION_EMAILS_INTERVAL_SEC))
       await this.emailQueue.add({ type: unreadEmailJobType }, { jobId: `${unreadEmailJobType}:${Date.now()}` })
+      done(error)
+    })
+
+    // Download Email notification queue
+    this.downloadEmailQueue.process(async (job, done) => {
+      logger.info('processDownloadEmails')
+      let error = null
+      try {
+        await processDownloadAppEmail(expressApp, audiusLibs)
+        await this.redis.set(NOTIFICATION_DOWNLOAD_EMAIL_JOB_LAST_SUCCESS_KEY, new Date().toISOString())
+      } catch (e) {
+        error = e
+        logger.error(`processDownloadEmails - Problem with processing emails: ${e}`)
+        this.errorHandler(e)
+      }
+      // Wait 10 minutes before re-running the job
+      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_EMAILS_INTERVAL_SEC))
+      await this.downloadEmailQueue.add({ type: downloadEmailJobType }, { jobId: `${downloadEmailJobType}:${Date.now()}` })
       done(error)
     })
 
@@ -273,6 +307,7 @@ class NotificationProcessor {
 
     await this.emailQueue.add({ type: unreadEmailJobType }, { jobId: `${unreadEmailJobType}:${Date.now()}` })
     await this.announcementQueue.add({ type: announcementJobType }, { jobId: `${announcementJobType}:${Date.now()}` })
+    await this.downloadEmailQueue.add({ type: downloadEmailJobType }, { jobId: `${downloadEmailJobType}:${Date.now()}` })
   }
 
   /**
@@ -404,3 +439,4 @@ module.exports = NotificationProcessor
 module.exports.NOTIFICATION_JOB_LAST_SUCCESS_KEY = NOTIFICATION_JOB_LAST_SUCCESS_KEY
 module.exports.NOTIFICATION_EMAILS_JOB_LAST_SUCCESS_KEY = NOTIFICATION_EMAILS_JOB_LAST_SUCCESS_KEY
 module.exports.NOTIFICATION_ANNOUNCEMENTS_JOB_LAST_SUCCESS_KEY = NOTIFICATION_ANNOUNCEMENTS_JOB_LAST_SUCCESS_KEY
+module.exports.NOTIFICATION_DOWNLOAD_EMAIL_JOB_LAST_SUCCESS_KEY = NOTIFICATION_DOWNLOAD_EMAIL_JOB_LAST_SUCCESS_KEY

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -30,7 +30,6 @@ const audiusLibsWrapper = require('../audiusLibsInstance')
 
 const NOTIFICATION_INTERVAL_SEC = 3 * 1000
 const NOTIFICATION_SOLANA_INTERVAL_SEC = 3 * 1000
-const NOTIFICATION_EMAILS_INTERVAL_SEC = 10 * 60 * 1000
 const NOTIFICATION_ANNOUNCEMENTS_INTERVAL_SEC = 30 * 1000
 
 const NOTIFICATION_JOB_LAST_SUCCESS_KEY = 'notifications:last-success'

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -319,7 +319,7 @@ async function renderAndSendNotificationEmail (
       startTime,
       5)
     const timeAfterEmailNotifications = Date.now()
-    const getEmailDuration = (timeAfterEmailNotifications - timeBeforeEmailNotifications)/1000
+    const getEmailDuration = (timeAfterEmailNotifications - timeBeforeEmailNotifications) / 1000
     logger.info(`renderAndSendNotificationEmail | time after getEmailNotifications | ${timeAfterEmailNotifications} | time elapsed is ${getEmailDuration} | ${notificationCount} unread notifications`)
 
     const emailSubject = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''} on Audius`
@@ -373,7 +373,7 @@ async function renderAndSendNotificationEmail (
     // Cache on file system
     await cacheEmail({ renderProps, emailParams })
 
-    const totalDuration = (Date.now() - timeBeforeEmailNotifications)/1000
+    const totalDuration = (Date.now() - timeBeforeEmailNotifications) / 1000
     logger.info({ job: 'renderAndSendNotificationEmail', totalDuration, getEmailDuration }, `renderAndSendNotificationEmail | ${userId}, ${userEmail}, in ${totalDuration} sec`)
     return true
   } catch (e) {

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -319,7 +319,8 @@ async function renderAndSendNotificationEmail (
       startTime,
       5)
     const timeAfterEmailNotifications = Date.now()
-    logger.info(`renderAndSendNotificationEmail | time after getEmailNotifications | ${timeAfterEmailNotifications} | time elapsed is ${timeAfterEmailNotifications - timeBeforeEmailNotifications} | ${notificationCount} unread notifications`)
+    const getEmailDuration = (timeAfterEmailNotifications - timeBeforeEmailNotifications)/1000
+    logger.info(`renderAndSendNotificationEmail | time after getEmailNotifications | ${timeAfterEmailNotifications} | time elapsed is ${getEmailDuration} | ${notificationCount} unread notifications`)
 
     const emailSubject = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''} on Audius`
     if (notificationCount === 0) {
@@ -372,8 +373,8 @@ async function renderAndSendNotificationEmail (
     // Cache on file system
     await cacheEmail({ renderProps, emailParams })
 
-    const totalDuration = (timeBeforeEmailNotifications - Date.now())/1000
-    logger.info({ job: 'renderAndSendNotificationEmail', duration: totalDuration }, `renderAndSendNotificationEmail | ${userId}, ${userEmail}, in ${totalDuration} sec`)
+    const totalDuration = (Date.now() - timeBeforeEmailNotifications)/1000
+    logger.info({ job: 'renderAndSendNotificationEmail', totalDuration, getEmailDuration }, `renderAndSendNotificationEmail | ${userId}, ${userEmail}, in ${totalDuration} sec`)
     return true
   } catch (e) {
     logger.error(`Error in renderAndSendNotificationEmail ${e}`)

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -291,7 +291,8 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       }
     }
     const timeAfterUserEmailLoop = Date.now()
-    logger.info(`processEmailNotifications | time after looping over users to send notification email | ${timeAfterUserEmailLoop} | time elapsed is ${timeAfterUserEmailLoop - timeBeforeUserEmailLoop} | ${userInfo.length} users`)
+    const totalDuration = (timeAfterUserEmailLoop - timeBeforeUserEmailLoop) / 1000
+    logger.info({ job: processEmailNotifications, duration: totalDuration }, `processEmailNotifications | time after looping over users to send notification email | ${timeAfterUserEmailLoop} | time elapsed is ${totalDuration} | ${userInfo.length} users`)
   } catch (e) {
     logger.error('processEmailNotifications | Error processing email notifications')
     logger.error(e)

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -19,7 +19,7 @@ const {
 let mg
 
 const loggingContext = {
-  job: "processEmailNotifications"
+  job: 'processEmailNotifications'
 }
 
 async function processEmailNotifications (expressApp, audiusLibs) {
@@ -95,7 +95,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
       const relevantUserIdsForAnnouncement = usersCreatedBeforeAnnouncement.filter(userId => !userIdSetToExcludeForAnnouncement.has(userId))
 
       const timeBeforeUserAnnouncementsLoop = Date.now()
-      logger.info({job: 'processEmailNotifications' , timing: 12 }`processEmailNotifications | time before looping over users for announcement id ${id}, entity id ${announcementEntityId} | ${timeBeforeUserAnnouncementsLoop} | ${usersCreatedBeforeAnnouncement.length} users`)
+      logger.info({ job: 'processEmailNotifications', timing: 12 }`processEmailNotifications | time before looping over users for announcement id ${id}, entity id ${announcementEntityId} | ${timeBeforeUserAnnouncementsLoop} | ${usersCreatedBeforeAnnouncement.length} users`)
       for (var user of relevantUserIdsForAnnouncement) {
         if (liveEmailUsers.includes(user)) {
           // As an added safety check, only process if the announcement was made in the last hour
@@ -120,7 +120,7 @@ async function processEmailNotifications (expressApp, audiusLibs) {
     }
     const timeAfterAnnouncementsLoop = Date.now()
     const announcementDurationSec = (timeAfterAnnouncementsLoop - timeBeforeAnnouncementsLoop) / 1000
-    logger.info({ ...loggingContext, announcementDuration: announcementDurationSec}, `processEmailNotifications | time after looping over announcements | ${timeAfterAnnouncementsLoop} | time elapsed is ${announcementDurationSec} | ${appAnnouncements.length} announcements`)
+    logger.info({ ...loggingContext, announcementDuration: announcementDurationSec }, `processEmailNotifications | time after looping over announcements | ${timeAfterAnnouncementsLoop} | time elapsed is ${announcementDurationSec} | ${appAnnouncements.length} announcements`)
 
     let pendingNotificationUsers = new Set()
     // Add users with pending announcement notifications
@@ -371,6 +371,8 @@ async function renderAndSendNotificationEmail (
     // Cache on file system
     await cacheEmail({ renderProps, emailParams })
 
+    const totalDuration = (timeBeforeEmailNotifications - Date.now())/1000
+    logger.info({ job: 'renderAndSendNotificationEmail', duration: totalDuration }, `renderAndSendNotificationEmail | ${userId}, ${userEmail}, in ${totalDuration} sec`)
     return true
   } catch (e) {
     logger.error(`Error in renderAndSendNotificationEmail ${e}`)


### PR DESCRIPTION
### Description

* Separates the download email job from the email job - so it's not stalled by the processing of emails
* During the processing of emails, if the user does not have any notifications to be sent, do not try to fetch resources 
  * fetching users/tracks/playlists even when there is nothing to fetch takes a second and appears to take up most of the time for processing emails
* Update some logs w/ json formatting

### Tests
Ran the identity service locally against a prod db to watch the logs 

### How will this change be monitored?
via the logs