### PR TITLE
allow skipping recovery link generation for test purposes

### DIFF
--- a/libs/src/api/account.js
+++ b/libs/src/api/account.js
@@ -105,6 +105,7 @@ class Account extends Base {
    * @param {?Function} [handleUserBankOutcomes] an optional callback to record user bank outcomes
    * @param {?Object} [userBankOutcomes] an optional object with request, succes, and failure keys to record user bank outcomes
    * @param {?string} [feePayerOverride] an optional string in case the client wants to switch between fee payers
+   * @param {?boolean} [generateRecoveryLink] an optional flag to skip generating recovery link for testing purposes
   */
   async signUp (
     email,
@@ -117,7 +118,8 @@ class Account extends Base {
     createWAudioUserBank = false,
     handleUserBankOutcomes = () => {},
     userBankOutcomes = {},
-    feePayerOverride = null
+    feePayerOverride = null,
+    generateRecoveryLink = true
   ) {
     const phases = {
       ADD_REPLICA_SET: 'ADD_REPLICA_SET',
@@ -143,7 +145,9 @@ class Account extends Base {
           phase = phases.HEDGEHOG_SIGNUP
           const ownerWallet = await this.hedgehog.signUp(email, password)
           await this.web3Manager.setOwnerWallet(ownerWallet)
-          await this.generateRecoveryLink({ handle: metadata.handle, host })
+          if (generateRecoveryLink) {
+            await this.generateRecoveryLink({ handle: metadata.handle, host })
+          }
         }
       }
 


### PR DESCRIPTION
### Description

During testing, I don't care if recovery links are able to be generated, but I also see a lot of noise when recovery links couldn't be generated. To make things cleaner, I've added an optional parameter to allow us to skip the skip generating recovery links.

### Tests

The default logic continues to generate recovery links. My test cases should no longer see recovery links being generated.

### How will this change be monitored? Are there sufficient logs?

Tests should see cleaner logs.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->