### PR TITLE
Rename /metrics -> /prometheus_metrics

### DIFF
--- a/discovery-provider/src/queries/prometheus_metrics_exporter.py
+++ b/discovery-provider/src/queries/prometheus_metrics_exporter.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 bp = Blueprint("prometheus_metrics_exporter", __name__)
 
 
-@bp.route("/metrics", methods=["GET"])
+@bp.route("/prometheus_metrics", methods=["GET"])
 def prometheus_metrics_exporter():
     registry = CollectorRegistry()
     multiprocess.MultiProcessCollector(registry)


### PR DESCRIPTION
### Description

Rename the new prometheus /metrics to be /prometheus_metrics to avoid logical collisions with our internal metrics.

### Tests

N/A

### How will this change be monitored? Are there sufficient logs?

Running a load test while actively monitoring the new endpoint.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->