### PR TITLE
record /followers and /following metrics

### DIFF
--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -650,6 +650,8 @@ def record_metrics(func):
         route = route.split("?")[0]
         if "/v1/full/" in route or "/users/intersection/" in route:
             route = "/".join(route.split("/")[:4])
+        elif "/v1/users/" in route and ("/followers" in route or "/following" in route):
+            route = "/".join(route.split("/")[:3] + ["*"] + route.split("/")[-1:])
         else:
             route = "/".join(route.split("/")[:3])
         metric.save_time({"route": route})


### PR DESCRIPTION
### Description

We are currently only recording metrics as `/v1/users/` for all `/v1/users/*` routes.

Since we're looking at `/followers` performance, we should also expose metrics for those routes.

This PR introduces two new metrics in addition to the previous `/v1/users/` metric:

* `/v1/users/*/followers`
* `/v1/users/*/following`

### Tests

The two metrics should be ingested by Prometheus and exposed by Grafana.

### How will this change be monitored? Are there sufficient logs?

The two metrics should be ingested by Prometheus and exposed by Grafana.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->