### PR TITLE
Fix ipld blacklist tests

### DIFF
--- a/libs/src/api/playlist.js
+++ b/libs/src/api/playlist.js
@@ -217,7 +217,7 @@ class Playlists extends Base {
 
     const updatedPlaylistImage = await this.creatorNode.uploadImage(
       coverPhotoFile,
-      'true' // square, this weirdly has to be a boolean string
+      true // square
     )
     return updatedPlaylistImage.dirCID
   }

--- a/libs/src/api/playlist.js
+++ b/libs/src/api/playlist.js
@@ -213,7 +213,7 @@ class Playlists extends Base {
    * @param {File} coverPhotoFile the file to upload as the cover photo
    * @return {string} CID of the uploaded cover photo
    */
-   async uploadPlaylistCoverPhoto (playlistId, coverPhotoFile) {
+  async uploadPlaylistCoverPhoto (playlistId, coverPhotoFile) {
     this.REQUIRES(Services.CREATOR_NODE)
 
     const updatedPlaylistImage = await this.creatorNode.uploadImage(
@@ -236,7 +236,8 @@ class Playlists extends Base {
     const updatedPlaylistImageDirCid = await this.uploadPlaylistCoverPhoto(coverPhoto, true)
     return this.contracts.PlaylistFactoryClient.updatePlaylistCoverPhoto(
       playlistId,
-      Utils.formatOptionalMultihash(updatedPlaylistImageDirCID))
+      Utils.formatOptionalMultihash(updatedPlaylistImageDirCid)
+    )
   }
 
   /**

--- a/libs/src/api/playlist.js
+++ b/libs/src/api/playlist.js
@@ -209,18 +209,15 @@ class Playlists extends Base {
 
   /**
    * Uploads a cover photo for a playlist without updating the actual playlist
-   * @param {number} playlistId
    * @param {File} coverPhotoFile the file to upload as the cover photo
    * @return {string} CID of the uploaded cover photo
    */
-  async uploadPlaylistCoverPhoto (playlistId, coverPhotoFile) {
+  async uploadPlaylistCoverPhoto (coverPhotoFile) {
     this.REQUIRES(Services.CREATOR_NODE)
 
     const updatedPlaylistImage = await this.creatorNode.uploadImage(
       coverPhotoFile,
-      'true', // square, this weirdly has to be a boolean string
-      () => {}, // onProgress
-      10000 // timeoutMs
+      'true' // square, this weirdly has to be a boolean string
     )
     return updatedPlaylistImage.dirCID
   }

--- a/libs/src/api/playlist.js
+++ b/libs/src/api/playlist.js
@@ -13,6 +13,7 @@ class Playlists extends Base {
     this.addPlaylistTrack = this.addPlaylistTrack.bind(this)
     this.orderPlaylistTracks = this.orderPlaylistTracks.bind(this)
     this.validateTracksInPlaylist = this.validateTracksInPlaylist.bind(this)
+    this.uploadPlaylistCoverPhoto = this.uploadPlaylistCoverPhoto.bind(this)
     this.updatePlaylistCoverPhoto = this.updatePlaylistCoverPhoto.bind(this)
     this.updatePlaylistName = this.updatePlaylistName.bind(this)
     this.updatePlaylistDescription = this.updatePlaylistDescription.bind(this)
@@ -207,17 +208,35 @@ class Playlists extends Base {
   }
 
   /**
-   * Updates the cover photo for a playlist
+   * Uploads a cover photo for a playlist without updating the actual playlist
    * @param {number} playlistId
-   * @param {File} fileData
+   * @param {File} coverPhotoFile the file to upload as the cover photo
+   * @return {string} CID of the uploaded cover photo
    */
-  async updatePlaylistCoverPhoto (playlistId, fileData) {
+   async uploadPlaylistCoverPhoto (playlistId, coverPhotoFile) {
     this.REQUIRES(Services.CREATOR_NODE)
 
-    const updatedPlaylistImage = await this.creatorNode.uploadImage(fileData, true)
+    const updatedPlaylistImage = await this.creatorNode.uploadImage(
+      coverPhotoFile,
+      'true', // square, this weirdly has to be a boolean string
+      () => {}, // onProgress
+      10000 // timeoutMs
+    )
+    return updatedPlaylistImage.dirCID
+  }
+
+  /**
+   * Updates the cover photo for a playlist
+   * @param {number} playlistId
+   * @param {File} coverPhoto
+   */
+  async updatePlaylistCoverPhoto (playlistId, coverPhoto) {
+    this.REQUIRES(Services.CREATOR_NODE)
+
+    const updatedPlaylistImageDirCid = await this.uploadPlaylistCoverPhoto(coverPhoto, true)
     return this.contracts.PlaylistFactoryClient.updatePlaylistCoverPhoto(
       playlistId,
-      Utils.formatOptionalMultihash(updatedPlaylistImage.dirCID))
+      Utils.formatOptionalMultihash(updatedPlaylistImageDirCID))
   }
 
   /**

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -73,7 +73,7 @@ class Users extends Base {
     this._addUserOperations = this._addUserOperations.bind(this)
     this._updateUserOperations = this._updateUserOperations.bind(this)
     this._validateUserMetadata = this._validateUserMetadata.bind(this)
-    this._cleanUserMetadata = this._cleanUserMetadata.bind(this)
+    this.cleanUserMetadata = this.cleanUserMetadata.bind(this)
 
     // For adding a creator_node_endpoint for a user if null
     this.assignReplicaSetIfNecessary = this.assignReplicaSetIfNecessary.bind(this)
@@ -289,9 +289,9 @@ class Users extends Base {
    * Util to upload profile picture and cover photo images and update
    * a metadata object. This method inherently calls triggerSecondarySyncs().
    * @param {?File} profilePictureFile an optional file to upload as the profile picture
-   * @param {?File} coverPhotoFile an optional file to upload as the cover phtoo
+   * @param {?File} coverPhotoFile an optional file to upload as the cover photo
    * @param {Object} metadata to update
-   * @returns {Object} the passed in metadata object with profile_picture and cover_photo fields added
+   * @returns {Object} the passed in metadata object with profile_picture_sizes and cover_photo_sizes fields added
    */
   async uploadProfileImages (profilePictureFile, coverPhotoFile, metadata) {
     let didMetadataUpdate = false
@@ -323,7 +323,7 @@ class Users extends Base {
    */
   async addUser (metadata) {
     this.IS_OBJECT(metadata)
-    const newMetadata = this._cleanUserMetadata(metadata)
+    const newMetadata = this.cleanUserMetadata(metadata)
     this._validateUserMetadata(newMetadata)
 
     let userId
@@ -343,7 +343,7 @@ class Users extends Base {
     this.userStateManager.setCurrentUser({
       ...newMetadata,
       // Initialize counts to be 0. We don't want to write this data to backends ever really
-      // (hence the _cleanUserMetadata above), but we do want to make sure clients
+      // (hence the cleanUserMetadata above), but we do want to make sure clients
       // can properly "do math" on these numbers.
       followee_count: 0,
       follower_count: 0,
@@ -360,7 +360,7 @@ class Users extends Base {
   async updateUser (userId, metadata) {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
     this.IS_OBJECT(metadata)
-    const newMetadata = this._cleanUserMetadata(metadata)
+    const newMetadata = this.cleanUserMetadata(metadata)
     this._validateUserMetadata(newMetadata)
 
     // Retrieve the current user metadata
@@ -383,7 +383,7 @@ class Users extends Base {
   async updateCreator (userId, metadata) {
     this.REQUIRES(Services.CREATOR_NODE, Services.DISCOVERY_PROVIDER)
     this.IS_OBJECT(metadata)
-    const newMetadata = this._cleanUserMetadata(metadata)
+    const newMetadata = this.cleanUserMetadata(metadata)
     this._validateUserMetadata(newMetadata)
 
     const logPrefix = `[User:updateCreator()] [userId: ${userId}]`
@@ -473,7 +473,7 @@ class Users extends Base {
     let startMs = fnStartMs
 
     // Clean and validate metadata
-    const newMetadata = this._cleanUserMetadata({ ...user })
+    const newMetadata = this.cleanUserMetadata({ ...user })
     this._validateUserMetadata(newMetadata)
 
     // Populate metadata with required fields - wallet, is_creator, creator_node_endpoint
@@ -602,7 +602,7 @@ class Users extends Base {
     const oldMetadata = this.userStateManager.getCurrentUser()
     if (!oldMetadata) { throw new Error('No current user.') }
 
-    newMetadata = this._cleanUserMetadata(newMetadata)
+    newMetadata = this.cleanUserMetadata(newMetadata)
     this._validateUserMetadata(newMetadata)
 
     const logPrefix = `[User:updateAndUploadMetadata()] [userId: ${userId}]`
@@ -821,7 +821,7 @@ Object.prototype.hasOwnProperty.call(replicaSet, 'secondaryIds') &&
    * - Add what user props might be missing to normalize
    * - Only keep core fields in USER_PROPS and 'user_id'.
    */
-  _cleanUserMetadata (metadata) {
+  cleanUserMetadata (metadata) {
     USER_PROPS.forEach(prop => {
       if (!(prop in metadata)) { metadata[prop] = null }
     })

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -445,7 +445,7 @@ export class CreatorNode {
       file,
       '/image_upload',
       onProgress,
-      { square: square },
+      { 'square': square },
       /* retries */ undefined,
       timeoutMs
     )
@@ -873,7 +873,7 @@ export class CreatorNode {
     const formData = new FormData()
     formData.append('file', file)
     Object.keys(extraFormDataOptions).forEach((key) => {
-      formData.append(key, extraFormDataOptions[key])
+      formData.append(key, `${extraFormDataOptions[key]}`)
     })
 
     let headers: Record<string, string | null> = {}

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -445,7 +445,7 @@ export class CreatorNode {
       file,
       '/image_upload',
       onProgress,
-      { 'square': square },
+      { square },
       /* retries */ undefined,
       timeoutMs
     )

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -310,7 +310,7 @@ export class CreatorNode {
    * @param trackFile the audio content
    * @param coverArtFile the image content
    * @param metadata the metadata for the track
-   * @param onProgress an optional on progerss callback
+   * @param onProgress an optional on progress callback
    */
   async uploadTrackContent(
     trackFile: File,

--- a/mad-dog/src/tests/test_ipldBlacklist.js
+++ b/mad-dog/src/tests/test_ipldBlacklist.js
@@ -658,7 +658,7 @@ IpldBlacklistTest.updatePlaylistCoverPhoto = async ({
     const randomCoverPhotoFilePath = await getRandomImageFilePath(TEMP_STORAGE_PATH)
     const cid = await executeOne(
       CREATOR_INDEX,
-      libsWrapper => uploadPlaylistCoverPhoto(libsWrapper, playlistId, randomCoverPhotoFilePath)
+      libsWrapper => uploadPlaylistCoverPhoto(libsWrapper, randomCoverPhotoFilePath)
     )
     return cid
   }
@@ -778,10 +778,10 @@ async function testUpdateFlow(
     // Create another property, upload it to a CN, and blacklist it
     const blacklistedCid = await executeOne(CREATOR_INDEX, libs => createAndUploadProperty(libs))
     const { digest: blacklistedDigest } = Utils.decodeMultihash(blacklistedCid)
-      const ipldTxReceipt = await executeOne(
-        BLACKLISTER_INDEX,
-        libs => addIPLDToBlacklist(libs, blacklistedDigest)
-      )
+    await executeOne(
+      BLACKLISTER_INDEX,
+      libs => addIPLDToBlacklist(libs, blacklistedDigest)
+    )
     await executeOne(BLACKLISTER_INDEX, libs => libs.waitForLatestIPLDBlock())
     
     // Attempt to update the object to have a blacklisted property

--- a/service-commands/src/commands/playlists.js
+++ b/service-commands/src/commands/playlists.js
@@ -22,13 +22,10 @@ Playlist.createPlaylist = async (
 
 Playlist.uploadPlaylistCoverPhoto = async (
   libs,
-  playlistId,
   coverPhotoFilePath
 ) => {
   const coverPhotoFile = fs.createReadStream(coverPhotoFilePath)
-  const dirCid = await libs.uploadPlaylistCoverPhoto(
-    playlistId, coverPhotoFile
-  )
+  const dirCid = await libs.uploadPlaylistCoverPhoto(coverPhotoFile)
   return dirCid
 }
 

--- a/service-commands/src/commands/playlists.js
+++ b/service-commands/src/commands/playlists.js
@@ -1,3 +1,5 @@
+const fs = require('fs')
+
 const Playlist = {}
 
 Playlist.createPlaylist = async (
@@ -16,6 +18,18 @@ Playlist.createPlaylist = async (
     trackIds
   )
   return createPlaylistTxReceipt
+}
+
+Playlist.uploadPlaylistCoverPhoto = async (
+  libs,
+  playlistId,
+  coverPhotoFilePath
+) => {
+  const coverPhotoFile = fs.createReadStream(coverPhotoFilePath)
+  const dirCid = await libs.uploadPlaylistCoverPhoto(
+    playlistId, coverPhotoFile
+  )
+  return dirCid
 }
 
 Playlist.updatePlaylistCoverPhoto = async (

--- a/service-commands/src/commands/tracks.js
+++ b/service-commands/src/commands/tracks.js
@@ -58,6 +58,15 @@ Track.addTrackToChain = async (libs, userId, { digest, hashFn, size }) => {
   return trackTxReceipt
 }
 
+Track.updateTrackOnChainAndCnode = async (libs, metadata) => {
+  const { blockHash, blockNumber, trackId } = await libs.updateTrackOnChainAndCnode(metadata)
+  return { blockHash, blockNumber, trackId }
+}
+
+Track.uploadTrackCoverArt = async (libs, imageFilePath) => {
+  return libs.uploadTrackCoverArt(imageFilePath)
+}
+
 Track.updateTrackOnChain = async (
   libs,
   trackId,

--- a/service-commands/src/commands/users.js
+++ b/service-commands/src/commands/users.js
@@ -58,8 +58,7 @@ User.uploadPhotoAndUpdateMetadata = async (libsWrapper, {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     userPicFile,
-    'true', // square, this weirdly has to be a boolean string
-    10000 // timeoutMs
+    'true' // square, this weirdly has to be a boolean string
   )
   if (updateProfilePicture) newMetadata.profile_picture_sizes = resp.dirCID
   if (updateCoverPhoto) newMetadata.cover_photo_sizes = resp.dirCID
@@ -75,8 +74,7 @@ User.uploadProfilePic = async (libsWrapper, picturePath) => {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     userPicFile,
-    'true', // square, this weirdly has to be a boolean string
-    10000 // timeoutMs
+    'true' // square, this weirdly has to be a boolean string
   )
 
   return resp.dirCID
@@ -87,8 +85,7 @@ User.uploadCoverPhoto = async (libsWrapper, photoPath) => {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     coverPhotoFile,
-    'false', // square, this weirdly has to be a boolean string
-    10000 // timeoutMs
+    'false' // square, this weirdly has to be a boolean string
   )
 
   return resp.dirCID

--- a/service-commands/src/commands/users.js
+++ b/service-commands/src/commands/users.js
@@ -70,6 +70,30 @@ User.uploadPhotoAndUpdateMetadata = async (libsWrapper, {
   return newMetadata
 }
 
+User.uploadProfilePic = async (libsWrapper, picturePath) => {
+  const userPicFile = fs.createReadStream(picturePath)
+
+  const resp = await libsWrapper.libsInstance.File.uploadImage(
+    userPicFile,
+    'true', // square, this weirdly has to be a boolean string
+    10000 // timeoutMs
+  )
+
+  return resp.dirCID
+}
+
+User.uploadCoverPhoto = async (libsWrapper, photoPath) => {
+  const coverPhotoFile = fs.createReadStream(photoPath)
+
+  const resp = await libsWrapper.libsInstance.File.uploadImage(
+    coverPhotoFile,
+    'false', // square, this weirdly has to be a boolean string
+    10000 // timeoutMs
+  )
+
+  return resp.dirCID
+}
+
 User.updateAndUploadMetadata = async (libsWrapper, { newMetadata, userId }) => {
   await libsWrapper.updateAndUploadMetadata({ newMetadata, userId })
 }
@@ -128,6 +152,10 @@ User.setCurrentUser = (libs, user) => {
 
 User.getLibsUserInfo = async libs => {
   return libs.getLibsUserInfo()
+}
+
+User.cleanUserMetadata = (libsWrapper, metadata) => {
+  return libsWrapper.cleanUserMetadata(metadata)
 }
 
 User.updateMultihash = async (libsWrapper, userId, multihashDigest) => {

--- a/service-commands/src/commands/users.js
+++ b/service-commands/src/commands/users.js
@@ -58,7 +58,7 @@ User.uploadPhotoAndUpdateMetadata = async (libsWrapper, {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     userPicFile,
-    'true' // square, this weirdly has to be a boolean string
+    true // square
   )
   if (updateProfilePicture) newMetadata.profile_picture_sizes = resp.dirCID
   if (updateCoverPhoto) newMetadata.cover_photo_sizes = resp.dirCID
@@ -74,7 +74,7 @@ User.uploadProfilePic = async (libsWrapper, picturePath) => {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     userPicFile,
-    'true' // square, this weirdly has to be a boolean string
+    true // square
   )
 
   return resp.dirCID
@@ -85,7 +85,7 @@ User.uploadCoverPhoto = async (libsWrapper, photoPath) => {
 
   const resp = await libsWrapper.libsInstance.File.uploadImage(
     coverPhotoFile,
-    'false' // square, this weirdly has to be a boolean string
+    false // square
   )
 
   return resp.dirCID

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -255,8 +255,7 @@ function LibsWrapper (walletIndex = 0) {
     const coverArtFile = fs.createReadStream(coverArtFilePath)
     const resp = await this.libsInstance.File.uploadImage(
       coverArtFile,
-      'true', // square, this weirdly has to be a boolean string
-      10000 // timeoutMs
+      'true' // square, this weirdly has to be a boolean string
     )
     const { dirCID } = resp
     return dirCID
@@ -591,13 +590,9 @@ function LibsWrapper (walletIndex = 0) {
     return addPlaylistTrackTxReceipt
   }
 
-  this.uploadPlaylistCoverPhoto = async (
-    playlistId,
-    coverPhotoFile
-  ) => {
+  this.uploadPlaylistCoverPhoto = async (coverPhotoFile) => {
     assertLibsDidInit()
     const dirCid = await this.libsInstance.Playlist.uploadPlaylistCoverPhoto(
-      playlistId,
       coverPhotoFile
     )
     return dirCid

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const untildify = require('untildify')
 const Web3 = require('web3')
 const axios = require('axios')
@@ -210,6 +211,17 @@ function LibsWrapper (walletIndex = 0) {
   }
 
   /**
+   * Exposes the function used by libs to clean the metadata object passed
+   * when updating or creating a user since it could have extra fields.
+   * - Add what user props might be missing to normalize
+   * - Only keep core fields in USER_PROPS and 'user_id'.
+   */
+  this.cleanUserMetadata = (metadata) => {
+    assertLibsDidInit()
+    return this.libsInstance.User.cleanUserMetadata(metadata)
+  }
+
+  /**
    * Upload a track.
    *
    * @param {*} args trackFile and metadata
@@ -227,6 +239,27 @@ function LibsWrapper (walletIndex = 0) {
     )
     if (error) throw error
     return trackId
+  }
+
+  /**
+   * Updates an existing track given metadata. This function expects that all associated files
+   * such as track content, cover art are already on creator node.
+   * @param {Object} metadata json of the track metadata with all fields, missing fields will error
+   */
+  this.updateTrackOnChainAndCnode = async (metadata) => {
+    const { blockHash, blockNumber, trackId } = await this.libsInstance.Track.updateTrack(metadata)
+    return { blockHash, blockNumber, trackId }
+  }
+
+  this.uploadTrackCoverArt = async (coverArtFilePath) => {
+    const coverArtFile = fs.createReadStream(coverArtFilePath)
+    const resp = await this.libsInstance.File.uploadImage(
+      coverArtFile,
+      'true', // square, this weirdly has to be a boolean string
+      10000 // timeoutMs
+    )
+    const { dirCID } = resp
+    return dirCID
   }
 
   /**
@@ -450,7 +483,9 @@ function LibsWrapper (walletIndex = 0) {
   }
 
   /**
-   * Add an update track txn to chain
+   * Add an update track txn to chain.
+   * WARNING: This will break indexing if the tx contains CIDs that don't exist on any CN.
+   * Make sure you call uploadTrackMetadata first!
    * @param {int} trackId
    * @param {int} userId
    * @param {object} param3 track data
@@ -554,6 +589,18 @@ function LibsWrapper (walletIndex = 0) {
       trackId
     )
     return addPlaylistTrackTxReceipt
+  }
+
+  this.uploadPlaylistCoverPhoto = async (
+    playlistId,
+    coverPhotoFile
+  ) => {
+    assertLibsDidInit()
+    const dirCid = await this.libsInstance.Playlist.uploadPlaylistCoverPhoto(
+      playlistId,
+      coverPhotoFile
+    )
+    return dirCid
   }
 
   /**

--- a/service-commands/src/libs.js
+++ b/service-commands/src/libs.js
@@ -255,7 +255,7 @@ function LibsWrapper (walletIndex = 0) {
     const coverArtFile = fs.createReadStream(coverArtFilePath)
     const resp = await this.libsInstance.File.uploadImage(
       coverArtFile,
-      'true' // square, this weirdly has to be a boolean string
+      true // square
     )
     const { dirCID } = resp
     return dirCID


### PR DESCRIPTION
### Description
Fixes failing mad dog blacklist test:
- Verifies non-blacklisted CID for each scenario to rule out false positives (this is important because some CIDs that were being generated locally didn’t match what CN returned without extra logic – e.g., cleaning user metadata)
- Adds and exposes service command functions to: upload cover art, update track metadata, and upload playlist cover photo
- Upload and hash actual data for each scenario (user data, track cover art, playlist cover, profile photo, etc…) instead of hashing random text, which was breaking indexing. DN looked up the hash of the random text and couldn’t find any file for it, so then it would enter regressed mode and not allow other tests to pass
- Modify the cover_art_sizes/profile_picture_sizes/cover_photo_sizes/playlist_image_sizes_multihash instead of only the (deprecated?) cover_art/profile_picture/cover_photo/playlist_image_multihash, which don’t appear to be used on any new tracks or users in prod


### Tests
`npm run start test-blacklist` in mad-dog now passes

### How will this change be monitored? Are there sufficient logs?
Run `test-blacklist` again to see if it starts failing