### PR TITLE
Improve attestation aggregation flow

### DIFF
--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -461,7 +461,7 @@ class Rewards extends Base {
     let needsAttestations = endpoints
 
     do {
-      logger.info(`Fetching attestations with retries for endpoints: ${needsAttestations}, attempt ${retryCount}`)
+      logger.info(`Aggregating attestations with retries challenge: ${challengeId}, userId: ${encodedUserId}, endpoints: ${needsAttestations}, attempt ${retryCount}`)
       if (retryCount > 0) {
         await (new Promise(resolve => setTimeout(resolve, 1000)))
       }
@@ -491,6 +491,12 @@ class Rewards extends Base {
       retryCount++
     }
     while (needsAttestations.length && retryCount <= maxAttempts)
+
+    if (needsAttestations.length) {
+      logger.info(`Failed to aggregate attestations for challenge ${challengeId}, userId: ${encodedUserId}`)
+    } else {
+      logger.info(`Successfully aggregated attestations for challenge ${challengeId}, userId: ${encodedUserId}`)
+    }
     return completedAttestations
   }
 

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -461,9 +461,11 @@ class RewardsAttester {
   async _processResponses (responses) {
     const errors = SubmitAndEvaluateError
     const AAO_ERRORS = new Set([errors.HCAPTCHA, errors.COGNITO_FLOW, errors.BLOCKED])
-    const NEEDS_RESELECT_ERRORS = new Set([errors.INSUFFICIENT_DISCOVERY_NODE_COUNT, errors.CHALLENGE_INCOMPLETE])
+    const NEEDS_RESELECT_ERRORS = new Set([errors.INSUFFICIENT_DISCOVERY_NODE_COUNT])
     // Account for errors from DN aggregation + Solana program
-    const NO_RETRY_ERRORS = new Set([errors.ALREADY_DISBURSED, errors.ALREADY_SENT])
+    // CHALLENGE_INCOMPLETE are already handled in the `submitAndEvaluate` flow -
+    // safe to assume those won't work if we see them at this point.
+    const NO_RETRY_ERRORS = new Set([errors.ALREADY_DISBURSED, errors.ALREADY_SENT, errors.CHALLENGE_INCOMPLETE])
 
     const noRetry = []
     const successful = []


### PR DESCRIPTION
### Description

Improve attestation flow by having attestation aggregation occur in a loop, and only retrying failed nodes. Incorporate changes into the identity attester as well.

### Tests

Tested against stage

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->