### PR TITLE
[AUD-73] Add country field to discovery health-check

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -77,5 +77,6 @@ owner_wallet = 0xFakeOwnerWallet
 private_key = 0xFakePrivateKey
 
 [serviceLocation]
+serviceCountry =
 serviceLatitude =
 serviceLongitude =

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -324,6 +324,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         # DB connections check
         db_connections_json, db_connections_error = _get_db_conn_state()
         health_results["db_connections"] = db_connections_json
+        health_results["country"] = shared_config["serviceLocation"]["serviceCountry"]
         health_results["latitude"] = shared_config["serviceLocation"]["serviceLatitude"]
         health_results["longitude"] = shared_config["serviceLocation"][
             "serviceLongitude"

--- a/discovery-provider/src/queries/get_health_unit_test.py
+++ b/discovery-provider/src/queries/get_health_unit_test.py
@@ -462,6 +462,7 @@ def test_get_health_verbose(web3_mock, redis_mock, db_mock, get_monitors_mock):
             "wait_event": "ClientRead",
         }
     ]
+    assert "country" in health_results
     assert "latitude" in health_results
     assert "longitude" in health_results
     assert "maximum_healthy_block_difference" in health_results

--- a/discovery-provider/src/utils/config.py
+++ b/discovery-provider/src/utils/config.py
@@ -128,10 +128,12 @@ except (KeyError, RuntimeError) as e:
     ) from e
 
 try:
-    # get latitude longitude
+    # get latitude longitude and country
     ip_info_url = "https://ipinfo.io"
     ip_info_response = requests.get(ip_info_url)
-    latitude, longitude = ip_info_response.json()["loc"].split(",")
+    response_data = ip_info_response.json()
+    shared_config["serviceLocation"]["serviceCountry"] = response_data["country"]
+    latitude, longitude = response_data["loc"].split(",")
     shared_config["serviceLocation"]["serviceLatitude"] = latitude
     shared_config["serviceLocation"]["serviceLongitude"] = longitude
 


### PR DESCRIPTION
### Description

Adds country flag to discovery health-check endpoint, to add consistency between content-node and discovery-node health-checks. This also makes it easy for the protocol-dashboard to display country flags for each node.

### Tests

Added assertion for health-check payload