### PR TITLE
[ASI-794] Skip tx with missing refs instead of skipping whole block -…

### DIFF
--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -581,6 +581,7 @@ class AggregatePlays(Base):
 play_item_id={self.play_item_id},\
 count={self.count})>"
 
+
 class IndexingCheckpoints(Base):
     __tablename__ = "indexing_checkpoints"
 
@@ -1048,6 +1049,11 @@ repost_count={self.repost_count},\
 save_count={self.save_count})>"
 
 
+class SkippedTransactionLevel(str, enum.Enum):
+    node = "node"
+    network = "network"
+
+
 class SkippedTransaction(Base):
     __tablename__ = "skipped_transactions"
 
@@ -1059,6 +1065,7 @@ class SkippedTransaction(Base):
     updated_at = Column(
         DateTime, nullable=False, default=func.now(), onupdate=func.now()
     )
+    level = Column(Enum(SkippedTransactionLevel), nullable=False, default="node")
 
     def __repr__(self):
         return f"<SkippedTransaction(\
@@ -1066,6 +1073,7 @@ id={self.id},\
 blocknumber={self.blocknumber},\
 blockhash={self.blockhash},\
 txhash={self.txhash},\
+level={self.level},\
 created_at={self.created_at},\
 updated_at={self.updated_at})>"
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -338,13 +338,18 @@ def save_and_get_skip_tx_hash(session, redis):
         and "has_consensus" in indexing_error
         and indexing_error["has_consensus"]
     ):
-        num_skipped_tx = session.query(func.count(SkippedTransaction.id)).scalar()
+        num_skipped_tx = (
+            session.query(func.count(SkippedTransaction))
+            .filter(SkippedTransaction.level == "network")
+            .scalar()
+        )
         if num_skipped_tx >= MAX_SKIPPED_TX:
             return None
         skipped_tx = SkippedTransaction(
             blocknumber=indexing_error["blocknumber"],
             blockhash=indexing_error["blockhash"],
             txhash=indexing_error["txhash"],
+            level="network",
         )
         session.add(skipped_tx)
         return indexing_error["txhash"]

--- a/discovery-provider/src/utils/indexing_errors.py
+++ b/discovery-provider/src/utils/indexing_errors.py
@@ -16,3 +16,23 @@ class IndexingError(Exception):
         self.blockhash = blockhash
         self.txhash = txhash
         self.message = message
+
+
+class EntityMissingRequiredFieldError(Exception):
+    """Exception raised for errors when processing transactions and a non-nullable field on a created entity is set to null.
+
+    Attributes:
+        type -- One of 'user', 'user_replica_set', 'user_library', 'tracks', 'social_features', 'playlists'
+        blocknumber -- block number of error
+        blockhash -- block hash of error
+        txhash -- transaction hash of error
+        message -- error message
+    """
+
+    def __init__(self, type, blocknumber, blockhash, txhash, message):
+        super().__init__(message)
+        self.type = type
+        self.blocknumber = blocknumber
+        self.blockhash = blockhash
+        self.txhash = txhash
+        self.message = message

--- a/discovery-provider/src/utils/model_nullable_validator.py
+++ b/discovery-provider/src/utils/model_nullable_validator.py
@@ -5,13 +5,14 @@ Base: Any = declarative_base()
 
 
 def all_required_fields_present(model: Base, instance):
-    required_fields = [
-        col.name
-        for col in model.__table__.columns
-        if not col.nullable and not col.primary_key
-    ]
+    required_fields = [col.name for col in model.__table__.columns if not col.nullable]
+    print(f"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFff {instance}, {required_fields}")
+    print(f"{[getattr(instance, x) for x in required_fields]}")
     all_required_fields_present = all(
-        map(lambda x: bool(getattr(instance, x)), required_fields)
+        map(
+            lambda x: True if getattr(instance, x) is not None else False,
+            required_fields,
+        )
     )
 
     return all_required_fields_present

--- a/discovery-provider/src/utils/model_nullable_validator.py
+++ b/discovery-provider/src/utils/model_nullable_validator.py
@@ -1,0 +1,17 @@
+from sqlalchemy.ext.declarative import declarative_base
+from typing import Any
+
+Base: Any = declarative_base()
+
+
+def all_required_fields_present(model: Base, instance):
+    required_fields = [
+        col.name
+        for col in model.__table__.columns
+        if not col.nullable and not col.primary_key
+    ]
+    all_required_fields_present = all(
+        map(lambda x: bool(getattr(instance, x)), required_fields)
+    )
+
+    return all_required_fields_present

--- a/discovery-provider/tests/utils/model_nullable_validator_unittest.py
+++ b/discovery-provider/tests/utils/model_nullable_validator_unittest.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from sqlalchemy import Boolean, Column, Integer, String, PrimaryKeyConstraint
+from sqlalchemy import Boolean, Column, Integer, PrimaryKeyConstraint, String
 from sqlalchemy.ext.declarative import declarative_base
 from src.utils.model_nullable_validator import all_required_fields_present
 

--- a/discovery-provider/tests/utils/test_model_nullable_validator.py
+++ b/discovery-provider/tests/utils/test_model_nullable_validator.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+import pytest
+from sqlalchemy import Boolean, Column, Integer, String, PrimaryKeyConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from src.utils.model_nullable_validator import all_required_fields_present
+
+Base: Any = declarative_base()
+
+
+def test_model_nullable_validator():
+    class TestModel(Base):
+        __tablename__ = "test"
+
+        pk_field = Column(Integer, nullable=False)
+        required_field_1 = Column(String, nullable=False)
+        required_field_2 = Column(Integer, nullable=False)
+        optional_field_1 = Column(Boolean, nullable=True)
+        optional_field_2 = Column(String, nullable=True)
+
+        PrimaryKeyConstraint(pk_field)
+
+    bad_instance = TestModel(pk_field=1, required_field_2=3, optional_field_1=False)
+    good_instance = TestModel(
+        pk_field=2, required_field_1="test", required_field_2=3, optional_field_1=False
+    )
+    assert all_required_fields_present(TestModel, good_instance) == True
+    assert all_required_fields_present(TestModel, bad_instance) == False


### PR DESCRIPTION
… Playlists

### Description

Fixes issue when we raise an error, disrupt session commit, and skip a whole block when we come across a row with a missing required field (such as when referencing an entity that was never created bc entity was created in a wrongly skipped block). 

This allows us to salvage the rest of tx in a block for processing. For more details, see Linear issue.

### Tests

* Added unit tests for util `all_required_fields_present`
* Need to add integration test reproducing broken case to tx processing tests 

### How will this change be monitored?

Added logs so will monitor for this in logs. 