### PR TITLE
Add middleware to ensure valid sp req

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -13,6 +13,7 @@ const models = require('./models')
 const utils = require('./utils')
 const { hasEnoughStorageSpace } = require('./fileManager')
 const { getMonitors, MONITORS } = require('./monitors/monitors')
+const { verifyRequesterIsValidSP } = require('./apiSigning')
 const BlacklistManager = require('./blacklistManager')
 
 /**
@@ -805,6 +806,32 @@ async function getReplicaSetSpIDs({
   return userReplicaSetSpIDs
 }
 
+async function ensureValidSPMiddleware(req, res, next) {
+  try {
+    const { timestamp, signature, spID } = req.query
+    if (!timestamp || !signature || !spID) {
+      throw new Error(
+        `Missing values: timestamp=${timestamp}, signature=${signature}, and/or spID=${spID}`
+      )
+    }
+
+    await verifyRequesterIsValidSP({
+      audiusLibs: req.app.get('audiusLibs'),
+      spID,
+      reqTimestamp: timestamp,
+      reqSignature: signature
+    })
+  } catch (e) {
+    return sendResponse(
+      req,
+      res,
+      errorResponseUnauthorized(`Request unauthorized -- ${e.message}`)
+    )
+  }
+
+  next()
+}
+
 // Regular expression to check if endpoint is a FQDN. https://regex101.com/r/kIowvx/2
 function _isFQDN(url) {
   if (config.get('creatorNodeIsDebug')) return true
@@ -818,6 +845,7 @@ module.exports = {
   authMiddleware,
   ensurePrimaryMiddleware,
   ensureStorageMiddleware,
+  ensureValidSPMiddleware,
   issueAndWaitForSecondarySyncRequests,
   syncLockMiddleware,
   getOwnEndpoint,


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

This is used later when a primary sends off the track transcoding task to another sp. there needs to be an auth middleware that a req is from a valid sp. This PR is part of the greater task to load balance transcoding

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

- not currently used anywhere
- uploaded a track and was successful

### How will this change be monitored? Are there sufficient logs?
- not currently used

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->