### PR TITLE
[AUD-1114] Add slot diff in discovery responses

### DIFF
--- a/discovery-provider/src/api/v1/models/common.py
+++ b/discovery-provider/src/api/v1/models/common.py
@@ -32,6 +32,8 @@ full_response = ns.model(
     {
         "latest_chain_block": fields.Integer(required=True),
         "latest_indexed_block": fields.Integer(required=True),
+        "latest_chain_slot_plays": fields.Integer(required=True),
+        "latest_indexed_slot_plays": fields.Integer(required=True),
         "signature": fields.String(required=True),
         "timestamp": fields.String(required=True),
         "version": fields.Nested(version_metadata, required=True),

--- a/discovery-provider/src/utils/cache_solana_program.py
+++ b/discovery-provider/src/utils/cache_solana_program.py
@@ -82,6 +82,6 @@ def cache_latest_sol_play_program_tx(
         )
         raise e
 
-def get_cache_latest_sol_program_tx(redis: Redis, cahce_key: str):
-    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(redis, cahce_key)
+def get_cache_latest_sol_program_tx(redis: Redis, cache_key: str):
+    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(redis, cache_key)
     return latest_sol_db


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Add plays slot info to all API responses so they can be monitored on every request and allow clients to reselect.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Local stack, verify API responses

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Should be a no-op until clients decide to consume values

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->