### PR TITLE
[AUD-1540] Skip if user not found instead of error (reward manager)

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_index_rewards_manager.py
@@ -2,7 +2,6 @@ from unittest.mock import create_autospec
 
 from integration_tests.utils import populate_mock_db
 from sqlalchemy import desc
-from src.exceptions import MissingEthRecipientError
 from src.models import ChallengeDisbursement, RewardManagerTransaction
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks.index_rewards_manager import (
@@ -277,7 +276,9 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
 
     populate_mock_db(db, test_user_entries)
     parsed_tx["tx_sig"] = second_tx_sig
-    parsed_tx["slot"] = parsed_tx["slot"] + 1
+    next_slot = parsed_tx["slot"] + 1
+    parsed_tx["slot"] = next_slot
+    parsed_tx["transfer_instruction"]["challenge_id"] = "tt"
     with db.scoped_session() as session:
         process_batch_sol_reward_manager_txs(session, [parsed_tx], redis)
         disbursments = (
@@ -290,13 +291,13 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
             .filter(RewardManagerTransaction.signature == second_tx_sig)
             .all()
         )
-        assert len(reward_manager_tx_1) == 2
+        assert len(reward_manager_tx_1) == 1
         assert len(disbursments) == 2
         disbursment = disbursments[0]
-        assert disbursment.challenge_id == "profile-completion"
+        assert disbursment.challenge_id == "tt"
         assert disbursment.user_id == 1
-        assert disbursment.signature == "tx_sig_two"
-        assert disbursment.slot == 72131741
+        assert disbursment.signature == second_tx_sig
+        assert disbursment.slot == next_slot
         assert disbursment.specifier == "123456789"
         reward_manager_tx_2 = (
             session.query(RewardManagerTransaction)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

* Explicitly log transactions where a user is not found, and set user_id = 0
* Can be rectified in a follow up, but unblocks indexing while still maintaining a record of disbursement


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->