### PR TITLE
Fix user listen history import

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -378,7 +378,7 @@ def configure_celery(flask_app, celery, test_config=None):
             "src.tasks.index_related_artists",
             "src.tasks.calculate_trending_challenges",
             "src.tasks.index_listen_count_milestones",
-            "src.tasks.index_user_listening_history",
+            "src.tasks.user_listening_history.index_user_listening_history",
         ],
         beat_schedule={
             "update_discovery_provider": {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Bug fix web server failed with `ModuleNotFoundError: No module named 'src.tasks.index_user_listening_history'`.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran disc prov locally and confirmed index_user_listening_history ran completely. 

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->