### PR TITLE
Add fetch ipfs timeout and optimize user indexing

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -347,16 +347,25 @@ def fetch_ipfs_metadata(
             futures.append(future)
             futures_map[future] = [cid, txhash]
 
-        for future in concurrent.futures.as_completed(futures):
-            cid, txhash = futures_map[future]
-            try:
-                ipfs_metadata[cid] = future.result()
-            except Exception as e:
-                logger.info("Error in fetch ipfs metadata")
-                blockhash = update_task.web3.toHex(block_hash)
-                raise IndexingError(
-                    "prefetch-cids", block_number, blockhash, txhash, str(e)
-                ) from e
+        try:
+            for future in concurrent.futures.as_completed(futures, timeout=3):
+                cid, txhash = futures_map[future]
+                try:
+                    ipfs_metadata[cid] = future.result()
+                except Exception as e:
+                    logger.info("Error in fetch ipfs metadata")
+                    blockhash = update_task.web3.toHex(block_hash)
+                    raise IndexingError(
+                        "prefetch-cids", block_number, blockhash, txhash, str(e)
+                    ) from e
+        except concurrent.futures.TimeoutError as exc:
+            logger.error(f"index.py | Timeout fetch_ipfs_metadata: {exc}")
+            # timeout in a ThreadPoolExecutor doesn't actually stop execution of the underlying thread
+            # in order to do that we need to actually clear the queue which we do here to force this
+            # task to stop execution
+            executor._threads.clear()
+            concurrent.futures.thread._threads_queues.clear()
+            raise exc
 
     return ipfs_metadata, blacklisted_cids
 

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -197,16 +197,10 @@ def lookup_user_record(
 
 
 def invalidate_old_user(session, user_id):
-    # Check if the userId is in the db
-    logger.info(f"index.py | invalidate user with id {user_id}")
-
     # Update existing record in db to is_current = False
-    num_invalidated_users = (
-        session.query(User)
-        .filter(User.user_id == user_id, User.is_current == True)
-        .update({"is_current": False})
+    session.query(User).filter(User.user_id == user_id, User.is_current == True).update(
+        {"is_current": False}
     )
-    logger.info(f"index.py | num_invalidated_users {num_invalidated_users}")
 
 
 def parse_user_event(


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

a couple changes to make indexing faster:
- fetch_ipfs_metadata often hangs for minutes and should only take a couple seconds this adds a timeout for 3 secs.
- also, this change removes extra queries in user indexing to check if users exist.

### Tests

manually tested and verified timeouts come up and speeds up indexing.
also tested on user indexing.

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

monitor indexing is completing and timeouts are happening when necessary. 
monitor user indexing. 
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->