### PR TITLE
[ASI-901] Ensure eth address array always has 20 bytes length

### DIFF
--- a/solana-programs/anchor/audius-data/lib/utils.ts
+++ b/solana-programs/anchor/audius-data/lib/utils.ts
@@ -13,7 +13,7 @@ export const SystemSysVarProgramKey = new PublicKey(
 /// Convert a string input to output array of Uint8
 export const ethAddressToArray = (ethAddress: string) => {
   const strippedEthAddress = ethAddress.replace("0x", "");
-  return Uint8Array.of(...new BN(strippedEthAddress, "hex").toArray("be"));
+  return Uint8Array.of(...new BN(strippedEthAddress, "hex").toArray("be", 20));
 };
 
 /// Retrieve a transaction with retries


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

No op. Error was not reproducible, might be fixed in new web3 version. Ensure array length is 20 to be consistent with [solanaWeb3Manager](https://github.com/AudiusProject/audius-protocol/blob/master/libs/src/services/solanaWeb3Manager/utils.js#L153).

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

All tests pass.

### How will this change be monitored? Are there sufficient logs?

No monitoring needed.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->