### PR TITLE
Identity rewards reporter slack and log

### DIFF
--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -19,6 +19,7 @@ const { generateETHWalletLockKey } = require('./relay/ethTxRelay.js')
 const { RewardsAttester } = require('@audius/libs')
 const models = require('./models')
 
+const { RewardsReporter } = require('./utils/rewardsReporter')
 const { sendResponse, errorResponseServerError } = require('./apiHelpers')
 const { fetchAnnouncements } = require('./announcements')
 const { logger, loggingMiddleware } = require('./logging')
@@ -232,6 +233,11 @@ class App {
       await initialVals.save()
     }
 
+    const rewardsReporter = new RewardsReporter({
+      slackUrl: config.get('rewardsReporterSlackUrl'),
+      childLogger
+    })
+
     // Init the RewardsAttester
     const attester = new RewardsAttester({
       libs,
@@ -243,6 +249,7 @@ class App {
       startingBlock: initialVals.startingBlock,
       offset: initialVals.offset,
       challengeIdsDenyList,
+      reporter: rewardsReporter,
       updateValues: async ({ startingBlock, offset, successCount }) => {
         childLogger.info(`Persisting offset: ${offset}, startingBlock: ${startingBlock}`)
 

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -679,10 +679,16 @@ const config = convict({
     default: 1
   },
   minSolanaNotificationSlot: {
-    doc: 'The slot number to start indexing if not slots defined"',
+    doc: 'The slot number to start indexing if no slots defined',
     format: Number,
     env: 'minSolanaNotificationSlot',
     default: 105400000
+  },
+  rewardsReporterSlackUrl: {
+    doc: 'The slack url to post messages for the rewards reporter',
+    format: String,
+    env: 'rewardsReporterSlackUrl',
+    default: ''
   }
 })
 

--- a/identity-service/src/utils/rewardsReporter.js
+++ b/identity-service/src/utils/rewardsReporter.js
@@ -1,0 +1,64 @@
+const axios = require('axios')
+
+const getJsonSlackMessage = (obj) => `\`\`\`
+Source: Identity
+${Object.entries(obj).map(([key, value]) => `${key}: ${value}`).join('\n')}
+\`\`\``
+
+class RewardsReporter {
+  constructor ({
+      slackUrl,
+      childLogger
+  }) {
+    this.slackUrl = slackUrl
+    this.childLogger = childLogger      
+  }
+
+  async reportSuccess ({ userId, challengeId, amount }) {
+    const slackMessage = getJsonSlackMessage({
+      status: 'success',
+      userId,
+      challengeId,
+      amount: amount.toString(),
+    })
+    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    childLogger.info({ status: 'success', userId, challengeId, amount: amount.toString() }, `Rewards Reporter`)
+  }
+
+  async reportFailure ({ userId, challengeId, amount, error, phase }) {
+    const slackMessage = getJsonSlackMessage({
+      status: 'failure',
+      userId,
+      challengeId,
+      amount: amount.toString(),
+      error: error?.toString(),
+      phase
+    })
+    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    childLogger.info({ status: 'failure', userId, challengeId, amount: amount.toString(), error, phase }, `Rewards Reporter`)
+  }
+
+  async reportAAORejection ({ userId, challengeId, amount, error }) {
+    const slackMessage = getJsonSlackMessage({
+      status: 'rejection',
+      userId,
+      challengeId,
+      amount: amount.toString(),
+      error: error.toString()
+    })
+    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    childLogger.info({ status: 'rejection', userId, challengeId, amount: amount.toString(), error }, `Rewards Reporter`)
+  }
+
+  async postToSlack ({
+    slackUrl,
+    message
+  }){
+    if (!slackUrl) return
+    const resp = await axios.post(slackUrl, {text: message})
+  }
+}
+
+module.exports = {
+  RewardsReporter
+}

--- a/identity-service/src/utils/rewardsReporter.js
+++ b/identity-service/src/utils/rewardsReporter.js
@@ -7,11 +7,11 @@ ${Object.entries(obj).map(([key, value]) => `${key}: ${value}`).join('\n')}
 
 class RewardsReporter {
   constructor ({
-      slackUrl,
-      childLogger
+    slackUrl,
+    childLogger
   }) {
     this.slackUrl = slackUrl
-    this.childLogger = childLogger      
+    this.childLogger = childLogger
   }
 
   async reportSuccess ({ userId, challengeId, amount }) {
@@ -19,10 +19,10 @@ class RewardsReporter {
       status: 'success',
       userId,
       challengeId,
-      amount: amount.toString(),
+      amount: amount.toString()
     })
     await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
-    childLogger.info({ status: 'success', userId, challengeId, amount: amount.toString() }, `Rewards Reporter`)
+    this.childLogger.info({ status: 'success', userId, challengeId, amount: amount.toString() }, `Rewards Reporter`)
   }
 
   async reportFailure ({ userId, challengeId, amount, error, phase }) {
@@ -31,11 +31,11 @@ class RewardsReporter {
       userId,
       challengeId,
       amount: amount.toString(),
-      error: error?.toString(),
+      error: error.toString(),
       phase
     })
     await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
-    childLogger.info({ status: 'failure', userId, challengeId, amount: amount.toString(), error, phase }, `Rewards Reporter`)
+    this.childLogger.info({ status: 'failure', userId, challengeId, amount: amount.toString(), error, phase }, `Rewards Reporter`)
   }
 
   async reportAAORejection ({ userId, challengeId, amount, error }) {
@@ -47,15 +47,15 @@ class RewardsReporter {
       error: error.toString()
     })
     await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
-    childLogger.info({ status: 'rejection', userId, challengeId, amount: amount.toString(), error }, `Rewards Reporter`)
+    this.childLogger.info({ status: 'rejection', userId, challengeId, amount: amount.toString(), error }, `Rewards Reporter`)
   }
 
   async postToSlack ({
     slackUrl,
     message
-  }){
+  }) {
     if (!slackUrl) return
-    const resp = await axios.post(slackUrl, {text: message})
+    await axios.post(slackUrl, { text: message })
   }
 }
 


### PR DESCRIPTION
### Description
Adds the reporter for identity rewards: success, error, and reject
Needs config for Slack URL

### Tests
Ran it locally and posted to a slack DM to myself and looked at the logs

### How will this change be monitored?
logs

Closes AUD-1121