### PR TITLE
Fix empty trending result bug

### DIFF
--- a/identity-service/src/notifications/trendingTrackProcessing.js
+++ b/identity-service/src/notifications/trendingTrackProcessing.js
@@ -178,8 +178,11 @@ async function processTrendingTracks (audiusLibs, blocknumber, trendingTracks, t
 
 async function indexTrendingTracks (audiusLibs, optimizelyClient, tx) {
   try {
-    const { trendingTracks, blocknumber } = await getTrendingTracks(optimizelyClient)
-    await processTrendingTracks(audiusLibs, blocknumber, trendingTracks, tx)
+    const trending = await getTrendingTracks(optimizelyClient)
+    if (trending) {
+      const { trendingTracks, blocknumber } = trending
+      await processTrendingTracks(audiusLibs, blocknumber, trendingTracks, tx)
+    }
   } catch (err) {
     logger.error(`Unable to process trending track notifications: ${err.message}`)
   }


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

If `getTrendingTracks` fails for network error, we have to check for null before destructuring

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->