### PR TITLE
Add lookup for creator_node_endpoint in indexing

### DIFF
--- a/discovery-provider/src/utils/ipfs_lib.py
+++ b/discovery-provider/src/utils/ipfs_lib.py
@@ -186,7 +186,7 @@ class IPFSClient:
         return formatted_json
 
     def get_metadata_from_gateway(
-        self, multihash, default_metadata_fields, user_replica_set=None
+        self, multihash, default_metadata_fields, user_replica_set: str = None
     ):
         """Args:
         args.user_replica_set - comma-separated string of user's replica urls


### PR DESCRIPTION
### Description
When metadata fetch in indexing was parallelized, it stopped passing in the user_replica_set param which makes fetching metadata less efficient since it has to go through all the nodes in the network. This adds that functionality back in.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->