### PR TITLE
missing get_health() argument

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -372,7 +372,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
 
 
 def health_check_prometheus_exporter():
-    health_results, is_unhealthy = get_health()
+    health_results, is_unhealthy = get_health({})
 
     PrometheusMetric(
         "health_check_is_healthy_current",

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -375,12 +375,6 @@ def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
     PrometheusMetric(
-        "health_check_is_healthy_current",
-        "Difference between the latest block and the latest indexed block",
-        metric_type=PrometheusType.GAUGE,
-    ).save(0 if is_unhealthy else 1)
-
-    PrometheusMetric(
         "health_check_block_difference_current",
         "Difference between the latest block and the latest indexed block",
         metric_type=PrometheusType.GAUGE,


### PR DESCRIPTION
### Description

#2770 was missing a positional argument which is currently breaking the `/prometheus_metrics` endpoint.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->