### PR TITLE
Fix attester endpoint bug

### DIFF
--- a/identity-service/src/utils/configureAttester.js
+++ b/identity-service/src/utils/configureAttester.js
@@ -17,7 +17,7 @@ const getRemoteConfig = async (optimizely) => {
   )
 
   const endpointsString = getRemoteVar(optimizely, REMOTE_VARS.REWARDS_ATTESTATION_ENDPOINTS)
-  const endpoints = endpointsString && endpointsString.length ? endpointsString.split(',') : []
+  const endpoints = endpointsString && endpointsString.length ? endpointsString.split(',') : null
 
   const aaoEndpoint = getRemoteVar(
     optimizely, REMOTE_VARS.ORACLE_ENDPOINT


### PR DESCRIPTION
### Description

- Passing in an empty array here was causing us to get INSUFFICIENT_DISCOVERY_COUNT errors, and then reselect constantly

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->