### PR TITLE
top playlists uses aggregate table

### DIFF
--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -75,6 +75,7 @@ def get_top_playlists(kind, args):
                 playlists_to_query.c.is_current == True,
                 playlists_to_query.c.is_delete == False,
                 playlists_to_query.c.is_private == False,
+                playlists_to_query.c.is_album == (kind == "album"),
             )
         )
 


### PR DESCRIPTION
### Description

Replaces count subquery with join on aggregate table for `get_top_playlists`.

### Tests

Loaded API JSON before and after change and confirmed same items in same order.

### How will this change be monitored? Are there sufficient logs?

GCP SQL panel


