### PR TITLE
[AUD-1796] Fix wormhole compilation issue

### DIFF
--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@amplitude/node": "^1.9.2",
     "@audius/libs": "1.2.95",
+    "@certusone/wormhole-sdk": "0.1.1",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@optimizely/optimizely-sdk": "^4.6.0",
     "@sentry/node": "^6.2.5",

--- a/identity-service/src/audiusLibsInstance.js
+++ b/identity-service/src/audiusLibsInstance.js
@@ -1,4 +1,5 @@
 const AudiusLibs = require('@audius/libs')
+const { setDefaultWasm } = require('@certusone/wormhole-sdk/lib/cjs/solana/wasm')
 
 const config = require('./config')
 const registryAddress = config.get('registryAddress')
@@ -10,6 +11,7 @@ const SOLANA_TOKEN_ADDRESS = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 class AudiusLibsWrapper {
   constructor () {
     this.audiusLibsInstance = null
+    setDefaultWasm('node')
   }
 
   async init () {

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -3,7 +3,6 @@ const { toBuffer } = require('ethereumjs-util')
 const { zeroPad } = require('ethers/lib/utils')
 const { providers } = require('ethers/lib/index')
 const wormholeSDK = require('@certusone/wormhole-sdk')
-const { setDefaultWasm } = require('@certusone/wormhole-sdk/lib/cjs/solana/wasm')
 
 const SolanaUtils = require('../solanaWeb3Manager/utils')
 const Utils = require('../../utils')
@@ -53,9 +52,6 @@ class Wormhole {
     this.ethBridgeAddress = ethBridgeAddress
     this.ethTokenBridgeAddress = ethTokenBridgeAddress
     this.wormholeSDK = wormholeSDK
-    if (isServer) {
-      setDefaultWasm('node')
-    }
   }
 
   async getSignedVAAWithRetry (


### PR DESCRIPTION
### Description

Fixes weird issue where our original wormhole fix for node results in a compilation issue for the mobile web app, since it is not able to correctly pull wasm files, which our node fix for some reason requires. The fix here is to remove the node compatible wormhole fix from libs and put it in identity service.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->