### PR TITLE
Consume libs 1.2.104 in Identity

### DIFF
--- a/identity-service/package-lock.json
+++ b/identity-service/package-lock.json
@@ -89,9 +89,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.103",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.103.tgz",
-      "integrity": "sha512-nehd5rqBfJBVXObb02dspUL4+SLenLnOqs0abqnesIhPmlVfCx/h7F6VVGgebLKqj0SmwIHjyke3iWm2rdeyqA==",
+      "version": "1.2.104",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.104.tgz",
+      "integrity": "sha512-XBev3OSLGJK4ASuOPZCgTuH2/DyaOL1UZdzR4dRT8SSD3Pff7paE57D40Ys+g0p5favLKnauWl/VEbd1CFU9xQ==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.1.1",

--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@amplitude/node": "^1.9.2",
-    "@audius/libs": "1.2.103",
+    "@audius/libs": "1.2.104",
     "@certusone/wormhole-sdk": "0.1.1",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@optimizely/optimizely-sdk": "^4.6.0",


### PR DESCRIPTION
### Description

Did a dumb merge order thing and forgot to include https://github.com/AudiusProject/audius-protocol/commit/93d91b3a392ccc2c69ba59448b0e5c2025fd2266 in version 103, so consuming latest here 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->