### PR TITLE
Disable client max body limit

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -5,7 +5,7 @@ events {
 }
 
 http {
-    client_max_body_size 1000M;
+    client_max_body_size 0;
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -5,6 +5,8 @@ events {
 }
 
 http {
+    # A value of 0 disables client upload size check on the nginx proxy layer, and shifts the responsibility
+    # back to the app
     client_max_body_size 0;
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Previously, this value was set to mimic the value in `maxAudioFileSizeBytes`. It is better to actually disable this upload size checking so we can allow the app to decide if an upload size is too big, rather than have two sources that check the upload size

Reference:
http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Uploaded a 195.1MB track locally successfully 

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Probers and sentry alerts!!

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->