### PR TITLE
Update indexes for SolanaNotifications and SolanaNotificationActions to have names

### DIFF
--- a/identity-service/sequelize/migrations/20211223183608-add-solana-notification-indexes.js
+++ b/identity-service/sequelize/migrations/20211223183608-add-solana-notification-indexes.js
@@ -3,18 +3,62 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (transaction) => {
-      await queryInterface.addIndex('SolanaNotifications', ['userId'], { transaction })
-      await queryInterface.addIndex('SolanaNotificationActions', ['slot'], { transaction })
-      await queryInterface.addIndex('SolanaNotificationActions', ['notificationId'], { transaction })
-      await queryInterface.addIndex('SolanaNotificationActions', ['notificationId', 'actionEntityType', 'actionEntityId', 'slot'], { transaction })
+      await queryInterface.addIndex(
+        'SolanaNotifications',
+        ['userId'],
+        {
+          transaction,
+          name: 'idx_solana_notifications_user_id'
+        }
+      )
+      await queryInterface.addIndex(
+        'SolanaNotificationActions',
+        ['slot'],
+        {
+          transaction,
+          name: 'idx_solana_notification_actions_slot'
+        }
+      )
+      await queryInterface.addIndex(
+        'SolanaNotificationActions',
+        ['notificationId'],
+        {
+          transaction,
+          name: 'idx_solana_notification_actions_notif_id'
+        }
+      )
+      await queryInterface.addIndex(
+        'SolanaNotificationActions',
+        ['notificationId', 'actionEntityType', 'actionEntityId', 'slot'],
+        {
+          transaction,
+          name: 'idx_solana_notification_actions_all'
+        }
+      )
     })
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (transaction) => {
-      await queryInterface.removeIndex('SolanaNotifications', ['userId'], { transaction })
-      await queryInterface.removeIndex('SolanaNotificationActions', ['slot'], { transaction })
-      await queryInterface.removeIndex('SolanaNotificationActions', ['notificationId'], { transaction })
-      await queryInterface.removeIndex('SolanaNotificationActions', ['notificationId', 'actionEntityType', 'actionEntityId', 'slot'], { transaction })
+      await queryInterface.removeIndex(
+        'SolanaNotifications',
+        'idx_solana_notifications_user_id',
+        { transaction }
+      )
+      await queryInterface.removeIndex(
+        'SolanaNotificationActions',
+        'idx_solana_notification_actions_slot',
+        { transaction }
+      )
+      await queryInterface.removeIndex(
+        'SolanaNotificationActions',
+        'idx_solana_notification_actions_notif_id',
+        { transaction }
+      )
+      await queryInterface.removeIndex(
+        'SolanaNotificationActions',
+        'idx_solana_notification_actions_all',
+        { transaction }
+      )
     })
   }
 }


### PR DESCRIPTION
### Description

Updated index for SolanaNotifications and SolanaNotificationActions to have names to prevent collisions with the current indexes and make it easier to remove them if needed

### Tests

Manually tested, adding and removing indexes works

### How will this change be monitored?

After this PR goes in and these indexes are created, the duplicate ones in prod DB will be removed