### PR TITLE
Fix stateMachineQueue health check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -109,7 +109,8 @@ const healthCheckController = async (req) => {
   if (enforceStateMachineQueueHealth && stateMachineQueueLatestJobSuccess) {
     const healthyThresholdMs = 5 * config.get('snapbackJobInterval')
 
-    const delta = Date.now() - stateMachineQueueLatestJobSuccess.getTime()
+    const delta =
+      Date.now() - new Date(stateMachineQueueLatestJobSuccess).getTime()
     if (delta > healthyThresholdMs) {
       return errorResponseServerError(
         `StateMachineQueue not healthy - last successful run ${delta}ms ago not within healthy threshold of ${healthyThresholdMs}ms`


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fixes bug in CN health check on new functionality (not consumed anywhere) - calling `<CNurl>/health_check?enforceStateMachineQueueHealth=true` currently breaks. Just need to cast to Date object.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Manually tested health check with and without flag

### How will this change be monitored? Are there sufficient logs?

Should be able to successfully call `<CNurl>/health_check?enforceStateMachineQueueHealth=true`

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->