### PR TITLE
Identity wormhole

### DIFF
--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@audius/libs": "1.2.42",
+    "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@optimizely/optimizely-sdk": "^4.6.0",
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",

--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -38,6 +38,14 @@ class AudiusLibsWrapper {
       feePayerSecretKey
     })
 
+    const wormholeConfig = AudiusLibs.configWormhole({
+      rpcHosts: config.get('wormholeRPCHosts'),
+      solBridgeAddress: config.get('solBridgeAddress'),
+      solTokenBridgeAddress: config.get('solTokenBridgeAddress'),
+      ethBridgeAddress: config.get('ethBridgeAddress'),
+      ethTokenBridgeAddress: config.get('ethTokenBridgeAddress')
+    })
+
     let audiusInstance = new AudiusLibs({
       discoveryProviderConfig: AudiusLibs.configDiscoveryProvider(discoveryProviderWhitelist),
       ethWeb3Config: AudiusLibs.configEthWeb3(
@@ -58,7 +66,8 @@ class AudiusLibsWrapper {
       },
       isServer: true,
       captchaConfig: { serviceKey: config.get('recaptchaServiceKey') },
-      solanaWeb3Config: solanaWeb3Config
+      solanaWeb3Config,
+      wormholeConfig
     })
 
     await audiusInstance.init()

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -707,7 +707,43 @@ const config = convict({
     format: String,
     env: 'rewardsReporterSlackUrl',
     default: ''
-  }
+  },
+  reporterSlackUrl: {
+    doc: 'The slack url to post messages for the general messages',
+    format: String,
+    env: 'reporterSlackUrl',
+    default: ''
+  },
+  wormholeRPCHosts: {
+    doc: 'Wormhole RPC Host',
+    format: String,
+    env: 'wormholeRPCHosts',
+    default: ''
+  },
+  solBridgeAddress: {
+    doc: 'Sol bridge address for wormhole',
+    format: String,
+    env: 'solBridgeAddress',
+    default: ''
+  },
+  solTokenBridgeAddress: {
+    doc: 'Sol token bridge address for wormhole',
+    format: String,
+    env: 'solTokenBridgeAddress',
+    default: ''
+  },
+  ethBridgeAddress: {
+    doc: 'Eth bridge address for wormhole',
+    format: String,
+    env: 'ethBridgeAddress',
+    default: ''
+  },
+  ethTokenBridgeAddress: {
+    doc: 'Eth token bridge address for wormhole',
+    format: String,
+    env: 'ethTokenBridgeAddress',
+    default: ''
+  },
 })
 
 // if you wanted to load a file

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -743,7 +743,7 @@ const config = convict({
     format: String,
     env: 'ethTokenBridgeAddress',
     default: ''
-  },
+  }
 })
 
 // if you wanted to load a file

--- a/identity-service/src/relay/ethTxRelay.js
+++ b/identity-service/src/relay/ethTxRelay.js
@@ -98,7 +98,7 @@ const sendEthTransaction = async (req, txProps, reqBodySHA) => {
 }
 
 const estimateEthTransactionGas = async (senderAddress, to, data) => {
-  let ethWalletIndex = getEthRelayerWalletIndex(senderAddress)
+  const ethWalletIndex = getEthRelayerWalletIndex(senderAddress)
   const selectedRelayerWallet = ethRelayerWallets[ethWalletIndex]
   const toChecksumAddress = ethWeb3.utils.toChecksumAddress
   const estimatedGas = await ethWeb3.eth.estimateGas({

--- a/identity-service/src/relay/ethTxRelay.js
+++ b/identity-service/src/relay/ethTxRelay.js
@@ -97,6 +97,18 @@ const sendEthTransaction = async (req, txProps, reqBodySHA) => {
   return resp
 }
 
+const estimateEthTransactionGas = async (senderAddress, to, data) => {
+  let ethWalletIndex = getEthRelayerWalletIndex(senderAddress)
+  const selectedRelayerWallet = ethRelayerWallets[ethWalletIndex]
+  const toChecksumAddress = ethWeb3.utils.toChecksumAddress
+  const estimatedGas = await ethWeb3.eth.estimateGas({
+    from: toChecksumAddress(selectedRelayerWallet.publicKey),
+    to: toChecksumAddress(to),
+    data
+  })
+  return estimatedGas
+}
+
 const createAndSendEthTransaction = async (sender, receiverAddress, value, web3, logger, gasPrice, gasLimit = null, data = null) => {
   const privateKeyBuffer = Buffer.from(sender.privateKey, 'hex')
   const walletAddress = EthereumWallet.fromPrivateKey(privateKeyBuffer)
@@ -205,6 +217,7 @@ const fundEthRelayerIfEmpty = async () => {
 }
 
 module.exports = {
+  estimateEthTransactionGas,
   fundEthRelayerIfEmpty,
   sendEthTransaction,
   queryEthRelayerWallet,

--- a/identity-service/src/relay/ethTxRelay.js
+++ b/identity-service/src/relay/ethTxRelay.js
@@ -38,7 +38,7 @@ const getEthRelayerFunds = async (walletPublicKey) => {
 
 const selectEthWallet = async (walletPublicKey, reqLogger) => {
   reqLogger.info(`L1 txRelay - Acquiring lock for ${walletPublicKey}`)
-  let ethWalletIndex = getEthRelayerWalletIndex(walletPublicKey)
+  const ethWalletIndex = getEthRelayerWalletIndex(walletPublicKey)
   const selectedRelayerWallet = ethRelayerWallets[ethWalletIndex]
 
   while ((await Lock.setLock(generateETHWalletLockKey(selectedRelayerWallet.publicKey))) !== true) {

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -47,7 +47,7 @@ module.exports = function (app) {
       logs.push(`Permit Succeded with tx hash: ${permitTxResponse.txHash}`)
       context.permitTxHash = permitTxResponse.txHash
 
-      // // Send off transfer tokens to eth wormhole tx
+      // Send off transfer tokens to eth wormhole tx
 
       logs.push(`Attempting Transfer Tokens for sender: ${body.senderAddress}`)
       const { sha: transferTokensSHA, txProps: transferTokensTxProps } = getTxProps(body.senderAddress, body.transferTokens)
@@ -66,6 +66,7 @@ module.exports = function (app) {
         return transaction
       }
 
+      // Gather VAA attestations, submit to solana and realize the funds at the taret address
       const response = await audiusLibs.wormholeClient.attestAndCompleteTransferEthToSol(transferTxHash, signTransaction, {
         transport: NodeHttpTransport()
       })
@@ -96,7 +97,7 @@ module.exports = function (app) {
       return sendResponse(
         req,
         res,
-        errorResponseServerError('it did not work')
+        errorResponseServerError(error.message.toString())
       )
     }
   })

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -21,7 +21,6 @@ const getTxProps = (senderAddress, method) => {
     }
   }
 }
-const feePayerAccount = getFeePayer()
 
 module.exports = function (app) {
   app.post('/wormhole_relay', async (req, res, next) => {
@@ -59,6 +58,7 @@ module.exports = function (app) {
       const transferTxHash = transferTokensTxResponse.txHash
       context.transferTxHash = transferTxHash
       logs.push(`Attempting Transfer Tokens for sender: ${transferTxHash}`)
+      const feePayerAccount = getFeePayer()
 
       const signTransaction = async (transaction) => {
         req.logger.info(`Signing Transaction`)

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -81,6 +81,7 @@ const relayWormhole = async (
       txHash: response.txHash
     }
   } catch (err) {
+    req.logger.error(context, logs.join(','))
     const errorMessage = err.toString()
     await reportError({ logs: logs.join(','), error: errorMessage })
     return { error: errorMessage }
@@ -123,6 +124,7 @@ module.exports = function (app) {
         txHash
       }))
     } catch (error) {
+      req.logger.error(error.message)
       const errorMessage = error.message.toString()
       await reportError({ error: errorMessage })
       return sendResponse(

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -1,4 +1,4 @@
-const { handleResponse, sendResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
+const { sendResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
 const ethTxRelay = require('../relay/ethTxRelay')
 const crypto = require('crypto')
 const { getFeePayer } = require('../solana-client')
@@ -6,20 +6,20 @@ const { getFeePayer } = require('../solana-client')
 const { NodeHttpTransport } = require('@improbable-eng/grpc-web-node-http-transport')
 
 const checkContract = (method) => {
-    return method.contractAddress && method.encodedABI && method.gasLimit
+  return method.contractAddress && method.encodedABI && method.gasLimit
 }
 
 const getTxProps = (senderAddress, method) => {
-    const sha = crypto.createHash('sha256').update(JSON.stringify({ senderAddress, ...method })).digest('hex')
-    return {
-        sha,
-        txProps: {
-            contractAddress: method.contractAddress,
-            encodedABI: method.encodedABI,
-            senderAddress: senderAddress,
-            gasLimit: method.gasLimit || null    
-        }
+  const sha = crypto.createHash('sha256').update(JSON.stringify({ senderAddress, ...method })).digest('hex')
+  return {
+    sha,
+    txProps: {
+      contractAddress: method.contractAddress,
+      encodedABI: method.encodedABI,
+      senderAddress: senderAddress,
+      gasLimit: method.gasLimit || null
     }
+  }
 }
 const feePayerAccount = getFeePayer()
 
@@ -31,76 +31,73 @@ module.exports = function (app) {
     const logs = []
     const context = {}
     try {
-
-        // Validate the request body is of correct shape
-        if (!body.senderAddress || !checkContract(body.permit) || !checkContract(body.transferTokens)) {
+      // Validate the request body is of correct shape
+      if (!body.senderAddress || !checkContract(body.permit) || !checkContract(body.transferTokens)) {
         return sendResponse(
-                req,
-                res,
-                errorResponseBadRequest('Missing one of the required fields: senderAddress, permit, transferTokens')
-            )
-        }
-
-        // Send off permit tx
-        logs.push(`Attempting Permit for sender: ${body.senderAddress}`)
-        const { sha: permitSHA, txProps: permitTxProps} = getTxProps(body.senderAddress, body.permit)
-        const permitTxResponse = await ethTxRelay.sendEthTransaction(req, permitTxProps, permitSHA)
-        logs.push(`Permit Succeded with tx hash: ${permitTxResponse.txHash}`)
-        context.permitTxHash = permitTxResponse.txHash
-        
-        // // Send off transfer tokens to eth wormhole tx
-
-        logs.push(`Attempting Transfer Tokens for sender: ${body.senderAddress}`)
-        const { sha: transferTokensSHA, txProps: transferTokensTxProps} = getTxProps(body.senderAddress, body.transferTokens)
-        const estimatedGas = await ethTxRelay.estimateEthTransactionGas(body.senderAddress, transferTokensTxProps.contractAddress, transferTokensTxProps.encodedABI)
-        const gasMultiplier = 1.5
-        transferTokensTxProps.gasLimit = Math.floor(estimatedGas * gasMultiplier)
-
-        const transferTokensTxResponse = await ethTxRelay.sendEthTransaction(req, transferTokensTxProps, transferTokensSHA)
-        const transferTxHash = transferTokensTxResponse.txHash
-        context.transferTxHash = transferTxHash
-        logs.push(`Attempting Transfer Tokens for sender: ${transferTxHash}`)
-
-        const signTransaction = async (transaction) => {
-            req.logger.info(`Signing Transaction`)
-            transaction.partialSign(feePayerAccount)
-            return transaction
-        }
-
-        const response = await audiusLibs.wormholeClient.attestAndCompleteTransferEthToSol(transferTxHash, signTransaction, {
-            transport: NodeHttpTransport()
-        })
-        if (response.error) {
-            logs.push(`Attest and complete transfer from eth to sol failed on phase: ${response.phase} \n error: ${response.error} \n with logs: ${response.logs.join(',')}`)
-            const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: response.error.toString() })
-            await slackReporter.postToSlack({ message })
-            return sendResponse(
-                req,
-                res,
-                errorResponseServerError(response.error.toString())
-            )
-        }
-
-        logs.push(`Attest and complete transfer from eth to sol succeeded: ${response.transactionSignature}`)
-        context.completeTransferSignature = response.transactionSignature
-
-        req.logger.info(context, logs.join(','))
-
-        return sendResponse(req, res, successResponse({
-            transferTxHash,
-            txHash: response.txHash
-        }))
-
-    } catch (error) {
-        const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: error.message.toString() })
-        await slackReporter.postToSlack({ message })
-        req.logger.error(context, logs.join(','))
-        return sendResponse(
-            req,
-            res,
-            errorResponseServerError('it did not work')
+          req,
+          res,
+          errorResponseBadRequest('Missing one of the required fields: senderAddress, permit, transferTokens')
         )
-    }
+      }
 
+      // Send off permit tx
+      logs.push(`Attempting Permit for sender: ${body.senderAddress}`)
+      const { sha: permitSHA, txProps: permitTxProps } = getTxProps(body.senderAddress, body.permit)
+      const permitTxResponse = await ethTxRelay.sendEthTransaction(req, permitTxProps, permitSHA)
+      logs.push(`Permit Succeded with tx hash: ${permitTxResponse.txHash}`)
+      context.permitTxHash = permitTxResponse.txHash
+
+      // // Send off transfer tokens to eth wormhole tx
+
+      logs.push(`Attempting Transfer Tokens for sender: ${body.senderAddress}`)
+      const { sha: transferTokensSHA, txProps: transferTokensTxProps } = getTxProps(body.senderAddress, body.transferTokens)
+      const estimatedGas = await ethTxRelay.estimateEthTransactionGas(body.senderAddress, transferTokensTxProps.contractAddress, transferTokensTxProps.encodedABI)
+      const gasMultiplier = 1.5
+      transferTokensTxProps.gasLimit = Math.floor(estimatedGas * gasMultiplier)
+
+      const transferTokensTxResponse = await ethTxRelay.sendEthTransaction(req, transferTokensTxProps, transferTokensSHA)
+      const transferTxHash = transferTokensTxResponse.txHash
+      context.transferTxHash = transferTxHash
+      logs.push(`Attempting Transfer Tokens for sender: ${transferTxHash}`)
+
+      const signTransaction = async (transaction) => {
+        req.logger.info(`Signing Transaction`)
+        transaction.partialSign(feePayerAccount)
+        return transaction
+      }
+
+      const response = await audiusLibs.wormholeClient.attestAndCompleteTransferEthToSol(transferTxHash, signTransaction, {
+        transport: NodeHttpTransport()
+      })
+      if (response.error) {
+        logs.push(`Attest and complete transfer from eth to sol failed on phase: ${response.phase} \n error: ${response.error} \n with logs: ${response.logs.join(',')}`)
+        const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: response.error.toString() })
+        await slackReporter.postToSlack({ message })
+        return sendResponse(
+          req,
+          res,
+          errorResponseServerError(response.error.toString())
+        )
+      }
+
+      logs.push(`Attest and complete transfer from eth to sol succeeded: ${response.transactionSignature}`)
+      context.completeTransferSignature = response.transactionSignature
+
+      req.logger.info(context, logs.join(','))
+
+      return sendResponse(req, res, successResponse({
+        transferTxHash,
+        txHash: response.txHash
+      }))
+    } catch (error) {
+      const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: error.message.toString() })
+      await slackReporter.postToSlack({ message })
+      req.logger.error(context, logs.join(','))
+      return sendResponse(
+        req,
+        res,
+        errorResponseServerError('it did not work')
+      )
+    }
   })
 }

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -1,0 +1,106 @@
+const { handleResponse, sendResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
+const ethTxRelay = require('../relay/ethTxRelay')
+const crypto = require('crypto')
+const { getFeePayer } = require('../solana-client')
+
+const { NodeHttpTransport } = require('@improbable-eng/grpc-web-node-http-transport')
+
+const checkContract = (method) => {
+    return method.contractAddress && method.encodedABI && method.gasLimit
+}
+
+const getTxProps = (senderAddress, method) => {
+    const sha = crypto.createHash('sha256').update(JSON.stringify({ senderAddress, ...method })).digest('hex')
+    return {
+        sha,
+        txProps: {
+            contractAddress: method.contractAddress,
+            encodedABI: method.encodedABI,
+            senderAddress: senderAddress,
+            gasLimit: method.gasLimit || null    
+        }
+    }
+}
+const feePayerAccount = getFeePayer()
+
+module.exports = function (app) {
+  app.post('/wormhole_relay', async (req, res, next) => {
+    const audiusLibs = req.app.get('audiusLibs')
+    const slackReporter = req.app.get('slackReporter')
+    const body = req.body
+    const logs = []
+    const context = {}
+    try {
+
+        // Validate the request body is of correct shape
+        if (!body.senderAddress || !checkContract(body.permit) || !checkContract(body.transferTokens)) {
+        return sendResponse(
+                req,
+                res,
+                errorResponseBadRequest('Missing one of the required fields: senderAddress, permit, transferTokens')
+            )
+        }
+
+        // Send off permit tx
+        logs.push(`Attempting Permit for sender: ${body.senderAddress}`)
+        const { sha: permitSHA, txProps: permitTxProps} = getTxProps(body.senderAddress, body.permit)
+        const permitTxResponse = await ethTxRelay.sendEthTransaction(req, permitTxProps, permitSHA)
+        logs.push(`Permit Succeded with tx hash: ${permitTxResponse.txHash}`)
+        context.permitTxHash = permitTxResponse.txHash
+        
+        // // Send off transfer tokens to eth wormhole tx
+
+        logs.push(`Attempting Transfer Tokens for sender: ${body.senderAddress}`)
+        const { sha: transferTokensSHA, txProps: transferTokensTxProps} = getTxProps(body.senderAddress, body.transferTokens)
+        const estimatedGas = await ethTxRelay.estimateEthTransactionGas(body.senderAddress, transferTokensTxProps.contractAddress, transferTokensTxProps.encodedABI)
+        const gasMultiplier = 1.5
+        transferTokensTxProps.gasLimit = Math.floor(estimatedGas * gasMultiplier)
+
+        const transferTokensTxResponse = await ethTxRelay.sendEthTransaction(req, transferTokensTxProps, transferTokensSHA)
+        const transferTxHash = transferTokensTxResponse.txHash
+        context.transferTxHash = transferTxHash
+        logs.push(`Attempting Transfer Tokens for sender: ${transferTxHash}`)
+
+        const signTransaction = async (transaction) => {
+            req.logger.info(`Signing Transaction`)
+            transaction.partialSign(feePayerAccount)
+            return transaction
+        }
+
+        const response = await audiusLibs.wormholeClient.attestAndCompleteTransferEthToSol(transferTxHash, signTransaction, {
+            transport: NodeHttpTransport()
+        })
+        if (response.error) {
+            logs.push(`Attest and complete transfer from eth to sol failed on phase: ${response.phase} \n error: ${response.error} \n with logs: ${response.logs.join(',')}`)
+            const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: response.error.toString() })
+            await slackReporter.postToSlack({ message })
+            return sendResponse(
+                req,
+                res,
+                errorResponseServerError(response.error.toString())
+            )
+        }
+
+        logs.push(`Attest and complete transfer from eth to sol succeeded: ${response.transactionSignature}`)
+        context.completeTransferSignature = response.transactionSignature
+
+        req.logger.info(context, logs.join(','))
+
+        return sendResponse(req, res, successResponse({
+            transferTxHash,
+            txHash: response.txHash
+        }))
+
+    } catch (error) {
+        const message = slackReporter.getJsonSlackMessage({ logs: logs.join(','), error: error.message.toString() })
+        await slackReporter.postToSlack({ message })
+        req.logger.error(context, logs.join(','))
+        return sendResponse(
+            req,
+            res,
+            errorResponseServerError('it did not work')
+        )
+    }
+
+  })
+}

--- a/identity-service/src/utils/rewardsReporter.js
+++ b/identity-service/src/utils/rewardsReporter.js
@@ -9,25 +9,23 @@ class SlackReporter {
     this.childLogger = childLogger
   }
 
-  getJsonSlackMessage = (obj) => {
-    return   `\`\`\`
+  getJsonSlackMessage (obj) {
+    return `\`\`\`
 Source: Identity
 ${Object.entries(obj).map(([key, value]) => `${key}: ${value}`).join('\n')}
 \`\`\``
   }
 
-  postToSlack = async ({
+  async postToSlack ({
     message
-  }) => {
-    console.log(this.slackUrl)
+  }) {
     if (!this.slackUrl) return
     await axios.post(this.slackUrl, { text: message })
   }
 }
 
 class RewardsReporter extends SlackReporter {
-
-  reportSuccess = async ({ userId, challengeId, amount }) => {
+  async reportSuccess ({ userId, challengeId, amount }) {
     const slackMessage = this.getJsonSlackMessage({
       status: 'success',
       userId,
@@ -38,7 +36,7 @@ class RewardsReporter extends SlackReporter {
     this.childLogger.info({ status: 'success', userId, challengeId, amount: amount.toString() }, `Rewards Reporter`)
   }
 
-  reportFailure = async ({ userId, challengeId, amount, error, phase }) => {
+  async reportFailure ({ userId, challengeId, amount, error, phase }) {
     const slackMessage = this.getJsonSlackMessage({
       status: 'failure',
       userId,
@@ -51,7 +49,7 @@ class RewardsReporter extends SlackReporter {
     this.childLogger.info({ status: 'failure', userId, challengeId, amount: amount.toString(), error, phase }, `Rewards Reporter`)
   }
 
-  reportAAORejection = async ({ userId, challengeId, amount, error }) => {
+  async reportAAORejection ({ userId, challengeId, amount, error }) {
     const slackMessage = this.getJsonSlackMessage({
       status: 'rejection',
       userId,

--- a/identity-service/src/utils/rewardsReporter.js
+++ b/identity-service/src/utils/rewardsReporter.js
@@ -1,11 +1,6 @@
 const axios = require('axios')
 
-const getJsonSlackMessage = (obj) => `\`\`\`
-Source: Identity
-${Object.entries(obj).map(([key, value]) => `${key}: ${value}`).join('\n')}
-\`\`\``
-
-class RewardsReporter {
+class SlackReporter {
   constructor ({
     slackUrl,
     childLogger
@@ -14,19 +9,37 @@ class RewardsReporter {
     this.childLogger = childLogger
   }
 
-  async reportSuccess ({ userId, challengeId, amount }) {
-    const slackMessage = getJsonSlackMessage({
+  getJsonSlackMessage = (obj) => {
+    return   `\`\`\`
+Source: Identity
+${Object.entries(obj).map(([key, value]) => `${key}: ${value}`).join('\n')}
+\`\`\``
+  }
+
+  postToSlack = async ({
+    message
+  }) => {
+    console.log(this.slackUrl)
+    if (!this.slackUrl) return
+    await axios.post(this.slackUrl, { text: message })
+  }
+}
+
+class RewardsReporter extends SlackReporter {
+
+  reportSuccess = async ({ userId, challengeId, amount }) => {
+    const slackMessage = this.getJsonSlackMessage({
       status: 'success',
       userId,
       challengeId,
       amount: amount.toString()
     })
-    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    await this.postToSlack({ message: slackMessage })
     this.childLogger.info({ status: 'success', userId, challengeId, amount: amount.toString() }, `Rewards Reporter`)
   }
 
-  async reportFailure ({ userId, challengeId, amount, error, phase }) {
-    const slackMessage = getJsonSlackMessage({
+  reportFailure = async ({ userId, challengeId, amount, error, phase }) => {
+    const slackMessage = this.getJsonSlackMessage({
       status: 'failure',
       userId,
       challengeId,
@@ -34,31 +47,24 @@ class RewardsReporter {
       error: error.toString(),
       phase
     })
-    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    await this.postToSlack({ message: slackMessage })
     this.childLogger.info({ status: 'failure', userId, challengeId, amount: amount.toString(), error, phase }, `Rewards Reporter`)
   }
 
-  async reportAAORejection ({ userId, challengeId, amount, error }) {
-    const slackMessage = getJsonSlackMessage({
+  reportAAORejection = async ({ userId, challengeId, amount, error }) => {
+    const slackMessage = this.getJsonSlackMessage({
       status: 'rejection',
       userId,
       challengeId,
       amount: amount.toString(),
       error: error.toString()
     })
-    await this.postToSlack({ slackUrl: this.slackUrl, message: slackMessage })
+    await this.postToSlack({ message: slackMessage })
     this.childLogger.info({ status: 'rejection', userId, challengeId, amount: amount.toString(), error }, `Rewards Reporter`)
-  }
-
-  async postToSlack ({
-    slackUrl,
-    message
-  }) {
-    if (!slackUrl) return
-    await axios.post(slackUrl, { text: message })
   }
 }
 
 module.exports = {
+  SlackReporter,
   RewardsReporter
 }

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -319,9 +319,9 @@
       }
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.1.1.tgz",
-      "integrity": "sha512-/FEOGOkDRVq5+aXNHb9W57WR03dI9ZvhFlc/qrrQhXJQYhkm4Y+i0L9NQN5J5TpZ/aZ3cX+E6Gw3nFsmbgCo/g==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.0.10.tgz",
+      "integrity": "sha512-BGAi3qdgFjA3UO0XMefnn8aDBpQUj+eDcDfcN90sl26QqlC01YDVPz93FyLsNTTjM3X1WHNX0V66B6UzPDr6Vw==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.14.0",
         "@solana/spl-token": "^0.1.8",
@@ -2185,9 +2185,9 @@
           }
         },
         "follow-redirects": {
-          "version": "1.14.5",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+          "version": "1.14.6",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
+          "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
         },
         "glob": {
           "version": "7.2.0",
@@ -3448,25 +3448,25 @@
       }
     },
     "@walletconnect/browser-utils": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.6.6.tgz",
-      "integrity": "sha512-E29xSHU7Akd4jaPehWVGx7ct+SsUzZbxcGc0fz+Pw6/j4Gh5tlfYZ9XuVixuYI4WPdQ2CmOraj8RrVOu5vba4w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.0.tgz",
+      "integrity": "sha512-bQsbCIDTT1OB4v8VF5bzg3byp03qTst9kLmjQj68ElecIUcdS6nZvEDhZdQK/r63WMVnA2KrTb5AEN6hPRGgIw==",
       "requires": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/types": "^1.7.0",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "@walletconnect/core": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.6.6.tgz",
-      "integrity": "sha512-pSftIVPY6mYz2koZPBEYmeFeAjVf2MSnRHOM6+vx+iAsUEcfMZHkgeXX6GtM6Fjza+zSZu1qnmdgURVXpmKwtQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-0YX9Y/CVYctKPcSgSyp2wLrk4OgSenmyzWj6Z3C93Hb7PG+tJ+dKCeNFeEIYA03QQRxHew5uMLPbVgmdtmB/0w==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.6.6",
-        "@walletconnect/types": "^1.6.6",
-        "@walletconnect/utils": "^1.6.6"
+        "@walletconnect/socket-transport": "^1.7.0",
+        "@walletconnect/types": "^1.7.0",
+        "@walletconnect/utils": "^1.7.0"
       }
     },
     "@walletconnect/crypto": {
@@ -3496,13 +3496,13 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.6.6.tgz",
-      "integrity": "sha512-wRYgKvd8K3A9FVLn2c0cDh4+9OUHkqibKtwQJTJsz+ibPGgd+n5j1/FjnzDDRGb9T1+TtlwYF3ZswKyys3diVQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.0.tgz",
+      "integrity": "sha512-ZUQ/MAM9TXtneIaRjxW/PuFF+es4I9OrCGFgVTCYAaa7p2zdy7BgHmVOnxxOpUh9VYwLXoiA/FU234NwS0ulYw==",
       "requires": {
         "@walletconnect/crypto": "^1.0.1",
-        "@walletconnect/types": "^1.6.6",
-        "@walletconnect/utils": "^1.6.6"
+        "@walletconnect/types": "^1.7.0",
+        "@walletconnect/utils": "^1.7.0"
       }
     },
     "@walletconnect/jsonrpc-types": {
@@ -3538,12 +3538,12 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "@walletconnect/socket-transport": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.6.6.tgz",
-      "integrity": "sha512-mugCEoeKTx75ogb5ROg/+LA3yGTsuRNcrYgrApceo7WNU9Z4dG8l6ycMPqrrFcODcrasq3NmXVWUYDv/CvrzSw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.0.tgz",
+      "integrity": "sha512-HSWGZxdxDtf8K1Kd1eD1QuObpoNxHui+A/+inuC8i8fcifDjZu85AeJIfCKQijlmgjLR/25Ry3eJFbYpRXxUjQ==",
       "requires": {
-        "@walletconnect/types": "^1.6.6",
-        "@walletconnect/utils": "^1.6.6",
+        "@walletconnect/types": "^1.7.0",
+        "@walletconnect/utils": "^1.7.0",
         "ws": "7.5.3"
       },
       "dependencies": {
@@ -3555,19 +3555,19 @@
       }
     },
     "@walletconnect/types": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.6.6.tgz",
-      "integrity": "sha512-op77cxexOmQQN36XB1sYouNTlBRV0Rup/2NYK8A1ffdwXa3a6HLHHdhBM7I/I9BVmRXoZ4+XoOnPKGGrYtlS3g=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.0.tgz",
+      "integrity": "sha512-eoqnF+U04IuMfGIBsqYhAR6SIM2kzcrZM/RCVcomT/lIcsRoBwNxR+86+3Vn12/iaGnuAKn8xDZhZ47SLFmanQ=="
     },
     "@walletconnect/utils": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.6.6.tgz",
-      "integrity": "sha512-s2X/cVXiMDSEoWV6i7HPMbP1obXlzP7KLMrBo9OMabiJKnQEh6HSZ39WLswB2PHnl8Hp1Sr4BdRvhM5kCcYWRw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.0.tgz",
+      "integrity": "sha512-DnYyKNMkpPUkbu6YwHfycvzlpx7Ro/qDPIDAuaNYT4FFWFyYxfx2ZY66kU3XklQivAc8dK7TyvYPJ08LWd8w4Q==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.6.6",
+        "@walletconnect/browser-utils": "^1.7.0",
         "@walletconnect/encoding": "^1.0.0",
         "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.6.6",
+        "@walletconnect/types": "^1.7.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"

--- a/libs/package.json
+++ b/libs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@audius/hedgehog": "1.0.12",
-    "@certusone/wormhole-sdk": "0.1.1",
+    "@certusone/wormhole-sdk": "0.0.10",
     "@ethersproject/solidity": "5.0.5",
     "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
     "@solana/spl-token": "0.1.6",

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -439,7 +439,7 @@ class Account extends Base {
    * Sends Eth `amount` tokens to `solanaAccount` on the identity service
    * by way of the wormhole.
    */
-   async proxySendTokensFromEthToSol (amount, solanaAccount) {
+  async proxySendTokensFromEthToSol (amount, solanaAccount) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
     const myWalletAddress = this.web3Manager.getWalletAddress()
     const wormholeAddress = this.ethContracts.WormholeClient.contractAddress
@@ -525,21 +525,21 @@ class Account extends Base {
    * Permits `relayerAddress` to send `amount` on behalf of the current user, `owner`
    */
   async getPermitProxySendTokensMethod (owner, relayerAddress, amount) {
-      const {
-        result,
-        deadline
-      } = await this._getPermitProxySendTokensParams(owner, relayerAddress, amount)
-      const contractMethod = this.ethContracts.AudiusTokenClient.AudiusTokenContract.methods.permit(
-        owner,
-        relayerAddress,
-        amount,
-        deadline,
-        result.v,
-        result.r,
-        result.s
-      )
-      return contractMethod
-    }
+    const {
+      result,
+      deadline
+    } = await this._getPermitProxySendTokensParams(owner, relayerAddress, amount)
+    const contractMethod = this.ethContracts.AudiusTokenClient.AudiusTokenContract.methods.permit(
+      owner,
+      relayerAddress,
+      amount,
+      deadline,
+      result.v,
+      result.r,
+      result.s
+    )
+    return contractMethod
+  }
 
   /**
    * Sends `amount` tokens to `address` from `owner`

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -522,7 +522,7 @@ class Account extends Base {
   }
 
   /**
-   * Permits `relayerAddress` to send `amount` on behalf of the current user, `owner`
+   * Gets the permit method to proxy send tokens `relayerAddress` to send `amount` on behalf of the current user, `owner`
    */
   async getPermitProxySendTokensMethod (owner, relayerAddress, amount) {
     const {

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -436,6 +436,29 @@ class Account extends Base {
   }
 
   /**
+   * Sends Eth `amount` tokens to `solanaAccount` on the identity service
+   * by way of the wormhole.
+   */
+   async proxySendTokensFromEthToSol (amount, solanaAccount) {
+    this.REQUIRES(Services.IDENTITY_SERVICE)
+    const myWalletAddress = this.web3Manager.getWalletAddress()
+    const wormholeAddress = this.ethContracts.WormholeClient.contractAddress
+    const { selectedEthWallet } = await this.identityService.getEthRelayer(myWalletAddress)
+    const permitMethod = await this.getPermitProxySendTokensMethod(myWalletAddress, wormholeAddress, amount)
+    const permit = await this.ethWeb3Manager.getRelayMethodParams(this.ethContracts.AudiusTokenClient.contractAddress, permitMethod, selectedEthWallet)
+    const transferTokensMethod = await this.wormholeClient.getTransferTokensToEthWormholeMethod(
+
+      myWalletAddress, amount, solanaAccount, selectedEthWallet
+    )
+    const transferTokens = await this.ethWeb3Manager.getRelayMethodParams(this.ethContracts.WormholeClient.contractAddress, transferTokensMethod, selectedEthWallet)
+    return this.identityService.wormholeRelay({
+      senderAddress: myWalletAddress,
+      permit,
+      transferTokens
+    })
+  }
+
+  /**
    * Sends `amount` tokens to `ethAccount` by way of the wormhole
    * 1.) Creates a solana root wallet
    * 2.) Sends the tokens from the user bank account to the solana wallet
@@ -448,10 +471,7 @@ class Account extends Base {
     return { error, logs, phase }
   }
 
-  /**
-   * Permits `relayerAddress` to send `amount` on behalf of the current user, `owner`
-   */
-  async permitProxySendTokens (owner, relayerAddress, amount) {
+  async _getPermitProxySendTokensParams (owner, relayerAddress, amount) {
     const web3 = this.ethWeb3Manager.getWeb3()
     const myPrivateKey = this.web3Manager.getOwnerWalletPrivateKey()
     const chainId = await new Promise(resolve => web3.eth.getChainId((_, chainId) => resolve(chainId)))
@@ -475,6 +495,20 @@ class Account extends Base {
       deadline
     )
     let result = sign(digest, myPrivateKey)
+    return {
+      result,
+      deadline
+    }
+  }
+
+  /**
+   * Permits `relayerAddress` to send `amount` on behalf of the current user, `owner`
+   */
+  async permitProxySendTokens (owner, relayerAddress, amount) {
+    const {
+      result,
+      deadline
+    } = await this._getPermitProxySendTokensParams(owner, relayerAddress, amount)
     const tx = await this.ethContracts.AudiusTokenClient.permit(
       owner,
       relayerAddress,
@@ -482,11 +516,30 @@ class Account extends Base {
       deadline,
       result.v,
       result.r,
-      result.s,
-      { from: owner }
+      result.s
     )
     return tx
   }
+
+  /**
+   * Permits `relayerAddress` to send `amount` on behalf of the current user, `owner`
+   */
+  async getPermitProxySendTokensMethod (owner, relayerAddress, amount) {
+      const {
+        result,
+        deadline
+      } = await this._getPermitProxySendTokensParams(owner, relayerAddress, amount)
+      const contractMethod = this.ethContracts.AudiusTokenClient.AudiusTokenContract.methods.permit(
+        owner,
+        relayerAddress,
+        amount,
+        deadline,
+        result.v,
+        result.r,
+        result.s
+      )
+      return contractMethod
+    }
 
   /**
    * Sends `amount` tokens to `address` from `owner`

--- a/libs/src/constants.js
+++ b/libs/src/constants.js
@@ -1,3 +1,4 @@
+module.exports.AUDIO_DECMIALS = 18
 module.exports.WAUDIO_DECMIALS = 8
 module.exports.CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY = '@audius/libs:found-user'
 module.exports.AuthHeaders = Object.freeze({

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -213,7 +213,7 @@ class AudiusLibs {
     if (typeof rpcHosts === 'string') {
       rpcHostList = rpcHosts.split(',')
     } else if (Array.isArray(rpcHosts)) {
-      rpcHostList = providers
+      rpcHostList = rpcHosts
     } else {
       throw new Error('rpcHosts must be of type string or Array')
     }

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -196,21 +196,29 @@ class AudiusLibs {
   /**
    * Configures wormhole
    * @param {Object} config
-   * @param {string} config.rpcHost
+   * @param {string | Array<string>} config.rpcHosts
    * @param {string} config.solBridgeAddress
    * @param {string} config.solTokenBridgeAddress
    * @param {string} config.ethBridgeAddress
    * @param {string} config.ethTokenBridgeAddress
    */
   static configWormhole ({
-    rpcHost,
+    rpcHosts,
     solBridgeAddress,
     solTokenBridgeAddress,
     ethBridgeAddress,
     ethTokenBridgeAddress
   }) {
+    let rpcHostList
+    if (typeof rpcHosts === 'string') {
+      rpcHostList = rpcHosts.split(',')
+    } else if (Array.isArray(rpcHosts)) {
+      rpcHostList = providers
+    } else {
+      throw new Error('rpcHosts must be of type string or Array')
+    }
     return {
-      rpcHost,
+      rpcHosts: rpcHostList,
       solBridgeAddress,
       solTokenBridgeAddress,
       ethBridgeAddress,
@@ -405,7 +413,7 @@ class AudiusLibs {
       contractsToInit.push(this.contracts.init())
     }
     await Promise.all(contractsToInit)
-    if (this.wormholeConfig && this.hedgehog && this.ethWeb3Manager && this.ethContracts && this.identityService && this.solanaWeb3Manager) {
+    if (this.wormholeConfig && this.ethWeb3Manager && this.ethContracts && this.solanaWeb3Manager) {
       this.wormholeClient = new Wormhole(
         this.hedgehog,
         this.ethWeb3Manager,

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -181,6 +181,21 @@ class EthWeb3Manager {
     })
     return response['resp']
   }
+
+  async getRelayMethodParams (contractAddress, contractMethod, relayerWallet) {
+    const encodedABI = contractMethod.encodeABI()
+    const gasLimit = await estimateGas({
+      from: relayerWallet,
+      method: contractMethod,
+      gasLimitMaximum: HIGH_GAS_PRICE
+    })
+    return {
+      contractAddress,
+      encodedABI,
+      gasLimit
+    }
+  }
+
 }
 
 module.exports = EthWeb3Manager

--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -195,7 +195,6 @@ class EthWeb3Manager {
       gasLimit
     }
   }
-
 }
 
 module.exports = EthWeb3Manager

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -288,6 +288,22 @@ class IdentityService {
     })
   }
 
+  async wormholeRelay ({
+    senderAddress,
+    permit,
+    transferTokens
+  }) {
+    return this._makeRequest({
+      url: '/wormhole_relay',
+      method: 'post',
+      data: {
+        senderAddress,
+        permit,
+        transferTokens
+      }
+    })
+  }
+
   /**
    * Gets the correct wallet that will relay a txn for `senderAddress`
    * @param {string} senderAddress wallet

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -12,7 +12,7 @@ const Utils = require('../../utils')
 const SolanaUtils = require('./utils')
 const { TransactionHandler } = require('./transactionHandler')
 const { submitAttestations, evaluateAttestations, createSender } = require('./rewards')
-const { WAUDIO_DECMIALS } = require('../../constants')
+const { AUDIO_DECMIALS, WAUDIO_DECMIALS } = require('../../constants')
 
 const { PublicKey } = solanaWeb3
 
@@ -116,7 +116,7 @@ class SolanaWeb3Manager {
     this.solanaTokenAddress = solanaTokenAddress
     this.solanaTokenKey = newPublicKeyNullable(solanaTokenAddress)
 
-    this.feePayerAddress = feePayerAddress
+    this.feePayerAddress = feePayerAddress || feePayerKeypair.publicKey
     this.feePayerKey = newPublicKeyNullable(feePayerAddress || feePayerKeypair.publicKey)
 
     this.claimableTokenProgramKey = newPublicKeyNullable(claimableTokenProgramAddress)
@@ -225,7 +225,8 @@ class SolanaWeb3Manager {
       if (!tokenAccount) return null
 
       // Multiply by 10^10 to maintain same decimals as eth $AUDIO
-      return tokenAccount.amount.mul(Utils.toBN('1'.padEnd(WAUDIO_DECMIALS + 1, '0')))
+      const decimals = AUDIO_DECMIALS - WAUDIO_DECMIALS
+      return tokenAccount.amount.mul(Utils.toBN('1'.padEnd(decimals + 1, '0')))
     } catch (e) {
       return null
     }

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -95,7 +95,7 @@ class Wormhole {
    * Sends `amount` tokens to `solanaAccount` by way of the wormhole
    * @param {string} ethTxReceipt The tx receipt
    * @param {function} [customSignTransaction] Optional custom sign transaction parameter
-   * 
+   *
    * else will attempt to relay
    * @returns {Promise} Promise object of {
         transactionSignature: string,
@@ -131,7 +131,6 @@ class Wormhole {
       if (customSignTransaction) {
         signTransaction = customSignTransaction
       } else {
-
         signTransaction = async (transaction) => {
           const { blockhash } = await connection.getRecentBlockhash()
           // Must call serialize message to set the correct signatures on the transaction
@@ -145,8 +144,6 @@ class Wormhole {
             }))
           }
 
-
-
           const { transactionSignature } = await this.identityService.solanaRelayRaw(transactionData)
           logs.push(`Relay sol tx for postVAA with signature ${transactionSignature}`)
           return {
@@ -155,7 +152,6 @@ class Wormhole {
         }
         connection.sendRawTransaction = async () => ''
         connection.confirmTransaction = async () => ''
-
       }
       phase = phases.POST_VAA_SOLANA
       await this.wormholeSDK.postVaaSolana(
@@ -182,7 +178,6 @@ class Wormhole {
         const signedTransaction = await signTransaction(transaction)
         const txid = await connection.sendRawTransaction(signedTransaction.serialize())
         finalTxSignature = txid
-
 
         await connection.confirmTransaction(txid)
       } else {
@@ -385,7 +380,7 @@ class Wormhole {
    * @param {string} solanaAccount The solana token account
    * @param {string} relayer The eth relayer to permission to aprrove and transfer
    */
-   async transferTokensToEthWormhole (fromAccount, amount, solanaAccount, relayer) {
+  async transferTokensToEthWormhole (fromAccount, amount, solanaAccount, relayer) {
     const {
       chainId,
       deadline,
@@ -426,7 +421,6 @@ class Wormhole {
       signedDigest.s
     )
     return method
-
   }
 }
 

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -95,6 +95,7 @@ class Wormhole {
    * Sends `amount` tokens to `solanaAccount` by way of the wormhole
    * @param {string} ethTxReceipt The tx receipt
    * @param {function} [customSignTransaction] Optional custom sign transaction parameter
+   * @param {Object?} options The grpc options passed to get signed VAA for different transport
    *
    * else will attempt to relay
    * @returns {Promise} Promise object of {
@@ -104,7 +105,7 @@ class Wormhole {
         logs: Array<string>
       }
    */
-  async attestAndCompleteTransferEthToSol (ethTxReceipt, customSignTransaction, options) {
+  async attestAndCompleteTransferEthToSol (ethTxReceipt, customSignTransaction, options = {}) {
     const phases = {
       GET_RECEIPT: 'GET_RECEIPT',
       GET_SIGNED_VAA: 'GET_SIGNED_VAA',
@@ -216,6 +217,7 @@ class Wormhole {
    * Sends `amount` tokens to `solanaAccount` by way of the wormhole
    * @param {BN} amount The amount of AUDIO to send in Wrapped Audio (8 decimals)
    * @param {string} ethTargetAddress The eth address to transfer AUDIO
+   * @param {Object?} options The grpc options passed to get signed VAA for different transport
    */
   async sendTokensFromSolToEthViaWormhole (amount, ethTargetAddress, options = {}) {
     const phases = {
@@ -328,9 +330,8 @@ class Wormhole {
    * @param {string} fromAccount the account holding the ETH AUDIO to transfer
    * @param {BN} amount The amount of AUDIO to send in WEI (18 decimals)
    * @param {string} solanaAccount The solana token account
-   * @param {string} relayer The eth relayer to permission to aprrove and transfer
    */
-  async _getTransferTokensToEthWormholeParams (fromAccount, amount, solanaAccount, relayer) {
+  async _getTransferTokensToEthWormholeParams (fromAccount, amount, solanaAccount) {
     const web3 = this.ethWeb3Manager.getWeb3()
     const wormholeClientAddress = this.ethContracts.WormholeClient.contractAddress
 
@@ -387,7 +388,7 @@ class Wormhole {
       recipient,
       arbiterFee,
       signedDigest
-    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount, relayer)
+    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount)
     const tx = await this.ethContracts.WormholeClient.transferTokens(
       fromAccount,
       amount,
@@ -408,7 +409,7 @@ class Wormhole {
       recipient,
       arbiterFee,
       signedDigest
-    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount, relayer)
+    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount)
     const method = await this.ethContracts.WormholeClient.WormholeContract.methods.transferTokens(
       fromAccount,
       amount,

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -18,7 +18,7 @@ class Wormhole {
    * @param {object} ethContracts
    * @param {object} identityService
    * @param {object} solanaWeb3Manager
-   * @param {string} rpcHost
+   * @param {Array<string>} rpcHosts
    * @param {string} solBridgeAddress
    * @param {string} solTokenBridgeAddress
    * @param {string} ethBridgeAddress
@@ -30,7 +30,7 @@ class Wormhole {
     ethContracts,
     identityService,
     solanaWeb3Manager,
-    rpcHost,
+    rpcHosts,
     solBridgeAddress,
     solTokenBridgeAddress,
     ethBridgeAddress,
@@ -44,7 +44,7 @@ class Wormhole {
     this.solanaWeb3Manager = solanaWeb3Manager
 
     // Wormhole config
-    this.rpcHost = rpcHost
+    this.rpcHosts = rpcHosts
     this.solBridgeAddress = solBridgeAddress
     this.solTokenBridgeAddress = solTokenBridgeAddress
     this.ethBridgeAddress = ethBridgeAddress
@@ -64,8 +64,8 @@ class Wormhole {
     emitterAddress,
     sequence,
     extraGrpcOpts = {},
-    retryTimeout = 1000,
-    retryAttempts = 5
+    retryTimeout = 5000,
+    retryAttempts = 60
   ) {
     let currentWormholeRpcHost = -1
     const getNextRpcHost = () => ++currentWormholeRpcHost % hosts.length
@@ -94,8 +94,17 @@ class Wormhole {
   /**
    * Sends `amount` tokens to `solanaAccount` by way of the wormhole
    * @param {string} ethTxReceipt The tx receipt
+   * @param {function} [customSignTransaction] Optional custom sign transaction parameter
+   * 
+   * else will attempt to relay
+   * @returns {Promise} Promise object of {
+        transactionSignature: string,
+        error: Error,
+        phase: string,
+        logs: Array<string>
+      }
    */
-  async attestAndCompleteTransferEthToSol (ethTxReceipt) {
+  async attestAndCompleteTransferEthToSol (ethTxReceipt, customSignTransaction, options) {
     const phases = {
       GET_RECEIPT: 'GET_RECEIPT',
       GET_SIGNED_VAA: 'GET_SIGNED_VAA',
@@ -110,15 +119,76 @@ class Wormhole {
       const emitterAddress = this.wormholeSDK.getEmitterAddressEth(this.ethTokenBridgeAddress)
       phase = phases.GET_SIGNED_VAA
       const { vaaBytes } = await this.getSignedVAAWithRetry(
-        [this.rpcHost],
+        this.rpcHosts,
         this.wormholeSDK.CHAIN_ID_ETH,
         emitterAddress,
-        sequence
+        sequence,
+        options
       )
-      const signTransaction = async (transaction) => {
-        const { blockhash } = await connection.getRecentBlockhash()
-        // Must call serialize message to set the correct signatures on the transaction
+
+      const connection = this.solanaWeb3Manager.connection
+      let signTransaction
+      if (customSignTransaction) {
+        signTransaction = customSignTransaction
+      } else {
+
+        signTransaction = async (transaction) => {
+          const { blockhash } = await connection.getRecentBlockhash()
+          // Must call serialize message to set the correct signatures on the transaction
+          transaction.serializeMessage()
+          const transactionData = {
+            recentBlockhash: blockhash,
+            instructions: transaction.instructions.map(SolanaUtils.prepareInstructionForRelay),
+            signatures: transaction.signatures.map(sig => ({
+              publicKey: sig.publicKey.toString(),
+              signature: sig.signature
+            }))
+          }
+
+
+
+          const { transactionSignature } = await this.identityService.solanaRelayRaw(transactionData)
+          logs.push(`Relay sol tx for postVAA with signature ${transactionSignature}`)
+          return {
+            'serialize': () => {}
+          }
+        }
+        connection.sendRawTransaction = async () => ''
+        connection.confirmTransaction = async () => ''
+
+      }
+      phase = phases.POST_VAA_SOLANA
+      await this.wormholeSDK.postVaaSolana(
+        connection,
+        signTransaction,
+        this.solBridgeAddress,
+        this.solanaWeb3Manager.feePayerAddress.toString(), // payerAddress
+        vaaBytes
+      )
+
+      // Finally, redeem on Solana
+      phase = phases.REDEEM_ON_SOLANA
+      const transaction = await this.wormholeSDK.redeemOnSolana(
+        connection,
+        this.solBridgeAddress,
+        this.solTokenBridgeAddress,
+        this.solanaWeb3Manager.feePayerAddress.toString(), // payerAddress,
+        vaaBytes
+      )
+
+      let finalTxSignature
+      // Must call serialize message to set the correct signatures on the transaction
+      if (customSignTransaction) {
+        const signedTransaction = await signTransaction(transaction)
+        const txid = await connection.sendRawTransaction(signedTransaction.serialize())
+        finalTxSignature = txid
+
+
+        await connection.confirmTransaction(txid)
+      } else {
         transaction.serializeMessage()
+
+        const { blockhash } = await connection.getRecentBlockhash()
         const transactionData = {
           recentBlockhash: blockhash,
           instructions: transaction.instructions.map(SolanaUtils.prepareInstructionForRelay),
@@ -129,50 +199,11 @@ class Wormhole {
         }
 
         const { transactionSignature } = await this.identityService.solanaRelayRaw(transactionData)
-        logs.push(`Relay sol tx for postVAA with signature ${transactionSignature}`)
-        return {
-          'serialize': () => {}
-        }
+        finalTxSignature = transactionSignature
       }
-      const connection = this.solanaWeb3Manager.connection
-      connection.sendRawTransaction = async () => ''
-      connection.confirmTransaction = async () => ''
-      phase = phases.POST_VAA_SOLANA
-      await this.wormholeSDK.postVaaSolana(
-        connection,
-        signTransaction,
-        this.solBridgeAddress,
-        this.solanaWeb3Manager.feePayerAddress, // payerAddress
-        vaaBytes
-      )
-
-      // Finally, redeem on Solana
-      phase = phases.REDEEM_ON_SOLANA
-      const transaction = await this.wormholeSDK.redeemOnSolana(
-        connection,
-        this.solBridgeAddress,
-        this.solTokenBridgeAddress,
-        this.solanaWeb3Manager.feePayerAddress, // payerAddress,
-        vaaBytes
-      )
-
-      // Must call serialize message to set the correct signatures on the transaction
-      transaction.serializeMessage()
-
-      const { blockhash } = await connection.getRecentBlockhash()
-      const transactionData = {
-        recentBlockhash: blockhash,
-        instructions: transaction.instructions.map(SolanaUtils.prepareInstructionForRelay),
-        signatures: transaction.signatures.map(sig => ({
-          publicKey: sig.publicKey.toString(),
-          signature: sig.signature
-        }))
-      }
-
-      const { transactionSignature } = await this.identityService.solanaRelayRaw(transactionData)
-      logs.push(`Complete redeem on sol with signature ${transactionSignature}`)
+      logs.push(`Complete redeem on sol with signature ${finalTxSignature}`)
       return {
-        transactionSignature,
+        transactionSignature: finalTxSignature,
         error: null,
         phase,
         logs
@@ -191,7 +222,7 @@ class Wormhole {
    * @param {BN} amount The amount of AUDIO to send in Wrapped Audio (8 decimals)
    * @param {string} ethTargetAddress The eth address to transfer AUDIO
    */
-  async sendTokensFromSolToEthViaWormhole (amount, ethTargetAddress) {
+  async sendTokensFromSolToEthViaWormhole (amount, ethTargetAddress, options = {}) {
     const phases = {
       GENERATE_SOL_ROOT_ACCT: 'GENERATE_SOL_ROOT_ACCT',
       TRANSFER_WAUDIO_TO_ROOT: 'TRANSFER_WAUDIO_TO_ROOT',
@@ -270,14 +301,14 @@ class Wormhole {
       const info = await connection.getTransaction(transactionSignature)
       const sequence = this.wormholeSDK.parseSequenceFromLogSolana(info)
       const emitterAddress = await this.wormholeSDK.getEmitterAddressSolana(this.solTokenBridgeAddress)
-
       // Fetch the signedVAA from the Wormhole Network (this may require retries while you wait for confirmation)
       phase = phases.GET_SIGNED_VAA
       const { vaaBytes } = await this.getSignedVAAWithRetry(
-        [this.rpcHost],
+        this.rpcHosts,
         this.wormholeSDK.CHAIN_ID_SOLANA,
         emitterAddress,
-        sequence
+        sequence,
+        options
       )
 
       // Redeem on Ethereum
@@ -304,7 +335,7 @@ class Wormhole {
    * @param {string} solanaAccount The solana token account
    * @param {string} relayer The eth relayer to permission to aprrove and transfer
    */
-  async transferTokensToEthWormhole (fromAccount, amount, solanaAccount, relayer) {
+  async _getTransferTokensToEthWormholeParams (fromAccount, amount, solanaAccount, relayer) {
     const web3 = this.ethWeb3Manager.getWeb3()
     const wormholeClientAddress = this.ethContracts.WormholeClient.contractAddress
 
@@ -337,6 +368,31 @@ class Wormhole {
     )
     const myPrivateKey = this.hedgehog.wallet._privKey
     const signedDigest = sign(digest, myPrivateKey)
+    return {
+      chainId,
+      deadline,
+      recipient,
+      arbiterFee,
+      signedDigest
+    }
+  }
+
+  /**
+   * Locks assets owned by `fromAccount` into the Solana wormhole with a target
+   * solanaAccount destination via the provided relayer wallet.
+   * @param {string} fromAccount the account holding the ETH AUDIO to transfer
+   * @param {BN} amount The amount of AUDIO to send in WEI (18 decimals)
+   * @param {string} solanaAccount The solana token account
+   * @param {string} relayer The eth relayer to permission to aprrove and transfer
+   */
+   async transferTokensToEthWormhole (fromAccount, amount, solanaAccount, relayer) {
+    const {
+      chainId,
+      deadline,
+      recipient,
+      arbiterFee,
+      signedDigest
+    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount, relayer)
     const tx = await this.ethContracts.WormholeClient.transferTokens(
       fromAccount,
       amount,
@@ -348,6 +404,29 @@ class Wormhole {
       relayer
     )
     return tx
+  }
+
+  async getTransferTokensToEthWormholeMethod (fromAccount, amount, solanaAccount, relayer) {
+    const {
+      chainId,
+      deadline,
+      recipient,
+      arbiterFee,
+      signedDigest
+    } = await this._getTransferTokensToEthWormholeParams(fromAccount, amount, solanaAccount, relayer)
+    const method = await this.ethContracts.WormholeClient.WormholeContract.methods.transferTokens(
+      fromAccount,
+      amount,
+      chainId,
+      recipient,
+      arbiterFee,
+      deadline,
+      signedDigest.v,
+      signedDigest.r,
+      signedDigest.s
+    )
+    return method
+
   }
 }
 


### PR DESCRIPTION
### Description
Moves logic into identity service for wormhole transfer
* Adds an endpoint in identity service to relay all operations of the wormhole transfer of AUDIO to WAUDIO
  * The post body contains the signed permit tx and signed transfer tx
  * The endpoint relays both requests (re-estimates the gas for the second request)
  * Using the eth transfer tx, the endpoint continue to gather attestations from wormhole VAA and completes the transfer of tokens
* Adds wormhole config to identity service
* Update libs to expose the `attestAndCompleteTransferEthToSol` method for identity to use
* downgrades the npm wormhole version bc the newer version do not work with node
* Adds a generic slack reporter to identity to post for failed wormhole transfers

### Tests
Ran everything locally with prod eth and sol relay configs and relayed 

### How will this change be monitored?
slack and logs

Closes AUD-989