### PR TITLE
Dont wipe state on secondary until divergent state merged

### DIFF
--- a/creator-node/src/services/sync/processSync.js
+++ b/creator-node/src/services/sync/processSync.js
@@ -556,20 +556,6 @@ async function processSync(
       }
     }
   } catch (e) {
-    // two errors where we wipe the state on the secondary
-    // if the clock values somehow becomes corrupted, wipe the records before future re-syncs
-    // if the secondary gets into a weird state with constraints, wipe the records before future re-syncs
-    if (
-      e.message.includes('Can only insert contiguous clock values') ||
-      e.message.includes('SequelizeForeignKeyConstraintError')
-    ) {
-      for (const wallet of walletPublicKeys) {
-        logger.error(
-          `Sync error for ${wallet} - "${e.message}". Clearing db state for wallet.`
-        )
-        await DBManager.deleteAllCNodeUserDataFromDB({ lookupWallet: wallet })
-      }
-    }
     errorObj = e
 
     for (const wallet of walletPublicKeys) {


### PR DESCRIPTION
### Description
Currently there are cases where the secondary will wipe it's own DB state in order to sync from a primary. This was an early attempt at divergent state recovery by preferring content on the primary, but if there's only one piece of content on the network in a content node before the replica set is failed over, we can no longer access that through the IPFS gateway. This allows the network to access it until proper divergent state recovery.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->