### PR TITLE
Trim cache if play tx batch is all errors

### DIFF
--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -402,7 +402,11 @@ def parse_sol_tx_batch(
     # This means every subsequent run will continue to no-op on error transactions and the cache will never be updated
     if tx_sig_batch_records and not plays:
         logger.info("index_solana_plays.py | Clearing redis cache")
-        redis.delete(REDIS_TX_CACHE_QUEUE_PREFIX)
+        # redis.delete(REDIS_TX_CACHE_QUEUE_PREFIX)
+
+        # don't delete instead, trim
+        redis.ltrim(REDIS_TX_CACHE_QUEUE_PREFIX, 1, -1)
+
 
     # Cache the latest play from this batch
     # This reflects the ordering from chain

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -407,7 +407,6 @@ def parse_sol_tx_batch(
         # don't delete instead, trim
         redis.ltrim(REDIS_TX_CACHE_QUEUE_PREFIX, 1, -1)
 
-
     # Cache the latest play from this batch
     # This reflects the ordering from chain
     for play in plays:
@@ -489,8 +488,10 @@ def fetch_traversed_tx_from_cache(redis: Redis, latest_db_slot: int):
             )
             redis.ltrim(REDIS_TX_CACHE_QUEUE_PREFIX, 1, -1)
             # If a single element is remaining, clear the list to avoid dupe processing
-            if redis.llen(REDIS_TX_CACHE_QUEUE_PREFIX) == 1:
-                redis.delete(REDIS_TX_CACHE_QUEUE_PREFIX)
+            # if redis.llen(REDIS_TX_CACHE_QUEUE_PREFIX) == 1:
+            #     redis.delete(REDIS_TX_CACHE_QUEUE_PREFIX)
+            # ^ don't think this is necessary  
+
             # Return if a valid signature is found
             if last_cached_tx["slot"] > latest_db_slot:
                 cached_offset_tx_found = True


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Currently, we cache the last tx in a batch as we try to find an intersection.
https://github.com/AudiusProject/audius-protocol/blob/936dbb172ac9446ef9c35ca9768a1758105aa2d8/discovery-provider/src/tasks/index_solana_plays.py#L589

This appends txs to the left of the queue, oldest txs first.
plays-tx-cache-queue = [0(prev intersection), 1 (all errors), 2 (next intersection), 3, 4, 5, 6] 

When we encounter a batch of all errors, we currently delete the whole queue. This leads to a large number of batches and trying to index them all at once.

Instead, maybe we should trim from the left until we encounter a valid batch (2), then try to index those. In the case of batches with errors, we simply skip those. In the worst case, the queue is empty and we check the chain tail. I think this maintains the progress of the queue without needing to resize max batches either. 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->