### PR TITLE
Do not redirect /notifications requests

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -82,6 +82,15 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        # Do not redirect /notifications requests, which are slow.
+        # TODO(ASI-820): When all discovery nodes can easily process
+        # notifications, allow this traffic to be shared.
+        location /notifications {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location ~* .*/trending/.* {
             access_by_lua_block {
                 local main = require "main"


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Notifications endpoint is currently quite slow (20s-2min). If we redirect to another discovery node it may not (yet) have proper origin timeout params

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested on prod discovery node

### How will this change be monitored?

Identity notif indexing

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->