### PR TITLE
Improve rewards retry logic

### DIFF
--- a/libs/src/services/solanaWeb3Manager/rewards.js
+++ b/libs/src/services/solanaWeb3Manager/rewards.js
@@ -270,7 +270,9 @@ async function submitAttestations ({
 
   // If there's any error in any of the transactions, just return that one
   for (const res of results) {
-    if (res.error || res.errorCode) {
+    // Opt to return anything with a known errorCode vs an error,
+    // because errorCode is usually actionable vs error is normally just Solana congestion
+    if (res.errorCode || res.error) {
       return res
     }
   }


### PR DESCRIPTION
### Description

For submitting reward attestations, we break it into multiple txns and submit in parallel. There is a subtle bug here where if any of them fail due to congestion, we don't propagate any of the error codes that we've seen out to the caller. Opt to propagate error codes instead of the general congestion error.

### Tests

Tested locally, helps claiming trending somewhat

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->