### PR TITLE
Fix wormhole rpc hosts

### DIFF
--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -419,7 +419,7 @@ class AudiusLibs {
         this.ethContracts,
         this.identityService,
         this.solanaWeb3Manager,
-        this.wormholeConfig.rpcHost,
+        this.wormholeConfig.rpcHosts,
         this.wormholeConfig.solBridgeAddress,
         this.wormholeConfig.solTokenBridgeAddress,
         this.wormholeConfig.ethBridgeAddress,


### PR DESCRIPTION
### Description
Fix the wormhole rpc config - broke when changing the env name from `rpcHost` to `rpcHosts` in #2151 

### Tests

### How will this change be monitored?
