### PR TITLE
Fix autocomplete search regression

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -107,7 +107,10 @@ def extend_user(user, current_user_id=None):
         del user["playlist_library"]
     # Marshal wallets into clear names
     user["erc_wallet"] = user["wallet"]
-    user["spl_wallet"] = user["spl_wallet"]
+
+    # Autocomplete search doesn't contain spl_wallet
+    if "spl_wallet" in user:
+        user["spl_wallet"] = user["spl_wallet"]
 
     return user
 

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -108,10 +108,6 @@ def extend_user(user, current_user_id=None):
     # Marshal wallets into clear names
     user["erc_wallet"] = user["wallet"]
 
-    # Autocomplete search doesn't contain spl_wallet
-    if "spl_wallet" in user:
-        user["spl_wallet"] = user["spl_wallet"]
-
     return user
 
 


### PR DESCRIPTION
### Description

Autocomplete search doesn't contain `spl_wallet` because it doesn't hit `populate_user_metadata`

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->