### PR TITLE
Add util in libs to convert from on chain digest -> CID

### DIFF
--- a/libs/src/utils/utils.js
+++ b/libs/src/utils/utils.js
@@ -106,6 +106,20 @@ class Utils {
       size: parseInt(base16Multihash[1])
     }
   }
+  /**
+ * Given a digest value (written on chain, obtained through AudiusABIDecoder.decodeMethod),
+ * convert back to a IFPS CIDv0
+ * @param {String} multihashDigest digest value from decodeMultihash
+ * @returns String CID value
+ */
+  static encodeMultihash (multihashDigest) {
+    // the 1220 is from reconstructing the hashFn and size with digest, the opposite of decodeMultihash
+    // since IPFS CIDv0 has a fixed hashFn and size, the first two values are always 12 and 20
+    // concat them together with digest and encode back to base58
+    var digestStr = `1220${multihashDigest.replace('0x', '')}`
+    // convert digestStr from hex to base 58
+    return bs58.encode(Buffer.from(digestStr, 'hex'))
+  }
 
   static parseDataFromResponse (response) {
     if (!response || !response.data) return null

--- a/libs/src/utils/utils.test.js
+++ b/libs/src/utils/utils.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert')
+const utils = require('./utils')
+
+describe('utils', () => {
+  it('should decodeMethod correctly', async () => {
+    const decoded = utils.decodeMultihash('QmWAoBkJzA1Ffur3aiVPr8h5YSV5aBxRFNeZDPmB7vnBQP')
+    assert.strictEqual(decoded.digest, '0x74574595073a25aaac18f1089239a26f8bceaf76cc29973d2be13352d2abca4c')
+    assert.strictEqual(decoded.hashFn, 18) // constant
+    assert.strictEqual(decoded.size, 32) // constant
+  })
+
+  it('should encodeMethod correctly with 0x prefix', async () => {
+    const encoded = utils.encodeMultihash('0x74574595073a25aaac18f1089239a26f8bceaf76cc29973d2be13352d2abca4c')
+    assert.strictEqual(encoded, 'QmWAoBkJzA1Ffur3aiVPr8h5YSV5aBxRFNeZDPmB7vnBQP')
+  })
+
+  it('should encodeMethod correctly without 0x prefix', async () => {
+    const encoded = utils.encodeMultihash('74574595073a25aaac18f1089239a26f8bceaf76cc29973d2be13352d2abca4c')
+    assert.strictEqual(encoded, 'QmWAoBkJzA1Ffur3aiVPr8h5YSV5aBxRFNeZDPmB7vnBQP')
+  })
+})


### PR DESCRIPTION
### Description
Adds a function to convert from AudiusABIDecoder.decodeMethod's multihashDigest property to a CID. Required for a companion notion page that finds all CIDs from the multihashDigest from on chain logs https://www.notion.so/audiusproject/Find-all-CIDs-in-block-ddbb3aac4c5143fdac9c991a4f7b78c6. Simple explanation of what this code does:
```
{
  name: 'updateMultihash',
  params: [
    { name: '_userId', value: '1234', type: 'uint256' },
    {
      name: '_multihashDigest',
      value: '0x4a7a53...',
      type: 'bytes32'
    },
    {
      name: '_nonce',
      value: '0x7816f...',
      type: 'bytes32'
    },
    {
      name: '_subjectSig',
      value: '0x1ef...',
      type: 'bytes'
    }
  ]
}

utils.encodeMultihash(_multihashDigest) returns Qm...
```
<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Added unit tests
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
Dev only feature, no logs or monitoring
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->