### PR TITLE
Move contract init to start of indexing

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -262,15 +262,8 @@ def fetch_ipfs_metadata(
     block_number,
     block_hash,
 ):
-    track_abi = update_task.abi_values[TRACK_FACTORY_CONTRACT_NAME]["abi"]
-    track_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["track_factory"], abi=track_abi
-    )
-
-    user_abi = update_task.abi_values[USER_FACTORY_CONTRACT_NAME]["abi"]
-    user_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()[USER_FACTORY], abi=user_abi
-    )
+    user_contract = update_task.user_contract
+    track_contract = update_task.track_contract
 
     blacklisted_cids = set()
     cids = set()
@@ -1030,6 +1023,50 @@ def update_task(self):
     db = update_task.db
     web3 = update_task.web3
     redis = update_task.redis
+
+    # Initialize contracts and attach to the task singleton
+    track_abi = update_task.abi_values[TRACK_FACTORY_CONTRACT_NAME]["abi"]
+    track_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()["track_factory"], abi=track_abi
+    )
+
+    user_abi = update_task.abi_values[USER_FACTORY_CONTRACT_NAME]["abi"]
+    user_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()[USER_FACTORY], abi=user_abi
+    )
+
+    playlist_abi = update_task.abi_values[PLAYLIST_FACTORY_CONTRACT_NAME]["abi"]
+    playlist_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()[PLAYLIST_FACTORY], abi=playlist_abi
+    )
+
+    social_feature_abi = update_task.abi_values[SOCIAL_FEATURE_FACTORY_CONTRACT_NAME][
+        "abi"
+    ]
+    social_feature_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()[SOCIAL_FEATURE_FACTORY],
+        abi=social_feature_abi,
+    )
+
+    user_library_abi = update_task.abi_values[USER_LIBRARY_FACTORY_CONTRACT_NAME]["abi"]
+    user_library_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()[USER_LIBRARY_FACTORY], abi=user_library_abi
+    )
+
+    user_replica_set_manager_abi = update_task.abi_values[
+        USER_REPLICA_SET_MANAGER_CONTRACT_NAME
+    ]["abi"]
+    user_replica_set_manager_contract = update_task.web3.eth.contract(
+        address=get_contract_addresses()[USER_REPLICA_SET_MANAGER],
+        abi=user_replica_set_manager_abi,
+    )
+
+    update_task.track_contract = track_contract
+    update_task.user_contract = user_contract
+    update_task.playlist_contract = playlist_contract
+    update_task.social_feature_contract = social_feature_contract
+    update_task.user_library_contract = user_library_contract
+    update_task.user_replica_set_manager_contract = user_replica_set_manager_contract
 
     # Update redis cache for health check queries
     update_latest_block_redis()

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Any, Dict, Set, Tuple
 
 from sqlalchemy.orm.session import Session, make_transient
-from src.app import get_contract_addresses
 from src.database_task import DatabaseTask
 from src.models import Playlist
 from src.queries.skipped_transactions import add_node_level_skipped_transaction
@@ -115,11 +114,9 @@ def playlist_state_update(
 
 
 def get_playlist_events_tx(update_task, event_type, tx_receipt):
-    playlist_abi = update_task.abi_values["PlaylistFactory"]["abi"]
-    playlist_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["playlist_factory"], abi=playlist_abi
+    return getattr(update_task.playlist_contract.events, event_type)().processReceipt(
+        tx_receipt
     )
-    return getattr(playlist_contract.events, event_type)().processReceipt(tx_receipt)
 
 
 def lookup_playlist_record(update_task, session, entry, block_number, txhash):

--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Dict, Set, Tuple
 
 from sqlalchemy.orm.session import Session
-from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.database_task import DatabaseTask
@@ -31,11 +30,6 @@ def social_feature_state_update(
     if not social_feature_factory_txs:
         return num_total_changes, empty_set
 
-    social_feature_factory_abi = update_task.abi_values["SocialFeatureFactory"]["abi"]
-    social_feature_factory_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["social_feature_factory"],
-        abi=social_feature_factory_abi,
-    )
     challenge_bus = update_task.challenge_event_bus
     block_datetime = datetime.utcfromtimestamp(block_timestamp)
 
@@ -51,7 +45,7 @@ def social_feature_state_update(
         try:
             add_track_repost(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -61,7 +55,7 @@ def social_feature_state_update(
             )
             delete_track_repost(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -71,7 +65,7 @@ def social_feature_state_update(
             )
             add_playlist_repost(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -81,7 +75,7 @@ def social_feature_state_update(
             )
             delete_playlist_repost(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -91,7 +85,7 @@ def social_feature_state_update(
             )
             add_follow(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -101,7 +95,7 @@ def social_feature_state_update(
             )
             delete_follow(
                 self,
-                social_feature_factory_contract,
+                update_task.social_feature_contract,
                 update_task,
                 session,
                 tx_receipt,

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from sqlalchemy.orm.session import Session, make_transient
 from sqlalchemy.sql import functions, null
-from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.database_task import DatabaseTask
@@ -149,11 +148,9 @@ def track_state_update(
 
 
 def get_track_events_tx(update_task, event_type, tx_receipt):
-    track_abi = update_task.abi_values["TrackFactory"]["abi"]
-    track_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["track_factory"], abi=track_abi
+    return getattr(update_task.track_contract.events, event_type)().processReceipt(
+        tx_receipt
     )
-    return getattr(track_contract.events, event_type)().processReceipt(tx_receipt)
 
 
 def lookup_track_record(

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Dict, Set, Tuple
 
 from sqlalchemy.orm.session import Session
-from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.database_task import DatabaseTask
@@ -30,10 +29,6 @@ def user_library_state_update(
     if not user_library_factory_txs:
         return num_total_changes, empty_set
 
-    user_library_abi = update_task.abi_values["UserLibraryFactory"]["abi"]
-    user_library_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["user_library_factory"], abi=user_library_abi
-    )
     challenge_bus = update_task.challenge_event_bus
     block_datetime = datetime.utcfromtimestamp(block_timestamp)
 
@@ -44,7 +39,7 @@ def user_library_state_update(
         try:
             add_track_save(
                 self,
-                user_library_contract,
+                update_task.user_library_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -55,7 +50,7 @@ def user_library_state_update(
 
             add_playlist_save(
                 self,
-                user_library_contract,
+                update_task.user_library_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -66,7 +61,7 @@ def user_library_state_update(
 
             delete_track_save(
                 self,
-                user_library_contract,
+                update_task.user_library_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -77,7 +72,7 @@ def user_library_state_update(
 
             delete_playlist_save(
                 self,
-                user_library_contract,
+                update_task.user_library_contract,
                 update_task,
                 session,
                 tx_receipt,
@@ -149,8 +144,10 @@ def add_track_save(
     track_state_changes: Dict[int, Dict[int, Save]],
 ):
     txhash = update_task.web3.toHex(tx_receipt.transactionHash)
-    new_add_track_events = user_library_contract.events.TrackSaveAdded().processReceipt(
-        tx_receipt
+    new_add_track_events = (
+        update_task.user_library_contract.events.TrackSaveAdded().processReceipt(
+            tx_receipt
+        )
     )
 
     for event in new_add_track_events:
@@ -192,7 +189,9 @@ def add_playlist_save(
 ):
     txhash = update_task.web3.toHex(tx_receipt.transactionHash)
     new_add_playlist_events = (
-        user_library_contract.events.PlaylistSaveAdded().processReceipt(tx_receipt)
+        update_task.user_library_contract.events.PlaylistSaveAdded().processReceipt(
+            tx_receipt
+        )
     )
 
     for event in new_add_playlist_events:
@@ -247,7 +246,9 @@ def delete_track_save(
 ):
     txhash = update_task.web3.toHex(tx_receipt.transactionHash)
     new_delete_track_events = (
-        user_library_contract.events.TrackSaveDeleted().processReceipt(tx_receipt)
+        update_task.user_library_contract.events.TrackSaveDeleted().processReceipt(
+            tx_receipt
+        )
     )
     for event in new_delete_track_events:
         event_args = event["args"]
@@ -288,7 +289,9 @@ def delete_playlist_save(
 ):
     txhash = update_task.web3.toHex(tx_receipt.transactionHash)
     new_add_playlist_events = (
-        user_library_contract.events.PlaylistSaveDeleted().processReceipt(tx_receipt)
+        update_task.user_library_contract.events.PlaylistSaveDeleted().processReceipt(
+            tx_receipt
+        )
     )
 
     for event in new_add_playlist_events:

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Set, Tuple
 
 from sqlalchemy.orm.session import Session, make_transient
-from src.app import get_contract_addresses, get_eth_abi_values
+from src.app import get_eth_abi_values
 from src.database_task import DatabaseTask
 from src.models import URSMContentNode, User
 from src.queries.skipped_transactions import add_node_level_skipped_transaction
@@ -193,14 +193,9 @@ def user_replica_set_state_update(
 
 
 def get_user_replica_set_mgr_tx(update_task, event_type, tx_receipt):
-    user_replica_set_manager_abi = update_task.abi_values["UserReplicaSetManager"][
-        "abi"
-    ]
-    user_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["user_replica_set_manager"],
-        abi=user_replica_set_manager_abi,
-    )
-    return getattr(user_contract.events, event_type)().processReceipt(tx_receipt)
+    return getattr(
+        update_task.user_replica_set_manager_contract.events, event_type
+    )().processReceipt(tx_receipt)
 
 
 # Reconstruct endpoint string from primary and secondary IDs

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -8,7 +8,6 @@ from eth_account.messages import defunct_hash_message
 from nacl.encoding import HexEncoder
 from nacl.signing import VerifyKey
 from sqlalchemy.orm.session import Session, make_transient
-from src.app import get_contract_addresses
 from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.database_task import DatabaseTask
@@ -221,11 +220,9 @@ def process_user_txs_serial(
 
 
 def get_user_events_tx(update_task, event_type, tx_receipt):
-    user_abi = update_task.abi_values["UserFactory"]["abi"]
-    user_contract = update_task.web3.eth.contract(
-        address=get_contract_addresses()["user_factory"], abi=user_abi
+    return getattr(update_task.user_contract.events, event_type)().processReceipt(
+        tx_receipt
     )
-    return getattr(user_contract.events, event_type)().processReceipt(tx_receipt)
 
 
 def lookup_user_record(


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Move contract init to save a network calls during core indexing flow. This is the most expensive part of indexing and is totally needless!

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested against sandbox discovery node.
https://discoveryprovider.sandbox.audius.co/health_check

### How will this change be monitored? Are there sufficient logs?

Index_block time in verbose health check

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->