### PR TITLE
Update old trending strategy to use lc name

### DIFF
--- a/discovery-provider/src/trending_strategies/aSPET_trending_tracks_strategy.py
+++ b/discovery-provider/src/trending_strategies/aSPET_trending_tracks_strategy.py
@@ -80,7 +80,7 @@ class TrendingTracksStrategyaSPET(BaseTrendingStrategy):
                         ELSE (:N * aip.week_listen_counts + :F * tp.repost_week_count + :O * tp.save_week_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
                         END as week_score,
                         now()
-                    from trending_params_aSPET tp 
+                    from trending_params_aspet tp 
                     inner join aggregate_interval_plays aip 
                         on tp.track_id = aip.track_id;
                 INSERT INTO track_trending_scores 


### PR DESCRIPTION
Postgres matviews are lower-cased

### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Not sure whether this is causing a bug in prod or not, but it looks like postgres auto-lowercases the name of the matview, so this query should need to change

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->