### PR TITLE
Link libs locally with hot reload in identity service

### DIFF
--- a/identity-service/scripts/dev-server.sh
+++ b/identity-service/scripts/dev-server.sh
@@ -7,6 +7,7 @@ link_libs=true
 if [ "$link_libs" = true ]
 then
     cd ../audius-libs
+    npm run dev &
     npm link
     cd ../app
     npm link @audius/libs


### PR DESCRIPTION
### Description
If you run A up, identity services doesn't successfully come up as a result of libs using rollup. This runs the rollup hot reload in the background to update if libs is changed while linked in identity service.

Note - content node needs something similar but that's defaulted to link_libs = false and we also have some TS so that's not compatible with what we do in identity

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Ran A up and observed that it works
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->