### PR TITLE
Fix retroactive profile completion start block

### DIFF
--- a/discovery-provider/src/challenges/challenges.json
+++ b/discovery-provider/src/challenges/challenges.json
@@ -5,7 +5,7 @@
 		"amount": "1",
 		"active": true,
 		"step_count": 7,
-		"starting_block": 25346436
+		"starting_block": 0
 	},
 	{
 		"id": "listen-streak",

--- a/discovery-provider/src/challenges/challenges.stage.json
+++ b/discovery-provider/src/challenges/challenges.stage.json
@@ -1,7 +1,8 @@
 [
 	{
 		"id": "listen-streak",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "track-upload",
@@ -10,30 +11,38 @@
 	},
 	{
 		"id": "referrals",
-		"active": true
+		"active": true,
+		"starting_block": 0
+
 	},
 	{
 		"id": "referred",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "connect-verified",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "mobile-install",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "trending-track",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "trending-underground-track",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	},
 	{
 		"id": "trending-playlist",
-		"active": true
+		"active": true,
+		"starting_block": 0
 	}
 ]


### PR DESCRIPTION
### Description

- Fix: Accidentally turned off retroactive profile completion challenge
- Fix: Also turned off every stage challenge 🤦‍♂️

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->