### PR TITLE
Raise MissingRequired error when no handle is found for a track

### DIFF
--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -427,6 +427,12 @@ def parse_track_event(
             .filter(User.user_id == owner_id, User.is_current == True)
             .first()
         )[0]
+        if not handle:
+            raise EntityMissingRequiredFieldError(
+                "track",
+                track_record,
+                f"No user found for {track_record}",
+            )
 
         update_track_routes_table(
             session, track_record, track_metadata, pending_track_routes
@@ -476,6 +482,12 @@ def parse_track_event(
             .filter(User.user_id == owner_id, User.is_current == True)
             .first()
         )[0]
+        if not handle:
+            raise EntityMissingRequiredFieldError(
+                "track",
+                track_record,
+                f"No user found for {track_record}",
+            )
 
         update_track_routes_table(
             session, track_record, track_metadata, pending_track_routes


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds a MissingRequired exception when the user for a track is not found as a part of the indexing flow. The handle is necessary to retrieve to create the track permalink (handle/track-name) and if we somehow failed to index that user, we need to skip ahead of this tx.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Deployed on prod discovery 2 and fixed stall

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->