### PR TITLE
Remove skipping of disbursement on foreign user address / user challenge

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
@@ -264,7 +264,7 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
         try:
             process_batch_sol_reward_manager_txs(session, [parsed_tx], redis)
             assert False
-        except MissingEthRecipientError as e:
+        except MissingEthRecipientError:
             disbursments = session.query(ChallengeDisbursement).all()
             assert len(disbursments) == 0
             reward_manager_tx_1 = (

--- a/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
@@ -1,6 +1,7 @@
 from unittest.mock import create_autospec
 
 from integration_tests.utils import populate_mock_db
+from src.exceptions import MissingEthRecipientError
 from src.models import ChallengeDisbursement, RewardManagerTransaction
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks.index_rewards_manager import (
@@ -249,40 +250,43 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
     assert parsed_tx["tx_sig"] == first_tx_sig
     assert parsed_tx["slot"] == 72131741
 
-    test_entries = {
+    test_user_entries = {
         "users": [
             {
                 "user_id": 1,
                 "handle": "piazza",
                 "wallet": "0x0403be3560116a12b467855cb29a393174a59876",
             },
-        ],
-        "user_challenges": [
-            {
-                "challenge_id": "profile-completion",
-                "user_id": 1,
-                "specifier": "123456789",
-            }
-        ],
+        ]
     }
+
+    with db.scoped_session() as session:
+        try:
+            process_batch_sol_reward_manager_txs(session, [parsed_tx], redis)
+            assert False
+        except MissingEthRecipientError as e:
+            disbursments = session.query(ChallengeDisbursement).all()
+            assert len(disbursments) == 0
+            reward_manager_tx_1 = (
+                session.query(RewardManagerTransaction)
+                .filter(RewardManagerTransaction.signature == first_tx_sig)
+                .all()
+            )
+            assert len(reward_manager_tx_1) == 1
+            assert True
+
+    populate_mock_db(db, test_user_entries)
+    parsed_tx["tx_sig"] = second_tx_sig
     with db.scoped_session() as session:
         process_batch_sol_reward_manager_txs(session, [parsed_tx], redis)
         disbursments = session.query(ChallengeDisbursement).all()
-        assert len(disbursments) == 0
         reward_manager_tx_1 = (
             session.query(RewardManagerTransaction)
-            .filter(RewardManagerTransaction.signature == first_tx_sig)
+            .filter(RewardManagerTransaction.signature == second_tx_sig)
             .all()
         )
         assert len(reward_manager_tx_1) == 1
 
-    # Update tx sig as the prior should already be present in database
-    parsed_tx["tx_sig"] = second_tx_sig
-
-    populate_mock_db(db, test_entries)
-    with db.scoped_session() as session:
-        process_batch_sol_reward_manager_txs(session, [parsed_tx], redis)
-        disbursments = session.query(ChallengeDisbursement).all()
         assert len(disbursments) == 1
         disbursment = disbursments[0]
         assert disbursment.challenge_id == "profile-completion"

--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -12,3 +12,24 @@ class NotFoundError(Base):
     """Invalid arguments passed to request"""
 
     pass  # pylint: disable=W0107
+
+
+class MissingEthRecipientError(Base):
+    """Exception raised for missing eth recipient error while indexing
+    Attributes:
+        eth_recipient -- Eth Address
+        challenge_id -- Challenge ID
+        specifier -- Challenge specifier
+        signature -- Solana tx signature
+        slot -- Solana slot number
+    """
+
+    def __init__(
+        self, eth_recipient, challenge_id, specifier, signature, slot, message
+    ):
+        super().__init__(message)
+        self.eth_recipient = eth_recipient
+        self.challenge_id = challenge_id
+        self.specifier = specifier
+        self.signature = signature
+        self.slot = slot

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -8,6 +8,7 @@ import base58
 from redis import Redis
 from sqlalchemy import desc
 from sqlalchemy.orm.session import Session
+from src.exceptions import MissingEthRecipientError
 from src.models import (
     ChallengeDisbursement,
     RewardManagerTransaction,
@@ -286,6 +287,15 @@ def process_batch_sol_reward_manager_txs(
             if eth_recipient not in users_map:
                 logger.error(
                     f"index_rewards_manager.py | eth_recipient {eth_recipient} not found while processing disbursement"
+                )
+                tx_signature = tx["tx_sig"]
+                raise MissingEthRecipientError(
+                    eth_recipient,
+                    transfer_instr["challenge_id"],
+                    specifier,
+                    tx["tx_sig"],
+                    tx["slot"],
+                    f"Error: eth_recipient {eth_recipient} not found while indexing rewards manager for tx signature {tx_signature}",
                 )
 
             user_id = users_map[eth_recipient]

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -283,12 +283,10 @@ def process_batch_sol_reward_manager_txs(
                     f"index_rewards_manager.py | Challenge specifier {specifier} not found"
                     "while processing disbursement"
                 )
-                continue
             if eth_recipient not in users_map:
                 logger.error(
                     f"index_rewards_manager.py | eth_recipient {eth_recipient} not found while processing disbursement"
                 )
-                continue
 
             user_id = users_map[eth_recipient]
             logger.info(


### PR DESCRIPTION
### Description
Removes `continue` statement if missing the user's eth address from the users tbl or a matching user challenge while processing a rewards manager challenge disbursement.
This should help the discovery nodes have a consistent challenge_disbursements table

Closes AUD-1321

### Tests


### How will this change be monitored?
