### PR TITLE
Make service-commands consume libs v1.2.97

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.96",
+  "version": "1.2.97",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.96",
+  "version": "1.2.97",
   "description": "",
   "main": "dist/index.js",
   "browser": {


### PR DESCRIPTION
### Description
Update the version of libs that service-commands consumes

### Tests
Running mad dog doesn't produce the following error anymore:
```
uploadTrackContent retry error:  TypeError: wait is not a function
    at CreatorNode$5.pollProcessingStatus (/home/ubuntu/audius-protocol/libs/dist/index.js:37904:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Promise.all (index 0)
    at async CreatorNode$5.uploadTrackContent (/home/ubuntu/audius-protocol/libs/dist/index.js:37791:46)
    at async Track.uploadTrack (/home/ubuntu/audius-protocol/libs/dist/index.js:43140:11)
    at async LibsWrapper.uploadTrack (/home/ubuntu/audius-protocol/service-commands/src/libs.js:222:32)
    at async Track.uploadTrack (/home/ubuntu/audius-protocol/service-commands/src/commands/tracks.js:9:19)
    at async /home/ubuntu/audius-protocol/mad-dog/src/helpers.js:317:16
    at async /home/ubuntu/audius-protocol/mad-dog/src/tests/test_snapbackSM.js:58:23
    at async Promise.all (index 6)
    at async /home/ubuntu/audius-protocol/mad-dog/src/helpers.js:294:17
    at async snapbackSMParallelSyncTest (/home/ubuntu/audius-protocol/mad-dog/src/tests/test_snapbackSM.js:47:3)
    at async wrappedTest (/home/ubuntu/audius-protocol/mad-dog/src/index.js:78:19)
    at async testRunner (/home/ubuntu/audius-protocol/mad-dog/src/index.js:114:23)
    at async main (/home/ubuntu/audius-protocol/mad-dog/src/index.js:356:9)
```

### How will this change be monitored? Are there sufficient logs?