### PR TITLE
Set client upload max size to 1000mb (1gb)

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -5,6 +5,7 @@ events {
 }
 
 http {
+    client_max_body_size 1000M;
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

With the Content Node CID proxy layer enabled, the default max upload size is 1MB. This causes any content (images, tracks) upload greater than 1MB from the client fail.

Example error message in proxy logs: `client intended to send too large body: 4051550 bytes` (~4.05MB)

The intention of this PR is to bump the size to 1GB -- the current max size for audio uploads. 

reference: https://stackoverflow.com/a/66777762

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Uploaded 11MB track to local node with proxy on successfully

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Lovely probers and sentry alerts 😬 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->