### PR TITLE
issue sync requests on metadata upload

### DIFF
--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -84,6 +84,8 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db: ${e}`)
       }
 
+      issueAndWaitForSecondarySyncRequests(req)
+
       return successResponse({
         metadataMultihash: multihash,
         metadataFileUUID: fileUUID

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -84,6 +84,7 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db: ${e}`)
       }
 
+      // This call is not await-ed to avoid delaying or errorring
       issueAndWaitForSecondarySyncRequests(req)
 
       return successResponse({

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -181,6 +181,8 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db db: ${e}`)
       }
 
+      issueAndWaitForSecondarySyncRequests(req)
+
       return successResponse({
         metadataMultihash: multihash,
         metadataFileUUID: fileUUID

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -181,6 +181,7 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db db: ${e}`)
       }
 
+      // This call is not await-ed to avoid delaying or errorring
       issueAndWaitForSecondarySyncRequests(req)
 
       return successResponse({


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Issues sync requests to secondaries on metadata upload to improve data availability during indexing
Previously syncs were issued only after chain write which creates unavailability risk

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Calls existing function in same manner on a different route, that flow has already been tested

### How will this change be monitored?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

No direct way but should see fewer indexing stalls due to content unavail

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->