### PR TITLE
Link identity service README to its wiki

### DIFF
--- a/identity-service/README.md
+++ b/identity-service/README.md
@@ -2,5 +2,4 @@
 
 The identity service maintains all the identity aspects of the Audius ecosystem such as storing encrypted auth ciphertexts, doing Twitter oauth and relay transactions on behalf of users
 
-This repo is based on the audius-creator-node repo with very similar structure and modules.
-
+This repo is based on the audius-creator-node repo with very similar structure and modules. Read [the wiki](https://github.com/AudiusProject/audius-protocol/wiki/Identity-Service:-Overview) for more info.


### PR DESCRIPTION
### Description

Updates README in identity-service to link to the wiki since the README itself is short.

### Tests
N/A - README update

### How will this change be monitored? Are there sufficient logs?
N/A - README update