### PR TITLE
Fix aggregate_plays on empty plays case

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_aggregate_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_index_aggregate_plays.py
@@ -185,7 +185,7 @@ def test_index_aggregate_plays_same_checkpoint(app):
 
 
 def test_index_aggregate_plays_no_plays(app):
-    """Raise exception when there are no plays"""
+    """Tests that aggregate_plays should skip indexing if there are no plays"""
     # setup
     with app.app_context():
         db = get_db()
@@ -196,10 +196,4 @@ def test_index_aggregate_plays_no_plays(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-        try:
-            _update_aggregate_plays(session)
-            assert (
-                False
-            ), "test_index_aggregate_plays [test_index_aggregate_plays_no_plays] failed"
-        except Exception:
-            assert True
+        _update_aggregate_plays(session)

--- a/discovery-provider/src/tasks/index_aggregate_plays.py
+++ b/discovery-provider/src/tasks/index_aggregate_plays.py
@@ -70,6 +70,12 @@ def _update_aggregate_plays(session):
     # get the new latest
     new_id_checkpoint = (session.query(func.max(Play.id))).scalar()
 
+    if not new_id_checkpoint or new_id_checkpoint == prev_id_checkpoint:
+        logger.info(
+            "index_aggregate_plays.py | Skip update because there are no new plays"
+        )
+        return
+
     # update aggregate plays with new plays that came after the prev_id_checkpoint
     logger.info(f"index_aggregate_plays.py | Updating {AGGREGATE_PLAYS_TABLE_NAME}")
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

When plays is empty, aggregate_plays will throw an exception. This change makes it skip gracefully. 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Adjusted unit test.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Can only repro error in dev box. Prod and stage wouldn't be empty.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->