### PR TITLE
Fix Solana Transaction Regex for Safari

### DIFF
--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -121,10 +121,10 @@ class TransactionHandler {
    * Returns null for unparsable strings.
    */
   _parseSolanaErrorCode (errorMessage) {
-    const matcher = /(?<=custom program error: 0x)(.*)$/
+    const matcher = /(?:custom program error: 0x)(.*)$/
     const res = errorMessage.match(matcher)
-    if (!res || !res.length) return null
-    return parseInt(res[0], 16) || null
+    if (!res || !res.length == 2) return null
+    return parseInt(res[1], 16) || null
   }
 }
 


### PR DESCRIPTION
### Description

Safari doesn't support lookbehind, so switched to a regular non-capturing group

### Tests

Tested in browser console

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->