### PR TITLE
Quickfix for ursm dict missing key

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -293,9 +293,9 @@ def fetch_ipfs_metadata(
                 else user_metadata_format
             )
             user_id = cid_to_user_id[cid]
-            if user_id in user_to_replica_set:
+            if user_id and user_id in user_to_replica_set:
                 user_replica_set = user_to_replica_set[
-                    cid_to_user_id[cid]
+                    user_id
                 ]  # user or track owner's replica set
                 future = executor.submit(
                     update_task.ipfs_client.get_metadata,
@@ -307,7 +307,7 @@ def fetch_ipfs_metadata(
                 futures_map[future] = [cid, txhash]
             else:
                 logger.warn(
-                    f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid}"
+                    f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid} - missing user id {user_id}"
                 )
 
         for future in concurrent.futures.as_completed(futures):

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -293,7 +293,7 @@ def fetch_ipfs_metadata(
                 else user_metadata_format
             )
             user_id = cid_to_user_id[cid]
-            if user_id in user_replica_set:
+            if user_id in user_to_replica_set:
                 user_replica_set = user_to_replica_set[
                     cid_to_user_id[cid]
                 ]  # user or track owner's replica set
@@ -306,7 +306,9 @@ def fetch_ipfs_metadata(
                 futures.append(future)
                 futures_map[future] = [cid, txhash]
             else:
-                logger.warn(f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid}")
+                logger.warn(
+                    f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid}"
+                )
 
         for future in concurrent.futures.as_completed(futures):
             cid, txhash = futures_map[future]

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -292,17 +292,21 @@ def fetch_ipfs_metadata(
                 if cid_type[cid] == "track"
                 else user_metadata_format
             )
-            user_replica_set = user_to_replica_set[
-                cid_to_user_id[cid]
-            ]  # user or track owner's replica set
-            future = executor.submit(
-                update_task.ipfs_client.get_metadata,
-                cid,
-                metadata_format,
-                user_replica_set,
-            )
-            futures.append(future)
-            futures_map[future] = [cid, txhash]
+            user_id = cid_to_user_id[cid]
+            if user_id in user_replica_set:
+                user_replica_set = user_to_replica_set[
+                    cid_to_user_id[cid]
+                ]  # user or track owner's replica set
+                future = executor.submit(
+                    update_task.ipfs_client.get_metadata,
+                    cid,
+                    metadata_format,
+                    user_replica_set,
+                )
+                futures.append(future)
+                futures_map[future] = [cid, txhash]
+            else:
+                logger.warn(f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid}")
 
         for future in concurrent.futures.as_completed(futures):
             cid, txhash = futures_map[future]


### PR DESCRIPTION
* When fetching metadata for users that do not exist due to skipped blocks/tx, we run into a KeyError due to optimization around URSM fetching. 
* This adds an existence check to bypass the error and continue indexing.