### PR TITLE
Cache latest timestamp from SOL and pass it into listen transactions

### DIFF
--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -118,14 +118,15 @@ function getFeePayerKeypair (singleFeePayer = true) {
 }
 
 let cachedListenBlocktime = null // in seconds, tracks recent blocktime
-let lastRetrievedListenBlocktime = null // in seconds, tracks time when cachedListenBlocktime was fetched 
+let lastRetrievedListenBlocktime = null // in seconds, tracks time when cachedListenBlocktime was fetched
 
 /**
  * Get the blocktime for a recently finalized block, this relative time will be passed into listen transaction.
  * Used to prevent clock skew errors when sol chain halts and sol clock diverges from real clock
+ * @param {Object} connection initialized solana connection object
  * @returns Number epoch in seconds
  */
- async function getListenTimestamp () {
+async function getListenTimestamp (connection) {
   const currentEpochInSec = Math.round(Date.now() / 1000)
   if (cachedListenBlocktime && Math.abs(lastRetrievedListenBlocktime - currentEpochInSec) < 30) {
     return cachedListenBlocktime
@@ -133,7 +134,7 @@ let lastRetrievedListenBlocktime = null // in seconds, tracks time when cachedLi
 
   const slot = await connection.getSlot('finalized')
   const blockTime = await connection.getBlockTime(slot)
-  
+
   // update cached values
   cachedListenBlocktime = blockTime
   lastRetrievedListenBlocktime = currentEpochInSec
@@ -164,7 +165,7 @@ async function createTrackListenTransaction ({
     userId: userId,
     trackId: trackId,
     source: source,
-    timestamp: (await getListenTimestamp()) || Math.round(new Date().getTime() / 1000)
+    timestamp: (await getListenTimestamp(connection)) || Math.round(new Date().getTime() / 1000)
   })
 
   const serializedTrackData = borsh.serialize(trackDataSchema, trackData)

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -117,6 +117,30 @@ function getFeePayerKeypair (singleFeePayer = true) {
   return feePayerKeypairs[randomFeePayerIndex]
 }
 
+let cachedListenBlocktime = null // in seconds, tracks recent blocktime
+let lastRetrievedListenBlocktime = null // in seconds, tracks time when cachedListenBlocktime was fetched 
+
+/**
+ * Get the blocktime for a recently finalized block, this relative time will be passed into listen transaction.
+ * Used to prevent clock skew errors when sol chain halts and sol clock diverges from real clock
+ * @returns Number epoch in seconds
+ */
+ async function getListenTimestamp () {
+  const currentEpochInSec = Math.round(Date.now() / 1000)
+  if (cachedListenBlocktime && Math.abs(lastRetrievedListenBlocktime - currentEpochInSec) < 30) {
+    return cachedListenBlocktime
+  }
+
+  const slot = await connection.getSlot('finalized')
+  const blockTime = await connection.getBlockTime(slot)
+  
+  // update cached values
+  cachedListenBlocktime = blockTime
+  lastRetrievedListenBlocktime = currentEpochInSec
+
+  return blockTime
+}
+
 async function createTrackListenTransaction ({
   validSigner,
   privateKey,
@@ -140,7 +164,7 @@ async function createTrackListenTransaction ({
     userId: userId,
     trackId: trackId,
     source: source,
-    timestamp: Math.round(new Date().getTime() / 1000)
+    timestamp: (await getListenTimestamp()) || Math.round(new Date().getTime() / 1000)
   })
 
   const serializedTrackData = borsh.serialize(trackDataSchema, trackData)


### PR DESCRIPTION
### Description
When SOL validator clocks diverge from real clocks due to the network halting, we see listen transactions fail to be confirmed. This checks the relative time from SOL and passes the time into the listen transaction, so it shouldn't diverge enough to be fail a transaction.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested via a script locally
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
If listens are successfully submitted, this change is successful 
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->