### PR TITLE
[AUD-1451] Add new playlist trending strategy

### DIFF
--- a/discovery-provider/src/queries/get_trending_playlists.py
+++ b/discovery-provider/src/queries/get_trending_playlists.py
@@ -30,7 +30,10 @@ from src.queries.query_helpers import (
 )
 from src.tasks.generate_trending import time_delta_map
 from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
-from src.trending_strategies.trending_type_and_version import TrendingType, TrendingVersion
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import decode_string_id
 from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
@@ -223,10 +226,7 @@ def make_get_unpopulated_playlists(session, time_range, strategy):
                 track_owner_ids = list(
                     filter(
                         lambda owner_id: owner_id != playlist_owner_id,
-                        map(
-                            lambda track: track["owner_id"],
-                            playlist["tracks"]
-                        )
+                        map(lambda track: track["owner_id"], playlist["tracks"]),
                     )
                 )
                 if len(track_owner_ids) < 3:

--- a/discovery-provider/src/trending_strategies/BDNxn_trending_playlists_strategy.py
+++ b/discovery-provider/src/trending_strategies/BDNxn_trending_playlists_strategy.py
@@ -1,0 +1,17 @@
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
+from src.trending_strategies.EJ57D_trending_tracks_strategy import z
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
+
+
+class TrendingPlaylistsStrategyBDNxn(BaseTrendingStrategy):
+    def __init__(self):
+        super().__init__(TrendingType.PLAYLISTS, TrendingVersion.BDNxn)
+
+    def get_track_score(self, time_range, playlist):
+        return z(time_range, playlist)
+
+    def get_score_params(self):
+        return {"zq": 1000, "xf": True, "pt": 0, "mt": 3}

--- a/discovery-provider/src/trending_strategies/trending_strategy_factory.py
+++ b/discovery-provider/src/trending_strategies/trending_strategy_factory.py
@@ -1,8 +1,8 @@
-from src.trending_strategies.EJ57D_trending_playlists_strategy import (
-    TrendingPlaylistsStrategyEJ57D,
-)
 from src.trending_strategies.BDNxn_trending_playlists_strategy import (
     TrendingPlaylistsStrategyBDNxn,
+)
+from src.trending_strategies.EJ57D_trending_playlists_strategy import (
+    TrendingPlaylistsStrategyEJ57D,
 )
 from src.trending_strategies.EJ57D_trending_tracks_strategy import (
     TrendingTracksStrategyEJ57D,

--- a/discovery-provider/src/trending_strategies/trending_strategy_factory.py
+++ b/discovery-provider/src/trending_strategies/trending_strategy_factory.py
@@ -1,6 +1,9 @@
 from src.trending_strategies.EJ57D_trending_playlists_strategy import (
     TrendingPlaylistsStrategyEJ57D,
 )
+from src.trending_strategies.BDNxn_trending_playlists_strategy import (
+    TrendingPlaylistsStrategyBDNxn,
+)
 from src.trending_strategies.EJ57D_trending_tracks_strategy import (
     TrendingTracksStrategyEJ57D,
 )
@@ -30,6 +33,7 @@ class TrendingStrategyFactory:
             },
             TrendingType.PLAYLISTS: {
                 TrendingVersion.EJ57D: TrendingPlaylistsStrategyEJ57D(),
+                TrendingVersion.BDNxn: TrendingPlaylistsStrategyBDNxn(),
             },
         }
 

--- a/discovery-provider/src/trending_strategies/trending_type_and_version.py
+++ b/discovery-provider/src/trending_strategies/trending_type_and_version.py
@@ -9,3 +9,4 @@ class TrendingType(Enum):
 
 class TrendingVersion(Enum):
     EJ57D = "EJ57D"
+    BDNxn = "BDNxn"


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

New strategy that disallows self-owned.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

* Local cluster, created two playlists that should be trending, one of them has only self owned tracks. It is filtered out until there are 3 unowned (on the new experiment http://dn1_web-server_1:5000/v1/full/playlists/trending/BDNxn only)

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Staging & prod via experiment

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->