### PR TITLE
Updating solana web3py to get_transaction from get_confirmed_transaction

### DIFF
--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -49,7 +49,7 @@ class SolanaClientManager:
                     logger.info(
                         f"solana_client_manager.py | get_sol_tx_info | Fetching tx {tx_sig} {endpoint}"
                     )
-                    tx_info: ConfirmedTransaction = client.get_confirmed_transaction(
+                    tx_info: ConfirmedTransaction = client.get_transaction(
                         tx_sig, encoding
                     )
                     logger.info(

--- a/discovery-provider/src/solana/solana_client_manager_unit_test.py
+++ b/discovery-provider/src/solana/solana_client_manager_unit_test.py
@@ -49,7 +49,7 @@ def test_get_sol_tx_info(_):
     expected_response = {"result": "OK"}
 
     # test that it returns the client call response
-    client_mocks[0].get_confirmed_transaction.return_value = expected_response
+    client_mocks[0].get_transaction.return_value = expected_response
     assert (
         solana_client_manager.get_sol_tx_info("transaction signature")
         == expected_response
@@ -62,16 +62,16 @@ def test_get_sol_tx_info(_):
     client_mocks[2].reset_mock()
 
     num_retries = 2
-    client_mocks[0].get_confirmed_transaction.side_effect = Exception()
-    client_mocks[1].get_confirmed_transaction.side_effect = Exception()
-    client_mocks[2].get_confirmed_transaction.return_value = expected_response
+    client_mocks[0].get_transaction.side_effect = Exception()
+    client_mocks[1].get_transaction.side_effect = Exception()
+    client_mocks[2].get_transaction.return_value = expected_response
     assert (
         solana_client_manager.get_sol_tx_info("transaction signature", num_retries)
         == expected_response
     )
-    assert client_mocks[0].get_confirmed_transaction.call_count == 2
-    assert client_mocks[1].get_confirmed_transaction.call_count == 2
-    assert client_mocks[2].get_confirmed_transaction.call_count == 1
+    assert client_mocks[0].get_transaction.call_count == 2
+    assert client_mocks[1].get_transaction.call_count == 2
+    assert client_mocks[2].get_transaction.call_count == 1
 
 
 @mock.patch("solana.rpc.api.Client")


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

* Use updated RPC method as the currently consumed one is being deprecated https://docs.solana.com/developing/clients/jsonrpc-api#getconfirmedtransaction

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Existing tests pass

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->