### PR TITLE
[AUD-1265] Make createUserBank to fire & forget

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -147,7 +147,18 @@ class Account extends Base {
       if (createWAudioUserBank && this.solanaWeb3Manager) {
         phase = phases.SOLANA_USER_BANK_CREATION
         try {
-          await this.solanaWeb3Manager.createUserBank()
+          // Fire and forget createUserBank. In the case of failure, we will
+          // retry to create user banks in a later session before usage
+          (async () => {
+            const { error, errorCode } = await this.solanaWeb3Manager.createUserBank()
+            if (error || errorCode) {
+              console.error(
+                `Failed to create userbank, with err: ${error}, ${errorCode}`
+              )
+            } else {
+              console.log(`Successfully created userbank!`)
+            }
+          })()
         } catch (err) {
           console.error(`Got error creating userbank: ${err}, continuing...`)
         }


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Move user bank to fire & forget

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Linked client vs. staging. Added artificial 60s delay in create user bank and was able to finish acct creation first.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Sign up success rate

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->