### PR TITLE
Reduce high-cardinality Prometheus metric labels from flask routes

### DIFF
--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -643,7 +643,7 @@ def record_metrics(func):
         metric = PrometheusMetric(
             "flask_route_latency_seconds",
             "Runtimes for flask routes",
-            ("route"),
+            ("route",),
         )
         result = func(*args, **kwargs)
 

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -643,13 +643,13 @@ def record_metrics(func):
         metric = PrometheusMetric(
             "flask_route_latency_seconds",
             "Runtimes for flask routes",
-            ("route", "params"),
+            ("route"),
         )
         result = func(*args, **kwargs)
 
         params = "".join(route.split("?")[1:])
         route = route.split("?")[0]
-        metric.save_time({"route": route, "params": params})
+        metric.save_time({"route": route})
 
         return result
 

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -647,7 +647,6 @@ def record_metrics(func):
         )
         result = func(*args, **kwargs)
 
-        params = "".join(route.split("?")[1:])
         route = route.split("?")[0]
         metric.save_time({"route": route})
 


### PR DESCRIPTION
### Description

The official docs state that we should not use labels with high-cardinality:

> CAUTION: Remember that every unique combination of key-value label pairs represents a new time series, which can dramatically increase the amount of data stored. Do not use labels to store dimensions with high cardinality (many different label values), such as user IDs, email addresses, or other unbounded sets of values.
> 
> Source: https://prometheus.io/docs/practices/naming/

We were including our flask parameters as labels and have thus introduced high-cardinality dimensions.

### Tests

We should continue to see flask metrics within Grafana.

### How will this change be monitored? Are there sufficient logs?

We should continue to see flask metrics within Grafana.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->