### PR TITLE
Add additional rewards fixes to libs

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -141,11 +141,16 @@ class Account extends Base {
         }
       }
 
-      // Create a wAudio user bank address
+      // Create a wAudio user bank address.
+      // If userbank creation fails, we still proceed
+      // through signup
       if (createWAudioUserBank && this.solanaWeb3Manager) {
         phase = phases.SOLANA_USER_BANK_CREATION
-        // Create a user bank if the solana web3 manager is present
-        await this.solanaWeb3Manager.createUserBank()
+        try {
+          await this.solanaWeb3Manager.createUserBank()
+        } catch (err) {
+          console.error(`Got error creating userbank: ${err}, continuing...`)
+        }
       }
 
       // Add user to chain

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -139,7 +139,7 @@ class SolanaWeb3Manager {
     }
 
     const ethAddress = this.web3Manager.getWalletAddress()
-    await createUserBankFrom({
+    return createUserBankFrom({
       ethAddress,
       claimableTokenPDAKey: this.claimableTokenPDAKey,
       feePayerKey: this.feePayerKey,

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -156,13 +156,12 @@ class RewardsAttester {
     }
   }
 
-
   /**
    * Escape hatch for manually setting starting block.
    *
    * @memberof RewardsAttester
    */
-  async _checkForStartingBlockOverride() {
+  async _checkForStartingBlockOverride () {
     const override = await this.getStartingBlockOverride()
     // Careful with 0...
     if (override === null || override === undefined) return

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -68,7 +68,21 @@ class RewardsAttester {
    *  }
    * @memberof RewardsAttester
    */
-  constructor ({ libs, startingBlock, offset, parallelization, logger, quorumSize, aaoEndpoint, aaoAddress, updateValues = () => {}, getStartingBlockOverride = () => null, maxRetries = 5, reporter, challengeIdsDenyList }) {
+  constructor ({
+    libs,
+    startingBlock,
+    offset,
+    parallelization,
+    logger,
+    quorumSize,
+    aaoEndpoint,
+    aaoAddress,
+    updateValues = () => {},
+    getStartingBlockOverride = () => null,
+    maxRetries = 5,
+    reporter,
+    challengeIdsDenyList
+  }) {
     this.libs = libs
     this.logger = logger
     this.parallelization = parallelization


### PR DESCRIPTION
### Description

- Better handle Solana userbank fails in signup
- Add escape hatch for setting start block in RewardsAttester

### Tests

Testing on stage

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->