### PR TITLE
Add inspect flag for debugger mode CN

### DIFF
--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -75,9 +75,9 @@ if [[ "$devMode" == "true" ]]; then
         npm link
         cd ../app
         npm link @audius/libs
-        npx nodemon --watch src/ --watch ../audius-libs/ src/index.ts | tee >(logger) | npx bunyan
+        npx nodemon  --exec 'node --inspect=0.0.0.0:${debuggerPort} --require ts-node/register src/index.ts' --watch src/ --watch ../audius-libs/ | tee >(logger) | ./node_modules/.bin/bunyan
     else
-        npx nodemon --watch src/ src/index.ts | tee >(logger) | npx bunyan
+        npx nodemon  --exec 'node --inspect=0.0.0.0:${debuggerPort} --require ts-node/register src/index.ts' --watch src/ | tee >(logger) | ./node_modules/.bin/bunyan
     fi
 else
     node build/src/index.js | tee >(logger)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Get debugger mode to work with typescript `index.ts` file. 

Reference https://github.com/remy/nodemon/issues/1565#issuecomment-494643872

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Brought up a local CN with `link_libs` true and false.