### PR TITLE
Use relative path for seed cache

### DIFF
--- a/service-commands/src/commands/seed/LocalStorageWrapper.js
+++ b/service-commands/src/commands/seed/LocalStorageWrapper.js
@@ -1,19 +1,14 @@
 const { LocalStorage } = require('node-localstorage')
 
-const {
-  Constants
-} = require('../../utils')
-const {
-  HEDGEHOG_ENTROPY_KEY,
-  SERVICE_COMMANDS_PATH
-} = Constants
+const { Constants } = require('../../utils')
+const { HEDGEHOG_ENTROPY_KEY } = Constants
 
 class LocalStorageWrapper {
   // local storage wrapper functions - because different instances of
   // localstorage in node don't sync, we must reinstantiate from the path
   // with each read/write to ensure we're getting the correct reference.
   get = () => {
-    return new LocalStorage(`${SERVICE_COMMANDS_PATH}/local-storage`)
+    return new LocalStorage(`./local-storage`)
   }
 
   getUserEntropy = () => {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Using `A seed create-user` outside of the service commands folder was failing to get the entropy keys

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->