### PR TITLE
[ASI-800] PR 2.5 - `/users/clock_status` route bugfixes

### DIFF
--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -259,12 +259,6 @@ class DBManager {
       )
 
       const filesHash = filesHashResp[0][0].md5
-
-      if (!filesHash)
-        throw new Error(
-          '[fetchFilesHashFromDB] Error: Failed to retrieve filesHash'
-        )
-
       return filesHash
     } catch (e) {
       throw new Error(e.message)

--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -246,6 +246,9 @@ module.exports = function (app) {
             response.filesHashForClockRange = filesHashForClockRange
           }
         }
+        if (returnFilesHash && !cnodeUserUUID) {
+          response.filesHash = null
+        }
       }
 
       await Promise.all([


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

1.  Standardizes response of /users/clock_status with /users/batch_clock_status in case where no user exists for provided wallet. Ensures value for filesHash if returnFilesHash = true always defaults to null if not found

2. Fix bug where `/users/clock_status` route 500s when no files found for requested clockRange. There's no reason for route to error, it should instead 200 and return `filesHashForClockRange = null`

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Additional unit test coverage

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->