### PR TITLE
Lower block processing interval

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -5,7 +5,7 @@ loglevel_flask = DEBUG
 ; set log level via command line in docker yml files instead
 ; loglevel_celery = INFO
 block_processing_window = 20
-block_processing_interval_sec = 5
+block_processing_interval_sec = 1
 blacklist_block_processing_window = 600
 blacklist_block_indexing_interval = 60
 peer_refresh_interval = 3000


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Indexing blocks every 5 seconds means there's a potential of waiting up to 5 seconds after indexing completes. This helps indexing start again more quickly.

### Tests

Tested on sandbox. 

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->