### PR TITLE
Fix loggly tag generation on discprov

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -16,6 +16,8 @@ if [[ -z "$audius_loggly_disable" ]]; then
 
         if [[ "$audius_loggly_tags" != "" ]]; then
             audius_loggly_tags="tag=\\\"${audius_loggly_tags//,/\\\" tag=\\\"}\\\""
+            # ${audius_loggly_tags//,/\\\" tag=\\\"} replaces , with \" tag=\"
+            # then we add tag=\" to the start and \" to the end
         fi
 
         mkdir -p /var/spool/rsyslog


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

There is a small bug that results in loggly tags being read incorrectly sometimes.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested by setting tags on local docker image

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->