### PR TITLE
Add timeout to discovery indexing redis lock

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -973,10 +973,12 @@ def update_task(self):
     # Update redis cache for health check queries
     update_latest_block_redis()
 
+    DEFAULT_LOCK_TIMEOUT = 60 * 10 # ten minutes
+    
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("disc_prov_lock", blocking_timeout=25)
+    update_lock = redis.lock("disc_prov_lock", blocking_timeout=25, timeout=DEFAULT_LOCK_TIMEOUT)
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -973,12 +973,16 @@ def update_task(self):
     # Update redis cache for health check queries
     update_latest_block_redis()
 
-    DEFAULT_LOCK_TIMEOUT = 60 * 10 # ten minutes
-    
+    DEFAULT_LOCK_TIMEOUT = 60 * 10  # ten minutes
+
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object
-    update_lock = redis.lock("disc_prov_lock", blocking_timeout=25, timeout=DEFAULT_LOCK_TIMEOUT)
+    # blocking_timeout is duration it waits to try to acquire lock
+    # timeout is the duration the lock is held
+    update_lock = redis.lock(
+        "disc_prov_lock", blocking_timeout=25, timeout=DEFAULT_LOCK_TIMEOUT
+    )
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)


### PR DESCRIPTION
### Description
Currently there's no timeout property in the redis lock. This means that the timeout can be held indefinitely. Here's my theory as to what happens to some discovery nodes
- node1 is running
- node2 comes up and deletes disc_prov_lock
- node1 acquires indexing lock (it's still up because we do rolling updates)
- node1 gets terminated
- node2 can never acquire the lock

Confirmed this task has no expiry in redis
```
127.0.0.1:6379> TTL disc_prov_lock
(integer) -1
```
<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested this locally by verifying TTL of key

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?
block_difference in health check
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->