### PR TITLE
Remove disbursements FK

### DIFF
--- a/discovery-provider/alembic/versions/85680793a611_remove_disbursement_fk.py
+++ b/discovery-provider/alembic/versions/85680793a611_remove_disbursement_fk.py
@@ -1,0 +1,30 @@
+"""remove disbursement fk
+
+Revision ID: 85680793a611
+Revises: 132955202f03
+Create Date: 2022-01-10 21:46:25.228543
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '85680793a611'
+down_revision = '132955202f03'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute(
+        """
+        --- Lose problematic FK
+        ALTER TABLE challenge_disbursements
+        DROP CONSTRAINT fk_disbursement;
+        """
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Description

Discovery Nodes that are missing a UserChallenge for some reason (i.e. they update late) will throw an error indexing a corresponding disbursement, as the disbursement table had an FK referencing UserChallenges

### Tests
Testing on stage DP2

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->