### PR TITLE
Revert "[AUD-726] Support create sender public in discovery"

### DIFF
--- a/discovery-provider/.test.env
+++ b/discovery-provider/.test.env
@@ -1,4 +1,3 @@
 # TODO: dummy ganache keys for local setup; should wire with dynamically generated keys
 audius_delegate_owner_wallet=0x1D9c77BcfBfa66D37390BF2335f0140979a6122B
 audius_delegate_private_key=0x3873ed01bfb13621f9301487cc61326580614a5b99f3c33cf39c6f9da3a19cad
-audius_solana_rewards_manager_account=8MzNUaBHskteN7poTrZG5wgSNSbXQwieMDB4wk9fgB7f

--- a/discovery-provider/src/utils/get_all_other_nodes.py
+++ b/discovery-provider/src/utils/get_all_other_nodes.py
@@ -12,6 +12,7 @@ REWARDS_CONTRACT_ABI = eth_abi_values["EthRewardsManager"]["abi"]
 SP_FACTORY_REGISTRY_KEY = bytes("ServiceProviderFactory", "utf-8")
 DISCOVERY_NODE_SERVICE_TYPE = bytes("discovery-node", "utf-8")
 
+
 # Perform eth web3 call to fetch endpoint info
 def fetch_discovery_node_info(sp_id, sp_factory_instance):
     return sp_factory_instance.functions.getServiceEndpointInfo(

--- a/discovery-provider/tests/test_get_attestation.py
+++ b/discovery-provider/tests/test_get_attestation.py
@@ -7,8 +7,6 @@ from eth_utils.conversions import to_bytes
 from hexbytes import HexBytes
 
 from src.queries.get_attestation import (
-    ADD_SENDER_MESSAGE_PREFIX,
-    REWARDS_MANAGER_PROGRAM_ACCOUNT,
     Attestation,
     AttestationError,
     get_attestation,
@@ -138,40 +136,10 @@ def test_get_create_sender_attestation(app, patch_get_all_other_nodes):
     new_sender_address = "0x94e140D27F3d5EE9EcA0109A71CcBa0109964DCa"
     owner_wallet, sender_attestation = get_create_sender_attestation(new_sender_address)
 
-    # confirm the attestation is what we think it should be
-    config_owner_wallet = shared_config["delegate"]["owner_wallet"]
-    config_private_key = shared_config["delegate"]["private_key"]
-
-    # Ensure we returned the correct owner wallet
-    assert owner_wallet == config_owner_wallet
-
-    # Ensure we can derive the owner wallet from the signed stringified attestation
-    items = [
-        to_bytes(text=ADD_SENDER_MESSAGE_PREFIX),
-        bytes(REWARDS_MANAGER_PROGRAM_ACCOUNT),
-        to_bytes(hexstr=new_sender_address),
-    ]
-    attestation_bytes = to_bytes(text="").join(items)
-    to_sign_hash = Web3.keccak(attestation_bytes)
-    private_key = keys.PrivateKey(HexBytes(config_private_key))
-    public_key = keys.PublicKey.from_private(private_key)
-    signture_bytes = to_bytes(hexstr=sender_attestation)
-    msg_signature = keys.Signature(signature_bytes=signture_bytes, vrs=None)
-
-    recovered_pubkey = public_key.recover_from_msg_hash(
-        message_hash=to_sign_hash, signature=msg_signature
-    )
-
+    assert owner_wallet == "0x1D9c77BcfBfa66D37390BF2335f0140979a6122B"
     assert (
-        Web3.toChecksumAddress(recovered_pubkey.to_address())
-        == config_owner_wallet
+        sender_attestation
+        == "0xdea0857f45136b5b986b45303d00051bb4c96313"
+        + "3c0e75945534a3bca1e6702d10106357a1d72e68c90f"
+        + "7d46f69f4023518ccc211a7994b41d359c9ea5d65f9700"
     )
-
-
-def test_get_create_sender_attestation_not_registered(app, patch_get_all_other_nodes):
-    new_sender_address = "0x04e140D27F3d5EE9EcA0109A71CcBa0109964DCa"
-    with pytest.raises(
-        Exception,
-        match=r"Expected 0x04e140D27F3d5EE9EcA0109A71CcBa0109964DCa to be registered on chain"
-    ):
-        get_create_sender_attestation(new_sender_address)

--- a/discovery-provider/tests/test_index_rewards_manager.py
+++ b/discovery-provider/tests/test_index_rewards_manager.py
@@ -14,7 +14,6 @@ from src.solana.solana_client_manager import SolanaClientManager
 from tests.utils import populate_mock_db
 
 REWARDS_MANAGER_PROGRAM = shared_config["solana"]["rewards_manager_program_address"]
-REWARDS_MANAGER_ACCOUNT = shared_config["solana"]["rewards_manager_account"]
 
 
 def test_decode_reward_manager_transfer_instruction():
@@ -177,7 +176,7 @@ mock_tx_info = {
         "transaction": {
             "message": {
                 "accountKeys": [
-                    REWARDS_MANAGER_ACCOUNT,
+                    "2HYDf9XvHRKhquxK1z4ETJ8ywueZcqEazyFZdRfLqGcT",
                     "54u7LVJhhbWaENGLzzgvTX72k9XSHSF3EhCcuvD9xMfk",
                     "3zKGHtF9aNjevZ2DETXzTDWiN65Fkwv9oeiScAfSVh3H",
                     "9ShGNjEm5repSKTkZMUXMj8cx31HAo363ovdm1AoLA8d",

--- a/libs/initScripts/local.js
+++ b/libs/initScripts/local.js
@@ -127,9 +127,9 @@ const run = async () => {
         break
       }
 
-      case 'register-discovery-node':
+      case 'register-discprov':
         const serviceCount = args[3]
-        if (serviceCount === undefined) throw new Error('register-discovery-node requires a service # as the second arg')
+        if (serviceCount === undefined) throw new Error('register-discprov requires a service # as the second arg')
         await _registerDiscProv(ethAccounts, parseInt(serviceCount))
         break
 

--- a/service-commands/scripts/rewardManagerLocal.js
+++ b/service-commands/scripts/rewardManagerLocal.js
@@ -223,29 +223,29 @@ const createSenderLocal = async ethAddress => {
   }
 }
 
-const findEthAddressForDiscoveryNodeAndRegister = async serviceNumber => {
+const findEthAddressForDiscProvAndRegister = async serviceNumber => {
   const ethWeb3 = new Web3(
     new Web3.providers.HttpProvider('http://localhost:8546')
   )
   const ethAccounts = await ethWeb3.eth.getAccounts()
-  console.log(`Finding address for discovery node #${serviceNumber}`)
+  console.log(`Finding address for disc prov #${serviceNumber}`)
   const accountIndex = 8 + parseInt(serviceNumber)
   console.log(`Account index = ${accountIndex}`)
-  const discoveryNodeAccount = ethAccounts[accountIndex]
-  console.log(`Eth address for discovery node #${serviceNumber}=${discoveryNodeAccount}`)
-  await createSenderLocal(discoveryNodeAccount)
+  const discProvAccount = ethAccounts[accountIndex]
+  console.log(`Eth address for disc prov #${serviceNumber}=${discProvAccount}`)
+  await createSenderLocal(discProvAccount)
 }
 
 const args = process.argv
 const run = async () => {
   try {
     switch (args[2]) {
-      case 'register-discovery-node':
+      case 'register-discprov':
         const serviceCount = args[3]
-        console.log(`RewardManager | Registering discovery node ${serviceCount}`)
-        await findEthAddressForDiscoveryNodeAndRegister(serviceCount)
+        console.log(`RewardManager | Registering disc prov ${serviceCount}`)
+        await findEthAddressForDiscProvAndRegister(serviceCount)
         console.log(
-          `RewardManager | Finished registering discovery node ${serviceCount}`
+          `RewardManager | Finished registering disc prov ${serviceCount}`
         )
         break
       case 'register-eth-address':

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -138,8 +138,8 @@
       "cd discovery-provider; . compose/env/unsetShellEnv.sh"
     ],
     "register": [
-      "cd libs/; node initScripts/local.js register-discovery-node #",
-      "cd service-commands/; node scripts/rewardManagerLocal.js register-discovery-node #"
+      "cd libs/; node initScripts/local.js register-discprov #",
+      "cd service-commands/; node scripts/rewardManagerLocal.js register-discprov #"
     ],
     "restart": [
       "cd discovery-provider; . compose/env/unsetShellEnv.sh",


### PR DESCRIPTION
Reverts AudiusProject/audius-protocol#1808
Reverts AudiusProject/audius-protocol#2082

@raymondjacobson reland this once you get the right config wired up. Looks like `REWARDS_MANAGER_PROGRAM_ACCOUNT` isn't connected properly
```
ValueError: ('invalid public key input:', '')
[2021-11-20 08:27:23 +0000] [30] [INFO] Worker exiting (pid: 30)
[2021-11-20 08:27:24 +0000] [19] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/geventlet.py", line 99, in init_process
    super().init_process()
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base.py", line 119, in init_process
    self.load_wsgi()
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
    return self.load_wsgiapp()
  File "/usr/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/lib/python3.8/site-packages/gunicorn/util.py", line 358, in import_app
    mod = importlib.import_module(module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/audius-discovery-provider/src/wsgi.py", line 4, in <module>
    from src.app import create_app
  File "/audius-discovery-provider/src/app.py", line 21, in <module>
    from src.api.v1 import api as api_v1
  File "/audius-discovery-provider/src/api/v1/api.py", line 7, in <module>
    from src.api.v1.challenges import ns as challenges_ns
  File "/audius-discovery-provider/src/api/v1/challenges.py", line 14, in <module>
    from src.queries.get_attestation import (
  File "/audius-discovery-provider/src/queries/get_attestation.py", line 24, in <module>
    REWARDS_MANAGER_PROGRAM_ACCOUNT = PublicKey(
  File "/usr/lib/python3.8/site-packages/solana/publickey.py", line 35, in __init__
    raise ValueError("invalid public key input:", value)
ValueError: ('invalid public key input:', '')
````