### PR TITLE
Change prod-server log level to info

### DIFF
--- a/discovery-provider/scripts/prod-server.sh
+++ b/discovery-provider/scripts/prod-server.sh
@@ -2,10 +2,10 @@
 set -e
 
 if [ "$audius_db_run_migrations" != false ]; then
-    echo "Running alembic migrations"
-    export PYTHONPATH='.'
-    alembic upgrade head
-    echo "Finished running migrations"
+  echo "Running alembic migrations"
+  export PYTHONPATH='.'
+  alembic upgrade head
+  echo "Finished running migrations"
 fi
 
 # Audius Discovery Provider / Gunicorn
@@ -29,6 +29,8 @@ else
   THREADS="${audius_gunicorn_threads}"
 fi
 
+audius_discprov_loglevel=${audius_discprov_loglevel:-info}
+
 if [[ "$audius_openresty_enable" == true ]]; then
   openresty -p /usr/local/openresty -c /usr/local/openresty/conf/nginx.conf
   tail -f /usr/local/openresty/logs/access.log | python3 scripts/openresty_log_convertor.py INFO &
@@ -36,17 +38,17 @@ if [[ "$audius_openresty_enable" == true ]]; then
 
   # If a worker class is specified, use that. Otherwise, use sync workers.
   if [[ -z "${audius_gunicorn_worker_class}" ]]; then
-    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --workers=$WORKERS --threads=$THREADS
+    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS
   else
     WORKER_CLASS="${audius_gunicorn_worker_class}"
-    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --worker-class=$WORKER_CLASS --workers=$WORKERS
+    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS
   fi
 else
   # If a worker class is specified, use that. Otherwise, use sync workers.
   if [[ -z "${audius_gunicorn_worker_class}" ]]; then
-    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --workers=$WORKERS --threads=$THREADS
+    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS
   else
     WORKER_CLASS="${audius_gunicorn_worker_class}"
-    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=debug --worker-class=$WORKER_CLASS --workers=$WORKERS
+    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS
   fi
 fi

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -67,16 +67,16 @@ export PYTHONUNBUFFERED=1
 audius_discprov_loglevel=${audius_discprov_loglevel:-info}
 
 if [[ "$audius_discprov_dev_mode" == "true" ]]; then
-    stdbuf -oL ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
+    ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        stdbuf -oL celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) worker.log &
-        stdbuf -oL celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) beat.log &
+        celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) worker.log &
+        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) beat.log &
     fi
 else
-    stdbuf -oL ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &
+    ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        stdbuf -oL celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
-        stdbuf -oL celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &
+        celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &
     fi
 
     docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 10

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -62,17 +62,21 @@ if [ -z "$audius_db_url" ]; then
     /wait
 fi
 
+export PYTHONUNBUFFERED=1
+
+audius_discprov_loglevel=${audius_discprov_loglevel:-info}
+
 if [[ "$audius_discprov_dev_mode" == "true" ]]; then
-    ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
+    stdbuf -oL ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        celery -A src.worker.celery worker --loglevel info 2>&1 | tee >(logger -t worker) worker.log &
-        celery -A src.worker.celery beat --loglevel info 2>&1 | tee >(logger -t beat) beat.log &
+        stdbuf -oL celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) worker.log &
+        stdbuf -oL celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) beat.log &
     fi
 else
-    ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &
+    stdbuf -oL ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        celery -A src.worker.celery worker --loglevel info 2>&1 | tee >(logger -t worker) &
-        celery -A src.worker.celery beat --loglevel info 2>&1 | tee >(logger -t beat) &
+        stdbuf -oL celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        stdbuf -oL celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &
     fi
 
     docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 10


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

This PR changes Discovery Provider log level from debug to info, and also adds and env var to control this.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Testing on Sandbox

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->