### PR TITLE
fix init-repos

### DIFF
--- a/solana-programs/anchor/audius-data/lib/lib.ts
+++ b/solana-programs/anchor/audius-data/lib/lib.ts
@@ -1490,4 +1490,4 @@ export const getKeypairFromSecretKey = async (secretKey: Uint8Array) => {
 
 export const idl = idll;
 
-export const programId = idll.metadata.address;
+export const programId = idll?.metadata?.address || 'program not deployed';


### PR DESCRIPTION
fix init-repos error w broken import when program not deployed

### Description

found this issue when testing locally

### Tests

tested this change locally and it fixed the issue

### How will this change be monitored? Are there sufficient logs?

this command is used in CI so if it breaks again, CI won't pass

