### PR TITLE
skip vacuum after updating search tables

### DIFF
--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -39,7 +39,7 @@ def update_views(self, db):
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
 
-    vacuum_matviews(db)
+    # vacuum_matviews(db)
 
     logger.info(
         f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time} sec."


### PR DESCRIPTION
### Description

Skip vacuum when updating search mat views to reduce DB load.  There is still a daily `vacuum` task that should be sufficient.

### Tests

Tested on sandbox-3.

### How will this change be monitored? Are there sufficient logs?

GCP SQL panel