### PR TITLE
Fix seed CLI track metadata parsing

### DIFF
--- a/service-commands/src/utils/seed.js
+++ b/service-commands/src/utils/seed.js
@@ -120,12 +120,11 @@ const getProgressCallback = () => {
   return progressCallback
 }
 
-const getUserProvidedOrRandomTrackMetadata = (userProvidedMetadataInput, seedSession) => {
+const getUserProvidedOrRandomTrackMetadata = (userProvidedMetadata, seedSession) => {
   const { userId } = seedSession.cache.getActiveUser()
   let metadataObj = getRandomTrackMetadata(userId)
-  if (userProvidedMetadataInput !== 'random') {
-    const userProvidedMetadata = parseMetadataIntoObject(userProvidedMetadataInput)
-    metadataObj = Object.assign(metadataObj, userProvidedMetadata, { })
+  if (userProvidedMetadata) {
+    metadataObj = Object.assign(metadataObj, userProvidedMetadata)
   }
   return metadataObj
 }


### PR DESCRIPTION
### Description

I think when I rebased before pushing seed stuff, missed this line - double parses due to vestigial check for `'random'` that I didn't take out -- this was the original planned API but I decided to make random metadata generation implicit instead. Pointed out by @rickyrombo - thanks! 