### PR TITLE
ASI-587 bump libs to 1.2.31

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "",
   "main": "src/index.js",
   "browser": {


### PR DESCRIPTION
Version-bump libs to roll in hedgehog changes to not throw errors when running in node due to trying to access undefined window global. 