### PR TITLE
accept different result types for @record_metrics

### DIFF
--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -4,6 +4,7 @@ import logging  # pylint: disable=C0302
 from datetime import datetime, timedelta
 
 import redis
+from flask import Response
 from flask.globals import request
 from src.models import (
     AggregateDailyAppNameMetrics,
@@ -652,13 +653,16 @@ def record_metrics(func):
         result = func(*args, **kwargs)
 
         try:
-            code = result[1]
+            if isinstance(result, Response):
+                code = result.status_code
+            else:
+                code = result[1]
         except Exception as e:
             code = -1
             logger.error(
                 "Error extracting response code from type<%s>: %s",
                 type(result),
-                e.message,
+                e,
             )
 
         route = route.split("?")[0]

--- a/service-commands/scripts/provision-dev-env.sh
+++ b/service-commands/scripts/provision-dev-env.sh
@@ -68,8 +68,11 @@ function setup_python() {
     sudo add-apt-repository ppa:deadsnakes/ppa # python3.9 installation
     sudo apt install -y "python$PYTHON_VERSION"
     sudo apt install -y "python$PYTHON_VERSION-dev"
-    pip install wheel yq
-    pip install pre-commit==2.16.0
+    pip install \
+        ipython \
+        pre-commit==2.16.0 \
+        wheel \
+        yq
 
     (
         cd $PROTOCOL_DIR/discovery-provider


### PR DESCRIPTION
### Description

We saw issues where result was a `Response` that raised a `TypeError` which does not include a `message`.

We no longer extract messages for the log message and extract status codes from `Response`s correctly.

### Tests

Monitor staging and soaking production nodes for error logs.

### How will this change be monitored? Are there sufficient logs?

N/A


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->