### PR TITLE
Add headers to send when making discovery node request

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -579,7 +579,8 @@ class DiscoveryProvider {
      endpoint: string,
      urlParams: string,
      queryParams: object,
-     method: string
+     method: string,
+     headers: object,
    }} requestObj
    * @param {string} discoveryProviderEndpoint
    * @returns
@@ -700,6 +701,7 @@ class DiscoveryProvider {
    *  urlParams: object
    *  queryParams: object
    *  method: string
+   *  headers: object
    * }} {
    *  endpoint: the base route
    *  urlParams: string of URL params to be concatenated after base route
@@ -818,7 +820,7 @@ class DiscoveryProvider {
       requestUrl = urlJoin(discoveryProviderEndpoint, requestObj.endpoint, requestObj.urlParams, { query: requestObj.queryParams })
     }
 
-    const headers = {}
+    const headers = requestObj.headers ?? {}
     const currentUserId = this.userStateManager.getCurrentUserId()
     if (currentUserId) {
       headers['X-User-ID'] = currentUserId


### PR DESCRIPTION
### Description
In order to pass headers from audius-client to discovery provider, need to make these changes.

### Tests

Tested working with a /users/handle/<handle>/tracks request to discovery node to ensure the correct headers were being passed. Tested that response was as expected (returned hidden tracks)

### How will this change be monitored?


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->