### PR TITLE
Add endpoint to retry flow session for handle

### DIFF
--- a/identity-service/src/cognitoFlowMiddleware.js
+++ b/identity-service/src/cognitoFlowMiddleware.js
@@ -36,4 +36,4 @@ async function cognitoFlowMiddleware (req, res, next) {
   next()
 }
 
-module.exports = cognitoFlowMiddleware
+module.exports = { cognitoFlowMiddleware, MAX_TIME_DRIFT_MILLISECONDS }

--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -779,6 +779,12 @@ const config = convict({
     format: String,
     env: 'cognitoIdentityHashSalt',
     default: ''
+  },
+  cognitoRetrySecret: {
+    doc: 'The secret necessary to request a retry for the cognito flow',
+    format: String,
+    env: 'cognitoRetrySecret',
+    default: ''
   }
 })
 

--- a/identity-service/src/routes/cognito.js
+++ b/identity-service/src/routes/cognito.js
@@ -153,6 +153,7 @@ module.exports = function (app) {
       // because there should be no need to redo the flow if score is already passing
       // also, it would otherwise be possible that the new flow will pass but the unique identity check will have a collision
       if (record && record.score === 1) {
+        logger.info(`cognito_retry | Not requesting flow session retry for handle ${handle} because user already passed cognito`)
         return successResponse({})
       }
 

--- a/identity-service/src/routes/cognito.js
+++ b/identity-service/src/routes/cognito.js
@@ -189,11 +189,9 @@ module.exports = function (app) {
       order: [['updatedAt', 'DESC']],
       limit: 1
     })
-    logger.info(`cognito_exists | ${JSON.stringify(records, null, 2)}`)
     if (records.length) {
       const timeDifferenceMilliseconds =
         Date.now() - new Date(records[0].updatedAt).getTime()
-      logger.info(`cognito_exists | ${Date.now()} | ${new Date(records[0].updatedAt).getTime()} | ${timeDifferenceMilliseconds}`)
       return successResponse({ exists: timeDifferenceMilliseconds <= MAX_TIME_DRIFT_MILLISECONDS })
     }
     return successResponse({ exists: false })

--- a/identity-service/src/routes/cognito.js
+++ b/identity-service/src/routes/cognito.js
@@ -135,6 +135,11 @@ module.exports = function (app) {
     }
   }))
 
+  /**
+   * This endpoint is not programatically called.
+   * It exists in case we want to request a flow session retry for a handle
+   * in case our webhook receiver runs into an issue
+   */
   app.post('/cognito_retry/:handle', handleResponse(async (req) => {
     const handle = req.params.handle
 
@@ -186,6 +191,11 @@ module.exports = function (app) {
     }
   }))
 
+  /**
+   * Returns whether a recent cognito entry exists for a given handle.
+   * This is so that the client can poll this endpoint to check whether
+   * or not to proceed with a reward claim retry.
+   */
   app.get('/cognito_recent_exists/:handle', handleResponse(async (req) => {
     const handle = req.params.handle
     const records = await models.CognitoFlows.findAll({

--- a/identity-service/src/routes/cognito.js
+++ b/identity-service/src/routes/cognito.js
@@ -130,13 +130,14 @@ module.exports = function (app) {
   }))
 
   app.post('/cognito_retry/:handle', handleResponse(async (req) => {
+    const handle = req.params.handle
+
     if (req.headers['x-cognito-retry'] !== config.get('cognitoRetrySecret')) {
-      return errorResponseForbidden(`Not permissioned to retry flow session for user handle ${}`)
+      return errorResponseForbidden(`Not permissioned to retry flow session for user handle ${handle}`)
     }
 
     const baseUrl = config.get('cognitoBaseUrl')
     const templateId = config.get('cognitoTemplateId')
-    const handle = req.params.handle
     const path = '/flow_sessions/retry'
     const method = 'POST'
     const body = JSON.stringify({


### PR DESCRIPTION
### Description

- Add endpoint to retry flow session for handle
- Add endpoint to check whether recent cognito entry exists
- Also add log for webhook error for more visibility.

### Tests

Tested manually by deploying to stage identity and calling the endpoints

### How will this change be monitored?

Added logs fr when it passes / fails


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->