### PR TITLE
Add ref to newly baked image and fix bake script

### DIFF
--- a/service-commands/scripts/bake-dev-image.sh
+++ b/service-commands/scripts/bake-dev-image.sh
@@ -97,7 +97,7 @@ bake_with_gcp () {
         provision_dev_with_gcp "$BUILD_INSTANCE_NAME" "$PROTOCOL_GIT_REF" "$CLIENT_GIT_REF"
         SOURCE_DISK="$BUILD_INSTANCE_NAME"
     fi
-    # prepare_gcp_instance_for_image_creation "$SOURCE_DISK"
+    prepare_gcp_instance_for_image_creation "$SOURCE_DISK"
     create_image_with_gcp "$SOURCE_DISK" "$PROTOCOL_GIT_REF" "$CLIENT_GIT_REF"
 }
 

--- a/service-commands/scripts/utils.sh
+++ b/service-commands/scripts/utils.sh
@@ -11,7 +11,7 @@ DEFAULT_GCP_IMAGE="project=ubuntu-os-cloud,family=ubuntu-2004-lts"
 DEFAULT_GCP_MACHINE_TYPE="n2-custom-12-24576"
 DEFAULT_PROVIDER="gcp"
 DEFAULT_USER="ubuntu"
-GCP_DEV_IMAGE="project=audius-infrastructure,image=christine-new-bake-bake-12-16-2021"
+GCP_DEV_IMAGE="project=audius-infrastructure,image=cj-bake-1-14-22-bake-01-14-2022"
 
 get_ssh_args() {
 	provider=$1


### PR DESCRIPTION
### Description

Automated nightly/master commit bake is WIP but I heard some folks were having dev provisioning issues so I baked anew and added the ref. With this update you can just run `A setup remote-dev <name-of-box> --fast` and you will be able to ssh in and run `A up` without additional setup.