### PR TITLE
Add create user and udpate admin cli bindings

### DIFF
--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -302,7 +302,7 @@ program
   .option("--id <integer>", "ID of entity targeted by transaction")
   .option("-sp-id, --cn-sp-id <string>", "ID of incoming content node")
   .option("-uid, --user-id <integer>", "ID of incoming user")
-  .option("-we, --write-enabled <bool>", "If write is enabled", false)
+  .option("-we, --write-enabled <bool>", "If write is enabled for admin", false)
   .option("-ci, <boolean>", "set to true to seed content node wallet and pkey with dummy values", false)
   .option("--user-replica-set <string>", "Comma separated list of integers representing spIDs - ex. 2,3,1")
   .option("-d, --delegate <string>", "user delegate account pda")

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -468,7 +468,7 @@ const main = async () => {
         const userReplicaSetSpIds = options.userReplicaSet.split(',').map(x => {
           return parseInt(x);
         })
-        const userContentNodeInfo = await Promise.all(userReplicaSet.map(async (x) => {
+        const userContentNodeInfo = await Promise.all(userReplicaSet.map(async (spId) => {
           return await getContentNode(
             cliVars.program,
             adminStorageKeypair.publicKey,

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -1,6 +1,7 @@
+import Web3 from "web3";
 import { Program, Provider, web3 } from "@project-serum/anchor";
 import NodeWallet from "@project-serum/anchor/dist/cjs/nodewallet";
-import { Connection, PublicKey, Keypair, SystemProgram } from "@solana/web3.js";
+import { Account, Connection, PublicKey, Keypair, SystemProgram } from "@solana/web3.js";
 import { AudiusData } from "../target/types/audius_data";
 import * as anchor from "@project-serum/anchor";
 import {
@@ -14,7 +15,9 @@ import {
   createPlaylist,
   updatePlaylist,
   deletePlaylist,
+  createUser,
   createContentNode,
+  updateAdmin,
 } from "../lib/lib";
 import {
   findDerivedPair,
@@ -26,6 +29,8 @@ import {
 
 import { Command } from "commander";
 import fs = require("fs");
+
+const EthWeb3 = new Web3();
 
 const AUDIUS_PROD_RPC_POOL = "https://audius.rpcpool.com/";
 const LOCALHOST_RPC_POOL = "http://localhost:8899";
@@ -262,9 +267,11 @@ async function timeManageEntity(args: CreateEntityParams, provider: Provider, ma
 
 const functionTypes = Object.freeze({
   initAdmin: "initAdmin",
+  updateAdmin: "updateAdmin",
   initUser: "initUser",
   initContentNode: "initContentNode",
   initUserSolPubkey: "initUserSolPubkey",
+  createUser: "createUser",
   createTrack: "createTrack",
   getTrackId: "getTrackId",
   createPlaylist: "createPlaylist",
@@ -294,6 +301,8 @@ program
   .option("--num-playlists <integer>", "number of playlists to generate")
   .option("--id <integer>", "ID of entity targeted by transaction")
   .option("-sp-id, --cn-sp-id <string>", "ID of incoming content node")
+  .option("-u-id, --user-id <integer>", "ID of incoming user")
+  .option("-we, --write-enabled <bool>", "If write is enabled", false)
   .option("-ci, <boolean>", "set to true to seed content node wallet and pkey with dummy values", false)
   .option("--user-replica-set <string>", "Comma separated list of integers representing spIDs - ex. 2,3,1")
   .option("-d, --delegate <string>", "user delegate account pda")
@@ -424,6 +433,75 @@ const main = async () => {
         await cliVars.provider.connection.confirmTransaction(tx);
         console.log(
           `initUserTx = ${tx}, userStorageAccount = ${options.userStoragePubkey}`
+        );
+      })();
+      break;
+
+    case functionTypes.updateAdmin:
+      const { writeEnabled } = options;
+
+      (async () => {
+        console.log({ writeEnabled })
+        const cliVars = initializeCLI(network, options.ownerKeypair);
+        const tx = await updateAdmin({
+          program: cliVars.program,
+          isWriteEnabled: Boolean(writeEnabled),
+          adminStorageAccount: adminStorageKeypair.publicKey,
+          adminAuthorityKeypair: adminKeypair,
+        });
+        await cliVars.provider.connection.confirmTransaction(tx);
+        console.log(
+          `updateAdmin = ${tx}`
+        );
+      })();
+      break;
+    case functionTypes.createUser:
+      const { userId, handle } = options;
+      console.log({ userId })
+      const ethAccount = EthWeb3.eth.accounts.create();
+
+      const handleBytesArray = getHandleBytesArray(handle);
+      const { baseAuthorityAccount, bumpSeed, derivedAddress } = await findDerivedPair(cliVars.programID, adminStorageKeypair.publicKey, handleBytesArray);
+      (async () => {
+
+        const cliVars = initializeCLI(network, options.ownerKeypair);
+        const userReplicaSet = options.userReplicaSet.split(',').map(x => {
+          return parseInt(x);
+        })
+        const userContentNodeInfo = await Promise.all(userReplicaSet.map(async (x) => {
+          return await getContentNode(
+            cliVars.program,
+            adminStorageKeypair.publicKey,
+            `${x}`
+          )
+        }))
+        const replicaSetBumps = [
+          userContentNodeInfo[0].bumpSeed,
+          userContentNodeInfo[1].bumpSeed,
+          userContentNodeInfo[2].bumpSeed
+        ]
+        const tx = await createUser({
+          program: cliVars.program,
+          provider: cliVars.provider,
+          ethAccount,
+          message: userSolKeypair.publicKey.toBytes(),
+          userId: new anchor.BN(userId),
+          handleBytesArray,
+          bumpSeed,
+          metadata: randomCID(),
+          userSolPubkey: userSolKeypair.publicKey,
+          userStorageAccount: derivedAddress,
+          adminStoragePublicKey: adminStorageKeypair.publicKey,
+          baseAuthorityAccount: baseAuthorityAccount,
+          replicaSet: userReplicaSet,
+          replicaSetBumps,
+          cn1: userContentNodeInfo[0].derivedAddress,
+          cn2: userContentNodeInfo[1].derivedAddress,
+          cn3: userContentNodeInfo[2].derivedAddress,
+        });
+        await cliVars.provider.connection.confirmTransaction(tx);
+        console.log(
+          `createUserTx = ${tx}, userStorageAccount = ${derivedAddress}`
         );
       })();
       break;

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -301,7 +301,7 @@ program
   .option("--num-playlists <integer>", "number of playlists to generate")
   .option("--id <integer>", "ID of entity targeted by transaction")
   .option("-sp-id, --cn-sp-id <string>", "ID of incoming content node")
-  .option("-u-id, --user-id <integer>", "ID of incoming user")
+  .option("-uid, --user-id <integer>", "ID of incoming user")
   .option("-we, --write-enabled <bool>", "If write is enabled", false)
   .option("-ci, <boolean>", "set to true to seed content node wallet and pkey with dummy values", false)
   .option("--user-replica-set <string>", "Comma separated list of integers representing spIDs - ex. 2,3,1")

--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -465,7 +465,7 @@ const main = async () => {
       (async () => {
 
         const cliVars = initializeCLI(network, options.ownerKeypair);
-        const userReplicaSet = options.userReplicaSet.split(',').map(x => {
+        const userReplicaSetSpIds = options.userReplicaSet.split(',').map(x => {
           return parseInt(x);
         })
         const userContentNodeInfo = await Promise.all(userReplicaSet.map(async (x) => {


### PR DESCRIPTION
### Description
Add bindings to the CLI for update admin and create user
NOTE: update admin is needed to set enable_write to false so that create user can work

### Tests
ran locally

### How will this change be monitored? Are there sufficient logs?
