### PR TITLE
Unblock bringing down services because of prune

### DIFF
--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -13,7 +13,7 @@
       "sudo rm -rf discovery-provider/.venv",
       "sudo rm -rf discovery-provider/.mypy_cache",
       "sudo rm -f discovery-provider/*.log",
-      "docker image prune --filter 'dangling=true' --filter 'until=360h'"
+      "docker image prune -f --filter 'dangling=true' --filter 'until=360h'"
     ]
   },
   "network": {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Currently, bringing down services will be stuck indefinitely. 
```
/home/ubuntu/.audius/eth-config.json
Bringing down services...
all - down
```

It's actually waiting for a confirmation prompt. This is only apparent when running `A down --verbose`. 
```
cd /home/ubuntu/Documents/Audius/audius-protocol; docker image prune --filter 'dangling=true' --filter 'until=360h'
WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] 
```

We just need to add a `-f` flag like the other commands to skip confirmation.


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Ran locally and `A down` is unblocked.

### How will this change be monitored? Are there sufficient logs?
No monitoring.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->