### PR TITLE
Fix auth middleware bug in solana relay

### DIFF
--- a/identity-service/src/authMiddleware.js
+++ b/identity-service/src/authMiddleware.js
@@ -72,7 +72,12 @@ async function authMiddleware (req, res, next) {
   }
 }
 
-async function parameterizedAuthMiddleware ({ shouldRespondBadRequest }) {
+/**
+ * Parameterized version of authentication middleware
+ * @param {{ shouldRespondBadRequest }: { shouldRespondBadRequest: boolean }} 
+ * @returns function `authMiddleware`
+ */
+const parameterizedAuthMiddleware = ({ shouldRespondBadRequest }) => {
   return async (req, res, next) => {
     try {
       const encodedDataMessage = req.get('Encoded-Data-Message')

--- a/identity-service/src/authMiddleware.js
+++ b/identity-service/src/authMiddleware.js
@@ -74,7 +74,11 @@ async function authMiddleware (req, res, next) {
 
 /**
  * Parameterized version of authentication middleware
- * @param {{ shouldRespondBadRequest }: { shouldRespondBadRequest: boolean }}
+ * @param {{
+ *  shouldRespondBadRequest, whether or not to return server error on auth failure
+ * }: {
+ *  shouldRespondBadRequest: boolean
+ * }}
  * @returns function `authMiddleware`
  */
 const parameterizedAuthMiddleware = ({ shouldRespondBadRequest }) => {

--- a/identity-service/src/authMiddleware.js
+++ b/identity-service/src/authMiddleware.js
@@ -72,4 +72,38 @@ async function authMiddleware (req, res, next) {
   }
 }
 
+async function parameterizedAuthMiddleware ({ shouldRespondBadRequest }) {
+  return async (req, res, next) => {
+    try {
+      const encodedDataMessage = req.get('Encoded-Data-Message')
+      const signature = req.get('Encoded-Data-Signature')
+      const handle = req.query.handle
+
+      if (!encodedDataMessage) throw new Error('[Error]: Encoded data missing')
+      if (!signature) throw new Error('[Error]: Encoded data signature missing')
+
+      const walletAddress = recoverPersonalSignature({ data: encodedDataMessage, sig: signature })
+      const user = await models.User.findOne({
+        where: { walletAddress },
+        attributes: ['id', 'blockchainUserId', 'walletAddress', 'createdAt', 'handle']
+      })
+      if (!user) throw new Error(`[Error]: no user found for wallet address ${walletAddress}`)
+
+      if (!user.blockchainUserId || !user.handle) {
+        const discprovUser = await queryDiscprovForUserId(walletAddress, handle)
+        await user.update({ blockchainUserId: discprovUser.user_id, handle: discprovUser.handle })
+      }
+      req.user = user
+      next()
+    } catch (err) {
+      if (shouldRespondBadRequest) {
+        const errorResponse = errorResponseBadRequest('[Error]: The wallet address is not associated with a user id')
+        return sendResponse(req, res, errorResponse)
+      }
+      next()
+    }
+  }
+}
+
 module.exports = authMiddleware
+module.exports.parameterizedAuthMiddleware = parameterizedAuthMiddleware

--- a/identity-service/src/authMiddleware.js
+++ b/identity-service/src/authMiddleware.js
@@ -74,7 +74,7 @@ async function authMiddleware (req, res, next) {
 
 /**
  * Parameterized version of authentication middleware
- * @param {{ shouldRespondBadRequest }: { shouldRespondBadRequest: boolean }} 
+ * @param {{ shouldRespondBadRequest }: { shouldRespondBadRequest: boolean }}
  * @returns function `authMiddleware`
  */
 const parameterizedAuthMiddleware = ({ shouldRespondBadRequest }) => {

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const crypto = require('crypto')
 
-const authMiddleware = require('../authMiddleware')
+const { parameterizedAuthMiddleware } = require('../authMiddleware')
 const { handleResponse, successResponse, errorResponseServerError } = require('../apiHelpers')
 const { getFeePayerKeypair } = require('../solana-client')
 const { isSendInstruction, doesUserHaveSocialProof } = require('../utils/relayHelpers')
@@ -24,62 +24,73 @@ const isValidInstruction = (instr) => {
   return true
 }
 
-solanaRouter.post('/relay', authMiddleware, handleResponse(async (req, res, next) => {
-  const redis = req.app.get('redis')
-  const libs = req.app.get('audiusLibs')
-  let optimizelyClient
-  let socialProofRequiredToSend = true
+solanaRouter.post(
+  '/relay',
+  parameterizedAuthMiddleware({ shouldResponseBadRequest: false }),
+  handleResponse(async (req, res, next) => {
+    const redis = req.app.get('redis')
+    const libs = req.app.get('audiusLibs')
+    let optimizelyClient
+    let socialProofRequiredToSend = true
 
-  let { instructions = [], skipPreflight, feePayerOverride } = req.body
-  try {
-    optimizelyClient = req.app.get('optimizelyClient')
-    socialProofRequiredToSend = getFeatureFlag(optimizelyClient, FEATURE_FLAGS.SOCIAL_PROOF_TO_SEND_AUDIO_ENABLED)
-  } catch (error) {
-    req.logger.error(`failed to retrieve optimizely feature flag for socialProofRequiredToSend: ${error}`)
-  }
-  if (socialProofRequiredToSend && isSendInstruction(instructions)) {
-    const userHasSocialProof = await doesUserHaveSocialProof(req.user)
-    if (!userHasSocialProof) {
-      let handle = req.user ? req.user.handle : ''
-      return errorResponseServerError(
-        `User ${handle} is missing social proof`,
-        { error: 'Missing social proof' }
-      )
+    let { instructions = [], skipPreflight, feePayerOverride } = req.body
+    try {
+      optimizelyClient = req.app.get('optimizelyClient')
+      socialProofRequiredToSend = getFeatureFlag(optimizelyClient, FEATURE_FLAGS.SOCIAL_PROOF_TO_SEND_AUDIO_ENABLED)
+    } catch (error) {
+      req.logger.error(`failed to retrieve optimizely feature flag for socialProofRequiredToSend: ${error}`)
     }
-  }
+    if (socialProofRequiredToSend && isSendInstruction(instructions)) {
+      if (!req.user) {
+        return errorResponseServerError(
+          `User has no auth record`,
+          { error: 'No auth record' }
+        )
+      }
 
-  const reqBodySHA = crypto.createHash('sha256').update(JSON.stringify({ instructions })).digest('hex')
+      const userHasSocialProof = await doesUserHaveSocialProof(req.user)
+      if (!userHasSocialProof) {
+        let handle = req.user ? req.user.handle : ''
+        return errorResponseServerError(
+          `User ${handle} is missing social proof`,
+          { error: 'Missing social proof' }
+        )
+      }
+    }
 
-  instructions = instructions.filter(isValidInstruction).map((instr) => {
-    const keys = instr.keys.map(key => ({
-      pubkey: new PublicKey(key.pubkey),
-      isSigner: key.isSigner,
-      isWritable: key.isWritable
-    }))
-    return new TransactionInstruction({
-      keys,
-      programId: new PublicKey(instr.programId),
-      data: Buffer.from(instr.data)
+    const reqBodySHA = crypto.createHash('sha256').update(JSON.stringify({ instructions })).digest('hex')
+
+    instructions = instructions.filter(isValidInstruction).map((instr) => {
+      const keys = instr.keys.map(key => ({
+        pubkey: new PublicKey(key.pubkey),
+        isSigner: key.isSigner,
+        isWritable: key.isWritable
+      }))
+      return new TransactionInstruction({
+        keys,
+        programId: new PublicKey(instr.programId),
+        data: Buffer.from(instr.data)
+      })
     })
-  })
 
-  const transactionHandler = libs.solanaWeb3Manager.transactionHandler
-  const { res: transactionSignature, error, errorCode } = await transactionHandler.handleTransaction({
-    instructions,
-    skipPreflight,
-    feePayerOverride
-  })
+    const transactionHandler = libs.solanaWeb3Manager.transactionHandler
+    const { res: transactionSignature, error, errorCode } = await transactionHandler.handleTransaction({
+      instructions,
+      skipPreflight,
+      feePayerOverride
+    })
 
-  if (error) {
-    // if the tx fails, store it in redis with a 24 hour expiration
-    await redis.setex(`solanaFailedTx:${reqBodySHA}`, 60 /* seconds */ * 60 /* minutes */ * 24 /* hours */, JSON.stringify(req.body))
-    req.logger.error('Error in solana transaction:', error, reqBodySHA)
-    const errorString = `Something caused the solana transaction to fail for payload ${reqBodySHA}`
-    return errorResponseServerError(errorString, { errorCode, error })
+    if (error) {
+      // if the tx fails, store it in redis with a 24 hour expiration
+      await redis.setex(`solanaFailedTx:${reqBodySHA}`, 60 /* seconds */ * 60 /* minutes */ * 24 /* hours */, JSON.stringify(req.body))
+      req.logger.error('Error in solana transaction:', error, reqBodySHA)
+      const errorString = `Something caused the solana transaction to fail for payload ${reqBodySHA}`
+      return errorResponseServerError(errorString, { errorCode, error })
+    }
+
+    return successResponse({ transactionSignature })
   }
-
-  return successResponse({ transactionSignature })
-}))
+  ))
 
 /**
  * The raw relay uses the `sendAndConfirmRawTransaction` as opposed to the `sendAndConfirmTransaction` method

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -50,7 +50,7 @@ solanaRouter.post(
 
       const userHasSocialProof = await doesUserHaveSocialProof(req.user)
       if (!userHasSocialProof) {
-        let handle = req.user ? req.user.handle : ''
+        const handle = req.user.handle || ''
         return errorResponseServerError(
           `User ${handle} is missing social proof`,
           { error: 'Missing social proof' }

--- a/identity-service/test/routes/solanaTest.js
+++ b/identity-service/test/routes/solanaTest.js
@@ -38,6 +38,6 @@ describe('test Solana relay route without social verification', function () {
         skipPreflight: false,
         feePayerOverride: null
       })
-      .expect(400, done)
+      .expect(500, done)
   })
 })


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

A user will not exist for all /solana/relays. We actually want authMiddleware to give us a user IFF this is a user bank relay (checked later on).

Offer a parameterized auth middleware that will only attach req.user and *not* return bad response so it can be checked downstream.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Need to test on staging.

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->