### PR TITLE
Return error status for authentication errors

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -189,7 +189,7 @@ class Account extends Base {
       phase = phases.UPLOAD_PROFILE_IMAGES
       await this.User.uploadProfileImages(profilePictureFile, coverPhotoFile, metadata)
     } catch (e) {
-      return { error: e.message, phase }
+      return { error: e.message, phase, errorStatus: e.response ? e.response.status : null }
     }
     return { blockHash, blockNumber, userId }
   }


### PR DESCRIPTION
### Description

Hedgehog sometimes return 429. Handle that better by sending error status to client.

### Tests

Manual test in client.

### How will this change be monitored? Are there sufficient logs?

Is it worth reporting to Sentry but not paging or tweaking the alert trigger somehow?
Or reporting a diff erro type to sentry that does not page?


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->