### PR TITLE
[AUD-1725] Add base rollup config to libs

### DIFF
--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -12,3 +12,4 @@ initScripts/*-config.json
 .npmrc
 .nyc_output/*
 coverage/
+dist

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -822,6 +822,63 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@rollup/plugin-commonjs": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
+      "integrity": "sha512-d/OmjaLVO4j/aQX69bwpWPpbvI3TJkQuxoAk7BH8ew1PyoMBLTOuvJTjzG8oEoW7drIIqB0KCJtfFLu/2GClWg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
+      "integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2201,6 +2258,12 @@
         "@types/node": "*"
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/express-serve-static-core": {
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
@@ -2243,6 +2306,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -3182,6 +3254,12 @@
         "node-gyp-build": "^4.3.0"
       }
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
@@ -3796,6 +3874,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "default-require-extensions": {
@@ -4502,6 +4586,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
@@ -5254,6 +5344,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5818,6 +5915,12 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -5848,6 +5951,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "is-regex": {
       "version": "1.1.4",
@@ -6364,6 +6476,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
     },
     "make-dir": {
       "version": "1.3.0",
@@ -7150,6 +7271,12 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -7773,6 +7900,15 @@
         }
       }
     },
+    "rollup": {
+      "version": "2.70.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
+      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "rpc-websockets": {
       "version": "7.4.16",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.16.tgz",
@@ -8088,6 +8224,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spawn-wrap": {
       "version": "2.0.0",

--- a/libs/package.json
+++ b/libs/package.json
@@ -2,7 +2,7 @@
   "name": "@audius/libs",
   "version": "1.2.92",
   "description": "",
-  "main": "src/index.js",
+  "main": "dist/index.cjs.js",
   "browser": {
     "fs": false,
     "node-localstorage": false,
@@ -15,6 +15,8 @@
     "test-circle-ci": "./scripts/circleci-test.sh",
     "test:units": "mocha './src/**/*.test.js' --exit",
     "setup": "./scripts/migrate_contracts.sh",
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
     "lint": "./node_modules/.bin/standard",
     "lint:fix": "./node_modules/.bin/standard --fix"
   },
@@ -49,9 +51,13 @@
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "0.5.6",
+    "@rollup/plugin-commonjs": "^21.0.2",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.1.3",
     "mocha": "5.2.0",
     "nock": "13.1.2",
     "nyc": "15.1.0",
+    "rollup": "^2.70.1",
     "sinon": "9.0.2",
     "standard": "12.0.1"
   },

--- a/libs/package.json
+++ b/libs/package.json
@@ -2,7 +2,8 @@
   "name": "@audius/libs",
   "version": "1.2.92",
   "description": "",
-  "main": "dist/index.cjs.js",
+  "main": "src/index.js",
+  "mainDist": "dist/index.cjs.js",
   "browser": {
     "fs": false,
     "node-localstorage": false,

--- a/libs/package.json
+++ b/libs/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.92",
   "description": "",
   "main": "src/index.js",
-  "mainDist": "dist/index.cjs.js",
+  "mainDist": "dist/index.js",
   "browser": {
     "fs": false,
     "node-localstorage": false,
@@ -52,9 +52,9 @@
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "0.5.6",
-    "@rollup/plugin-commonjs": "^21.0.2",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-commonjs": "21.0.2",
+    "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-node-resolve": "13.1.3",
     "mocha": "5.2.0",
     "nock": "13.1.2",
     "nyc": "15.1.0",

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -1,0 +1,55 @@
+import pkg from "./package.json";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+
+export default {
+  input: "src/index.js",
+  output: [{ file: pkg.main, format: "cjs" }],
+  plugins: [
+    json(),
+    commonjs({
+      dynamicRequireTargets: [
+        "data-contracts/ABIs/*.json",
+        "eth-contracts/ABIs/*.json",
+      ],
+    }),
+  ],
+  external: [
+    "@audius/hedgehog",
+    "@certusone/wormhole-sdk",
+    "@ethersproject/solidity",
+    "@solana/spl-token",
+    "@solana/web3.js",
+    "ajv",
+    "async-retry",
+    "axios",
+    "borsh",
+    "bs58",
+    "elliptic",
+    "esm",
+    "eth-sig-util",
+    "ethereumjs-tx",
+    "ethereumjs-util",
+    "ethereumjs-wallet",
+    "ethers",
+    "ethers/lib/utils",
+    "ethers/lib/index",
+    "form-data",
+    "hashids",
+    "jsonschema",
+    "lodash",
+    "node-localstorage",
+    "proper-url-join",
+    "semver",
+    "web3",
+    "xmlhttprequest",
+    "abi-decoder",
+    "bn.js",
+    "keccak256",
+    "secp256k1",
+    "assert",
+    "util",
+    "hashids/cjs",
+    "safe-buffer",
+  ],
+};

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -1,18 +1,22 @@
 import pkg from './package.json'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
+import resolve from '@rollup/plugin-node-resolve'
 
 export default {
   input: 'src/index.js',
-  output: [{ file: pkg.main, format: 'cjs' }],
+  output: [
+    { file: pkg.mainDist, format: 'cjs', exports: 'named', sourcemap: true }
+  ],
   plugins: [
-    json(),
     commonjs({
       dynamicRequireTargets: [
         'data-contracts/ABIs/*.json',
         'eth-contracts/ABIs/*.json'
       ]
-    })
+    }),
+    json(),
+    resolve({ preferBuiltins: true })
   ],
   external: [
     '@audius/hedgehog',

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -1,55 +1,55 @@
-import pkg from "./package.json";
-import commonjs from "@rollup/plugin-commonjs";
-import json from "@rollup/plugin-json";
+import pkg from './package.json'
+import commonjs from '@rollup/plugin-commonjs'
+import json from '@rollup/plugin-json'
 
 export default {
-  input: "src/index.js",
-  output: [{ file: pkg.main, format: "cjs" }],
+  input: 'src/index.js',
+  output: [{ file: pkg.main, format: 'cjs' }],
   plugins: [
     json(),
     commonjs({
       dynamicRequireTargets: [
-        "data-contracts/ABIs/*.json",
-        "eth-contracts/ABIs/*.json",
-      ],
-    }),
+        'data-contracts/ABIs/*.json',
+        'eth-contracts/ABIs/*.json'
+      ]
+    })
   ],
   external: [
-    "@audius/hedgehog",
-    "@certusone/wormhole-sdk",
-    "@ethersproject/solidity",
-    "@solana/spl-token",
-    "@solana/web3.js",
-    "ajv",
-    "async-retry",
-    "axios",
-    "borsh",
-    "bs58",
-    "elliptic",
-    "esm",
-    "eth-sig-util",
-    "ethereumjs-tx",
-    "ethereumjs-util",
-    "ethereumjs-wallet",
-    "ethers",
-    "ethers/lib/utils",
-    "ethers/lib/index",
-    "form-data",
-    "hashids",
-    "jsonschema",
-    "lodash",
-    "node-localstorage",
-    "proper-url-join",
-    "semver",
-    "web3",
-    "xmlhttprequest",
-    "abi-decoder",
-    "bn.js",
-    "keccak256",
-    "secp256k1",
-    "assert",
-    "util",
-    "hashids/cjs",
-    "safe-buffer",
-  ],
-};
+    '@audius/hedgehog',
+    '@certusone/wormhole-sdk',
+    '@ethersproject/solidity',
+    '@solana/spl-token',
+    '@solana/web3.js',
+    'ajv',
+    'async-retry',
+    'axios',
+    'borsh',
+    'bs58',
+    'elliptic',
+    'esm',
+    'eth-sig-util',
+    'ethereumjs-tx',
+    'ethereumjs-util',
+    'ethereumjs-wallet',
+    'ethers',
+    'ethers/lib/utils',
+    'ethers/lib/index',
+    'form-data',
+    'hashids',
+    'jsonschema',
+    'lodash',
+    'node-localstorage',
+    'proper-url-join',
+    'semver',
+    'web3',
+    'xmlhttprequest',
+    'abi-decoder',
+    'bn.js',
+    'keccak256',
+    'secp256k1',
+    'assert',
+    'util',
+    'hashids/cjs',
+    'safe-buffer'
+  ]
+}


### PR DESCRIPTION
### Description

Adds base rollup config to libs. This helps ensure libs is compiled in a performant way, and paves the way towards a typescript + es-modules refactor.

### Open question

Since libs needs to be built before publish, not sure what the best approach is for that