### PR TITLE
Fix reboot instance and disable pg auto-start 

### DIFF
--- a/service-commands/scripts/provision-dev-env.sh
+++ b/service-commands/scripts/provision-dev-env.sh
@@ -28,6 +28,7 @@ echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main"
 sudo apt-get update
 sudo apt -y install postgresql-11
 dpkg -l | grep postgresql
+sudo systemctl disable postgresql # disable auto-start on boot
 
 # python setup
 sudo add-apt-repository ppa:deadsnakes/ppa # python3.9 installation
@@ -79,6 +80,3 @@ cd ~
 git clone https://github.com/AudiusProject/audius-client.git
 cd audius-client
 npm link @audius/libs
-
-echo 'Rebooting machine...'
-reboot

--- a/service-commands/scripts/setup-instance.sh
+++ b/service-commands/scripts/setup-instance.sh
@@ -10,7 +10,7 @@
 #   -l <audius-client-git-ref>
 #   -f (fast setup with prebaked dev image)
 
-set -e
+set -ex
 
 PROTOCOL_DIR=${PROTOCOL_DIR:-$(dirname $(realpath $0))/../../}
 
@@ -95,15 +95,14 @@ case "$service" in
 		;;
 	remote-dev)
 		wait_for_instance $provider $user $name
-
 		execute_with_ssh $provider $user $name \
 			"[[ ! -d ~/audius-protocol ]]" \
 			"&& git clone https://github.com/AudiusProject/audius-protocol.git" \
-			"&& yes | bash audius-protocol/service-commands/scripts/provision-dev-env.sh"
+			"&& yes | bash audius-protocol/service-commands/scripts/provision-dev-env.sh" \
+			"&& yes | bash audius-protocol/service-commands/scripts/set-git-refs.sh $audius_protocol_git_ref $audius_client_git_ref"
 
 		wait_for_instance $provider $user $name
-
-        execute_with_ssh $provider $user $name "bash ~/audius-protocol/service-commands/scripts/set-git-refs.sh $audius_protocol_git_ref $audius_client_git_ref"
+        reboot_instance $provider $name
 
 		read -p "Configure local /etc/hosts? [y/N] " -n 1 -r && echo
 		if [[ "$REPLY" =~ ^[Yy]$ ]]; then

--- a/service-commands/scripts/utils.sh
+++ b/service-commands/scripts/utils.sh
@@ -107,6 +107,19 @@ wait_for_instance() {
 	done
 }
 
+reboot_instance() {
+	echo "Rebooting instance $2 on $1 platform..."
+	case "$1" in
+		azure)
+			az vm restart --name $2
+			;;
+		gcp)
+			gcloud compute instances stop $2
+			gcloud compute instances start $2
+			;;
+	esac
+}
+
 
 get_ip_addr() {
 	provider=$1


### PR DESCRIPTION
### Description

* Fixes A `remote-dev` provisioning early exit due to non-interactive shell allocated by ssh in python
* Disables pg auto-start which conflicts with DN provisioning

### Tests

Tested by manually provisioning an instance. 