### PR TITLE
Fix circ dep for utils in libs

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -7,7 +7,8 @@
     "fs": false,
     "node-localstorage": false,
     "crypto": false,
-    "web3": false
+    "web3": false,
+    "esm": false
   },
   "scripts": {
     "test": "./scripts/test.sh",

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -15,7 +15,7 @@ const AudiusABIDecoder = require('./services/ABIDecoder/index')
 const SchemaValidator = require('./services/schemaValidator')
 const UserStateManager = require('./userStateManager')
 const SanityChecks = require('./sanityChecks')
-const Utils = require('./utils.js')
+const Utils = require('./utils')
 const Captcha = Utils.Captcha
 
 const Account = require('./api/account')

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -2,27 +2,14 @@ const bs58 = require('bs58')
 const { toBuffer } = require('ethereumjs-util')
 const { zeroPad } = require('ethers/lib/utils')
 const { providers } = require('ethers/lib/index')
-const requireESM = require('esm')(module)
 
 const SolanaUtils = require('../solanaWeb3Manager/utils')
 const Utils = require('../../utils')
 const { wAudioFromWeiAudio } = require('../solanaWeb3Manager/wAudio')
 const { sign, getTransferTokensDigest } = require('../../utils/signatures')
-const {
-  getSignedVAA,
-  getEmitterAddressEth,
-  parseSequenceFromLogEth,
-  redeemOnSolana,
-  postVaaSolana,
-  parseSequenceFromLogSolana,
-  getEmitterAddressSolana,
-  transferFromSolana,
-  redeemOnEth,
-  CHAIN_ID_SOLANA,
-  CHAIN_ID_ETH
-} = requireESM('@certusone/wormhole-sdk')
-
 /** Singleton state-manager for Audius Eth Contracts */
+
+const IS_BROWSER = typeof window !== 'undefined' && window !== null
 class Wormhole {
   /**
    * Wormhole constructor
@@ -62,6 +49,13 @@ class Wormhole {
     this.solTokenBridgeAddress = solTokenBridgeAddress
     this.ethBridgeAddress = ethBridgeAddress
     this.ethTokenBridgeAddress = ethTokenBridgeAddress
+    console.log()
+    if (IS_BROWSER) {
+      this.wormholeSDK = require('@certusone/wormhole-sdk')
+    } else {
+      const requireESM = require('esm')(module)
+      this.wormholeSDK = requireESM('@certusone/wormhole-sdk')
+    }
   }
 
   /**
@@ -79,12 +73,12 @@ class Wormhole {
     let logs = [`Attest and complete transfer for eth to sol for reciept ${ethTxReceipt}`]
     try {
       const receipt = await this.ethWeb3Manager.web3.eth.getTransactionReceipt(ethTxReceipt)
-      const sequence = parseSequenceFromLogEth(receipt, this.ethBridgeAddress)
-      const emitterAddress = getEmitterAddressEth(this.ethTokenBridgeAddress)
+      const sequence = this.wormholeSDK.parseSequenceFromLogEth(receipt, this.ethBridgeAddress)
+      const emitterAddress = this.wormholeSDK.getEmitterAddressEth(this.ethTokenBridgeAddress)
       phase = phases.GET_SIGNED_VAA
-      let { vaaBytes } = await getSignedVAA(
+      let { vaaBytes } = await this.wormholeSDK.getSignedVAA(
         this.rpcHost,
-        CHAIN_ID_ETH,
+        this.wormholeSDK.CHAIN_ID_ETH,
         emitterAddress,
         sequence
       )
@@ -111,7 +105,7 @@ class Wormhole {
       connection.sendRawTransaction = async () => ''
       connection.confirmTransaction = async () => ''
       phase = phases.POST_VAA_SOLANA
-      await postVaaSolana(
+      await this.wormholeSDK.postVaaSolana(
         connection,
         signTransaction,
         this.solBridgeAddress,
@@ -121,7 +115,7 @@ class Wormhole {
 
       // Finally, redeem on Solana
       phase = phases.REDEEM_ON_SOLANA
-      const transaction = await redeemOnSolana(
+      const transaction = await this.wormholeSDK.redeemOnSolana(
         connection,
         this.solBridgeAddress,
         this.solTokenBridgeAddress,
@@ -207,7 +201,7 @@ class Wormhole {
       const connection = this.solanaWeb3Manager.connection
 
       // Submit transaction - results in a Wormhole message being published
-      const tx = await transferFromSolana(
+      const tx = await this.wormholeSDK.transferFromSolana(
         connection, // solana web3 Connection
         this.solBridgeAddress, // bridge address
         this.solTokenBridgeAddress, // token bridge address
@@ -216,9 +210,9 @@ class Wormhole {
         this.solanaWeb3Manager.mintAddress, // mintAddress
         wAudioAmount, // BigInt
         zeroPad(toBuffer(ethTargetAddress), 32), // Uint8Array of length 32 targetAddress
-        CHAIN_ID_ETH, // ChainId targetChain
+        this.wormholeSDK.CHAIN_ID_ETH, // ChainId targetChain
         zeroPad(toBuffer(this.ethContracts.AudiusTokenClient.contractAddress), 32), // Uint8Array of length 32 originAddress
-        CHAIN_ID_ETH, //  ChainId originChain
+        this.wormholeSDK.CHAIN_ID_ETH, //  ChainId originChain
         solanaAddress // from owner address
       )
 
@@ -241,14 +235,14 @@ class Wormhole {
 
       // Get the sequence number and emitter address required to fetch the signedVAA of our message
       const info = await connection.getTransaction(transactionSignature)
-      const sequence = parseSequenceFromLogSolana(info)
-      const emitterAddress = await getEmitterAddressSolana(this.solTokenBridgeAddress)
+      const sequence = this.wormholeSDK.parseSequenceFromLogSolana(info)
+      const emitterAddress = await this.wormholeSDK.getEmitterAddressSolana(this.solTokenBridgeAddress)
 
       // Fetch the signedVAA from the Wormhole Network (this may require retries while you wait for confirmation)
       phase = phases.GET_SIGNED_VAA
-      const { vaaBytes } = await getSignedVAA(
+      const { vaaBytes } = await this.wormholeSDK.getSignedVAA(
         this.rpcHost,
-        CHAIN_ID_SOLANA,
+        this.wormholeSDK.CHAIN_ID_SOLANA,
         emitterAddress,
         sequence
       )
@@ -257,7 +251,7 @@ class Wormhole {
       // NOTE: The signer should be the user's personal wallet
       phase = phases.REDEEM_ON_ETH
       const signer = (new providers.Web3Provider(window.ethereum)).getSigner()
-      await redeemOnEth(this.ethTokenBridgeAddress, signer, vaaBytes)
+      await this.wormholeSDK.redeemOnEth(this.ethTokenBridgeAddress, signer, vaaBytes)
       logs.push(`Redeemed on eth`)
       return { phase, logs, error: null }
     } catch (error) {

--- a/libs/src/utils/index.js
+++ b/libs/src/utils/index.js
@@ -5,13 +5,13 @@ const MultiProvider = require('./multiProvider.js')
 const promiseFight = require('./promiseFight.js')
 const signatures = require('./signatures.js')
 const uuid = require('./uuid.js')
+const utils = require('./utils.js')
 
-module.exports = {
-  apiSigning,
-  Captcha,
-  estimateGas,
-  MultiProvider,
-  promiseFight,
-  signatures,
-  uuid
-}
+module.exports = utils
+module.exports.apiSigning = apiSigning
+module.exports.Captcha = Captcha
+module.exports.estimateGas = estimateGas
+module.exports.MultiProvider = MultiProvider
+module.exports.promiseFight = promiseFight
+module.exports.signatures = signatures
+module.exports.uuid = uuid

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const semver = require('semver')
 
-const Utils = require('../utils')
+const Utils = require('./utils')
 const promiseFight = require('./promiseFight')
 
 /**

--- a/libs/src/utils/network.js
+++ b/libs/src/utils/network.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const semver = require('semver')
 
-const Utils = require('./utils')
+const Utils = require('./utils.js')
 const promiseFight = require('./promiseFight')
 
 /**

--- a/libs/src/utils/signatures.js
+++ b/libs/src/utils/signatures.js
@@ -1,4 +1,4 @@
-const Utils = require('./utils')
+const Utils = require('./utils.js')
 const { ecsign, toBuffer } = require('ethereumjs-util')
 const { pack } = require('@ethersproject/solidity')
 

--- a/libs/src/utils/signatures.js
+++ b/libs/src/utils/signatures.js
@@ -1,5 +1,4 @@
-const Utils = require('../utils')
-
+const Utils = require('./utils')
 const { ecsign, toBuffer } = require('ethereumjs-util')
 const { pack } = require('@ethersproject/solidity')
 

--- a/libs/src/utils/utils.js
+++ b/libs/src/utils/utils.js
@@ -1,17 +1,16 @@
 const bs58 = require('bs58')
-const Web3 = require('./web3')
+const Web3 = require('../web3')
 const axios = require('axios')
 
-const UtilsDir = require('./utils/index.js')
-const MultiProvider = UtilsDir.MultiProvider
-const uuid = UtilsDir.uuid
+const MultiProvider = require('./multiProvider.js')
+const uuid = require('./uuid.js')
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 
 class Utils {
   static importDataContractABI (pathStr) {
     // need to specify part of path here because of https://github.com/webpack/webpack/issues/4921#issuecomment-357147299
-    const importFile = require(`../data-contracts/ABIs/${pathStr}`)
+    const importFile = require(`../../data-contracts/ABIs/${pathStr}`)
 
     if (importFile) return importFile
     else throw new Error(`Data contract ABI not found ${pathStr}`)
@@ -19,7 +18,7 @@ class Utils {
 
   static importEthContractABI (pathStr) {
     // need to specify part of path here because of https://github.com/webpack/webpack/issues/4921#issuecomment-357147299
-    const importFile = require(`../eth-contracts/ABIs/${pathStr}`)
+    const importFile = require(`../../eth-contracts/ABIs/${pathStr}`)
 
     if (importFile) return importFile
     else throw new Error(`Eth contract ABI not found ${pathStr}`)
@@ -146,8 +145,8 @@ class Utils {
 }
 
 // Export all modules inside ./utils/ dir
-Object.entries(UtilsDir).forEach(
-  ([utilName, utilProps]) => { Utils[utilName] = utilProps }
-)
+// Object.entries(UtilsDir).forEach(
+//   ([utilName, utilProps]) => { Utils[utilName] = utilProps }
+// )
 
 module.exports = Utils

--- a/libs/src/utils/utils.js
+++ b/libs/src/utils/utils.js
@@ -144,9 +144,4 @@ class Utils {
   }
 }
 
-// Export all modules inside ./utils/ dir
-// Object.entries(UtilsDir).forEach(
-//   ([utilName, utilProps]) => { Utils[utilName] = utilProps }
-// )
-
 module.exports = Utils


### PR DESCRIPTION
### Description

* Fixes the circular dependency for utils in libs - changed in #2095 
  * `/src/utils.js` was importing `/src/utils/index.js` which was importing `/src/utils/network.js` and `/src/utils/signatures.js` - both of which import `/src/utils.js`... causing the import of utils in those files to be an empty object and breaking any function that used the network.js or signatures.js files
* Only imports the `esm` for cetusone/wormhole if not a browser and updates package.json to exclude the module is a browser

### Tests
Linked libs against the client and logged out the utils

### How will this change be monitored?
