### PR TITLE
Conditional on empty Plays insert

### DIFF
--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -357,16 +357,17 @@ def parse_sol_tx_batch(
 
                     # Append plays to a list that will be written if all plays are successfully retrieved
                     # from the rpc pool
-                    play: PlayInfo = {
-                        "user_id": user_id,
-                        "play_item_id": track_id,
-                        "created_at": created_at,
-                        "updated_at": datetime.now(),
-                        "source": source,
-                        "slot": slot,
-                        "signature": tx_sig,
-                    }
-                    plays.append(play)
+                    if track_id is not None:
+                        play: PlayInfo = {
+                            "user_id": user_id,
+                            "play_item_id": track_id,
+                            "created_at": created_at,
+                            "updated_at": datetime.now(),
+                            "source": source,
+                            "slot": slot,
+                            "signature": tx_sig,
+                        }
+                        plays.append(play)
                     # Only enqueue a challenge event if it's *not*
                     # an anonymous listen
                     if user_id is not None:

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -357,17 +357,16 @@ def parse_sol_tx_batch(
 
                     # Append plays to a list that will be written if all plays are successfully retrieved
                     # from the rpc pool
-                    if track_id is not None:
-                        play: PlayInfo = {
-                            "user_id": user_id,
-                            "play_item_id": track_id,
-                            "created_at": created_at,
-                            "updated_at": datetime.now(),
-                            "source": source,
-                            "slot": slot,
-                            "signature": tx_sig,
-                        }
-                        plays.append(play)
+                    play: PlayInfo = {
+                        "user_id": user_id,
+                        "play_item_id": track_id,
+                        "created_at": created_at,
+                        "updated_at": datetime.now(),
+                        "source": source,
+                        "slot": slot,
+                        "signature": tx_sig,
+                    }
+                    plays.append(play)
                     # Only enqueue a challenge event if it's *not*
                     # an anonymous listen
                     if user_id is not None:

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -404,6 +404,7 @@ def parse_sol_tx_batch(
 
     # Cache the latest play from this batch
     # This reflects the ordering from chain
+    logger.info(f"index_solana_plays.py | Committing {plays}")
     for play in plays:
         if play.get("signature") == last_tx_in_batch:
             most_recent_db_play = {


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

* Explicitly do not insert if `Plays` array is empty
* Exposed during incident on 5-1-21 due to clock skew issues resulting in thousands of failed transactions for which no `Play` is added to array but a commit of empty array fails with the following
```
Failing row contains (109243114, null, null, null, 2022-05-01 13:03:29.303709, 2022-05-01 13:03:29.303709, null, null)
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->