### PR TITLE
Update ffmpeg-static

### DIFF
--- a/service-commands/package-lock.json
+++ b/service-commands/package-lock.json
@@ -1580,9 +1580,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-layout": {
       "version": "1.2.2",
@@ -2265,9 +2265,9 @@
       }
     },
     "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2998,9 +2998,9 @@
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "ffmpeg-static": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-4.2.7.tgz",
-      "integrity": "sha512-SGnOr2d+k0/9toRIv9t5/hN/DMYbm5XMtG0wVwGM1tEyXJAD6dbcWOEvfHq4LOySm9uykKL6LMC4eVPeteUnbQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-4.4.0.tgz",
+      "integrity": "sha512-NIJHVPXlSsIK9pYvsTPh4ZlppauorpPLLeOaIG7VOXWQck4Fx4Qi7Ahe+j8mj8KZXhWwCg3Hx46JdWAIOWLcpg==",
       "requires": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",

--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -14,7 +14,7 @@
     "colors": "^1.4.0",
     "commander": "^6.0.0",
     "convict": "^5.2.0",
-    "ffmpeg-static": "^4.2.7",
+    "ffmpeg-static": "^4.4.0",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
     "untildify": "^4.0.0",


### PR DESCRIPTION
### Description

So that installs with m1 macs work.

### Tests

Ran `npm install` on my m1 machine. this package is only used for generating mp3 files. should be fine to upgrade

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->