### PR TITLE
Fix content node init in solana-programs

### DIFF
--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -139,9 +139,11 @@
     anchor deploy --provider.cluster $SOLANA_HOST
 
     # Initialize Audius Admin account
-    yarn run ts-node cli/main.ts -f initAdmin -k $owner_wallet_path -n $SOLANA_HOST
+    yarn run ts-node cli/main.ts --function initAdmin --owner-keypair $owner_wallet_path --network $SOLANA_HOST
 
     # Propagate local variables
+    admin_keypair_path="$PWD/adminKeypair.json"
+    admin_storage_keypair_path="$PWD/adminStorageKeypair.json"
     admin_keypair_publickey=$(solana-keygen pubkey adminKeypair.json)
     admin_keypair_privatekey=$(cat adminKeypair.json)
     admin_storage_keypair_publickey=$(solana-keygen pubkey adminStorageKeypair.json)
@@ -150,22 +152,26 @@
     # initialize Content/URSM nodes - initContentNode uses deterministic 
     # addresses and pkeys from eth-contracts ganache chain.
     yarn run ts-node cli/main.ts -f initContentNode \
-        -k "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_privatekey" \
-        --admin-storage-keypair "$admin_storage_keypair_privatekey" \
-        --cn-sp-id 1
+        ---owner-keypair "$owner_wallet_path" \
+        --admin-keypair "$admin_keypair_path"\
+        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --cn-sp-id 1 \
+        --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts -f initContentNode \
-        -k "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_privatekey" \
-        --admin-storage-keypair "$admin_storage_keypair_privatekey" \
-        --cn-sp-id 2
+        --owner-keypair "$owner_wallet_path" \
+        --admin-keypair "$admin_keypair_path"\
+        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --cn-sp-id 2 \
+        --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts -f initContentNode \
-        -k "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_privatekey" \
-        --admin-storage-keypair "$admin_storage_keypair_privatekey" \
-        --cn-sp-id 3
+        --owner-keypair "$owner_wallet_path" \
+        --admin-keypair "$admin_keypair_path"\
+        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --cn-sp-id 3 \
+        --network "$SOLANA_HOST"
+
 } >&2
 
 # Back up 2 directories to audius-protocol/solana-programs


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Content nodes were not initialized on solana-programs start up. This change fixes a couple bugs.

* init content nodes with keypair paths not actual keypairs
* use solana validator not localhost


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Verified solana-programs inited content nodes with confirmation logs in start.sh.

### How will this change be monitored? Are there sufficient logs?

No monitoring. 
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->