### PR TITLE
Provision with freshly baked freeze-dried dev image

### DIFF
--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -248,7 +248,7 @@ def setup(name, azure, service, config, user, fast, protocol_git_ref, client_git
         image_project = "ubuntu-os-cloud"
         if fast:
             use_image = True
-            image_name = "audius-dev-poc"
+            image_name = "audius-dev-8feda2f-82c1dea-11-22-21"
             image_project = "audius-infrastructure"
 
         ip = create_instance(


### PR DESCRIPTION
### Description

Baked new image with command:
```
gcloud compute images create audius-dev-8feda2f-82c1dea-11-22-21 \
  --project=audius-infrastructure \
  --description="dev instance image 11/22/21" \
  --source-disk=cj-remote-bake \
  --labels=protocol-git-hash=8feda2fae8b1a55b8e16ca0dca9a199aa00b102e,client-git-hash=82c1dea5906b872b64fae6a068cc8c8beb1d6466 \
  --storage-location=us
```

Next step - will automate this in CI by using stepping-stone of https://github.com/AudiusProject/audius-protocol/pulls/2071 and then publishing images to hosted container registry and pulling `:latest` in service-commands. 

### Tests

tested manually locally by changing image ref in code and was able to provision with `A setup remote-dev cj-remote-test-new --fast`

