### PR TITLE
Fix es-indexer repost handler for playlist.

### DIFF
--- a/discovery-provider/es-indexer/src/listener.ts
+++ b/discovery-provider/es-indexer/src/listener.ts
@@ -65,7 +65,7 @@ const handlers = {
     if (repost.repost_type == 'track') {
       pending.trackIds.add(repost.repost_item_id)
     } else {
-      pending.trackIds.add(repost.repost_item_id)
+      pending.playlistIds.add(repost.repost_item_id)
     }
   },
   follows: (follow: FollowRow) => {


### PR DESCRIPTION
### Description

Repost handler for playlist was marking track ID stale.  Classic copy paste bug.
