### PR TITLE
Bump worker connections to 4096

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes 1;
 
 events {
-    worker_connections 1024;
+    worker_connections 4096;
 }
 
 http {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Noticed this error log in proxy:
```
2022/02/02 22:17:15 [alert] 19#19: *2258131 1024 worker_connections are not enough while connecting to upstream,
```

PR is to bump to `4096`.  This is also done in Discovery Node. Reference: https://github.com/AudiusProject/audius-protocol/blob/ca3867b0ffbd415a7261f47f1a54b79a2a18ae10/discovery-provider/nginx_conf/nginx.conf#L19

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->