### PR TITLE
Set proxy_read_timeout to 10m

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -25,6 +25,8 @@ http {
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cache:10m max_size=1g inactive=1m use_temp_path=off;
 
+    proxy_read_timeout 600; # 10 mins in seconds
+
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     lua_shared_dict limit_count_store 100m;


### PR DESCRIPTION
### Description
The default proxy read timeout was too low, was failing fetching notifications. This bumps it up to 10m

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Pushed to prod via hotfix and it progressed past the notifications block 
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->