### PR TITLE
Make maddog run twice on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
             export ipfsHost="localhost"
             export ipfsPort=6001
             npm run start << parameters.mad-dog-type >> verbose
+            npm run start << parameters.mad-dog-type >> 2 verbose
       - store_artifacts:
           path: /home/circleci/project/service-commands/output.log
       - store_artifacts:


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Change maddog to run twice on each CI run. this ensures there are no regressions from local maddog state management, and gives us slightly more coverage. The additional time of this run is also marginal - it took 1hr for entire setup, and the test run takes ~1-2 min.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

see successful CI run logs

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->