### PR TITLE
[CN] Change batch_clock_status requests to batches

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -685,11 +685,11 @@ class SnapbackSM {
   }
 
   /**
-   * Given map(replica set node => userWallets[]), retrieves clock values for every (node, userWallet) pair
+   * Given map(replica node => userWallets[]), retrieves clock values for every (node, userWallet) pair
    * @param {Object} replicaSetNodesToUserWalletsMap map of <replica set node : wallets>
    * @param {Set<string>} unhealthyPeers set of unhealthy peer endpoints
    *
-   * @returns {Object} map(replica => map(wallet => clockValue))
+   * @returns {Object} map(replica node => map(wallet => clockValue))
    */
   async retrieveClockStatusesForUsersAcrossReplicaSet(
     replicasToWalletsMap,

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1,6 +1,7 @@
 const Bull = require('bull')
 const axios = require('axios')
 const _ = require('lodash')
+const retry = require('async-retry')
 
 const utils = require('../utils')
 const models = require('../models')
@@ -23,6 +24,10 @@ const BATCH_CLOCK_STATUS_REQUEST_TIMEOUT = 20000 // 20s
 
 // Timeout for fetching a clock value for a singular user
 const CLOCK_STATUS_REQUEST_TIMEOUT_MS = 2000 // 2s
+
+const MAX_BATCH_CLOCK_STATUS_BATCH_SIZE = 5000
+
+const MAX_USER_BATCH_CLOCK_FETCH_RETRIES = 5
 
 // Describes the type of sync operation
 const SyncType = Object.freeze({
@@ -683,83 +688,79 @@ class SnapbackSM {
    * Given map(replica set node => userWallets[]), retrieves clock values for every (node, userWallet) pair
    * @param {Object} replicaSetNodesToUserWalletsMap map of <replica set node : wallets>
    * @param {Set<string>} unhealthyPeers set of unhealthy peer endpoints
-   * @param {number?} [maxUserClockFetchAttempts=10] max number of attempts to fetch clock values
    *
-   * @returns {Object} map of peer endpoints to (map of user wallet strings to clock value of replica set node for user)
+   * @returns {Object} map(replica => map(wallet => clockValue))
    */
   async retrieveClockStatusesForUsersAcrossReplicaSet(
-    replicaSetNodesToUserWalletsMap,
-    unhealthyPeers,
-    maxUserClockFetchAttempts = 10
+    replicasToWalletsMap,
+    unhealthyPeers
   ) {
-    const replicaSetNodesToUserClockValuesMap = {}
+    const replicasToUserClockStatusMap = {}
 
-    const replicaSetNodes = Object.keys(replicaSetNodesToUserWalletsMap)
-
-    // TODO change to batched parallel requests
+    /** In parallel for every replica, fetch clock status for all users on that replica */
+    const replicas = Object.keys(replicasToWalletsMap)
     await Promise.all(
-      replicaSetNodes.map(async (replicaSetNode) => {
-        replicaSetNodesToUserClockValuesMap[replicaSetNode] = {}
+      replicas.map(async (replica) => {
+        replicasToUserClockStatusMap[replica] = {}
 
-        const replicaSetNodeUserWallets =
-          replicaSetNodesToUserWalletsMap[replicaSetNode]
-        const { timestamp, signature } = generateTimestampAndSignature(
-          { spID: this.spID },
-          this.delegatePrivateKey
-        )
+        const walletsOnReplica = replicasToWalletsMap[replica]
 
-        const axiosReqParams = {
-          baseURL: replicaSetNode,
-          url: '/users/batch_clock_status',
-          method: 'post',
-          data: { walletPublicKeys: replicaSetNodeUserWallets },
-          timeout: BATCH_CLOCK_STATUS_REQUEST_TIMEOUT,
-          params: {
-            spID: this.spID,
-            timestamp,
-            signature
+        // Make requests in batches, sequentially, to ensure POST request body does not exceed max size
+        for (
+          let i = 0;
+          i < walletsOnReplica.length;
+          i += MAX_BATCH_CLOCK_STATUS_BATCH_SIZE
+        ) {
+          const walletsOnReplicaSlice = walletsOnReplica.slice(
+            i,
+            i + MAX_BATCH_CLOCK_STATUS_BATCH_SIZE
+          )
+
+          const axiosReqParams = {
+            baseURL: replica,
+            url: '/users/batch_clock_status',
+            method: 'post',
+            data: { walletPublicKeys: walletsOnReplicaSlice },
+            timeout: BATCH_CLOCK_STATUS_REQUEST_TIMEOUT
           }
-        }
 
-        let userClockValuesResp = []
-        let userClockFetchAttempts = 0
-        let errorMsg
-        while (userClockFetchAttempts++ < maxUserClockFetchAttempts) {
+          // Sign request to other CN to bypass rate limiting
+          const { timestamp, signature } = generateTimestampAndSignature(
+            { spID: this.spID },
+            this.delegatePrivateKey
+          )
+          axiosReqParams.params = { spID: this.spID, timestamp, signature }
+
+          let batchClockStatusResp = []
+          let errorMsg
           try {
-            userClockValuesResp = (await axios(axiosReqParams)).data.data.users
+            batchClockStatusResp = (
+              await retry(async () => axios(axiosReqParams), {
+                retries: MAX_USER_BATCH_CLOCK_FETCH_RETRIES
+              })
+            ).data.data.users
           } catch (e) {
             errorMsg = e
           }
-        }
 
-        // If failed to get response after all attempts, add replica to `unhealthyPeers` list for reconfig
-        if (userClockValuesResp.length === 0) {
-          this.logError(
-            `[retrieveClockStatusesForUsersAcrossReplicaSet] Could not fetch clock values for wallets=${replicaSetNodeUserWallets} on replica node=${replicaSetNode} ${
-              errorMsg ? ': ' + errorMsg.toString() : ''
-            }`
-          )
-          unhealthyPeers.add(replicaSetNode)
-        }
-
-        userClockValuesResp.forEach((userClockValueResp) => {
-          const { walletPublicKey, clock } = userClockValueResp
-          try {
-            replicaSetNodesToUserClockValuesMap[replicaSetNode][
-              walletPublicKey
-            ] = clock
-          } catch (e) {
-            // TODO: would this ever error actually?
-            this.log(
-              `Error updating replicaSetNodesToUserClockValuesMap for wallet ${walletPublicKey} to clock ${clock}`
+          // If failed to get response after all attempts, add replica to `unhealthyPeers` list for reconfig
+          if (errorMsg) {
+            this.logError(
+              `[retrieveClockStatusesForUsersAcrossReplicaSet] Could not fetch clock values for wallets=${walletsOnReplica} on replica=${replica} ${errorMsg.toString()}`
             )
-            throw e
+            unhealthyPeers.add(replica)
           }
-        })
+
+          // Add batch response data to aggregate output map
+          batchClockStatusResp.forEach((userClockValueResp) => {
+            const { walletPublicKey, clock } = userClockValueResp
+            replicasToUserClockStatusMap[replica][walletPublicKey] = clock
+          })
+        }
       })
     )
 
-    return replicaSetNodesToUserClockValuesMap
+    return replicasToUserClockStatusMap
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fixes an issue with Snapback that is currently preventing it from running
At start of each run, each node fetches all its replica set users, grouped by other replica, and makes a single `/users/batch_clock_status` POST req to each replica, passing the entire wallet set in the body. This has gotten so large that it now far exceeds the max body size
This PR changes the request to be made in sequential batches

Also includes some minor renaming / cleanup

Example of the current error:
```
{"name":"audius_creator_node","hostname":"creator-node-backend-89fd4f86b-8q57b","pid":28,"requestID":"L3jRRj_nr","requestMethod":"POST","requestHostname":"127.0.0.1","requestUrl":"/users/batch_clock_status","requestQueryParams":"spID=7&timestamp=2022-03-23T16:43:40.506Z&signature=0xe383dfd6167d15f446c8666ea4ac23a50ecae6ab808ede3c193b699b007c469c79339a2c7704583b2ed610a110b6fa721795f7a2d6ca6900c49d39d32b916dcc1b","level":50,"msg":"PayloadTooLargeError: request entity too large\n    at readStream (/usr/src/app/node_modules/raw-body/index.js:155:17)\n    at getRawBody (/usr/src/app/node_modules/raw-body/index.js:108:12)\n    at read (/usr/src/app/node_modules/body-parser/lib/read.js:77:3)\n    at jsonParser (/usr/src/app/node_modules/body-parser/lib/types/json.js:135:5)\n    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)\n    at /usr/src/app/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)\n    at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)\n    at loggingMiddleware (/usr/src/app/build/src/logging.js:65:5)\n    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)\n    at /usr/src/app/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)\n    at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)\n    at expressInit (/usr/src/app/node_modules/express/lib/middleware/init.js:40:5)\n    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)\n    at /usr/src/app/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)\n    at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)\n    at query (/usr/src/app/node_modules/express/lib/middleware/query.js:45:5)","time":"2022-03-23T16:43:43.293Z","v":0}
{"name":"audius_creator_node","hostname":"creator-node-backend-89fd4f86b-8q57b","pid":28,"requestID":"L3jRRj_nr","requestMethod":"POST","requestHostname":"127.0.0.1","requestUrl":"/users/batch_clock_status","requestQueryParams":"spID=7&timestamp=2022-03-23T16:43:40.506Z&signature=0xe383dfd6167d15f446c8666ea4ac23a50ecae6ab808ede3c193b699b007c469c79339a2c7704583b2ed610a110b6fa721795f7a2d6ca6900c49d39d32b916dcc1b","duration":45,"statusCode":500,"errorMessage":"Internal server error","level":30,"msg":"Error processing request: Internal server error || Request Body: {} || Request Query Params: {\n  spID: '7',\n  timestamp: '2022-03-23T16:43:40.506Z',\n  signature: '0xe383dfd6167d15f446c8666ea4ac23a50ecae6ab808ede3c193b699b007c469c79339a2c7704583b2ed610a110b6fa721795f7a2d6ca6900c49d39d32b916dcc1b'\n}","time":"2022-03-23T16:43:43.293Z","v":0}
{"name":"audius_creator_node","hostname":"creator-node-backend-89fd4f86b-8q57b","pid":28,"level":50,"msg":"SnapbackSM ERROR: [retrieveClockStatusesForUsersAcrossReplicaSet] Could not fetch clock values for wallets=0xb5f6a1b59feac1453cb9e768b8f0cf7fc172dca3,0xa9da020b2fc1bb4e67717bc9120f289e46222e62,0x006377725b495c27ffff0b510a74a6b4be3ab2b5,0x5dfd3aca8e44ea05b7ecb47e5742b84e124d4d16,0x398933ae7c0bd5be070a70ddc91c09c244009ed6,0x05d5ab853410341670de18cde5fb77e3f8e9356f,0xc347c9db955f609f0c5713c0fb354fe2837e40ec,0x240b5264668ad9ab782c138d56fd5a8f7ce5092a,0xb456f3bf2c4e6e113967c39870ab541729817f10,0x989e9ce06c71623e10442c3a9397776ca04522f5,0x55d5b536b05ecb812a5f0e653ed754edc136e2b4,0xd155f7c4ce228f0121c315f67e73c34b604237ab,0xdf232b0e259d00b9215073ff585e413bf80de87b,0x4aa51799ad32ed3a9bcbfda4fdac146bdb587802,0xb7a30d4cd2fc4c4979fd55ee3264b7ba667296cc,0xde4fa8efca4e084a609e9676ecf0375388e5e9c1,0x2d21e79e6adb1a8c061904bcc59156199097bfd4,0x8d6e015b22be5d3048b8818118c6efe52c064927,0x15885cd2d16880d42eec8bd6570316c903fe0e5f,0x13670c9d8e057a47e0c38ae55718abec99198593,0x95630de0b48ce3089d3e7f5a7698f85ee6df26c8,0x3fb2a771858e867387de72674f82b196a892a19f,0x3e3d0e69086b834d386507870cfe3336985caf13,0x5020f238e2179f42048a93dae273a7568b583f63,0x8e4ff862cda37f897e8b42d13f44f521829e32d9,0xfe56a6afaeb1510d13bcfc56df34cc1c97499854,0xc7432c37c504e554a047d4367a08479fd787e015,0x327cf7fcd5fc12675aa8dbe3646d48b59b36bbd0,0x7277eea3bb75c9093710b4677d634573c8911e2f,0x2fa8014e14ccd1d9eac05750f415a202aa2802d2,0xeef47fc0aa14ac073cce27c1b11b292ff049d133,0xdc5d75d46ad3a41160fc13998ee1a59d5602a8e3,0x557542720fc9d0425b1abf12da6ef950f0b782b4,0xdc817e5da7ba0d5cb583de393cf1336e32b1988c,0x2255651fcfff1c1644b3b501bdccee2b52a6db4e,0x533eb65ac142bf6194cbbed97cde0caea9663b99,0xcf0ec5f98454fd493bb9e075f9af0bf5901f1242,0x48584f25a667aea213ab97ac6be7bfa3ab149b9c,
...
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested locally to confirm no regressions, real test will be when staging errors go away
EDIT - released to all staging nodes and confirmed with below link + manual log inspection that there are no further errors

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Monitor for instances of this error: https://audius.loggly.com/search#terms=%22batch_clock_status%22%20%22Internal%20server%20error%22%20tag:%22audius-stage%22&from=2022-03-09T19:38:17.168Z&until=2022-03-23T19:38:17.168Z&source_group=&numeric=json.statusCode;neq;200


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->