### PR TITLE
StateMachineQueue improvements

### DIFF
--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -704,7 +704,7 @@ class BlacklistManager {
     })
     stream.on('error', function (e) {
       console.error(
-        `Could not delete ${REDIS_MAP_BLACKLIST_SEGMENTCID_TO_TRACKID_KEY} entries: ${e.toString}`
+        `Could not delete ${REDIS_MAP_BLACKLIST_SEGMENTCID_TO_TRACKID_KEY} entries: ${e.toString()}`
       )
     })
   }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1167,7 +1167,9 @@ class SnapbackSM {
     }
     decisionTree.push(obj)
 
-    this.log(logStr)
+    if (log) {
+      this.log(logStr)
+    }
   }
 
   _printStateMachineQueueDecisionTree(decisionTree, msg = '') {

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -284,7 +284,7 @@ class SnapbackSM {
     )
   }
 
-  wipeStateMachineQueueRedisState () {
+  wipeStateMachineQueueRedisState() {
     // Wipe all redis keys matching pattern `bull:state-machine*` (legacy and new)
     const stream = redis.scanStream({ match: 'bull:state-machine*' })
     let numDeletedKeys = 0

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -214,8 +214,7 @@ class SnapbackSM {
     // Removes waiting/delayed jobs (does not remove active, failed, completed, or repeatable)
     await this.manualSyncQueue.empty()
     await this.recurringSyncQueue.empty()
-    // Wipes ALL queue state
-    await this.stateMachineQueue.obliterate({ force: true })
+    // Not necessary for this.stateMachineQueue because all associated redis state is manually wiped above
 
     // SyncDeDuplicator ensure a sync for a (syncType, userWallet, secondaryEndpoint) tuple is only enqueued once
     this.syncDeDuplicator = new SyncDeDuplicator()

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -144,6 +144,15 @@ class SnapbackSM {
     this.snapbackJobInterval = this.nodeConfig.get('snapbackJobInterval') // ms
 
     this.stateMachineQueueJobMaxDuration = this.snapbackJobInterval * 5
+
+    this.updateEnabledReconfigModesSet()
+
+    // PeerSetManager instance to determine the peer set and its health state
+    this.peerSetManager = new PeerSetManager({
+      discoveryProviderEndpoint:
+        this.audiusLibs.discoveryProvider.discoveryProviderEndpoint,
+      creatorNodeEndpoint: this.endpoint
+    })
   }
 
   /**
@@ -201,15 +210,6 @@ class SnapbackSM {
     this.recurringSyncQueue.on('global:stalled', (jobId) => {
       this.logError(`recurringSyncQueue Job Stalled - ID ${jobId}`)
     })
-
-    // PeerSetManager instance to determine the peer set and its health state
-    this.peerSetManager = new PeerSetManager({
-      discoveryProviderEndpoint:
-        this.audiusLibs.discoveryProvider.discoveryProviderEndpoint,
-      creatorNodeEndpoint: this.endpoint
-    })
-
-    this.updateEnabledReconfigModesSet()
 
     // Removes waiting/delayed jobs (does not remove active, failed, completed, or repeatable)
     await this.manualSyncQueue.empty()

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -214,7 +214,7 @@ class SnapbackSM {
     await this.recurringSyncQueue.empty()
 
     // Removes ALL previous state to ensure clean slate
-    await this.stateMachineQueue.obliterate()
+    await this.stateMachineQueue.obliterate({ force: true })
 
     // SyncDeDuplicator ensure a sync for a (syncType, userWallet, secondaryEndpoint) tuple is only enqueued once
     this.syncDeDuplicator = new SyncDeDuplicator()


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

- Wipe redis state for state machine queues with `Queue#obliterate()`
- Increase max job duration from 2x job interval to 5x, to allow for long running/delayed jobs
- Add event handlers for all possible events for statemachinequeue to help with debugging
- add logging after each statemachine phase to help debug when things die

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran locally and on staging CN 11, all look good

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->