### PR TITLE
Fix datetime caching

### DIFF
--- a/discovery-provider/src/queries/get_unpopulated_playlists.py
+++ b/discovery-provider/src/queries/get_unpopulated_playlists.py
@@ -1,6 +1,7 @@
 import logging  # pylint: disable=C0302
 from datetime import datetime
 
+from dateutil import parser
 from src.models import Playlist
 from src.utils import helpers, redis_connection
 from src.utils.redis_cache import (
@@ -8,7 +9,6 @@ from src.utils.redis_cache import (
     get_playlist_id_cache_key,
     set_json_cached_key,
 )
-from werkzeug.http import parse_date
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,8 @@ def get_cached_playlists(playlist_ids):
     for playlist in playlists:
         if playlist:
             for field in playlist_datetime_fields:
-                # Parse date using the werkzeug parser, equivalent to Flask.JSONEncoder.
-                # Since werkzeug gives us timezone aware-UTC, drop the timezone.
-                playlist[field] = parse_date(playlist[field]).replace(tzinfo=None)
+                if playlist[field]:
+                    playlist[field] = parser.parse(playlist[field])
     return playlists
 
 

--- a/discovery-provider/src/queries/get_unpopulated_tracks.py
+++ b/discovery-provider/src/queries/get_unpopulated_tracks.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from dateutil import parser
 from src.models import Track
 from src.utils import helpers, redis_connection
 from src.utils.redis_cache import (
@@ -8,7 +9,6 @@ from src.utils.redis_cache import (
     get_track_id_cache_key,
     set_json_cached_key,
 )
-from werkzeug.http import parse_date
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,8 @@ def get_cached_tracks(track_ids):
     for track in tracks:
         if track:
             for field in track_datetime_fields:
-                # Parse date using the werkzeug parser, equivalent to Flask.JSONEncoder.
-                # Since werkzeug gives us timezone aware-UTC, drop the timezone.
-                track[field] = parse_date(track[field]).replace(tzinfo=None)
+                if track[field]:
+                    track[field] = parser.parse(track[field])
     return tracks
 
 

--- a/discovery-provider/src/queries/get_unpopulated_users.py
+++ b/discovery-provider/src/queries/get_unpopulated_users.py
@@ -1,6 +1,7 @@
 import logging  # pylint: disable=C0302
 from datetime import datetime
 
+from dateutil import parser
 from src.models import User
 from src.utils import helpers, redis_connection
 from src.utils.redis_cache import (
@@ -8,7 +9,6 @@ from src.utils.redis_cache import (
     get_user_id_cache_key,
     set_json_cached_key,
 )
-from werkzeug.http import parse_date
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,8 @@ def get_cached_users(user_ids):
     for user in users:
         if user:
             for field in user_datetime_fields:
-                # Parse date using the werkzeug parser, equivalent to Flask.JSONEncoder.
-                # Since werkzeug gives us timezone aware-UTC, drop the timezone.
-                user[field] = parse_date(user[field]).replace(tzinfo=None)
+                if user[field]:
+                    user[field] = parser.parse(user[field])
     return users
 
 

--- a/discovery-provider/src/utils/redis_cache_unit_test.py
+++ b/discovery-provider/src/utils/redis_cache_unit_test.py
@@ -1,16 +1,16 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from time import sleep
 from unittest.mock import patch
 
 import flask
+from dateutil import parser
 from src.utils.redis_cache import (
     cache,
     get_all_json_cached_key,
     get_json_cached_key,
     set_json_cached_key,
 )
-from werkzeug.http import parse_date
 
 
 def test_json_cache_single_key(redis_mock):
@@ -50,7 +50,7 @@ def test_json_cache_date_value(redis_mock):
     date = datetime(2016, 2, 18, 9, 50, 20)
     set_json_cached_key(redis_mock, "key", {"date": date})
     result = get_json_cached_key(redis_mock, "key")
-    assert parse_date(result["date"]) == date.astimezone(timezone.utc)
+    assert parser.parse(result["date"]) == date
 
 
 def test_cache_decorator(redis_mock):


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Two issues fixed in this PR:
* playlists contain a nullable datetime field called `last_added_to,` which was trying to be parsed as `None`
* The underlying assumption in the original PR to use the flask JSONEncoder was incorrect. It appears as if our stack does default str(datetime) in python. This was leading to all sorts of weird behavior where sometimes datetime would be cached as `2022-03-15 21:43:50` and sometimes as `Tue, 15 Mar 2022 21:43:50 GMT` (the former being our desired response).

Worth noting that the client is "smart enough" to handle either date format, but the inconsistency is really bad.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran local stack verified queries (cached and uncached) for:
* users
* tracks
* playlists
* autocomplete

Tested against staging node with previously failing queries:
* autocomplete

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This one is hard to monitor because the caching layer is so omnipresent, but 500 request responses was the way I discovered this issue on stage discovery nodes. Needs a full 2 week QA/soak.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->