### PR TITLE
Need to account for TimeoutError here

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -355,18 +355,27 @@ def fetch_ipfs_metadata(
             futures.append(future)
             futures_map[future] = [cid, txhash]
 
-        for future in concurrent.futures.as_completed(
-            futures, timeout=NEW_BLOCK_TIMEOUT_SECONDS * 1.2
-        ):
-            cid, txhash = futures_map[future]
-            try:
-                ipfs_metadata[cid] = future.result()
-            except Exception as e:
-                logger.info("Error in fetch ipfs metadata")
-                blockhash = update_task.web3.toHex(block_hash)
-                raise IndexingError(
-                    "prefetch-cids", block_number, blockhash, txhash, str(e)
-                ) from e
+        try:
+            for future in concurrent.futures.as_completed(
+                futures, timeout=NEW_BLOCK_TIMEOUT_SECONDS * 1.2
+            ):
+                cid, txhash = futures_map[future]
+                try:
+                    ipfs_metadata[cid] = future.result()
+                except Exception as e:
+                    logger.info("Error in fetch ipfs metadata")
+                    blockhash = update_task.web3.toHex(block_hash)
+                    raise IndexingError(
+                        "prefetch-cids", block_number, blockhash, txhash, str(e)
+                    ) from e
+        except concurrent.futures.TimeoutError as exc:
+            logger.error(f"index.py | Timeout fetch_ipfs_metadata: {exc}")
+            # timeout in a ThreadPoolExecutor doesn't actually stop execution of the underlying thread
+            # in order to do that we need to actually clear the queue which we do here to force this
+            # task to stop execution
+            executor._threads.clear()
+            concurrent.futures.thread._threads_queues.clear()
+            raise exc
 
     return ipfs_metadata, blacklisted_cids
 


### PR DESCRIPTION
### Description
I think this is why the discovery indexing didn't time out after ~20s on Friday morning. I believe what was happening was the future was raising TimeoutError but since it didn't cancel the future, it actually completed every future and it either resolved or timed out. This would cancel all other jobs. Might be a possible no-op with @isaacsolo's async change

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->