### PR TITLE
Add proxy buffer var

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -44,6 +44,7 @@ http {
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffer_size 16k;
 
         location = /openresty_pubkey {
             content_by_lua_block {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

```
2022/01/31 21:44:46 [error] 37#37: *2705 proxy_buffer_size 4096 is not enough for cache key, it should be increased to at least 7168, client: 10.244.0.1, server: , request: "GET /tracks?
```

^ Related to this error occurring

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Pending some testing on sandbox

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->