### PR TITLE
Fix transaction handler bug

### DIFF
--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -88,10 +88,14 @@ class TransactionHandler {
   }
 
   async _locallyConfirmTransaction (instructions, recentBlockhash, logger, skipPreflight, feePayerOverride = null) {
-    const stringFeePayer = feePayerOverride.toString()
-    const feePayerKeypairOverride = (feePayerOverride && this.feePayerKeypairs)
-      ? this.feePayerKeypairs.find(keypair => keypair.publicKey.toString() === stringFeePayer)
-      : null
+    const feePayerKeypairOverride = (() => {
+      if (feePayerOverride && this.feePayerKeypairs) {
+        const stringFeePayer = feePayerOverride.toString()
+        return this.feePayerKeypairs.find(keypair => keypair.publicKey.toString() === stringFeePayer)
+      }
+      return null
+    })()
+
     const feePayerAccount = feePayerKeypairOverride || (this.feePayerKeypairs && this.feePayerKeypairs[0])
     if (!feePayerAccount) {
       console.error('Local feepayer keys missing for direct confirmation!')


### PR DESCRIPTION
### Description

- If feePayerOverride was null, we call .toString() on null 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->