### PR TITLE
further limit the amount of metrics generated

### DIFF
--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -648,6 +648,10 @@ def record_metrics(func):
         result = func(*args, **kwargs)
 
         route = route.split("?")[0]
+        if "/v1/full/" in route or "/users/intersection/" in route:
+            route = "/".join(route.split("/")[:4])
+        else:
+            route = "/".join(route.split("/")[:3])
         metric.save_time({"route": route})
 
         return result


### PR DESCRIPTION
### Description

There were quite a few unique flask routes being recorded from discoveryprovider3.audius.co. Since discoveryprovider3.audius.co just had a memory leak + high CPU, we'll further restrict the flask-generated metrics for this first release.

### Tests

Ensure each node produces few unique urls via Grafana.

### How will this change be monitored? Are there sufficient logs?

Ensure each node produces few unique urls via Grafana.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->