### PR TITLE
Up worker connections + delete unused file

### DIFF
--- a/creator-node/scripts/prod-server.sh
+++ b/creator-node/scripts/prod-server.sh
@@ -1,3 +1,0 @@
-if [[ "$openRestyCacheCIDEnabled" == "true" ]]; then
-    openresty -p /usr/local/openresty -c /usr/local/openresty/conf/nginx.conf
-fi

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -16,7 +16,7 @@ env audius_openresty_rsa_private_key;
 env audius_openresty_rsa_public_key;
 
 events {
-    worker_connections 1024;
+    worker_connections 4096;
 }
 
 http {


### PR DESCRIPTION
### Description
Increase the worker connections count to 4096. This also cleans up an unused content node file.


<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
This has been hotfixed onto prod for the last week.
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->