### PR TITLE
[ASI-943] Make discovery node unhealthy block diff configurable

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -58,3 +58,6 @@ minimumStoragePathSize=1000000000 # bytes; 1gb
 minimumMemoryAvailable=2000000000 # bytes; 2gb
 maxFileDescriptorsAllocatedPercentage=95
 maxNumberSecondsPrimaryRemainsUnhealthy=5
+
+# Number of missed blocks after which we would consider a discovery node unhealthy
+discoveryNodeUnhealthyBlockDiff=500

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -402,6 +402,12 @@ const config = convict({
     env: 'discoveryProviderWhitelist',
     default: ''
   },
+  discoveryNodeUnhealthyBlockDiff: {
+    doc: 'Number of missed blocks after which a discovery node would be considered unhealthy',
+    format: 'nat',
+    env: 'discoveryNodeUnhealthyBlockDiff',
+    default: 500
+  },
   identityService: {
     doc: 'Identity service endpoint to record creator-node driven plays against',
     format: String,

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -321,7 +321,9 @@ class ServiceRegistry {
       ? new Set(config.get('discoveryProviderWhitelist').split(','))
       : null
     const identityService = config.get('identityService')
-    const discoveryNodeUnhealthyBlockDiff = config.get('discoveryNodeUnhealthyBlockDiff')
+    const discoveryNodeUnhealthyBlockDiff = config.get(
+      'discoveryNodeUnhealthyBlockDiff'
+    )
 
     const audiusLibs = new AudiusLibs({
       ethWeb3Config: AudiusLibs.configEthWeb3(

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -321,6 +321,7 @@ class ServiceRegistry {
       ? new Set(config.get('discoveryProviderWhitelist').split(','))
       : null
     const identityService = config.get('identityService')
+    const discoveryNodeUnhealthyBlockDiff = config.get('discoveryNodeUnhealthyBlockDiff')
 
     const audiusLibs = new AudiusLibs({
       ethWeb3Config: AudiusLibs.configEthWeb3(
@@ -344,7 +345,7 @@ class ServiceRegistry {
         /* selectionRequestTimeout */ null,
         /* selectionRequestRetries */ null,
         /* unhealthySlotDiffPlays */ null,
-        /* unhealthyBlockDiff */ 500
+        discoveryNodeUnhealthyBlockDiff
       ),
       // If an identity service config is present, set up libs with the connection, otherwise do nothing
       identityServiceConfig: identityService

--- a/libs/src/index.js
+++ b/libs/src/index.js
@@ -44,7 +44,7 @@ class AudiusLibs {
    * @param {number?} selectionRequestTimeout the amount of time (ms) an individual request should take before reselecting
    * @param {number?} selectionRequestRetries the number of retries to a given discovery node we make before reselecting
    * @param {number?} unhealthySlotDiffPlays the number of slots we would consider a discovery node unhealthy
-   * @param {number?} unhealthyBlockDiff the number of blocks we would consider a discovery node unhealthy
+   * @param {number?} unhealthyBlockDiff the number of missed blocks after which we would consider a discovery node unhealthy
    */
   static configDiscoveryProvider (
     whitelist = null,

--- a/libs/src/services/discoveryProvider/index.js
+++ b/libs/src/services/discoveryProvider/index.js
@@ -30,7 +30,7 @@ const MAX_MAKE_REQUEST_RETRIES_WITH_404 = 2
  * @param {number?} selectionRequestTimeout the amount of time (ms) an individual request should take before reselecting
  * @param {number?} selectionRequestRetries the number of retries to a given discovery node we make before reselecting
  * @param {number?} unhealthySlotDiffPlays the number of slots we would consider a discovery node unhealthy
- * @param {number?} unhealthyBlockDiff the number of blocks we would consider a discovery node unhealthy
+ * @param {number?} unhealthyBlockDiff the number of missed blocks after which we would consider a discovery node unhealthy
  */
 class DiscoveryProvider {
   constructor (


### PR DESCRIPTION
### Description
Changes content-node's hardcoded `unhealthyBlockDiff` into an env var with a default value of 500.

### Tests
Related tests should pass.