### PR TITLE
[AUD-1170] Support uniquely owned discovery node selection

### DIFF
--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -467,12 +467,13 @@ class Rewards extends Base {
     endpoints,
     numAttestations = 3
   }) {
-    if (!endpoints) {
-      endpoints = await this.discoveryProvider.serviceSelector.findAll()
+    let attestEndpoints
+    if (endpoints) {
+      attestEndpoints = sampleSize(endpoints, numAttestations)
+    } else {
+      attestEndpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes(numAttestations)
     }
-    const attestEndpoints = shuffle(
-      endpoints
-    ).filter(s => s !== senderEndpoint).slice(0, numAttestations)
+
     if (attestEndpoints.length < numAttestations) {
       throw new Error(`Not enough other nodes found, need ${numAttestations}, found ${attestEndpoints.length}`)
     }

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -1,10 +1,10 @@
 const axios = require('axios')
+const { sampleSize } = require('lodash')
+
 const { Base, Services } = require('./base')
 const BN = require('bn.js')
 const { RewardsManagerError } = require('../services/solanaWeb3Manager/errors')
-const { shuffle } = require('lodash')
 const { WAUDIO_DECMIALS } = require('../constants')
-const { sampleSize } = require('lodash')
 const { decodeHashId } = require('../utils/utils')
 
 const GetAttestationError = Object.freeze({

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -1,3 +1,5 @@
+const { sampleSize } = require('lodash')
+
 const { Base } = require('./base')
 const { timeRequests } = require('../utils/network')
 const { CreatorNodeSelection } = require('../services/creatorNode/CreatorNodeSelection')
@@ -109,6 +111,36 @@ class ServiceProvider extends Base {
 
   async listDiscoveryProviders () {
     return this.ethContracts.ServiceProviderFactoryClient.getServiceProviderList(DISCOVERY_NODE_SERVICE_NAME)
+  }
+
+  /**
+   * Returns a list of discovery nodes of size `quorumSize` that belong to
+   * unique service operators.
+   * Throws if unable to find a large enough list.
+   * @param {number} quorumSize
+   */
+  async getUniquelyOwnedDiscoveryNodes (quorumSize) {
+    const selectable = await this.discoveryProvider.serviceSelector.findAll({ verbose: true })
+
+    // Group nodes by owner
+    const grouped = selectable.reduce((acc, curr) => {
+      if (curr.owner in acc) {
+        acc[curr.owner].push(curr)
+      } else {
+        acc[curr.owner] = [ curr ]
+      }
+      return acc
+    }, {})
+
+    if (Object.keys(grouped) < quorumSize) {
+      throw new Error('Not enough unique owners to choose from')
+    }
+
+    // Select quorumSize owners from the groups
+    const owners = sampleSize(Object.keys(grouped), quorumSize)
+
+    // Select 1 node from each owner selected
+    return owners.map(owner => sampleSize(grouped[owner], 1)[0].endpoint)
   }
 }
 

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -496,7 +496,7 @@ class AudiusLibs {
     this.Track = new Track(...services)
     this.Playlist = new Playlist(...services)
     this.File = new File(this.User, ...services)
-    this.Rewards = new Rewards(...services)
+    this.Rewards = new Rewards(this.ServiceProvider, ...services)
   }
 }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.js
@@ -25,10 +25,10 @@ class DiscoveryProviderSelection extends ServiceSelection {
        * Gets the "current" expected service version as well as
        * the list of registered providers from chain
        */
-      getServices: async () => {
+      getServices: async ({ verbose = false } = {}) => {
         this.currentVersion = await ethContracts.getCurrentVersion(DISCOVERY_SERVICE_NAME)
         const services = await this.ethContracts.getServiceProviderList(DISCOVERY_SERVICE_NAME)
-        return services.map(e => e.endpoint)
+        return verbose ? services : services.map(e => e.endpoint)
       },
       ...config
     })

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -455,7 +455,7 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(sixthService, initiallyUnhealthy)
   })
 
-  it.only('will reselect a healthy disc prov if initialized disc prov becomes unhealthy', async () => {
+  it('will reselect a healthy disc prov if initialized disc prov becomes unhealthy', async () => {
     const LocalStorage = require('node-localstorage').LocalStorage
     const localStorage = new LocalStorage('./local-storage')
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.js
@@ -455,7 +455,7 @@ describe('DiscoveryProviderSelection', () => {
     assert.strictEqual(sixthService, initiallyUnhealthy)
   })
 
-  it('will reselect a healthy disc prov if initialized disc prov becomes unhealthy', async () => {
+  it.only('will reselect a healthy disc prov if initialized disc prov becomes unhealthy', async () => {
     const LocalStorage = require('node-localstorage').LocalStorage
     const localStorage = new LocalStorage('./local-storage')
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds ability in Rewards.js API for discovery nodes to be selected using unique owner as criteria.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran
`await audiusLibs.Rewards.aggregateAttestations({ quorumSize: 3})`
`await audiusLibs.Rewards.createSenderPublic({ numAttestations: 3 })`
And logged out the endpoints selected


### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Rewards attestations succeeding

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->