### PR TITLE
[ASI-763] SessionExpirationQueue bugfix - created_at -> createdAt

### DIFF
--- a/creator-node/src/services/SessionExpirationQueue.js
+++ b/creator-node/src/services/SessionExpirationQueue.js
@@ -49,7 +49,7 @@ class SessionExpirationQueue {
           let progress = 0
           const SESSION_EXPIRED_CONDITION = {
             where: {
-              created_at: {
+              createdAt: {
                 [Sequelize.Op.gt]: new Date(Date.now() - this.sessionExpirationAge)
               }
             }


### PR DESCRIPTION
Seen locally:
```
Session Expiration Queue: Error SequelizeDatabaseError: column SessionToken.created_at does not exist
```
The column name is actually `createdAt`

Fixes bug introduced in https://github.com/AudiusProject/audius-protocol/pull/1905/files
