### PR TITLE
Fix play metrics indexing on empty plays case

### DIFF
--- a/discovery-provider/integration_tests/test_index_hourly_play_counts.py
+++ b/discovery-provider/integration_tests/test_index_hourly_play_counts.py
@@ -314,3 +314,27 @@ def test_index_hourly_play_counts_no_change(app):
             .scalar()
         )
         assert new_checkpoint == 13
+
+
+def test_index_hourly_play_counts_empty_plays(app):
+    """Test that hourly play counts should skip indexing if there are no plays"""
+
+    # setup
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "tracks": [
+            {"track_id": 1, "title": "track 0"},
+            {"track_id": 2, "title": "track 1"},
+            {"track_id": 3, "title": "track 2"},
+            {"track_id": 4, "title": "track 3"},
+        ],
+        "plays": [],
+    }
+
+    populate_mock_db(db, entities)
+
+    # run
+    with db.scoped_session() as session:
+        _index_hourly_play_counts(session)

--- a/discovery-provider/src/tasks/index_hourly_play_counts.py
+++ b/discovery-provider/src/tasks/index_hourly_play_counts.py
@@ -33,7 +33,7 @@ def _index_hourly_play_counts(session):
 
     new_id_checkpoint = (session.query(func.max(Play.id))).scalar()
 
-    if new_id_checkpoint == prev_id_checkpoint:
+    if not new_id_checkpoint or new_id_checkpoint == prev_id_checkpoint:
         logger.info(
             "index_hourly_play_counts.py | Skip update because there are no new plays"
         )


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fix bug when plays table is empty.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->