### PR TITLE
Fix folder model again

### DIFF
--- a/discovery-provider/src/api/v1/models/playlist_library.py
+++ b/discovery-provider/src/api/v1/models/playlist_library.py
@@ -32,7 +32,7 @@ class PlaylistLibraryIdentifier(fields.Raw):
                 return marshal(value, playlist_library_folder)
         except Exception as e:
             raise MarshallingError(
-                "Unable to marshal as playlist library identifier"
+                "Unable to marshal as playlist library identifier: " + value
             ) from e
 
     def output(self, key, obj, **kwargs):
@@ -42,7 +42,7 @@ class PlaylistLibraryIdentifier(fields.Raw):
 playlist_library_folder = ns.model(
     "playlist_library_folder",
     {
-        "type": "folder",
+        "type": fields.FormattedString("folder"),
         "id": fields.String(required=True),
         "name": fields.String(required=True),
         "contents": fields.List(PlaylistLibraryIdentifier),

--- a/discovery-provider/src/api/v1/models/playlist_library.py
+++ b/discovery-provider/src/api/v1/models/playlist_library.py
@@ -33,7 +33,7 @@ class PlaylistLibraryIdentifier(fields.Raw):
                 return marshal(value, playlist_library_folder)
         except Exception as e:
             raise MarshallingError(
-                "Unable to marshal as playlist library identifier: " + value
+                f"Unable to marshal as playlist library identifier: {str(value)}"
             ) from e
 
     def output(self, key, obj, **kwargs):

--- a/discovery-provider/src/api/v1/models/playlist_library.py
+++ b/discovery-provider/src/api/v1/models/playlist_library.py
@@ -7,6 +7,7 @@ from .common import ns
 playlist_identifier = ns.model(
     "playlist_identifier",
     {
+        # Use `FormattedString`s in these models to act as a constant via the source string arg ("playlist" here)
         "type": fields.FormattedString("playlist"),
         "playlist_id": fields.Integer(required=True),
     },


### PR DESCRIPTION
### Description
Fixes issue where discovery node full user endpoint would fail for any user that had a playlist folder in their library due to incorrect Flask model. 
Full context here:
https://audius-internal.slack.com/archives/CA80RCL77/p1647017223805299

I thought [my last PR](https://audius-internal.slack.com/archives/CA80RCL77/p1647021978829119?thread_ts=1647017223.805299&cid=CA80RCL77) would have fixed this but turns out there was one last issue here.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->
Tested in browser running client against remote dev box 
<img width="531" alt="Screen Shot 2022-03-14 at 11 37 09 AM" src="https://user-images.githubusercontent.com/36916764/158207490-bf06e692-36f2-4969-a496-25d77fcf61c3.png">
<img width="944" alt="Screen Shot 2022-03-14 at 11 37 21 AM" src="https://user-images.githubusercontent.com/36916764/158207492-b97c64e2-4294-46ba-844b-31efc28b237f.png">
<img width="1110" alt="Screen Shot 2022-03-14 at 11 37 52 AM" src="https://user-images.githubusercontent.com/36916764/158207493-c91cffe2-2641-40d2-b485-33b5522c8e8b.png">


### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->