### PR TITLE
[AUD-720] Add automatic rewards attestation

### DIFF
--- a/discovery-provider/src/api/v1/challenges.py
+++ b/discovery-provider/src/api/v1/challenges.py
@@ -5,6 +5,7 @@ from src.api.v1.helpers import (
     get_current_user_id,
     make_response,
     success_response,
+    extend_undisbursed_challenge
 )
 from src.api.v1.models.challenges import (
     undisbursed_challenge,
@@ -112,6 +113,7 @@ class GetUndisbursedChallenges(Resource):
                     "completed_blocknumber": args["completed_blocknumber"],
                 },
             )
+            undisbursed_challenges = list(map(extend_undisbursed_challenge, undisbursed_challenges))
             return success_response(undisbursed_challenges)
 
 

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from .models.common import full_response
 from src.queries.get_challenges import ChallengeResponse
 from src.models import ChallengeType
+from src.queries.get_undisbursed_challenges import UndisbursedChallengeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +276,10 @@ def extend_challenge_response(challenge: ChallengeResponse):
     new_challenge["challenge_type"] = challenge_type_map[challenge["challenge_type"]]
     return new_challenge
 
+def extend_undisbursed_challenge(undisbursed_challenge: UndisbursedChallengeResponse):
+    new_undisbursed_challenge = undisbursed_challenge.copy()
+    new_undisbursed_challenge["user_id"] = encode_int_id(new_undisbursed_challenge["user_id"])
+    return new_undisbursed_challenge
 
 def abort_bad_path_param(param, namespace):
     namespace.abort(400, "Oh no! Bad path parameter {}.".format(param))

--- a/discovery-provider/src/api/v1/models/challenges.py
+++ b/discovery-provider/src/api/v1/models/challenges.py
@@ -17,6 +17,8 @@ undisbursed_challenge = ns.model(
         "specifier": fields.String(required=True),
         "amount": fields.String(required=True),
         "completed_blocknumber": fields.Integer(required=True),
+        "handle": fields.String(required=True),
+        "wallet": fields.String(required=True)
     },
 )
 

--- a/discovery-provider/tests/test_undisbursed_challeges.py
+++ b/discovery-provider/tests/test_undisbursed_challeges.py
@@ -1,4 +1,5 @@
-from src.models import Challenge, UserChallenge, ChallengeType
+from datetime import datetime
+from src.models import Challenge, UserChallenge, ChallengeType, User
 from src.utils.db_session import get_db
 from src.queries.get_undisbursed_challenges import get_undisbursed_challenges
 from tests.utils import populate_mock_db_blocks
@@ -32,6 +33,24 @@ def setup_challenges(app):
                 starting_block=100,
             ),
         ]
+        users = [
+            User(
+                blockhash=hex(99),
+                blocknumber=99,
+                txhash=f"xyz{i}",
+                user_id=i,
+                is_current=True,
+                handle=f"TestHandle{i}",
+                handle_lc=f"testhandle{i}",
+                wallet=f"0x{i}",
+                is_creator=False,
+                is_verified=False,
+                name=f"test_name{i}",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            ) for i in range(7)
+        ]
+
         user_challenges = [
             UserChallenge(
                 challenge_id="test_challenge_1",
@@ -87,6 +106,7 @@ def setup_challenges(app):
         with db.scoped_session() as session:
             session.add_all(challenges)
             session.flush()
+            session.add_all(users)
             session.add_all(user_challenges)
 
 
@@ -111,6 +131,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "6",
                 "amount": "5",
                 "completed_blocknumber": 100,
+                "handle": "TestHandle6",
+                "wallet": '0x6'
             },
             {
                 "challenge_id": "test_challenge_3",
@@ -118,6 +140,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "7",
                 "amount": "5",
                 "completed_blocknumber": 100,
+                "handle": "TestHandle6",
+                "wallet": '0x6'
             },
             {
                 "challenge_id": "test_challenge_2",
@@ -125,6 +149,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "4",
                 "amount": "5",
                 "completed_blocknumber": 102,
+                "handle": "TestHandle4",
+                "wallet": '0x4'
             },
             {
                 "challenge_id": "test_challenge_2",
@@ -132,6 +158,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "5",
                 "amount": "5",
                 "completed_blocknumber": 102,
+                "handle": "TestHandle5",
+                "wallet": '0x5'
             },
         ]
         assert expected == undisbursed
@@ -149,6 +177,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "6",
                 "amount": "5",
                 "completed_blocknumber": 100,
+                "handle": "TestHandle6",
+                "wallet": "0x6",
             },
             {
                 "challenge_id": "test_challenge_3",
@@ -156,6 +186,8 @@ def test_undisbursed_challenges(app):
                 "specifier": "7",
                 "amount": "5",
                 "completed_blocknumber": 100,
+                "handle": "TestHandle6",
+                "wallet": "0x6",
             },
         ]
         assert expected == undisbursed

--- a/identity-service/.gitignore
+++ b/identity-service/.gitignore
@@ -12,6 +12,7 @@ local-test/
 contract-config.json
 eth-contract-config.json
 solana-program-config.json
+aao-config.json
 .nyc_output/
 coverage/
 

--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -66,6 +66,5 @@
   "hCaptchaSecret": "",
   "solanaFeePayerWallet": "[]",
   "sentryDSN": "",
-  "solanaEndpoint": "https://api.mainnet-beta.solana.com",
-  "optimizelySdkKey": ""
+  "solanaEndpoint": "https://api.mainnet-beta.solana.com"
 }

--- a/identity-service/package-lock.json
+++ b/identity-service/package-lock.json
@@ -28,11 +28,12 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.31",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.31.tgz",
-      "integrity": "sha512-eldTO9tCwmJoZekjpOxCl6FVx6p7VROWd6+iXg2IG/BlK1sp2i7hVq2N9G+xI3dMDTIXXoPhMZOs1rEx9UYkPg==",
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.35.tgz",
+      "integrity": "sha512-WgOceCTItI4aCaWjtW1JE/loo9h5gOxtBK8ph4hjGrdCgGsvsNbYVrjoYeXwkNBCaIcKJwA7/lljKrbCOwPSZA==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
+        "@certusone/wormhole-sdk": "0.1.1",
         "@ethersproject/solidity": "5.0.5",
         "@solana/spl-token": "0.1.6",
         "@solana/web3.js": "1.24.1",
@@ -43,8 +44,10 @@
         "borsh": "0.4.0",
         "bs58": "4.0.1",
         "elliptic": "6.5.4",
+        "esm": "3.2.25",
         "eth-sig-util": "2.5.4",
         "ethereumjs-tx": "2.1.2",
+        "ethers": "5.4.7",
         "form-data": "3.0.0",
         "jsonschema": "1.2.6",
         "keccak256": "1.0.2",
@@ -557,7 +560,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
       "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.12.13"
       }
@@ -627,7 +629,6 @@
       "version": "7.13.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
       "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
@@ -637,8 +638,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -742,7 +742,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
       "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
@@ -753,7 +752,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
       "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -781,7 +779,6 @@
       "version": "7.13.12",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
       "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
       }
@@ -862,7 +859,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
       "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -870,8 +866,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -906,7 +901,6 @@
       "version": "7.13.10",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
       "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -916,8 +910,7 @@
     "@babel/parser": {
       "version": "7.13.13",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.13.12",
@@ -1664,7 +1657,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
       "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/parser": "^7.12.13",
@@ -1675,7 +1667,6 @@
       "version": "7.13.13",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
       "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
@@ -1691,7 +1682,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -1699,8 +1689,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1708,12 +1697,87 @@
       "version": "7.13.14",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
       "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@certusone/wormhole-sdk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.1.1.tgz",
+      "integrity": "sha512-/FEOGOkDRVq5+aXNHb9W57WR03dI9ZvhFlc/qrrQhXJQYhkm4Y+i0L9NQN5J5TpZ/aZ3cX+E6Gw3nFsmbgCo/g==",
+      "requires": {
+        "@improbable-eng/grpc-web": "^0.14.0",
+        "@solana/spl-token": "^0.1.8",
+        "@solana/web3.js": "^1.24.0",
+        "@terra-money/terra.js": "^2.0.14",
+        "@terra-money/wallet-provider": "^2.2.0",
+        "bech32": "^2.0.0",
+        "js-base64": "^3.6.1",
+        "protobufjs": "^6.11.2",
+        "rxjs": "^7.3.0"
+      },
+      "dependencies": {
+        "@solana/spl-token": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
+          "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+          "requires": {
+            "@babel/runtime": "^7.10.5",
+            "@solana/web3.js": "^1.21.0",
+            "bn.js": "^5.1.0",
+            "buffer": "6.0.3",
+            "buffer-layout": "^1.2.0",
+            "dotenv": "10.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        }
+      }
+    },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@ethersproject/abi": {
       "version": "5.0.7",
@@ -1777,6 +1841,38 @@
         "@ethersproject/bytes": "^5.1.0"
       }
     },
+    "@ethersproject/basex": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        }
+      }
+    },
     "@ethersproject/bignumber": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.0.tgz",
@@ -1803,6 +1899,223 @@
         "@ethersproject/bignumber": "^5.1.0"
       }
     },
+    "@ethersproject/contracts": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
+      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
+      "requires": {
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
+          "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/hash": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+          "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.5.0",
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
+      }
+    },
     "@ethersproject/hash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
@@ -1816,6 +2129,388 @@
         "@ethersproject/logger": "^5.1.0",
         "@ethersproject/properties": "^5.1.0",
         "@ethersproject/strings": "^5.1.0"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
       }
     },
     "@ethersproject/keccak256": {
@@ -1840,12 +2535,280 @@
         "@ethersproject/logger": "^5.1.0"
       }
     },
+    "@ethersproject/pbkdf2": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        }
+      }
+    },
     "@ethersproject/properties": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
       "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
       "requires": {
         "@ethersproject/logger": "^5.1.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
+      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+          "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.5.0",
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "bech32": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        }
       }
     },
     "@ethersproject/rlp": {
@@ -1932,6 +2895,255 @@
         "@ethersproject/signing-key": "^5.1.0"
       }
     },
+    "@ethersproject/units": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        }
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+          "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.5.0",
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
+      }
+    },
     "@ethersproject/web": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.1.0.tgz",
@@ -1942,6 +3154,210 @@
         "@ethersproject/logger": "^5.1.0",
         "@ethersproject/properties": "^5.1.0",
         "@ethersproject/strings": "^5.1.0"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+          "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/networks": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/transactions": "^5.5.0",
+            "@ethersproject/web": "^5.5.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+          "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+          "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+          "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+          "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+          "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.5.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+          "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.5.0",
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+          "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
+          "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+          "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+          "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+          "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+          "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "requires": {
+            "@ethersproject/address": "^5.5.0",
+            "@ethersproject/bignumber": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/constants": "^5.5.0",
+            "@ethersproject/keccak256": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/rlp": "^5.5.0",
+            "@ethersproject/signing-key": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+          "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
+      }
+    },
+    "@improbable-eng/grpc-web": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.14.1.tgz",
+      "integrity": "sha512-XaIYuunepPxoiGVLLHmlnVminUGzBTnXr8Wv7khzmLWbNw4TCwJKX09GSMJlKhu/TRk6gms0ySFxewaETSBqgw==",
+      "requires": {
+        "browser-headers": "^0.4.1"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -2091,6 +3507,60 @@
         "json-schema": "^0.2.3",
         "murmurhash": "0.0.2"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
       "version": "6.2.5",
@@ -2324,53 +3794,10 @@
         "dotenv": "10.0.0"
       },
       "dependencies": {
-        "@solana/web3.js": {
-          "version": "1.30.2",
-          "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.30.2.tgz",
-          "integrity": "sha512-hznCj+rkfvM5taRP3Z+l5lumB7IQnDrB4l55Wpsg4kDU9Zds8pE5YOH5Z9bbF/pUzZJKQjyBjnY/6kScBm3Ugg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@ethersproject/sha2": "^5.5.0",
-            "@solana/buffer-layout": "^3.0.0",
-            "bn.js": "^5.0.0",
-            "borsh": "^0.4.0",
-            "bs58": "^4.0.1",
-            "buffer": "6.0.1",
-            "cross-fetch": "^3.1.4",
-            "jayson": "^3.4.4",
-            "js-sha3": "^0.8.0",
-            "rpc-websockets": "^7.4.2",
-            "secp256k1": "^4.0.2",
-            "superstruct": "^0.14.2",
-            "tweetnacl": "^1.0.0"
-          },
-          "dependencies": {
-            "buffer": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
-              "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-              }
-            }
-          }
-        },
         "bn.js": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-        },
-        "borsh": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
-          "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "bn.js": "^5.0.0",
-            "bs58": "^4.0.0",
-            "text-encoding-utf-8": "^1.0.2"
-          }
         },
         "buffer": {
           "version": "6.0.3",
@@ -2380,11 +3807,6 @@
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
           }
-        },
-        "js-sha3": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         }
       }
     },
@@ -2449,6 +3871,262 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@terra-dev/browser-check": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/browser-check/-/browser-check-2.5.3.tgz",
+      "integrity": "sha512-r4CrL0tTco4yg1UnHq1L2fUIsrEjkBY/pbYlA1p61teZ8OJJLz1yOkXa8OLLHpOl89oXn+ak9iZ1lN0VxSdeuA==",
+      "requires": {
+        "bowser": "^2.11.0",
+        "mobile-detect": "^1.4.5"
+      }
+    },
+    "@terra-dev/chrome-extension": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/chrome-extension/-/chrome-extension-2.5.3.tgz",
+      "integrity": "sha512-8tjKKvfRGAs5ve26vHdk5nWCt6GGoxswFMgF3UcdLcLHRnH3N3g7fjBa+95VTs8eTT4terpUl83+7ngwdy4A/g==",
+      "requires": {
+        "@terra-dev/browser-check": "^2.5.3",
+        "@terra-dev/wallet-types": "^2.5.3",
+        "fix-hmr": "^1.0.2",
+        "rxjs": "^7.4.0",
+        "styled-components": "^5.0.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        }
+      }
+    },
+    "@terra-dev/readonly-wallet": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/readonly-wallet/-/readonly-wallet-2.5.3.tgz",
+      "integrity": "sha512-oZU4u2cO0lvpZiMdB91UHrLfBubYba5ziqP6fzxYbtFxPhRt0sF3vTcqSg7ReGXzOTqNt0fd4Mj7ZnkFJ5wUrQ==",
+      "requires": {
+        "@terra-dev/wallet-types": "^2.5.3"
+      }
+    },
+    "@terra-dev/readonly-wallet-modal": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/readonly-wallet-modal/-/readonly-wallet-modal-2.5.3.tgz",
+      "integrity": "sha512-1+7NJ+UVLQVxO4FH6Y0cniPKGZXPtaUZy0/9qfgKoCvaGN9m6VshC0NHrDcwKpH6aqXlm1AqCu2obSSIH1qMGw==",
+      "requires": {
+        "@terra-dev/readonly-wallet": "^2.5.3",
+        "@terra-dev/wallet-types": "^2.5.3",
+        "styled-components": "^5.0.0"
+      }
+    },
+    "@terra-dev/use-wallet": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/use-wallet/-/use-wallet-2.5.3.tgz",
+      "integrity": "sha512-VTJ0ZKBoSDH6Tjv3g9RlMDg5QVI5CMxmW8Isto5t1q3tEhwmo7QcaFtd53diqIk7tq9ogS+I1Lhkh2PzLj2o5A==",
+      "requires": {
+        "@terra-dev/wallet-types": "^2.5.3"
+      }
+    },
+    "@terra-dev/wallet-types": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/wallet-types/-/wallet-types-2.5.3.tgz",
+      "integrity": "sha512-fqOVDxQT/BLQTmTq0GjOzHS/oVtjQcuJibcgDZz26mS0YNypixG1bGbk/Z2tRQxiB2lcKxXP71oORdNipwDXLw=="
+    },
+    "@terra-dev/walletconnect": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/walletconnect/-/walletconnect-2.5.3.tgz",
+      "integrity": "sha512-y0ZF6tbHcq/kAVevAalT74IUHubcmSqCbdzucU0LAVDEQr/z2HmW0Fk/92p8WLejUxIz8mAUNRtm/3oJW4F07Q==",
+      "requires": {
+        "@terra-dev/browser-check": "^2.5.3",
+        "@terra-dev/walletconnect-qrcode-modal": "^2.5.3",
+        "@walletconnect/core": "^1.6.6",
+        "@walletconnect/iso-crypto": "^1.6.6",
+        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/utils": "^1.6.6",
+        "rxjs": "^7.4.0",
+        "ws": "^7.5.5"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        },
+        "ws": {
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+        }
+      }
+    },
+    "@terra-dev/walletconnect-qrcode-modal": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-dev/walletconnect-qrcode-modal/-/walletconnect-qrcode-modal-2.5.3.tgz",
+      "integrity": "sha512-85n4MsOa0fzRGhxDKrgjfWm4EMV0fx9+d1fnJtVu2sdbGstXOt5uCt/7iOiQ0fEmL18EhJg1BjqGcRks2u3EcA==",
+      "requires": {
+        "@terra-dev/browser-check": "^2.5.3",
+        "@walletconnect/types": "^1.6.6",
+        "qrcode.react": "^1.0.1",
+        "styled-components": "^5.0.0"
+      }
+    },
+    "@terra-dev/web-connector-controller": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@terra-dev/web-connector-controller/-/web-connector-controller-0.8.1.tgz",
+      "integrity": "sha512-TIwFtta7vN2GdDUy8SbIIsfTd9XWiU+U6yjizd82yUAhlOJNAGHshG0r1j0irkA5MycYG1duAlr7foeKRu4PGA==",
+      "requires": {
+        "@terra-dev/web-connector-interface": "^0.8.1",
+        "bowser": "^2.11.0",
+        "rxjs": "^7.4.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        }
+      }
+    },
+    "@terra-dev/web-connector-interface": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@terra-dev/web-connector-interface/-/web-connector-interface-0.8.1.tgz",
+      "integrity": "sha512-ryA3xtTFJ7OkAF6pTlrsuqxtSUp0DxHhyxvzwRPbT3h8VqlkFStknvYjRwNRspN2LOpi4/F1TNFzcUBNHPCo2g==",
+      "requires": {
+        "rxjs": "^7.4.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        }
+      }
+    },
+    "@terra-money/terra.js": {
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-2.1.23.tgz",
+      "integrity": "sha512-nSAR35zqjKUn1Jzqevf30s47XRlW/VXU01YgK3n9ndmX15lkdlgFvqaV7UezK0xAmCpm+7xWIrtBTMmZpVBkMQ==",
+      "requires": {
+        "@terra-money/terra.proto": "^0.1.7",
+        "axios": "^0.21.1",
+        "bech32": "^2.0.0",
+        "bip32": "^2.0.6",
+        "bip39": "^3.0.3",
+        "bufferutil": "^4.0.3",
+        "decimal.js": "^10.2.1",
+        "jscrypto": "^1.0.1",
+        "readable-stream": "^3.6.0",
+        "secp256k1": "^4.0.2",
+        "tmp": "^0.2.1",
+        "utf-8-validate": "^5.0.5",
+        "ws": "^7.4.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "bip39": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
+          "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
+          "requires": {
+            "@types/node": "11.11.6",
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.14.5",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+        },
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "utf-8-validate": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
+          "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "ws": {
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+        }
+      }
+    },
+    "@terra-money/terra.proto": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-0.1.7.tgz",
+      "integrity": "sha512-NXD7f6pQCulvo6+mv6MAPzhOkUzRjgYVuHZE/apih+lVnPG5hDBU0rRYnOGGofwvKT5/jQoOENnFn/gioWWnyQ==",
+      "requires": {
+        "google-protobuf": "^3.17.3",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
+    "@terra-money/wallet-provider": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@terra-money/wallet-provider/-/wallet-provider-2.5.3.tgz",
+      "integrity": "sha512-v/5Z35gCo4nZyZCu3nYDFvhwuvlyDeNSSYmN9KUc9ewoIO9K/2fi3vxcOLcvqq5PYowwwod21vgaQ9QHFV+8eA==",
+      "requires": {
+        "@terra-dev/browser-check": "^2.5.3",
+        "@terra-dev/chrome-extension": "^2.5.3",
+        "@terra-dev/readonly-wallet": "^2.5.3",
+        "@terra-dev/readonly-wallet-modal": "^2.5.3",
+        "@terra-dev/use-wallet": "^2.5.3",
+        "@terra-dev/wallet-types": "^2.5.3",
+        "@terra-dev/walletconnect": "^2.5.3",
+        "@terra-dev/web-connector-controller": "^0.8.1",
+        "@terra-dev/web-connector-interface": "^0.8.1",
+        "fast-deep-equal": "^3.1.3",
+        "rxjs": "^7.4.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        }
+      }
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -2485,6 +4163,11 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz",
       "integrity": "sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw=="
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
@@ -2514,6 +4197,172 @@
       "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@walletconnect/browser-utils": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.6.6.tgz",
+      "integrity": "sha512-E29xSHU7Akd4jaPehWVGx7ct+SsUzZbxcGc0fz+Pw6/j4Gh5tlfYZ9XuVixuYI4WPdQ2CmOraj8RrVOu5vba4w==",
+      "requires": {
+        "@walletconnect/safe-json": "1.0.0",
+        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/window-getters": "1.0.0",
+        "@walletconnect/window-metadata": "1.0.0",
+        "detect-browser": "5.2.0"
+      }
+    },
+    "@walletconnect/core": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.6.6.tgz",
+      "integrity": "sha512-pSftIVPY6mYz2koZPBEYmeFeAjVf2MSnRHOM6+vx+iAsUEcfMZHkgeXX6GtM6Fjza+zSZu1qnmdgURVXpmKwtQ==",
+      "requires": {
+        "@walletconnect/socket-transport": "^1.6.6",
+        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/utils": "^1.6.6"
+      }
+    },
+    "@walletconnect/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-IgUReNrycIFxkGgq8YT9HsosCkhutakWD9Q411PR0aJfxpEa/VKJeaLRtoz6DvJpztWStwhIHnAbBoOVR72a6g==",
+      "requires": {
+        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/environment": "^1.0.0",
+        "@walletconnect/randombytes": "^1.0.1",
+        "aes-js": "^3.1.2",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "@walletconnect/encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.0.tgz",
+      "integrity": "sha512-4nkJFnS0QF5JdieG/3VPD1/iEWkLSZ14EBInLZ00RWxmC6EMZrzAeHNAWIgm+xP3NK0lqz+7lEsmWGtcl5gYnQ==",
+      "requires": {
+        "is-typedarray": "1.0.0",
+        "typedarray-to-buffer": "3.1.5"
+      }
+    },
+    "@walletconnect/environment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.0.tgz",
+      "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
+    },
+    "@walletconnect/iso-crypto": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.6.6.tgz",
+      "integrity": "sha512-wRYgKvd8K3A9FVLn2c0cDh4+9OUHkqibKtwQJTJsz+ibPGgd+n5j1/FjnzDDRGb9T1+TtlwYF3ZswKyys3diVQ==",
+      "requires": {
+        "@walletconnect/crypto": "^1.0.1",
+        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/utils": "^1.6.6"
+      }
+    },
+    "@walletconnect/jsonrpc-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
+      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@walletconnect/jsonrpc-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
+      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "requires": {
+        "@walletconnect/environment": "^1.0.0",
+        "@walletconnect/jsonrpc-types": "^1.0.0"
+      }
+    },
+    "@walletconnect/randombytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.1.tgz",
+      "integrity": "sha512-YJTyq69i0PtxVg7osEpKfvjTaWuAsR49QEcqGKZRKVQWMbGXBZ65fovemK/SRgtiFRv0V8PwsrlKSheqzfPNcg==",
+      "requires": {
+        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/environment": "^1.0.0",
+        "randombytes": "^2.1.0"
+      }
+    },
+    "@walletconnect/safe-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
+      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
+    },
+    "@walletconnect/socket-transport": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.6.6.tgz",
+      "integrity": "sha512-mugCEoeKTx75ogb5ROg/+LA3yGTsuRNcrYgrApceo7WNU9Z4dG8l6ycMPqrrFcODcrasq3NmXVWUYDv/CvrzSw==",
+      "requires": {
+        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/utils": "^1.6.6",
+        "ws": "7.5.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+        }
+      }
+    },
+    "@walletconnect/types": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.6.6.tgz",
+      "integrity": "sha512-op77cxexOmQQN36XB1sYouNTlBRV0Rup/2NYK8A1ffdwXa3a6HLHHdhBM7I/I9BVmRXoZ4+XoOnPKGGrYtlS3g=="
+    },
+    "@walletconnect/utils": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.6.6.tgz",
+      "integrity": "sha512-s2X/cVXiMDSEoWV6i7HPMbP1obXlzP7KLMrBo9OMabiJKnQEh6HSZ39WLswB2PHnl8Hp1Sr4BdRvhM5kCcYWRw==",
+      "requires": {
+        "@walletconnect/browser-utils": "^1.6.6",
+        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/types": "^1.6.6",
+        "bn.js": "4.11.8",
+        "js-sha3": "0.8.0",
+        "query-string": "6.13.5"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "query-string": {
+          "version": "6.13.5",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+          "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
+      }
+    },
+    "@walletconnect/window-getters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
+      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
+    },
+    "@walletconnect/window-metadata": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
+      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
+      "requires": {
+        "@walletconnect/window-getters": "^1.0.0"
       }
     },
     "@web3-js/scrypt-shim": {
@@ -2682,7 +4531,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -3074,6 +4922,49 @@
         "@babel/helper-define-polyfill-provider": "^0.1.5"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
+      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -3083,8 +4974,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
@@ -3285,6 +5175,11 @@
         }
       }
     },
+    "bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
     "bignumber.js": {
       "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
       "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
@@ -3299,9 +5194,29 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
+      "integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.3",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
       }
     },
     "bip39": {
@@ -3376,6 +5291,11 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -3441,6 +5361,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-headers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -3572,9 +5497,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-layout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.1.tgz",
-      "integrity": "sha512-RUTGEYG1vX0Zp1dStQFl8yeU/LEBPXVtHwzzDbPWkE5zq+Prt9fkFLKNiwmaeHg6BBiRMcQAgj4cynazO6eekw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="
     },
     "buffer-to-arraybuffer": {
       "version": "0.0.5",
@@ -3595,7 +5520,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
       "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
-      "optional": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -3798,6 +5722,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
     "caniuse-lite": {
       "version": "1.0.30001205",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
@@ -3819,7 +5748,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4152,7 +6080,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4160,8 +6087,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
       "version": "1.2.2",
@@ -4568,6 +6494,21 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
     "custom-error-instance": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
@@ -4623,6 +6564,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -4801,6 +6747,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "dicer": {
       "version": "0.2.5",
@@ -5115,8 +7066,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -5454,6 +7404,11 @@
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
@@ -5677,6 +7632,260 @@
         "scryptsy": "^1.2.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "ethers": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
+      "requires": {
+        "@ethersproject/abi": "5.4.1",
+        "@ethersproject/abstract-provider": "5.4.1",
+        "@ethersproject/abstract-signer": "5.4.1",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.2",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.1",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.1",
+        "@ethersproject/networks": "5.4.2",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.1",
+        "@ethersproject/providers": "5.4.5",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/hash": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+          "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+          "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/solidity": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+          "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/sha2": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "ethjs-unit": {
@@ -6099,6 +8308,25 @@
         "locate-path": "^3.0.0"
       }
     },
+    "fix-hmr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fix-hmr/-/fix-hmr-1.0.2.tgz",
+      "integrity": "sha512-N0lDDYiu0yplOZt1Q+d3CSpie4mimTMUQ9ftOnT4DDWdGuNH8BFs1bpLKJKd9DXFtkiAR9Y5updgmI7kyW8AuQ==",
+      "requires": {
+        "react": "^17.0.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -6295,8 +8523,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -6524,8 +8751,12 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "google-protobuf": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.1.tgz",
+      "integrity": "sha512-Isv1RlNC+IzZzilcxnlVSf+JvuhxmY7DaxYCBy+zPS9XVuJRtlTTIXR9hnZ1YL1MMusJn/7eSy2swCzZIomQSg=="
     },
     "got": {
       "version": "9.6.0",
@@ -6615,8 +8846,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -6729,6 +8959,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -7551,9 +9789,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-beautify": {
       "version": "1.13.5",
@@ -7626,11 +9864,15 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jscrypto": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.2.tgz",
+      "integrity": "sha512-r+oNJLGTv1nkNMBBq3c70xYrFDgJOYVgs2OHijz5Ht+0KJ0yObD0oYxC9mN72KLzVfXw+osspg6t27IZvuTUxw=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -7843,6 +10085,11 @@
         "json-buffer": "3.0.0"
       }
     },
+    "keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -8038,6 +10285,11 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8344,6 +10596,11 @@
       "requires": {
         "mkdirp": "*"
       }
+    },
+    "mobile-detect": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.5.tgz",
+      "integrity": "sha512-yc0LhH6tItlvfLBugVUEtgawwFU2sIe+cSdmRJJCTMZ5GEJyLxNyC/NIOAOGk67Fa8GNpOttO3Xz/1bHpXFD/g=="
     },
     "mocha": {
       "version": "5.2.0",
@@ -9600,6 +11857,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
     "postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -9716,6 +11978,26 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
+    "protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -9811,6 +12093,21 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+    },
+    "qrcode.react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-1.0.1.tgz",
+      "integrity": "sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.0",
+        "qr.js": "0.0.0"
+      }
     },
     "qs": {
       "version": "6.7.0",
@@ -10358,7 +12655,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       },
@@ -10367,7 +12663,6 @@
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -10813,6 +13108,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -11158,6 +13458,11 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11345,6 +13650,23 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "styled-components": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
+      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      }
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -11425,7 +13747,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -11627,6 +13948,18 @@
         "next-tick": "1"
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -11639,8 +13972,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -11758,6 +14090,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
           "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
+        "js-base64": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+          "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
         }
       }
     },
@@ -11816,6 +14153,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "uglify-js": {
       "version": "3.13.3",
@@ -12636,6 +14978,14 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
       }
     },
     "with-callback": {

--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "./node_modules/.bin/standard --fix"
   },
   "dependencies": {
-    "@audius/libs": "1.2.31",
+    "@audius/libs": "1.2.35",
     "@optimizely/optimizely-sdk": "^4.6.0",
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",

--- a/identity-service/sequelize/migrations/20211123173149-rewards_attester.js
+++ b/identity-service/sequelize/migrations/20211123173149-rewards_attester.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
@@ -12,7 +12,7 @@ module.exports = {
       offset: {
         type: Sequelize.INTEGER,
         allowNull: false,
-        defaultValue: 0,
+        defaultValue: 0
       },
       createdAt: {
         allowNull: false,
@@ -28,4 +28,4 @@ module.exports = {
   down: (queryInterface) => {
     return queryInterface.dropTable('RewardAttesterValues')
   }
-};
+}

--- a/identity-service/sequelize/migrations/20211123173149-rewards_attester.js
+++ b/identity-service/sequelize/migrations/20211123173149-rewards_attester.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('RewardAttesterValues', {
+      startingBlock: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+        primaryKey: true
+      },
+      offset: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.dropTable('RewardAttesterValues')
+  }
+};

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -201,11 +201,11 @@ class App {
     return audiusInstance
   }
 
-  async configureRewardsAttester(libs) {
+  async configureRewardsAttester (libs) {
     // Make a more greppable child logger
-    const childLogger = logger.child({'service': 'RewardsAttester'})
+    const childLogger = logger.child({ 'service': 'RewardsAttester' })
 
-    // Await for optimizely config so we know 
+    // Await for optimizely config so we know
     // whether rewards attestation is enabled,
     // returning early if false
     await this.optimizelyPromise
@@ -219,7 +219,7 @@ class App {
     // arbitrary challenges by their challengeId
     const challengeIdsDenyList = (
       (getRemoteVar(this.optimizelyClientInstance, REMOTE_VARS.CHALLENGE_IDS_DENY_LIST) || '')
-      .split(',')
+        .split(',')
     )
 
     // Fetch the last saved offset and startingBLock from the DB,
@@ -233,23 +233,23 @@ class App {
     }
 
     // Init the RewardsAttester
-    const attester = new RewardsAttester({ 
+    const attester = new RewardsAttester({
       libs,
       logger: childLogger,
       parallelization: config.get('rewardsParallelization'),
       quorumSize: config.get('rewardsQuorumSize'),
       aaoEndpoint: config.get('aaoEndpoint'),
       aaoAddress: config.get('aaoAddress'),
-      startingBlock: initialVals.startingBlock, 
+      startingBlock: initialVals.startingBlock,
       offset: initialVals.offset,
       challengeIdsDenyList,
       updateValues: async ({ startingBlock, offset, successCount }) => {
         childLogger.info(`Persisting offset: ${offset}, startingBlock: ${startingBlock}`)
 
         await models.RewardAttesterValues.update({
-          startingBlock, 
+          startingBlock,
           offset
-        }, { where: {}})
+        }, { where: {} })
 
         // If we succeeded in attesting for at least a single reward,
         // store in Redis so we can healthcheck it.

--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -12,9 +12,12 @@ const txRelay = require('./relay/txRelay')
 const ethTxRelay = require('./relay/ethTxRelay')
 const { runMigrations } = require('./migrationManager')
 const audiusLibsWrapper = require('./audiusLibsInstance')
+
 const NotificationProcessor = require('./notifications/index.js')
 const { generateWalletLockKey } = require('./relay/txRelay.js')
 const { generateETHWalletLockKey } = require('./relay/ethTxRelay.js')
+const { RewardsAttester } = require('@audius/libs')
+const models = require('./models')
 
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { fetchAnnouncements } = require('./announcements')
@@ -26,8 +29,11 @@ const {
   getIP
 } = require('./rateLimiter.js')
 const cors = require('./corsMiddleware')
+const { getFeatureFlag, FEATURE_FLAGS } = require('./featureFlag')
+const { REMOTE_VARS, getRemoteVar } = require('./remoteConfig')
 
 const DOMAIN = 'mail.audius.co'
+const REDIS_ATTEST_HEALTH_KEY = 'last-attestation-time'
 
 class App {
   constructor (port) {
@@ -36,7 +42,9 @@ class App {
     this.redisClient = redisClient
     this.configureSentry()
     this.configureMailgun()
-    this.configureOptimizely()
+
+    this.optimizelyPromise = null
+    this.optimizelyClientInstance = this.configureOptimizely()
 
     // Async job configuration
     this.notificationProcessor = new NotificationProcessor({
@@ -93,6 +101,8 @@ class App {
           this.express,
           this.redisClient
         )
+
+        await this.configureRewardsAttester(audiusInstance)
 
         // Fork extra web server workers
         // note - we can't have more than 1 worker at the moment because POA and ETH relays
@@ -175,9 +185,13 @@ class App {
       sdkKey
     })
 
-    optimizelyClientInstance.onReady().then(() => {
-      this.express.set('optimizelyClient', optimizelyClientInstance)
+    this.optimizelyPromise = new Promise(resolve => {
+      optimizelyClientInstance.onReady().then(() => {
+        this.express.set('optimizelyClient', optimizelyClientInstance)
+        resolve()
+      })
     })
+    return optimizelyClientInstance
   }
 
   async configureAudiusInstance () {
@@ -185,6 +199,69 @@ class App {
     const audiusInstance = audiusLibsWrapper.getAudiusLibs()
     this.express.set('audiusLibs', audiusInstance)
     return audiusInstance
+  }
+
+  async configureRewardsAttester(libs) {
+    // Make a more greppable child logger
+    const childLogger = logger.child({'service': 'RewardsAttester'})
+
+    // Await for optimizely config so we know 
+    // whether rewards attestation is enabled,
+    // returning early if false
+    await this.optimizelyPromise
+    const isEnabled = getFeatureFlag(this.optimizelyClientInstance, FEATURE_FLAGS.REWARDS_ATTESTATION_ENABLED)
+    if (!isEnabled) {
+      childLogger.info('Attestation disabled!')
+      return
+    }
+
+    // Fetch the challengeDenyList, used to filter out
+    // challenges by ID 
+    const challengeIdsDenyList = (
+      (getRemoteVar(this.optimizelyClientInstance, REMOTE_VARS.CHALLENGE_IDS_DENY_LIST) || '')
+      .split(',')
+    )
+
+    // Fetch the last saved offset and startingBLock from the DB,
+    // or create them if necessary.
+    let values = await models.RewardAttesterValues.findOne()
+    if (!values) {
+      values = models.RewardAttesterValues.build()
+      values.startingBlock = 0
+      values.offset = 0
+      await values.save()
+    }
+
+    // Init the RewardsAttester
+    const attester = new RewardsAttester({ 
+      libs,
+      logger: childLogger,
+      parallelization: config.get('rewardsParallelization'),
+      quorumSize: config.get('rewardsQuorumSize'),
+      aaoEndpoint: config.get('aaoEndpoint'),
+      aaoAddress: config.get('aaoAddress'),
+      startingBlock: values.startingBlock, 
+      offset: values.offset,
+      challengeIdsDenyList,
+      updateValues: async ({ startingBlock, offset, successCount }) => {
+        let values = await models.RewardAttesterValues.findOne()
+        // Safe to assume it exists b/c it's created
+        // at initialization time above.
+        values.startingBlock = startingBlock
+        values.offset = offset
+
+        // If we succeeded in attesting for at least a single reward,
+        // store in Redis so we can healthcheck it.
+        if (successCount > 0) {
+          await this.redisClient.set(REDIS_ATTEST_HEALTH_KEY, Date.now())
+        }
+        childLogger.info(`Persisting offset: ${offset}, startingBlock: ${startingBlock}`)
+        return values.save()
+      }
+    })
+    attester.start()
+    this.express.set('rewardsAttester', attester)
+    return attester
   }
 
   async runMigrations () {
@@ -331,3 +408,4 @@ class App {
 }
 
 module.exports = App
+module.exports.REDIS_ATTEST_HEALTH_KEY = REDIS_ATTEST_HEALTH_KEY

--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -35,7 +35,7 @@ class AudiusLibsWrapper {
       rewardsManagerTokenPDA: config.get('solanaRewardsManagerTokenPDA'),
       // Never use the relay path in identity
       useRelay: false,
-      feePayerSecretKey,
+      feePayerSecretKey
     })
 
     let audiusInstance = new AudiusLibs({
@@ -58,7 +58,7 @@ class AudiusLibsWrapper {
       },
       isServer: true,
       captchaConfig: { serviceKey: config.get('recaptchaServiceKey') },
-      solanaWeb3Config: solanaWeb3Config,
+      solanaWeb3Config: solanaWeb3Config
     })
 
     await audiusInstance.init()

--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -4,6 +4,9 @@ const config = require('./config')
 const registryAddress = config.get('registryAddress')
 const web3ProviderUrl = config.get('web3Provider')
 
+// Fixed address of the SPL token program
+const SOLANA_TOKEN_ADDRESS = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+
 class AudiusLibsWrapper {
   constructor () {
     this.audiusLibsInstance = null
@@ -21,6 +24,19 @@ class AudiusLibsWrapper {
     if (feePayerSecretKey) {
       feePayerSecretKey = Uint8Array.from(feePayerSecretKey)
     }
+
+    const solanaWeb3Config = AudiusLibs.configSolanaWeb3({
+      solanaClusterEndpoint: config.get('solanaEndpoint'),
+      mintAddress: config.get('solanaMintAddress'),
+      solanaTokenAddress: SOLANA_TOKEN_ADDRESS,
+      claimableTokenProgramAddress: config.get('solanaClaimableTokenProgramAddress'),
+      rewardsManagerProgramId: config.get('solanaRewardsManagerProgramId'),
+      rewardsManagerProgramPDA: config.get('solanaRewardsManagerProgramPDA'),
+      rewardsManagerTokenPDA: config.get('solanaRewardsManagerTokenPDA'),
+      // Never use the relay path in identity
+      useRelay: false,
+      feePayerSecretKey,
+    })
 
     let audiusInstance = new AudiusLibs({
       discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(discoveryProviderWhitelist),
@@ -42,12 +58,7 @@ class AudiusLibsWrapper {
       },
       isServer: true,
       captchaConfig: { serviceKey: config.get('recaptchaServiceKey') },
-      solanaWeb3Config: AudiusLibs.configSolanaWeb3({
-        solanaClusterEndpoint: config.get('solanaEndpoint'),
-        // Never use the relay path in identity
-        shouldUseRelay: false,
-        feePayerSecretKey
-      })
+      solanaWeb3Config: solanaWeb3Config,
     })
 
     await audiusInstance.init()

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -718,13 +718,13 @@ if (fs.existsSync('solana-program-config.json')) {
     solanaClaimableTokenProgramAddress: solanaContractConfig.claimableTokenAddress,
     solanaRewardsManagerProgramId: solanaContractConfig.rewardsManagerAddress,
     solanaRewardsManagerProgramPDA: solanaContractConfig.rewardsManagerAccount,
-    solanaRewardsManagerTokenPDA: solanaContractConfig.rewardsManagerTokenAccount,
+    solanaRewardsManagerTokenPDA: solanaContractConfig.rewardsManagerTokenAccount
   })
 }
 
 if (fs.existsSync('aao-config.json')) {
   let aaoConfig = require('../aao-config.json')
-  console.log("rewards: " + JSON.stringify(aaoConfig))
+  console.log('rewards: ' + JSON.stringify(aaoConfig))
   config.load({
     aaoAddress: aaoConfig[0]
   })

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -594,6 +594,60 @@ const config = convict({
     default: 'processed',
     env: 'solanaTxCommitmentLevel'
   },
+  solanaMintAddress: {
+    doc: 'The address of our SPL token',
+    format: String,
+    default: null,
+    env: 'solanaMintAddress'
+  },
+  solanaClaimableTokenProgramAddress: {
+    doc: 'The address of our Claimable Token program',
+    format: String,
+    default: null,
+    env: 'solanaClaimableTokenProgramAddress'
+  },
+  solanaRewardsManagerProgramId: {
+    doc: 'The address of our Rewards Manager program',
+    format: String,
+    default: null,
+    env: 'solanaRewardsManagerProgramId'
+  },
+  solanaRewardsManagerProgramPDA: {
+    doc: 'The PDA of this Rewards Manager deployment',
+    format: String,
+    default: null,
+    env: 'solanaRewardsManagerProgramPDA'
+  },
+  solanaRewardsManagerTokenPDA: {
+    doc: 'The PDA for the Rewards Manager token account',
+    format: String,
+    default: null,
+    env: 'solanaRewardsManagerTokenPDA'
+  },
+  rewardsParallelization: {
+    doc: 'How many requests to perform in parallel when disbursing rewards',
+    format: Number,
+    default: '2',
+    env: 'rewardsParallelization'
+  },
+  rewardsQuorumSize: {
+    doc: 'How many Discovery Nodes constitute a quorum for disbursing a reward',
+    format: Number,
+    default: '2',
+    env: 'rewardsQuorumSize'
+  },
+  aaoEndpoint: {
+    doc: 'AAO Endpoint for fetching attestations',
+    format: String,
+    default: 'http://anti-abuse-oracle_anti_abuse_oracle_1:8000',
+    env: 'aaoEndpoint'
+  },
+  aaoAddress: {
+    doc: 'AAO eth address',
+    format: String,
+    default: '',
+    env: 'aaoAddress'
+  },
   sentryDSN: {
     doc: 'Sentry DSN key',
     format: String,
@@ -610,7 +664,7 @@ const config = convict({
     doc: 'Optimizely SDK key to use to fetch remote configuration',
     format: String,
     env: 'optimizelySdkKey',
-    default: null
+    default: 'MX4fYBgANQetvmBXGpuxzF'
   },
   discoveryProviderWhitelist: {
     doc: 'Whitelisted discovery providers to select from (comma-separated)',
@@ -658,7 +712,21 @@ if (fs.existsSync('solana-program-config.json')) {
     solanaValidSigner: solanaContractConfig.validSigner,
     solanaFeePayerWallet: solanaContractConfig.feePayerWallet,
     solanaEndpoint: solanaContractConfig.endpoint,
-    solanaSignerPrivateKey: solanaContractConfig.signerPrivateKey
+    solanaSignerPrivateKey: solanaContractConfig.signerPrivateKey,
+
+    solanaMintAddress: solanaContractConfig.splToken,
+    solanaClaimableTokenProgramAddress: solanaContractConfig.claimableTokenAddress,
+    solanaRewardsManagerProgramId: solanaContractConfig.rewardsManagerAddress,
+    solanaRewardsManagerProgramPDA: solanaContractConfig.rewardsManagerAccount,
+    solanaRewardsManagerTokenPDA: solanaContractConfig.rewardsManagerTokenAccount,
+  })
+}
+
+if (fs.existsSync('aao-config.json')) {
+  let aaoConfig = require('../aao-config.json')
+  console.log("rewards: " + JSON.stringify(aaoConfig))
+  config.load({
+    aaoAddress: aaoConfig[0]
   })
 }
 

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -597,31 +597,31 @@ const config = convict({
   solanaMintAddress: {
     doc: 'The address of our SPL token',
     format: String,
-    default: null,
+    default: '',
     env: 'solanaMintAddress'
   },
   solanaClaimableTokenProgramAddress: {
     doc: 'The address of our Claimable Token program',
     format: String,
-    default: null,
+    default: '',
     env: 'solanaClaimableTokenProgramAddress'
   },
   solanaRewardsManagerProgramId: {
     doc: 'The address of our Rewards Manager program',
     format: String,
-    default: null,
+    default: '',
     env: 'solanaRewardsManagerProgramId'
   },
   solanaRewardsManagerProgramPDA: {
     doc: 'The PDA of this Rewards Manager deployment',
     format: String,
-    default: null,
+    default: '',
     env: 'solanaRewardsManagerProgramPDA'
   },
   solanaRewardsManagerTokenPDA: {
     doc: 'The PDA for the Rewards Manager token account',
     format: String,
-    default: null,
+    default: '',
     env: 'solanaRewardsManagerTokenPDA'
   },
   rewardsParallelization: {

--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -3,7 +3,7 @@ const uuidv4 = require('uuid/v4')
 // Declaration of feature flags set in optimizely
 const FEATURE_FLAGS = Object.freeze({
   SOLANA_LISTEN_ENABLED_SERVER: 'solana_listen_enabled_server',
-  REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled',
+  REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded

--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -2,14 +2,16 @@ const uuidv4 = require('uuid/v4')
 
 // Declaration of feature flags set in optimizely
 const FEATURE_FLAGS = Object.freeze({
-  SOLANA_LISTEN_ENABLED_SERVER: 'solana_listen_enabled_server'
+  SOLANA_LISTEN_ENABLED_SERVER: 'solana_listen_enabled_server',
+  REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled',
 })
 
 // Default values for feature flags while optimizely has not loaded
 // Generally, these should be never seen unless variables are
 // consumed within a few seconds of server init
 const DEFAULTS = Object.freeze({
-  [FEATURE_FLAGS.SOLANA_LISTEN_ENABLED_SERVER]: false
+  [FEATURE_FLAGS.SOLANA_LISTEN_ENABLED_SERVER]: false,
+  [FEATURE_FLAGS.REWARDS_ATTESTATION_ENABLED]: false
 })
 
 /**

--- a/identity-service/src/models/rewardsAttester.js
+++ b/identity-service/src/models/rewardsAttester.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
     offset: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      defaultValue: 0,
+      defaultValue: 0
     }
   }, {})
   return RewardAttesterValues

--- a/identity-service/src/models/rewardsAttester.js
+++ b/identity-service/src/models/rewardsAttester.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = (sequelize, DataTypes) => {
+  const RewardAttesterValues = sequelize.define('RewardAttesterValues', {
+    startingBlock: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+      primaryKey: true
+    },
+    offset: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    }
+  }, {})
+  return RewardAttesterValues
+}

--- a/identity-service/src/remoteConfig.js
+++ b/identity-service/src/remoteConfig.js
@@ -2,14 +2,16 @@ const REMOTE_CONFIG_FEATURE = 'remote_config'
 
 // Declaration of remote config variables set in optimizely
 const REMOTE_VARS = Object.freeze({
-  TRENDING_EXPERIMENT: 'TRENDING_EXPERIMENT'
+  TRENDING_EXPERIMENT: 'TRENDING_EXPERIMENT',
+  CHALLENGE_IDS_DENY_LIST: 'CHALLENGE_IDS_DENY_LIST'
 })
 
 // Default values for remote vars while optimizely has not loaded
 // Generally, these should be never seen unless variables are
 // consumed within a few seconds of server init
 const DEFAULTS = Object.freeze({
-  [REMOTE_VARS.TRENDING_EXPERIMENT]: null
+  [REMOTE_VARS.TRENDING_EXPERIMENT]: null,
+  [REMOTE_VARS.CHALLENGE_IDS_DENY_LIST]: []
 })
 
 // Use a dummy user id since remote config is enabled by default

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -407,7 +407,7 @@ module.exports = function (app) {
     const { maxDrift } = req.query
     const redis = req.app.get('redis')
     const lastSuccessfulDisbursement = await redis.get(REDIS_ATTEST_HEALTH_KEY)
-    const isHealthy = lastSuccessfulDisbursement && ((Date.now() - lastSuccessfulDisbursement)/1000 < maxDrift)
+    const isHealthy = lastSuccessfulDisbursement && ((Date.now() - lastSuccessfulDisbursement) / 1000 < maxDrift)
     const resp = {
       lastSuccessfulDisbursement
     }

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "description": "",
   "main": "src/index.js",
   "browser": {

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -120,8 +120,7 @@ class Rewards extends Base {
         tokenAmount: fullTokenAmount
       })
 
-
-      // In the case of an unparseable error, 
+      // In the case of an unparseable error,
       // we'll only have the error, not the code.
       if (submitErrorCode || submitError) {
         throw new Error(submitErrorCode || submitError)

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -120,6 +120,9 @@ class Rewards extends Base {
         tokenAmount: fullTokenAmount
       })
 
+
+      // In the case of an unparseable error, 
+      // we'll only have the error, not the code.
       if (submitErrorCode || submitError) {
         throw new Error(submitErrorCode || submitError)
       }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -29,6 +29,7 @@ const Web3 = require('./web3')
 const SolanaUtils = require('./services/solanaWeb3Manager/utils')
 
 const { Keypair } = require('@solana/web3.js')
+const RewardsAttester = require('./services/solanaWeb3Manager/rewardsAttester')
 
 class AudiusLibs {
   /**
@@ -490,3 +491,4 @@ module.exports.AudiusABIDecoder = AudiusABIDecoder
 module.exports.Utils = Utils
 module.exports.SolanaUtils = SolanaUtils
 module.exports.SanityChecks = SanityChecks
+module.exports.RewardsAttester = RewardsAttester

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -243,6 +243,12 @@ class ServiceSelection {
     return `${service}/health_check`
   }
 
+  /**
+   * What the criteria is for a healthy service
+   * @param {Object} response axios response
+   * @param {{ [key: string]: string}} urlMap health check urls mapped to their cannonical url
+   * e.g. https://discoveryprovider.audius.co/health_check => https://discoveryprovider.audius.co
+   */
   isHealthy (response, urlMap) {
     return response.status === 200
   }

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -179,7 +179,7 @@ class ServiceSelection {
       const results = await allRequests({
         urlMap: map,
         timeout: this.requestTimeout,
-        validationCheck: (resp) => this.isHealthy(resp, map)
+        validationCheck: (resp) => resp.status === 200
       })
       return results
     } catch (e) {
@@ -243,16 +243,6 @@ class ServiceSelection {
     return `${service}/health_check`
   }
 
-  /**
-   * What the criteria is for a healthy service
-   * @param {Object} response axios response
-   * @param {{ [key: string]: string}} urlMap health check urls mapped to their cannonical url
-   * e.g. https://discoveryprovider.audius.co/health_check => https://discoveryprovider.audius.co
-   */
-  isHealthy (response, urlMap) {
-    return response.status === 200
-  }
-
   /** Races requests against each other with provided timeouts and health checks */
   async race (services) {
     // Key the services by their health check endpoint
@@ -269,7 +259,7 @@ class ServiceSelection {
         {},
         /* timeout */ this.requestTimeout,
         /* timeBetweenRequests */ 0,
-        /* validationCheck */ (resp) => this.isHealthy(resp, map)
+        /* validationCheck */ (resp) => resp.status === 200
       )
       this.decisionTree.push({ stage: 'Raced And Found Best', val: best })
       return { best, errored: errored.map(e => map[e.config.url]) }

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -179,7 +179,7 @@ class ServiceSelection {
       const results = await allRequests({
         urlMap: map,
         timeout: this.requestTimeout,
-        validationCheck: (resp) => resp.status === 200
+        validationCheck: (resp) => this.isHealthy(resp)
       })
       return results
     } catch (e) {
@@ -243,6 +243,10 @@ class ServiceSelection {
     return `${service}/health_check`
   }
 
+  isHealthy (response, urlMap) {
+    return response.status === 200
+  }
+
   /** Races requests against each other with provided timeouts and health checks */
   async race (services) {
     // Key the services by their health check endpoint
@@ -259,7 +263,7 @@ class ServiceSelection {
         {},
         /* timeout */ this.requestTimeout,
         /* timeBetweenRequests */ 0,
-        /* validationCheck */ (resp) => resp.status === 200
+        /* validationCheck */ (resp) => this.isHealthy(resp)
       )
       this.decisionTree.push({ stage: 'Raced And Found Best', val: best })
       return { best, errored: errored.map(e => map[e.config.url]) }

--- a/libs/src/service-selection/ServiceSelection.js
+++ b/libs/src/service-selection/ServiceSelection.js
@@ -179,7 +179,7 @@ class ServiceSelection {
       const results = await allRequests({
         urlMap: map,
         timeout: this.requestTimeout,
-        validationCheck: (resp) => this.isHealthy(resp)
+        validationCheck: (resp) => this.isHealthy(resp, map)
       })
       return results
     } catch (e) {
@@ -263,7 +263,7 @@ class ServiceSelection {
         {},
         /* timeout */ this.requestTimeout,
         /* timeBetweenRequests */ 0,
-        /* validationCheck */ (resp) => this.isHealthy(resp)
+        /* validationCheck */ (resp) => this.isHealthy(resp, map)
       )
       this.decisionTree.push({ stage: 'Raced And Found Best', val: best })
       return { best, errored: errored.map(e => map[e.config.url]) }

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -560,6 +560,12 @@ class DiscoveryProvider {
     return data
   }
 
+  async getUndisbursedChallenges (limit = null, offset = null, completedBlockNumber = null, encodedUserId = null) {
+    const req = Requests.getUndisbursedChallenges(limit, offset, completedBlockNumber, encodedUserId)
+    const res = await this._makeRequest(req)
+    return res.map(r => ({ ...r, amount: parseInt(r.amount) }))
+  }
+
   /* ------- INTERNAL FUNCTIONS ------- */
 
   /**
@@ -576,7 +582,7 @@ class DiscoveryProvider {
    * @memberof DiscoveryProvider
    */
   async _performRequestWithMonitoring (requestObj, discoveryProviderEndpoint) {
-    let axiosRequest = this._createDiscProvRequest(requestObj, discoveryProviderEndpoint)
+    const axiosRequest = this._createDiscProvRequest(requestObj, discoveryProviderEndpoint)
     let response
     let parsedResponse
 
@@ -726,6 +732,15 @@ class DiscoveryProvider {
    */
   _createDiscProvRequest (requestObj, discoveryProviderEndpoint) {
     let requestUrl
+
+    // Sanitize URL params if needed
+    if (requestObj.queryParams) {
+      Object.entries(requestObj.queryParams).forEach(([k, v]) => {
+        if (v === undefined || v === null) {
+          delete requestObj.queryParams[k]
+        }
+      })
+    }
 
     if (urlJoin && urlJoin.default) {
       requestUrl = urlJoin.default(discoveryProviderEndpoint, requestObj.endpoint, requestObj.urlParams, { query: requestObj.queryParams })

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -661,7 +661,7 @@ class DiscoveryProvider {
     try {
       parsedResponse = await this._performRequestWithMonitoring(requestObj, this.discoveryProviderEndpoint)
     } catch (e) {
-      const fullErrString = `Failed to make Discovery Provider request at attempt #${attemptedRetries}: ${JSON.stringify(e.message)}`
+      const fullErrString = `Failed to make Discovery Provider request at attempt #${attemptedRetries}, error ${JSON.stringify(e.message)}, request: ${JSON.stringify(requestObj)}`
       console.error(fullErrString)
       if (retry) {
         return this._makeRequest(requestObj, retry, attemptedRetries + 1)

--- a/libs/src/services/discoveryProvider/requests.js
+++ b/libs/src/services/discoveryProvider/requests.js
@@ -1,5 +1,5 @@
 module.exports.getUsers = (limit = 100, offset = 0, idsArray = null, walletAddress = null, handle = null, isCreator = null, minBlockNumber = null) => {
-  let req = {
+  const req = {
     endpoint: 'users',
     queryParams: { limit: limit, offset: offset }
   }
@@ -25,7 +25,7 @@ module.exports.getUsers = (limit = 100, offset = 0, idsArray = null, walletAddre
 }
 
 module.exports.getTracks = (limit = 100, offset = 0, idsArray = null, targetUserId = null, sort = null, minBlockNumber = null, filterDeleted = null, withUsers = false) => {
-  let req = { endpoint: 'tracks', queryParams: { limit: limit, offset: offset } }
+  const req = { endpoint: 'tracks', queryParams: { limit: limit, offset: offset } }
   if (idsArray) {
     if (!Array.isArray(idsArray)) {
       throw new Error('Expected array of track ids')
@@ -59,7 +59,7 @@ module.exports.getTracksByHandleAndSlug = (handle, slug) => {
 }
 
 module.exports.getTracksIncludingUnlisted = (identifiers, withUsers = false) => {
-  let req = {
+  const req = {
     endpoint: 'tracks_including_unlisted',
     method: 'post',
     data: {
@@ -74,7 +74,7 @@ module.exports.getTracksIncludingUnlisted = (identifiers, withUsers = false) => 
 }
 
 module.exports.getRandomTracks = (genre, limit, exclusionList, time) => {
-  let req = {
+  const req = {
     endpoint: 'tracks/random',
     queryParams: {
       genre,
@@ -414,6 +414,18 @@ module.exports.getCreateSenderAttestation = (senderEthAddress) => {
     endpoint: `/v1/challenges/attest_sender`,
     queryParams: {
       sender_eth_address: senderEthAddress
+    }
+  }
+}
+
+module.exports.getUndisbursedChallenges = (limit, offset, completedBlockNumber, encodedUserId) => {
+  return {
+    endpoint: '/v1/challenges/undisbursed',
+    queryParams: {
+      limit,
+      offset,
+      completed_blocknumber: completedBlockNumber,
+      user_id: encodedUserId
     }
   }
 }

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -105,7 +105,7 @@ class SolanaWeb3Manager {
     this.solanaTokenKey = newPublicKeyNullable(solanaTokenAddress)
 
     this.feePayerAddress = feePayerAddress
-    this.feePayerKey = newPublicKeyNullable(feePayerAddress)
+    this.feePayerKey = newPublicKeyNullable(feePayerAddress || feePayerKeypair.publicKey)
 
     this.claimableTokenProgramKey = newPublicKeyNullable(claimableTokenProgramAddress)
     this.claimableTokenPDA = claimableTokenPDA || (

--- a/libs/src/services/solanaWeb3Manager/rewards.js
+++ b/libs/src/services/solanaWeb3Manager/rewards.js
@@ -215,7 +215,7 @@ async function submitAttestations ({
   const encodedOracleMessage = SolanaUtils.constructAttestation(
     recipientEthAddress,
     tokenAmount,
-    transferId,
+    transferId
   )
 
   // Add instructions from oracle attestation
@@ -522,7 +522,6 @@ const generateSubmitAttestationInstruction = async ({
   )
 
   ///   Submit attestations
-  ///
   ///   0. `[writable]` Verified messages - New or existing account PDA storing verified messages
   ///   1. `[]` Reward manager
   ///   2. `[]` Reward manager authority

--- a/libs/src/services/solanaWeb3Manager/rewards.js
+++ b/libs/src/services/solanaWeb3Manager/rewards.js
@@ -212,6 +212,12 @@ async function submitAttestations ({
     }, [])
   )
 
+  const encodedOracleMessage = SolanaUtils.constructAttestation(
+    recipientEthAddress,
+    tokenAmount,
+    transferId,
+  )
+
   // Add instructions from oracle attestation
   const oracleSecp = await generateAttestationSecpInstruction({
     attestationMeta: oracleAttestation,
@@ -219,8 +225,9 @@ async function submitAttestations ({
     instructionIndex: instructions.length,
     tokenAmount,
     transferId,
-    encodedSenderMessage
+    encodedSenderMessage: encodedOracleMessage
   })
+
   const oracleTransfer = await generateSubmitAttestationInstruction({
     attestationMeta: oracleAttestation,
     derivedMessageAccount,
@@ -514,14 +521,16 @@ const generateSubmitAttestationInstruction = async ({
     rewardManagerAccount
   )
 
-  ///   Verify transfer signature
-  ///   0. `[writable]` New or existing account storing verified messages
+  ///   Submit attestations
+  ///
+  ///   0. `[writable]` Verified messages - New or existing account PDA storing verified messages
   ///   1. `[]` Reward manager
   ///   2. `[]` Reward manager authority
-  ///   3. `[]` fee payer
+  ///   3. `[signer]` Funder
   ///   4. `[]` Sender
-  ///   5. `[]` sysvar rent
-  ///   6. `[]` Sysvar instruction id
+  ///   5. `[]` Sysvar rent
+  ///   6. `[]` Instruction info
+  ///   7. `[]` System program id
   const verifyInstructionAccounts = [
     {
       pubkey: derivedMessageAccount,

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -272,7 +272,7 @@ class RewardsAttester {
     }
 
     // Handle error path
-    this.logger.error(`Failed to attest for challenge [${challengeId}] for user [${userId}], amount [${amount}] at phase: [${phase}] with error [${error}]`)
+    this.logger.error(`Failed to attest for challenge [${challengeId}] for user [${userId}], amount [${amount}], oracle: [${this.aaoAddress}] at phase: [${phase}] with error [${error}]`)
     await this.reporter.reportFailure({
       phase,
       error,

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -47,7 +47,7 @@ class RewardsAttester {
    *    maxRetries: number
    *    reporter: BaseRewardsReporter
    *    challengeIdsDenyList: Array<string>
-   * }} { 
+   * }} {
    *    libs,
    *    startingBlock,
    *    offset,
@@ -59,7 +59,7 @@ class RewardsAttester {
    *    updateValues = ({ startingBlock, offset, successCount }) => {},
    *    maxRetries = 3,
    *    reporter,
-   *    challengeIdsDenyList 
+   *    challengeIdsDenyList
    *  }
    * @memberof RewardsAttester
    */

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -1,0 +1,421 @@
+const { sampleSize } = require('lodash')
+const { SubmitAndEvaluateError } = require('../../api/rewards')
+
+// `BaseRewardsReporter` is intended to be subclassed, and provides
+// "reporting" functionality to RewardsAttester (i.e. posts to Slack if something notable happens)
+class BaseRewardsReporter {
+  async reportSuccess ({ userId, challengeId, amount }) {}
+
+  async reportFailure ({ userId, challengeId, amount, error, phase }) {}
+
+  async reportAAORejection ({ userId, challengeId, amount, error }) {}
+}
+
+/**
+ * `RewardsAttester` is responsible for repeatedly attesting for completed rewards.
+ *
+ * **Implementation**
+ *
+ * `RewardsAttester` attempts to attest for `parallelization` rewards in parallel.
+ * It won't move onto the next batch of rewards until every reward in that batch has
+ * either succeeded or failed attestation. It retries errors that might be due to DN
+ * timing issues, and skips AAO errors and some Solana program errors.
+ *
+ * Internally, state is tracked with two variables: `offset` and `startingBlock`.
+ * `startingBlock` represents which block it start requesting attestations from, while `offset` determines
+ * where within those results we offset. AAO rejected rewards
+ * are never cleared from the DN rewards queue, so we have to move past them either with `offset` or `startingBlock`.
+ * `RewardsAttester` accepts callbacks (`updateValues`) for a client to persist these values periodically.
+ *
+ * RewardsAttester will fetch a single large list of undisbursed rewards (`undisbursedQueue`), and
+ * process that entire list before fetching new undisbursed rewards. It also maintains a list of
+ * recently processed rewards, and filters those out when re-fetching new undisbursed rewards.
+ */
+class RewardsAttester {
+  /**
+   * Creates an instance of RewardsAttester.
+   * @param {{
+   *    libs
+   *    startingBlock: number
+   *    offset: number
+   *    parallelization: number
+   *    logger: any
+   *    quorumSize: number
+   *    aaoEndpoint: string
+   *    aaoAddress: string
+   *    updateValues: function
+   *    maxRetries: number
+   *    reporter: BaseRewardsReporter
+   *    challengeIdsDenyList: Array<string>
+   * }} { 
+   *    libs,
+   *    startingBlock,
+   *    offset,
+   *    parallelization,
+   *    logger,
+   *    quorumSize,
+   *    aaoEndpoint,
+   *    aaoAddress,
+   *    updateValues = ({ startingBlock, offset, successCount }) => {},
+   *    maxRetries = 3,
+   *    reporter,
+   *    challengeIdsDenyList 
+   *  }
+   * @memberof RewardsAttester
+   */
+  constructor ({ libs, startingBlock, offset, parallelization, logger, quorumSize, aaoEndpoint, aaoAddress, updateValues = () => {}, maxRetries = 3, reporter, challengeIdsDenyList }) {
+    this.libs = libs
+    this.logger = logger
+    this.parallelization = parallelization
+    this.startingBlock = startingBlock
+    this.offset = offset
+    this.quorumSize = quorumSize
+    this.aaoEndpoint = aaoEndpoint
+    this.aaoAddress = aaoAddress
+    this.reporter = reporter || new BaseRewardsReporter()
+    this.endpoints = []
+    this.maxRetries = maxRetries
+    this.updateValues = updateValues
+    this.challengeIdsDenyList = new Set(...challengeIdsDenyList)
+    // Stores a queue of undisbursed challenges
+    this.undisbursedQueue = []
+    // Stores a set of identifiers representing
+    // recently disbursed challenges.
+    this.recentlyDisbursedSet = new Set()
+    // How long wait wait before retrying
+    this.cooldownMsec = 1000
+    // How much we increase the cooldown between attempts:
+    // coolDown = min(cooldownMsec * backoffExponent ^ retryCount, maxCooldownMsec)
+    this.backoffExponent = 1.5
+    // Maximum time to wait before retrying
+    this.maxCooldownMsec = 10000
+    // Maximum number of retries before moving on
+    this.maxRetries = 5
+
+    this._performSingleAttestation = this._performSingleAttestation.bind(this)
+    this._disbursementToKey = this._disbursementToKey.bind(this)
+  }
+
+  /**
+   * Begin attestation loop.
+   *
+   * @memberof RewardsAttester
+   */
+  async start () {
+    this.logger.info(`Starting attester with:
+      quorum size: ${this.quorumSize}, \
+      parallelization: ${this.parallelization} \
+      AAO endpoint: ${this.aaoEndpoint} \
+      AAO address: ${this.aaoAddress}
+    `)
+    await this._selectDiscoveryNodes()
+
+    while (true) {
+      try {
+        await this._attestInParallel()
+      } catch (e) {
+        this.logger.error(`Got error: ${e}, sleeping`)
+        await this._delay(1000)
+      }
+    }
+  }
+
+  /**
+   * Main method to attest for a bucket of challenges in parallel.
+   *
+   * Algorithm:
+   * - Gets `this.parallelization` undisbursed challenges from the queue, refilling it from DN if necessary.
+   * - Call `_performSingleAttestation` on those in parallel.
+   * - For challenges that failed, either keep retrying or discard them, depending on the error.
+   * - Set offset and startingBlock
+   *
+   * @memberof RewardsAttester
+   */
+  async _attestInParallel () {
+    this.logger.info(`Attesting in parallel with startingBlock: ${this.startingBlock}, offset: ${this.offset}, parallelization: ${this.parallelization}`)
+
+    // Refill queue if necessary, returning early if error
+    const { error } = await this._refillQueueIfNecessary()
+    if (error) {
+      this.logger.error(`Got error trying to refill challenges: [${error}]`)
+      throw new Error(error)
+    }
+
+    // If queue is still empty, sleep and return
+    if (!this.undisbursedQueue.length) {
+      this.logger.info(`No undisbursed challenges. Sleeping...`)
+      await this._delay(1000)
+      return
+    }
+
+    // Get undisbursed rewards
+    let toAttest = this.undisbursedQueue.splice(0, this.parallelization)
+    const highestBlock = Math.max(...toAttest.map(e => e.completedBlocknumber))
+
+    // Attempt to attest in a single sweep
+    const results = await Promise.all(toAttest.map(this._performSingleAttestation))
+
+    // "Process" the results of attestation into noRetry and needsRetry errors,
+    // as well as a flag that indicates whether we should reselect.
+    let { successful, noRetry, needsRetry, shouldReselect } = await this._processResponses(results)
+    let successCount = successful.length
+
+    // Increment offset by the # of errors we're not retrying that have the max block #.
+    //
+    // Note: any successfully completed rewards will eventually be flushed from the
+    // disbursable queue on DN, but ignored rewards will stay stuck in that list, so we
+    // have to move past them with offset if they're not already moved past with `startingBlock`.
+    let offset = 0
+    offset += noRetry.filter(({ completedBlocknumber }) => completedBlocknumber === highestBlock).length
+
+    // Retry loop
+    let retryCount = 0
+    while (needsRetry.length && retryCount < this.maxRetries) {
+      await this._backoff(retryCount++)
+      if (shouldReselect) {
+        await this._selectDiscoveryNodes()
+      }
+      const res = await Promise.all(needsRetry.map(this._performSingleAttestation))
+      ;({ successful, needsRetry, noRetry, shouldReselect } = await this._processResponses(res))
+
+      offset += noRetry.filter(({ completedBlocknumber }) => completedBlocknumber === highestBlock).length
+      successCount += successful.length
+    }
+
+    if (retryCount === this.maxRetries) {
+      this.logger.error(`Gave up with ${retryCount} retries`)
+    }
+
+    // Set startingBlock and offset
+    this.startingBlock = highestBlock ? highestBlock - 1 : 0
+    this.offset = offset
+    this.logger.info(`Updating values: startingBlock: ${this.startingBlock}, offset: ${this.offset}`)
+
+    // Set the recently disbursed set
+    this.recentlyDisbursedSet = new Set(results.map(this._disbursementToKey))
+
+    // run the `updateValues` callback
+    await this.updateValues({ startingBlock: this.startingBlock, offset: this.offset, successCount })
+  }
+
+  /**
+   * @typedef {Object} AttestationResponse
+   * @property {string} challengeId
+   * @property {string} userId
+   * @property {string} specifier
+   * @property {number} amount
+   * @property {string} handle
+   * @property {string} wallet
+   * @property {number} completedBlocknumber
+   * @property {string?} error
+   * @property {string?} phase
+   */
+
+  /**
+   * Attempts to attest for a single challenge.
+   *
+   * @param {{
+   *     challengeId: string,
+   *     userId: string,
+   *     specifier: string,
+   *     amount: number,
+   *     handle: string,
+   *     wallet: string,
+   *     completedBlocknumber: number
+   * }} {
+   *     challengeId,
+   *     userId,
+   *     specifier,
+   *     amount,
+   *     handle,
+   *     wallet,
+   *     completedBlocknumber
+   *   }
+   * @return {Promise<AttestationResponse>}
+   * @memberof RewardsAttester
+   */
+  async _performSingleAttestation ({
+    challengeId,
+    userId,
+    specifier,
+    amount,
+    handle,
+    wallet,
+    completedBlocknumber
+  }) {
+    this.logger.info(`Attempting to attest for userId [${userId}], challengeId: [${challengeId}], quorum size: [${this.quorumSize}]`)
+    const { success, error, phase } = await this.libs.Rewards.submitAndEvaluate({
+      challengeId,
+      encodedUserId: userId,
+      handle,
+      recipientEthAddress: wallet,
+      specifier,
+      oracleEthAddress: this.aaoAddress,
+      amount,
+      quorumSize: this.quorumSize,
+      AAOEndpoint: this.aaoEndpoint,
+      endpoints: this.endpoints
+    })
+
+    if (success) {
+      this.logger.info(`Successfully attestested for challenge [${challengeId}] for user [${userId}], amount [${amount}]!`)
+      await this.reporter.reportSuccess({ userId, challengeId, amount })
+      return {
+        challengeId,
+        userId,
+        specifier,
+        amount,
+        handle,
+        wallet,
+        completedBlocknumber
+      }
+    }
+
+    // Handle error path
+    this.logger.error(`Failed to attest for challenge [${challengeId}] for user [${userId}], amount [${amount}] at phase: [${phase}] with error [${error}]`)
+    await this.reporter.reportFailure({
+      phase,
+      error,
+      amount,
+      userId,
+      challengeId
+    })
+
+    return {
+      challengeId,
+      userId,
+      specifier,
+      amount,
+      handle,
+      wallet,
+      completedBlocknumber,
+      error,
+      phase
+    }
+  }
+
+  async _selectDiscoveryNodes () {
+    this.logger.info(`Selecting discovery nodes`)
+    const endpoints = await this.libs.discoveryProvider.serviceSelector.findAll()
+    this.endpoints = sampleSize(endpoints, this.quorumSize)
+    this.logger.info(`Selected new discovery nodes: [${this.endpoints}]`)
+  }
+
+  /**
+   * Fetches new undisbursed rewards and inserts them into the undisbursedQueue
+   * if the queue is currently empty.
+   *
+   * @memberof RewardsAttester
+   */
+  async _refillQueueIfNecessary () {
+    if (this.undisbursedQueue.length) return {}
+
+    this.logger.info(`Refilling queue, recently disbursed: ${JSON.stringify(this.recentlyDisbursedSet)}`)
+    const { success: disbursable, error } = await this.libs.Rewards.getUndisbursedChallenges({ offset: this.offset, completedBlockNumber: this.startingBlock })
+
+    if (error) {
+      return { error }
+    }
+
+    // Map to camelCase, and filter out
+    // any challenges in the denylist or recently disbursed set
+    this.undisbursedQueue = disbursable
+      .map(({
+        challenge_id, // eslint-disable-line
+        user_id, // eslint-disable-line
+        specifier,
+        amount,
+        handle,
+        wallet,
+        completed_blocknumber // eslint-disable-line
+      }) => ({
+        challengeId: challenge_id,
+        userId: user_id,
+        specifier,
+        amount,
+        handle,
+        wallet,
+        completedBlocknumber: completed_blocknumber
+      }))
+      .filter(d => !(this.challengeIdsDenyList.has(d.challengeId) || this.recentlyDisbursedSet.has(this._disbursementToKey(d))))
+
+    this.logger.info(`Got ${disbursable.length} undisbursed challenges${this.undisbursedQueue.length !== disbursable.length ? `, filtered out [${disbursable.length - this.undisbursedQueue.length}] recently disbursed challenges.` : '.'}`)
+    return {}
+  }
+
+  /**
+   * Processes responses from `_performSingleAttestation`,
+   * bucketing errors into those that need retry and those that should be skipped.
+   *
+   * @param {Array<AttestationResponse>} responses
+   * @return {{
+   *    successful: Array<AttestationResponse>,
+   *    noRetry: Array<AttestationResponse>,
+   *    needsRetry: Array<AttestationResponse>,
+   *    shouldReslect: boolean
+   * }}
+   * @memberof RewardsAttester
+   */
+  async _processResponses (responses) {
+    const errors = SubmitAndEvaluateError
+    const AAO_ERRORS = new Set([errors.HCAPTCHA, errors.COGNITO_FLOW, errors.BLOCKED])
+    const NEEDS_RESELECT_ERRORS = new Set([errors.INSUFFICIENT_DISCOVERY_NODE_COUNT, errors.CHALLENGE_INCOMPLETE])
+    // Account for errors from DN aggregation + Solana program
+    const NO_RETRY_ERRORS = new Set([errors.ALREADY_DISBURSED, errors.ALREADY_SENT])
+
+    const noRetry = []
+    const successful = []
+    // Filter down to errors needing retry
+    let needsRetry = (responses
+      // Filter our successful responses
+      .filter((res) => {
+        if (!res.error) {
+          successful.push(res)
+          return false
+        }
+        return true
+      })
+      // Filter out responses that are already disbursed
+      .filter(({ error }) => !NO_RETRY_ERRORS.has(error))
+      // Handle any AAO errors - report them and then exclude them from result set
+      .filter((res) => {
+        const isAAO = AAO_ERRORS.has(res.error)
+        if (isAAO) {
+          this.reporter.reportAAORejection({ userId: res.userId, challengeId: res.challengeId, amount: res.amount, error: res.error })
+          noRetry.push(res)
+        }
+        return !isAAO
+      })
+    )
+
+    if (needsRetry.length) {
+      this.logger.info(`Handling errors: ${JSON.stringify(needsRetry.map(({ error, phase }) => ({ error, phase })))}`)
+    }
+
+    // Reselect if necessary
+    const shouldReselect = needsRetry.some(({ error }) => NEEDS_RESELECT_ERRORS.has(error))
+
+    return {
+      successful,
+      noRetry,
+      needsRetry,
+      shouldReselect
+    }
+  }
+
+  _disbursementToKey ({ challengeId, userId }) {
+    return `${challengeId}_${userId}`
+  }
+
+  async _backoff (retryCount) {
+    const backoff = Math.min(this.cooldownMsec * Math.pow(this.backoffExponent, retryCount), this.maxCooldownMsec)
+    this.logger.info(`Waiting [${backoff}] msec`)
+    return this._delay(backoff)
+  }
+
+  async _delay (waitTime) {
+    return new Promise(resolve => setTimeout(resolve, waitTime))
+  }
+}
+
+module.exports = RewardsAttester

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -53,7 +53,7 @@ class TransactionHandler {
     } else {
       result = await this._locallyConfirmTransaction(instructions)
     }
-    if (result.errorCode !== null && errorMapping) {
+    if (result.error && result.errorCode !== null && errorMapping) {
       result.errorCode = errorMapping.fromErrorCode(result.errorCode)
     }
     return result
@@ -73,7 +73,8 @@ class TransactionHandler {
       const response = await this.identityService.solanaRelay(transactionData)
       return { res: response, error: null, errorCode: null }
     } catch (e) {
-      const { errorCode, error } = e.response.data
+      const { error } = e.response.data
+      const errorCode = this._parseSolanaErrorCode(error)
       return { res: null, error, errorCode }
     }
   }

--- a/libs/src/services/solanaWeb3Manager/utils.js
+++ b/libs/src/services/solanaWeb3Manager/utils.js
@@ -103,7 +103,7 @@ class SolanaUtils {
    * @returns {Promise<[PublicKey, number]>}
    */
   static async findProgramAddressFromPubkey (programId, pubkey, seed) {
-    let seedsArr = [pubkey.toBytes().slice(0, 32)]
+    const seedsArr = [pubkey.toBytes().slice(0, 32)]
     if (seed) {
       seedsArr.push(seed)
     }

--- a/service-commands/scripts/hosts.js
+++ b/service-commands/scripts/hosts.js
@@ -42,7 +42,8 @@ const SERVICES = [
   'cn-um_creator-node_1',
   'audius_ganache_cli',
   'audius_client',
-  'audius-identity-service_identity-service_1'
+  'audius-identity-service_identity-service_1',
+  'solana'
 ]
 
 const exitWithError = () => {

--- a/service-commands/src/commands/seed/SeedSession.js
+++ b/service-commands/src/commands/seed/SeedSession.js
@@ -92,9 +92,10 @@ class SeedSession {
     try {
       signUpResponse = await this.libs.Account.signUp(email, password, metadata, profilePictureFile, coverPhotoFile, hasWallet, host, createWAudioUserBank)
     } catch (error) {
-      console.log(error, signUpResponse)
+      console.error(error, signUpResponse)
     }
     if (signUpResponse.error) {
+      console.error(`Got signup error: ${signUpResponse.error} at phase: ${signUpResponse.phase}`)
       throw new Error(signUpResponse.error)
     } else {
       const hedgehogEntropyKey = this.localstorage.getUserEntropy()

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -240,6 +240,7 @@
       "if [[ -z \"$AAO_DIR\" ]]; then echo \"!!!ERROR: need to set AAO_DIR\"; exit 1; fi",
       "echo 'Starting AAO...'",
       "cd $AAO_DIR; ./scripts/configureLocal.sh; docker-compose -f docker-compose-dev.yml up -d",
+      "cp ~/.audius/aao-config.json $PROTOCOL_DIR/identity-service",
       "sleep 5",
       "echo 'AAO Started'"
     ],

--- a/service-commands/src/utils/constants.js
+++ b/service-commands/src/utils/constants.js
@@ -46,7 +46,7 @@ const config = {
     SOLANA_REWARDS_MANAGER_PROGRAM_ID: solanaConfig.rewardsManagerAddress,
     SOLANA_REWARDS_MANAGER_PROGRAM_PDA: solanaConfig.rewardsManagerAccount,
     SOLANA_REWARDS_MANAGER_TOKEN_PDA: solanaConfig.rewardsManagerTokenAccount,
-    SOLANA_FEE_PAYER_SECRET_KEY: Uint8Array.from(solanaConfig.feePayerWallet)
+    SOLANA_FEE_PAYER_SECRET_KEY: solanaConfig.feePayerWallet ? Uint8Array.from(solanaConfig.feePayerWallet) : undefined 
 }
 
 module.exports = config

--- a/service-commands/src/utils/constants.js
+++ b/service-commands/src/utils/constants.js
@@ -2,11 +2,10 @@ const os = require('os')
 const fs = require('fs')
 const SERVICE_COMMANDS_PATH = `${process.env.PROTOCOL_DIR}/service-commands`
 
-const dotenv = require('dotenv').config({
+require('dotenv').config({
     path: `${SERVICE_COMMANDS_PATH}/.env.dev`
 })
 
-const ETH_PROVIDER_ENDPOINT = process.env.ETH_PROVIDER_ENDPOINT
 
 const DOT_AUDIUS_PATH = `${os.homedir()}/.audius`
 
@@ -15,51 +14,39 @@ let dataContractsConfig
 if (fs.existsSync(`${DOT_AUDIUS_PATH}`)) {
     ethContractsConfig = require(`${DOT_AUDIUS_PATH}/eth-config.json`)
     dataContractsConfig = require(`${DOT_AUDIUS_PATH}/config.json`)
+    solanaConfig = require(`${DOT_AUDIUS_PATH}/solana-program-config.json`)
 } else {
     ethContractsConfig = {}
     dataContractsConfig = {}
+    solanaConfig = {}
 }
 
-const ETH_REGISTRY_ADDRESS = process.env.ETH_REGISTRY_ADDRESS || ethContractsConfig.registryAddress
-
-const ETH_TOKEN_ADDRESS = process.env.ETH_TOKEN_ADDRESS || ethContractsConfig.audiusTokenAddress
-
-const ETH_OWNER_WALLET = process.env.ETH_OWNER_WALLET || ethContractsConfig.ownerWallet
-
-const DATA_CONTRACTS_REGISTRY_ADDRESS = process.env.DATA_CONTRACTS_REGISTRY_ADDRESS || dataContractsConfig.registryAddress
-
-const HEDGEHOG_ENTROPY_KEY = 'hedgehog-entropy-key'
-
-const SEED_CACHE_PATH = `${DOT_AUDIUS_PATH}/seed-cache.json`
-
-const TEMP_TRACK_STORAGE_PATH = `${SERVICE_COMMANDS_PATH}/local-storage/tmp-tracks`
-
-const TEMP_IMAGE_STORAGE_PATH = `${SERVICE_COMMANDS_PATH}/local-storage/tmp-imgs`
-
-const CONTENT_NODE_ALLOWLIST = process.env.CONTENT_NODE_ALLOWLIST
-    ? new Set(process.env.CONTENT_NODE_ALLOWLIST.split(','))
-    : undefined
-
-const DATA_CONTRACTS_PROVIDER_ENDPOINTS = [process.env.DATA_CONTRACTS_PROVIDER_ENDPOINT]
-
-const USER_METADATA_ENDPOINT = process.env.USER_METADATA_ENDPOINT
-
-const IDENTITY_SERVICE_ENDPOINT = process.env.IDENTITY_SERVICE_ENDPOINT
-
-module.exports = {
+const config = {
     DOT_AUDIUS_PATH,
-    HEDGEHOG_ENTROPY_KEY,
-    SEED_CACHE_PATH,
     SERVICE_COMMANDS_PATH,
-    TEMP_IMAGE_STORAGE_PATH,
-    TEMP_TRACK_STORAGE_PATH,
-    ETH_REGISTRY_ADDRESS,
-    ETH_TOKEN_ADDRESS,
-    ETH_OWNER_WALLET,
-    DATA_CONTRACTS_REGISTRY_ADDRESS,
-    ETH_PROVIDER_ENDPOINT,
-    CONTENT_NODE_ALLOWLIST,
-    DATA_CONTRACTS_PROVIDER_ENDPOINTS,
-    USER_METADATA_ENDPOINT,
-    IDENTITY_SERVICE_ENDPOINT
+    ETH_PROVIDER_ENDPOINT: process.env.ETH_PROVIDER_ENDPOINT,
+    ETH_REGISTRY_ADDRESS: process.env.ETH_REGISTRY_ADDRESS || ethContractsConfig.registryAddress,
+    ETH_TOKEN_ADDRESS: process.env.ETH_TOKEN_ADDRESS || ethContractsConfig.audiusTokenAddress,
+    ETH_OWNER_WALLET: process.env.ETH_OWNER_WALLET || ethContractsConfig.ownerWallet,
+    DATA_CONTRACTS_REGISTRY_ADDRESS: process.env.DATA_CONTRACTS_REGISTRY_ADDRESS || dataContractsConfig.registryAddress,
+    HEDGEHOG_ENTROPY_KEY: 'hedgehog-entropy-key',
+    SEED_CACHE_PATH: `${DOT_AUDIUS_PATH}/seed-cache.json`,
+    TEMP_TRACK_STORAGE_PATH: `${SERVICE_COMMANDS_PATH}/local-storage/tmp-tracks`,
+    TEMP_IMAGE_STORAGE_PATH:  `${SERVICE_COMMANDS_PATH}/local-storage/tmp-imgs`,
+    CONTENT_NODE_ALLOWLIST:  process.env.CONTENT_NODE_ALLOWLIST
+        ? new Set(process.env.CONTENT_NODE_ALLOWLIST.split(','))
+        : undefined,
+    DATA_CONTRACTS_PROVIDER_ENDPOINTS:  [process.env.DATA_CONTRACTS_PROVIDER_ENDPOINT],
+    USER_METADATA_ENDPOINT: process.env.USER_METADATA_ENDPOINT,
+    IDENTITY_SERVICE_ENDPOINT:  process.env.IDENTITY_SERVICE_ENDPOINT,
+    SOLANA_ENDPOINT: solanaConfig.endpoint,
+    SOLANA_MINT_ADDRESS: solanaConfig.splToken,
+    SOLANA_TOKEN_ADDRESS: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    SOLANA_CLAIMABLE_TOKEN_PROGRAM_ADDRESS: solanaConfig.claimableTokenAddress,
+    SOLANA_REWARDS_MANAGER_PROGRAM_ID: solanaConfig.rewardsManagerAddress,
+    SOLANA_REWARDS_MANAGER_PROGRAM_PDA: solanaConfig.rewardsManagerAccount,
+    SOLANA_REWARDS_MANAGER_TOKEN_PDA: solanaConfig.rewardsManagerTokenAccount,
+    SOLANA_FEE_PAYER_SECRET_KEY: Uint8Array.from(solanaConfig.feePayerWallet)
 }
+
+module.exports = config

--- a/service-commands/src/utils/seed.js
+++ b/service-commands/src/utils/seed.js
@@ -12,7 +12,15 @@ const {
   DATA_CONTRACTS_PROVIDER_ENDPOINTS,
   USER_METADATA_ENDPOINT,
   IDENTITY_SERVICE_ENDPOINT,
-  ETH_PROVIDER_ENDPOINT
+  ETH_PROVIDER_ENDPOINT,
+  SOLANA_ENDPOINT,
+  SOLANA_MINT_ADDRESS,
+  SOLANA_TOKEN_ADDRESS,
+  SOLANA_CLAIMABLE_TOKEN_PROGRAM_ADDRESS,
+  SOLANA_REWARDS_MANAGER_PROGRAM_ID,
+  SOLANA_REWARDS_MANAGER_PROGRAM_PDA,
+  SOLANA_REWARDS_MANAGER_TOKEN_PDA,
+  SOLANA_FEE_PAYER_SECRET_KEY,
 } = require('./constants')
 
 const {
@@ -46,6 +54,17 @@ const getLibsConfig = overrideConfig => {
       IDENTITY_SERVICE_ENDPOINT,
       useHedgehogLocalStorage
     ),
+    solanaWeb3Config: AudiusLibs.configSolanaWeb3({
+      solanaClusterEndpoint: SOLANA_ENDPOINT,
+      mintAddress: SOLANA_MINT_ADDRESS,
+      solanaTokenAddress: SOLANA_TOKEN_ADDRESS,
+      claimableTokenProgramAddress: SOLANA_CLAIMABLE_TOKEN_PROGRAM_ADDRESS,
+      rewardsManagerProgramId: SOLANA_REWARDS_MANAGER_PROGRAM_ID,
+      rewardsManagerProgramPDA: SOLANA_REWARDS_MANAGER_PROGRAM_PDA,
+      rewardsManagerTokenPDA: SOLANA_REWARDS_MANAGER_TOKEN_PDA,
+      useRelay: false,
+      feePayerSecretKey: SOLANA_FEE_PAYER_SECRET_KEY,
+    }),
     isServer: true,
     enableUserReplicaSetManagerContract: true,
     useTrackContentPolling: true


### PR DESCRIPTION
### Description

**💡 Please review commit by commit!**

This has all of the changes for rewards attestation in identity. 

@csjiang you won't have context on most of this, but I included service command fixes if you want to take a look at those

### Tests

Tested extensively locally. You can test it by bringing a stack up and then running seed-cli commands like:

```
node ./scripts/seed.js create-user --count 2
docker exec --user postgres:postgres dn1_discovery-provider-db_1 psql -d audius_discovery --echo-queries --command='update user_challenges set is_complete = true, current_step_count=7, completed_blocknumber=user_challenges.user_id;'
docker exec --user postgres:postgres dn3_discovery-provider-db_1 psql -d audius_discovery --echo-queries --command='update user_challenges set is_complete = true, current_step_count=7, completed_blocknumber=user_challenges.user_id;'
```

### How will this change be monitored?

- New healthcheck endpoint. Needs to be wired up to pingdom.
- Added skeleton functionality to update slack/amplitude/etc. Needs to be fleshed out in the future

