### PR TITLE
Remove diff before building docker tags, reverting to original behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,13 +650,6 @@ jobs:
             # 3. 'latest', which is the default
             echo "export IMAGE_TAG=`[ $CIRCLE_TAG ] && echo $(echo $CIRCLE_TAG | cut -d@ -f3) || [[ "$CIRCLE_BRANCH" =~ (hotfix) ]] && echo $CIRCLE_BRANCH || echo "latest" `" | tee -a $BASH_ENV
       - run:
-          name: Check whether new tag should be built and pushed for << parameters.repo >>
-          command: |
-              if [[ !`git diff --exit-code << parameters.repo >>` ]]; then
-                echo "No changes detected in << parameters.repo >>; exiting docker-build-and-push job early"
-                circleci-agent step halt
-              fi
-      - run:
           name: Docker login
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin


### PR DESCRIPTION
### Description

PR #2157 introduced a potential bug where it didn't build all docker tags that changed and no tags on master. Reverting that behavior.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->