### PR TITLE
Use user id as seed for user storage account PDA derivation

### DIFF
--- a/solana-programs/anchor/audius-data/cli/README.md
+++ b/solana-programs/anchor/audius-data/cli/README.md
@@ -43,24 +43,24 @@ What are these 2 accounts?
 
 ## 2. Initializing a user account from administrator
 
-For a user with handle=`handlebcdef` and ethereum public key = `0x0a93d8cb0Be85B3Ea8f33FA63500D118deBc83F7`
+For a user with userId=1 and ethereum public key = `0x0a93d8cb0Be85B3Ea8f33FA63500D118deBc83F7`
 
 ```
 yarn run ts-node cli/main.ts -f initUser \
 -k ~/.config/solana/id.json \
 --admin-keypair $PWD/adminKeypair.json \
 --admin-storage-keypair $PWD/adminStorageKeypair.json \
--h handlebcdef \
+--user-id 1 \
 -e 0x0a93d8cb0Be85B3Ea8f33FA63500D118deBc83F7 # this value is hard-coded
 ```
 
 Output:
 
 ```
-Initialized user=handlebcdef, tx=3M88gDkFm8bXuwdmCRV28NPNakLENutdFx7N4tzWjQydaQt2mQccG2STTqtdm29hR8FSD6aGsavGqXYNo1FbbK6h, userAcct=BmBwwWjcSduP7ZWUoavxBh1kV8dvHmakmfrqjsVyA2Sx
+Initialized user id=1, tx=3M88gDkFm8bXuwdmCRV28NPNakLENutdFx7N4tzWjQydaQt2mQccG2STTqtdm29hR8FSD6aGsavGqXYNo1FbbK6h, userAcct=BmBwwWjcSduP7ZWUoavxBh1kV8dvHmakmfrqjsVyA2Sx
 ```
 
-At this point, the account associated with the handle has been initialized by the administrator account, at `BmBwwWjcSduP7ZWUoavxBh1kV8dvHmakmfrqjsVyA2Sx`
+At this point, the account associated with the user ID has been initialized by the administrator account, at `BmBwwWjcSduP7ZWUoavxBh1kV8dvHmakmfrqjsVyA2Sx`
 
 Export the value after `userAcct=` as `USER_STORAGE_PUBKEY`.
 
@@ -94,7 +94,7 @@ yarn run ts-node cli/main.ts -f createTrack \
 --user-solana-keypair $PWD/userKeypair.json \
 --user-storage-pubkey $USER_STORAGE_PUBKEY \
 --admin-storage-keypair $PWD/adminStorageKeypair.json \
---handle handlebcdef
+--user-id 1
 ```
 
 ## 4. Creating a playlist
@@ -107,7 +107,7 @@ yarn run ts-node cli/main.ts -f createPlaylist \
 --user-solana-keypair $PWD/userKeypair.json \
 --user-storage-pubkey $USER_STORAGE_PUBKEY \
 --admin-storage-keypair $PWD/adminStorageKeypair.json \
---handle handlebcdef
+--user-id 1
 ```
 
 Export the created playlist ID in logs as $PLAYLIST_ID.
@@ -122,7 +122,7 @@ yarn run ts-node cli/main.ts -f updatePlaylist \
 --user-storage-pubkey $USER_STORAGE_PUBKEY \
 --admin-storage-keypair $PWD/adminStorageKeypair.json \
 --id "$PLAYLIST_ID" \
---handle handlebcdef
+--user-id 1
 ```
 
 ## 4. Delete a playlist
@@ -134,5 +134,5 @@ yarn run ts-node cli/main.ts -f deletePlaylist \
 --user-solana-keypair $PWD/userKeypair.json \
 --user-storage-pubkey $USER_STORAGE_PUBKEY \
 --id "$PLAYLIST_ID" \
---handle handlebcdef
+--user-id 1
 ```

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -517,16 +517,16 @@ const main = async () => {
       })();
       break;
     case functionTypes.createUser:
-      const { userId, handle } = options;
+      const { userId } = options;
       console.log({ userId });
       const ethAccount = EthWeb3.eth.accounts.create();
 
-      const handleBytesArray = getHandleBytesArray(handle);
+      const userIdBytesArray = getUserIdBytesArray(userId);
       const { baseAuthorityAccount, bumpSeed, derivedAddress } =
         await findDerivedPair(
           cliVars.programID,
           adminStorageKeypair.publicKey,
-          handleBytesArray
+          userIdBytesArray
         );
       (async () => {
         const cliVars = initializeCLI(network, options.ownerKeypair);
@@ -551,7 +551,7 @@ const main = async () => {
           ethAccount,
           message: userSolKeypair.publicKey.toBytes(),
           userId: new anchor.BN(userId),
-          handleBytesArray,
+          userIdBytesArray,
           bumpSeed,
           metadata: randomCID(),
           userSolPubkey: userSolKeypair.publicKey,

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -582,7 +582,7 @@ const main = async () => {
       (async () => {
         const promises = [];
         const cliVars = initializeCLI(network, options.ownerKeypair);
-        const userIdBytesArray = getUserIdBytesArray(options.handle);
+        const userIdBytesArray = getUserIdBytesArray(options.userId);
         const { baseAuthorityAccount, bumpSeed, derivedAddress } =
           await findDerivedPair(
             cliVars.programID,
@@ -629,7 +629,7 @@ const main = async () => {
       (async () => {
         const promises = [];
         const cliVars = initializeCLI(network, options.ownerKeypair);
-        const userIdBytesArray = getUserIdBytesArray(options.handle);
+        const userIdBytesArray = getUserIdBytesArray(options.userId);
         const { baseAuthorityAccount, bumpSeed, derivedAddress } =
           await findDerivedPair(
             cliVars.programID,
@@ -675,7 +675,7 @@ const main = async () => {
       );
       (async () => {
         const cliVars = initializeCLI(network, options.ownerKeypair);
-        const userIdBytesArray = getUserIdBytesArray(options.handle);
+        const userIdBytesArray = getUserIdBytesArray(options.userId);
         const { baseAuthorityAccount, bumpSeed, derivedAddress } =
           await findDerivedPair(
             cliVars.programID,
@@ -716,7 +716,7 @@ const main = async () => {
       );
       (async () => {
         const cliVars = initializeCLI(network, options.ownerKeypair);
-        const userIdBytesArray = getUserIdBytesArray(options.handle);
+        const userIdBytesArray = getUserIdBytesArray(options.userId);
         const { baseAuthorityAccount, bumpSeed, derivedAddress } =
           await findDerivedPair(
             cliVars.programID,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -212,7 +212,7 @@ export type UpdateUserReplicaSet = {
   cn2: anchor.web3.PublicKey;
   cn3: anchor.web3.PublicKey;
   userAcct: anchor.web3.PublicKey;
-  userHandle: { seed: number[]; bump: number };
+  userId: { seed: number[]; bump: number };
 };
 
 export const updateUserReplicaSet = ({
@@ -223,7 +223,7 @@ export const updateUserReplicaSet = ({
   replicaSet,
   userAcct,
   replicaSetBumps,
-  userHandle,
+  userId,
   contentNodeAuthorityPublicKey,
   cn1,
   cn2,
@@ -233,7 +233,7 @@ export const updateUserReplicaSet = ({
   tx.add(
     program.instruction.updateUserReplicaSet(
       baseAuthorityAccount,
-      userHandle,
+      userId,
       replicaSet,
       replicaSetBumps,
       {
@@ -734,7 +734,7 @@ export type DeleteEntityParams = {
   userStorageAccountPDA: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminStorageAccount: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
 };
 
@@ -752,6 +752,7 @@ export const createTrack = ({
   bumpSeed,
 }: CreateEntityParams) => {
   const tx = new Transaction();
+  console.log('MANAGING ENTITYYYYY', 'create trac', userIdBytesArray, bumpSeed)
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
@@ -1160,7 +1161,7 @@ export const deleteTrackRepost = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -367,7 +367,6 @@ export type CreateUserParams = {
   program: Program<AudiusData>;
   ethAccount: Account;
   message: Uint8Array;
-  userId: anchor.BN;
   userIdBytesArray: number[];
   bumpSeed: number;
   metadata: string;
@@ -389,11 +388,10 @@ export const createUser = ({
   message,
   replicaSet,
   replicaSetBumps,
-  userIdBytesArray,
   cn1,
   cn2,
   cn3,
-  userId,
+  userIdBytesArray,
   bumpSeed,
   metadata,
   payer,
@@ -426,10 +424,9 @@ export const createUser = ({
       [...anchor.utils.bytes.hex.decode(ethAccount.address)],
       replicaSet,
       replicaSetBumps,
-      userIdBytesArray,
       bumpSeed,
       metadata,
-      userId,
+      userIdBytesArray,
       userSolPubkey,
       {
         accounts: {
@@ -576,7 +573,7 @@ type AddUserAuthorityDelegateParams = {
   user: anchor.web3.PublicKey;
   currentUserAuthorityDelegate: anchor.web3.PublicKey;
   adminStoragePublicKey: anchor.web3.PublicKey;
-  userHandleBytesArray: number[];
+  userIdBytesArray: number[];
   userBumpSeed: number;
   signerUserAuthorityDelegate: anchor.web3.PublicKey;
   authorityDelegationStatus: anchor.web3.PublicKey;
@@ -591,7 +588,7 @@ export const addUserAuthorityDelegate = ({
   user,
   authorityDelegationStatus,
   currentUserAuthorityDelegate,
-  userHandleBytesArray,
+  userIdBytesArray,
   userBumpSeed,
   adminStoragePublicKey,
   signerUserAuthorityDelegate,
@@ -602,7 +599,7 @@ export const addUserAuthorityDelegate = ({
   tx.add(
     program.instruction.addUserAuthorityDelegate(
       baseAuthorityAccount,
-      { seed: userHandleBytesArray, bump: userBumpSeed },
+      { seed: userIdBytesArray, bump: userBumpSeed },
       delegatePublicKey,
       {
         accounts: {
@@ -629,7 +626,7 @@ type RemoveUserAuthorityDelegateParams = {
   user: anchor.web3.PublicKey;
   currentUserAuthorityDelegate: anchor.web3.PublicKey;
   adminStoragePublicKey: anchor.web3.PublicKey;
-  userHandleBytesArray: number[];
+  userIdBytesArray: number[];
   userBumpSeed: number;
   signerUserAuthorityDelegate: anchor.web3.PublicKey;
   authorityDelegationStatus: anchor.web3.PublicKey;
@@ -645,7 +642,7 @@ export const removeUserAuthorityDelegate = ({
   user,
   authorityDelegationStatus,
   currentUserAuthorityDelegate,
-  userHandleBytesArray,
+  userIdBytesArray,
   userBumpSeed,
   adminStoragePublicKey,
   signerUserAuthorityDelegate,
@@ -656,7 +653,7 @@ export const removeUserAuthorityDelegate = ({
   tx.add(
     program.instruction.removeUserAuthorityDelegate(
       baseAuthorityAccount,
-      { seed: userHandleBytesArray, bump: userBumpSeed },
+      { seed: userIdBytesArray, bump: userBumpSeed },
       delegatePublicKey,
       delegateBump,
       {
@@ -683,7 +680,7 @@ export type UpdateIsVerifiedParams = {
   verifierPublicKey: anchor.web3.PublicKey;
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminPublicKey: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
 };
 
@@ -694,14 +691,14 @@ export const updateIsVerified = ({
   userStorageAccount,
   verifierPublicKey,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
 }: UpdateIsVerifiedParams) => {
   const tx = new Transaction();
   tx.add(
     program.instruction.updateIsVerified(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       {
         accounts: {
           user: userStorageAccount,
@@ -750,7 +747,7 @@ export const createTrack = ({
   authorityDelegationStatusAccountPDA,
   userStorageAccountPDA,
   metadata,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: CreateEntityParams) => {
@@ -758,7 +755,7 @@ export const createTrack = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.track,
       ManagementActions.create,
       id,
@@ -1345,9 +1342,9 @@ type UserSocialActionParams = {
   authorityDelegationStatusAccountPDA: anchor.web3.PublicKey;
   userAuthorityPublicKey: anchor.web3.PublicKey;
   adminStoragePublicKey: anchor.web3.PublicKey;
-  sourceUserHandleBytesArray: number[];
+  sourceUserIdBytesArray: number[];
   sourceUserBumpSeed: number;
-  targetUserHandleBytesArray: number[];
+  targetUserIdBytesArray: number[];
   targetUserBumpSeed: number;
 };
 
@@ -1359,9 +1356,9 @@ export const followUser = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  sourceUserHandleBytesArray,
+  sourceUserIdBytesArray,
   sourceUserBumpSeed,
-  targetUserHandleBytesArray,
+  targetUserIdBytesArray,
   targetUserBumpSeed,
   adminStoragePublicKey,
 }: UserSocialActionParams) => {
@@ -1370,8 +1367,8 @@ export const followUser = ({
     program.instruction.writeUserSocialAction(
       baseAuthorityAccount,
       UserSocialActions.followUser,
-      { seed: sourceUserHandleBytesArray, bump: sourceUserBumpSeed },
-      { seed: targetUserHandleBytesArray, bump: targetUserBumpSeed },
+      { seed: sourceUserIdBytesArray, bump: sourceUserBumpSeed },
+      { seed: targetUserIdBytesArray, bump: targetUserBumpSeed },
       {
         accounts: {
           audiusAdmin: adminStoragePublicKey,
@@ -1395,9 +1392,9 @@ export const unfollowUser = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  sourceUserHandleBytesArray,
+  sourceUserIdBytesArray,
   sourceUserBumpSeed,
-  targetUserHandleBytesArray,
+  targetUserIdBytesArray,
   targetUserBumpSeed,
   adminStoragePublicKey,
 }: UserSocialActionParams) => {
@@ -1406,8 +1403,8 @@ export const unfollowUser = ({
     program.instruction.writeUserSocialAction(
       baseAuthorityAccount,
       UserSocialActions.unfollowUser,
-      { seed: sourceUserHandleBytesArray, bump: sourceUserBumpSeed },
-      { seed: targetUserHandleBytesArray, bump: targetUserBumpSeed },
+      { seed: sourceUserIdBytesArray, bump: sourceUserBumpSeed },
+      { seed: targetUserIdBytesArray, bump: targetUserBumpSeed },
       {
         accounts: {
           audiusAdmin: adminStoragePublicKey,
@@ -1431,9 +1428,9 @@ export const subscribeUser = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  sourceUserHandleBytesArray,
+  sourceUserIdBytesArray,
   sourceUserBumpSeed,
-  targetUserHandleBytesArray,
+  targetUserIdBytesArray,
   targetUserBumpSeed,
   adminStoragePublicKey,
 }: UserSocialActionParams) => {
@@ -1442,8 +1439,8 @@ export const subscribeUser = ({
     program.instruction.writeUserSocialAction(
       baseAuthorityAccount,
       UserSocialActions.subscribeUser,
-      { seed: sourceUserHandleBytesArray, bump: sourceUserBumpSeed },
-      { seed: targetUserHandleBytesArray, bump: targetUserBumpSeed },
+      { seed: sourceUserIdBytesArray, bump: sourceUserBumpSeed },
+      { seed: targetUserIdBytesArray, bump: targetUserBumpSeed },
       {
         accounts: {
           audiusAdmin: adminStoragePublicKey,
@@ -1467,9 +1464,9 @@ export const unsubscribeUser = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  sourceUserHandleBytesArray,
+  sourceUserIdBytesArray,
   sourceUserBumpSeed,
-  targetUserHandleBytesArray,
+  targetUserIdBytesArray,
   targetUserBumpSeed,
   adminStoragePublicKey,
 }: UserSocialActionParams) => {
@@ -1478,8 +1475,8 @@ export const unsubscribeUser = ({
     program.instruction.writeUserSocialAction(
       baseAuthorityAccount,
       UserSocialActions.unsubscribeUser,
-      { seed: sourceUserHandleBytesArray, bump: sourceUserBumpSeed },
-      { seed: targetUserHandleBytesArray, bump: targetUserBumpSeed },
+      { seed: sourceUserIdBytesArray, bump: sourceUserBumpSeed },
+      { seed: targetUserIdBytesArray, bump: targetUserBumpSeed },
       {
         accounts: {
           audiusAdmin: adminStoragePublicKey,

--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -61,7 +61,7 @@ export type InitUserParams = {
   payer: anchor.web3.PublicKey;
   program: Program<AudiusData>;
   ethAddress: string;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   metadata: string;
   userStorageAccount: anchor.web3.PublicKey;
@@ -81,7 +81,7 @@ export const initUser = ({
   payer,
   program,
   ethAddress,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   replicaSet,
   replicaSetBumps,
@@ -101,7 +101,7 @@ export const initUser = ({
       [...anchor.utils.bytes.hex.decode(ethAddress)],
       replicaSet,
       replicaSetBumps,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       {
@@ -368,7 +368,7 @@ export type CreateUserParams = {
   ethAccount: Account;
   message: Uint8Array;
   userId: anchor.BN;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   metadata: string;
   userSolPubkey: anchor.web3.PublicKey;
@@ -389,7 +389,7 @@ export const createUser = ({
   message,
   replicaSet,
   replicaSetBumps,
-  handleBytesArray,
+  userIdBytesArray,
   cn1,
   cn2,
   cn3,
@@ -426,7 +426,7 @@ export const createUser = ({
       [...anchor.utils.bytes.hex.decode(ethAccount.address)],
       replicaSet,
       replicaSetBumps,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userId,
@@ -718,7 +718,7 @@ export type CreateEntityParams = {
   program: Program<AudiusData>;
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminStorageAccount: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   userAuthorityPublicKey: anchor.web3.PublicKey;
   userStorageAccountPDA: anchor.web3.PublicKey;
@@ -799,7 +799,7 @@ export type UpdateEntityParams = {
   program: Program<AudiusData>;
   baseAuthorityAccount: anchor.web3.PublicKey;
   adminStorageAccount: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   metadata: string;
   id: anchor.BN;
@@ -830,7 +830,7 @@ export type EntitySocialActionArgs = {
   authorityDelegationStatusAccountPDA: anchor.web3.PublicKey;
   userAuthorityPublicKey: anchor.web3.PublicKey;
   adminStoragePublicKey: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   id: string;
 };
@@ -844,7 +844,7 @@ export const updateTrack = ({
   userStorageAccountPDA,
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: UpdateEntityParams) => {
@@ -852,7 +852,7 @@ export const updateTrack = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.track,
       ManagementActions.update,
       id,
@@ -881,7 +881,7 @@ export const deleteTrack = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: DeleteEntityParams) => {
@@ -889,7 +889,7 @@ export const deleteTrack = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.track,
       ManagementActions.delete,
       id,
@@ -919,7 +919,7 @@ export const createPlaylist = ({
   authorityDelegationStatusAccountPDA,
   userStorageAccountPDA,
   metadata,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: CreateEntityParams) => {
@@ -927,7 +927,7 @@ export const createPlaylist = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.playlist,
       ManagementActions.create,
       id,
@@ -957,7 +957,7 @@ export const updatePlaylist = ({
   authorityDelegationStatusAccountPDA,
   userStorageAccountPDA,
   metadata,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: UpdateEntityParams) => {
@@ -965,7 +965,7 @@ export const updatePlaylist = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.playlist,
       ManagementActions.update,
       id,
@@ -993,7 +993,7 @@ export const deletePlaylist = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   adminStorageAccount,
   bumpSeed,
 }: DeleteEntityParams) => {
@@ -1001,7 +1001,7 @@ export const deletePlaylist = ({
   tx.add(
     program.instruction.manageEntity(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntityTypesEnumValues.playlist,
       ManagementActions.delete,
       id,
@@ -1048,7 +1048,7 @@ type EntitySocialActionParams = {
   authorityDelegationStatusAccountPDA: anchor.web3.PublicKey;
   userAuthorityPublicKey: anchor.web3.PublicKey;
   adminStoragePublicKey: anchor.web3.PublicKey;
-  handleBytesArray: number[];
+  userIdBytesArray: number[];
   bumpSeed: number;
   id: string;
 };
@@ -1061,7 +1061,7 @@ export const addTrackSave = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1070,7 +1070,7 @@ export const addTrackSave = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.addSave,
       EntityTypesEnumValues.track,
       id,
@@ -1095,7 +1095,7 @@ export const deleteTrackSave = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1104,7 +1104,7 @@ export const deleteTrackSave = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.deleteSave,
       EntityTypesEnumValues.track,
       id,
@@ -1129,7 +1129,7 @@ export const addTrackRepost = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1138,7 +1138,7 @@ export const addTrackRepost = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.addRepost,
       EntityTypesEnumValues.track,
       id,
@@ -1172,7 +1172,7 @@ export const deleteTrackRepost = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.deleteRepost,
       EntityTypesEnumValues.track,
       id,
@@ -1197,7 +1197,7 @@ export const addPlaylistSave = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1206,7 +1206,7 @@ export const addPlaylistSave = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.addSave,
       EntityTypesEnumValues.playlist,
       id,
@@ -1231,7 +1231,7 @@ export const deletePlaylistSave = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1240,7 +1240,7 @@ export const deletePlaylistSave = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.deleteSave,
       EntityTypesEnumValues.playlist,
       id,
@@ -1265,7 +1265,7 @@ export const addPlaylistRepost = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1274,7 +1274,7 @@ export const addPlaylistRepost = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.addRepost,
       EntityTypesEnumValues.playlist,
       id,
@@ -1299,7 +1299,7 @@ export const deletePlaylistRepost = ({
   userAuthorityDelegateAccountPDA,
   authorityDelegationStatusAccountPDA,
   userAuthorityPublicKey,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStoragePublicKey,
   id,
@@ -1308,7 +1308,7 @@ export const deletePlaylistRepost = ({
   tx.add(
     program.instruction.writeEntitySocialAction(
       baseAuthorityAccount,
-      { seed: handleBytesArray, bump: bumpSeed },
+      { seed: userIdBytesArray, bump: bumpSeed },
       EntitySocialActions.deleteRepost,
       EntityTypesEnumValues.playlist,
       id,
@@ -1416,7 +1416,8 @@ export const unfollowUser = ({
           userAuthorityDelegate: userAuthorityDelegateAccountPDA,
           authorityDelegationStatus: authorityDelegationStatusAccountPDA,
           authority: userAuthorityPublicKey,
-        }      }
+        }
+      }
     )
   );
   return tx;

--- a/solana-programs/anchor/audius-data/lib/utils.ts
+++ b/solana-programs/anchor/audius-data/lib/utils.ts
@@ -134,20 +134,20 @@ export const findDerivedAddress = async (
 };
 
 // Finds the target PDA with the base audius admin as the initial seed
-// In conjunction with the secondary seed as the users handle in bytes
+// In conjunction with the secondary seed as the users ID in bytes
 export const findDerivedPair = async (programId, adminAccount, seed) => {
   const [baseAuthorityAccount] = await findProgramAddress(
     programId,
     adminAccount
   );
-  const derivedAddresInfo = await findDerivedAddress(
+  const derivedAddressInfo = await findDerivedAddress(
     programId,
     baseAuthorityAccount,
     seed
   );
 
-  const derivedAddress = derivedAddresInfo.result[0];
-  const bumpSeed = derivedAddresInfo.result[1];
+  const derivedAddress = derivedAddressInfo.result[0];
+  const bumpSeed = derivedAddressInfo.result[1];
 
   return { baseAuthorityAccount, derivedAddress, bumpSeed };
 };

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -345,7 +345,7 @@ pub mod audius_data {
         _replica_set_bumps: [u8; 3],
         _user_bump: u8,
         _metadata: String,
-        _id: u64,
+        _id_bytes_array: [u8; 32],
         user_authority: Pubkey,
     ) -> Result<()> {
         // Confirm that the base used for user account seed is derived from this Audius admin storage account

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -712,7 +712,7 @@ pub struct PublicDeleteContentNode<'info> {
 #[instruction(base: Pubkey, user_id: UserSeedBump, replica_set: [u16; 3], replica_set_bumps: [u8; 3])]
 pub struct UpdateUserReplicaSet<'info> {
     pub admin: Account<'info, AudiusAdmin>,
-    #[account(mut, seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump=user_id.bump)]
+    #[account(mut, seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()], bump=user_id.bump)]
     pub user: Account<'info, User>,
     #[account(seeds = [&base.to_bytes()[..32], CONTENT_NODE_SEED_PREFIX, &replica_set[0].to_le_bytes()], bump = replica_set_bumps[0])]
     pub cn1: Account<'info, ContentNode>,
@@ -851,7 +851,7 @@ pub struct AddUserAuthorityDelegate<'info> {
     #[account()]
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
-        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()],
         bump = user_id.bump
     )]
     pub user: Account<'info, User>,
@@ -884,7 +884,7 @@ pub struct RemoveUserAuthorityDelegate<'info> {
     #[account()]
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
-        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()],
         bump = user_id.bump
     )]
     pub user: Account<'info, User>,
@@ -925,7 +925,7 @@ pub struct ManageEntity<'info> {
     pub audius_admin: Account<'info, AudiusAdmin>,
     // Audiusadmin
     #[account(
-        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()],
         bump = user_id.bump
     )]
     pub user: Account<'info, User>,
@@ -947,7 +947,7 @@ pub struct WriteEntitySocialAction<'info> {
     // TODO - Verify removal here
     #[account()]
     pub audius_admin: Account<'info, AudiusAdmin>,
-    #[account(seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump = user_id.bump)]
+    #[account(seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()], bump = user_id.bump)]
     pub user: Account<'info, User>,
     #[account()]
     pub authority: Signer<'info>, 
@@ -966,10 +966,10 @@ pub struct WriteUserSocialAction<'info> {
     #[account(mut)]
     pub audius_admin: Account<'info, AudiusAdmin>,
     // Confirm the source user PDA matches the expected value provided the target id and base
-    #[account(mut, seeds = [&base.to_bytes()[..32], source_user_id.seed.as_ref()], bump = source_user_id.bump)]
+    #[account(mut, seeds = [&base.to_bytes()[..32], source_user_id.user_id.to_le_bytes().as_ref()], bump = source_user_id.bump)]
     pub source_user_storage: Account<'info, User>,
     // Confirm the target user PDA matches the expected value provided the target id and base
-    #[account(mut, seeds = [&base.to_bytes()[..32], target_user_id.seed.as_ref()], bump = target_user_id.bump)]
+    #[account(mut, seeds = [&base.to_bytes()[..32], target_user_id.user_id.to_le_bytes().as_ref()], bump = target_user_id.bump)]
     pub target_user_storage: Account<'info, User>,
     /// CHECK: When signer is a delegate, validate UserAuthorityDelegate PDA  (default SystemProgram when signer is user)
     #[account()]
@@ -987,7 +987,7 @@ pub struct WriteUserSocialAction<'info> {
 #[instruction(base: Pubkey, user_id: UserSeedBump)]
 pub struct UpdateIsVerified<'info> {
     pub audius_admin: Account<'info, AudiusAdmin>,
-    #[account(seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump = user_id.bump)]
+    #[account(seeds = [&base.to_bytes()[..32], user_id.user_id.to_le_bytes().as_ref()], bump = user_id.bump)]
     pub user: Account<'info, User>,
     pub verifier: Signer<'info>,
 }
@@ -1067,7 +1067,7 @@ pub enum EntityTypes {
 // Seed & bump used to validate the user's id with the account base
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct UserSeedBump {
-    pub seed: [u8; 32],
+    pub user_id: u32,
     pub bump: u8,
 }
 

--- a/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
+++ b/solana-programs/anchor/audius-data/programs/audius-data/src/lib.rs
@@ -41,7 +41,7 @@ pub mod audius_data {
     pub fn update_is_verified(
         ctx: Context<UpdateIsVerified>,
         base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
     ) -> Result<()> {
         // Validate that the audius admin verifier matches the verifier passed in
         if ctx.accounts.audius_admin.verifier != ctx.accounts.verifier.key() {
@@ -61,7 +61,7 @@ pub mod audius_data {
     }
 
     /// Initialize a user account from the admin account.
-    /// The user's account is derived from the admin base PDA + handle bytes.
+    /// The user's account is derived from the admin base PDA + id.
     /// Populates the user account with their Ethereum address as bytes and an empty Pubkey for their Solana identity.
     /// Allows the user to later "claim" their account by submitting a signed object and setting their own identity.
     /// Important to note that the metadata object is simply logged out to be picked up by the Audius indexing layer.
@@ -71,7 +71,7 @@ pub mod audius_data {
         eth_address: [u8; 20],
         replica_set: [u16; 3],
         _replica_set_bumps: [u8; 3],
-        handle_seed: [u8; 32],
+        _id_bytes_array: [u8; 32],
         _user_bump: u8,
         _metadata: String,
     ) -> Result<()> {
@@ -87,7 +87,7 @@ pub mod audius_data {
 
         // Confirm that the derived pda from base is the same as the user storage account
         let (derived_user_acct, _) = Pubkey::find_program_address(
-            &[&derived_base.to_bytes()[..32], &handle_seed],
+            &[&derived_base.to_bytes()[..32], &_id_bytes_array],
             ctx.program_id,
         );
         if derived_user_acct != ctx.accounts.user.key() {
@@ -245,7 +245,7 @@ pub mod audius_data {
     pub fn update_user_replica_set(
         ctx: Context<UpdateUserReplicaSet>,
         base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
         replica_set: [u16;3],
         _replica_set_bumps: [u8; 3]
     ) -> Result<()> {
@@ -343,7 +343,6 @@ pub mod audius_data {
         eth_address: [u8; 20],
         replica_set: [u16; 3],
         _replica_set_bumps: [u8; 3],
-        _handle_seed: [u8; 32],
         _user_bump: u8,
         _metadata: String,
         _id: u64,
@@ -418,7 +417,7 @@ pub mod audius_data {
     pub fn manage_entity(
         ctx: Context<ManageEntity>,
         base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
         _entity_type: EntityTypes,
         _management_action: ManagementActions,
         _id: u64,
@@ -447,7 +446,7 @@ pub mod audius_data {
     pub fn write_entity_social_action(
         ctx: Context<WriteEntitySocialAction>,
         base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
         _entity_social_action: EntitySocialActionValues,
         _entity_type: EntityTypes,
         _id: String,
@@ -477,7 +476,7 @@ pub mod audius_data {
         User social action functions
 
         Follow/subscribe a user, transaction sent from 1 known valid source user to another target user
-        Both User accounts are re-derived from the handle seed and validated
+        Both User accounts are re-derived from the id seed and validated
         Only the follower must have already claimed their solana public key -
         in order to facilitate the scenario where an 'initialized' user follows an 'unitialized' user
         Note that both follow/subscribe and unfollow/unsubscribe are handled in this single function through an enum, with identical
@@ -487,8 +486,8 @@ pub mod audius_data {
         ctx: Context<WriteUserSocialAction>,
         base: Pubkey,
         _user_action: UserAction,
-        _source_user_handle: UserHandle,
-        _target_user_handle: UserHandle,
+        _source_user_id: UserSeedBump,
+        _target_user_id: UserSeedBump,
     ) -> Result<()> {
         let admin_key: &Pubkey = &ctx.accounts.audius_admin.key();
         let (base_pda, _bump) =
@@ -538,7 +537,7 @@ pub mod audius_data {
     pub fn add_user_authority_delegate(
         ctx: Context<AddUserAuthorityDelegate>,
         _base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
         delegate_pubkey: Pubkey,
     ) -> Result<()> {
         // validate signer is the user or delegate
@@ -563,7 +562,7 @@ pub mod audius_data {
     pub fn remove_user_authority_delegate(
         ctx: Context<RemoveUserAuthorityDelegate>,
         _base: Pubkey,
-        _user_handle: UserHandle,
+        _user_id: UserSeedBump,
         _user_authority_delegate: Pubkey,
         _delegate_bump: u8,
     ) -> Result<()> {
@@ -599,19 +598,19 @@ pub struct Initialize<'info> {
 
 /// Instruction container to initialize a user account, must be invoked from an existing Audius
 /// `admin` account.
-/// `user` is a PDA derived from the Audius account and handle.
+/// `user` is a PDA derived from the Audius account and user id.
 /// `authority` is a signer key matching the admin value stored in AudiusAdmin root. Only the
 ///  admin of this Audius root program may initialize users through this function
 /// `payer` is the account responsible for the lamports required to allocate this account.
 /// `system_program` is required for PDA derivation.
 #[derive(Accounts)]
-#[instruction(base: Pubkey, eth_address: [u8;20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], handle_seed: [u8;32])]
+#[instruction(base: Pubkey, eth_address: [u8; 20], replica_set: [u16; 3], replica_set_bumps:[u8; 3], _id_bytes_array: [u8; 32])]
 pub struct InitializeUser<'info> {
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
         init,
         payer = payer,
-        seeds = [&base.to_bytes()[..32], handle_seed.as_ref()],
+        seeds = [&base.to_bytes()[..32], &_id_bytes_array],
         bump,
         space = USER_ACCOUNT_SIZE
     )]
@@ -710,10 +709,10 @@ pub struct PublicDeleteContentNode<'info> {
 
 /// Instruction container for updating a user's replica set signed by the user's authority or a content node
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_handle: UserHandle, replica_set: [u16; 3], replica_set_bumps: [u8; 3])]
+#[instruction(base: Pubkey, user_id: UserSeedBump, replica_set: [u16; 3], replica_set_bumps: [u8; 3])]
 pub struct UpdateUserReplicaSet<'info> {
     pub admin: Account<'info, AudiusAdmin>,
-    #[account(mut, seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()], bump=user_handle.bump)]
+    #[account(mut, seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump=user_id.bump)]
     pub user: Account<'info, User>,
     #[account(seeds = [&base.to_bytes()[..32], CONTENT_NODE_SEED_PREFIX, &replica_set[0].to_le_bytes()], bump = replica_set_bumps[0])]
     pub cn1: Account<'info, ContentNode>,
@@ -744,20 +743,19 @@ pub struct InitializeUserSolIdentity<'info> {
 #[derive(Accounts)]
 #[instruction(
     base: Pubkey,
-    eth_address: [u8;20],
+    eth_address: [u8; 20],
     replica_set: [u16; 3],
     replica_set_bumps:[u8; 3],
-    handle_seed: [u8;32],
     _user_bump: u8,
     _metadata: String,
-    _id: u64,
+    _id_bytes_array: [u8; 32],
     _user_authority: Pubkey,
 )]
 pub struct CreateUser<'info> {
     #[account(
         init,
         payer = payer,
-        seeds = [&base.to_bytes()[..32], handle_seed.as_ref()],
+        seeds = [&base.to_bytes()[..32], &_id_bytes_array],
         bump,
         space = USER_ACCOUNT_SIZE
     )]
@@ -848,13 +846,13 @@ pub struct RevokeAuthorityDelegationStatus<'info> {
 /// Instruction container to allow user delegation
 /// Allocates a new account that will be used for fallback in auth scenarios
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_handle: UserHandle, delegate_pubkey: Pubkey)]
+#[instruction(base: Pubkey, user_id: UserSeedBump, delegate_pubkey: Pubkey)]
 pub struct AddUserAuthorityDelegate<'info> {
     #[account()]
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
-        seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()],
-        bump = user_handle.bump
+        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        bump = user_id.bump
     )]
     pub user: Account<'info, User>,
     #[account(
@@ -881,13 +879,13 @@ pub struct AddUserAuthorityDelegate<'info> {
 /// Instruction container to remove allocated user authority delegation
 /// Returns funds to payer
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_handle: UserHandle, delegate_pubkey: Pubkey, delegate_bump:u8)]
+#[instruction(base: Pubkey, user_id: UserSeedBump, delegate_pubkey: Pubkey, delegate_bump:u8)]
 pub struct RemoveUserAuthorityDelegate<'info> {
     #[account()]
     pub admin: Account<'info, AudiusAdmin>,
     #[account(
-        seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()],
-        bump = user_handle.bump
+        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        bump = user_id.bump
     )]
     pub user: Account<'info, User>,
     #[account(
@@ -915,20 +913,20 @@ pub struct RemoveUserAuthorityDelegate<'info> {
 #[derive(Accounts)]
 #[instruction(
     base: Pubkey,
-    user_handle: UserHandle,
+    user_id: UserSeedBump,
     _entity_type: EntityTypes,
     _management_action:ManagementActions,
     _id: u64,
     _metadata: String
 )]
-// Instruction base pda, handle
+// Instruction base pda, user id
 pub struct ManageEntity<'info> {
     #[account()]
     pub audius_admin: Account<'info, AudiusAdmin>,
     // Audiusadmin
     #[account(
-        seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()],
-        bump = user_handle.bump
+        seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()],
+        bump = user_id.bump
     )]
     pub user: Account<'info, User>,
     #[account()]
@@ -944,12 +942,12 @@ pub struct ManageEntity<'info> {
 /// Instruction container for track social action event
 /// Confirm that the user authority matches signer authority field
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_handle: UserHandle)]
+#[instruction(base: Pubkey, user_id: UserSeedBump)]
 pub struct WriteEntitySocialAction<'info> {
     // TODO - Verify removal here
     #[account()]
     pub audius_admin: Account<'info, AudiusAdmin>,
-    #[account(seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()], bump = user_handle.bump)]
+    #[account(seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump = user_id.bump)]
     pub user: Account<'info, User>,
     #[account()]
     pub authority: Signer<'info>, 
@@ -963,15 +961,15 @@ pub struct WriteEntitySocialAction<'info> {
 
 /// Instruction container for user social actions
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_instr:UserAction, source_user_handle: UserHandle, target_user_handle: UserHandle)]
+#[instruction(base: Pubkey, user_instr:UserAction, source_user_id: UserSeedBump, target_user_id: UserSeedBump)]
 pub struct WriteUserSocialAction<'info> {
     #[account(mut)]
     pub audius_admin: Account<'info, AudiusAdmin>,
-    // Confirm the source user PDA matches the expected value provided the target handle and base
-    #[account(mut, seeds = [&base.to_bytes()[..32], source_user_handle.seed.as_ref()], bump = source_user_handle.bump)]
+    // Confirm the source user PDA matches the expected value provided the target id and base
+    #[account(mut, seeds = [&base.to_bytes()[..32], source_user_id.seed.as_ref()], bump = source_user_id.bump)]
     pub source_user_storage: Account<'info, User>,
-    // Confirm the target user PDA matches the expected value provided the target handle and base
-    #[account(mut, seeds = [&base.to_bytes()[..32], target_user_handle.seed.as_ref()], bump = target_user_handle.bump)]
+    // Confirm the target user PDA matches the expected value provided the target id and base
+    #[account(mut, seeds = [&base.to_bytes()[..32], target_user_id.seed.as_ref()], bump = target_user_id.bump)]
     pub target_user_storage: Account<'info, User>,
     /// CHECK: When signer is a delegate, validate UserAuthorityDelegate PDA  (default SystemProgram when signer is user)
     #[account()]
@@ -986,10 +984,10 @@ pub struct WriteUserSocialAction<'info> {
 
 /// Instruction container for verifying a user
 #[derive(Accounts)]
-#[instruction(base: Pubkey, user_handle: UserHandle)]
+#[instruction(base: Pubkey, user_id: UserSeedBump)]
 pub struct UpdateIsVerified<'info> {
     pub audius_admin: Account<'info, AudiusAdmin>,
-    #[account(seeds = [&base.to_bytes()[..32], user_handle.seed.as_ref()], bump = user_handle.bump)]
+    #[account(seeds = [&base.to_bytes()[..32], user_id.seed.as_ref()], bump = user_id.bump)]
     pub user: Account<'info, User>,
     pub verifier: Signer<'info>,
 }
@@ -1066,9 +1064,9 @@ pub enum EntityTypes {
     Playlist,
 }
 
-// Seed & bump used to validate the user's handle with the account base
+// Seed & bump used to validate the user's id with the account base
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
-pub struct UserHandle {
+pub struct UserSeedBump {
     pub seed: [u8; 32],
     pub bump: u8,
 }

--- a/solana-programs/anchor/audius-data/scripts/seed-tx.sh
+++ b/solana-programs/anchor/audius-data/scripts/seed-tx.sh
@@ -46,7 +46,7 @@ yarn run ts-node cli/main.ts -f initUser \
     --admin-keypair "$ADMIN_KEYPAIR_PATH" \
     --admin-storage-keypair "$ADMIN_STORAGE_KEYPAIR_PATH" \
     --user-replica-set 1,2,3 \
-    --handle handlebcdef \
+    --user-id 1 \
     -e 0x0a93d8cb0Be85B3Ea8f33FA63500D118deBc83F7 | tee /tmp/initUserOutput.txt
 
 USER_STORAGE_PUBKEY=$(cut -d '=' -f 4 <<< $(cat /tmp/initUserOutput.txt | grep userAcct))
@@ -70,7 +70,7 @@ yarn run ts-node cli/main.ts -f createTrack \
     --user-solana-keypair "$USER_KEYPAIR_PATH" \
     --user-storage-pubkey "$USER_STORAGE_PUBKEY" \
     --admin-storage-keypair "$ADMIN_STORAGE_KEYPAIR_PATH" \
-    --handle handlebcdef # metadata CID that would point off-chain is randomly generated here
+    --user-id 1 # metadata CID that would point off-chain is randomly generated here
 
 echo "Creating playlist"
 
@@ -79,7 +79,7 @@ yarn run ts-node cli/main.ts -f createPlaylist \
     --user-solana-keypair "$USER_KEYPAIR_PATH" \
     --user-storage-pubkey "$USER_STORAGE_PUBKEY" \
     --admin-storage-keypair "$ADMIN_STORAGE_KEYPAIR_PATH" \
-    --handle handlebcdef | tee /tmp/createPlaylistOutput.txt # metadata CID that would point off-chain is randomly generated here 
+    --user-id 1 | tee /tmp/createPlaylistOutput.txt # metadata CID that would point off-chain is randomly generated here 
 
 PLAYLIST_ID=$(cut -d '=' -f 3 <<< $(cat /tmp/createPlaylistOutput.txt | grep "Transacting on entity"))
 
@@ -91,7 +91,7 @@ yarn run ts-node cli/main.ts -f updatePlaylist \
     --user-storage-pubkey "$USER_STORAGE_PUBKEY" \
     --admin-storage-keypair "$ADMIN_STORAGE_KEYPAIR_PATH" \
     --id "$PLAYLIST_ID" \
-    --handle handlebcdef # metadata CID that would point off-chain is randomly generated here 
+    --user-id 1 # metadata CID that would point off-chain is randomly generated here 
 
 echo "Deleting playlist"
 
@@ -101,7 +101,7 @@ yarn run ts-node cli/main.ts -f deletePlaylist \
     --user-storage-pubkey "$USER_STORAGE_PUBKEY" \
     --admin-storage-keypair "$ADMIN_STORAGE_KEYPAIR_PATH" \
     --id "$PLAYLIST_ID" \
-    --handle handlebcdef
+    --user-id 1
 
 echo "Successfully seeded tx:"
 

--- a/solana-programs/anchor/audius-data/tests/audius-data.ts
+++ b/solana-programs/anchor/audius-data/tests/audius-data.ts
@@ -134,7 +134,7 @@ describe("audius-data", function () {
   });
 
   it("Initializing user!", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -143,7 +143,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -151,7 +151,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -162,7 +162,7 @@ describe("audius-data", function () {
   });
 
   it("Initializing + claiming user!", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -171,7 +171,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -179,7 +179,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -216,7 +216,7 @@ describe("audius-data", function () {
   });
 
   it("Initializing + claiming user with bad message should fail!", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -225,7 +225,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -233,7 +233,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -262,7 +262,7 @@ describe("audius-data", function () {
   });
 
   it("Initializing + claiming + updating user!", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -271,7 +271,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -279,7 +279,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -329,7 +329,7 @@ describe("audius-data", function () {
   });
 
   it("Initializing + claiming user, creating + updating track", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -338,7 +338,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -346,7 +346,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -378,7 +378,7 @@ describe("audius-data", function () {
       provider,
       program,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       id: trackID,
       trackMetadata,
@@ -399,7 +399,7 @@ describe("audius-data", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         id: randomId(),
         trackMetadata,
@@ -417,7 +417,7 @@ describe("audius-data", function () {
       provider,
       program,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       adminStorageAccount: adminStorageKeypair.publicKey,
       id: trackID,
@@ -430,7 +430,7 @@ describe("audius-data", function () {
   });
 
   it("Creating user with admin writes enabled should fail", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -440,7 +440,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // enable admin writes
@@ -465,11 +465,10 @@ describe("audius-data", function () {
         message,
         ethAccount,
         baseAuthorityAccount,
-        handleBytesArray,
         bumpSeed,
         metadata,
         newUserKeypair,
-        userId,
+        userIdBytesArray,
         userStorageAccount: newUserAcctPDA,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
         ...getURSMParams(),
@@ -478,7 +477,7 @@ describe("audius-data", function () {
   });
 
   it("Creating user with bad message should fail!", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -488,7 +487,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // disable admin writes
@@ -513,10 +512,9 @@ describe("audius-data", function () {
         message,
         ethAccount,
         baseAuthorityAccount,
-        handleBytesArray,
         bumpSeed,
         metadata,
-        userId,
+        userIdBytesArray,
         newUserKeypair,
         userStorageAccount: newUserAcctPDA,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
@@ -526,7 +524,7 @@ describe("audius-data", function () {
   });
 
   it("Creating user!", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -536,7 +534,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // disable admin writes
@@ -562,11 +560,10 @@ describe("audius-data", function () {
       message,
       ethAccount,
       baseAuthorityAccount,
-      handleBytesArray,
       bumpSeed,
       metadata,
       newUserKeypair,
-      userId,
+      userIdBytesArray,
       userStorageAccount: newUserAcctPDA,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       ...getURSMParams(),
@@ -579,11 +576,10 @@ describe("audius-data", function () {
         message,
         ethAccount,
         baseAuthorityAccount,
-        handleBytesArray,
         bumpSeed,
         metadata,
         newUserKeypair,
-        userId,
+        userIdBytesArray,
         userStorageAccount: newUserAcctPDA,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
         ...getURSMParams(),
@@ -647,7 +643,7 @@ describe("audius-data", function () {
       program,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       baseAuthorityAccount: userDelegate.baseAuthorityAccount,
-      userHandleBytesArray: userDelegate.userHandleBytesArray,
+      userIdBytesArray: userDelegate.userIdBytesArray,
       userBumpSeed: userDelegate.userBumpSeed,
       user: userDelegate.userAccountPDA,
       currentUserAuthorityDelegate: userDelegate.userAuthorityDelegatePDA,
@@ -792,7 +788,7 @@ describe("audius-data", function () {
       program,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       baseAuthorityAccount: firstUserDelegate.baseAuthorityAccount,
-      userHandleBytesArray: firstUserDelegate.userHandleBytesArray,
+      userIdBytesArray: firstUserDelegate.userIdBytesArray,
       userBumpSeed: firstUserDelegate.userBumpSeed,
       user: firstUserDelegate.userAccountPDA,
       currentUserAuthorityDelegate: currentUserAuthorityDelegatePDA,
@@ -810,7 +806,7 @@ describe("audius-data", function () {
       program,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       baseAuthorityAccount: firstUserDelegate.baseAuthorityAccount,
-      userHandleBytesArray: firstUserDelegate.userHandleBytesArray,
+      userIdBytesArray: firstUserDelegate.userIdBytesArray,
       userBumpSeed: firstUserDelegate.userBumpSeed,
       user: firstUserDelegate.userAccountPDA,
       currentUserAuthorityDelegate: currentUserAuthorityDelegatePDA,
@@ -826,7 +822,7 @@ describe("audius-data", function () {
   });
 
   it("creating initialized user should fail", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -836,7 +832,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -844,7 +840,7 @@ describe("audius-data", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -867,9 +863,8 @@ describe("audius-data", function () {
         message,
         ethAccount,
         baseAuthorityAccount,
-        handleBytesArray,
         bumpSeed,
-        userId,
+        userIdBytesArray,
         metadata,
         newUserKeypair,
         userStorageAccount: newUserAcctPDA,
@@ -884,12 +879,12 @@ describe("audius-data", function () {
   });
 
   it("creating user with incorrect bump seed / pda should fail", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const { baseAuthorityAccount, bumpSeed } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // New sol key that will be used to permission user updates
@@ -899,13 +894,13 @@ describe("audius-data", function () {
     // Message as the incoming public key
     const message = newUserKeypair.publicKey.toBytes();
 
-    const { handleBytesArray: incorrectHandleBytesArray, userId } =
+    const { userIdBytesArray: incorrectUserIdBytesArray } =
       initTestConstants();
 
     const { derivedAddress: incorrectPDA } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(incorrectHandleBytesArray)
+      Buffer.from(incorrectUserIdBytesArray)
     );
 
     await expect(
@@ -915,9 +910,8 @@ describe("audius-data", function () {
         message,
         ethAccount,
         baseAuthorityAccount,
-        handleBytesArray,
         bumpSeed,
-        userId,
+        userIdBytesArray,
         metadata,
         newUserKeypair,
         userStorageAccount: incorrectPDA,
@@ -932,7 +926,7 @@ describe("audius-data", function () {
   });
 
   it("Verify user", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -942,7 +936,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // New sol key that will be used to permission user updates
@@ -958,8 +952,7 @@ describe("audius-data", function () {
       message,
       ethAccount,
       baseAuthorityAccount,
-      handleBytesArray,
-      userId,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       newUserKeypair,
@@ -973,7 +966,7 @@ describe("audius-data", function () {
       userStorageAccount: newUserAcctPDA,
       verifierPublicKey: verifierKeypair.publicKey,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
     });
     const txSignature = await provider.send(tx, [verifierKeypair]);
@@ -982,7 +975,7 @@ describe("audius-data", function () {
   });
 
   it("creating + deleting a track", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -992,7 +985,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await updateAdmin({
@@ -1014,10 +1007,9 @@ describe("audius-data", function () {
       message,
       baseAuthorityAccount,
       ethAccount,
-      handleBytesArray,
       bumpSeed,
       metadata,
-      userId,
+      userIdBytesArray,
       newUserKeypair,
       userStorageAccount: newUserAcctPDA,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
@@ -1032,7 +1024,7 @@ describe("audius-data", function () {
       program,
       id: trackID,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       adminStorageAccount: adminStorageKeypair.publicKey,
       bumpSeed,
       trackMetadata,
@@ -1051,7 +1043,7 @@ describe("audius-data", function () {
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityKeypair: newUserKeypair,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       adminStorageAccount: adminStorageKeypair.publicKey,
     });
@@ -1059,7 +1051,7 @@ describe("audius-data", function () {
 
   it("delegate creates a track (manage entity) + all validation errors", async function () {
     // create user and delegate
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
     const {
       baseAuthorityAccount,
@@ -1068,7 +1060,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // disable admin writes
@@ -1092,14 +1084,13 @@ describe("audius-data", function () {
       message,
       ethAccount,
       baseAuthorityAccount,
-      handleBytesArray,
       bumpSeed: userBumpSeed,
       metadata,
       newUserKeypair,
       userStorageAccount: userAccountPDA,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       ...getURSMParams(),
-      userId,
+      userIdBytesArray,
     });
 
     // New sol key that will be used as user authority delegate
@@ -1137,7 +1128,7 @@ describe("audius-data", function () {
         program,
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1155,7 +1146,7 @@ describe("audius-data", function () {
         program,
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1183,7 +1174,7 @@ describe("audius-data", function () {
       program,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       baseAuthorityAccount: baseAuthorityAccount,
-      userHandleBytesArray: handleBytesArray,
+      userIdBytesArray: userIdBytesArray,
       userBumpSeed: userBumpSeed,
       user: userAccountPDA,
       currentUserAuthorityDelegate: userAuthorityDelegatePDA,
@@ -1203,7 +1194,7 @@ describe("audius-data", function () {
         program,
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1220,7 +1211,7 @@ describe("audius-data", function () {
         program,
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1237,7 +1228,7 @@ describe("audius-data", function () {
         program: anchor.web3.Keypair.generate().publicKey, // wrong program
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1254,7 +1245,7 @@ describe("audius-data", function () {
         program: anchor.web3.Keypair.generate().publicKey, // wrong program
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1279,7 +1270,7 @@ describe("audius-data", function () {
         program: anchor.web3.Keypair.generate().publicKey, // wrong program
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1299,7 +1290,7 @@ describe("audius-data", function () {
         program: anchor.web3.Keypair.generate().publicKey, // wrong program
         id: trackID,
         baseAuthorityAccount: baseAuthorityAccount,
-        handleBytesArray: handleBytesArray,
+        userIdBytesArray: userIdBytesArray,
         adminStorageAccount: adminStorageKeypair.publicKey,
         bumpSeed: userBumpSeed,
         trackMetadata,
@@ -1316,7 +1307,7 @@ describe("audius-data", function () {
       program,
       id: trackID,
       baseAuthorityAccount: baseAuthorityAccount,
-      handleBytesArray: handleBytesArray,
+      userIdBytesArray: userIdBytesArray,
       adminStorageAccount: adminStorageKeypair.publicKey,
       bumpSeed: userBumpSeed,
       trackMetadata,
@@ -1328,7 +1319,7 @@ describe("audius-data", function () {
   });
 
   it("create multiple tracks in parallel", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata } =
       initTestConstants();
 
     const {
@@ -1338,7 +1329,7 @@ describe("audius-data", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // Disable admin writes
@@ -1362,11 +1353,10 @@ describe("audius-data", function () {
       message,
       baseAuthorityAccount,
       ethAccount,
-      handleBytesArray,
       bumpSeed,
       metadata,
       newUserKeypair,
-      userId,
+      userIdBytesArray,
       userStorageAccount: newUserAcctPDA,
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       ...getURSMParams(),
@@ -1381,7 +1371,7 @@ describe("audius-data", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),
@@ -1395,7 +1385,7 @@ describe("audius-data", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),
@@ -1409,7 +1399,7 @@ describe("audius-data", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),

--- a/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist-social-actions.ts
@@ -108,11 +108,11 @@ describe("playlist-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
-    
+
     const txSignature = await provider.send(tx, [user.keypair])
 
     const info = await getTransaction(provider, txSignature);
@@ -121,11 +121,11 @@ describe("playlist-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.deleteSave
     );
@@ -145,7 +145,7 @@ describe("playlist-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -157,11 +157,11 @@ describe("playlist-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.addSave
     );
@@ -181,7 +181,7 @@ describe("playlist-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -193,11 +193,11 @@ describe("playlist-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.addRepost
     );
@@ -217,7 +217,7 @@ describe("playlist-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -228,11 +228,11 @@ describe("playlist-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.deleteRepost
     );

--- a/solana-programs/anchor/audius-data/tests/playlist.ts
+++ b/solana-programs/anchor/audius-data/tests/playlist.ts
@@ -100,7 +100,7 @@ describe("playlists", function () {
   });
 
   it("Initializing + claiming user, creating + updating playlist", async function () {
-    const { ethAccount, handleBytesArray, metadata } = initTestConstants();
+    const { ethAccount, userIdBytesArray, metadata } = initTestConstants();
 
     const {
       baseAuthorityAccount,
@@ -109,7 +109,7 @@ describe("playlists", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     await testInitUser({
@@ -117,7 +117,7 @@ describe("playlists", function () {
       program,
       baseAuthorityAccount,
       ethAddress: ethAccount.address,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       metadata,
       userStorageAccount: newUserAcctPDA,
@@ -149,7 +149,7 @@ describe("playlists", function () {
       provider,
       program,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       id: playlistID,
       playlistMetadata,
@@ -170,7 +170,7 @@ describe("playlists", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         id: randomId(),
         playlistMetadata,
@@ -188,7 +188,7 @@ describe("playlists", function () {
       provider,
       program,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       adminStorageAccount: adminStorageKeypair.publicKey,
       id: playlistID,
@@ -201,7 +201,7 @@ describe("playlists", function () {
   });
 
   it("creating + deleting a playlist", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata, userId } =
       initTestConstants();
 
     const {
@@ -211,7 +211,7 @@ describe("playlists", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // disable admin writes
@@ -237,7 +237,6 @@ describe("playlists", function () {
       message,
       baseAuthorityAccount,
       ethAccount,
-      handleBytesArray,
       bumpSeed,
       metadata,
       newUserKeypair,
@@ -255,7 +254,7 @@ describe("playlists", function () {
       program,
       id: playlistID,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       adminStorageAccount: adminStorageKeypair.publicKey,
       bumpSeed,
       playlistMetadata,
@@ -274,14 +273,14 @@ describe("playlists", function () {
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityKeypair: newUserKeypair,
       baseAuthorityAccount,
-      handleBytesArray,
+      userIdBytesArray,
       bumpSeed,
       adminStorageAccount: adminStorageKeypair.publicKey,
     });
   });
 
   it("create multiple playlists in parallel", async function () {
-    const { ethAccount, handleBytesArray, metadata, userId } =
+    const { ethAccount, userIdBytesArray, metadata, userId } =
       initTestConstants();
 
     const {
@@ -291,7 +290,7 @@ describe("playlists", function () {
     } = await findDerivedPair(
       program.programId,
       adminStorageKeypair.publicKey,
-      Buffer.from(handleBytesArray)
+      Buffer.from(userIdBytesArray)
     );
 
     // Disable admin writes
@@ -317,7 +316,6 @@ describe("playlists", function () {
       message,
       baseAuthorityAccount,
       ethAccount,
-      handleBytesArray,
       bumpSeed,
       metadata,
       newUserKeypair,
@@ -336,7 +334,7 @@ describe("playlists", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),
@@ -350,7 +348,7 @@ describe("playlists", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),
@@ -364,7 +362,7 @@ describe("playlists", function () {
         provider,
         program,
         baseAuthorityAccount,
-        handleBytesArray,
+        userIdBytesArray,
         bumpSeed,
         adminStorageAccount: adminStorageKeypair.publicKey,
         id: randomId(),

--- a/solana-programs/anchor/audius-data/tests/test-helpers.ts
+++ b/solana-programs/anchor/audius-data/tests/test-helpers.ts
@@ -2,7 +2,6 @@ import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
 import Web3 from "web3";
 import { Account } from "web3-core";
-import { randomBytes } from "crypto";
 import { expect } from "chai";
 import {
   findDerivedPair,
@@ -38,26 +37,23 @@ const DefaultPubkey = new PublicKey("11111111111111111111111111111111");
 
 type InitTestConsts = {
   ethAccount: Account;
-  handle: string;
-  handleBytes: Buffer;
-  handleBytesArray: number[];
+  userIdBytes: Buffer;
+  userIdBytesArray: number[];
   metadata: string;
   userId: anchor.BN;
 };
 
 export const initTestConstants = (): InitTestConsts => {
   const ethAccount = EthWeb3.eth.accounts.create();
-  const handle = randomBytes(40).toString("hex");
-  const handleBytes = Buffer.from(anchor.utils.bytes.utf8.encode(handle));
-  const handleBytesArray = Array.from({ ...handleBytes, length: 32 });
-  const metadata = randomCID();
   const userId = randomId();
+  const userIdBytes = Buffer.from(anchor.utils.bytes.utf8.encode(userId.toString()));
+  const userIdBytesArray = Array.from({ ...userIdBytes, length: 32 });
+  const metadata = randomCID();
 
   return {
     ethAccount,
-    handle,
-    handleBytes,
-    handleBytesArray,
+    userIdBytes,
+    userIdBytesArray,
     metadata,
     userId,
   };
@@ -68,7 +64,7 @@ export const testInitUser = async ({
   program,
   baseAuthorityAccount,
   ethAddress,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   metadata,
   userStorageAccount,
@@ -86,7 +82,7 @@ export const testInitUser = async ({
     ethAddress,
     replicaSet,
     replicaSetBumps,
-    handleBytesArray,
+    userIdBytesArray,
     bumpSeed,
     metadata,
     userStorageAccount,
@@ -162,7 +158,6 @@ export const testCreateUser = async ({
   message,
   baseAuthorityAccount,
   ethAccount,
-  handleBytesArray,
   bumpSeed,
   metadata,
   newUserKeypair,
@@ -173,14 +168,13 @@ export const testCreateUser = async ({
   cn1,
   cn2,
   cn3,
-  userId,
+  userIdBytesArray,
 }) => {
   const tx = createUser({
     payer: provider.wallet.publicKey,
     program,
     ethAccount,
     message,
-    handleBytesArray,
     bumpSeed,
     replicaSet,
     replicaSetBumps,
@@ -192,7 +186,7 @@ export const testCreateUser = async ({
     cn1,
     cn2,
     cn3,
-    userId,
+    userIdBytesArray,
   });
   const txSignature = await provider.send(tx)
 
@@ -204,7 +198,8 @@ export const testCreateUser = async ({
   expect(decodedData.ethAddress).to.deep.equal([
     ...anchor.utils.bytes.hex.decode(ethAccount.address),
   ]);
-  expect(decodedData.handleSeed).to.deep.equal(handleBytesArray);
+  console.log('DECODED DATAAAAAAAAAAAAA', JSON.stringify(decodedData))
+  expect(decodedData.userSeed).to.deep.equal(userIdBytesArray);
   expect(decodedData.userBump).to.equal(bumpSeed);
   expect(decodedData.metadata).to.equal(metadata);
   expect(accountPubKeys[0]).to.equal(userStorageAccount.toString());
@@ -227,7 +222,7 @@ export const testCreateTrack = async ({
   program,
   id,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
   trackMetadata,
@@ -245,7 +240,7 @@ export const testCreateTrack = async ({
     authorityDelegationStatusAccountPDA,
     metadata: trackMetadata,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     adminStorageAccount,
     bumpSeed,
   });
@@ -276,7 +271,7 @@ export const testDeleteTrack = async ({
   authorityDelegationStatusAccountPDA,
   userAuthorityKeypair,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
 }) => {
@@ -288,7 +283,7 @@ export const testDeleteTrack = async ({
     authorityDelegationStatusAccountPDA,
     userAuthorityPublicKey: userAuthorityKeypair.publicKey,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     bumpSeed,
     adminStorageAccount,
   });
@@ -318,14 +313,14 @@ export const testUpdateTrack = async ({
   metadata,
   userAuthorityKeypair,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
 }) => {
   const tx = await updateTrack({
     program,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     bumpSeed,
     adminStorageAccount,
     id,
@@ -358,7 +353,7 @@ export const testCreatePlaylist = async ({
   program,
   id,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
   playlistMetadata,
@@ -376,7 +371,7 @@ export const testCreatePlaylist = async ({
     authorityDelegationStatusAccountPDA,
     metadata: playlistMetadata,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     adminStorageAccount,
     bumpSeed,
   });
@@ -408,7 +403,7 @@ export const testDeletePlaylist = async ({
   authorityDelegationStatusAccountPDA,
   userAuthorityKeypair,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
 }) => {
@@ -420,7 +415,7 @@ export const testDeletePlaylist = async ({
     authorityDelegationStatusAccountPDA,
     userAuthorityPublicKey: userAuthorityKeypair.publicKey,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     bumpSeed,
     adminStorageAccount,
   });
@@ -449,14 +444,14 @@ export const testUpdatePlaylist = async ({
   metadata,
   userAuthorityKeypair,
   baseAuthorityAccount,
-  handleBytesArray,
+  userIdBytesArray,
   bumpSeed,
   adminStorageAccount,
 }) => {
   const tx = await updatePlaylist({
     program,
     baseAuthorityAccount,
-    handleBytesArray,
+    userIdBytesArray,
     bumpSeed,
     adminStorageAccount,
     id,
@@ -556,7 +551,7 @@ export const testCreateUserDelegate = async ({
     program,
     adminStoragePublicKey: adminStorageKeypair.publicKey,
     baseAuthorityAccount: user.authority,
-    userHandleBytesArray: user.handleBytesArray,
+    userIdBytesArray: user.userIdBytesArray,
     userBumpSeed: user.bumpSeed,
     user: user.pda,
     currentUserAuthorityDelegate: userAuthorityDelegatePDA,
@@ -584,17 +579,17 @@ export const testCreateUserDelegate = async ({
   expect(addUserAuthorityDelegateData.base.toString()).to.equal(
     user.authority.toString()
   );
-  expect(addUserAuthorityDelegateData.userHandle.seed.toString()).to.equal(
-    user.handleBytesArray.toString()
+  expect(addUserAuthorityDelegateData.userBumpSeed.seed.toString()).to.equal(
+    user.userIdBytesArray.toString()
   );
-  expect(addUserAuthorityDelegateData.userHandle.bump).to.equal(user.bumpSeed);
+  expect(addUserAuthorityDelegateData.userBumpSeed.bump).to.equal(user.bumpSeed);
   expect(addUserAuthorityDelegateData.delegatePubkey.toString()).to.equal(
     userAuthorityDelegateKeypair.publicKey.toString()
   );
 
   return {
     baseAuthorityAccount: user.authority,
-    userHandleBytesArray: user.handleBytesArray,
+    userIdBytesArray: user.userIdBytesArray,
     userBumpSeed: user.bumpSeed,
     userAccountPDA: user.pda,
     userAuthorityDelegatePDA,
@@ -664,7 +659,7 @@ export const createSolanaUser = async (
   } = await findDerivedPair(
     program.programId,
     adminStorageKeypair.publicKey,
-    Buffer.from(testConsts.handleBytesArray)
+    Buffer.from(testConsts.userIdBytesArray)
   );
 
   // New sol key that will be used to permission user updates
@@ -682,7 +677,7 @@ export const createSolanaUser = async (
     payer: provider.wallet.publicKey,
     program,
     ethAccount: testConsts.ethAccount,
-    handleBytesArray: testConsts.handleBytesArray,
+    userIdBytesArray: testConsts.userIdBytesArray,
     message,
     bumpSeed,
     metadata: testConsts.metadata,
@@ -695,7 +690,6 @@ export const createSolanaUser = async (
     cn1: cn1.derivedAddress,
     cn2: cn2.derivedAddress,
     cn3: cn3.derivedAddress,
-    userId: testConsts.userId,
   });
 
   await provider.send(tx)
@@ -705,7 +699,7 @@ export const createSolanaUser = async (
   return {
     account,
     pda: newUserAcctPDA,
-    handleBytesArray: testConsts.handleBytesArray,
+    userIdBytesArray: testConsts.userIdBytesArray,
     bumpSeed,
     keypair: newUserKeypair,
     authority: baseAuthorityAccount,

--- a/solana-programs/anchor/audius-data/tests/track-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/track-social-actions.ts
@@ -108,7 +108,7 @@ describe("track-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -119,11 +119,11 @@ describe("track-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.deleteSave
     );
@@ -143,7 +143,7 @@ describe("track-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -155,11 +155,11 @@ describe("track-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.addSave
     );
@@ -179,7 +179,7 @@ describe("track-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -191,11 +191,11 @@ describe("track-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.addRepost
     );
@@ -221,7 +221,7 @@ describe("track-actions", function () {
       authorityDelegationStatusAccountPDA:
         userDelegate.authorityDelegationStatusPDA,
       userAuthorityPublicKey: userDelegate.userAuthorityDelegateKeypair.publicKey,
-      handleBytesArray: userDelegate.userHandleBytesArray,
+      userIdBytesArray: userDelegate.useruserIdBytesArray,
       bumpSeed: userDelegate.userBumpSeed,
       id: randomString(10),
     });
@@ -232,13 +232,13 @@ describe("track-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(
-      ...userDelegate.userHandleBytesArray
+    const userId = String.fromCharCode(
+      ...userDelegate.userIdBytesArray
     );
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.addRepost
     );
@@ -258,7 +258,7 @@ describe("track-actions", function () {
       userAuthorityDelegateAccountPDA: SystemProgram.programId,
       authorityDelegationStatusAccountPDA: SystemProgram.programId,
       userAuthorityPublicKey: user.keypair.publicKey,
-      handleBytesArray: user.handleBytesArray,
+      userIdBytesArray: user.userIdBytesArray,
       bumpSeed: user.bumpSeed,
       id: randomString(10),
     });
@@ -270,11 +270,11 @@ describe("track-actions", function () {
       info.transaction.message.instructions[0].data,
       "base58"
     );
-    const userHandle = String.fromCharCode(...user.handleBytesArray);
-    const instructionHandle = String.fromCharCode(
-      ...decodedInstruction.data.userHandle.seed
+    const userId = String.fromCharCode(...user.userIdBytesArray);
+    const instructionUserId = String.fromCharCode(
+      ...decodedInstruction.data.userId.seed
     );
-    assert.equal(instructionHandle, userHandle);
+    assert.equal(instructionUserId, userId);
     expect(decodedInstruction.data.entitySocialAction).to.deep.equal(
       EntitySocialActionEnumValues.deleteRepost
     );

--- a/solana-programs/anchor/audius-data/tests/ursm.ts
+++ b/solana-programs/anchor/audius-data/tests/ursm.ts
@@ -438,7 +438,7 @@ describe("replicaSet", function () {
       program,
       baseAuthorityAccount,
       userAcct: user.pda,
-      userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
+      userSeedBump: { seed: [...user.userIdBytesArray], bump: user.bumpSeed },
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       replicaSet: [2, 3, 6],
       replicaSetBumps: [
@@ -483,7 +483,7 @@ describe("replicaSet", function () {
       program,
       baseAuthorityAccount,
       userAcct: user.pda,
-      userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
+      userSeedBump: { seed: [...user.userIdBytesArray], bump: user.bumpSeed },
       adminStoragePublicKey: adminStorageKeypair.publicKey,
       replicaSet: [6, 7, 8],
       replicaSetBumps: [
@@ -528,7 +528,7 @@ describe("replicaSet", function () {
         program,
         baseAuthorityAccount,
         userAcct: user.pda,
-        userHandle: { seed: [...user.handleBytesArray], bump: user.bumpSeed },
+        userSeedBump: { seed: [...user.userIdBytesArray], bump: user.bumpSeed },
         adminStoragePublicKey: adminStorageKeypair.publicKey,
         replicaSet: [2, 7, 8],
         replicaSetBumps: [

--- a/solana-programs/anchor/audius-data/tests/user-social-actions.ts
+++ b/solana-programs/anchor/audius-data/tests/user-social-actions.ts
@@ -114,41 +114,41 @@ describe("user social actions", function () {
   describe("user social action tests", function () {
     let constants1;
     let constants2;
-    let handleBytesArray1;
-    let handleBytesArray2;
+    let userIdBytesArray1;
+    let userIdBytesArray2;
     // New sol keys that will be used to permission user updates
     let newUser1Key;
     let newUser2Key;
     let userStorageAccount1;
     let userStorageAccount2;
     let baseAuthorityAccount;
-    let handle1DerivedInfo;
-    let handle2DerivedInfo;
+    let userId1DerivedInfo;
+    let userId2DerivedInfo;
 
     // Initialize user for each test
     beforeEach(async function () {
       // Initialize 2 users
       constants1 = initTestConstants();
       constants2 = initTestConstants();
-      handleBytesArray1 = constants1.handleBytesArray;
-      handleBytesArray2 = constants2.handleBytesArray;
+      userIdBytesArray1 = constants1.userIdBytesArray;
+      userIdBytesArray2 = constants2.userIdBytesArray;
 
-      handle1DerivedInfo = await findDerivedPair(
+      userId1DerivedInfo = await findDerivedPair(
         program.programId,
         adminStorageKeypair.publicKey,
-        Buffer.from(handleBytesArray1)
+        Buffer.from(userIdBytesArray1)
       );
 
-      handle2DerivedInfo = await findDerivedPair(
+      userId2DerivedInfo = await findDerivedPair(
         program.programId,
         adminStorageKeypair.publicKey,
-        Buffer.from(handleBytesArray2)
+        Buffer.from(userIdBytesArray2)
       );
 
-      baseAuthorityAccount = handle1DerivedInfo.baseAuthorityAccount;
+      baseAuthorityAccount = userId1DerivedInfo.baseAuthorityAccount;
 
-      userStorageAccount1 = handle1DerivedInfo.derivedAddress;
-      userStorageAccount2 = handle2DerivedInfo.derivedAddress;
+      userStorageAccount1 = userId1DerivedInfo.derivedAddress;
+      userStorageAccount2 = userId2DerivedInfo.derivedAddress;
 
       // New sol keys that will be used to permission user updates
       newUser1Key = anchor.web3.Keypair.generate();
@@ -174,13 +174,12 @@ describe("user social actions", function () {
         message: message1,
         baseAuthorityAccount,
         ethAccount: constants1.ethAccount,
-        handleBytesArray: handleBytesArray1,
-        bumpSeed: handle1DerivedInfo.bumpSeed,
+        bumpSeed: userId1DerivedInfo.bumpSeed,
         metadata: constants1.metadata,
         newUserKeypair: newUser1Key,
         userStorageAccount: userStorageAccount1,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
-        userId: constants1.userId,
+        userIdBytesArray: constants1.userIdBytesArray,
         ...getURSMParams(),
       });
 
@@ -190,8 +189,7 @@ describe("user social actions", function () {
         message: message2,
         baseAuthorityAccount,
         ethAccount: constants2.ethAccount,
-        handleBytesArray: handleBytesArray2,
-        bumpSeed: handle2DerivedInfo.bumpSeed,
+        bumpSeed: userId2DerivedInfo.bumpSeed,
         metadata: constants2.metadata,
         newUserKeypair: newUser2Key,
         userStorageAccount: userStorageAccount2,
@@ -211,10 +209,10 @@ describe("user social actions", function () {
         userAuthorityDelegateAccountPDA: SystemProgram.programId,
         authorityDelegationStatusAccountPDA: SystemProgram.programId,
         userAuthorityPublicKey: newUser1Key.publicKey,
-        sourceUserHandleBytesArray: handleBytesArray1,
-        sourceUserBumpSeed: handle1DerivedInfo.bumpSeed,
-        targetUserHandleBytesArray: handleBytesArray2,
-        targetUserBumpSeed: handle2DerivedInfo.bumpSeed,
+        sourceUserIdBytesArray: userIdBytesArray1,
+        sourceUserBumpSeed: userId1DerivedInfo.bumpSeed,
+        targetUserIdBytesArray: userIdBytesArray2,
+        targetUserBumpSeed: userId2DerivedInfo.bumpSeed,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
       });
       const followTxSig = await provider.send(followTx, [newUser1Key])
@@ -229,11 +227,11 @@ describe("user social actions", function () {
       expect(decodedData.userAction).to.deep.equal(
         UserActionEnumValues.followUser
       );
-      expect(decodedData.sourceUserHandle.seed).to.deep.equal(
-        constants1.handleBytesArray
+      expect(decodedData.sourceUserId.seed).to.deep.equal(
+        constants1.userIdBytesArray
       );
-      expect(decodedData.targetUserHandle.seed).to.deep.equal(
-        constants2.handleBytesArray
+      expect(decodedData.targetUserId.seed).to.deep.equal(
+        constants2.userIdBytesArray
       );
       expect(accountPubKeys[0]).to.equal(
         adminStorageKeypair.publicKey.toString()
@@ -259,10 +257,10 @@ describe("user social actions", function () {
         authorityDelegationStatusAccountPDA:
           userDelegate.authorityDelegationStatusPDA,
         userAuthorityPublicKey: userDelegate.userAuthorityDelegateKeypair.publicKey,
-        sourceUserHandleBytesArray: userDelegate.userHandleBytesArray,
+        sourceUserIdBytesArray: userDelegate.useruserIdBytesArray,
         sourceUserBumpSeed: userDelegate.userBumpSeed,
-        targetUserHandleBytesArray: handleBytesArray2,
-        targetUserBumpSeed: handle2DerivedInfo.bumpSeed,
+        targetUserIdBytesArray: userIdBytesArray2,
+        targetUserBumpSeed: userId2DerivedInfo.bumpSeed,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
       });
       const followTxSig = await provider.send(followTx, [userDelegate.userAuthorityDelegateKeypair])
@@ -277,11 +275,11 @@ describe("user social actions", function () {
       expect(decodedData.userAction).to.deep.equal(
         UserActionEnumValues.followUser
       );
-      expect(decodedData.sourceUserHandle.seed).to.deep.equal(
-        userDelegate.userHandleBytesArray
+      expect(decodedData.sourceUserId.seed).to.deep.equal(
+        userDelegate.userIdBytesArray
       );
-      expect(decodedData.targetUserHandle.seed).to.deep.equal(
-        constants2.handleBytesArray
+      expect(decodedData.targetUserId.seed).to.deep.equal(
+        constants2.userIdBytesArray
       );
       expect(accountPubKeys[0]).to.equal(
         adminStorageKeypair.publicKey.toString()
@@ -301,10 +299,10 @@ describe("user social actions", function () {
         userAuthorityDelegateAccountPDA: SystemProgram.programId,
         authorityDelegationStatusAccountPDA: SystemProgram.programId,
         userAuthorityPublicKey: newUser1Key.publicKey,
-        sourceUserHandleBytesArray: handleBytesArray1,
-        sourceUserBumpSeed: handle1DerivedInfo.bumpSeed,
-        targetUserHandleBytesArray: handleBytesArray2,
-        targetUserBumpSeed: handle2DerivedInfo.bumpSeed,
+        sourceUserIdBytesArray: userIdBytesArray1,
+        sourceUserBumpSeed: userId1DerivedInfo.bumpSeed,
+        targetUserIdBytesArray: userIdBytesArray2,
+        targetUserBumpSeed: userId2DerivedInfo.bumpSeed,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
       });
       const unfollowTxSig = await provider.send(unfollowTx, [newUser1Key])
@@ -319,11 +317,11 @@ describe("user social actions", function () {
       expect(decodedData.userAction).to.deep.equal(
         UserActionEnumValues.unfollowUser
       );
-      expect(decodedData.sourceUserHandle.seed).to.deep.equal(
-        constants1.handleBytesArray
+      expect(decodedData.sourceUserId.seed).to.deep.equal(
+        constants1.userIdBytesArray
       );
-      expect(decodedData.targetUserHandle.seed).to.deep.equal(
-        constants2.handleBytesArray
+      expect(decodedData.targetUserId.seed).to.deep.equal(
+        constants2.userIdBytesArray
       );
       expect(accountPubKeys[0]).to.equal(
         adminStorageKeypair.publicKey.toString()
@@ -351,8 +349,8 @@ describe("user social actions", function () {
         const txHash = await program.rpc.writeUserSocialAction(
           baseAuthorityAccount,
           UserActionEnumValues.invalidEnumValue,
-          { seed: handleBytesArray1, bump: handle1DerivedInfo.bumpSeed },
-          { seed: handleBytesArray2, bump: handle2DerivedInfo.bumpSeed },
+          { seed: userIdBytesArray1, bump: userId1DerivedInfo.bumpSeed },
+          { seed: userIdBytesArray2, bump: userId2DerivedInfo.bumpSeed },
           followArgs
         );
         console.log(`invalid follow txHash=${txHash}`);
@@ -386,8 +384,8 @@ describe("user social actions", function () {
         await program.rpc.writeUserSocialAction(
           baseAuthorityAccount,
           UserActionEnumValues.followUser,
-          { seed: handleBytesArray1, bump: handle1DerivedInfo.bumpSeed },
-          { seed: handleBytesArray2, bump: handle2DerivedInfo.bumpSeed },
+          { seed: userIdBytesArray1, bump: userId1DerivedInfo.bumpSeed },
+          { seed: userIdBytesArray2, bump: userId2DerivedInfo.bumpSeed },
           followArgs
         );
       } catch (e) {
@@ -411,9 +409,9 @@ describe("user social actions", function () {
         await program.rpc.writeUserSocialAction(
           baseAuthorityAccount,
           UserActionEnumValues.followUser,
-          { seed: handleBytesArray1, bump: handle1DerivedInfo.bumpSeed },
-          // Note the intentionally incorrect handle bytes below for followee target PDA
-          { seed: handleBytesArray1, bump: handle1DerivedInfo.bumpSeed },
+          { seed: userIdBytesArray1, bump: userId1DerivedInfo.bumpSeed },
+          // Note the intentionally incorrect user id bytes below for followee target PDA
+          { seed: userIdBytesArray1, bump: userId1DerivedInfo.bumpSeed },
           followArgs
         );
       } catch (e) {
@@ -439,10 +437,10 @@ describe("user social actions", function () {
         userAuthorityDelegateAccountPDA: SystemProgram.programId,
         authorityDelegationStatusAccountPDA: SystemProgram.programId,
         userAuthorityPublicKey: newUser1Key.publicKey,
-        sourceUserHandleBytesArray: handleBytesArray1,
-        sourceUserBumpSeed: handle1DerivedInfo.bumpSeed,
-        targetUserHandleBytesArray: handleBytesArray2,
-        targetUserBumpSeed: handle2DerivedInfo.bumpSeed,
+        sourceUserIdBytesArray: userIdBytesArray1,
+        sourceUserBumpSeed: userId1DerivedInfo.bumpSeed,
+        targetUserIdBytesArray: userIdBytesArray2,
+        targetUserBumpSeed: userId2DerivedInfo.bumpSeed,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
       });
       const subscribeTxSig = await provider.send(subscribeTx, [newUser1Key])
@@ -457,11 +455,11 @@ describe("user social actions", function () {
       expect(decodedData.userAction).to.deep.equal(
         UserActionEnumValues.subscribeUser
       );
-      expect(decodedData.sourceUserHandle.seed).to.deep.equal(
-        constants1.handleBytesArray
+      expect(decodedData.sourceUserId.seed).to.deep.equal(
+        constants1.userIdBytesArray
       );
-      expect(decodedData.targetUserHandle.seed).to.deep.equal(
-        constants2.handleBytesArray
+      expect(decodedData.targetUserId.seed).to.deep.equal(
+        constants2.userIdBytesArray
       );
       expect(accountPubKeys[0]).to.equal(
         adminStorageKeypair.publicKey.toString()
@@ -479,10 +477,10 @@ describe("user social actions", function () {
         userAuthorityDelegateAccountPDA: SystemProgram.programId,
         authorityDelegationStatusAccountPDA: SystemProgram.programId,
         userAuthorityPublicKey: newUser1Key.publicKey,
-        sourceUserHandleBytesArray: handleBytesArray1,
-        sourceUserBumpSeed: handle1DerivedInfo.bumpSeed,
-        targetUserHandleBytesArray: handleBytesArray2,
-        targetUserBumpSeed: handle2DerivedInfo.bumpSeed,
+        sourceUserIdBytesArray: userIdBytesArray1,
+        sourceUserBumpSeed: userId1DerivedInfo.bumpSeed,
+        targetUserIdBytesArray: userIdBytesArray2,
+        targetUserBumpSeed: userId2DerivedInfo.bumpSeed,
         adminStoragePublicKey: adminStorageKeypair.publicKey,
       });
       const unsubscribeTxSig = await provider.send(unsubscribeTx, [newUser1Key])
@@ -497,11 +495,11 @@ describe("user social actions", function () {
       expect(decodedData.userAction).to.deep.equal(
         UserActionEnumValues.unsubscribeUser
       );
-      expect(decodedData.sourceUserHandle.seed).to.deep.equal(
-        constants1.handleBytesArray
+      expect(decodedData.sourceUserId.seed).to.deep.equal(
+        constants1.userIdBytesArray
       );
-      expect(decodedData.targetUserHandle.seed).to.deep.equal(
-        constants2.handleBytesArray
+      expect(decodedData.targetUserId.seed).to.deep.equal(
+        constants2.userIdBytesArray
       );
       expect(accountPubKeys[0]).to.equal(
         adminStorageKeypair.publicKey.toString()


### PR DESCRIPTION
### Description

Instead of user handle and user handle bytes array as a seed in user storage account PDA derivation, use user ID. This allows handle to be changed. 

A separate PR will be submitted with work on the indexing/relay sides to validate handle uniqueness. 

### Tests

WIP - wanted to ensure that we want to use user ID bytes array over using user ID integer as a seed here.

### How will this change be monitored? Are there sufficient logs?

However the program is monitored - it will be deployed as part of the program.