### PR TITLE
Pipe skipPreflight out to relay

### DIFF
--- a/libs/src/services/solanaWeb3Manager/rewards.js
+++ b/libs/src/services/solanaWeb3Manager/rewards.js
@@ -258,7 +258,7 @@ async function submitAttestations ({
     return acc
   }, [[]])
 
-  const results = await Promise.all(bucketedInstructions.map(i => transactionHandler.handleTransaction(i, RewardsManagerError, null, logger, false)))
+  const results = await Promise.all(bucketedInstructions.map(i => transactionHandler.handleTransaction({ instructions: i, errorMapping: RewardsManagerError, logger, skipPreflight: false })))
   logger.info(`submitAttestations: submitted attestations with results: ${JSON.stringify(results)}`)
 
   // If there's any error in any of the transactions, just return that one
@@ -332,7 +332,7 @@ async function createSender ({
   })
 
   const instructions = [...signerInstructions, createSenderInstruction]
-  return transactionHandler.handleTransaction(instructions, RewardsManagerError)
+  return transactionHandler.handleTransaction({ instructions, errorMapping: RewardsManagerError })
 }
 
 /**
@@ -505,7 +505,7 @@ const evaluateAttestations = async ({
     data: serializedInstructionEnum
   })
 
-  return transactionHandler.handleTransaction([transferInstruction], RewardsManagerError, null, logger, false)
+  return transactionHandler.handleTransaction({ instructions: [transferInstruction], errorMapping: RewardsManagerError, logger, skipPreflight: false })
 }
 
 // Helpers

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -65,14 +65,14 @@ class TransactionHandler {
     return result
   }
 
-  async _relayTransaction (instructions, recentBlockhash, skipPreflight = false) {
+  async _relayTransaction (instructions, recentBlockhash, skipPreflight) {
     const relayable = instructions.map(SolanaUtils.prepareInstructionForRelay)
     recentBlockhash = recentBlockhash || (await this.connection.getRecentBlockhash()).blockhash
 
     const transactionData = {
       recentBlockhash,
       instructions: relayable,
-      skipPreflight
+      skipPreflight: skipPreflight === null ? this.skipPreflight : skipPreflight
     }
 
     try {

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -52,10 +52,10 @@ class TransactionHandler {
    * @returns {Promise<HandleTransactionReturn>}
    * @memberof TransactionHandler
    */
-  async handleTransaction (instructions, errorMapping = null, recentBlockhash = null, logger = console, skipPreflight = null) {
+  async handleTransaction ({ instructions, errorMapping = null, recentBlockhash = null, logger = console, skipPreflight = null }) {
     let result = null
     if (this.useRelay) {
-      result = await this._relayTransaction(instructions, recentBlockhash)
+      result = await this._relayTransaction(instructions, recentBlockhash, skipPreflight)
     } else {
       result = await this._locallyConfirmTransaction(instructions, recentBlockhash, logger, skipPreflight)
     }
@@ -65,13 +65,14 @@ class TransactionHandler {
     return result
   }
 
-  async _relayTransaction (instructions, recentBlockhash) {
+  async _relayTransaction (instructions, recentBlockhash, skipPreflight = false) {
     const relayable = instructions.map(SolanaUtils.prepareInstructionForRelay)
     recentBlockhash = recentBlockhash || (await this.connection.getRecentBlockhash()).blockhash
 
     const transactionData = {
       recentBlockhash,
-      instructions: relayable
+      instructions: relayable,
+      skipPreflight
     }
 
     try {

--- a/libs/src/services/solanaWeb3Manager/transfer.js
+++ b/libs/src/services/solanaWeb3Manager/transfer.js
@@ -263,7 +263,7 @@ async function transferWAudioBalance ({
       data: Buffer.from(transferDataInstr)
     })
   ]
-  return transactionHandler.handleTransaction(instructions, ClaimableProgramError)
+  return transactionHandler.handleTransaction({ instructions, errorMapping: ClaimableProgramError })
 }
 
 module.exports = {

--- a/libs/src/services/solanaWeb3Manager/userBank.js
+++ b/libs/src/services/solanaWeb3Manager/userBank.js
@@ -151,7 +151,7 @@ const createUserBankFrom = async ({
     data: Buffer.from(serializedInstructionEnum)
   })]
 
-  return transactionHandler.handleTransaction(instructions, null, recentBlockhash)
+  return transactionHandler.handleTransaction({ instructions, recentBlockhash })
 }
 
 module.exports = {


### PR DESCRIPTION
### Description

- Client wasn't getting error codes from Solana relays because there was no way to tell identity to not skip preflight, which is required for proper error code handling. 
- Also refactor to use non-positional args

### Tests

Tested on stage

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->