### PR TITLE
Increase ethWeb3Manager max gas limit

### DIFF
--- a/libs/src/services/ethWeb3Manager/index.js
+++ b/libs/src/services/ethWeb3Manager/index.js
@@ -6,7 +6,7 @@ const retry = require('async-retry')
 const MIN_GAS_PRICE = Math.pow(10, 9) // 1 GWei, ETH minimum allowed gas price
 const HIGH_GAS_PRICE = 250 * MIN_GAS_PRICE // 250 GWei
 const DEFAULT_GAS_PRICE = 100 * MIN_GAS_PRICE // 100 Gwei is a reasonably average gas price
-const MAX_GAS_LIMIT = 2000000 // ETH block gas limit is 30M, set to 1/15 of that or 2M
+const MAX_GAS_LIMIT = 5000000 // We've seen prod tx's take up to 4M. Set to the highest we've observed + a buffer
 
 /** Singleton state-manager for Audius Eth Contracts */
 class EthWeb3Manager {


### PR DESCRIPTION
### Description
Currently the max limit is 2M but we've seen prod tx's go as high as 3.7M. Set to 5M just in case

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->