### PR TITLE
Fix how PrometheusMetrics sets Gauge metrics

### DIFF
--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -58,9 +58,15 @@ class PrometheusMetric:
 
     def save(self, value, labels=None):
         if labels:
-            self.metric.labels(**labels).observe(value)
+            if metric_type == PrometheusType.HISTOGRAM:
+                self.metric.labels(**labels).observe(value)
+            elif metric_type == PrometheusType.GAUGE:
+                self.metric.labels(**labels).set(value)
         else:
-            self.metric.observe(value)
+            if metric_type == PrometheusType.HISTOGRAM:
+                self.metric.observe(value)
+            elif metric_type == PrometheusType.GAUGE:
+                self.metric.set(value)
 
     @classmethod
     def register_collector(cls, name, collector_func):

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -34,16 +34,17 @@ class PrometheusMetric:
         # CollectorRegistries must be uniquely named
         # NOTE: we only set labelnames once.
         # unsure if overloading is supported.
-        if metric_type == PrometheusType.HISTOGRAM:
+        self.metric_type = metric_type
+        if self.metric_type == PrometheusType.HISTOGRAM:
             self.__init_metric(
                 name, description, labelnames, PrometheusMetric.histograms, Histogram
             )
-        elif metric_type == PrometheusType.GAUGE:
+        elif self.metric_type == PrometheusType.GAUGE:
             self.__init_metric(
                 name, description, labelnames, PrometheusMetric.gauges, Gauge
             )
         else:
-            raise TypeError(f"metric_type '{metric_type}' not found")
+            raise TypeError(f"metric_type '{self.metric_type}' not found")
 
     def reset_timer(self):
         self.start_time = time()
@@ -58,14 +59,14 @@ class PrometheusMetric:
 
     def save(self, value, labels=None):
         if labels:
-            if metric_type == PrometheusType.HISTOGRAM:
+            if self.metric_type == PrometheusType.HISTOGRAM:
                 self.metric.labels(**labels).observe(value)
-            elif metric_type == PrometheusType.GAUGE:
+            elif self.metric_type == PrometheusType.GAUGE:
                 self.metric.labels(**labels).set(value)
         else:
-            if metric_type == PrometheusType.HISTOGRAM:
+            if self.metric_type == PrometheusType.HISTOGRAM:
                 self.metric.observe(value)
-            elif metric_type == PrometheusType.GAUGE:
+            elif self.metric_type == PrometheusType.GAUGE:
                 self.metric.set(value)
 
     @classmethod


### PR DESCRIPTION
### Description

The interface for gauges and counters is different than the interface for histograms and summaries since it uses `.set()` instead of `.observe()`.

### Tests

A ticket has been filed to do basic checking on the `/prometheus_exporter` endpoint: 

* https://linear.app/audius/issue/ASI-996/add-mad-dog-test-to-hit-prometheus-metrics

Today's manual test looks good:

```
$ curl http://localhost:5000/prometheus_metrics
# HELP audius_dn_health_check_block_difference_current Multiprocess metric
# TYPE audius_dn_health_check_block_difference_current gauge
audius_dn_health_check_block_difference_current{pid="ser"} 0.0
# HELP audius_dn_health_check_latest_indexed_block_num_current Multiprocess metric
# TYPE audius_dn_health_check_latest_indexed_block_num_current gauge
audius_dn_health_check_latest_indexed_block_num_current{pid="ser"} 292.0
...
```

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->