### PR TITLE
Add solana ursm

### DIFF
--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -110,7 +110,7 @@ async function initUserCLI(args: initUserCLIParams) {
   } = args;
   const cliVars = initializeCLI(network, ownerKeypairPath);
   const handleBytes = Buffer.from(anchor.utils.bytes.utf8.encode(handle));
-  const handleBytesArray = Array.from({ ...handleBytes, length: 16 });
+  const handleBytesArray = Array.from({ ...handleBytes, length: 32 });
   const { baseAuthorityAccount, bumpSeed, derivedAddress } =
     await findDerivedPair(
       cliVars.program.programId,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -212,6 +212,32 @@ type PublicCreateContentNode = {
   proposer3: Proposer;
 };
 
+type PublicUpdateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  cn: Proposer;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
+};
+
+/// Create a content node with proposers
+type PublicDeleteContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  adminAuthorityPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  cnDelete: Proposer;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
+};
+
 /// Initialize an Audius Admin instance
 export const initAdmin = async ({
   provider,
@@ -419,18 +445,6 @@ export const publicCreateContentNode = async ({
 };
 
 /// Update a content node with proposers
-type PublicUpdateContentNode = {
-  provider: Provider;
-  program: Program<AudiusData>;
-  adminStgPublicKey: anchor.web3.PublicKey;
-  baseAuthorityAccount: anchor.web3.PublicKey;
-  contentNodeAcct: anchor.web3.PublicKey;
-  contentNodeAuthority: anchor.web3.PublicKey;
-  cn: Proposer;
-  proposer1: Proposer;
-  proposer2: Proposer;
-  proposer3: Proposer;
-};
 export const publicUpdateContentNode = async ({
   provider,
   program,
@@ -468,18 +482,6 @@ export const publicUpdateContentNode = async ({
   );
 };
 
-/// Create a content node with proposers
-type PublicDeleteContentNode = {
-  provider: Provider;
-  program: Program<AudiusData>;
-  adminStgPublicKey: anchor.web3.PublicKey;
-  adminAuthorityPublicKey: anchor.web3.PublicKey;
-  baseAuthorityAccount: anchor.web3.PublicKey;
-  cnDelete: Proposer;
-  proposer1: Proposer;
-  proposer2: Proposer;
-  proposer3: Proposer;
-};
 export const publicDeleteContentNode = async ({
   provider,
   program,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -354,8 +354,8 @@ type PublicDeleteContentNode = {
   provider: Provider;
   program: Program<AudiusData>;
   adminStgPublicKey: anchor.web3.PublicKey;
+  adminAuthorityPublicKey: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
-  contentNodeAcct: anchor.web3.PublicKey;
   cnDelete: Proposer,
   proposer1: Proposer,
   proposer2: Proposer,
@@ -365,8 +365,8 @@ export const publicDeleteContentNode = async ({
   provider,
   program,
   adminStgPublicKey,
+  adminAuthorityPublicKey,
   baseAuthorityAccount,
-  contentNodeAcct,
   cnDelete,
   proposer1,
   proposer2,
@@ -382,8 +382,9 @@ export const publicDeleteContentNode = async ({
     {
       accounts: {
         admin: adminStgPublicKey,
+        adminAuthority: adminAuthorityPublicKey,
         payer: provider.wallet.publicKey,
-        contentNode: contentNodeAcct,
+        contentNode: cnDelete.pda,
         systemProgram: SystemProgram.programId,
         proposer1: proposer1.pda,
         proposer1Authority: proposer1.authority.publicKey,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -248,6 +248,156 @@ export const initUserSolPubkey = async ({
   return provider.send(tx);
 };
 
+/// Verify user with authenticatorKeypair
+type CreateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminKeypair: Keypair;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  spID: anchor.BN,
+  ownerEthAddress: string
+};
+export const createContentNode = async ({
+  provider,
+  program,
+  adminStgPublicKey,
+  adminKeypair,
+  baseAuthorityAccount,
+  spID,
+  contentNodeAuthority,
+  contentNodeAcct,
+  ownerEthAddress
+}: CreateContentNode) => {
+  return program.rpc.createContentNode(
+    baseAuthorityAccount,
+    spID.toNumber(),
+    contentNodeAuthority,
+    [...anchor.utils.bytes.hex.decode(ownerEthAddress)],
+    {
+      accounts: {
+        admin: adminStgPublicKey,
+        payer: provider.wallet.publicKey,
+        contentNode: contentNodeAcct,
+        authority: adminKeypair.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      signers: [adminKeypair],
+    }
+  );
+};
+
+type Proposer = {
+  pda: anchor.web3.PublicKey,
+  authority: anchor.web3.Keypair,
+  seedBump: { seed: Buffer, bump: number }
+}
+
+/// Create a content node with proposers
+type PublicCreateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  spID: anchor.BN,
+  ownerEthAddress: string,
+  proposer1: Proposer,
+  proposer2: Proposer,
+  proposer3: Proposer,
+};
+export const publicCreateContentNode = async ({
+  provider,
+  program,
+  adminStgPublicKey,
+  baseAuthorityAccount,
+  spID,
+  contentNodeAcct,
+  ownerEthAddress,
+  contentNodeAuthority,
+  proposer1,
+  proposer2,
+  proposer3,
+}: PublicCreateContentNode) => {
+
+  return program.rpc.publicCreateContentNode(
+    baseAuthorityAccount,
+    { seed: [...proposer1.seedBump.seed], bump: proposer1.seedBump.bump },
+    { seed: [...proposer2.seedBump.seed], bump: proposer2.seedBump.bump },
+    { seed: [...proposer3.seedBump.seed], bump: proposer3.seedBump.bump },
+    spID.toNumber(),
+    contentNodeAuthority,
+    [...anchor.utils.bytes.hex.decode(ownerEthAddress)],
+    {
+      accounts: {
+        admin: adminStgPublicKey,
+        payer: provider.wallet.publicKey,
+        contentNode: contentNodeAcct,
+        systemProgram: SystemProgram.programId,
+        proposer1: proposer1.pda,
+        proposer1Authority: proposer1.authority.publicKey,
+        proposer2: proposer2.pda,
+        proposer2Authority: proposer2.authority.publicKey,
+        proposer3: proposer3.pda,
+        proposer3Authority: proposer3.authority.publicKey
+      },
+      signers: [proposer1.authority, proposer2.authority, proposer3.authority],
+    }
+  );
+};
+
+/// Create a content node with proposers
+type PublicDeleteContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  cnDelete: Proposer,
+  proposer1: Proposer,
+  proposer2: Proposer,
+  proposer3: Proposer,
+};
+export const publicDeleteContentNode = async ({
+  provider,
+  program,
+  adminStgPublicKey,
+  baseAuthorityAccount,
+  contentNodeAcct,
+  cnDelete,
+  proposer1,
+  proposer2,
+  proposer3,
+}: PublicDeleteContentNode) => {
+
+  return program.rpc.publicDeleteContentNode(
+    baseAuthorityAccount,
+    { seed: [...cnDelete.seedBump.seed], bump: cnDelete.seedBump.bump },
+    { seed: [...proposer1.seedBump.seed], bump: proposer1.seedBump.bump },
+    { seed: [...proposer2.seedBump.seed], bump: proposer2.seedBump.bump },
+    { seed: [...proposer3.seedBump.seed], bump: proposer3.seedBump.bump },
+    {
+      accounts: {
+        admin: adminStgPublicKey,
+        payer: provider.wallet.publicKey,
+        contentNode: contentNodeAcct,
+        systemProgram: SystemProgram.programId,
+        proposer1: proposer1.pda,
+        proposer1Authority: proposer1.authority.publicKey,
+        proposer2: proposer2.pda,
+        proposer2Authority: proposer2.authority.publicKey,
+        proposer3: proposer3.pda,
+        proposer3Authority: proposer3.authority.publicKey
+      },
+      signers: [proposer1.authority, proposer2.authority, proposer3.authority],
+    }
+  );
+};
+
+
 /// Create a user without Audius Admin account
 
 export const createUser = async ({

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -418,6 +418,56 @@ export const publicCreateContentNode = async ({
   );
 };
 
+/// Update a content node with proposers
+type PublicUpdateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  cn: Proposer;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
+};
+export const publicUpdateContentNode = async ({
+  provider,
+  program,
+  adminStgPublicKey,
+  baseAuthorityAccount,
+  contentNodeAcct,
+  contentNodeAuthority,
+  cn,
+  proposer1,
+  proposer2,
+  proposer3,
+}: PublicUpdateContentNode) => {
+  return program.rpc.publicUpdateContentNode(
+    baseAuthorityAccount,
+    { seed: [...cn.seedBump.seed], bump: cn.seedBump.bump },
+    { seed: [...proposer1.seedBump.seed], bump: proposer1.seedBump.bump },
+    { seed: [...proposer2.seedBump.seed], bump: proposer2.seedBump.bump },
+    { seed: [...proposer3.seedBump.seed], bump: proposer3.seedBump.bump },
+    contentNodeAuthority,
+    {
+      accounts: {
+        admin: adminStgPublicKey,
+        payer: provider.wallet.publicKey,
+        contentNode: contentNodeAcct,
+        systemProgram: SystemProgram.programId,
+        proposer1: proposer1.pda,
+        proposer1Authority: proposer1.authority.publicKey,
+        proposer2: proposer2.pda,
+        proposer2Authority: proposer2.authority.publicKey,
+        proposer3: proposer3.pda,
+        proposer3Authority: proposer3.authority.publicKey,
+      },
+      signers: [proposer1.authority, proposer2.authority, proposer3.authority],
+    }
+  );
+};
+
 /// Create a content node with proposers
 type PublicDeleteContentNode = {
   provider: Provider;

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -48,8 +48,8 @@ type InitUserParams = {
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminStgKey: anchor.web3.PublicKey;
   adminKeypair: anchor.web3.Keypair;
-  ursm: number[];
-  ursmBumps: number[];
+  replicaSet: number[];
+  replicaSetBumps: number[];
   cn1: anchor.web3.PublicKey;
   cn2: anchor.web3.PublicKey;
   cn3: anchor.web3.PublicKey;
@@ -67,8 +67,8 @@ type CreateUserParams = {
   userStgAccount: anchor.web3.PublicKey;
   adminStgPublicKey: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
-  ursm: number[];
-  ursmBumps: number[];
+  replicaSet: number[];
+  replicaSetBumps: number[];
   cn1: anchor.web3.PublicKey;
   cn2: anchor.web3.PublicKey;
   cn3: anchor.web3.PublicKey;
@@ -144,6 +144,35 @@ type DeleteEntityParams = {
   bumpSeed: number;
 };
 
+/// Create a content node with the audius admin authority
+type CreateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminKeypair: Keypair;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  spID: anchor.BN;
+  ownerEthAddress: string;
+};
+
+/// Verify user with authenticatorKeypair
+type UpdateUserReplicaSet = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  replicaSet: number[];
+  replicaSetBumps: number[];
+  contentNodeAuthority: anchor.web3.Keypair;
+  cn1: anchor.web3.PublicKey;
+  cn2: anchor.web3.PublicKey;
+  cn3: anchor.web3.PublicKey;
+  userAcct: anchor.web3.PublicKey;
+  userHandle: { seed: number[]; bump: number };
+}; 
+
 export const EntitySocialActionEnumValues = {
   addSave: { addSave: {} },
   deleteSave: { deleteSave: {} },
@@ -162,8 +191,28 @@ type EntitySocialActionArgs = {
   id: string;
 };
 
-/// Initialize an Audius Admin instance
+type Proposer = {
+  pda: anchor.web3.PublicKey;
+  authority: anchor.web3.Keypair;
+  seedBump: { seed: Buffer; bump: number };
+};
 
+/// Create a content node with proposers
+type PublicCreateContentNode = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  contentNodeAcct: anchor.web3.PublicKey;
+  contentNodeAuthority: anchor.web3.PublicKey;
+  spID: anchor.BN;
+  ownerEthAddress: string;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
+};
+
+/// Initialize an Audius Admin instance
 export const initAdmin = async ({
   provider,
   program,
@@ -192,8 +241,8 @@ export const initUser = async ({
   ethAddress,
   handleBytesArray,
   bumpSeed,
-  ursm,
-  ursmBumps,
+  replicaSet,
+  replicaSetBumps,
   metadata,
   userStgAccount,
   baseAuthorityAccount,
@@ -206,8 +255,8 @@ export const initUser = async ({
   return program.rpc.initUser(
     baseAuthorityAccount,
     [...anchor.utils.bytes.hex.decode(ethAddress)],
-    ursm,
-    ursmBumps,
+    replicaSet,
+    replicaSetBumps,
     handleBytesArray,
     bumpSeed,
     metadata,
@@ -228,7 +277,6 @@ export const initUser = async ({
 };
 
 /// Claim a user's account using given an eth private key
-
 export const initUserSolPubkey = async ({
   provider,
   program,
@@ -267,18 +315,6 @@ export const initUserSolPubkey = async ({
   return provider.send(tx);
 };
 
-/// Create a content node with the audius admin authority
-type CreateContentNode = {
-  provider: Provider;
-  program: Program<AudiusData>;
-  adminKeypair: Keypair;
-  adminStgPublicKey: anchor.web3.PublicKey;
-  baseAuthorityAccount: anchor.web3.PublicKey;
-  contentNodeAcct: anchor.web3.PublicKey;
-  contentNodeAuthority: anchor.web3.PublicKey;
-  spID: anchor.BN;
-  ownerEthAddress: string;
-};
 export const createContentNode = async ({
   provider,
   program,
@@ -308,30 +344,14 @@ export const createContentNode = async ({
   );
 };
 
-/// Verify user with authenticatorKeypair
-type UpdateUserReplicaSet = {
-  provider: Provider;
-  program: Program<AudiusData>;
-  adminStgPublicKey: anchor.web3.PublicKey;
-  baseAuthorityAccount: anchor.web3.PublicKey;
-  ursm: number[];
-  ursmBumps: number[];
-  contentNodeAuthority: anchor.web3.Keypair;
-  cn1: anchor.web3.PublicKey;
-  cn2: anchor.web3.PublicKey;
-  cn3: anchor.web3.PublicKey;
-  userAcct: anchor.web3.PublicKey;
-  userHandle: { seed: number[]; bump: number };
-};
-
 export const updateUserReplicaSet = async ({
   provider,
   program,
   adminStgPublicKey,
   baseAuthorityAccount,
-  ursm,
+  replicaSet,
   userAcct,
-  ursmBumps,
+  replicaSetBumps,
   userHandle,
   contentNodeAuthority,
   cn1,
@@ -341,8 +361,8 @@ export const updateUserReplicaSet = async ({
   return program.rpc.updateUserReplicaSet(
     baseAuthorityAccount,
     userHandle,
-    ursm,
-    ursmBumps,
+    replicaSet,
+    replicaSetBumps,
     {
       accounts: {
         admin: adminStgPublicKey,
@@ -359,26 +379,6 @@ export const updateUserReplicaSet = async ({
   );
 };
 
-type Proposer = {
-  pda: anchor.web3.PublicKey;
-  authority: anchor.web3.Keypair;
-  seedBump: { seed: Buffer; bump: number };
-};
-
-/// Create a content node with proposers
-type PublicCreateContentNode = {
-  provider: Provider;
-  program: Program<AudiusData>;
-  adminStgPublicKey: anchor.web3.PublicKey;
-  baseAuthorityAccount: anchor.web3.PublicKey;
-  contentNodeAcct: anchor.web3.PublicKey;
-  contentNodeAuthority: anchor.web3.PublicKey;
-  spID: anchor.BN;
-  ownerEthAddress: string;
-  proposer1: Proposer;
-  proposer2: Proposer;
-  proposer3: Proposer;
-};
 export const publicCreateContentNode = async ({
   provider,
   program,
@@ -522,8 +522,8 @@ export const createUser = async ({
   program,
   ethAccount,
   message,
-  ursm,
-  ursmBumps,
+  replicaSet,
+  replicaSetBumps,
   handleBytesArray,
   cn1,
   cn2,
@@ -558,8 +558,8 @@ export const createUser = async ({
     program.instruction.createUser(
       baseAuthorityAccount,
       [...anchor.utils.bytes.hex.decode(ethAccount.address)],
-      ursm,
-      ursmBumps,
+      replicaSet,
+      replicaSetBumps,
       handleBytesArray,
       bumpSeed,
       metadata,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -308,7 +308,6 @@ export const createContentNode = async ({
   );
 };
 
-
 /// Verify user with authenticatorKeypair
 type UpdateUserReplicaSet = {
   provider: Provider;
@@ -321,8 +320,8 @@ type UpdateUserReplicaSet = {
   cn1: anchor.web3.PublicKey;
   cn2: anchor.web3.PublicKey;
   cn3: anchor.web3.PublicKey;
-  userAcct: anchor.web3.PublicKey,
-  userHandle: { seed: number[]; bump: number }
+  userAcct: anchor.web3.PublicKey;
+  userHandle: { seed: number[]; bump: number };
 };
 
 export const updateUserReplicaSet = async ({

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -197,8 +197,8 @@ type Proposer = {
   seedBump: { seed: Buffer; bump: number };
 };
 
-/// Create a content node with proposers
-type PublicCreateContentNode = {
+/// Create or update a content node with proposers
+type PublicCreateOrUpdateContentNode = {
   provider: Provider;
   program: Program<AudiusData>;
   adminStgPublicKey: anchor.web3.PublicKey;
@@ -405,7 +405,7 @@ export const updateUserReplicaSet = async ({
   );
 };
 
-export const publicCreateContentNode = async ({
+export const publicCreateOrUpdateContentNode = async ({
   provider,
   program,
   adminStgPublicKey,
@@ -417,8 +417,8 @@ export const publicCreateContentNode = async ({
   proposer1,
   proposer2,
   proposer3,
-}: PublicCreateContentNode) => {
-  return program.rpc.publicCreateContentNode(
+}: PublicCreateOrUpdateContentNode) => {
+  return program.rpc.publicCreateOrUpdateContentNode(
     baseAuthorityAccount,
     { seed: [...proposer1.seedBump.seed], bump: proposer1.seedBump.bump },
     { seed: [...proposer2.seedBump.seed], bump: proposer2.seedBump.bump },

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -48,6 +48,11 @@ type InitUserParams = {
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminStgKey: anchor.web3.PublicKey;
   adminKeypair: anchor.web3.Keypair;
+  ursm: number[];
+  ursmBumps: number[];
+  cn1: anchor.web3.PublicKey;
+  cn2: anchor.web3.PublicKey;
+  cn3: anchor.web3.PublicKey;
 };
 
 type CreateUserParams = {
@@ -62,6 +67,11 @@ type CreateUserParams = {
   userStgAccount: anchor.web3.PublicKey;
   adminStgPublicKey: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
+  ursm: number[];
+  ursmBumps: number[];
+  cn1: anchor.web3.PublicKey;
+  cn2: anchor.web3.PublicKey;
+  cn3: anchor.web3.PublicKey;
 };
 
 type UpdateUserParams = {
@@ -176,22 +186,28 @@ export const initAdmin = async ({
 };
 
 /// Initialize a user from the Audius Admin account
-
 export const initUser = async ({
   provider,
   program,
   ethAddress,
   handleBytesArray,
   bumpSeed,
+  ursm,
+  ursmBumps,
   metadata,
   userStgAccount,
   baseAuthorityAccount,
   adminStgKey,
   adminKeypair,
+  cn1,
+  cn2,
+  cn3,
 }: InitUserParams) => {
   return program.rpc.initUser(
     baseAuthorityAccount,
     [...anchor.utils.bytes.hex.decode(ethAddress)],
+    ursm,
+    ursmBumps,
     handleBytesArray,
     bumpSeed,
     metadata,
@@ -200,6 +216,9 @@ export const initUser = async ({
         admin: adminStgKey,
         payer: provider.wallet.publicKey,
         user: userStgAccount,
+        cn1,
+        cn2,
+        cn3,
         authority: adminKeypair.publicKey,
         systemProgram: SystemProgram.programId,
       },
@@ -257,8 +276,8 @@ type CreateContentNode = {
   baseAuthorityAccount: anchor.web3.PublicKey;
   contentNodeAcct: anchor.web3.PublicKey;
   contentNodeAuthority: anchor.web3.PublicKey;
-  spID: anchor.BN,
-  ownerEthAddress: string
+  spID: anchor.BN;
+  ownerEthAddress: string;
 };
 export const createContentNode = async ({
   provider,
@@ -269,7 +288,7 @@ export const createContentNode = async ({
   spID,
   contentNodeAuthority,
   contentNodeAcct,
-  ownerEthAddress
+  ownerEthAddress,
 }: CreateContentNode) => {
   return program.rpc.createContentNode(
     baseAuthorityAccount,
@@ -290,10 +309,10 @@ export const createContentNode = async ({
 };
 
 type Proposer = {
-  pda: anchor.web3.PublicKey,
-  authority: anchor.web3.Keypair,
-  seedBump: { seed: Buffer, bump: number }
-}
+  pda: anchor.web3.PublicKey;
+  authority: anchor.web3.Keypair;
+  seedBump: { seed: Buffer; bump: number };
+};
 
 /// Create a content node with proposers
 type PublicCreateContentNode = {
@@ -303,11 +322,11 @@ type PublicCreateContentNode = {
   baseAuthorityAccount: anchor.web3.PublicKey;
   contentNodeAcct: anchor.web3.PublicKey;
   contentNodeAuthority: anchor.web3.PublicKey;
-  spID: anchor.BN,
-  ownerEthAddress: string,
-  proposer1: Proposer,
-  proposer2: Proposer,
-  proposer3: Proposer,
+  spID: anchor.BN;
+  ownerEthAddress: string;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
 };
 export const publicCreateContentNode = async ({
   provider,
@@ -322,7 +341,6 @@ export const publicCreateContentNode = async ({
   proposer2,
   proposer3,
 }: PublicCreateContentNode) => {
-
   return program.rpc.publicCreateContentNode(
     baseAuthorityAccount,
     { seed: [...proposer1.seedBump.seed], bump: proposer1.seedBump.bump },
@@ -342,7 +360,7 @@ export const publicCreateContentNode = async ({
         proposer2: proposer2.pda,
         proposer2Authority: proposer2.authority.publicKey,
         proposer3: proposer3.pda,
-        proposer3Authority: proposer3.authority.publicKey
+        proposer3Authority: proposer3.authority.publicKey,
       },
       signers: [proposer1.authority, proposer2.authority, proposer3.authority],
     }
@@ -356,10 +374,10 @@ type PublicDeleteContentNode = {
   adminStgPublicKey: anchor.web3.PublicKey;
   adminAuthorityPublicKey: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
-  cnDelete: Proposer,
-  proposer1: Proposer,
-  proposer2: Proposer,
-  proposer3: Proposer,
+  cnDelete: Proposer;
+  proposer1: Proposer;
+  proposer2: Proposer;
+  proposer3: Proposer;
 };
 export const publicDeleteContentNode = async ({
   provider,
@@ -372,7 +390,6 @@ export const publicDeleteContentNode = async ({
   proposer2,
   proposer3,
 }: PublicDeleteContentNode) => {
-
   return program.rpc.publicDeleteContentNode(
     baseAuthorityAccount,
     { seed: [...cnDelete.seedBump.seed], bump: cnDelete.seedBump.bump },
@@ -391,22 +408,25 @@ export const publicDeleteContentNode = async ({
         proposer2: proposer2.pda,
         proposer2Authority: proposer2.authority.publicKey,
         proposer3: proposer3.pda,
-        proposer3Authority: proposer3.authority.publicKey
+        proposer3Authority: proposer3.authority.publicKey,
       },
       signers: [proposer1.authority, proposer2.authority, proposer3.authority],
     }
   );
 };
 
-
 /// Create a user without Audius Admin account
-
 export const createUser = async ({
   baseAuthorityAccount,
   program,
   ethAccount,
   message,
+  ursm,
+  ursmBumps,
   handleBytesArray,
+  cn1,
+  cn2,
+  cn3,
   bumpSeed,
   metadata,
   provider,
@@ -437,6 +457,8 @@ export const createUser = async ({
     program.instruction.createUser(
       baseAuthorityAccount,
       [...anchor.utils.bytes.hex.decode(ethAccount.address)],
+      ursm,
+      ursmBumps,
       handleBytesArray,
       bumpSeed,
       metadata,
@@ -445,6 +467,9 @@ export const createUser = async ({
         accounts: {
           payer: provider.wallet.publicKey,
           user: userStgAccount,
+          cn1,
+          cn2,
+          cn3,
           systemProgram: SystemProgram.programId,
           sysvarProgram: SystemSysVarProgramKey,
           audiusAdmin: adminStgPublicKey,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -267,7 +267,7 @@ export const initUserSolPubkey = async ({
   return provider.send(tx);
 };
 
-/// Verify user with authenticatorKeypair
+/// Create a content node with the audius admin authority
 type CreateContentNode = {
   provider: Provider;
   program: Program<AudiusData>;
@@ -304,6 +304,58 @@ export const createContentNode = async ({
         systemProgram: SystemProgram.programId,
       },
       signers: [adminKeypair],
+    }
+  );
+};
+
+
+/// Verify user with authenticatorKeypair
+type UpdateUserReplicaSet = {
+  provider: Provider;
+  program: Program<AudiusData>;
+  adminStgPublicKey: anchor.web3.PublicKey;
+  baseAuthorityAccount: anchor.web3.PublicKey;
+  ursm: number[];
+  ursmBumps: number[];
+  contentNodeAuthority: anchor.web3.Keypair;
+  cn1: anchor.web3.PublicKey;
+  cn2: anchor.web3.PublicKey;
+  cn3: anchor.web3.PublicKey;
+  userAcct: anchor.web3.PublicKey,
+  userHandle: { seed: number[]; bump: number }
+};
+
+export const updateUserReplicaSet = async ({
+  provider,
+  program,
+  adminStgPublicKey,
+  baseAuthorityAccount,
+  ursm,
+  userAcct,
+  ursmBumps,
+  userHandle,
+  contentNodeAuthority,
+  cn1,
+  cn2,
+  cn3,
+}: UpdateUserReplicaSet) => {
+  return program.rpc.updateUserReplicaSet(
+    baseAuthorityAccount,
+    userHandle,
+    ursm,
+    ursmBumps,
+    {
+      accounts: {
+        admin: adminStgPublicKey,
+        user: userAcct,
+        cnAuthority: contentNodeAuthority.publicKey,
+        cn1,
+        cn2,
+        cn3,
+        payer: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      signers: [contentNodeAuthority],
     }
   );
 };

--- a/solana-programs/anchor/audius-data/programs/audius-data/Cargo.toml
+++ b/solana-programs/anchor/audius-data/programs/audius-data/Cargo.toml
@@ -15,4 +15,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.22.0"
+anchor-lang = { version = "0.22.0", features = ["init-if-needed"] }

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
@@ -11,6 +11,7 @@ pub const ADMIN_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 /// Size of user account
 pub const USER_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 20 + // eth_address: [u8; 20]
+6 + // ursm: [u16; 3]
 32; // authority: Pubkey
 
 /// Size of user authority delegation account
@@ -19,7 +20,7 @@ pub const USER_AUTHORITY_DELEGATE_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 32; // user_storage_account: Pubkey
 
 /// Size of user content node account
-/// 8 bytes (anchor prefix) + 32 (PublicKey) + 20 (Ethereum PublicKey Bytes) + 20 (Ethereum PublicKey Bytes)
-pub const CONTENT_NODE_ACCOUNT_SIZE: usize = 8 + 32 + 20 + 20;
+/// 8 bytes (anchor prefix) + 32 (PublicKey) + 20 (Ethereum PublicKey Bytes)
+pub const CONTENT_NODE_ACCOUNT_SIZE: usize = 8 + 32 + 20;
 
 pub const CONTENT_NODE_SEED_PREFIX: &[u8; 5] = b"sp_id";

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
@@ -17,3 +17,9 @@ pub const USER_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 pub const USER_AUTHORITY_DELEGATE_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 32 + // delegate_authority: Pubkey
 32; // user_storage_account: Pubkey
+
+/// Size of user content node account
+/// 8 bytes (anchor prefix) + 32 (PublicKey) + 20 (Ethereum PublicKey Bytes) + 20 (Ethereum PublicKey Bytes)
+pub const CONTENT_NODE_ACCOUNT_SIZE: usize = 8 + 32 + 20 + 20;
+
+pub const CONTENT_NODE_SEED_PREFIX: &[u8; 5] = b"sp_id";

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/constants.rs
@@ -11,7 +11,7 @@ pub const ADMIN_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 /// Size of user account
 pub const USER_ACCOUNT_SIZE: usize = 8 + // anchor prefix
 20 + // eth_address: [u8; 20]
-6 + // ursm: [u16; 3]
+6 + // replica set: [u16; 3]
 32; // authority: Pubkey
 
 /// Size of user authority delegation account

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -31,7 +31,8 @@ pub mod audius_data {
         verifier: Pubkey,
     ) -> Result<()> {
         let audius_admin = &mut ctx.accounts.admin;
-        audius_admin.authority = authority;        audius_admin.verifier = verifier;
+        audius_admin.authority = authority;
+        audius_admin.verifier = verifier;
         audius_admin.is_write_enabled = true;
         Ok(())
     }
@@ -272,13 +273,13 @@ pub mod audius_data {
                     is_valid_authority = true;
                     // Validate that one of the user's replica set nodes signed the transaction
                     if !user_replica_set.iter().any(|cn| {
-                        let (base_pda, _bump) = Pubkey::find_program_address(
+                        let (cn_account_pda, _bump) = Pubkey::find_program_address(
                             &[
                                 &base.to_bytes()[..32],
                                 CONTENT_NODE_SEED_PREFIX,
                                 &cn.to_le_bytes()
                             ], &ctx.program_id);
-                        return base_pda == proposer.key();
+                        return cn_account_pda == proposer.key();
                     }) {
                         return Err(ErrorCode::Unauthorized.into());
                     }

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -70,7 +70,7 @@ pub mod audius_data {
         eth_address: [u8; 20],
         replica_set: [u16; 3],
         _replica_set_bumps: [u8; 3],
-        handle_seed: [u8; 16],
+        handle_seed: [u8; 32],
         _user_bump: u8,
         _metadata: String,
     ) -> Result<()> {
@@ -390,7 +390,7 @@ pub mod audius_data {
         eth_address: [u8; 20],
         replica_set: [u16; 3],
         _replica_set_bumps: [u8; 3],
-        _handle_seed: [u8; 16],
+        _handle_seed: [u8; 32],
         _user_bump: u8,
         _metadata: String,
         user_authority: Pubkey,
@@ -599,7 +599,7 @@ pub struct Initialize<'info> {
 /// `payer` is the account responsible for the lamports required to allocate this account.
 /// `system_program` is required for PDA derivation.
 #[derive(Accounts)]
-#[instruction(base: Pubkey, eth_address: [u8;20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], handle_seed: [u8;16])]
+#[instruction(base: Pubkey, eth_address: [u8;20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], handle_seed: [u8;32])]
 pub struct InitializeUser<'info> {
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
@@ -757,7 +757,7 @@ pub struct InitializeUserSolIdentity<'info> {
 /// `user` is the target user PDA.
 /// The global sys var program is required to enable instruction introspection.
 #[derive(Accounts)]
-#[instruction(base: Pubkey, eth_address: [u8;20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], handle_seed: [u8;16])]
+#[instruction(base: Pubkey, eth_address: [u8;20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], handle_seed: [u8;32])]
 pub struct CreateUser<'info> {
     #[account(
         init,

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -156,7 +156,7 @@ pub mod audius_data {
         _p1: ProposerSeedBump,
         _p2: ProposerSeedBump,
         _p3: ProposerSeedBump,
-        sp_id: u16,
+        _sp_id: u16,
         authority: Pubkey,
         owner_eth_address: [u8; 20],
     ) -> Result<()> {

--- a/solana-programs/anchor/audius-data/tests/audius-data.ts
+++ b/solana-programs/anchor/audius-data/tests/audius-data.ts
@@ -49,12 +49,12 @@ describe("audius-data", function () {
   const contentNodes = {};
   const getURSMParams = () => {
     return {
-      ursm: [
+      replicaSet: [
         contentNodes["1"].spId.toNumber(),
         contentNodes["2"].spId.toNumber(),
         contentNodes["3"].spId.toNumber(),
       ],
-      ursmBumps: [
+      replicaSetBumps: [
         contentNodes["1"].seedBump.bump,
         contentNodes["2"].seedBump.bump,
         contentNodes["3"].seedBump.bump,
@@ -798,7 +798,7 @@ describe("audius-data", function () {
     )
       .to.eventually.be.rejected.and.property("logs")
       .to.include(
-        `Program ${SystemProgram.programId.toString()} failed: Cross-program invocation with unauthorized signer or writable account`
+        `Program ${program.programId.toString()} failed: Cross-program invocation with unauthorized signer or writable account`
       );
   });
 

--- a/solana-programs/anchor/audius-data/tests/follows.ts
+++ b/solana-programs/anchor/audius-data/tests/follows.ts
@@ -33,12 +33,12 @@ describe("follows", function () {
   const contentNodes = {};
   const getURSMParams = () => {
     return {
-      ursm: [
+      replicaSet: [
         contentNodes["1"].spId.toNumber(),
         contentNodes["2"].spId.toNumber(),
         contentNodes["3"].spId.toNumber(),
       ],
-      ursmBumps: [
+      replicaSetBumps: [
         contentNodes["1"].seedBump.bump,
         contentNodes["2"].seedBump.bump,
         contentNodes["3"].seedBump.bump,

--- a/solana-programs/anchor/audius-data/tests/follows.ts
+++ b/solana-programs/anchor/audius-data/tests/follows.ts
@@ -4,7 +4,11 @@ import { expect, assert } from "chai";
 import { initAdmin, updateAdmin } from "../lib/lib";
 import { findDerivedPair, getTransactionWithData } from "../lib/utils";
 import { AudiusData } from "../target/types/audius_data";
-import { initTestConstants, testCreateUser } from "./test-helpers";
+import {
+  createSolanaContentNode,
+  initTestConstants,
+  testCreateUser,
+} from "./test-helpers";
 
 const UserActionEnumValues = {
   unfollowUser: { unfollowUser: {} },
@@ -26,6 +30,24 @@ describe("follows", function () {
   const adminKeypair = anchor.web3.Keypair.generate();
   const adminStgKeypair = anchor.web3.Keypair.generate();
   const verifierKeypair = anchor.web3.Keypair.generate();
+  const contentNodes = {};
+  const getURSMParams = () => {
+    return {
+      ursm: [
+        contentNodes["1"].spId.toNumber(),
+        contentNodes["2"].spId.toNumber(),
+        contentNodes["3"].spId.toNumber(),
+      ],
+      ursmBumps: [
+        contentNodes["1"].seedBump.bump,
+        contentNodes["2"].seedBump.bump,
+        contentNodes["3"].seedBump.bump,
+      ],
+      cn1: contentNodes["1"].pda,
+      cn2: contentNodes["2"].pda,
+      cn3: contentNodes["3"].pda,
+    };
+  };
 
   it("follows - Initializing admin account!", async function () {
     await initAdmin({
@@ -47,6 +69,33 @@ describe("follows", function () {
       console.log("Provided admin info: ", adminKeypair.publicKey.toString());
       throw new Error("Invalid returned values");
     }
+  });
+
+  it("Initializing Content Node accounts!", async function () {
+    const cn1 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(1),
+    });
+    const cn2 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(2),
+    });
+    const cn3 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(3),
+    });
+    contentNodes["1"] = cn1;
+    contentNodes["2"] = cn2;
+    contentNodes["3"] = cn3;
   });
 
   describe("follow / unfollow tests", function () {
@@ -117,6 +166,7 @@ describe("follows", function () {
         newUserKeypair: newUser1Key,
         userStgAccount: userStorageAccount1,
         adminStgPublicKey: adminStgKeypair.publicKey,
+        ...getURSMParams(),
       });
 
       await testCreateUser({
@@ -131,6 +181,7 @@ describe("follows", function () {
         newUserKeypair: newUser2Key,
         userStgAccount: userStorageAccount2,
         adminStgPublicKey: adminStgKeypair.publicKey,
+        ...getURSMParams(),
       });
     });
 

--- a/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
@@ -36,23 +36,7 @@ describe("playlist-actions", function () {
   const adminStgKeypair = anchor.web3.Keypair.generate();
   const verifierKeypair = anchor.web3.Keypair.generate();
   const contentNodes = {};
-  const getURSMParams = () => {
-    return {
-      ursm: [
-        contentNodes["1"].spId.toNumber(),
-        contentNodes["2"].spId.toNumber(),
-        contentNodes["3"].spId.toNumber(),
-      ],
-      ursmBumps: [
-        contentNodes["1"].seedBump.bump,
-        contentNodes["2"].seedBump.bump,
-        contentNodes["3"].seedBump.bump,
-      ],
-      cn1: contentNodes["1"].pda,
-      cn2: contentNodes["2"].pda,
-      cn3: contentNodes["3"].pda,
-    };
-  };
+
   it("playlist actions - Initializing admin account!", async function () {
     await initAdmin({
       provider,

--- a/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
@@ -14,7 +14,10 @@ import {
 } from "../lib/lib";
 import { getTransaction, randomString } from "../lib/utils";
 import { AudiusData } from "../target/types/audius_data";
-import { createSolanaUser } from "./test-helpers";
+import {
+  createSolanaUser,
+  createSolanaContentNode,
+} from "./test-helpers";
 
 chai.use(chaiAsPromised);
 
@@ -32,7 +35,24 @@ describe("playlist-actions", function () {
   const adminKeypair = anchor.web3.Keypair.generate();
   const adminStgKeypair = anchor.web3.Keypair.generate();
   const verifierKeypair = anchor.web3.Keypair.generate();
-
+  const contentNodes = {};
+  const getURSMParams = () => {
+    return {
+      ursm: [
+        contentNodes["1"].spId.toNumber(),
+        contentNodes["2"].spId.toNumber(),
+        contentNodes["3"].spId.toNumber(),
+      ],
+      ursmBumps: [
+        contentNodes["1"].seedBump.bump,
+        contentNodes["2"].seedBump.bump,
+        contentNodes["3"].seedBump.bump,
+      ],
+      cn1: contentNodes["1"].pda,
+      cn2: contentNodes["2"].pda,
+      cn3: contentNodes["3"].pda,
+    };
+  };
   it("playlist actions - Initializing admin account!", async function () {
     await initAdmin({
       provider,
@@ -61,6 +81,33 @@ describe("playlist-actions", function () {
       adminStgAccount: adminStgKeypair.publicKey,
       adminAuthorityKeypair: adminKeypair,
     });
+  });
+
+  it("Initializing Content Node accounts!", async function () {
+    const cn1 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(1),
+    });
+    const cn2 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(2),
+    });
+    const cn3 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(3),
+    });
+    contentNodes["1"] = cn1;
+    contentNodes["2"] = cn2;
+    contentNodes["3"] = cn3;
   });
 
   it("Delete save for a playlist", async function () {

--- a/solana-programs/anchor/audius-data/tests/playlist.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist.ts
@@ -119,7 +119,7 @@ describe("audius-data", function () {
       userStgAccount: newUserAcctPDA,
       adminStgKeypair,
       adminKeypair,
-      ...getURSMParams()
+      ...getURSMParams(),
     });
 
     // New sol key that will be used to permission user updates
@@ -228,6 +228,7 @@ describe("audius-data", function () {
       newUserKeypair,
       userStgAccount: newUserAcctPDA,
       adminStgPublicKey: adminStgKeypair.publicKey,
+      ...getURSMParams(),
     });
 
     const playlistMetadata = randomCID();
@@ -299,6 +300,7 @@ describe("audius-data", function () {
       newUserKeypair,
       userStgAccount: newUserAcctPDA,
       adminStgPublicKey: adminStgKeypair.publicKey,
+      ...getURSMParams(),
     });
 
     const playlistMetadata = randomCID();

--- a/solana-programs/anchor/audius-data/tests/playlist.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist.ts
@@ -7,6 +7,7 @@ import { findDerivedPair, randomCID, randomString } from "../lib/utils";
 import { AudiusData } from "../target/types/audius_data";
 import {
   testCreatePlaylist,
+  createSolanaContentNode,
   initTestConstants,
   testCreateUser,
   testInitUser,
@@ -31,7 +32,24 @@ describe("audius-data", function () {
   const adminKeypair = anchor.web3.Keypair.generate();
   const adminStgKeypair = anchor.web3.Keypair.generate();
   const verifierKeypair = anchor.web3.Keypair.generate();
-
+  const contentNodes = {};
+  const getURSMParams = () => {
+    return {
+      ursm: [
+        contentNodes["1"].spId.toNumber(),
+        contentNodes["2"].spId.toNumber(),
+        contentNodes["3"].spId.toNumber(),
+      ],
+      ursmBumps: [
+        contentNodes["1"].seedBump.bump,
+        contentNodes["2"].seedBump.bump,
+        contentNodes["3"].seedBump.bump,
+      ],
+      cn1: contentNodes["1"].pda,
+      cn2: contentNodes["2"].pda,
+      cn3: contentNodes["3"].pda,
+    };
+  };
   it("Initializing admin account!", async function () {
     await initAdmin({
       provider,
@@ -48,6 +66,33 @@ describe("audius-data", function () {
     const expectedAuthority = adminKeypair.publicKey.toString();
     expect(chainAuthority, "authority").to.equal(expectedAuthority);
     expect(adminAccount.isWriteEnabled, "is_write_enabled").to.equal(true);
+  });
+
+  it("Initializing Content Node accounts!", async function () {
+    const cn1 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(1),
+    });
+    const cn2 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(2),
+    });
+    const cn3 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(3),
+    });
+    contentNodes["1"] = cn1;
+    contentNodes["2"] = cn2;
+    contentNodes["3"] = cn3;
   });
 
   it("Initializing + claiming user, creating + updating playlist", async function () {
@@ -74,6 +119,7 @@ describe("audius-data", function () {
       userStgAccount: newUserAcctPDA,
       adminStgKeypair,
       adminKeypair,
+      ...getURSMParams()
     });
 
     // New sol key that will be used to permission user updates

--- a/solana-programs/anchor/audius-data/tests/playlist.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist.ts
@@ -35,12 +35,12 @@ describe("audius-data", function () {
   const contentNodes = {};
   const getURSMParams = () => {
     return {
-      ursm: [
+      replicaSet: [
         contentNodes["1"].spId.toNumber(),
         contentNodes["2"].spId.toNumber(),
         contentNodes["3"].spId.toNumber(),
       ],
-      ursmBumps: [
+      replicaSetBumps: [
         contentNodes["1"].seedBump.bump,
         contentNodes["2"].seedBump.bump,
         contentNodes["3"].seedBump.bump,

--- a/solana-programs/anchor/audius-data/tests/test-helpers.ts
+++ b/solana-programs/anchor/audius-data/tests/test-helpers.ts
@@ -605,6 +605,6 @@ export const createSolanaContentNode = async (props: {
     pda: derivedAddress,
     authority,
     seedBump: { seed, bump: bumpSeed },
-    tx
-  }
+    tx,
+  };
 };

--- a/solana-programs/anchor/audius-data/tests/test-helpers.ts
+++ b/solana-programs/anchor/audius-data/tests/test-helpers.ts
@@ -547,6 +547,7 @@ export const createSolanaContentNode = async (props: {
   }
 
   return {
+    spId: props.spId,
     account: contentNode,
     pda: derivedAddress,
     authority,

--- a/solana-programs/anchor/audius-data/tests/test-helpers.ts
+++ b/solana-programs/anchor/audius-data/tests/test-helpers.ts
@@ -600,6 +600,7 @@ export const createSolanaContentNode = async (props: {
   }
 
   return {
+    ownerEthAddress: ownerEth.address,
     spId: props.spId,
     account: contentNode,
     pda: derivedAddress,

--- a/solana-programs/anchor/audius-data/tests/test-helpers.ts
+++ b/solana-programs/anchor/audius-data/tests/test-helpers.ts
@@ -66,8 +66,8 @@ export const testInitUser = async ({
   userStgAccount,
   adminStgKeypair,
   adminKeypair,
-  ursm,
-  ursmBumps,
+  replicaSet,
+  replicaSetBumps,
   cn1,
   cn2,
   cn3,
@@ -76,8 +76,8 @@ export const testInitUser = async ({
     provider,
     program,
     ethAddress,
-    ursm,
-    ursmBumps,
+    replicaSet,
+    replicaSetBumps,
     handleBytesArray,
     bumpSeed,
     metadata,
@@ -157,8 +157,8 @@ export const testCreateUser = async ({
   newUserKeypair,
   userStgAccount,
   adminStgPublicKey,
-  ursm,
-  ursmBumps,
+  replicaSet,
+  replicaSetBumps,
   cn1,
   cn2,
   cn3,
@@ -170,8 +170,8 @@ export const testCreateUser = async ({
     message,
     handleBytesArray,
     bumpSeed,
-    ursm,
-    ursmBumps,
+    replicaSet,
+    replicaSetBumps,
     metadata,
     userSolPubkey: newUserKeypair.publicKey,
     userStgAccount,
@@ -194,7 +194,7 @@ export const testCreateUser = async ({
   expect(decodedData.userBump).to.equal(bumpSeed);
   expect(decodedData.metadata).to.equal(metadata);
   expect(accountPubKeys[0]).to.equal(userStgAccount.toString());
-  expect(accountPubKeys[2]).to.equal(adminStgPublicKey.toString());
+  expect(accountPubKeys[5]).to.equal(adminStgPublicKey.toString());
 
   const account = await program.account.user.fetch(userStgAccount);
 
@@ -539,8 +539,8 @@ export const createSolanaUser = async (
     userStgAccount: newUserAcctPDA,
     adminStgPublicKey: adminStgKeypair.publicKey,
     baseAuthorityAccount,
-    ursm: [1, 2, 3],
-    ursmBumps: [cn1.bumpSeed, cn2.bumpSeed, cn3.bumpSeed],
+    replicaSet: [1, 2, 3],
+    replicaSetBumps: [cn1.bumpSeed, cn2.bumpSeed, cn3.bumpSeed],
     cn1: cn1.derivedAddress,
     cn2: cn2.derivedAddress,
     cn3: cn3.derivedAddress,

--- a/solana-programs/anchor/audius-data/tests/track-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/track-social-actions.ts
@@ -90,37 +90,6 @@ describe("track-actions", function () {
     });
   });
 
-  it("Save a track with a low track id", async function () {
-    const user = await createSolanaUser(program, provider, adminStgKeypair);
-    const tx = await writeTrackSocialAction({
-      program,
-      baseAuthorityAccount: user.authority,
-      adminStgPublicKey: adminStgKeypair.publicKey,
-      userStgAccountPDA: user.pda,
-      userAuthorityKeypair: user.keypair,
-      handleBytesArray: user.handleBytesArray,
-      bumpSeed: user.bumpSeed,
-      trackSocialAction: TrackSocialActionEnumValues.addSave,
-      trackId: randomString(44),
-    });
-
-    const info = await getTransaction(provider, tx);
-    const instructionCoder = program.coder.instruction as BorshInstructionCoder;
-    const decodedInstruction = instructionCoder.decode(
-      info.transaction.message.instructions[0].data,
-      "base58"
-    );
-
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
-    );
-    assert.equal(instructionHandle, userHandle);
-    expect(decodedInstruction.data.trackSocialAction).to.deep.equal(
-      TrackSocialActionEnumValues.addSave
-    );
-  });
-
   it("Delete save for a track", async function () {
     const user = await createSolanaUser(program, provider, adminStgKeypair);
 

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -5,8 +5,7 @@ import { sendAndConfirmRawTransaction } from "@solana/web3.js";
 import {
   initAdmin,
   createContentNode,
-  publicCreateContentNode,
-  publicUpdateContentNode,
+  publicCreateOrUpdateContentNode,
   publicDeleteContentNode,
   updateUserReplicaSet,
   updateAdmin,
@@ -122,7 +121,7 @@ describe("replicaSet", function () {
       Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
     );
     const authority = anchor.web3.Keypair.generate();
-    await publicCreateContentNode({
+    await publicCreateOrUpdateContentNode({
       provider,
       program,
       baseAuthorityAccount,
@@ -197,7 +196,7 @@ describe("replicaSet", function () {
     const authority = anchor.web3.Keypair.generate();
     const createTransaction = (recentBlockhash) => {
       const tx = new anchor.web3.Transaction({ recentBlockhash });
-      const txInstr = program.instruction.publicCreateContentNode(
+      const txInstr = program.instruction.publicCreateOrUpdateContentNode(
         baseAuthorityAccount,
         { seed: [...cn6.seedBump.seed], bump: cn6.seedBump.bump },
         { seed: [...cn7.seedBump.seed], bump: cn7.seedBump.bump },
@@ -290,18 +289,15 @@ describe("replicaSet", function () {
       await findDerivedPair(program.programId, adminStgKeypair.publicKey, seed);
     const updatedAuthority = anchor.web3.Keypair.generate();
 
-    await publicUpdateContentNode({
+    await publicCreateOrUpdateContentNode({
       provider,
       program,
       baseAuthorityAccount,
       adminStgPublicKey: adminStgKeypair.publicKey,
       contentNodeAuthority: updatedAuthority.publicKey,
       contentNodeAcct: cnToUpdate.pda,
-      cn: {
-        pda: cnToUpdate.pda,
-        authority: cnToUpdate.authority,
-        seedBump: cnToUpdate.seedBump
-      },
+      spID: cnToUpdate.spId,
+      ownerEthAddress: cnToUpdate.ownerEthAddress,
       proposer1: {
         pda: cn4.pda,
         authority: cn4.authority,

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -12,10 +12,14 @@ import {
 } from "../lib/lib";
 import { findDerivedPair } from "../lib/utils";
 import { AudiusData } from "../target/types/audius_data";
-import { createSolanaContentNode, createSolanaUser, EthWeb3 } from "./test-helpers";
+import {
+  createSolanaContentNode,
+  createSolanaUser,
+  EthWeb3,
+} from "./test-helpers";
 const { SystemProgram } = anchor.web3;
 
-describe.only("ursm", function () {
+describe("ursm", function () {
   const provider = anchor.Provider.local("http://localhost:8899", {
     preflightCommitment: "confirmed",
     commitment: "confirmed",
@@ -38,7 +42,6 @@ describe.only("ursm", function () {
       adminKeypair,
       adminStgKeypair,
       verifierKeypair,
-      playlistIdOffset: new anchor.BN("0"),
     });
     // disable admin writes
     await updateAdmin({
@@ -47,21 +50,19 @@ describe.only("ursm", function () {
       adminStgAccount: adminStgKeypair.publicKey,
       adminAuthorityKeypair: adminKeypair,
     });
-    
   });
 
   it("Creates Content Node with the Admin account", async function () {
     const ownerEth = EthWeb3.eth.accounts.create();
     const spID = new anchor.BN(1);
     const authority = anchor.web3.Keypair.generate();
-    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(
-        program.programId,
-        adminStgKeypair.publicKey,
-        Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
-      );
+    const { baseAuthorityAccount, derivedAddress } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+    );
 
-    const tx = await createContentNode({
+    await createContentNode({
       provider,
       program,
       adminKeypair,
@@ -114,14 +115,13 @@ describe.only("ursm", function () {
     const spID = new anchor.BN(5);
     const ownerEth = EthWeb3.eth.accounts.create();
 
-    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(
-        program.programId,
-        adminStgKeypair.publicKey,
-        Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
-      );
+    const { baseAuthorityAccount, derivedAddress } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+    );
     const authority = anchor.web3.Keypair.generate();
-    const tx = await publicCreateContentNode({
+    await publicCreateContentNode({
       provider,
       program,
       baseAuthorityAccount,
@@ -326,11 +326,14 @@ describe.only("ursm", function () {
     // Note that there appears to be a delay in the propagation, hence the retries
     let updatedAudiusAdminBalance = initAudiusAdminBalance;
     let retries = 20;
-    while (updatedAudiusAdminBalance == initAudiusAdminBalance && retries > 0) {
+    while (
+      updatedAudiusAdminBalance === initAudiusAdminBalance &&
+      retries > 0
+    ) {
       updatedAudiusAdminBalance = await provider.connection.getBalance(
         adminKeypair.publicKey
       );
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100));
       retries--;
     }
 
@@ -339,7 +342,7 @@ describe.only("ursm", function () {
     }
 
     try {
-      const account = await program.account.contentNode.fetch(derivedAddress);
+      await program.account.contentNode.fetch(derivedAddress);
       throw new Error("Should throw error on fetch deleted account");
     } catch (e) {
       expect(e.message, "content node account should not exist").to.contain(
@@ -358,11 +361,14 @@ describe.only("ursm", function () {
       Buffer.from("sp_id", "utf8"),
       spID.toBuffer("le", 2),
     ]);
-    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(program.programId, adminStgKeypair.publicKey, seed);
+    const { baseAuthorityAccount } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      seed
+    );
 
-    const user = await createSolanaUser(program, provider, adminStgKeypair)
-    const tx = await updateUserReplicaSet({
+    const user = await createSolanaUser(program, provider, adminStgKeypair);
+    await updateUserReplicaSet({
       provider,
       program,
       baseAuthorityAccount,
@@ -376,10 +382,10 @@ describe.only("ursm", function () {
       cn2: cn3.pda,
       cn3: cn6.pda,
     });
-    const updatedUser = await program.account.user.fetch(
-      user.pda
-    );
-    expect(updatedUser.ursm, 'Expect user ursm to be updates').to.deep.equal([2, 3, 6])
+    const updatedUser = await program.account.user.fetch(user.pda);
+    expect(updatedUser.ursm, "Expect user ursm to be updates").to.deep.equal([
+      2, 3, 6,
+    ]);
   });
 
   it("Updates a user replica set with the user's athority", async function () {
@@ -392,11 +398,14 @@ describe.only("ursm", function () {
       Buffer.from("sp_id", "utf8"),
       spID.toBuffer("le", 2),
     ]);
-    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(program.programId, adminStgKeypair.publicKey, seed);
+    const { baseAuthorityAccount } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      seed
+    );
 
-    const user = await createSolanaUser(program, provider, adminStgKeypair)
-    const tx = await updateUserReplicaSet({
+    const user = await createSolanaUser(program, provider, adminStgKeypair);
+    await updateUserReplicaSet({
       provider,
       program,
       baseAuthorityAccount,
@@ -410,10 +419,10 @@ describe.only("ursm", function () {
       cn2: cn7.pda,
       cn3: cn8.pda,
     });
-    const updatedUser = await program.account.user.fetch(
-      user.pda
-    );
-    expect(updatedUser.ursm, 'Expect user ursm to be updates').to.deep.equal([6, 7, 8])
+    const updatedUser = await program.account.user.fetch(user.pda);
+    expect(updatedUser.ursm, "Expect user ursm to be updates").to.deep.equal([
+      6, 7, 8,
+    ]);
   });
 
   it("Fail on update to a user's replica set with a non authority", async function () {
@@ -426,10 +435,13 @@ describe.only("ursm", function () {
       Buffer.from("sp_id", "utf8"),
       spID.toBuffer("le", 2),
     ]);
-    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(program.programId, adminStgKeypair.publicKey, seed);
+    const { baseAuthorityAccount } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      seed
+    );
 
-    const user = await createSolanaUser(program, provider, adminStgKeypair)
+    const user = await createSolanaUser(program, provider, adminStgKeypair);
 
     await expect(
       updateUserReplicaSet({
@@ -449,5 +461,5 @@ describe.only("ursm", function () {
     )
       .to.eventually.be.rejected.and.property("msg")
       .to.include(`You are not authorized to perform this action.`);
-    });
+  });
 });

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -20,7 +20,7 @@ import {
 } from "./test-helpers";
 const { SystemProgram } = anchor.web3;
 
-describe.only("ursm", function () {
+describe("replicaSet", function () {
   const provider = anchor.Provider.local("http://localhost:8899", {
     preflightCommitment: "confirmed",
     commitment: "confirmed",
@@ -425,15 +425,15 @@ describe.only("ursm", function () {
       userAcct: user.pda,
       userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
       adminStgPublicKey: adminStgKeypair.publicKey,
-      ursm: [2, 3, 6],
-      ursmBumps: [cn2.seedBump.bump, cn3.seedBump.bump, cn6.seedBump.bump],
+      replicaSet: [2, 3, 6],
+      replicaSetBumps: [cn2.seedBump.bump, cn3.seedBump.bump, cn6.seedBump.bump],
       contentNodeAuthority: cn2.authority,
       cn1: cn2.pda,
       cn2: cn3.pda,
       cn3: cn6.pda,
     });
     const updatedUser = await program.account.user.fetch(user.pda);
-    expect(updatedUser.ursm, "Expect user ursm to be updates").to.deep.equal([
+    expect(updatedUser.replicaSet, "Expect user replicaSet to be updates").to.deep.equal([
       2, 3, 6,
     ]);
   });
@@ -462,15 +462,15 @@ describe.only("ursm", function () {
       userAcct: user.pda,
       userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
       adminStgPublicKey: adminStgKeypair.publicKey,
-      ursm: [6, 7, 8],
-      ursmBumps: [cn6.seedBump.bump, cn7.seedBump.bump, cn8.seedBump.bump],
+      replicaSet: [6, 7, 8],
+      replicaSetBumps: [cn6.seedBump.bump, cn7.seedBump.bump, cn8.seedBump.bump],
       contentNodeAuthority: user.keypair,
       cn1: cn6.pda,
       cn2: cn7.pda,
       cn3: cn8.pda,
     });
     const updatedUser = await program.account.user.fetch(user.pda);
-    expect(updatedUser.ursm, "Expect user ursm to be updates").to.deep.equal([
+    expect(updatedUser.replicaSet, "Expect user replicaSet to be updates").to.deep.equal([
       6, 7, 8,
     ]);
   });
@@ -501,8 +501,8 @@ describe.only("ursm", function () {
         userAcct: user.pda,
         userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
         adminStgPublicKey: adminStgKeypair.publicKey,
-        ursm: [2, 7, 8],
-        ursmBumps: [cn2.seedBump.bump, cn7.seedBump.bump, cn8.seedBump.bump],
+        replicaSet: [2, 7, 8],
+        replicaSetBumps: [cn2.seedBump.bump, cn7.seedBump.bump, cn8.seedBump.bump],
         contentNodeAuthority: cn7.authority,
         cn1: cn2.pda,
         cn2: cn7.pda,

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -10,14 +10,10 @@ import {
 } from "../lib/lib";
 import { findDerivedPair } from "../lib/utils";
 import { AudiusData } from "../target/types/audius_data";
-import {
-
-  createSolanaContentNode,
-  EthWeb3,
-} from "./test-helpers";
+import { createSolanaContentNode, EthWeb3 } from "./test-helpers";
 const { SystemProgram } = anchor.web3;
 
-describe.only("ursm", function () {
+describe("ursm", function () {
   const provider = anchor.Provider.local("http://localhost:8899", {
     preflightCommitment: "confirmed",
     commitment: "confirmed",
@@ -31,7 +27,7 @@ describe.only("ursm", function () {
   const adminKeypair = anchor.web3.Keypair.generate();
   const adminStgKeypair = anchor.web3.Keypair.generate();
   const verifierKeypair = anchor.web3.Keypair.generate();
-  const contentNodes = {}
+  const contentNodes = {};
 
   it("Initializing admin account!", async function () {
     await initAdmin({
@@ -101,9 +97,9 @@ describe.only("ursm", function () {
       adminStgKeypair,
       spId: new anchor.BN(4),
     });
-    contentNodes[cn2.spId.toString()] = cn2
-    contentNodes[cn3.spId.toString()] = cn3
-    contentNodes[cn4.spId.toString()] = cn4
+    contentNodes[cn2.spId.toString()] = cn2;
+    contentNodes[cn3.spId.toString()] = cn3;
+    contentNodes[cn4.spId.toString()] = cn4;
 
     const spID = new anchor.BN(5);
     const ownerEth = EthWeb3.eth.accounts.create();
@@ -175,9 +171,9 @@ describe.only("ursm", function () {
       adminStgKeypair,
       spId: new anchor.BN(8),
     });
-    contentNodes[cn6.spId.toString()] = cn6
-    contentNodes[cn7.spId.toString()] = cn7
-    contentNodes[cn8.spId.toString()] = cn8
+    contentNodes[cn6.spId.toString()] = cn6;
+    contentNodes[cn7.spId.toString()] = cn7;
+    contentNodes[cn8.spId.toString()] = cn8;
 
     const spID = new anchor.BN(9);
     const ownerEth = EthWeb3.eth.accounts.create();
@@ -267,23 +263,21 @@ describe.only("ursm", function () {
     ).to.equal(ownerEth.address.toLowerCase());
   });
 
-
   it("Deletes a Content Node with the proposers", async function () {
-    const cn2 = contentNodes['2']
-    const cn3 = contentNodes['3']
-    const cn4 = contentNodes['4']
+    const cn2 = contentNodes["2"];
+    const cn3 = contentNodes["3"];
+    const cn4 = contentNodes["4"];
 
-    const cnToDelete = contentNodes['6']
+    const cnToDelete = contentNodes["6"];
 
     const spID = new anchor.BN(4);
-    const seed = Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+    const seed = Buffer.concat([
+      Buffer.from("sp_id", "utf8"),
+      spID.toBuffer("le", 2),
+    ]);
     const { baseAuthorityAccount, bumpSeed, derivedAddress } =
-      await findDerivedPair(
-        program.programId,
-        adminStgKeypair.publicKey,
-        seed
-      );
- 
+      await findDerivedPair(program.programId, adminStgKeypair.publicKey, seed);
+
     const initAudiusAdminBalance = await provider.connection.getBalance(
       adminKeypair.publicKey
     );
@@ -299,7 +293,7 @@ describe.only("ursm", function () {
         authority: cnToDelete.authority,
         seedBump: {
           seed,
-          bump: bumpSeed
+          bump: bumpSeed,
         },
       },
       proposer1: {
@@ -328,7 +322,7 @@ describe.only("ursm", function () {
       );
       retries--;
     }
-    
+
     if (initAudiusAdminBalance === updatedAudiusAdminBalance) {
       throw new Error("Failed to deallocate track");
     }
@@ -337,10 +331,9 @@ describe.only("ursm", function () {
       const account = await program.account.contentNode.fetch(derivedAddress);
       throw new Error("Should throw error on fetch deleted account");
     } catch (e) {
-      expect(
-        e.message,
-        "content node account should not exist"
-      ).to.contain('Account does not exist');
-      }
+      expect(e.message, "content node account should not exist").to.contain(
+        "Account does not exist"
+      );
+    }
   });
 });

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -1,0 +1,340 @@
+import { expect } from "chai";
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { sendAndConfirmRawTransaction } from "@solana/web3.js";
+
+import {
+  initAdmin,
+  createContentNode,
+  publicCreateContentNode,
+} from "../lib/lib";
+import { findDerivedPair } from "../lib/utils";
+import { AudiusData } from "../target/types/audius_data";
+import {
+  confirmLogInTransaction,
+  createSolanaContentNode,
+  EthWeb3,
+} from "./test-helpers";
+const { SystemProgram } = anchor.web3;
+
+describe.only("ursm", function () {
+  const provider = anchor.Provider.local("http://localhost:8899", {
+    preflightCommitment: "confirmed",
+    commitment: "confirmed",
+  });
+
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.Provider.env());
+
+  const program = anchor.workspace.AudiusData as Program<AudiusData>;
+
+  const adminKeypair = anchor.web3.Keypair.generate();
+  const adminStgKeypair = anchor.web3.Keypair.generate();
+  const verifierKeypair = anchor.web3.Keypair.generate();
+
+  it("Initializing admin account!", async function () {
+    await initAdmin({
+      provider,
+      program,
+      adminKeypair,
+      adminStgKeypair,
+      verifierKeypair,
+      playlistIdOffset: new anchor.BN("0"),
+    });
+    const adminAccount = await program.account.audiusAdmin.fetch(
+      adminStgKeypair.publicKey
+    );
+
+    const chainAuthority = adminAccount.authority.toString();
+    const expectedAuthority = adminKeypair.publicKey.toString();
+  });
+
+  it("Creates Content Node with the Admin account", async function () {
+    const ownerEth = EthWeb3.eth.accounts.create();
+    const spID = new anchor.BN(1);
+    const authority = anchor.web3.Keypair.generate();
+    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
+      await findDerivedPair(
+        program.programId,
+        adminStgKeypair.publicKey,
+        Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+      );
+
+    const tx = await createContentNode({
+      provider,
+      program,
+      adminKeypair,
+      baseAuthorityAccount,
+      adminStgPublicKey: adminStgKeypair.publicKey,
+      contentNodeAuthority: authority.publicKey,
+      contentNodeAcct: derivedAddress,
+      spID,
+      ownerEthAddress: ownerEth.address,
+    });
+
+    const account = await program.account.contentNode.fetch(derivedAddress);
+
+    expect(
+      account.authority.toString(),
+      "content node authority set correctly"
+    ).to.equal(authority.publicKey.toString());
+    expect(
+      anchor.utils.bytes.hex.encode(Buffer.from(account.ownerEthAddress)),
+      "content node owner eth addr set correctly"
+    ).to.equal(ownerEth.address.toLowerCase());
+  });
+
+  it("Creates Content Node with the proposers", async function () {
+    const cn1 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(2),
+    });
+    const cn2 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(3),
+    });
+    const cn3 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(4),
+    });
+
+    const spID = new anchor.BN(5);
+    const ownerEth = EthWeb3.eth.accounts.create();
+
+    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
+      await findDerivedPair(
+        program.programId,
+        adminStgKeypair.publicKey,
+        Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+      );
+    const authority = anchor.web3.Keypair.generate();
+    const tx = await publicCreateContentNode({
+      provider,
+      program,
+      baseAuthorityAccount,
+      adminStgPublicKey: adminStgKeypair.publicKey,
+      contentNodeAcct: derivedAddress,
+      spID,
+      contentNodeAuthority: authority.publicKey,
+      ownerEthAddress: ownerEth.address,
+      proposer1: {
+        pda: cn1.pda,
+        authority: cn1.authority,
+        seedBump: cn1.seedBump,
+      },
+      proposer2: {
+        pda: cn2.pda,
+        authority: cn2.authority,
+        seedBump: cn2.seedBump,
+      },
+      proposer3: {
+        pda: cn3.pda,
+        authority: cn3.authority,
+        seedBump: cn3.seedBump,
+      },
+    });
+
+    const account = await program.account.contentNode.fetch(derivedAddress);
+
+    expect(
+      account.authority.toString(),
+      "content node authority set correctly"
+    ).to.equal(authority.publicKey.toString());
+    expect(
+      anchor.utils.bytes.hex.encode(Buffer.from(account.ownerEthAddress)),
+      "content node owner eth addr set correctly"
+    ).to.equal(ownerEth.address.toLowerCase());
+  });
+
+  it("Creates Content Node with multiple signed proposers", async function () {
+    const cn6 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(6),
+    });
+    const cn7 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(7),
+    });
+    const cn8 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(8),
+    });
+
+    const spID = new anchor.BN(9);
+    const ownerEth = EthWeb3.eth.accounts.create();
+
+    const { baseAuthorityAccount, derivedAddress } = await findDerivedPair(
+      program.programId,
+      adminStgKeypair.publicKey,
+      Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+    );
+    const authority = anchor.web3.Keypair.generate();
+    const createTransaction = (recentBlockhash) => {
+      const tx = new anchor.web3.Transaction({ recentBlockhash });
+      const txInstr = program.instruction.publicCreateContentNode(
+        baseAuthorityAccount,
+        { seed: [...cn6.seedBump.seed], bump: cn6.seedBump.bump },
+        { seed: [...cn7.seedBump.seed], bump: cn7.seedBump.bump },
+        { seed: [...cn8.seedBump.seed], bump: cn8.seedBump.bump },
+        spID.toNumber(),
+        authority.publicKey,
+        [...anchor.utils.bytes.hex.decode(ownerEth.address)],
+        {
+          accounts: {
+            admin: adminStgKeypair.publicKey,
+            payer: provider.wallet.publicKey,
+            contentNode: derivedAddress,
+            systemProgram: SystemProgram.programId,
+            proposer1: cn6.pda,
+            proposer1Authority: cn6.authority.publicKey,
+            proposer2: cn7.pda,
+            proposer2Authority: cn7.authority.publicKey,
+            proposer3: cn8.pda,
+            proposer3Authority: cn8.authority.publicKey,
+          },
+        }
+      );
+      tx.add(txInstr);
+      return tx;
+    };
+    const feePayerWallet = provider.wallet;
+
+    // Create tx on signer 1 and sign
+    const blockhash = (
+      await provider.connection.getRecentBlockhash("confirmed")
+    ).blockhash;
+    const tx1 = createTransaction(blockhash);
+    tx1.feePayer = feePayerWallet.publicKey;
+    tx1.partialSign(cn6.authority);
+    const sig1 = tx1.signatures.find(
+      (s) => s.publicKey.toBase58() === cn6.authority.publicKey.toBase58()
+    );
+
+    const tx2 = createTransaction(blockhash);
+    tx2.feePayer = feePayerWallet.publicKey;
+    tx2.partialSign(cn7.authority);
+    const sig2 = tx2.signatures.find(
+      (s) => s.publicKey.toBase58() === cn7.authority.publicKey.toBase58()
+    );
+
+    const tx3 = createTransaction(blockhash);
+    tx3.feePayer = feePayerWallet.publicKey;
+    tx3.partialSign(cn8.authority);
+    const sig3 = tx3.signatures.find(
+      (s) => s.publicKey.toBase58() === cn8.authority.publicKey.toBase58()
+    );
+
+    const tx = createTransaction(blockhash);
+    tx.feePayer = feePayerWallet.publicKey;
+    await feePayerWallet.signTransaction(tx);
+
+    tx.addSignature(cn6.authority.publicKey, sig1.signature);
+    tx.addSignature(cn7.authority.publicKey, sig2.signature);
+    tx.addSignature(cn8.authority.publicKey, sig3.signature);
+
+    // NOTE: this must be raw transaction or else the send metho will nodify the transaction's recent blockhash and
+    // invalidate the signatures
+    await sendAndConfirmRawTransaction(provider.connection, tx.serialize(), {});
+
+    const account = await program.account.contentNode.fetch(derivedAddress);
+
+    expect(
+      account.authority.toString(),
+      "content node authority set correctly"
+    ).to.equal(authority.publicKey.toString());
+    expect(
+      anchor.utils.bytes.hex.encode(Buffer.from(account.ownerEthAddress)),
+      "content node owner eth addr set correctly"
+    ).to.equal(ownerEth.address.toLowerCase());
+  });
+
+
+  it("Deletes a Content Node with the proposers", async function () {
+    const cn1 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(2),
+    });
+    const cn2 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(3),
+    });
+    const cn3 = await createSolanaContentNode({
+      program,
+      provider,
+      adminKeypair,
+      adminStgKeypair,
+      spId: new anchor.BN(4),
+    });
+
+    const spID = new anchor.BN(5);
+    const ownerEth = EthWeb3.eth.accounts.create();
+
+    const { baseAuthorityAccount, bumpSeed, derivedAddress } =
+      await findDerivedPair(
+        program.programId,
+        adminStgKeypair.publicKey,
+        Buffer.concat([Buffer.from("sp_id", "utf8"), spID.toBuffer("le", 2)])
+      );
+    const authority = anchor.web3.Keypair.generate();
+    const tx = await publicCreateContentNode({
+      provider,
+      program,
+      baseAuthorityAccount,
+      adminStgPublicKey: adminStgKeypair.publicKey,
+      contentNodeAcct: derivedAddress,
+      spID,
+      contentNodeAuthority: authority.publicKey,
+      ownerEthAddress: ownerEth.address,
+      proposer1: {
+        pda: cn1.pda,
+        authority: cn1.authority,
+        seedBump: cn1.seedBump,
+      },
+      proposer2: {
+        pda: cn2.pda,
+        authority: cn2.authority,
+        seedBump: cn2.seedBump,
+      },
+      proposer3: {
+        pda: cn3.pda,
+        authority: cn3.authority,
+        seedBump: cn3.seedBump,
+      },
+    });
+
+    const account = await program.account.contentNode.fetch(derivedAddress);
+
+    expect(
+      account.authority.toString(),
+      "content node authority set correctly"
+    ).to.equal(authority.publicKey.toString());
+    expect(
+      anchor.utils.bytes.hex.encode(Buffer.from(account.ownerEthAddress)),
+      "content node owner eth addr set correctly"
+    ).to.equal(ownerEth.address.toLowerCase());
+  });
+});


### PR DESCRIPTION
### Description
Adds usrm to solana 
Methods:
* CreateContentNode - creates a content node with the audius admin authority
* PublicCreateContentNode - creates a content node with 3 proposers (existing content nodes)
* PublicUpdateContentNode - Updates a content node's authority - in the case where their delegator wallet is changed -  needs 3 proposers
* PublicDeleteContentNode - Deletes a content node account with 3 proposers and sends the funds to the audius admin account
* UpdateUserReplicaSet - updates a user's replica set - permissioned to the user's authority or any of the current ursm content nodes 

Updates the createUser method to add 3 ursm nodes
Updates the initUser method to add 3 ursm nodes

### Tests
URSM tests

### How will this change be monitored? Are there sufficient logs?
