### PR TITLE
Aud 1186 refactor db session indexing

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import logging
 from operator import itemgetter
+
 from sqlalchemy import func
 from src.app import get_contract_addresses
 from src.challenges.challenge_event_bus import ChallengeEventBus
@@ -37,6 +38,7 @@ from src.tasks.user_library import user_library_state_update
 from src.tasks.user_replica_set import user_replica_set_state_update
 from src.tasks.users import user_event_types_lookup, user_state_update
 from src.utils import helpers, multihash
+from src.utils.constants import CONTRACT_TYPES
 from src.utils.indexing_errors import IndexingError
 from src.utils.redis_cache import (
     remove_cached_playlist_ids,
@@ -50,7 +52,6 @@ from src.utils.redis_constants import (
     most_recent_indexed_block_redis_key,
 )
 from src.utils.session_manager import SessionManager
-from src.utils.constants import CONTRACT_TYPES
 
 (
     USER_FACTORY,

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,7 +1,8 @@
 # pylint: disable=C0302
 import concurrent.futures
 import logging
-
+import time
+from operator import itemgetter
 from sqlalchemy import func
 from src.app import get_contract_addresses
 from src.challenges.challenge_event_bus import ChallengeEventBus
@@ -50,7 +51,25 @@ from src.utils.redis_constants import (
     most_recent_indexed_block_redis_key,
 )
 from src.utils.session_manager import SessionManager
+from src.utils.constants import CONTRACT_TYPES
 
+(
+    USER_FACTORY,
+    TRACK_FACTORY,
+    SOCIAL_FEATURE_FACTORY,
+    PLAYLIST_FACTORY,
+    USER_LIBRARY_FACTORY,
+    USER_REPLICA_SET_MANAGER,
+) = itemgetter(
+    "USER_FACTORY",
+    "TRACK_FACTORY",
+    "SOCIAL_FEATURE_FACTORY",
+    "PLAYLIST_FACTORY",
+    "USER_LIBRARY_FACTORY",
+    "USER_REPLICA_SET_MANAGER",
+)(
+    CONTRACT_TYPES
+)
 logger = logging.getLogger(__name__)
 
 
@@ -353,6 +372,45 @@ def save_and_get_skip_tx_hash(session, redis):
     return None
 
 
+def group_transaction_by_type(tx_type_to_grouped_lists_map, tx, tx_receipt):
+    tx_target_contract_address = tx["to"]
+    for tx_type, tx_list in tx_type_to_grouped_lists_map.items():
+        tx_is_type = tx_target_contract_address == get_contract_addresses()[tx_type]
+        if tx_is_type:
+            contract_name = helpers.snake_to_pascal(tx_type)
+            logger.info(
+                f"index.py | {contract_name} contract addr: {tx_target_contract_address}"
+                f" tx from block - {tx}, receipt - {tx_receipt}"
+            )
+            tx_list.append(tx_receipt)
+            break
+
+
+def add_indexed_block_to_db(db_session, block):
+    web3 = update_task.web3
+    current_block_query = db_session.query(Block).filter_by(is_current=True)
+
+    # Without this check we may end up duplicating an insert operation
+    block_model = Block(
+        blockhash=web3.toHex(block.hash),
+        parenthash=web3.toHex(block.parentHash),
+        number=block.number,
+        is_current=True,
+    )
+
+    # Update blocks table after
+    assert current_block_query.count() == 1, "Expected single row marked as current"
+
+    previous_block = current_block_query.first()
+    previous_block.is_current = False
+    db_session.add(block_model)
+
+
+def add_indexed_block_to_redis(block, redis):
+    redis.set(most_recent_indexed_block_redis_key, block.number)
+    redis.set(most_recent_indexed_block_hash_redis_key, block.hash.hex())
+
+
 def index_blocks(self, db, blocks_list):
     web3 = update_task.web3
     redis = update_task.redis
@@ -363,306 +421,222 @@ def index_blocks(self, db, blocks_list):
         update_ursm_address(self)
         block = blocks_list[i]
         block_index = num_blocks - i
-        block_number = block.number
-        block_hash = block.hash
-        block_timestamp = block.timestamp
+        block_number, block_hash, block_timestamp = itemgetter(
+            "number", "hash", "timestamp"
+        )(block)
         logger.info(
             f"index.py | index_blocks | {self.request.id} | block {block.number} - {block_index}/{num_blocks}"
         )
         challenge_bus: ChallengeEventBus = update_task.challenge_event_bus
+
         with db.scoped_session() as session, challenge_bus.use_scoped_dispatch_queue():
-            current_block_query = session.query(Block).filter_by(is_current=True)
-
-            # Without this check we may end up duplicating an insert operation
-            block_model = Block(
-                blockhash=web3.toHex(block.hash),
-                parenthash=web3.toHex(block.parentHash),
-                number=block.number,
-                is_current=True,
-            )
-
-            # Update blocks table after
-            assert (
-                current_block_query.count() == 1
-            ), "Expected single row marked as current"
-
-            previous_block = current_block_query.first()
-            previous_block.is_current = False
-            session.add(block_model)
-
-            user_factory_txs = []
-            track_factory_txs = []
-            social_feature_factory_txs = []
-            playlist_factory_txs = []
-            user_library_factory_txs = []
-            user_replica_set_manager_txs = []
-
-            tx_receipt_dict = fetch_tx_receipts(self, block.transactions)
-
-            # Sort transactions by hash
-            sorted_txs = sorted(block.transactions, key=lambda entry: entry["hash"])
-
             skip_tx_hash = save_and_get_skip_tx_hash(session, redis)
-            # Parse tx events in each block
-            for tx in sorted_txs:
-                tx_hash = web3.toHex(tx["hash"])
-                tx_target_contract_address = tx["to"]
-                tx_receipt = tx_receipt_dict[tx_hash]
+            skip_whole_block = skip_tx_hash == "commit"  # db tx failed at commit level
+            if skip_whole_block:
+                logger.info(f"index.py | Skipping all txs in block {block.hash}")
+            else:
+                add_indexed_block_to_db(session, block)
+                TXS_GROUPED_BY_TYPE = {
+                    USER_FACTORY: [],
+                    TRACK_FACTORY: [],
+                    SOCIAL_FEATURE_FACTORY: [],
+                    PLAYLIST_FACTORY: [],
+                    USER_LIBRARY_FACTORY: [],
+                    USER_REPLICA_SET_MANAGER: [],
+                }
 
-                # Skip in case a transaction targets zero address
-                if tx_target_contract_address == zero_address:
-                    logger.info(
-                        f"index.py | Skipping tx {tx_hash} targeting {tx_target_contract_address}"
+                tx_receipt_dict = fetch_tx_receipts(self, block.transactions)
+
+                # Sort transactions by hash
+                sorted_txs = sorted(block.transactions, key=lambda entry: entry["hash"])
+
+                # Parse tx events in each block
+                for tx in sorted_txs:
+                    tx_hash = web3.toHex(tx["hash"])
+                    tx_target_contract_address = tx["to"]
+                    tx_receipt = tx_receipt_dict[tx_hash]
+                    should_skip_tx = (tx_target_contract_address == zero_address) or (
+                        skip_tx_hash is not None and skip_tx_hash == tx_hash
                     )
-                    continue
 
-                if skip_tx_hash == "commit":
-                    # The whole block is worth skipping because we failed at the database commit
-                    logger.info(f"index.py | Skipping all txs in block {block.hash}")
-                    break
+                    if should_skip_tx:
+                        logger.info(
+                            f"index.py | Skipping tx {tx_hash} targeting {tx_target_contract_address}"
+                        )
+                        continue
+                    else:
+                        group_transaction_by_type(TXS_GROUPED_BY_TYPE, tx, tx_receipt)
 
-                if skip_tx_hash is not None and skip_tx_hash == tx_hash:
-                    logger.info(f"index.py | Skipping tx {tx_hash}")
-                    continue
+                # grab references to use in further processing
+                user_factory_txs = TXS_GROUPED_BY_TYPE[USER_FACTORY]
+                track_factory_txs = TXS_GROUPED_BY_TYPE[TRACK_FACTORY]
+                social_feature_factory_txs = TXS_GROUPED_BY_TYPE[SOCIAL_FEATURE_FACTORY]
+                playlist_factory_txs = TXS_GROUPED_BY_TYPE[PLAYLIST_FACTORY]
+                user_library_factory_txs = TXS_GROUPED_BY_TYPE[USER_LIBRARY_FACTORY]
+                user_replica_set_manager_txs = TXS_GROUPED_BY_TYPE[
+                    USER_REPLICA_SET_MANAGER
+                ]
 
-                # Handle user operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["user_factory"]
-                ):
-                    logger.info(
-                        f"index.py | UserFactory contract addr: {tx_target_contract_address}"
-                        f" tx from block - {tx}, receipt - {tx_receipt}, adding to user_factory_txs to process in bulk"
-                    )
-                    user_factory_txs.append(tx_receipt)
-
-                # Handle track operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["track_factory"]
-                ):
-                    logger.info(
-                        f"index.py | TrackFactory contract addr: {tx_target_contract_address}"
-                        f" tx from block - {tx}, receipt - {tx_receipt}"
-                    )
-                    # Track state operations
-                    track_factory_txs.append(tx_receipt)
-
-                # Handle social operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["social_feature_factory"]
-                ):
-                    logger.info(
-                        f"index.py | Social feature contract addr: {tx_target_contract_address}"
-                        f"tx from block - {tx}, receipt - {tx_receipt}"
-                    )
-                    social_feature_factory_txs.append(tx_receipt)
-
-                # Handle repost operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["playlist_factory"]
-                ):
-                    logger.info(
-                        f"index.py | Playlist contract addr: {tx_target_contract_address}"
-                        f"tx from block - {tx}, receipt - {tx_receipt}"
-                    )
-                    playlist_factory_txs.append(tx_receipt)
-
-                # Handle User Library operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["user_library_factory"]
-                ):
-                    logger.info(
-                        f"index.py | User Library contract addr: {tx_target_contract_address}"
-                        f"tx from block - {tx}, receipt - {tx_receipt}"
-                    )
-                    user_library_factory_txs.append(tx_receipt)
-
-                # Handle UserReplicaSetManager operations
-                if (
-                    tx_target_contract_address
-                    == get_contract_addresses()["user_replica_set_manager"]
-                ):
-                    logger.info(
-                        f"index.py | User Replica Set Manager contract addr: {tx_target_contract_address}"
-                        f"tx from block - {tx}, receipt - {tx_receipt}"
-                    )
-                    user_replica_set_manager_txs.append(tx_receipt)
-
-            # pre-fetch cids asynchronously to not have it block in user_state_update
-            # and track_state_update
-            try:
-                ipfs_metadata, blacklisted_cids = fetch_ipfs_metadata(
-                    db,
-                    user_factory_txs,
-                    track_factory_txs,
-                    block_number,
-                    block_hash,
-                )
-            except IndexingError as err:
-                logger.info(
-                    f"index.py | Error in the indexing task at"
-                    f" block={err.blocknumber} and hash={err.txhash}"
-                )
-                set_indexing_error(
-                    redis, err.blocknumber, err.blockhash, err.txhash, err.message
-                )
-                confirm_indexing_transaction_error(
-                    redis, err.blocknumber, err.blockhash, err.txhash, err.message
-                )
-                raise err
-
-            try:
-                # bulk process operations once all tx's for block have been parsed
-                total_user_changes, user_ids = user_state_update(
-                    self,
-                    update_task,
-                    session,
-                    ipfs_metadata,
-                    blacklisted_cids,
-                    user_factory_txs,
-                    block_number,
-                    block_timestamp,
-                    block_hash,
-                )
-                user_state_changed = total_user_changes > 0
-                logger.info(
-                    f"index.py | user_state_update completed"
-                    f" user_state_changed={user_state_changed} for block={block_number}"
-                )
-
-                total_track_changes, track_ids = track_state_update(
-                    self,
-                    update_task,
-                    session,
-                    blacklisted_cids,
-                    ipfs_metadata,
-                    track_factory_txs,
-                    block_number,
-                    block_timestamp,
-                    block_hash,
-                )
-                track_state_changed = total_track_changes > 0
-                logger.info(
-                    f"index.py | track_state_update completed"
-                    f" track_state_changed={track_state_changed} for block={block_number}"
-                )
-
-                social_feature_state_changed = (  # pylint: disable=W0612
-                    social_feature_state_update(
-                        self,
-                        update_task,
-                        session,
-                        social_feature_factory_txs,
-                        block_number,
-                        block_timestamp,
-                        block_hash,
-                    )
-                    > 0
-                )
-                logger.info(
-                    f"index.py | social_feature_state_update completed"
-                    f" social_feature_state_changed={social_feature_state_changed} for block={block_number}"
-                )
-
-                # Index UserReplicaSet changes
-                (
-                    total_user_replica_set_changes,
-                    replica_user_ids,
-                ) = user_replica_set_state_update(
-                    self,
-                    update_task,
-                    session,
-                    user_replica_set_manager_txs,
-                    block_number,
-                    block_timestamp,
-                    block_hash,
-                    redis,
-                )
-                user_replica_set_state_changed = total_user_replica_set_changes > 0
-                logger.info(
-                    f"index.py | user_replica_set_state_update completed"
-                    f" user_replica_set_state_changed={user_replica_set_state_changed} for block={block_number}"
-                )
-
-                # Playlist state operations processed in bulk
-                total_playlist_changes, playlist_ids = playlist_state_update(
-                    self,
-                    update_task,
-                    session,
-                    playlist_factory_txs,
-                    block_number,
-                    block_timestamp,
-                    block_hash,
-                )
-                playlist_state_changed = total_playlist_changes > 0
-                logger.info(
-                    f"index.py | playlist_state_update completed"
-                    f" playlist_state_changed={playlist_state_changed} for block={block_number}"
-                )
-
-                user_library_state_changed = (
-                    user_library_state_update(  # pylint: disable=W0612
-                        self,
-                        update_task,
-                        session,
-                        user_library_factory_txs,
-                        block_number,
-                        block_timestamp,
-                        block_hash,
-                    )
-                )
-                logger.info(
-                    f"index.py | user_library_state_update completed"
-                    f" user_library_state_changed={user_library_state_changed} for block={block_number}"
-                )
-
-                track_lexeme_state_changed = user_state_changed or track_state_changed
+                # pre-fetch cids asynchronously to not have it block in user_state_update
+                # and track_state_update
                 try:
-                    session.commit()
-                except Exception as e:
-                    # Use 'commit' as the tx hash here.
-                    # We're at a point where the whole block can't be added to the database, so
-                    # we should skip it in favor of making progress
-                    blockhash = update_task.web3.toHex(block_hash)
-                    raise IndexingError(
-                        "session.commit", block_number, blockhash, "commit", str(e)
-                    ) from e
-                logger.info(
-                    f"index.py | session commmited to db for block=${block_number}"
-                )
-                if skip_tx_hash:
-                    clear_indexing_error(redis)
-                if user_state_changed:
-                    if user_ids:
-                        remove_cached_user_ids(redis, user_ids)
-                if user_replica_set_state_changed:
-                    if replica_user_ids:
-                        remove_cached_user_ids(redis, replica_user_ids)
-                if track_lexeme_state_changed:
-                    if track_ids:
-                        remove_cached_track_ids(redis, track_ids)
-                if playlist_state_changed:
-                    if playlist_ids:
-                        remove_cached_playlist_ids(redis, playlist_ids)
-                logger.info(
-                    f"index.py | redis cache clean operations complete for block=${block_number}"
-                )
-            except IndexingError as err:
-                logger.info(
-                    f"index.py | Error in the indexing task at"
-                    f" block={err.blocknumber} and hash={err.txhash}"
-                )
-                set_indexing_error(
-                    redis, err.blocknumber, err.blockhash, err.txhash, err.message
-                )
-                confirm_indexing_transaction_error(
-                    redis, err.blocknumber, err.blockhash, err.txhash, err.message
-                )
-                raise err
+                    ipfs_metadata, blacklisted_cids = fetch_ipfs_metadata(
+                        db,
+                        user_factory_txs,
+                        track_factory_txs,
+                        block_number,
+                        block_hash,
+                    )
+
+                    # bulk process operations once all tx's for block have been parsed
+                    total_user_changes, user_ids = user_state_update(
+                        self,
+                        update_task,
+                        session,
+                        ipfs_metadata,
+                        blacklisted_cids,
+                        user_factory_txs,
+                        block_number,
+                        block_timestamp,
+                        block_hash,
+                    )
+                    user_state_changed = total_user_changes > 0
+                    logger.info(
+                        f"index.py | user_state_update completed"
+                        f" user_state_changed={user_state_changed} for block={block_number}"
+                    )
+
+                    total_track_changes, track_ids = track_state_update(
+                        self,
+                        update_task,
+                        session,
+                        blacklisted_cids,
+                        ipfs_metadata,
+                        track_factory_txs,
+                        block_number,
+                        block_timestamp,
+                        block_hash,
+                    )
+                    track_state_changed = total_track_changes > 0
+                    logger.info(
+                        f"index.py | track_state_update completed"
+                        f" track_state_changed={track_state_changed} for block={block_number}"
+                    )
+
+                    social_feature_state_changed = (  # pylint: disable=W0612
+                        social_feature_state_update(
+                            self,
+                            update_task,
+                            session,
+                            social_feature_factory_txs,
+                            block_number,
+                            block_timestamp,
+                            block_hash,
+                        )
+                        > 0
+                    )
+                    logger.info(
+                        f"index.py | social_feature_state_update completed"
+                        f" social_feature_state_changed={social_feature_state_changed} for block={block_number}"
+                    )
+
+                    # Index UserReplicaSet changes
+                    (
+                        total_user_replica_set_changes,
+                        replica_user_ids,
+                    ) = user_replica_set_state_update(
+                        self,
+                        update_task,
+                        session,
+                        user_replica_set_manager_txs,
+                        block_number,
+                        block_timestamp,
+                        block_hash,
+                        redis,
+                    )
+                    user_replica_set_state_changed = total_user_replica_set_changes > 0
+                    logger.info(
+                        f"index.py | user_replica_set_state_update completed"
+                        f" user_replica_set_state_changed={user_replica_set_state_changed} for block={block_number}"
+                    )
+
+                    # Playlist state operations processed in bulk
+                    total_playlist_changes, playlist_ids = playlist_state_update(
+                        self,
+                        update_task,
+                        session,
+                        playlist_factory_txs,
+                        block_number,
+                        block_timestamp,
+                        block_hash,
+                    )
+                    playlist_state_changed = total_playlist_changes > 0
+                    logger.info(
+                        f"index.py | playlist_state_update completed"
+                        f" playlist_state_changed={playlist_state_changed} for block={block_number}"
+                    )
+
+                    user_library_state_changed = (
+                        user_library_state_update(  # pylint: disable=W0612
+                            self,
+                            update_task,
+                            session,
+                            user_library_factory_txs,
+                            block_number,
+                            block_timestamp,
+                            block_hash,
+                        )
+                    )
+                    logger.info(
+                        f"index.py | user_library_state_update completed"
+                        f" user_library_state_changed={user_library_state_changed} for block={block_number}"
+                    )
+
+                    track_lexeme_state_changed = (
+                        user_state_changed or track_state_changed
+                    )
+                    try:
+                        session.commit()
+                        logger.info(
+                            f"index.py | session commmited to db for block=${block_number}"
+                        )
+                    except Exception as e:
+                        # Use 'commit' as the tx hash here.
+                        # We're at a point where the whole block can't be added to the database, so
+                        # we should skip it in favor of making progress
+                        blockhash = update_task.web3.toHex(block_hash)
+                        raise IndexingError(
+                            "session.commit", block_number, blockhash, "commit", str(e)
+                        ) from e
+                    if skip_tx_hash:
+                        clear_indexing_error(redis)
+                    if user_state_changed:
+                        if user_ids:
+                            remove_cached_user_ids(redis, user_ids)
+                    if user_replica_set_state_changed:
+                        if replica_user_ids:
+                            remove_cached_user_ids(redis, replica_user_ids)
+                    if track_lexeme_state_changed:
+                        if track_ids:
+                            remove_cached_track_ids(redis, track_ids)
+                    if playlist_state_changed:
+                        if playlist_ids:
+                            remove_cached_playlist_ids(redis, playlist_ids)
+                    logger.info(
+                        f"index.py | redis cache clean operations complete for block=${block_number}"
+                    )
+                except IndexingError as err:
+                    logger.info(
+                        f"index.py | Error in the indexing task at"
+                        f" block={err.blocknumber} and hash={err.txhash}"
+                    )
+                    set_indexing_error(
+                        redis, err.blocknumber, err.blockhash, err.txhash, err.message
+                    )
+                    confirm_indexing_transaction_error(
+                        redis, err.blocknumber, err.blockhash, err.txhash, err.message
+                    )
+                    raise err
         # NOTE: This is commented out to prevent unncessary load on the DB to calculate trending
         #       until it is fully tested on staging. The challenge was not registed so the job will
         #       continually run for the hour interval.
@@ -680,9 +654,7 @@ def index_blocks(self, db, blocks_list):
         #         exc_info=True,
         #     )
 
-        # add the block number of the most recently processed block to redis
-        redis.set(most_recent_indexed_block_redis_key, block.number)
-        redis.set(most_recent_indexed_block_hash_redis_key, block.hash.hex())
+        add_indexed_block_to_redis(block, redis)
         logger.info(
             f"index.py | update most recently processed block complete for block=${block_number}"
         )

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -391,7 +391,6 @@ def add_indexed_block_to_db(db_session, block):
     web3 = update_task.web3
     current_block_query = db_session.query(Block).filter_by(is_current=True)
 
-    # Without this check we may end up duplicating an insert operation
     block_model = Block(
         blockhash=web3.toHex(block.hash),
         parenthash=web3.toHex(block.parentHash),
@@ -495,6 +494,7 @@ def index_blocks(self, db, blocks_list):
     num_blocks = len(blocks_list)
     block_order_range = range(len(blocks_list) - 1, -1, -1)
     latest_block_timestamp = None
+    changed_entity_ids_map = {}
     for i in block_order_range:
         update_ursm_address(self)
         block = blocks_list[i]
@@ -509,9 +509,11 @@ def index_blocks(self, db, blocks_list):
             skip_tx_hash = save_and_get_skip_tx_hash(session, redis)
             skip_whole_block = skip_tx_hash == "commit"  # db tx failed at commit level
             if skip_whole_block:
-                logger.info(f"index.py | Skipping all txs in block {block.hash}")
-            else:
+                logger.info(
+                    f"index.py | Skipping all txs in block {block.hash} {block.number}"
+                )
                 add_indexed_block_to_db(session, block)
+            else:
                 TXS_GROUPED_BY_TYPE = {
                     USER_FACTORY: [],
                     TRACK_FACTORY: [],
@@ -520,32 +522,35 @@ def index_blocks(self, db, blocks_list):
                     USER_LIBRARY_FACTORY: [],
                     USER_REPLICA_SET_MANAGER: [],
                 }
+                try:
+                    tx_receipt_dict = fetch_tx_receipts(self, block.transactions)
 
-                tx_receipt_dict = fetch_tx_receipts(self, block.transactions)
-
-                # Sort transactions by hash
-                sorted_txs = sorted(block.transactions, key=lambda entry: entry["hash"])
-
-                # Parse tx events in each block
-                for tx in sorted_txs:
-                    tx_hash = web3.toHex(tx["hash"])
-                    tx_target_contract_address = tx["to"]
-                    tx_receipt = tx_receipt_dict[tx_hash]
-                    should_skip_tx = (tx_target_contract_address == zero_address) or (
-                        skip_tx_hash is not None and skip_tx_hash == tx_hash
+                    # Sort transactions by hash
+                    sorted_txs = sorted(
+                        block.transactions, key=lambda entry: entry["hash"]
                     )
 
-                    if should_skip_tx:
-                        logger.info(
-                            f"index.py | Skipping tx {tx_hash} targeting {tx_target_contract_address}"
-                        )
-                        continue
-                    else:
-                        group_transaction_by_type(TXS_GROUPED_BY_TYPE, tx, tx_receipt)
+                    # Parse tx events in each block
+                    for tx in sorted_txs:
+                        tx_hash = web3.toHex(tx["hash"])
+                        tx_target_contract_address = tx["to"]
+                        tx_receipt = tx_receipt_dict[tx_hash]
+                        should_skip_tx = (
+                            tx_target_contract_address == zero_address
+                        ) or (skip_tx_hash is not None and skip_tx_hash == tx_hash)
 
-                # pre-fetch cids asynchronously to not have it block in user_state_update
-                # and track_state_update
-                try:
+                        if should_skip_tx:
+                            logger.info(
+                                f"index.py | Skipping tx {tx_hash} targeting {tx_target_contract_address}"
+                            )
+                            continue
+                        else:
+                            group_transaction_by_type(
+                                TXS_GROUPED_BY_TYPE, tx, tx_receipt
+                            )
+
+                    # pre-fetch cids asynchronously to not have it block in user_state_update
+                    # and track_state_update
                     ipfs_metadata, blacklisted_cids = fetch_ipfs_metadata(
                         db,
                         TXS_GROUPED_BY_TYPE[USER_FACTORY],
@@ -553,6 +558,8 @@ def index_blocks(self, db, blocks_list):
                         block_number,
                         block_hash,
                     )
+
+                    add_indexed_block_to_db(session, block)
 
                     # bulk process operations once all tx's for block have been parsed
                     # and get changed entity IDs for cache clearing
@@ -566,27 +573,6 @@ def index_blocks(self, db, blocks_list):
                         block,
                         redis,
                     )
-
-                    try:
-                        session.commit()
-                        logger.info(
-                            f"index.py | session committed to db for block=${block_number}"
-                        )
-                    except Exception as e:
-                        # Use 'commit' as the tx hash here.
-                        # We're at a point where the whole block can't be added to the database, so
-                        # we should skip it in favor of making progress
-                        blockhash = update_task.web3.toHex(block_hash)
-                        raise IndexingError(
-                            "session.commit", block_number, blockhash, "commit", str(e)
-                        ) from e
-                    if skip_tx_hash:
-                        clear_indexing_error(redis)
-
-                    remove_updated_entities_from_cache(redis, changed_entity_ids_map)
-                    logger.info(
-                        f"index.py | redis cache clean operations complete for block=${block_number}"
-                    )
                 except IndexingError as err:
                     logger.info(
                         f"index.py | Error in the indexing task at"
@@ -599,19 +585,45 @@ def index_blocks(self, db, blocks_list):
                         redis, err.blocknumber, err.blockhash, err.txhash, err.message
                     )
                     raise err
-        try:
-            # Check the last block's timestamp for updating the trending challenge
-            [should_update, date] = should_trending_challenge_update(
-                session, latest_block_timestamp
-            )
-            if should_update:
-                celery.send_task("calculate_trending_challenges", kwargs={"date": date})
-        except Exception as e:
-            # Do not throw error, as this should not stop indexing
-            logger.error(
-                f"index.py | Error in calling update trending challenge {e}",
-                exc_info=True,
-            )
+
+            try:
+                session.commit()
+                logger.info(
+                    f"index.py | session committed to db for block=${block_number}"
+                )
+            except Exception as e:
+                # Use 'commit' as the tx hash here.
+                # We're at a point where the whole block can't be added to the database, so
+                # we should skip it in favor of making progress
+                blockhash = update_task.web3.toHex(block_hash)
+                raise IndexingError(
+                    "session.commit", block_number, blockhash, "commit", str(e)
+                ) from e
+            try:
+                # Check the last block's timestamp for updating the trending challenge
+                [should_update, date] = should_trending_challenge_update(
+                    session, latest_block_timestamp
+                )
+                if should_update:
+                    celery.send_task(
+                        "calculate_trending_challenges", kwargs={"date": date}
+                    )
+            except Exception as e:
+                # Do not throw error, as this should not stop indexing
+                logger.error(
+                    f"index.py | Error in calling update trending challenge {e}",
+                    exc_info=True,
+                )
+        if skip_tx_hash:
+            clear_indexing_error(redis)
+
+        if changed_entity_ids_map:
+            remove_updated_entities_from_cache(redis, changed_entity_ids_map)
+
+        logger.info(
+            f"index.py | redis cache clean operations complete for block=${block_number}"
+        )
+
         add_indexed_block_to_redis(block, redis)
         logger.info(
             f"index.py | update most recently processed block complete for block=${block_number}"

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,7 +1,6 @@
 # pylint: disable=C0302
 import concurrent.futures
 import logging
-import time
 from operator import itemgetter
 from sqlalchemy import func
 from src.app import get_contract_addresses
@@ -442,7 +441,6 @@ def bulk_process_state_changes(
         USER_REPLICA_SET_MANAGER: [],
     }
 
-    track_metadata_state_changed = False
     for tx_type, bulk_processor in TX_TYPE_TO_HANDLER_MAP.items():
         txs_to_process = tx_type_to_grouped_lists_map[tx_type]
         tx_processing_args = [
@@ -472,8 +470,6 @@ def bulk_process_state_changes(
         if tx_type in changed_entity_ids_map.keys():
             changed_entity_ids_map[tx_type] = changed_entity_ids
 
-        if tx_type in track_metadata_affecting_contracts and entity_state_changed:
-            track_metadata_state_changed = True
         logger.info(
             f"index.py | {bulk_processor.__name__} completed"
             f" {tx_type}_state_changed={entity_state_changed} for block={block_number}"

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -424,6 +424,7 @@ def bulk_process_state_changes(
     block_number, block_hash, block_timestamp = itemgetter(
         "number", "hash", "timestamp"
     )(block)
+
     TX_TYPE_TO_HANDLER_MAP = {
         USER_FACTORY: user_state_update,
         TRACK_FACTORY: track_state_update,
@@ -432,10 +433,6 @@ def bulk_process_state_changes(
         USER_LIBRARY_FACTORY: user_library_state_update,
         USER_REPLICA_SET_MANAGER: user_replica_set_state_update,
     }
-    track_metadata_affecting_contracts = [
-        USER_FACTORY,
-        TRACK_FACTORY,
-    ]
     changed_entity_ids_map = {
         USER_FACTORY: [],
         TRACK_FACTORY: [],
@@ -444,38 +441,34 @@ def bulk_process_state_changes(
     }
 
     for tx_type, bulk_processor in TX_TYPE_TO_HANDLER_MAP.items():
+
         txs_to_process = tx_type_to_grouped_lists_map[tx_type]
         tx_processing_args = [
             main_indexing_task,
             update_task,
             session,
-        ]
-        if tx_type in track_metadata_affecting_contracts:
-            tx_processing_args += [
-                ipfs_metadata,
-                blacklisted_cids,
-            ]
-        tx_processing_args += [
             txs_to_process,
             block_number,
             block_timestamp,
             block_hash,
+            ipfs_metadata,
+            blacklisted_cids,
+            redis,
         ]
-        # ursm update takes redis to find replica sets
-        if tx_type == USER_REPLICA_SET_MANAGER:
-            tx_processing_args += [redis]
+
         (
             total_changes_for_tx_type,
             changed_entity_ids,
         ) = bulk_processor(*tx_processing_args)
-        entity_state_changed = total_changes_for_tx_type > 0
+
         if tx_type in changed_entity_ids_map.keys():
             changed_entity_ids_map[tx_type] = changed_entity_ids
 
         logger.info(
             f"index.py | {bulk_processor.__name__} completed"
-            f" {tx_type}_state_changed={entity_state_changed} for block={block_number}"
+            f" {tx_type}_state_changed={total_changes_for_tx_type > 0} for block={block_number}"
         )
+
     return changed_entity_ids_map
 
 

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -1,7 +1,9 @@
 import logging
 from datetime import datetime
+from typing import Set, Tuple
 
-from sqlalchemy.orm.session import make_transient
+from src.database_task import DatabaseTask
+from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_contract_addresses
 from src.models import Playlist
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
@@ -17,14 +19,14 @@ logger = logging.getLogger(__name__)
 
 def playlist_state_update(
     self,
-    update_task,
-    session,
+    update_task: DatabaseTask,
+    session: Session,
     playlist_factory_txs,
     block_number,
     block_timestamp,
     block_hash,
-):
-    """Return int representing number of Playlist model state changes found in transaction."""
+) -> Tuple[int, Set]:
+    """Return Tuple containing int representing number of Playlist model state changes found in transaction and set of processed playlist IDs."""
     num_total_changes = 0
     # This stores the playlist_ids created or updated in the set of transactions
     playlist_ids = set()

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -25,6 +25,9 @@ def playlist_state_update(
     block_number,
     block_timestamp,
     block_hash,
+    _ipfs_metadata,  # prefix unused args with underscore to prevent pylint
+    _blacklisted_cids,
+    _redis,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of Playlist model state changes found in transaction and set of processed playlist IDs."""
     num_total_changes = 0

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -2,9 +2,9 @@ import logging
 from datetime import datetime
 from typing import Set, Tuple
 
-from src.database_task import DatabaseTask
 from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_contract_addresses
+from src.database_task import DatabaseTask
 from src.models import Playlist
 from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.utils import helpers
@@ -29,7 +29,7 @@ def playlist_state_update(
     """Return Tuple containing int representing number of Playlist model state changes found in transaction and set of processed playlist IDs."""
     num_total_changes = 0
     # This stores the playlist_ids created or updated in the set of transactions
-    playlist_ids = set()
+    playlist_ids: Set[int] = set()
 
     if not playlist_factory_txs:
         return num_total_changes, playlist_ids

--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -21,6 +21,9 @@ def social_feature_state_update(
     block_number,
     block_timestamp,
     block_hash,
+    _ipfs_metadata,  # prefix unused args with underscore to prevent pylint
+    _blacklisted_cids,
+    _redis,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of social feature related state changes in this transaction and empty Set (to align with other _state_update function signatures)"""
     empty_set: Set[int] = set()

--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Dict, Tuple, Set
+from typing import Dict, Set, Tuple
 
 from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
@@ -23,7 +23,7 @@ def social_feature_state_update(
     block_hash,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of social feature related state changes in this transaction and empty Set (to align with other _state_update function signatures)"""
-    empty_set = set()
+    empty_set: Set[int] = set()
     num_total_changes = 0
     if not social_feature_factory_txs:
         return num_total_changes, empty_set

--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Tuple, Set
 
 from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
@@ -21,12 +21,12 @@ def social_feature_state_update(
     block_number,
     block_timestamp,
     block_hash,
-):
-    """Return int representing number of social feature related state changes in this transaction"""
-
+) -> Tuple[int, Set]:
+    """Return Tuple containing int representing number of social feature related state changes in this transaction and empty Set (to align with other _state_update function signatures)"""
+    empty_set = set()
     num_total_changes = 0
     if not social_feature_factory_txs:
-        return num_total_changes
+        return num_total_changes, empty_set
 
     social_feature_factory_abi = update_task.abi_values["SocialFeatureFactory"]["abi"]
     social_feature_factory_contract = update_task.web3.eth.contract(
@@ -147,8 +147,7 @@ def social_feature_state_update(
             dispatch_challenge_follow(challenge_bus, follow, block_number)
             queue_related_artist_calculation(update_task.redis, followee_user_id)
         num_total_changes += len(followee_user_ids)
-
-    return num_total_changes
+    return num_total_changes, empty_set
 
 
 # ####### HELPERS ####### #

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 from sqlalchemy.orm.session import make_transient
 from sqlalchemy.sql import functions, null
@@ -32,14 +32,14 @@ def track_state_update(
     self,
     update_task: DatabaseTask,
     session,
-    blacklisted_cids,
     ipfs_metadata,
+    blacklisted_cids,
     track_factory_txs,
     block_number,
     block_timestamp,
     block_hash,
-):
-    """Return int representing number of Track model state changes found in transaction."""
+) -> Tuple[int, Set]:
+    """Return tuple containing int representing number of Track model state changes found in transaction and set of processed track IDs."""
     num_total_changes = 0
 
     # This stores the track_ids created or updated in the set of transactions

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -32,12 +32,13 @@ def track_state_update(
     self,
     update_task: DatabaseTask,
     session,
-    ipfs_metadata,
-    blacklisted_cids,
     track_factory_txs,
     block_number,
     block_timestamp,
     block_hash,
+    ipfs_metadata,
+    blacklisted_cids,
+    _redis,  # prefix unused args with underscore to prevent pylint
 ) -> Tuple[int, Set]:
     """Return tuple containing int representing number of Track model state changes found in transaction and set of processed track IDs."""
     num_total_changes = 0

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Dict, Tuple, Set
+from typing import Dict, Set, Tuple
 
 from sqlalchemy.orm.session import Session
 from src.app import get_contract_addresses
@@ -23,7 +23,7 @@ def user_library_state_update(
     block_hash,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of User Library model state changes found in transaction and empty Set (to align with fn signature of other _state_update functions."""
-    empty_set = set()
+    empty_set: Set[int] = set()
     num_total_changes = 0
     if not user_library_factory_txs:
         return num_total_changes, empty_set

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Tuple, Set
 
+from sqlalchemy.orm.session import Session
 from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
@@ -15,17 +16,17 @@ logger = logging.getLogger(__name__)
 def user_library_state_update(
     self,
     update_task: DatabaseTask,
-    session,
+    session: Session,
     user_library_factory_txs,
     block_number,
     block_timestamp,
     block_hash,
-):
-    """Return int representing number of User Library model state changes found in transaction."""
-
+) -> Tuple[int, Set]:
+    """Return Tuple containing int representing number of User Library model state changes found in transaction and empty Set (to align with fn signature of other _state_update functions."""
+    empty_set = set()
     num_total_changes = 0
     if not user_library_factory_txs:
-        return num_total_changes
+        return num_total_changes, empty_set
 
     user_library_abi = update_task.abi_values["UserLibraryFactory"]["abi"]
     user_library_contract = update_task.web3.eth.contract(
@@ -109,7 +110,7 @@ def user_library_state_update(
             session.add(playlist_ids[playlist_id])
         num_total_changes += len(playlist_ids)
 
-    return num_total_changes
+    return num_total_changes, empty_set
 
 
 # ####### HELPERS ####### #

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -21,6 +21,9 @@ def user_library_state_update(
     block_number,
     block_timestamp,
     block_hash,
+    _ipfs_metadata,  # prefix unused args with underscore to prevent pylint
+    _blacklisted_cids,
+    _redis,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of User Library model state changes found in transaction and empty Set (to align with fn signature of other _state_update functions."""
     empty_set: Set[int] = set()

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -2,9 +2,9 @@ import logging
 from datetime import datetime
 from typing import Set, Tuple
 
-from src.database_task import DatabaseTask
 from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_contract_addresses, get_eth_abi_values
+from src.database_task import DatabaseTask
 from src.models import URSMContentNode
 from src.tasks.index_network_peers import (
     content_node_service_type,
@@ -34,7 +34,7 @@ def user_replica_set_state_update(
     """Return Tuple containing int representing number of User model state changes found in transaction and set of user_id values"""
 
     num_user_replica_set_changes = 0
-    user_ids = set()
+    user_ids: Set[int] = set()
     if not user_replica_set_mgr_txs:
         return num_user_replica_set_changes, user_ids
 

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -29,6 +29,8 @@ def user_replica_set_state_update(
     block_number,
     block_timestamp,
     block_hash,
+    _ipfs_metadata,  # prefix unused args with underscore to prevent pylint
+    _blacklisted_cids,
     redis,
 ) -> Tuple[int, Set]:
     """Return Tuple containing int representing number of User model state changes found in transaction and set of user_id values"""

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -1,7 +1,9 @@
 import logging
 from datetime import datetime
+from typing import Set, Tuple
 
-from sqlalchemy.orm.session import make_transient
+from src.database_task import DatabaseTask
+from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_contract_addresses, get_eth_abi_values
 from src.models import URSMContentNode
 from src.tasks.index_network_peers import (
@@ -21,15 +23,15 @@ logger = logging.getLogger(__name__)
 
 def user_replica_set_state_update(
     self,
-    update_task,
-    session,
+    update_task: DatabaseTask,
+    session: Session,
     user_replica_set_mgr_txs,
     block_number,
     block_timestamp,
     block_hash,
     redis,
-):
-    """Return int representing number of User model state changes found in transaction and set of user_id values"""
+) -> Tuple[int, Set]:
+    """Return Tuple containing int representing number of User model state changes found in transaction and set of user_id values"""
 
     num_user_replica_set_changes = 0
     user_ids = set()

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -26,12 +26,13 @@ def user_state_update(
     self,
     update_task: DatabaseTask,
     session: Session,
-    ipfs_metadata,
-    blacklisted_cids,
     user_factory_txs,
     block_number,
     block_timestamp,
     block_hash,
+    ipfs_metadata,
+    blacklisted_cids,
+    _redis,  # prefix unused args with underscore to prevent pylint
 ) -> Tuple[int, Set]:
     """Return tuple containing int representing number of User model state changes found in transaction and set of processed user IDs."""
 

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -33,7 +33,7 @@ def user_state_update(
     block_timestamp,
     block_hash,
 ) -> Tuple[int, Set]:
-    """Return int representing number of User model state changes found in transaction."""
+    """Return tuple containing int representing number of User model state changes found in transaction and set of processed user IDs."""
 
     num_total_changes = 0
     user_ids: Set[int] = set()

--- a/discovery-provider/src/utils/constants.py
+++ b/discovery-provider/src/utils/constants.py
@@ -1023,3 +1023,12 @@ default_lengths = {
     0xB3DF: 0x7F,
     0xB3E0: 0x80,
 }
+
+CONTRACT_TYPES = {
+    "USER_FACTORY": "user_factory",
+    "TRACK_FACTORY": "track_factory",
+    "SOCIAL_FEATURE_FACTORY": "social_feature_factory",
+    "PLAYLIST_FACTORY": "playlist_factory",
+    "USER_LIBRARY_FACTORY": "user_library_factory",
+    "USER_REPLICA_SET_MANAGER": "user_replica_set_manager",
+}

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -506,3 +506,7 @@ def time_method(func):
         return result
 
     return wrapper
+
+
+def snake_to_pascal(snake_case_name):
+    return snake_case_name.replace("_", " ").title().replace(" ", "")


### PR DESCRIPTION
### Description

* Refactor DB session indexing and DRY up main indexing task with helper functions
* Standardize function signatures for batch tx processing functions, which facilitates consolidation of DB scoped session for aggregated changes 

### Tests

* I intended to add tests to test whether indexingerrors would properly be thrown in the case of failures in different stages of indexing such as 1) skipped block save, 2) ipfs metadata fetch, 3) batch processing of grouped transactions... but there's some scope leakage issue with monkeypatch such that neither manually clearing the patched method nor adding additional test cases to the integration test nor adding additional test files worked for getting test state to reset between cases. I can try to rewrite the indexing integration tests in pytest-mock and add those cases, but the refactor part is ready for review.
