### PR TITLE
Ignore non-existant tracks while calc listen count milestones

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_listen_count_milestone.py
+++ b/discovery-provider/integration_tests/tasks/test_index_listen_count_milestone.py
@@ -145,3 +145,11 @@ def test_listen_count_milestone_processing(app):
             ]
 
             assert sorted_milestones == [(1, 10), (2, 100), (4, 1000), (9, 5000)]
+
+        # Add a track that's not been indexed yet
+        redis_conn.sadd(TRACK_LISTEN_IDS, 20)
+        set_json_cached_key(
+            redis_conn, CURRENT_PLAY_INDEXING, {"slot": 14, "timestamp": 1634836056}
+        )
+        index_listen_count_milestones(db, redis_conn)
+        # expect this to not error

--- a/discovery-provider/src/tasks/index_listen_count_milestones.py
+++ b/discovery-provider/src/tasks/index_listen_count_milestones.py
@@ -111,7 +111,9 @@ def index_listen_count_milestones(db: SessionManager, redis: Redis):
         listen_milestones = []
         for track_id in check_track_ids:
             current_milestone = None
-            if track_id in milestones and track_id in play_counts:
+            if not track_id in play_counts:
+                continue
+            if track_id in milestones:
                 current_milestone = milestones[track_id]
             next_milestone_threshold = get_next_track_milestone(
                 play_counts[track_id], current_milestone

--- a/discovery-provider/src/tasks/index_listen_count_milestones.py
+++ b/discovery-provider/src/tasks/index_listen_count_milestones.py
@@ -111,7 +111,7 @@ def index_listen_count_milestones(db: SessionManager, redis: Redis):
         listen_milestones = []
         for track_id in check_track_ids:
             current_milestone = None
-            if track_id in milestones:
+            if track_id in milestones and track_id in play_counts:
                 current_milestone = milestones[track_id]
             next_milestone_threshold = get_next_track_milestone(
                 play_counts[track_id], current_milestone

--- a/discovery-provider/src/tasks/index_listen_count_milestones.py
+++ b/discovery-provider/src/tasks/index_listen_count_milestones.py
@@ -111,7 +111,7 @@ def index_listen_count_milestones(db: SessionManager, redis: Redis):
         listen_milestones = []
         for track_id in check_track_ids:
             current_milestone = None
-            if not track_id in play_counts:
+            if track_id not in play_counts:
                 continue
             if track_id in milestones:
                 current_milestone = milestones[track_id]


### PR DESCRIPTION
### Description
Ignore track_ids that are not in the play counts dictionary.
Note this was causing a KeyError previously where we would try to index a dictionary that did not have the key

### Tests
Update the test to use a track_id that is not in the tracks or aggregate tracks tbl and check that it doesn't error

### How will this change be monitored?
