### PR TITLE
[AUD-1178] Remove old /unlisted endpoint on content node

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -714,36 +714,4 @@ module.exports = function (app) {
     },
     getCID
   )
-
-  /**
-   * List all unlisted tracks for a user
-   */
-  app.get(
-    '/tracks/unlisted',
-    authMiddleware,
-    handleResponse(async (req, res) => {
-      const tracks = (
-        await models.sequelize.query(
-          `select "metadataJSON"->'title' as "title", "blockchainId" from (
-        select "metadataJSON", "blockchainId", row_number() over (
-          partition by "blockchainId" order by "clock" desc
-        ) from "Tracks"
-        where "cnodeUserUUID" = :cnodeUserUUID
-        and ("metadataJSON"->>'is_unlisted')::boolean = true
-      ) as a
-      where a.row_number = 1;`,
-          {
-            replacements: { cnodeUserUUID: req.session.cnodeUserUUID }
-          }
-        )
-      )[0]
-
-      return successResponse({
-        tracks: tracks.map((track) => ({
-          title: track.title,
-          id: track.blockchainId
-        }))
-      })
-    })
-  )
 }


### PR DESCRIPTION
### Description
No longer using the /tracks/unlisted endpoint from the client so removing it here for cleanup.

### Tests
Ran client on my dev machine. Artist dashboard page working fine

### How will this change be monitored?
