### PR TITLE
[PLAT-111] Install Anchor deps in init-repos

### DIFF
--- a/service-commands/scripts/init-repos.sh
+++ b/service-commands/scripts/init-repos.sh
@@ -37,8 +37,7 @@ cd $PROTOCOL_DIR/creator-node
 npm install
 
 cd $PROTOCOL_DIR/solana-programs/anchor/audius-data
-yarn install
-chown -R $(whoami) . # needed for some weird cargo perm err
+npm run install-dev
 npm run build
 
 cd $PROTOCOL_DIR/libs
@@ -51,6 +50,7 @@ npm install
 cd $PROTOCOL_DIR/..
 if [ -d "audius-client" ]; then
     cd audius-client
+    git checkout main
     npm run init
 fi
 

--- a/solana-programs/anchor/audius-data/scripts/install-dev-dependencies.sh
+++ b/solana-programs/anchor/audius-data/scripts/install-dev-dependencies.sh
@@ -17,8 +17,14 @@ rustup component add rustfmt
 # install solana
 sh -c "$(curl -sSfL https://release.solana.com/$SOLANA_CLI_VERSION/install)"
 # add solana to PATH
-export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
-echo 'export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"' | tee -a "$HOME/.profile"
+SET_SOL_PATH='export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"'
+if ! grep -q "$SET_SOL_PATH" "$HOME/.profile"; then
+  TMP_SOURCE_FILE="$HOME/.tmp-anchor"
+  echo "$SET_SOL_PATH" | tee -a "$HOME/.profile"
+  echo "$SET_SOL_PATH" | tee -a "$TMP_SOURCE_FILE"
+  source "$TMP_SOURCE_FILE"
+  rm "$TMP_SOURCE_FILE"
+fi
 # set local validator
 solana config set --url localhost
 
@@ -30,13 +36,9 @@ npm i -g "@project-serum/anchor-cli@$ANCHOR_CLI_VERSION"
 anchor --version
 # install dependencies
 yarn install
-chown -R $(whoami) . # needed to resolve some weirdness...
+sudo chown -R $(whoami) . # needed to resolve some weirdness...
 
 # init solana keypair
 solana-keygen new --no-bip39-passphrase --force -o "$HOME/.config/solana/id.json"
 
-if [[ "${CI:-false}" == false ]]; then
-    # reload shell 
-    exec $SHELL
-fi
 echo "Installed deps for anchor development."


### PR DESCRIPTION
### Description
* Makes Anchor's `install-dev` script source newly-installed commands instead of reloading the shell via `exec`, which was completely replacing the existing shell process and breaking stdout from init-repos
* Fixes `install-dev` appending duplicate export PATH lines to ~/.profile
* Makes init-repos change to branch main in audius-client before running `npm run init` (this command is only on main, but our pre-baked image is still using branch master which causes the script to abort early when it can't find the command)

### Tests
* Run `A up` and verify that this only adds a few extra seconds if the dependencies are already installed
* Run `npm run install-dev` in audius-data more than once and verify that ~/.profile doesn't have duplicate export lines at the bottom

### How will this change be monitored? Are there sufficient logs?
Impacts dev flow -- keep an eye out for issues with `A up` or `npm run install-dev` in audius-data