### PR TITLE
Use all DNs for endpointPool if not configured

### DIFF
--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.js
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.js
@@ -234,6 +234,14 @@ class RewardsAttester {
       AAO address: ${this.aaoAddress} \
       endpoints: ${this.endpoints}
     `)
+
+    // If a list of endpoints was not specified,
+    // set the pool to the entire list of discovery providers.
+    // This overrides any configured whitelist for the service selector.
+    if (this.endpointPool.size === 0) {
+      const pool = this.libs.discoveryProvider.serviceSelector.getServices()
+      this.endpointPool = new Set(pool)
+    }
     await this._selectDiscoveryNodes()
     await this.delayCalculator.start()
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Identity is configured to only use the foundation nodes for notification reasons, but the `RewardsAttester` needs nodes from three different operators. If no endpoint list is passed to the rewards attester, default to all the discovery nodes instead of using the configured whitelist.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->