### PR TITLE
Get Shareable URL for Cognito Flow

### DIFF
--- a/identity-service/compose/.env
+++ b/identity-service/compose/.env
@@ -59,3 +59,5 @@ recaptchaServiceKey=
 hCaptchaSecret=
 cognitoAPISecret=
 cognitoAPIKey=
+cognitoBaseUrl=
+cognitoTemplateId=

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -570,6 +570,18 @@ const config = convict({
     env: 'cognitoAPIKey',
     default: ''
   },
+  cognitoBaseUrl: {
+    doc: 'Base URL for Cognito API',
+    format: String,
+    env: 'cognitoBaseUrl',
+    default: ''
+  },
+  cognitoTemplateId: {
+    doc: 'Template for using Cognito Flow API',
+    format: String,
+    env: 'cognitoTemplateId',
+    default: ''
+  },
   solanaEndpoint: {
     doc: 'The Solana RPC endpoint to make requests against',
     format: String,

--- a/identity-service/src/routes/cognito.js
+++ b/identity-service/src/routes/cognito.js
@@ -8,6 +8,8 @@ const models = require('../models')
 const authMiddleware = require('../authMiddleware')
 const cognitoFlowMiddleware = require('../cognitoFlowMiddleware')
 const { sign, createCognitoHeaders } = require('../utils/cognitoHelpers')
+const axios = require('axios')
+const axiosHttpAdapter = require('axios/lib/adapters/http')
 
 const COGNITO_API_BASE_URL = 'https://sandbox.cognitohq.com'
 
@@ -86,8 +88,12 @@ module.exports = function (app) {
       }
     })
     const headers = await createCognitoHeaders({path, method, body})
+    console.error(body)
+    logger.error(headers)
     try {
-      const response = await fetch(`${COGNITO_API_BASE_URL}${path}`, {
+      const response = await axios({
+        adapter: axiosHttpAdapter,
+        url: `${COGNITO_API_BASE_URL}${path}`,
         method,
         headers,
         body
@@ -95,7 +101,8 @@ module.exports = function (app) {
       const json = await response.json()
       return successResponse({ shareable_url: json.shareable_url })
     } catch (err) {
-      console.error(err)
+      console.error({headers, body})
+      console.error({errr: err.response.data.errors})
       return errorResponseServerError(err.message)
     }
   }))

--- a/identity-service/src/utils/cognitoHelpers.js
+++ b/identity-service/src/utils/cognitoHelpers.js
@@ -1,6 +1,5 @@
 const crypto = require('crypto')
 const config = require('../config')
-const { logger } = require('../logging')
 
 const sign = (reference) => {
   const apiSecret = config.get('cognitoAPISecret')
@@ -15,7 +14,6 @@ const sign = (reference) => {
 const createDigest = async (data) => {
   const hasher = crypto.createHash('sha256')
   const result = hasher.update(data, 'utf-8').digest('base64')
-  // const base64 = Buffer.from(result).toString('base64')
   return `SHA-256=${result}`
 }
 
@@ -41,14 +39,13 @@ const createCognitoHeaders = async ({path, method, body}) => {
     `digest: ${digest}`
   ].join('\n')
   const signature = sign(signingString)
-  logger.error(signingString)
   return {
     Date: httpDate,
     Digest: digest,
     Authorization: `Signature keyId="${apiKey}",algorithm="hmac-sha256",headers="(request-target) date digest",signature="${signature}"`,
     'Content-Type': 'application/vnd.api+json',
     Accept: 'application/vnd.api+json',
-    'Cognito-Version': '2016-09-01'
+    'Cognito-Version': '2020-08-14'
   }
 }
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

In order to enable a WebView for the Cognito Flow on mobile, we need to get the `shareable_url` of the the Flow.

This is the "server-side" setup of the [Mobile Integration](https://cognitohq.com/docs/flow/mobile-integration) guide. It uses the [Authentication Guide](https://cognitohq.com/docs/guides/authenticating) as well.

❗  **Note:** this adds two more config variables to identity ❗ 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested manually against a local iOS emulator and with Fiddler requests.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Added logging on failure that includes the request being made and the response, with any errors that Cognito sends back. Should I add an alert via Loggly?

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->