### PR TITLE
Fix attestation reselection logic

### DIFF
--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -539,9 +539,9 @@ class Rewards extends Base {
     while (needsAttestations.length && retryCount <= maxAttempts)
 
     if (needsAttestations.length || unrecoverableError) {
-      logger.info(`Failed to aggregate attestations for challenge ${challengeId}, userId: ${encodedUserId}`)
+      logger.info(`Failed to aggregate attestations for challenge [${challengeId}], userId: [${decodeHashId(encodedUserId)}]`)
     } else {
-      logger.info(`Successfully aggregated attestations for challenge ${challengeId}, userId: ${encodedUserId}`)
+      logger.info(`Successfully aggregated attestations for challenge [${challengeId}], userId: [${decodeHashId(encodedUserId)}]`)
     }
     return completedAttestations
   }


### PR DESCRIPTION
### Description

- Fixes an recently introduced bug where we don't reselect off of INCOMPLETE/MISSING errors, because they were considered not retryable.
- Also breaks this code down to be more readable

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

- Testing on stage, will fast follow with a unit test 

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

- Same level of Reporter logs
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->