### PR TITLE
Identity rewards notifications feature flag

### DIFF
--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -3,7 +3,8 @@ const uuidv4 = require('uuid/v4')
 // Declaration of feature flags set in optimizely
 const FEATURE_FLAGS = Object.freeze({
   SOLANA_LISTEN_ENABLED_SERVER: 'solana_listen_enabled_server',
-  REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled'
+  REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled',
+  REWARDS_NOTIFICATIONS_ENABLED: 'rewards_notifications_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded
@@ -11,7 +12,8 @@ const FEATURE_FLAGS = Object.freeze({
 // consumed within a few seconds of server init
 const DEFAULTS = Object.freeze({
   [FEATURE_FLAGS.SOLANA_LISTEN_ENABLED_SERVER]: false,
-  [FEATURE_FLAGS.REWARDS_ATTESTATION_ENABLED]: false
+  [FEATURE_FLAGS.REWARDS_ATTESTATION_ENABLED]: false,
+  [FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED]: false
 })
 
 /**

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -193,7 +193,8 @@ class NotificationProcessor {
           logger.debug('solana notification queue processing error - tried to process a minSlot < oldMaxSlot', minSlot, oldMaxSlot)
           maxSlot = oldMaxSlot
         } else {
-          maxSlot = await this.indexAllSolanaNotifications(audiusLibs, minSlot, oldMaxSlot)
+          const optimizelyClient = expressApp.get('optimizelyClient')
+          maxSlot = await this.indexAllSolanaNotifications(audiusLibs, optimizelyClient, minSlot, oldMaxSlot)
         }
 
         // Update cached max slot number
@@ -348,7 +349,7 @@ class NotificationProcessor {
       time = Date.now()
 
       // Fetch additional metadata from DP, query for the user's notification settings, and send push notifications (mobile/browser)
-      await sendNotifications(audiusLibs, notifications, tx)
+      await sendNotifications(audiusLibs, notifications, tx, optimizelyClient)
       logger.info(`notifications main indexAll job - sendNotifications complete in ${Date.now() - time}ms`)
       time = Date.now()
 
@@ -384,10 +385,11 @@ class NotificationProcessor {
   /**
    * Doing the solana notification things
    * @param {AudiusLibs} audiusLibs
+   * @param {OptimizelyClient} optimizelyClient
    * @param {number} minSlot min slot number to start querying discprov for new notifications
    * @param {number} oldMaxSlot last max slot number seen
    */
-  async indexAllSolanaNotifications (audiusLibs, minSlot, oldMaxSlot) {
+  async indexAllSolanaNotifications (audiusLibs, optimizelyClient, minSlot, oldMaxSlot) {
     const startDate = Date.now()
     const startTime = process.hrtime()
     const logLabel = 'notifications main indexAllSolanaNotifications job'
@@ -409,7 +411,7 @@ class NotificationProcessor {
       logger.info(`${logLabel} - processNotifications complete`)
 
       // Fetch additional metadata from DP, query for the user's notification settings, and send push notifications (mobile/browser)
-      await sendNotifications(audiusLibs, processedNotifications, tx)
+      await sendNotifications(audiusLibs, processedNotifications, tx, optimizelyClient)
       logger.info(`${logLabel} - sendNotifications complete`)
 
       // Commit

--- a/identity-service/src/notifications/sendNotifications/index.js
+++ b/identity-service/src/notifications/sendNotifications/index.js
@@ -56,8 +56,9 @@ const getUserNotificationSettings = async (userIdsToNotify, tx) => {
  * @param {Object} audiusLibs Instance of audius libs
  * @param {Array<Object>} notifications Array of notifications from DP
  * @param {*} tx The DB transaction to add to every DB query
+ * @param {*} optimizelyClient Optimizely client for feature flags
  */
-async function sendNotifications (audiusLibs, notifications, tx) {
+async function sendNotifications (audiusLibs, notifications, tx, optimizelyClient) {
   // Parse the notification to grab the user ids that we want to notify
   const userIdsToNotify = getUserIdsToNotify(notifications)
 
@@ -71,7 +72,7 @@ async function sendNotifications (audiusLibs, notifications, tx) {
   const metadata = await fetchNotificationMetadata(audiusLibs, users, formattedNotifications)
 
   // using the metadata, populate the notifications, and push them to the publish queue
-  await publishNotifications(formattedNotifications, metadata, userNotificationSettings, tx)
+  await publishNotifications(formattedNotifications, metadata, userNotificationSettings, tx, optimizelyClient)
 }
 
 module.exports = sendNotifications

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -103,12 +103,12 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
  * @param {string} notificationType
  * @param {*} optimizelyClient Optimizely client
  */
-const shouldFilterNotification = (notificationType, optimizelyClient) => {
+const shouldFilterOutNotification = (notificationType, optimizelyClient) => {
   if (!optimizelyClient) {
     return false
   }
   if (notificationType === notificationTypes.ChallengeReward) {
-    return getFeatureFlag(optimizelyClient, FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED)
+    return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED)
   }
   return false
 }
@@ -138,7 +138,7 @@ const publishNotifications = async (notifications, metadata, userNotificationSet
     if (metadata.users[userId] && metadata.users[userId].is_deactivated) {
       continue
     }
-    const shouldFilter = shouldFilterNotification(notification.type, optimizelyClient)
+    const shouldFilter = shouldFilterOutNotification(notification.type, optimizelyClient)
     if (shouldFilter) {
       continue
     }

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -5,6 +5,7 @@ const {
   pushNotificationMessagesMap
 } = require('../formatNotificationMetadata')
 const { publish, publishSolanaNotification } = require('../notificationQueue')
+const { getFeatureFlag, FEATURE_FLAGS } = require('../../featureFlag')
 
 // Maps a notification type to it's base notification
 const getPublishNotifBaseType = (notification) => {
@@ -97,6 +98,22 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
   return types
 }
 
+
+/**
+ * Checks if a notification type is enabled with optimizely
+ * @param {string} notificationType
+ * @param {*} optimizelyClient Optimizely client
+ */
+const shouldFilterNotification = (notificationType, optimizelyClient) => {
+  if (!optimizelyClient) {
+    return false
+  }
+  if (notificationType === notificationTypes.ChallengeReward) {
+    return getFeatureFlag(optimizelyClient, FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED)
+  }
+  return false
+}
+
 /**
  * Takes a list of notifications, populates them with extra metadata, checks their notification settings
  * and publishes it to the notification queue to be sent out.
@@ -105,7 +122,7 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
  * @param {Object} userNotificationSettings A map of userID to their mobile & browser notification settings
  * @param {*} tx Transction for DB queries
  */
-const publishNotifications = async (notifications, metadata, userNotificationSettings, tx) => {
+const publishNotifications = async (notifications, metadata, userNotificationSettings, tx, optimizelyClient) => {
   for (const notification of notifications) {
     const mapNotification = notificationResponseMap[notification.type]
     const populatedNotification = {
@@ -120,6 +137,10 @@ const publishNotifications = async (notifications, metadata, userNotificationSet
 
     // Don't publish events for deactivated users
     if (metadata.users[userId] && metadata.users[userId].is_deactivated) {
+      continue
+    }
+    const shouldFilter = shouldFilterNotification(notification.type, optimizelyClient)
+    if (shouldFilter) {
       continue
     }
 

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -98,7 +98,6 @@ const getPublishTypes = (userId, baseNotificationType, userNotificationSettings)
   return types
 }
 
-
 /**
  * Checks if a notification type is enabled with optimizely
  * @param {string} notificationType


### PR DESCRIPTION
### Description
Feature flag for rewards notifications in identity service
* Add feature flag to identity service
* Stop sending push notifications for rewards notifications based off feature flag - but still stored in db
* Stop sending notifications as part of `GET /notifications` endpoint unless query params passed `withRewards`
* Removes legacy query params for /notifications endpoint for `withRemix` and `withTrendingTrack`

NOTE: Still requires a client pass in query param based off of feature flag

Closes AUD-1272

### Tests
Tested against staging

### How will this change be monitored?
