### PR TITLE
Tweak pre-commit logic in init-repos.sh

### DIFF
--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -10,10 +10,10 @@ cd $PROTOCOL_DIR/
 npm install
 
 # setup pre-commit hooks
-if command -v pre-commit &>/dev/null; then
-    pre-commit install -t pre-commit -t pre-push
-else
+if ! command -v pre-commit &>/dev/null; then
     echo "pre-commit not installed; not setting up pre-commit hooks"
+else
+    pre-commit install -t pre-commit -t pre-push
 fi
 
 cd $PROTOCOL_DIR/service-commands


### PR DESCRIPTION
### Description
We see the error "ModuleNotFoundError: No module named 'pre_commit'". This seems to be a much more accurate way of checking if pre-commit exists

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested on remote dev box and it was successful
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->