### PR TITLE
Switch log duration order

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -100,8 +100,8 @@ const streamFromFileSystem = async (req, res, path) => {
       fileStream
         .on('open', () => fileStream.pipe(res))
         .on('end', () => {
-          res.end()
           logInfoWithDuration(req, 'Successfully served from fs!')
+          res.end()
           resolve()
         })
         .on('error', e => { reject(e) })
@@ -226,8 +226,8 @@ const getCID = async (req, res) => {
       stream
         .on('data', streamData => { res.write(streamData) })
         .on('end', () => {
-          res.end()
           logInfoWithDuration(req, 'Successfully served from ipfs!')
+          res.end()
           resolve()
         })
         .on('error', e => { reject(e) })


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Move the duration log before res.end() for successful log message.

Example:
```
{"name":"audius_creator_node","hostname":"creator-node-backend-78b7c7b964-7kxs8","pid":18,"requestID":"eeHhKvahFL","requestMethod":"GET","requestHostname":"creatornode7.staging.audius.co","requestUrl":"/ipfs/QmZdQmuimnRjmj2rsgeoBRjJRRdtWDbo5bhLpjEPVsLjyn","level":30,"duration":22,"msg":"Successfully served from fs!","time":"2021-12-15T23:59:04.494Z","v":0}
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->