### PR TITLE
Improve startBlock override for attester

### DIFF
--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -574,6 +574,7 @@ class DiscoveryProvider {
   async getUndisbursedChallenges (limit = null, offset = null, completedBlockNumber = null, encodedUserId = null) {
     const req = Requests.getUndisbursedChallenges(limit, offset, completedBlockNumber, encodedUserId)
     const res = await this._makeRequest(req)
+    if (!res) return []
     return res.map(r => ({ ...r, amount: parseInt(r.amount) }))
   }
 

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -174,9 +174,10 @@ class RewardsAttester {
     const override = await this.getStartingBlockOverride()
     // Careful with 0...
     if (override === null || override === undefined) return
-    this.logger.info(`Setting starting block override: ${override}`)
+    this.logger.info(`Setting starting block override: ${override}, emptying recent disbursed queue`)
     this.startingBlock = override
     this.offset = 0
+    this.recentlyDisbursedQueue = []
   }
 
   /**


### PR DESCRIPTION
### Description

- Empty recently disbursed queue if we override startBlock
- Fix a bug where we crash if discover undisbursed endpoint fails to return a value (not sure why this happens, but I've seen it)

### Tests

None

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->