### PR TITLE
fix getCID Regression

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -330,6 +330,7 @@ const getCID = async (req, res) => {
         decisionTree.push({
           stage: `DB_CID_QUERY_CID_FOUND`
         })
+        storagePath = queryResults.storagePath
       }
     } catch (e) {
       decisionTree.push({


### PR DESCRIPTION
[recent change to check FS before DB](https://github.com/AudiusProject/audius-protocol/commit/7426dc7f201ac340cf1a8ff5bbbae98b031a0ae3) introduced regression where any file at legacy storage path (/file_storage/Qm...) would not be correctly served.

This removes regression by always using storagePath returned from DB