### PR TITLE
Finalize deprecating recentBlockhash

### DIFF
--- a/libs/src/services/solanaWeb3Manager/tokenAccount.js
+++ b/libs/src/services/solanaWeb3Manager/tokenAccount.js
@@ -121,7 +121,7 @@ async function createAssociatedTokenAccount ({
     }
   ]
 
-  const { blockhash } = await connection.getRecentBlockhash()
+  const { blockhash } = await connection.getLatestBlockhash()
 
   const transactionData = {
     recentBlockhash: blockhash,

--- a/libs/src/services/solanaWeb3Manager/transactionHandler.js
+++ b/libs/src/services/solanaWeb3Manager/transactionHandler.js
@@ -76,7 +76,7 @@ class TransactionHandler {
     }
 
     if (sendBlockhash) {
-      transactionData.recentBlockhash = (recentBlockhash || (await this.connection.getRecentBlockhash('confirmed')).blockhash)
+      transactionData.recentBlockhash = (recentBlockhash || (await this.connection.getLatestBlockhash('confirmed')).blockhash)
     }
 
     try {
@@ -108,7 +108,7 @@ class TransactionHandler {
       }
     }
 
-    recentBlockhash = recentBlockhash || (await this.connection.getRecentBlockhash('confirmed')).blockhash
+    recentBlockhash = recentBlockhash || (await this.connection.getLatestBlockhash('confirmed')).blockhash
     const tx = new Transaction({ recentBlockhash })
 
     instructions.forEach(i => tx.add(i))

--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -129,7 +129,7 @@ class Wormhole {
         signTransaction = customSignTransaction
       } else {
         signTransaction = async (transaction) => {
-          const { blockhash } = await connection.getRecentBlockhash()
+          const { blockhash } = await connection.getLatestBlockhash()
           // Must call serialize message to set the correct signatures on the transaction
           transaction.serializeMessage()
           const transactionData = {
@@ -180,7 +180,7 @@ class Wormhole {
       } else {
         transaction.serializeMessage()
 
-        const { blockhash } = await connection.getRecentBlockhash()
+        const { blockhash } = await connection.getLatestBlockhash()
         const transactionData = {
           recentBlockhash: blockhash,
           instructions: transaction.instructions.map(SolanaUtils.prepareInstructionForRelay),
@@ -277,7 +277,7 @@ class Wormhole {
       tx.serializeMessage()
       tx.partialSign(rootSolanaAccount)
 
-      const { blockhash } = await connection.getRecentBlockhash()
+      const { blockhash } = await connection.getLatestBlockhash()
       const transactionData = {
         recentBlockhash: blockhash,
         instructions: tx.instructions.map(SolanaUtils.prepareInstructionForRelay),

--- a/service-commands/package.json
+++ b/service-commands/package.json
@@ -7,8 +7,8 @@
     "preinstall": "mkdir -p ~/.local/bin && ln -sf $PWD/scripts/A ~/.local/bin/A"
   },
   "dependencies": {
-    "@audius/libs": "1.2.97",
-    "@solana/web3.js": "1.20.0",
+    "@audius/libs": "1.2.108",
+    "@solana/web3.js": "1.37.1",
     "axios": "0.19.2",
     "borsh": "0.4.0",
     "colors": "1.4.0",

--- a/service-commands/scripts/rewardManagerLocal.js
+++ b/service-commands/scripts/rewardManagerLocal.js
@@ -182,7 +182,7 @@ const createSenderLocal = async ethAddress => {
     data: serializedInstructionEnum
   })
 
-  const { blockhash: recentBlockhash } = await connection.getRecentBlockhash()
+  const { blockhash: recentBlockhash } = await connection.getLatestBlockhash()
   const transaction = new Transaction({
     feepayerWalletPubkey,
     recentBlockhash


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

* Propagate change initialized in https://github.com/AudiusProject/audius-protocol/pull/2929
* https://docs.solana.com/developing/clients/jsonrpc-api#getrecentblockhash <-- Is being deprecated
* Bump svc cmds solana/web3js version

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

* Tested on staging with relay for listens, can test additionally if needed for these flows

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->