### PR TITLE
Modify listen tracking window and key lifetime

### DIFF
--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -268,7 +268,7 @@ module.exports = function (app) {
         .sort((a, b) => (new Date(b) - new Date(a)))
         .map(key => hourlyResponseData[key])
 
-    // Calculate success of the last 10% of submissions
+    // Calculate success of submissions before the cutoff
     let recentSubmissionCount = 0
     let recentSuccessCount = 0
     let cutoffTimestamp

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -262,7 +262,6 @@ module.exports = function (app) {
     }
 
     const percentSuccess = success / submission
-
     // Sort response in descending time order
     const sortedHourlyData =
       Object.keys(hourlyResponseData)
@@ -274,16 +273,19 @@ module.exports = function (app) {
     let recentSuccessCount = 0
     let cutoffTimestamp
     const now = Date.now()
+
     for (var sortedHourlyEntry of sortedHourlyData) {
       // Convert diff from ms to minutes
       const diff = (now - sortedHourlyEntry.time.getTime()) / 60000
-      if (diff > cutoffMinutes) {
-        break
-      }
       recentSubmissionCount += sortedHourlyEntry.submission
       recentSuccessCount += sortedHourlyEntry.success
       cutoffTimestamp = sortedHourlyEntry.time
+      // Exit calculation
+      if (diff > cutoffMinutes) {
+        break
+      }
     }
+
     const recentSuccessPercent = recentSuccessCount / recentSubmissionCount
     const recentInfo = {
       recentSubmissionCount,

--- a/identity-service/src/routes/trackListens.js
+++ b/identity-service/src/routes/trackListens.js
@@ -31,7 +31,8 @@ const defaultOffset = 0
 const minOffset = 0
 
 // Duration for listen tracking redis keys prior to expiry (in seconds)
-const redisTxTrackingExpirySeconds = 10 * 60 * 60
+// 1 week in in seconds = 7 days * 24hrs * 60 min * 60s
+const redisTxTrackingExpirySeconds = 7 * 24 * 60 * 60
 
 const getPaginationVars = (limit, offset) => {
   if (!limit) limit = defaultLimit
@@ -236,6 +237,8 @@ module.exports = function (app) {
   app.get('/tracks/listen/solana/status', handleResponse(async (req, res) => {
     const redis = req.app.get('redis')
     const results = await redis.keys('listens-tx-*')
+    // Expected percent success
+    let { percent = 0.9, cutoffMinutes = 60 } = req.query
     let hourlyResponseData = {}
     let success = 0
     let submission = 0
@@ -250,7 +253,7 @@ module.exports = function (app) {
           hourlyResponseData[hourSuffix] = {
             submission: Number(await redis.get(trackingRedisKeys.submission)),
             success: Number(await redis.get(trackingRedisKeys.success)),
-            time: hourSuffix
+            time: new Date(hourSuffix)
           }
           submission += hourlyResponseData[hourSuffix].submission
           success += hourlyResponseData[hourSuffix].success
@@ -258,12 +261,42 @@ module.exports = function (app) {
       }
     }
 
+    const percentSuccess = success / submission
+
     // Sort response in descending time order
     const sortedHourlyData =
       Object.keys(hourlyResponseData)
         .sort((a, b) => (new Date(b) - new Date(a)))
         .map(key => hourlyResponseData[key])
-    return successResponse({ success, submission, sortedHourlyData })
+
+    // Calculate success of the last 10% of submissions
+    let recentSubmissionCount = 0
+    let recentSuccessCount = 0
+    let cutoffTimestamp
+    const now = Date.now()
+    for (var sortedHourlyEntry of sortedHourlyData) {
+      // Convert diff from ms to minutes
+      const diff = (now - sortedHourlyEntry.time.getTime()) / 60000
+      if (diff > cutoffMinutes) {
+        break
+      }
+      recentSubmissionCount += sortedHourlyEntry.submission
+      recentSuccessCount += sortedHourlyEntry.success
+      cutoffTimestamp = sortedHourlyEntry.time
+    }
+    const recentSuccessPercent = recentSuccessCount / recentSubmissionCount
+    const recentInfo = {
+      recentSubmissionCount,
+      recentSuccessCount,
+      recentSuccessPercent,
+      cutoffTimestamp
+    }
+
+    const resp = { percentSuccess, success, submission, sortedHourlyData, recentInfo }
+    if (recentSuccessPercent < percent) {
+      return errorResponseBadRequest(resp)
+    }
+    return successResponse(resp)
   }))
 
   app.post('/tracks/:id/listen', handleResponse(async (req, res) => {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Extend listen tracking in redis to a week of data and provide health check cutoffs configurable by request arguments to identity. Eliminates dependence on sauron as well for automated health checks

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->