### PR TITLE
Pinning 1.4.0 dependency for colors

### DIFF
--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -11,7 +11,7 @@
     "@solana/web3.js": "1.20.0",
     "axios": "^0.19.2",
     "borsh": "^0.4.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^6.0.0",
     "convict": "^5.2.0",
     "ffmpeg-static": "^4.4.0",


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

So `v1.4.44-liberty-2` is a bad version that intentionally runs an infinite loop if you use the America theme. 

We use this package in service-commands, and this pr is to pin colors to v1.4.0 since we do not do that right now.

https://snyk.io/blog/open-source-npm-packages-colors-faker/ (see colors closer to the middle of the article)

I took a scan through the audius-protocol repo, and it looks like other packages we use also have colors as part of its dependencies. Should be ok but just flagging. For example:

eth-contracts package-lock.json
```
    "@truffle/compile-common": {
      "version": "0.7.20",
      "resolved": "https://registry.npmjs.org/@truffle/compile-common/-/compile-common-0.7.20.tgz",
      "integrity": "sha512-Ko1uk4N52TpMerYyDIuwJKyx4HXVetn+PQu2g4peqMfkOQHd4tG3DB4I6L4sMLSL40rOWsKcyVrgkv9QxW1b7g==",
      "requires": {
        "@truffle/contract-sources": "^0.1.12",
        "@truffle/error": "^0.0.14",
        "@truffle/expect": "^0.0.18",
        "colors": "^1.4.0", // here
        "debug": "^4.3.1"
      },
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

This is the version we were using prior, and this is PR is just pinning the version

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

The America theme is not used anywhere but will monitor if things look weird


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->