### PR TITLE
Index perf tracking

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -19,7 +19,7 @@ from src.queries.get_sol_user_bank import get_sol_user_bank_health_info
 from src.utils import db_session, helpers, redis_connection, web3_provider
 from src.utils.config import shared_config
 from src.utils.helpers import redis_get_or_restore, redis_set_and_dump
-from src.utils.index_blocks_performance import get_average_index_blocks_seconds_since
+from src.utils.index_blocks_performance import get_average_index_blocks_ms_since
 from src.utils.redis_constants import (
     challenges_last_processed_event_redis_key,
     index_eth_last_completion_redis_key,
@@ -269,21 +269,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         if last_scanned_block_for_balance_refresh
         else None
     )
-    # Get index blocks performance
-    index_blocks_minute = get_average_index_blocks_seconds_since(
-        redis, MINUTE_IN_SECONDS
-    )
-    index_blocks_ten_minutes = get_average_index_blocks_seconds_since(
-        redis, TEN_MINUTES_IN_SECONDS
-    )
-    index_blocks_hour = get_average_index_blocks_seconds_since(redis, HOUR_IN_SECONDS)
-    index_blocks_six_hours = get_average_index_blocks_seconds_since(
-        redis, SIX_HOURS_IN_SECONDS
-    )
-    index_blocks_twelve_hours = get_average_index_blocks_seconds_since(
-        redis, TWELVE_HOURS_IN_SECONDS
-    )
-    index_blocks_day = get_average_index_blocks_seconds_since(redis, DAY_IN_SECONDS)
 
     # Get system information monitor values
     sys_info = monitors.get_monitors(
@@ -324,14 +309,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "rewards_manager": rewards_manager_health_info,
         "user_bank": user_bank_health_info,
         "openresty_public_key": openresty_public_key,
-        "index_blocks_avg_seconds": {
-            "minute": index_blocks_minute,
-            "ten_minutes": index_blocks_ten_minutes,
-            "hour": index_blocks_hour,
-            "six_hours": index_blocks_six_hours,
-            "twelve_hours": index_blocks_twelve_hours,
-            "day": index_blocks_day,
-        },
     }
 
     block_difference = abs(latest_block_num - latest_indexed_block_num)
@@ -379,6 +356,30 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
 
         health_results["tables"] = table_size_info_json
+
+        # Get index blocks performance
+        index_blocks_minute = get_average_index_blocks_ms_since(
+            redis, MINUTE_IN_SECONDS
+        )
+        index_blocks_ten_minutes = get_average_index_blocks_ms_since(
+            redis, TEN_MINUTES_IN_SECONDS
+        )
+        index_blocks_hour = get_average_index_blocks_ms_since(redis, HOUR_IN_SECONDS)
+        index_blocks_six_hours = get_average_index_blocks_ms_since(
+            redis, SIX_HOURS_IN_SECONDS
+        )
+        index_blocks_twelve_hours = get_average_index_blocks_ms_since(
+            redis, TWELVE_HOURS_IN_SECONDS
+        )
+        index_blocks_day = get_average_index_blocks_ms_since(redis, DAY_IN_SECONDS)
+        health_results["index_blocks_avg_ms"] = {
+            "minute": index_blocks_minute,
+            "ten_minutes": index_blocks_ten_minutes,
+            "hour": index_blocks_hour,
+            "six_hours": index_blocks_six_hours,
+            "twelve_hours": index_blocks_twelve_hours,
+            "day": index_blocks_day,
+        }
 
     unhealthy_blocks = bool(
         enforce_block_diff and block_difference > healthy_block_diff

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -41,8 +41,8 @@ from src.tasks.users import user_event_types_lookup, user_state_update
 from src.utils import helpers, multihash
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
 from src.utils.index_blocks_performance import (
-    record_index_blocks_seconds,
-    sweep_old_index_blocks_seconds,
+    record_index_blocks_ms,
+    sweep_old_index_blocks_ms,
 )
 from src.utils.indexing_errors import IndexingError
 from src.utils.ipfs_lib import NEW_BLOCK_TIMEOUT_SECONDS
@@ -691,10 +691,11 @@ def index_blocks(self, db, blocks_list):
         )
 
         # Record the time this took in redis
-        record_index_blocks_seconds(redis, datetime.now() - start_time)
+        duration_ms = round((datetime.now() - start_time).total_seconds() * 1000)
+        record_index_blocks_ms(redis, duration_ms)
         # Sweep records older than 30 days every day
         if block_number % BLOCKS_PER_DAY == 0:
-            sweep_old_index_blocks_seconds(redis, 30)
+            sweep_old_index_blocks_ms(redis, 30)
 
     if num_blocks > 0:
         logger.warning(f"index.py | index_blocks | Indexed {num_blocks} blocks")

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0302
 import concurrent.futures
 import logging
+from datetime import datetime
 from operator import itemgetter, or_
 
 from src.app import get_contract_addresses
@@ -39,6 +40,10 @@ from src.tasks.user_replica_set import user_replica_set_state_update
 from src.tasks.users import user_event_types_lookup, user_state_update
 from src.utils import helpers, multihash
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
+from src.utils.index_blocks_performance import (
+    record_index_blocks_seconds,
+    sweep_old_index_blocks_seconds,
+)
 from src.utils.indexing_errors import IndexingError
 from src.utils.ipfs_lib import NEW_BLOCK_TIMEOUT_SECONDS
 from src.utils.redis_cache import (
@@ -84,6 +89,8 @@ TX_TYPE_TO_HANDLER_MAP = {
     USER_LIBRARY_FACTORY: user_library_state_update,
     USER_REPLICA_SET_MANAGER: user_replica_set_state_update,
 }
+
+BLOCKS_PER_DAY = (24 * 60 * 60) / 5
 
 logger = logging.getLogger(__name__)
 
@@ -551,6 +558,7 @@ def index_blocks(self, db, blocks_list):
     latest_block_timestamp = None
     changed_entity_ids_map = {}
     for i in block_order_range:
+        start_time = datetime.now()
         update_ursm_address(self)
         block = blocks_list[i]
         block_index = num_blocks - i
@@ -681,6 +689,12 @@ def index_blocks(self, db, blocks_list):
         logger.info(
             f"index.py | update most recently processed block complete for block=${block_number}"
         )
+
+        # Record the time this took in redis
+        record_index_blocks_seconds(redis, datetime.now() - start_time)
+        # Sweep records older than 30 days every day
+        if block_number % BLOCKS_PER_DAY == 0:
+            sweep_old_index_blocks_seconds(redis, 30)
 
     if num_blocks > 0:
         logger.warning(f"index.py | index_blocks | Indexed {num_blocks} blocks")

--- a/discovery-provider/src/utils/index_blocks_performance.py
+++ b/discovery-provider/src/utils/index_blocks_performance.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+INDEX_BLOCKS_SECONDS_REDIS_KEY = "index_blocks:seconds"
+
+
+def record_index_blocks_seconds(redis, index_blocks_duration_seconds):
+    """Records that a round of index_blocks took some number of seconds."""
+    now = round(datetime.now().timestamp())
+    redis.zadd(INDEX_BLOCKS_SECONDS_REDIS_KEY, now, index_blocks_duration_seconds)
+
+
+def get_average_index_blocks_seconds_since(redis, seconds_ago):
+    """From seconds ago until now, get the average seconds index_blocks took"""
+    ago = round((datetime.now() - timedelta(seconds=seconds_ago)).timestamp())
+    res = redis.zrange(
+        INDEX_BLOCKS_SECONDS_REDIS_KEY,
+        ago,
+        -1,
+        withscores=True,
+    )
+    seconds_per_block = map(res, lambda x: x[1])
+    return sum(seconds_per_block) / len(seconds_per_block)
+
+
+def sweep_old_index_blocks_seconds(redis, expire_after_days):
+    """Sweep old records after `expire_after_days`"""
+    timestamp = round((datetime.now() - timedelta(days=expire_after_days)).timestamp())
+    redis.zremrangebyscore(INDEX_BLOCKS_SECONDS_REDIS_KEY, 0, timestamp)

--- a/discovery-provider/src/utils/index_blocks_performance.py
+++ b/discovery-provider/src/utils/index_blocks_performance.py
@@ -1,28 +1,29 @@
 from datetime import datetime, timedelta
 
-INDEX_BLOCKS_SECONDS_REDIS_KEY = "index_blocks:seconds"
+INDEX_BLOCKS_SECONDS_REDIS_KEY = "index_blocks:ms"
 
 
-def record_index_blocks_seconds(redis, index_blocks_duration_seconds):
-    """Records that a round of index_blocks took some number of seconds."""
+def record_index_blocks_ms(redis, index_blocks_duration_ms):
+    """Records that a round of index_blocks took some number of ms"""
     now = round(datetime.now().timestamp())
-    redis.zadd(INDEX_BLOCKS_SECONDS_REDIS_KEY, now, index_blocks_duration_seconds)
-
-
-def get_average_index_blocks_seconds_since(redis, seconds_ago):
-    """From seconds ago until now, get the average seconds index_blocks took"""
-    ago = round((datetime.now() - timedelta(seconds=seconds_ago)).timestamp())
-    res = redis.zrange(
-        INDEX_BLOCKS_SECONDS_REDIS_KEY,
-        ago,
-        -1,
-        withscores=True,
+    # Key as ms:date, value as date so that we can sort by range (on values)
+    # Zset lets you only query by ranges of the value.
+    redis.zadd(
+        INDEX_BLOCKS_SECONDS_REDIS_KEY, {f"{index_blocks_duration_ms}:{now}": now}
     )
-    seconds_per_block = map(res, lambda x: x[1])
-    return sum(seconds_per_block) / len(seconds_per_block)
 
 
-def sweep_old_index_blocks_seconds(redis, expire_after_days):
+def get_average_index_blocks_ms_since(redis, seconds_ago):
+    """From seconds ago until now, get the average ms index_blocks took"""
+    ago = round((datetime.now() - timedelta(seconds=seconds_ago)).timestamp())
+    res = redis.zrangebyscore(INDEX_BLOCKS_SECONDS_REDIS_KEY, ago, "+inf")
+    ms_per_block = list(map(lambda x: int(x.decode("utf-8").split(":")[0]), res))
+    if len(ms_per_block) > 0:
+        return sum(ms_per_block) / len(ms_per_block)
+    return None
+
+
+def sweep_old_index_blocks_ms(redis, expire_after_days):
     """Sweep old records after `expire_after_days`"""
     timestamp = round((datetime.now() - timedelta(days=expire_after_days)).timestamp())
     redis.zremrangebyscore(INDEX_BLOCKS_SECONDS_REDIS_KEY, 0, timestamp)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Tracks index_blocks perf over time ranges in redis. Prunes every day things are are older than 30 days

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran indexing locally and verified responses. Looks like this:

```
index_blocks_avg_ms: {
day: 37.666666666666664,
hour: 37.666666666666664,
minute: 37.666666666666664,
six_hours: 37.666666666666664,
ten_minutes: 37.666666666666664,
twelve_hours: 37.666666666666664
},
```

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->