### PR TITLE
Add script to transfer community rewards to solana

### DIFF
--- a/libs/eth-contracts/ABIs/EthRewardsManager.json
+++ b/libs/eth-contracts/ABIs/EthRewardsManager.json
@@ -3,6 +3,15 @@
   "abi": [
     {
       "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
       "inputs": [
         {
           "internalType": "address",
@@ -30,15 +39,6 @@
           "type": "address[]"
         }
       ],
-      "name": "initialize",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [],
       "name": "initialize",
       "outputs": [],
       "payable": false,
@@ -93,6 +93,11 @@
     {
       "constant": false,
       "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "arbiterFee",
+          "type": "uint256"
+        },
         {
           "internalType": "uint32",
           "name": "_nonce",

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1584,6 +1584,11 @@
         "browser-headers": "^0.4.1"
       }
     },
+    "@improbable-eng/grpc-web-node-http-transport": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.15.0.tgz",
+      "integrity": "sha512-HLgJfVolGGpjc9DWPhmMmXJx8YGzkek7jcCFO1YYkSOoO81MWRZentPOd/JiKiZuU08wtc4BG+WNuGzsQB5jZA=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/libs/package.json
+++ b/libs/package.json
@@ -22,6 +22,7 @@
     "@audius/hedgehog": "1.0.12",
     "@certusone/wormhole-sdk": "0.1.1",
     "@ethersproject/solidity": "5.0.5",
+    "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
     "@solana/spl-token": "0.1.6",
     "@solana/web3.js": "1.24.1",
     "abi-decoder": "1.2.0",

--- a/libs/scripts/communityRewards/transferCommunityRewardsToSolana.js
+++ b/libs/scripts/communityRewards/transferCommunityRewardsToSolana.js
@@ -1,0 +1,209 @@
+/*
+Script that has no internal dependencies outside of web3, solanaWeb3, certusOne SDK to initialize and transfer
+*/
+
+const axios = require('axios')
+const Web3 = require('web3')
+const solanaWeb3 = require('@solana/web3.js')
+const { Keypair } = solanaWeb3
+const requireESM = require("esm")(module)
+const {
+  getSignedVAA,
+  getEmitterAddressEth,
+  parseSequenceFromLogEth,
+  redeemOnSolana,
+  postVaaSolana,
+  CHAIN_ID_ETH
+} = requireESM('@certusone/wormhole-sdk')
+const EthRewardManagerABI = require('../../eth-contracts/ABIs/EthRewardsManager.json').abi
+
+const { grpc } = require("@improbable-eng/grpc-web")
+const { NodeHttpTransport } = require("@improbable-eng/grpc-web-node-http-transport")
+
+// Without this, we get the error:
+// "This environment's XHR implementation cannot support binary transfer."
+grpc.setDefaultTransport(NodeHttpTransport());
+
+const ETH_PROVIDER = 'https://mainnet.infura.io/v3/a3ed533ddfca4c76ab4df7556e2745e1'
+const SOLANA_CLUSTER_ENDPOINT = 'https://api.mainnet-beta.solana.com'
+const ETH_BRIDGE_ADDRESS = '0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B'
+const SOL_BRIDGE_ADDRESS = 'worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth'
+const ETH_TOKEN_BRIDGE_ADDRESS = '0x3ee18B2214AFF97000D974cf647E7C347E8fa585'
+const SOL_TOKEN_BRIDGE_ADDRESS = 'wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb'
+const WAUDIO_MINT_ADDRESS = 'BCD75RNBHrJJpW4dXVagL5mPjzRLnVZq4YirJdjEYMV7'
+
+// https://github.com/certusone/wormhole/blob/7f5740754b8d722c42310be086dc21efa7ed8c83/bridge_ui/src/utils/consts.ts#L150
+const WORMHOLE_RPC_HOSTS = [
+  "https://wormhole-v2-mainnet-api.certus.one",
+  "https://wormhole.inotel.ro",
+  "https://wormhole-v2-mainnet-api.mcf.rocks",
+  "https://wormhole-v2-mainnet-api.chainlayer.network",
+  "https://wormhole-v2-mainnet-api.staking.fund",
+  "https://wormhole-v2-mainnet-api.chainlayer.network",
+]
+
+// num attempts and delay between attempts to find transaction receipt
+const NUM_RETRIES_RECEIPT = 5
+const RETRY_DELAY_MS_RECEIPT = 1000
+
+// num attempts and delay between attempts to find requested VAA
+// stop if not found after 5 minutes (60 * 5000ms)
+const NUM_RETRIES_VAA = 60
+const RETRY_DELAY_MS_VAA = 5000
+
+const ETH_REWARD_MANAGER_ADDRESS = '0xF9B0871d3A8dc365f6231653f7D879c9578ED039'
+const TEST_PRIVATE_KEY = process.env.testPrivateKey
+const FEE_PAYER_SECRET_KEY = process.env.feePayerAddress
+
+const feePayerSecretKey = Uint8Array.from(JSON.parse(FEE_PAYER_SECRET_KEY))
+const feePayerKeypair = Keypair.fromSecretKey(feePayerSecretKey)
+const feePayerPublicKey = feePayerKeypair.publicKey
+const feePayerAddress = feePayerPublicKey.toString()
+
+const web3 = new Web3(ETH_PROVIDER)
+const ethAccount = web3.eth.accounts.wallet.add(TEST_PRIVATE_KEY)
+
+const arbiterFee = 0
+const nonce = 2 // this is just some random number atm
+
+async function getGasPrice() {
+  try {
+    const gasPrices = await axios.get(
+      'https://ethgasstation.info/json/ethgasAPI.json'
+    )
+    return web3.utils.toWei((gasPrices.data.fastest / 10).toString(), 'gwei')
+  } catch (err) {
+    console.error(
+      `Got ${err} when trying to fetch gas from ethgasstation.info, falling back web3's gas estimation`
+    )
+    return (await web3.eth.getGasPrice()).toString()
+  }
+}
+
+// "Fetch the signedVAA from the Wormhole Network (this may require retries while you wait for confirmation)"
+// https://github.com/certusone/wormhole/blob/c824a996360103eb2147bc43f7b0f7e3b989bdf5/sdk/js/src/rpc/getSignedVAAWithRetry.ts#L3
+const getSignedVAAWithRetry = async function (
+  hosts,
+  emitterChain,
+  emitterAddress,
+  sequence,
+  extraGrpcOpts = {},
+  retryTimeout = RETRY_DELAY_MS_VAA,
+  retryAttempts = NUM_RETRIES_VAA
+) {
+  let currentWormholeRpcHost = -1;
+  const getNextRpcHost = () => ++currentWormholeRpcHost % hosts.length;
+  let result;
+  let attempts = 0;
+  while (!result) {
+    attempts++;
+    console.log(`transferCommunityRewardsToSolana.js | getSignedVAAWithRetry | attempt # ${attempts}`)
+    await new Promise((resolve) => setTimeout(resolve, retryTimeout));
+    try {
+      result = await getSignedVAA(
+        hosts[getNextRpcHost()],
+        emitterChain,
+        emitterAddress,
+        sequence,
+        extraGrpcOpts
+      );
+    } catch (e) {
+      if (retryAttempts !== undefined && attempts >= retryAttempts) {
+        throw e;
+      }
+    }
+  }
+  return result;
+}
+
+const getReceipt = async (txHash, numRetries) => {
+  console.log(`transferCommunityRewardsToSolana.js | getReceipt | txHash ${txHash} | ${numRetries} retries left`)
+  if (numRetries <= 0) {
+    return null
+  }
+  const txReceipt = await web3.eth.getTransactionReceipt(txHash)
+  if (!txReceipt) {
+    await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS_RECEIPT))
+    return getReceipt(numRetries - 1)
+  }
+  return txReceipt
+}
+
+async function run() {
+  try {
+    const ethRewardsManagerContract = new web3.eth.Contract(
+      EthRewardManagerABI,
+      ETH_REWARD_MANAGER_ADDRESS
+    )
+    const gasPrice = await getGasPrice()
+    console.log({ gasPrice })
+
+    const txResp = await ethRewardsManagerContract.methods.transferToSolana(
+      arbiterFee,
+      nonce
+    ).send({
+      from: ethAccount.address,
+      gas: 200000, // should this be dynamic?
+      gasPrice
+    })
+    console.log({ txResp })
+
+    const txHash = txResp.transactionHash
+    console.log({ txHash })
+
+    const txReceipt = await getReceipt(txHash, NUM_RETRIES_RECEIPT)
+    console.log({ txReceipt })
+    if (!txReceipt) {
+      return
+    }
+
+    const connection = new solanaWeb3.Connection(SOLANA_CLUSTER_ENDPOINT)
+
+    const sequence = parseSequenceFromLogEth(txReceipt, ETH_BRIDGE_ADDRESS)
+    const emitterAddress = getEmitterAddressEth(ETH_TOKEN_BRIDGE_ADDRESS)
+    console.log({ sequence, emitterAddress })
+
+    const { vaaBytes } = await getSignedVAAWithRetry(
+      WORMHOLE_RPC_HOSTS,
+      CHAIN_ID_ETH,
+      emitterAddress,
+      sequence
+    )
+    console.log({ vaaBytes })
+
+    const signTransaction = async (transaction) => {
+      transaction.partialSign(feePayerKeypair);
+      return transaction;
+    }
+
+    await postVaaSolana(
+      connection,
+      signTransaction,
+      SOL_BRIDGE_ADDRESS,
+      feePayerAddress,
+      vaaBytes
+    );
+
+    const transaction = await redeemOnSolana(
+      connection,
+      SOL_BRIDGE_ADDRESS,
+      SOL_TOKEN_BRIDGE_ADDRESS,
+      feePayerAddress,
+      vaaBytes,
+      /* isSolanaNative */ false, // todo: is this correct?
+      /* mintAddress */ WAUDIO_MINT_ADDRESS
+    );
+    console.log({ transaction })
+    const signed = await signTransaction(transaction);
+    console.log({ signed })
+    const txid = await connection.sendRawTransaction(signed.serialize());
+    console.log({ txid })
+    await connection.confirmTransaction(txid);
+    console.log('Success!')
+  } catch (e) {
+    console.error(e)
+    console.log(`Error: ${e.message}`)
+  }
+}
+
+run()

--- a/libs/scripts/communityRewards/transferCommunityRewardsToSolana.js
+++ b/libs/scripts/communityRewards/transferCommunityRewardsToSolana.js
@@ -6,7 +6,7 @@ const axios = require('axios')
 const Web3 = require('web3')
 const solanaWeb3 = require('@solana/web3.js')
 const { Keypair } = solanaWeb3
-const requireESM = require("esm")(module)
+const requireESM = require('esm')(module)
 const {
   getSignedVAA,
   getEmitterAddressEth,
@@ -17,12 +17,12 @@ const {
 } = requireESM('@certusone/wormhole-sdk')
 const EthRewardManagerABI = require('../../eth-contracts/ABIs/EthRewardsManager.json').abi
 
-const { grpc } = require("@improbable-eng/grpc-web")
-const { NodeHttpTransport } = require("@improbable-eng/grpc-web-node-http-transport")
+const { grpc } = require('@improbable-eng/grpc-web')
+const { NodeHttpTransport } = require('@improbable-eng/grpc-web-node-http-transport')
 
 // Without this, we get the error:
 // "This environment's XHR implementation cannot support binary transfer."
-grpc.setDefaultTransport(NodeHttpTransport());
+grpc.setDefaultTransport(NodeHttpTransport())
 
 const ETH_PROVIDER = 'https://mainnet.infura.io/v3/a3ed533ddfca4c76ab4df7556e2745e1'
 const SOLANA_CLUSTER_ENDPOINT = 'https://api.mainnet-beta.solana.com'
@@ -34,12 +34,12 @@ const WAUDIO_MINT_ADDRESS = 'BCD75RNBHrJJpW4dXVagL5mPjzRLnVZq4YirJdjEYMV7'
 
 // https://github.com/certusone/wormhole/blob/7f5740754b8d722c42310be086dc21efa7ed8c83/bridge_ui/src/utils/consts.ts#L150
 const WORMHOLE_RPC_HOSTS = [
-  "https://wormhole-v2-mainnet-api.certus.one",
-  "https://wormhole.inotel.ro",
-  "https://wormhole-v2-mainnet-api.mcf.rocks",
-  "https://wormhole-v2-mainnet-api.chainlayer.network",
-  "https://wormhole-v2-mainnet-api.staking.fund",
-  "https://wormhole-v2-mainnet-api.chainlayer.network",
+  'https://wormhole-v2-mainnet-api.certus.one',
+  'https://wormhole.inotel.ro',
+  'https://wormhole-v2-mainnet-api.mcf.rocks',
+  'https://wormhole-v2-mainnet-api.chainlayer.network',
+  'https://wormhole-v2-mainnet-api.staking.fund',
+  'https://wormhole-v2-mainnet-api.chainlayer.network'
 ]
 
 // num attempts and delay between attempts to find transaction receipt
@@ -66,7 +66,7 @@ const ethAccount = web3.eth.accounts.wallet.add(TEST_PRIVATE_KEY)
 const arbiterFee = 0
 const nonce = 2 // this is just some random number atm
 
-async function getGasPrice() {
+async function getGasPrice () {
   try {
     const gasPrices = await axios.get(
       'https://ethgasstation.info/json/ethgasAPI.json'
@@ -91,14 +91,14 @@ const getSignedVAAWithRetry = async function (
   retryTimeout = RETRY_DELAY_MS_VAA,
   retryAttempts = NUM_RETRIES_VAA
 ) {
-  let currentWormholeRpcHost = -1;
-  const getNextRpcHost = () => ++currentWormholeRpcHost % hosts.length;
-  let result;
-  let attempts = 0;
+  let currentWormholeRpcHost = -1
+  const getNextRpcHost = () => ++currentWormholeRpcHost % hosts.length
+  let result
+  let attempts = 0
   while (!result) {
-    attempts++;
+    attempts++
     console.log(`transferCommunityRewardsToSolana.js | getSignedVAAWithRetry | attempt # ${attempts}`)
-    await new Promise((resolve) => setTimeout(resolve, retryTimeout));
+    await new Promise((resolve) => setTimeout(resolve, retryTimeout))
     try {
       result = await getSignedVAA(
         hosts[getNextRpcHost()],
@@ -106,14 +106,14 @@ const getSignedVAAWithRetry = async function (
         emitterAddress,
         sequence,
         extraGrpcOpts
-      );
+      )
     } catch (e) {
       if (retryAttempts !== undefined && attempts >= retryAttempts) {
-        throw e;
+        throw e
       }
     }
   }
-  return result;
+  return result
 }
 
 const getReceipt = async (txHash, numRetries) => {
@@ -129,7 +129,7 @@ const getReceipt = async (txHash, numRetries) => {
   return txReceipt
 }
 
-async function run() {
+async function run () {
   try {
     const ethRewardsManagerContract = new web3.eth.Contract(
       EthRewardManagerABI,
@@ -172,8 +172,8 @@ async function run() {
     console.log({ vaaBytes })
 
     const signTransaction = async (transaction) => {
-      transaction.partialSign(feePayerKeypair);
-      return transaction;
+      transaction.partialSign(feePayerKeypair)
+      return transaction
     }
 
     await postVaaSolana(
@@ -182,7 +182,7 @@ async function run() {
       SOL_BRIDGE_ADDRESS,
       feePayerAddress,
       vaaBytes
-    );
+    )
 
     const transaction = await redeemOnSolana(
       connection,
@@ -192,13 +192,13 @@ async function run() {
       vaaBytes,
       /* isSolanaNative */ false, // todo: is this correct?
       /* mintAddress */ WAUDIO_MINT_ADDRESS
-    );
+    )
     console.log({ transaction })
-    const signed = await signTransaction(transaction);
+    const signed = await signTransaction(transaction)
     console.log({ signed })
-    const txid = await connection.sendRawTransaction(signed.serialize());
+    const txid = await connection.sendRawTransaction(signed.serialize())
     console.log({ txid })
-    await connection.confirmTransaction(txid);
+    await connection.confirmTransaction(txid)
     console.log('Success!')
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Add script to transfer community rewards to solana.
Also updates the eth rewards manager abi.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Manual testing with env var private keys set for:
- eth account responsible for transferring to solana
- fee payer

Executed script by `cd`ing into libs and running `node scripts/communityRewards/transferCommunityRewardsToSolana.js` after having set the `testPrivateKey` and `feePayerAddress` env vars

e.g. results:
for this eth transaction https://etherscan.io/tx/0x9b290ac6db60371227573fcb76b325b63abaace091a1908b441713ee2c5df5c9
we ended up with this solana transaction https://explorer.solana.com/tx/pTH4cSSLJMXQ89bC7JyUrVfPom21kpUFRrN7zGQzAS12QvBCZbJ2vjhh6rRq2PtyjLqgL3Jb31DjJ4nqpZspGaz

fyi the getSignedVAAWithRetry takes about 2 minutes to get a successful attempt

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->