### PR TITLE
Improve attestation logging

### DIFF
--- a/identity-service/src/analytics.js
+++ b/identity-service/src/analytics.js
@@ -16,7 +16,7 @@ class AnalyticsProvider {
       await this.amplitudeInstance.logEvent({
         event_type: eventName,
         event_properties: properties,
-        user_id: userId
+        user_id: `${userId}`
       })
     } catch (e) {
       console.log(`Failed to log amplitude event with error: ${e}`)

--- a/identity-service/src/routes/rewards.js
+++ b/identity-service/src/routes/rewards.js
@@ -13,6 +13,9 @@ const handleResult = async ({ status, userId, challengeId, amount, error, phase,
     case 'failure':
       await reporter.reportFailure({ userId, challengeId, amount, error, phase, specifier })
       break
+    case 'retry':
+      await reporter.reportRetry({ userId, challengeId, amount, error, phase, specifier })
+      break
     case 'rejection':
       await reporter.reportAAORejection({ userId, challengeId, amount, error, specifier })
       break

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -7,6 +7,8 @@ const { decodeHashId } = require('../../utils/utils')
 class BaseRewardsReporter {
   async reportSuccess ({ userId, challengeId, amount }) {}
 
+  async reportRetry ({ userId, challengeId, amount, error, phase }) {}
+
   async reportFailure ({ userId, challengeId, amount, error, phase }) {}
 
   async reportAAORejection ({ userId, challengeId, amount, error }) {}
@@ -392,7 +394,7 @@ class RewardsAttester {
 
     // "Process" the results of attestation into noRetry and needsRetry errors,
     // as well as a flag that indicates whether we should reselect.
-    let { successful, noRetry, needsRetry, shouldReselect } = await this._processResponses(results)
+    let { successful, noRetry, needsRetry, shouldReselect } = this._processResponses(results, false)
     let successCount = successful.length
     let accumulatedErrors = noRetry
 
@@ -412,7 +414,7 @@ class RewardsAttester {
         await this._selectDiscoveryNodes()
       }
       const res = await Promise.all(needsRetry.map(this._performSingleAttestation))
-      ;({ successful, needsRetry, noRetry, shouldReselect } = await this._processResponses(res))
+      ;({ successful, needsRetry, noRetry, shouldReselect } = this._processResponses(res, retryCount === this.maxRetries))
       accumulatedErrors = [...accumulatedErrors, ...noRetry]
 
       offset += noRetry.filter(({ completedBlocknumber }) => completedBlocknumber === highestBlock).length
@@ -476,7 +478,7 @@ class RewardsAttester {
     amount,
     handle,
     wallet,
-    completedBlocknumber
+    completedBlocknumber,
   }) {
     this.logger.info(`Attempting to attest for userId [${decodeHashId(userId)}], challengeId: [${challengeId}], quorum size: [${this.quorumSize}]}`)
 
@@ -497,7 +499,6 @@ class RewardsAttester {
 
     if (success) {
       this.logger.info(`Successfully attestested for challenge [${challengeId}] for user [${decodeHashId(userId)}], amount [${amount}]!`)
-      await this.reporter.reportSuccess({ userId: decodeHashId(userId), challengeId, amount, specifier })
       return {
         challengeId,
         userId,
@@ -511,14 +512,6 @@ class RewardsAttester {
 
     // Handle error path
     this.logger.error(`Failed to attest for challenge [${challengeId}] for user [${decodeHashId(userId)}], amount [${amount}], oracle: [${this.aaoAddress}] at phase: [${phase}] with error [${error}]`)
-    await this.reporter.reportFailure({
-      phase,
-      error,
-      amount,
-      userId: decodeHashId(userId),
-      challengeId,
-      specifier
-    })
 
     return {
       challengeId,
@@ -601,7 +594,8 @@ class RewardsAttester {
    * }}
    * @memberof RewardsAttester
    */
-  async _processResponses (responses) {
+
+  _processResponses (responses, isFinalAttempt) {
     const errors = SubmitAndEvaluateError
     const AAO_ERRORS = new Set([errors.HCAPTCHA, errors.COGNITO_FLOW, errors.BLOCKED])
     // Account for errors from DN aggregation + Solana program
@@ -619,21 +613,31 @@ class RewardsAttester {
       .filter((res) => {
         if (!res.error) {
           successful.push(res)
+          this.reporter.reportSuccess({ userId: decodeHashId(res.userId), challengeId: res.challengeId, amount: res.amount, specifier: res.specifier })
           return false
         }
         return true
       })
       // Filter out responses that are already disbursed
       .filter(({ error }) => !ALREADY_COMPLETE_ERRORS.has(error))
-      // Handle any AAO errors - report them and then exclude them from result set
+      // Handle no retry errors
       .filter((res) => {
+        const report = { userId: decodeHashId(res.userId), challengeId: res.challengeId, amount: res.amount, error: res.error, phase: res.phase, specifier: res.specifier }
         const isNoRetry = NO_RETRY_ERRORS.has(res.error)
         if (isNoRetry) {
           noRetry.push(res)
           const isAAO = AAO_ERRORS.has(res.error)
+          // `noRetry` errors are never retried, so
+          // they're always logged as failure or AAO
           if (isAAO) {
-            this.reporter.reportAAORejection({ userId: res.userId, challengeId: res.challengeId, amount: res.amount, error: res.error, specifier: res.specifier })
+            this.reporter.reportAAORejection(report)
+          } else {
+            this.reporter.reportFailure(report)
           }
+        } else if (isFinalAttempt) {
+            this.reporter.reportFailure(report)
+        } else {
+            this.reporter.reportRetry(report)
         }
         return !isNoRetry
       })


### PR DESCRIPTION
### Description

- Fix user_id as number instead of string in amplitude
- Log retries distinct from errors

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->