### PR TITLE
Always submit get_metadata function to ThreadPoolExecutor

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -332,23 +332,20 @@ def fetch_ipfs_metadata(
                 if cid_type[cid] == "track"
                 else user_metadata_format
             )
+            user_replica_set = None
             user_id = cid_to_user_id[cid]
             if user_id and user_id in user_to_replica_set:
                 user_replica_set = user_to_replica_set[
                     user_id
                 ]  # user or track owner's replica set
-                future = executor.submit(
-                    update_task.ipfs_client.get_metadata,
-                    cid,
-                    metadata_format,
-                    user_replica_set,
-                )
-                futures.append(future)
-                futures_map[future] = [cid, txhash]
-            else:
-                logger.warn(
-                    f"index.py | failed to find existing user for txhash {txhash} with metadata cid {cid} - missing user id {user_id}"
-                )
+            future = executor.submit(
+                update_task.ipfs_client.get_metadata,
+                cid,
+                metadata_format,
+                user_replica_set,
+            )
+            futures.append(future)
+            futures_map[future] = [cid, txhash]
 
         for future in concurrent.futures.as_completed(futures):
             cid, txhash = futures_map[future]


### PR DESCRIPTION
### Description
We never want to not submit a get_metadata function call for any CID. If the CID is unavailable the TPE would go into the except block and raise IndexingError. This statement was just meant to optimize the lookup of user_replica_set. It should never stop the call from happening.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->