### PR TITLE
[AUD-1309][AUD-1291] Improve Identity challenge attestation

### DIFF
--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -482,7 +482,7 @@ class RewardsAttester {
 
   async _addRecentlyDisbursed(challenges) {
     const ids = challenges.map(this._disbursementToKey)
-    this.recentlyDisbursedQueue.push(ids)
+    this.recentlyDisbursedQueue.push(...ids)
     if (this.recentlyDisbursedQueue.length > MAX_DISBURSED_CACHE_SIZE) {
       this.recentlyDisbursedQueue.splice(0, this.recentlyDisbursedQueue.length - MAX_DISBURSED_CACHE_SIZE)
     }

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -13,6 +13,7 @@ class BaseRewardsReporter {
 }
 
 const SOLANA_BASED_CHALLENGE_IDS = new Set(['listen-streak'])
+const MAX_DISBURSED_CACHE_SIZE = 100
 
 /**
  * `RewardsAttester` is responsible for repeatedly attesting for completed rewards.
@@ -100,7 +101,9 @@ class RewardsAttester {
     this.undisbursedQueue = []
     // Stores a set of identifiers representing
     // recently disbursed challenges.
-    this.recentlyDisbursedSet = new Set()
+    // Stored as an array to make it simpler to prune
+    // old entries
+    this.recentlyDisbursedQueue = []
     // How long wait wait before retrying
     this.cooldownMsec = 2000
     // How much we increase the cooldown between attempts:
@@ -247,7 +250,7 @@ class RewardsAttester {
     this.logger.info(`Updating values: startingBlock: ${this.startingBlock}, offset: ${this.offset}`)
 
     // Set the recently disbursed set
-    this.recentlyDisbursedSet = new Set(results.map(this._disbursementToKey))
+    this._addRecentlyDisbursed(results)
 
     // run the `updateValues` callback
     await this.updateValues({ startingBlock: this.startingBlock, offset: this.offset, successCount })
@@ -370,7 +373,7 @@ class RewardsAttester {
   async _refillQueueIfNecessary () {
     if (this.undisbursedQueue.length) return {}
 
-    this.logger.info(`Refilling queue, recently disbursed: ${JSON.stringify(this.recentlyDisbursedSet)}`)
+    this.logger.info(`Refilling queue, recently disbursed: ${JSON.stringify(this.recentlyDisbursedQueue)}`)
     const { success: disbursable, error } = await this.libs.Rewards.getUndisbursedChallenges({ offset: this.offset, completedBlockNumber: this.startingBlock, logger: this.logger })
 
     if (error) {
@@ -397,7 +400,7 @@ class RewardsAttester {
         wallet,
         completedBlocknumber: completed_blocknumber
       }))
-      .filter(d => !(this.challengeIdsDenyList.has(d.challengeId) || this.recentlyDisbursedSet.has(this._disbursementToKey(d))))
+      .filter(d => !(this.challengeIdsDenyList.has(d.challengeId) || (new Set(this.recentlyDisbursedQueue)).has(this._disbursementToKey(d))))
 
     this.logger.info(`Got ${disbursable.length} undisbursed challenges${this.undisbursedQueue.length !== disbursable.length ? `, filtered out [${disbursable.length - this.undisbursedQueue.length}] recently disbursed challenges.` : '.'}`)
     return {}
@@ -475,6 +478,14 @@ class RewardsAttester {
 
   async _delay (waitTime) {
     return new Promise(resolve => setTimeout(resolve, waitTime))
+  }
+
+  async _addRecentlyDisbursed(challenges) {
+    const ids = challenges.map(this._disbursementToKey)
+    this.recentlyDisbursedQueue.push(ids)
+    if (this.recentlyDisbursedQueue.length > MAX_DISBURSED_CACHE_SIZE) {
+      this.recentlyDisbursedQueue.splice(0, this.recentlyDisbursedQueue.length - MAX_DISBURSED_CACHE_SIZE)
+    }
   }
 }
 

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -480,7 +480,7 @@ class RewardsAttester {
     return new Promise(resolve => setTimeout(resolve, waitTime))
   }
 
-  async _addRecentlyDisbursed(challenges) {
+  async _addRecentlyDisbursed (challenges) {
     const ids = challenges.map(this._disbursementToKey)
     this.recentlyDisbursedQueue.push(...ids)
     if (this.recentlyDisbursedQueue.length > MAX_DISBURSED_CACHE_SIZE) {

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -463,8 +463,8 @@ class RewardsAttester {
     }
   }
 
-  _disbursementToKey ({ challengeId, userId }) {
-    return `${challengeId}_${userId}`
+  _disbursementToKey ({ challengeId, userId, specifier }) {
+    return `${challengeId}_${userId}_${specifier}`
   }
 
   async _backoff (retryCount) {


### PR DESCRIPTION
### Description

- Keep a longer lived cache of recently disbursed entries, instead of resetting it on each disbursement batch
- Include specifier in the cache key, to handle trending edge-cases


### Tests

- Tested on staging

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->