### PR TITLE
Set proxy read timeout to 1 hour

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -12,6 +12,7 @@ http {
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
 					max_size=10g inactive=10m use_temp_path=off;
+    proxy_read_timeout 3600; # 1 hour in seconds
 
     server {
         listen 4000;


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

This PR is to bump the read timeout to 1 hour (3600 seconds). This is the timeout set at the load balancer level. The default timeout is 60s. ([reference](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout))

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Set the proxy read timeout to 4s:
```
proxy_read_timeout 4;
```

Created a route that waits n ms:
```
  app.get(
    '/test',
    handleResponse(async (req, res) => {
      await new Promise((resolve) => setTimeout(resolve, req.query.duration))

      return successResponse({
        msg: `you should see this after ${req.query.duration}ms`
      })
    })
  )
```

Hit route at `duration=100` (under read timeout):
```
{
    "data": {
        "msg": "you should see this after 100ms"
    },
    "signer": "0x11e486b1532e3f5a0090266e550a7e15d9721acf",
    "timestamp": "2022-01-20T18:56:33.759Z",
    "signature": "0xd789898c9fa1b14541674cd64578771002ad7a29f9fdd9c62e35bd6c2d4b5a084d540482b626fc4eaf8efa13f6f7332cdc094623436d4185d1c91bcf026796d51c"
}
```

Hit route at `duration=4010` (over read timeout):
Proxy response:
```
<html>

<head>
	<title>504 Gateway Time-out</title>
</head>

<body>
	<center>
		<h1>504 Gateway Time-out</h1>
	</center>
	<hr>
	<center>openresty/1.19.9.1</center>
</body>

</html>
```

Proxy logs:
```
2022/01/20 18:53:22 [error] 10#10: *1652 upstream timed out (110: Operation timed out) while reading response header from upstream, client: 73.222.231.193, server: , request: "GET /test?duration=4010 HTTP/1.1", upstream: "http://127.0.0.1:3000/test?duration=4010", host: "34.133.121.197:4000"
```

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Will monitor CN5 stage node to see if any unexpected errors come about via the error.log file and sentry alerts

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->