### PR TITLE
Fix aggregate plays double count when migrating

### DIFF
--- a/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
+++ b/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
@@ -33,8 +33,8 @@ def upgrade():
                 )
                 INSERT INTO indexing_checkpoints (tablename, last_checkpoint)
                 VALUES(
-                'aggregate_plays',
-                (COALESCE((SELECT id FROM latest_play_id), 0))
+                    'aggregate_plays',
+                    (COALESCE((SELECT id FROM latest_play_id), 0))
                 )
                 ON CONFLICT (tablename)
                 DO UPDATE SET last_checkpoint = EXCLUDED.last_checkpoint;

--- a/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
+++ b/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
@@ -47,7 +47,11 @@ def upgrade():
                         count(*) as count
                     FROM
                         plays
-                    WHERE plays.id <= (SELECT last_checkpoint FROM indexing_checkpoints WHERE tablename = 'aggregate_plays')
+                    WHERE plays.id <= (
+                        SELECT last_checkpoint
+                        FROM indexing_checkpoints
+                        WHERE tablename = 'aggregate_plays'
+                    )
                     GROUP BY plays.play_item_id
                 );
 

--- a/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
+++ b/discovery-provider/alembic/versions/6b5186e7d28f_replace_aggregate_plays_mat_view_with_.py
@@ -27,10 +27,29 @@ def upgrade():
                 SELECT FROM information_schema.tables
                 WHERE table_name   = 'aggregate_plays'
             ) THEN
+                -- update indexing checkpoints based on current plays
+                WITH latest_play_id AS (
+                    SELECT MAX(id) AS id FROM plays
+                )
+                INSERT INTO indexing_checkpoints (tablename, last_checkpoint)
+                VALUES(
+                'aggregate_plays',
+                (COALESCE((SELECT id FROM latest_play_id), 0))
+                )
+                ON CONFLICT (tablename)
+                DO UPDATE SET last_checkpoint = EXCLUDED.last_checkpoint;
 
                 -- create aggregate_plays table
                 DROP TABLE IF EXISTS aggregate_plays_table;
-                CREATE TABLE aggregate_plays_table AS TABLE aggregate_plays;
+                CREATE TABLE aggregate_plays_table AS (
+                    SELECT
+                        plays.play_item_id as play_item_id,
+                        count(*) as count
+                    FROM
+                        plays
+                    WHERE plays.id <= (SELECT last_checkpoint FROM indexing_checkpoints WHERE tablename = 'aggregate_plays')
+                    GROUP BY plays.play_item_id
+                );
 
                 -- drop existing aggregate_plays mat view and its dependencies
 

--- a/discovery-provider/tests/test_index_aggregate_plays.py
+++ b/discovery-provider/tests/test_index_aggregate_plays.py
@@ -82,38 +82,38 @@ def test_index_aggregate_plays_update(app):
     # run
     entities = {
         "tracks": [
-            {"track_id": 0, "title": "track 0"},
             {"track_id": 1, "title": "track 1"},
             {"track_id": 2, "title": "track 2"},
             {"track_id": 3, "title": "track 3"},
+            {"track_id": 4, "title": "track 4"},
         ],
         "aggregate_plays" : [
             # Current Plays
-            {"play_item_id": 0, "count": 3},
             {"play_item_id": 1, "count": 3},
             {"play_item_id": 2, "count": 3},
+            {"play_item_id": 3, "count": 3},
         ],
         "indexing_checkpoints" : [
             {"tablename": "aggregate_plays", "last_checkpoint": 9}
         ],
         "plays" : [
             # Current Plays
-            {"item_id": 0},
-            {"item_id": 0},
-            {"item_id": 0},
             {"item_id": 1},
             {"item_id": 1},
             {"item_id": 1},
             {"item_id": 2},
             {"item_id": 2},
             {"item_id": 2},
+            {"item_id": 3},
+            {"item_id": 3},
+            {"item_id": 3},
 
             # New plays
-            {"item_id": 0},
-            {"item_id": 0},
             {"item_id": 1},
-            {"item_id": 3},
-            {"item_id": 3},
+            {"item_id": 1},
+            {"item_id": 2},
+            {"item_id": 4},
+            {"item_id": 4},
         ]
 
     }
@@ -130,13 +130,13 @@ def test_index_aggregate_plays_update(app):
         )
 
         assert len(results) == 4
-        assert results[0].play_item_id == 0
+        assert results[0].play_item_id == 1
         assert results[0].count == 5
-        assert results[1].play_item_id == 1
+        assert results[1].play_item_id == 2
         assert results[1].count == 4
-        assert results[2].play_item_id == 2
+        assert results[2].play_item_id == 3
         assert results[2].count == 3
-        assert results[3].play_item_id == 3
+        assert results[3].play_item_id == 4
         assert results[3].count == 2
 
 def test_index_aggregate_plays_same_checkpoint(app):
@@ -148,31 +148,31 @@ def test_index_aggregate_plays_same_checkpoint(app):
     # run
     entities = {
         "tracks": [
-            {"track_id": 0, "title": "track 0"},
             {"track_id": 1, "title": "track 1"},
             {"track_id": 2, "title": "track 2"},
             {"track_id": 3, "title": "track 3"},
+            {"track_id": 4, "title": "track 4"},
         ],
         "aggregate_plays" : [
             # Current Plays
-            {"play_item_id": 0, "count": 3},
             {"play_item_id": 1, "count": 3},
             {"play_item_id": 2, "count": 3},
+            {"play_item_id": 3, "count": 3},
         ],
         "indexing_checkpoints" : [
             {"tablename": "aggregate_plays", "last_checkpoint": 9}
         ],
         "plays" : [
             # Current Plays
-            {"item_id": 0},
-            {"item_id": 0},
-            {"item_id": 0},
             {"item_id": 1},
             {"item_id": 1},
             {"item_id": 1},
             {"item_id": 2},
             {"item_id": 2},
             {"item_id": 2},
+            {"item_id": 3},
+            {"item_id": 3},
+            {"item_id": 3},
         ]
 
     }
@@ -210,3 +210,4 @@ def test_index_aggregate_plays_no_plays(app):
             assert False, "test_index_aggregate_plays [test_index_aggregate_plays_no_plays] failed"
         except NoResultFound:
             assert True
+

--- a/discovery-provider/tests/test_index_aggregate_plays.py
+++ b/discovery-provider/tests/test_index_aggregate_plays.py
@@ -210,4 +210,3 @@ def test_index_aggregate_plays_no_plays(app):
             assert False, "test_index_aggregate_plays [test_index_aggregate_plays_no_plays] failed"
         except NoResultFound:
             assert True
-

--- a/discovery-provider/tests/utils.py
+++ b/discovery-provider/tests/utils.py
@@ -226,12 +226,14 @@ def populate_mock_db(db, entities, block_offset=0):
             )
             session.add(user_listening_history)
 
-        for i, indexing_checkpoint_meta in enumerate(indexing_checkpoints):
-            indexing_checkpoint = models.IndexingCheckpoints(
-                tablename=indexing_checkpoint_meta.get("tablename", None),
-                last_checkpoint=indexing_checkpoint_meta.get("last_checkpoint", 0),
-            )
-            session.add(indexing_checkpoint)
+        if indexing_checkpoints:
+            session.execute("TRUNCATE TABLE indexing_checkpoints") # clear primary keys before adding
+            for i, indexing_checkpoint_meta in enumerate(indexing_checkpoints):
+                indexing_checkpoint = models.IndexingCheckpoints(
+                    tablename=indexing_checkpoint_meta.get("tablename", None),
+                    last_checkpoint=indexing_checkpoint_meta.get("last_checkpoint", 0),
+                )
+                session.add(indexing_checkpoint)
 
 
         for i, route_meta in enumerate(track_routes):


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Bug fix. Previously when migrating aggregate_plays from mat view to table, the migration would copy the table without updating indexing_checkpoints. Then the indexing task would assume the table needs to be repopulated and increment on top of existing counts.

The new migrations calculates aggregate_plays and saves the indexing checkpoint so the indexing task would pick up where the migration left off. This is safe assuming no plays are pruned.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Updated unit tests to avoid play_item_id 0 and clear indexing_checkpoints before populating mock.

Ran migration against a prod snapshot and confirmed indexing_checkpoints was updated and aggregate_plays_table and aggregate_plays were identical. 

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->