### PR TITLE
Link libs in CN by default

### DIFF
--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-link_libs=false
+link_libs=true
 
 if [[ "$WAIT_HOSTS" != "" ]]; then
     /usr/bin/wait


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Link libs in local CN dev by default to ensure early detection of issues
Identity service already does this locally, so also makes the two consistent

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran locally and confirmed libs were correcty linked by default

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Only impacts local dev

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->