### PR TITLE
Add independent command to bring up a CN

### DIFF
--- a/service-commands/scripts/setup.js
+++ b/service-commands/scripts/setup.js
@@ -5,6 +5,7 @@ const {
   discoveryNodeUp,
   discoveryNodeWebServerUp,
   identityServiceUp,
+  creatorNodeUp,
   Service,
   SetupCommand,
   runSetupCommand,
@@ -230,5 +231,16 @@ program
     false
   )
   .action(async opts => await identityServiceUp(opts))
+
+// Example: `A content-node-stack up -i 5`
+// Bring up one content node with the service number of 5
+program
+  .command('content-node-stack up')
+  .description('Brings up relevant services for a content node')
+  .requiredOption(
+    '-i, --instance-number <instanceNumber>',
+    'the instance number'
+  )
+  .action(async opts => await creatorNodeUp(opts.instanceNumber))
 
 program.parse(process.argv)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

If the `A up` command fails, we can use this independent command to bring up a Content Node independently. 


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran `A content-node-stack up -i 5` and was able to bring up a Content Node with the registered service number of 5.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

If this command breaks, we will fix as necessary. This is on the local stack so shouldn't make an impact on stage/prod.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->