### PR TITLE
Support Multiple Fee Payers

### DIFF
--- a/identity-service/default-config.json
+++ b/identity-service/default-config.json
@@ -67,7 +67,7 @@
   "scoreSecret": "score_secret",
   "recaptchaServiceKey": "",
   "hCaptchaSecret": "",
-  "solanaFeePayerWallet": "[]",
+  "solanaFeePayerWallets": "[]",
   "sentryDSN": "",
   "solanaEndpoint": "https://api.mainnet-beta.solana.com"
 }

--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -20,10 +20,11 @@ class AudiusLibsWrapper {
       ? new Set(config.get('discoveryProviderWhitelist').split(','))
       : null
 
-    let feePayerSecretKey = config.get('solanaFeePayerWallet')
-    if (feePayerSecretKey) {
-      feePayerSecretKey = Uint8Array.from(feePayerSecretKey)
-    }
+    const feePayerSecretKeys = config.get('solanaFeePayerWallets')
+      ? config.get('solanaFeePayerWallets')
+        .map(item => item.privateKey)
+        .map(key => Uint8Array.from(key))
+      : null
 
     const solanaWeb3Config = AudiusLibs.configSolanaWeb3({
       solanaClusterEndpoint: config.get('solanaEndpoint'),
@@ -35,7 +36,7 @@ class AudiusLibsWrapper {
       rewardsManagerTokenPDA: config.get('solanaRewardsManagerTokenPDA'),
       // Never use the relay path in identity
       useRelay: false,
-      feePayerSecretKey,
+      feePayerSecretKeys,
       confirmationTimeout: config.get('solanaConfirmationTimeout')
     })
 

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -606,12 +606,6 @@ const config = convict({
     default: '',
     env: 'solanaValidSigner'
   },
-  solanaFeePayerWallet: {
-    doc: 'solanaFeePayerWallet',
-    format: 'string-array',
-    default: null,
-    env: 'solanaFeePayerWallet'
-  },
   solanaFeePayerWallets: {
     doc: 'solanaFeePayerWallets - Stringified array like[{ privateKey: [] },...]',
     format: 'string-array',
@@ -800,7 +794,7 @@ if (fs.existsSync('solana-program-config.json')) {
     solanaTrackListenCountAddress: solanaContractConfig.trackListenCountAddress,
     solanaAudiusEthRegistryAddress: solanaContractConfig.audiusEthRegistryAddress,
     solanaValidSigner: solanaContractConfig.validSigner,
-    solanaFeePayerWallet: solanaContractConfig.feePayerWallet,
+    solanaFeePayerWallets: solanaContractConfig.feePayerWallets,
     solanaEndpoint: solanaContractConfig.endpoint,
     solanaSignerPrivateKey: solanaContractConfig.signerPrivateKey,
 

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -293,7 +293,6 @@ module.exports = function (app) {
         if (balance < minimumBalance) {
           belowMinimumBalances.push({ wallet: feePayerBase58, balance })
         }
-        // todo: should it be base58 or the pubkey here? e.g. solanaFeePayerBalances[feePayerPubKey] = balance
         solanaFeePayerBalances[feePayerBase58] = balance
         return { wallet: feePayerBase58, balance }
       }))

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -293,8 +293,8 @@ module.exports = function (app) {
         if (balance < minimumBalance) {
           belowMinimumBalances.push({ wallet: feePayerBase58, balance })
         }
-        // todo: should it be base58 or the pubkey here? e.g. solanaFeePayerBalances[feePayerBase58] = balance
-        solanaFeePayerBalances[feePayerPubKey] = balance
+        // todo: should it be base58 or the pubkey here? e.g. solanaFeePayerBalances[feePayerPubKey] = balance
+        solanaFeePayerBalances[feePayerBase58] = balance
         return { wallet: feePayerBase58, balance }
       }))
     }

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -139,7 +139,7 @@ solanaRouter.get('/random_fee_payer', handleResponse(async () => {
   if (!feePayerAccount) {
     return errorResponseServerError('There is no fee payer.')
   }
-  return successResponse({ feePayer: feePayerAccount.publicKey })
+  return successResponse({ feePayer: feePayerAccount.publicKey.toString() })
 }))
 
 module.exports = function (app) {

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -137,14 +137,11 @@ solanaRouter.post('/relay/raw', handleResponse(async (req, res, next) => {
 }))
 
 solanaRouter.get('/random_fee_payer', handleResponse(async () => {
-  const solanaFeePayerWallets = config.get('solanaFeePayerWallets')
-  if (!solanaFeePayerWallets || !solanaFeePayerWallets.length) {
-    return errorResponseServerError('There is no list of fee payers to choose from.')
+  const feePayerAccount = getFeePayerKeypair(false)
+  if (!feePayerAccount) {
+    return errorResponseServerError('There is no fee payer.')
   }
-
-  const randomFeePayerIndex = Math.floor(Math.random() * solanaFeePayerWallets.length)
-  const randomFeePayer = solanaWeb3.Keypair.fromSecretKey(Uint8Array.from(solanaFeePayerWallets[randomFeePayerIndex].privateKey))
-  return successResponse({ feePayer: randomFeePayer.publicKey })
+  return successResponse({ feePayer: feePayerAccount.publicKey })
 }))
 
 module.exports = function (app) {

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -1,7 +1,5 @@
 const express = require('express')
 const crypto = require('crypto')
-const solanaWeb3 = require('@solana/web3.js')
-const config = require('../config.js')
 
 const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const { getFeePayerKeypair } = require('../solana-client')

--- a/identity-service/src/routes/wormhole.js
+++ b/identity-service/src/routes/wormhole.js
@@ -1,7 +1,7 @@
 const { sendResponse, successResponse, errorResponseBadRequest, errorResponseServerError } = require('../apiHelpers')
 const ethTxRelay = require('../relay/ethTxRelay')
 const crypto = require('crypto')
-const { getFeePayer } = require('../solana-client')
+const { getFeePayerKeypair } = require('../solana-client')
 
 const { NodeHttpTransport } = require('@improbable-eng/grpc-web-node-http-transport')
 
@@ -50,7 +50,7 @@ const relayWormhole = async (
     const transferTxHash = transferTokensTxResponse.txHash
     context.transferTxHash = transferTxHash
     logs.push(`Attempting Transfer Tokens for sender: ${transferTxHash}`)
-    const feePayerAccount = getFeePayer()
+    const feePayerAccount = getFeePayerKeypair()
 
     const signTransaction = async (transaction) => {
       transaction.partialSign(feePayerAccount)

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -91,26 +91,30 @@ const instructionSchema = new Map([
   ]
 ])
 
-let feePayer
-
-const feePayers = config.get('solanaFeePayerWallets')
+let feePayerKeypair = null
+let feePayerKeypairs = null
 
 // Optionally returns the existing singleFeePayer
 // Ensures other usages of this function do not break as we upgrade to multiple
-function getFeePayer (singleFeePayer = true) {
-  if (!feePayer) {
-    feePayer = config.get('solanaFeePayerWallet') ? solanaWeb3.Keypair.fromSecretKey(Uint8Array.from(config.get('solanaFeePayerWallet'))) : null
+function getFeePayerKeypair (singleFeePayer = true) {
+  if (!feePayerKeypairs) {
+    feePayerKeypairs = config.get('solanaFeePayerWallets')
+      ? config.get('solanaFeePayerWallets')
+        .map(item => item.privateKey)
+        .map(key => solanaWeb3.Keypair.fromSecretKey(Uint8Array.from(key)))
+      : null
+  }
+  if (!feePayerKeypair) {
+    feePayerKeypair = (feePayerKeypairs && feePayerKeypairs[0]) || null
   }
   // Ensure legacy usage of single feePayer is not broken
   // If multiple feepayers are not provided, default to single value as well
-  if (singleFeePayer || feePayers === null || feePayers.length === 0) {
-    return feePayer
+  if (singleFeePayer || feePayerKeypairs === null || feePayerKeypairs.length === 0) {
+    return feePayerKeypair
   }
 
-  const randomFeePayerIndex = Math.floor(Math.random() * feePayers.length)
-  const randomFeePayer = solanaWeb3.Keypair.fromSecretKey(Uint8Array.from(feePayers[randomFeePayerIndex].privateKey))
-
-  return randomFeePayer
+  const randomFeePayerIndex = Math.floor(Math.random() * feePayerKeypairs.length)
+  return feePayerKeypairs[randomFeePayerIndex]
 }
 
 async function createAndVerifyMessage (
@@ -186,7 +190,7 @@ async function createAndVerifyMessage (
     data: serializedInstructionArgs
   })
 
-  let feePayerAccount = getFeePayer(false)
+  let feePayerAccount = getFeePayerKeypair(false)
 
   let signature = await solanaWeb3.sendAndConfirmTransaction(
     connection,
@@ -203,4 +207,4 @@ async function createAndVerifyMessage (
 }
 
 exports.createAndVerifyMessage = createAndVerifyMessage
-exports.getFeePayer = getFeePayer
+exports.getFeePayerKeypair = getFeePayerKeypair

--- a/identity-service/test/configTest.js
+++ b/identity-service/test/configTest.js
@@ -70,7 +70,7 @@ describe('convict configuration test', function () {
 
     for (var key in schema) {
       // special case this property since config.load will override the test value in the env var because of custom type coercion
-      if (key === 'relayerWallets' || key === 'ethRelayerWallets' || key === 'solanaFeePayerWallet' || key === 'solanaFeePayerWallets') {
+      if (key === 'relayerWallets' || key === 'ethRelayerWallets' || key === 'solanaFeePayerWallets') {
         assert.deepStrictEqual(Array.isArray(config.get(key)), true)
         continue
       }

--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -104,6 +104,7 @@ class Account extends Base {
    * @param {?boolean} [createWAudioUserBank] an optional flag to create the solana user bank account
    * @param {?Function} [handleUserBankOutcomes] an optional callback to record user bank outcomes
    * @param {?Object} [userBankOutcomes] an optional object with request, succes, and failure keys to record user bank outcomes
+   * @param {?string} [feePayerOverride] an optional string in case the client wants to switch between fee payers
   */
   async signUp (
     email,
@@ -115,7 +116,8 @@ class Account extends Base {
     host = (typeof window !== 'undefined' && window.location.origin) || null,
     createWAudioUserBank = false,
     handleUserBankOutcomes = () => {},
-    userBankOutcomes = {}
+    userBankOutcomes = {},
+    feePayerOverride = null
   ) {
     const phases = {
       ADD_REPLICA_SET: 'ADD_REPLICA_SET',
@@ -155,7 +157,7 @@ class Account extends Base {
         (async () => {
           try {
             handleUserBankOutcomes(userBankOutcomes.Request)
-            const { error, errorCode } = await this.solanaWeb3Manager.createUserBank()
+            const { error, errorCode } = await this.solanaWeb3Manager.createUserBank(feePayerOverride)
             if (error || errorCode) {
               console.error(
                 `Failed to create userbank, with err: ${error}, ${errorCode}`

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -81,6 +81,7 @@ class Rewards extends Base {
    *   instructionsPerTransaction?: number,
    *   maxAggregationAttempts?: number
    *   logger: any
+   *   feePayerOverride: string | null
    * }} {
    *   challengeId,
    *   encodedUserId,
@@ -94,13 +95,14 @@ class Rewards extends Base {
    *   endpoints,
    *   maxAggregationAttempts,
    *   instructionsPerTransaction,
-   *   logger
-   *   }
+   *   logger,
+   *   feePayerOverride
+   * }
    * @returns {Promise<GetSubmitAndEvaluateAttestationsReturn>}
    * @memberof Challenge
    */
   async submitAndEvaluate ({
-    challengeId, encodedUserId, handle, recipientEthAddress, specifier, oracleEthAddress, amount, quorumSize, AAOEndpoint, instructionsPerTransaction, maxAggregationAttempts = 20, endpoints = null, logger = console
+    challengeId, encodedUserId, handle, recipientEthAddress, specifier, oracleEthAddress, amount, quorumSize, AAOEndpoint, instructionsPerTransaction, maxAggregationAttempts = 20, endpoints = null, logger = console, feePayerOverride = null
   }) {
     let phase
     try {
@@ -135,7 +137,8 @@ class Rewards extends Base {
         recipientEthAddress,
         tokenAmount: fullTokenAmount,
         instructionsPerTransaction,
-        logger
+        logger,
+        feePayerOverride
       })
 
       // In the case of an unparseable error,
@@ -161,7 +164,8 @@ class Rewards extends Base {
             recipientEthAddress,
             tokenAmount: fullTokenAmount,
             instructionsPerTransaction: 2, // SECP + Attestation
-            logger
+            logger,
+            feePayerOverride
           })
         } else {
           throw new Error(submitErrorCode || submitError)
@@ -178,7 +182,8 @@ class Rewards extends Base {
         recipientEthAddress,
         oracleEthAddress,
         tokenAmount: fullTokenAmount,
-        logger
+        logger,
+        feePayerOverride
       })
 
       if (evaluateErrorCode || evaluateError) {

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -240,7 +240,7 @@ class AudiusLibs {
    * @param {string} rewardsManagerProgramPDA Rewards Manager PDA
    * @param {string} rewardsManagerTokenPDA The PDA of the rewards manager funds holder account
    * @param {boolean} useRelay Whether to use identity as a relay or submit transactions locally
-   * @param {Uint8Array} [feePayerSecretKey] optional fee payer secret key, if not using relay
+   * @param {Uint8Array} feePayerSecretKeys fee payer secret keys, if client wants to switch between different fee payers during relay
    * @param {number} confirmationTimeout solana web3 connection confirmationTimeout in ms
    */
   static configSolanaWeb3 ({
@@ -254,7 +254,7 @@ class AudiusLibs {
     rewardsManagerProgramPDA,
     rewardsManagerTokenPDA,
     useRelay,
-    feePayerSecretKey = null,
+    feePayerSecretKeys,
     confirmationTimeout
   }) {
     return {
@@ -268,7 +268,7 @@ class AudiusLibs {
       rewardsManagerProgramPDA,
       rewardsManagerTokenPDA,
       useRelay,
-      feePayerKeypair: feePayerSecretKey ? Keypair.fromSecretKey(feePayerSecretKey) : null,
+      feePayerKeypairs: feePayerSecretKeys ? feePayerSecretKeys.map(key => Keypair.fromSecretKey(key)) : null,
       confirmationTimeout
     }
   }

--- a/libs/src/services/identity/index.js
+++ b/libs/src/services/identity/index.js
@@ -318,6 +318,16 @@ class IdentityService {
     })
   }
 
+  async getRandomFeePayer () {
+    return this._makeRequest({
+      url: '/solana/random_fee_payer',
+      method: 'get',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+  }
+
   // Relays tx data through the solana relay endpoint
   // type TransactionData = {
   //   recentBlockhash: string

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -464,6 +464,10 @@ class SolanaWeb3Manager {
   async getSlot () {
     return this.connection.getSlot('processed')
   }
+
+  async getRandomFeePayer () {
+    return this.identityService.getRandomFeePayer()
+  }
 }
 
 module.exports = SolanaWeb3Manager

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -59,11 +59,11 @@ class SolanaWeb3Manager {
    *  the manager account of the rewards manager program
    * @param {string} solanaWeb3Config.rewardsManagerTokenPDA
    *  the token holder account of the rewards manager program
-   * @param {boolean} solanaWeb3Config.shouldUseRelay
+   * @param {boolean} solanaWeb3Config.useRelay
    *  whether to submit transactions via a relay, or locally
-   * @param {KeyPair} solanaWeb3Config.feePayerKepair
+   * @param {KeyPair} solanaWeb3Config.feePayerKepairs
+   *  KeyPairs for feepayers
    * @param {number} [solanaWeb3Config.confirmationTimeout] optional default confirmation timeout
-   *  KeyPair for feepayer
    * @param {IdentityService} identityService
    * @param {Web3Manager} web3Manager
    */
@@ -92,12 +92,9 @@ class SolanaWeb3Manager {
       rewardsManagerProgramPDA,
       rewardsManagerTokenPDA,
       useRelay,
-      feePayerKeypair,
+      feePayerKeypairs,
       confirmationTimeout
     } = this.solanaWeb3Config
-
-    // Helper to safely create pubkey from nullable val
-    const newPublicKeyNullable = (val) => val ? new PublicKey(val) : null
 
     this.solanaClusterEndpoint = solanaClusterEndpoint
     this.connection = new solanaWeb3.Connection(this.solanaClusterEndpoint, {
@@ -108,32 +105,37 @@ class SolanaWeb3Manager {
       connection: this.connection,
       useRelay,
       identityService: this.identityService,
-      feePayerKeypair
+      feePayerKeypairs
     })
 
     this.mintAddress = mintAddress
-    this.mintKey = newPublicKeyNullable(mintAddress)
+    this.mintKey = SolanaUtils.newPublicKeyNullable(mintAddress)
 
     this.solanaTokenAddress = solanaTokenAddress
-    this.solanaTokenKey = newPublicKeyNullable(solanaTokenAddress)
+    this.solanaTokenKey = SolanaUtils.newPublicKeyNullable(solanaTokenAddress)
 
-    this.feePayerAddress = feePayerAddress || feePayerKeypair.publicKey
-    this.feePayerKey = newPublicKeyNullable(feePayerAddress || feePayerKeypair.publicKey)
+    if (feePayerAddress) {
+      this.feePayerAddress = feePayerAddress
+      this.feePayerKey = SolanaUtils.newPublicKeyNullable(feePayerAddress)
+    } else if (feePayerKeypairs && feePayerKeypairs.length) {
+      this.feePayerAddress = feePayerKeypairs[0].publicKey
+      this.feePayerKey = SolanaUtils.newPublicKeyNullable(feePayerKeypairs[0].publicKey)
+    }
 
-    this.claimableTokenProgramKey = newPublicKeyNullable(claimableTokenProgramAddress)
+    this.claimableTokenProgramKey = SolanaUtils.newPublicKeyNullable(claimableTokenProgramAddress)
     this.claimableTokenPDA = claimableTokenPDA || (
       this.claimableTokenProgramKey ? ((await SolanaUtils.findProgramAddressFromPubkey(this.claimableTokenProgramKey, this.mintKey))[0].toString()) : null
     )
-    this.claimableTokenPDAKey = newPublicKeyNullable(this.claimableTokenPDA)
-    this.rewardManagerProgramId = newPublicKeyNullable(rewardsManagerProgramId)
-    this.rewardManagerProgramPDA = newPublicKeyNullable(rewardsManagerProgramPDA)
-    this.rewardManagerTokenPDA = newPublicKeyNullable(rewardsManagerTokenPDA)
+    this.claimableTokenPDAKey = SolanaUtils.newPublicKeyNullable(this.claimableTokenPDA)
+    this.rewardManagerProgramId = SolanaUtils.newPublicKeyNullable(rewardsManagerProgramId)
+    this.rewardManagerProgramPDA = SolanaUtils.newPublicKeyNullable(rewardsManagerProgramPDA)
+    this.rewardManagerTokenPDA = SolanaUtils.newPublicKeyNullable(rewardsManagerTokenPDA)
   }
 
   /**
    * Creates a solana bank account from the web3 provider's eth address
    */
-  async createUserBank () {
+  async createUserBank (feePayerOverride) {
     if (!this.web3Manager) {
       throw new Error('A web3Manager is required for this solanaWeb3Manager method')
     }
@@ -142,7 +144,7 @@ class SolanaWeb3Manager {
     return createUserBankFrom({
       ethAddress,
       claimableTokenPDAKey: this.claimableTokenPDAKey,
-      feePayerKey: this.feePayerKey,
+      feePayerKey: SolanaUtils.newPublicKeyNullable(feePayerOverride) || this.feePayerKey,
       mintKey: this.mintKey,
       solanaTokenProgramKey: this.solanaTokenKey,
       claimableTokenProgramKey: this.claimableTokenProgramKey,
@@ -336,7 +338,8 @@ class SolanaWeb3Manager {
     recipientEthAddress,
     tokenAmount,
     instructionsPerTransaction,
-    logger = console
+    logger = console,
+    feePayerOverride = null
   }) {
     return submitAttestations({
       rewardManagerProgramId: this.rewardManagerProgramId,
@@ -345,7 +348,7 @@ class SolanaWeb3Manager {
       oracleAttestation,
       challengeId,
       specifier,
-      feePayer: this.feePayerKey,
+      feePayer: SolanaUtils.newPublicKeyNullable(feePayerOverride) || this.feePayerKey,
       recipientEthAddress,
       tokenAmount,
       transactionHandler: this.transactionHandler,
@@ -379,7 +382,8 @@ class SolanaWeb3Manager {
     recipientEthAddress,
     oracleEthAddress,
     tokenAmount,
-    logger = console
+    logger = console,
+    feePayerOverride = null
   }) {
     return evaluateAttestations({
       rewardManagerProgramId: this.rewardManagerProgramId,
@@ -390,7 +394,7 @@ class SolanaWeb3Manager {
       recipientEthAddress,
       userBankProgramAccount: this.claimableTokenPDAKey,
       oracleEthAddress,
-      feePayer: this.feePayerKey,
+      feePayer: SolanaUtils.newPublicKeyNullable(feePayerOverride) || this.feePayerKey,
       tokenAmount,
       transactionHandler: this.transactionHandler,
       logger

--- a/libs/src/services/solanaWeb3Manager/index.js
+++ b/libs/src/services/solanaWeb3Manager/index.js
@@ -318,6 +318,7 @@ class SolanaWeb3Manager {
    *     tokenAmount: BN,
    *     instructionsPerTransaction?: number,
    *     logger: any
+   *     feePayerOverride: string | null
    * }} {
    *     attestations,
    *     oracleAttestation,
@@ -327,6 +328,7 @@ class SolanaWeb3Manager {
    *     tokenAmount,
    *     instructionsPerTransaction,
    *     logger
+   *     feePayerOverride
    *    }
    * @memberof SolanaWeb3Manager
    */
@@ -366,6 +368,7 @@ class SolanaWeb3Manager {
    *    recipientEthAddress: string
    *    oracleEthAddress: string
    *    logger: any
+   *    feePayerOverride: string | null
    * }} {
    *     challengeId,
    *     specifier,
@@ -373,6 +376,7 @@ class SolanaWeb3Manager {
    *     oracleEthAddress,
    *     tokenAmount,
    *     logger
+   *     feePayerOverride
    *   }
    * @memberof SolanaWeb3Manager
    */

--- a/libs/src/services/solanaWeb3Manager/rewards.js
+++ b/libs/src/services/solanaWeb3Manager/rewards.js
@@ -258,7 +258,13 @@ async function submitAttestations ({
     return acc
   }, [[]])
 
-  const results = await Promise.all(bucketedInstructions.map(i => transactionHandler.handleTransaction({ instructions: i, errorMapping: RewardsManagerError, logger, skipPreflight: false })))
+  const results = await Promise.all(bucketedInstructions.map(i => transactionHandler.handleTransaction({
+    instructions: i,
+    errorMapping: RewardsManagerError,
+    logger,
+    skipPreflight: false,
+    feePayerOverride: feePayer
+  })))
   logger.info(`submitAttestations: submitted attestations with results: ${JSON.stringify(results)}`)
 
   // If there's any error in any of the transactions, just return that one
@@ -505,7 +511,13 @@ const evaluateAttestations = async ({
     data: serializedInstructionEnum
   })
 
-  return transactionHandler.handleTransaction({ instructions: [transferInstruction], errorMapping: RewardsManagerError, logger, skipPreflight: false })
+  return transactionHandler.handleTransaction({
+    instructions: [transferInstruction],
+    errorMapping: RewardsManagerError,
+    logger,
+    skipPreflight: false,
+    feePayerOverride: feePayer
+  })
 }
 
 // Helpers

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -456,6 +456,14 @@ class RewardsAttester {
     completedBlocknumber
   }) {
     this.logger.info(`Attempting to attest for userId [${decodeHashId(userId)}], challengeId: [${challengeId}], quorum size: [${this.quorumSize}]}`)
+
+    let feePayerOverride = null
+    const feePayerKeypairs = this.libs.solanaWeb3Manager.solanaWeb3Config.feePayerKeypairs
+    if (feePayerKeypairs && feePayerKeypairs.length) {
+      const randomFeePayerIndex = Math.floor(Math.random() * feePayerKeypairs.length)
+      feePayerOverride = feePayerKeypairs[randomFeePayerIndex].publicKey
+    }
+
     const { success, error, phase } = await this.libs.Rewards.submitAndEvaluate({
       challengeId,
       encodedUserId: userId,
@@ -467,7 +475,8 @@ class RewardsAttester {
       quorumSize: this.quorumSize,
       AAOEndpoint: this.aaoEndpoint,
       endpoints: this.endpoints,
-      logger: this.logger
+      logger: this.logger,
+      feePayerOverride
     })
 
     if (success) {

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -330,6 +330,20 @@ class RewardsAttester {
   }
 
   /**
+   * Returns a random fee payer from among the list of existing fee payers.
+   *
+   * @memberof RewardsAttester
+   */
+  async _getRandomFeePayer () {
+    const feePayerKeypairs = this.libs.solanaWeb3Manager.solanaWeb3Config.feePayerKeypairs
+    if (feePayerKeypairs && feePayerKeypairs.length) {
+      const randomFeePayerIndex = Math.floor(Math.random() * feePayerKeypairs.length)
+      return feePayerKeypairs[randomFeePayerIndex].publicKey
+    }
+    return null
+  }
+
+  /**
    * Escape hatch for manually setting starting block.
    *
    * @memberof RewardsAttester
@@ -457,13 +471,6 @@ class RewardsAttester {
   }) {
     this.logger.info(`Attempting to attest for userId [${decodeHashId(userId)}], challengeId: [${challengeId}], quorum size: [${this.quorumSize}]}`)
 
-    let feePayerOverride = null
-    const feePayerKeypairs = this.libs.solanaWeb3Manager.solanaWeb3Config.feePayerKeypairs
-    if (feePayerKeypairs && feePayerKeypairs.length) {
-      const randomFeePayerIndex = Math.floor(Math.random() * feePayerKeypairs.length)
-      feePayerOverride = feePayerKeypairs[randomFeePayerIndex].publicKey
-    }
-
     const { success, error, phase } = await this.libs.Rewards.submitAndEvaluate({
       challengeId,
       encodedUserId: userId,
@@ -476,7 +483,7 @@ class RewardsAttester {
       AAOEndpoint: this.aaoEndpoint,
       endpoints: this.endpoints,
       logger: this.logger,
-      feePayerOverride
+      feePayerOverride: this._getRandomFeePayer()
     })
 
     if (success) {

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -46,6 +46,7 @@ class TransactionHandler {
    * @property {string} [recentBlockhash=null] optional recent blockhash to prefer over fetching
    * @property {boolean} [skipPreflight=null] optional per transaction override to skipPreflight
    * @property {any} [logger=console] optional logger
+   * @property {any} [feePayerOverride=null] optional fee payer override
    *
    * @param {Array<TransactionInstruction>} instructions an array of `TransactionInstructions`
    * @param {*} [errorMapping=null] an optional error mapping. Should expose a `fromErrorCode` method.

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -16,22 +16,22 @@ class TransactionHandler {
    *  connection: Connection,
    *  useRelay: boolean,
    *  identityService: Object,
-   *  feePayerKeypair: KeyPair
+   *  feePayerKeypairs: KeyPair[]
    *  skipPreflight: boolean
    * }} {
    *  connection,
    *  useRelay,
    *  identityService = null,
-   *  feePayerKeypair = null,
+   *  feePayerKeypairs = null,
    *  skipPreflight = true
    * }
    * @memberof TransactionHandler
    */
-  constructor ({ connection, useRelay, identityService = null, feePayerKeypair = null, skipPreflight = true }) {
+  constructor ({ connection, useRelay, identityService = null, feePayerKeypairs = null, skipPreflight = true }) {
     this.connection = connection
     this.useRelay = useRelay
     this.identityService = identityService
-    this.feePayerKeypair = feePayerKeypair
+    this.feePayerKeypairs = feePayerKeypairs
     this.skipPreflight = skipPreflight
   }
 
@@ -52,12 +52,12 @@ class TransactionHandler {
    * @returns {Promise<HandleTransactionReturn>}
    * @memberof TransactionHandler
    */
-  async handleTransaction ({ instructions, errorMapping = null, recentBlockhash = null, logger = console, skipPreflight = null }) {
+  async handleTransaction ({ instructions, errorMapping = null, recentBlockhash = null, logger = console, skipPreflight = null, feePayerOverride = null }) {
     let result = null
     if (this.useRelay) {
-      result = await this._relayTransaction(instructions, recentBlockhash, skipPreflight)
+      result = await this._relayTransaction(instructions, recentBlockhash, skipPreflight, feePayerOverride)
     } else {
-      result = await this._locallyConfirmTransaction(instructions, recentBlockhash, logger, skipPreflight)
+      result = await this._locallyConfirmTransaction(instructions, recentBlockhash, logger, skipPreflight, feePayerOverride)
     }
     if (result.error && result.errorCode !== null && errorMapping) {
       result.errorCode = errorMapping.fromErrorCode(result.errorCode)
@@ -65,14 +65,15 @@ class TransactionHandler {
     return result
   }
 
-  async _relayTransaction (instructions, recentBlockhash, skipPreflight) {
+  async _relayTransaction (instructions, recentBlockhash, skipPreflight, feePayerOverride = null) {
     const relayable = instructions.map(SolanaUtils.prepareInstructionForRelay)
     recentBlockhash = recentBlockhash || (await this.connection.getRecentBlockhash('confirmed')).blockhash
 
     const transactionData = {
       recentBlockhash,
       instructions: relayable,
-      skipPreflight: skipPreflight === null ? this.skipPreflight : skipPreflight
+      skipPreflight: skipPreflight === null ? this.skipPreflight : skipPreflight,
+      feePayerOverride
     }
 
     try {
@@ -85,8 +86,12 @@ class TransactionHandler {
     }
   }
 
-  async _locallyConfirmTransaction (instructions, recentBlockhash, logger, skipPreflight) {
-    if (!this.feePayerKeypair) {
+  async _locallyConfirmTransaction (instructions, recentBlockhash, logger, skipPreflight, feePayerOverride = null) {
+    const feePayerKeypairOverride = (feePayerOverride && this.feePayerKeypairs)
+      ? this.feePayerKeypairs.find(keypair => keypair.publicKey.toString() === feePayerOverride)
+      : null
+    const feePayerAccount = feePayerKeypairOverride || (this.feePayerKeypairs && this.feePayerKeypairs[0])
+    if (!feePayerAccount) {
       console.error('Local feepayer keys missing for direct confirmation!')
       return {
         res: null,
@@ -100,13 +105,13 @@ class TransactionHandler {
 
     instructions.forEach(i => tx.add(i))
 
-    tx.sign(this.feePayerKeypair)
+    tx.sign(feePayerAccount)
 
     try {
       const transactionSignature = await sendAndConfirmTransaction(
         this.connection,
         tx,
-        [this.feePayerKeypair],
+        [feePayerAccount],
         {
           skipPreflight: skipPreflight === null ? this.skipPreflight : skipPreflight,
           commitment: 'processed',

--- a/libs/src/services/solanaWeb3Manager/userBank.js
+++ b/libs/src/services/solanaWeb3Manager/userBank.js
@@ -151,7 +151,7 @@ const createUserBankFrom = async ({
     data: Buffer.from(serializedInstructionEnum)
   })]
 
-  return transactionHandler.handleTransaction({ instructions, recentBlockhash })
+  return transactionHandler.handleTransaction({ instructions, recentBlockhash, feePayerOverride: feePayerKey })
 }
 
 module.exports = {

--- a/libs/src/services/solanaWeb3Manager/utils.js
+++ b/libs/src/services/solanaWeb3Manager/utils.js
@@ -152,6 +152,11 @@ class SolanaUtils {
     // result in truncated arrays, while eth spec is always 20 bytes
     return Uint8Array.of(...new BN(strippedEthAddress, 'hex').toArray('be', 20))
   }
+
+  // Safely create pubkey from nullable val
+  static newPublicKeyNullable (val) {
+    return val ? new PublicKey(val) : null
+  }
 }
 
 /**

--- a/service-commands/scripts/createSolanaUserBanks.js
+++ b/service-commands/scripts/createSolanaUserBanks.js
@@ -142,9 +142,9 @@ async function setupConfig(config) {
           )[0].toString()
         : null)
   )
+  const feePayerKeys = (solanaConfig.SOLANA_FEE_PAYER_SECRET_KEYS || []).map(key => Keypair.fromSecretKey(key).publicKey)
   const feePayerKey = newPublicKeyNullable(
-    solanaConfig.SOLANA_FEE_PAYER_ADDRESS ||
-      Keypair.fromSecretKey(solanaConfig.SOLANA_FEE_PAYER_SECRET_KEY).publicKey
+    feePayerKeys && feePayerKeys.length ? newPublicKeyNullable(feePayerKeys[0]) : null
   )
   const solanaTokenProgramKey = newPublicKeyNullable(
     solanaConfig.SOLANA_TOKEN_ADDRESS
@@ -191,8 +191,7 @@ function getConfigForEnv(env) {
       SOLANA_REWARDS_MANAGER_PROGRAM_ID: solanaConfig.rewardsManagerAddress,
       SOLANA_REWARDS_MANAGER_PROGRAM_PDA: solanaConfig.rewardsManagerAccount,
       SOLANA_REWARDS_MANAGER_TOKEN_PDA: solanaConfig.rewardsManagerTokenAccount,
-      SOLANA_FEE_PAYER_ADDRESS: solanaConfig.feePayerWallet.ethAddress,
-      SOLANA_FEE_PAYER_SECRET_KEY: Uint8Array.from(solanaConfig.feePayerWallet)
+      SOLANA_FEE_PAYER_SECRET_KEYS: solanaConfig.feePayerWallets ? solanaConfig.feePayerWallets.map(wallet => Uint8Array.from(wallet.privateKey)) : undefined
     },
     identityServiceConfig: { url: config.get('identity_service') },
     discoveryProviderConfig: {

--- a/service-commands/scripts/rewardManagerLocal.js
+++ b/service-commands/scripts/rewardManagerLocal.js
@@ -83,7 +83,11 @@ const createSenderLocal = async ethAddress => {
   const protocolDir = getEnv('PROTOCOL_DIR')
   const solanaConfig = require(`${protocolDir}/solana-programs/solana-program-config.json`)
   const ownerWalletBytes = solanaConfig.ownerWallet
-  const feepayerWalletBytes = solanaConfig.feePayerWallet
+  const feepayerWalletBytes = (solanaConfig.feePayerWallets && solanaConfig.feePayerWallets.length) ? solanaConfig.feePayerWallets[0].privateKey : null
+  if (!feepayerWalletBytes) {
+    return
+  }
+
   const connection = new solanaWeb3.Connection('http://localhost:8899')
 
   // Log in as current owner wallet

--- a/service-commands/src/utils/constants.js
+++ b/service-commands/src/utils/constants.js
@@ -46,7 +46,7 @@ const config = {
     SOLANA_REWARDS_MANAGER_PROGRAM_ID: solanaConfig.rewardsManagerAddress,
     SOLANA_REWARDS_MANAGER_PROGRAM_PDA: solanaConfig.rewardsManagerAccount,
     SOLANA_REWARDS_MANAGER_TOKEN_PDA: solanaConfig.rewardsManagerTokenAccount,
-    SOLANA_FEE_PAYER_SECRET_KEY: solanaConfig.feePayerWallet ? Uint8Array.from(solanaConfig.feePayerWallet) : undefined 
+    SOLANA_FEE_PAYER_SECRET_KEYS: solanaConfig.feePayerWallets ? solanaConfig.feePayerWallets.map(wallet => Uint8Array.from(wallet.privateKey)) : undefined
 }
 
 module.exports = config

--- a/service-commands/src/utils/seed.js
+++ b/service-commands/src/utils/seed.js
@@ -20,7 +20,7 @@ const {
   SOLANA_REWARDS_MANAGER_PROGRAM_ID,
   SOLANA_REWARDS_MANAGER_PROGRAM_PDA,
   SOLANA_REWARDS_MANAGER_TOKEN_PDA,
-  SOLANA_FEE_PAYER_SECRET_KEY,
+  SOLANA_FEE_PAYER_SECRET_KEYS,
 } = require('./constants')
 
 const {
@@ -63,7 +63,7 @@ const getLibsConfig = overrideConfig => {
       rewardsManagerProgramPDA: SOLANA_REWARDS_MANAGER_PROGRAM_PDA,
       rewardsManagerTokenPDA: SOLANA_REWARDS_MANAGER_TOKEN_PDA,
       useRelay: false,
-      feePayerSecretKey: SOLANA_FEE_PAYER_SECRET_KEY,
+      feePayerSecretKeys: SOLANA_FEE_PAYER_SECRET_KEYS
     }),
     isServer: true,
     enableUserReplicaSetManagerContract: true,

--- a/solana-programs/.gitignore
+++ b/solana-programs/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 .python-version
 test-ledger
 solana-program-config.json
+feepayer.json

--- a/solana-programs/reward-manager/README.md
+++ b/solana-programs/reward-manager/README.md
@@ -6,7 +6,7 @@ Audius Reward Manager will be a program which allows trusted node operators (ide
 
 Node operators (or senders) will be using their own business logic to identify which users need to be rewarded with tokens. Each reward can be sent to the user only once, so there will be a unique identifier (called `specifier`) ensuring just a single payout. Also the reward payout can happen only if several senders agree on it (3 for example).
 
-There is also a separate type of the sender called `anti abuse oracle`. This will be a sender operated by Audius and while any 3 senders can sign the reward transfer, all transfers also require a signature by the `anti abuse oracle` and messages from the senders also should specify the same `anti abuse oracle` address.
+There is also a separate type of the sender called `anti abuse oracle`. This will be a sender operated by the community and while any 3 senders can sign the reward transfer, all transfers also require a signature by the `anti abuse oracle` and messages from the senders also should specify the same `anti abuse oracle` address.
 
 After signatures from 3 senders and `anti abuse oracle` are verified the tokens are transferred and we create and maintain a `transfer` record which will store an account in the blockchain derived from the `specifier` ensuring no other transfer with the same ID happens again.
 

--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -122,7 +122,7 @@ cat <<EOF
     "audiusEthRegistryAddress": "$audius_eth_registry_address",
     "validSigner": "$valid_signer",
     "signerGroup": "$signer_group",
-    "feePayerWallet": $(cat feepayer.json),
+    "feePayerWallets": [{ "privateKey": $(cat feepayer.json) }],
     "feePayerWalletPubkey": "$feepayer_pubkey",
     "ownerWallet": $owner_wallet,
     "ownerWalletPubkey": "$owner_wallet_pubkey",


### PR DESCRIPTION
### Description

Keep track of multiple fee payers and expose endpoint that returns a random one so that clients can override which fee payer to use for solana transactions. Update functions to accept a fee payer override.

Here is the client counterpart PR: https://github.com/AudiusProject/audius-client/pull/880

### Tests

Locally by spinning up all the services and client.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->