### PR TITLE
Shift libs user signup from Discprov indexing to direct chain call

### DIFF
--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -387,6 +387,10 @@ class Users extends Base {
     const newMetadata = this._cleanUserMetadata(metadata)
     this._validateUserMetadata(newMetadata)
 
+    const logPrefix = `[User:updateCreator()] [userId: ${userId}]`
+    const fnStartMs = Date.now()
+    let startMs = fnStartMs
+
     // Error if libs instance does not already have existing user state
     const user = this.userStateManager.getCurrentUser()
     if (!user) {
@@ -410,11 +414,11 @@ class Users extends Base {
         txReceipt: updateEndpointTxReceipt, replicaSetSPIDs
       } = await this._updateReplicaSetOnChain(userId, newMetadata.creator_node_endpoint)
       updateEndpointTxBlockNumber = updateEndpointTxReceipt.blockNumber
-      console.log(`${logPrefix} [phase: ${phase}] _updateReplicaSetOnChain() completed in ${Date.now() - startMs}ms`)
+      console.log(`${logPrefix} _updateReplicaSetOnChain() completed in ${Date.now() - startMs}ms`)
       startMs = Date.now()
 
       await this._waitForURSMCreatorNodeEndpointIndexing(userId, replicaSetSPIDs)
-      console.log(`${logPrefix} [phase: ${phase}] _waitForURSMCreatorNodeEndpointIndexing() completed in ${Date.now() - startMs}ms`)
+      console.log(`${logPrefix} _waitForURSMCreatorNodeEndpointIndexing() completed in ${Date.now() - startMs}ms`)
     }
 
     // Upload new metadata object to CN
@@ -465,6 +469,10 @@ class Users extends Base {
     const userId = user.user_id
     const oldMetadata = { ...user }
 
+    const logPrefix = `[User:upgradeToCreator()] [userId: ${userId}]`
+    const fnStartMs = Date.now()
+    let startMs = fnStartMs
+
     // Clean and validate metadata
     const newMetadata = this._cleanUserMetadata({ ...user })
     this._validateUserMetadata(newMetadata)
@@ -509,11 +517,11 @@ class Users extends Base {
         txReceipt: updateEndpointTxReceipt, replicaSetSPIDs
       } = await this._updateReplicaSetOnChain(userId, newMetadata.creator_node_endpoint)
       updateEndpointTxBlockNumber = updateEndpointTxReceipt.blockNumber
-      console.log(`${logPrefix} [phase: ${phase}] _updateReplicaSetOnChain() completed in ${Date.now() - startMs}ms`)
+      console.log(`${logPrefix} _updateReplicaSetOnChain() completed in ${Date.now() - startMs}ms`)
       startMs = Date.now()
 
       await this._waitForURSMCreatorNodeEndpointIndexing(userId, replicaSetSPIDs)
-      console.log(`${logPrefix} [phase: ${phase}] _waitForURSMCreatorNodeEndpointIndexing() completed in ${Date.now() - startMs}ms`)
+      console.log(`${logPrefix} _waitForURSMCreatorNodeEndpointIndexing() completed in ${Date.now() - startMs}ms`)
     }
 
     // Upload new metadata object to CN

--- a/libs/src/utils/utils.js
+++ b/libs/src/utils/utils.js
@@ -193,6 +193,16 @@ class Utils {
       return null
     }
   }
+
+  /**
+   * If `requestPromise` responds before `timeoutMs`, this function returns its response; else rejects with `timeoutErrorMsg`
+   */
+  static async racePromiseWithTimeout (requestPromise, timeoutMs, timeoutErrorMsg) {
+    const timeoutPromise = new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error(timeoutErrorMsg)), timeoutMs)
+    })
+    return Promise.race([requestPromise, timeoutPromise])
+  }
 }
 
 module.exports = Utils

--- a/libs/src/utils/utils.js
+++ b/libs/src/utils/utils.js
@@ -195,13 +195,17 @@ class Utils {
   }
 
   /**
-   * If `requestPromise` responds before `timeoutMs`, this function returns its response; else rejects with `timeoutErrorMsg`
+   * If `promise` responds before `timeoutMs`,
+   * this function returns its response; else rejects with `timeoutMessage`
+   * @param {Promise} promise
+   * @param {number} timeoutMs
+   * @param {string} timeoutMessage
    */
-  static async racePromiseWithTimeout (requestPromise, timeoutMs, timeoutErrorMsg) {
+  static async racePromiseWithTimeout (promise, timeoutMs, timeoutMessage) {
     const timeoutPromise = new Promise((resolve, reject) => {
-      setTimeout(() => reject(new Error(timeoutErrorMsg)), timeoutMs)
+      setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)
     })
-    return Promise.race([requestPromise, timeoutPromise])
+    return Promise.race([promise, timeoutPromise])
   }
 }
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Uses chain call for URSM updates instead of waiting for discovery.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Linked client
 - create account
 - upload track
 - update creator

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->