### PR TITLE
Cleanup discovery log

### DIFF
--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -45,7 +45,7 @@ def redis_restore(redis, key):
         with open(filename, "rb") as f:
             dumped = f.read()
             redis.restore(key, 0, dumped)
-            logger.info(f"successfully restored redis value for key: {key}")
+            logger.debug(f"successfully restored redis value for key: {key}")
             return redis.get(key)
     except FileNotFoundError as not_found:
         logger.error(f"could not read redis dump file: {filename}")
@@ -88,7 +88,7 @@ def redis_dump(redis, key):
         filename = f"{key}_dump"
         with open(filename, "wb") as f:
             f.write(dumped)
-            logger.info(f"successfully performed redis dump for key: {key}")
+            logger.debug(f"successfully performed redis dump for key: {key}")
     except Exception as e:
         logger.error(f"could not perform redis dump for key: {key}")
         logger.error(e)

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -535,7 +535,7 @@ def update_personal_metrics(key, old_timestamp, timestamp, value, metric_type):
     }
     if updated_metrics:
         redis_set_and_dump(REDIS, key, json.dumps(updated_metrics))
-    logger.info(f"updated cached personal {metric_type} metrics")
+    logger.debug(f"updated cached personal {metric_type} metrics")
 
 
 def update_summed_unique_metrics(now, ip):


### PR DESCRIPTION
### Description

Some logs show up too often and make it hard to read DN logs when inspecting an incident. This PR changes those logs to only show up in debug vs info mode.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->