### PR TITLE
Move migrations back into server.sh

### DIFF
--- a/discovery-provider/scripts/dev-server.sh
+++ b/discovery-provider/scripts/dev-server.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+if [ "$audius_db_run_migrations" != false ]; then
+    echo "Running alembic migrations"
+    export PYTHONPATH='.'
+    alembic upgrade head
+    echo "Finished running migrations"
+fi
+
 # Audius Discovery Provider / Flask
 # Exports environment variables necessary for Flask app
 

--- a/discovery-provider/scripts/prod-server.sh
+++ b/discovery-provider/scripts/prod-server.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+if [ "$audius_db_run_migrations" != false ]; then
+    echo "Running alembic migrations"
+    export PYTHONPATH='.'
+    alembic upgrade head
+    echo "Finished running migrations"
+fi
+
 # Audius Discovery Provider / Gunicorn
 
 # run with gunicorn web server in prod for greater performance and robustness

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -62,13 +62,6 @@ if [ -z "$audius_db_url" ]; then
     /wait
 fi
 
-if [ "$audius_db_run_migrations" != false ]; then
-    echo "Running alembic migrations"
-    export PYTHONPATH='.'
-    alembic upgrade head
-    echo "Finished running migrations"
-fi
-
 if [[ "$audius_discprov_dev_mode" == "true" ]]; then
     ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Move migrations back to corresponding -server.sh files. Previously they were in both start.sh AND -server.sh files. This was changed in https://github.com/AudiusProject/audius-protocol/pull/1842 to be only in start.sh, but since start.sh is not the uniform tool SPs use, this can cause migrations to never run.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->