### PR TITLE
pin werkzeug

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -39,6 +39,7 @@ psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1
 werkzeug==2.0.3
+click==8.0.4
 
 # Solana support
 base58==2.1.0

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -38,6 +38,7 @@ eventlet==0.28.0
 psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1
+werkzeug==2.0.3
 
 # Solana support
 base58==2.1.0


### PR DESCRIPTION
### Description

werkzeug added this 23 hours ago:

```
the 2.0.x branch will become a tag marking the end of support for that branch
```

-- https://github.com/pallets/werkzeug/releases/tag/2.1.0

This change allows us to satisfy dependencies for `flask-restx`, for example.

click did the same 23 hours ago:

```
the 8.0.x branch will become a tag marking the end of support for that branch
```

-- https://github.com/pallets/click/releases/tag/8.1.0

### Tests

Running `$ A run discovery-provider restart` to ensure the build process still works:

```
$ curl http://localhost:5000/prometheus_metrics
...
# HELP audius_dn_health_check_block_difference_current Multiprocess metric
# TYPE audius_dn_health_check_block_difference_current gauge
audius_dn_health_check_block_difference_current{pid="ser"} 11483.0
# HELP audius_dn_health_check_latest_indexed_block_num_current Multiprocess metric
# TYPE audius_dn_health_check_latest_indexed_block_num_current gauge
audius_dn_health_check_latest_indexed_block_num_current{pid="ser"} 11483.0
```

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->