### PR TITLE
Add solana retries to listen endpoint

### DIFF
--- a/identity-service/package-lock.json
+++ b/identity-service/package-lock.json
@@ -2389,19 +2389,20 @@
       }
     },
     "@solana/web3.js": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.11.0.tgz",
-      "integrity": "sha512-kmngWxntzp0HNhWInd7/3g2uqxdOrahvaHOyjilcRe+WCiC777gERz3+eIAbxIYx2zAZPjy02MZzLgoRHccZoQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.30.2.tgz",
+      "integrity": "sha512-hznCj+rkfvM5taRP3Z+l5lumB7IQnDrB4l55Wpsg4kDU9Zds8pE5YOH5Z9bbF/pUzZJKQjyBjnY/6kScBm3Ugg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
+        "@ethersproject/sha2": "^5.5.0",
+        "@solana/buffer-layout": "^3.0.0",
         "bn.js": "^5.0.0",
+        "borsh": "^0.4.0",
         "bs58": "^4.0.1",
         "buffer": "6.0.1",
-        "buffer-layout": "^1.2.0",
-        "crypto-hash": "^1.2.2",
+        "cross-fetch": "^3.1.4",
         "jayson": "^3.4.4",
         "js-sha3": "^0.8.0",
-        "node-fetch": "^2.6.1",
         "rpc-websockets": "^7.4.2",
         "secp256k1": "^4.0.2",
         "superstruct": "^0.14.2",
@@ -2412,6 +2413,17 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "borsh": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+          "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "bn.js": "^5.0.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
+          }
         },
         "buffer": {
           "version": "6.0.1",

--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -21,7 +21,7 @@
     "@optimizely/optimizely-sdk": "^4.6.0",
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
-    "@solana/web3.js": "^1.11.0",
+    "@solana/web3.js": "^1.30.2",
     "apn": "^2.2.0",
     "aws-sdk": "^2.595.0",
     "axios": "^0.19.0",

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -1,5 +1,6 @@
 const Sequelize = require('sequelize')
 const moment = require('moment-timezone')
+const retry = require('async-retry')
 
 const models = require('../models')
 const { handleResponse, successResponse, errorResponseBadRequest } = require('../apiHelpers')
@@ -219,17 +220,32 @@ module.exports = function (app) {
     // Dedicated listen flow
     if (solanaListen) {
       logger.info(`Sending Track listen transaction trackId=${trackId} userId=${userId}`)
-      let solTxSignature = await solClient.createAndVerifyMessage(
-        null,
-        config.get('solanaSignerPrivateKey'),
-        userId.toString(),
-        trackId.toString(),
-        'relay' // Static source value to indicate relayed listens
-      )
-      logger.info(`Track listen tx confirmed, ${solTxSignature} userId=${userId}, trackId=${trackId}`)
-      return successResponse({
-        solTxSignature
+      let response = await retry(async () => {
+        let solTxSignature = await solClient.createAndVerifyMessage(
+          null,
+          config.get('solanaSignerPrivateKey'),
+          userId.toString(),
+          trackId.toString(),
+          'relay' // Static source value to indicate relayed listens
+        )
+        logger.info(`Track listen tx confirmed, ${solTxSignature} userId=${userId}, trackId=${trackId}`)
+        return successResponse({
+          solTxSignature
+        })
+      }, {
+        // Retry function 5x by default
+        // 1st retry delay = 500ms, 2nd = 1500ms, 3rd...nth retry = 4000 ms (capped)
+        minTimeout: 500,
+        maxTimeout: 4000,
+        factor: 3,
+        retries: 3,
+        onRetry: (err, i) => {
+          if (err) {
+            console.error(`TrackListens: retry error : ${err}`)
+          }
+        }
       })
+      return response
     }
 
     let currentHour = await getListenHour()

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -220,7 +220,7 @@ module.exports = function (app) {
     // Dedicated listen flow
     if (solanaListen) {
       logger.info(`Sending Track listen transaction trackId=${trackId} userId=${userId}`)
-      let response = await retry(async () => {
+      const response = await retry(async () => {
         let solTxSignature = await solClient.createAndVerifyMessage(
           null,
           config.get('solanaSignerPrivateKey'),

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -91,8 +91,9 @@ const instructionSchema = new Map([
   ]
 ])
 
-let solanaConnection = new solanaWeb3.Connection(config.get('solanaEndpoint'), {
-  confirmTransactionInitialTimeout: 180 * 1000
+const SOLANA_CONFIRMATION_TIMEOUT_MS = 180 * 1000
+const solanaConnection = new solanaWeb3.Connection(config.get('solanaEndpoint'), {
+  confirmTransactionInitialTimeout: SOLANA_CONFIRMATION_TIMEOUT_MS
 })
 let feePayer
 
@@ -181,7 +182,7 @@ async function createAndVerifyMessage (
     transaction,
     [feePayerAccount],
     {
-      skipPreflight: false,
+      skipPreflight: true,
       commitment: config.get('solanaTxCommitmentLevel'),
       preflightCommitment: config.get('solanaTxCommitmentLevel')
     }

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -91,7 +91,9 @@ const instructionSchema = new Map([
   ]
 ])
 
-let solanaConnection = new solanaWeb3.Connection(config.get('solanaEndpoint'))
+let solanaConnection = new solanaWeb3.Connection(config.get('solanaEndpoint'), {
+  confirmTransactionInitialTimeout: 180 * 1000
+})
 let feePayer
 
 function getFeePayer () {
@@ -179,7 +181,7 @@ async function createAndVerifyMessage (
     transaction,
     [feePayerAccount],
     {
-      skipPreflight: true,
+      skipPreflight: false,
       commitment: config.get('solanaTxCommitmentLevel'),
       preflightCommitment: config.get('solanaTxCommitmentLevel')
     }


### PR DESCRIPTION
### Description

- Adds retries to the listen route; if Solana RPC suffers another outage, this can help
- Increases the initial confirmation timeout, which can also help RPC slowdown

### Tests

Live on prod 😆 

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->