### PR TITLE
Identity logging - fixing NaN value log

### DIFF
--- a/identity-service/src/awsSNS.js
+++ b/identity-service/src/awsSNS.js
@@ -151,7 +151,7 @@ async function drainMessageObject (bufferObj) {
   const newBadgeCount = incrementBadgeQuery[0][0][0].iosBadgeCount
   const devices = await models.NotificationDeviceToken.findAll({ where: { userId } })
   // If no devices found, short-circuit
-  if (devices.length === 0) return
+  if (devices.length === 0) return numSentNotifs
   // Dispatch to all devices
   await Promise.all(devices.map(async (device) => {
     const { deviceType, awsARN, deviceToken } = device

--- a/identity-service/src/notifications/notificationQueue.js
+++ b/identity-service/src/notifications/notificationQueue.js
@@ -66,7 +66,7 @@ async function _sendNotification (notifFn, bufferObj, logger) {
     logger.error(`${logPrefix} ERROR ${e.message}`)
   }
 
-  return numSentNotifs
+  return numSentNotifs || 0
 }
 
 async function drainPublishedMessages (logger) {

--- a/identity-service/src/webPush.js
+++ b/identity-service/src/webPush.js
@@ -35,7 +35,7 @@ const sendBrowserNotification = async ({ userId, notificationParams }) => {
   let numSentNotifs = 0
 
   try {
-    if (!webPushIsConfigured) return
+    if (!webPushIsConfigured) return numSentNotifs
     const { message, title } = notificationParams
     const notificationBrowsers = await models.NotificationBrowserSubscription.findAll({ where: { userId, enabled: true } })
     await Promise.all(notificationBrowsers.map(async (notificationBrowser) => {
@@ -99,7 +99,7 @@ const sendSafariNotification = async ({ userId, notificationParams }) => {
   let numSentNotifs = 0
 
   try {
-    if (!apnProvider) return
+    if (!apnProvider) return numSentNotifs
     const note = new apn.Notification()
 
     const { message, title } = notificationParams


### PR DESCRIPTION
In some scenarios, identity logs incorrectly show `NaN` value for a number

```
{"name":"audius_identity_service","hostname":"identity-backend-7b485f9f96-fct4q","pid":17,"level":30,"msg":"notifications main indexAll job - drainPublishedMessages complete - processed NaN notifs in 3653ms","time":"2022-01-26T15:56:32.115Z","v":0}
{"name":"audius_identity_service","hostname":"identity-backend-7b485f9f96-fct4q","pid":17,"level":30,"msg":"notifications main indexAll job - drainPublishedMessages complete - processed NaN notifs in 2724ms","time":"2022-01-26T15:55:57.402Z","v":0}
```

Fixed this to ensure number value is always returned, also added a 0 default