### PR TITLE
Fix solana programs admin key naming

### DIFF
--- a/solana-programs/anchor/audius-data/cli/main.ts
+++ b/solana-programs/anchor/audius-data/cli/main.ts
@@ -329,7 +329,7 @@ program
   .option("-f, --function <type>", "function to invoke")
   .option("-n, --network <string>", "solana network")
   .option("-k, --owner-keypair <keypair>", "owner keypair path")
-  .option("-ak, --admin-keypair <keypair>", "admin keypair path")
+  .option("-ak, --admin-authority-keypair <keypair>", "admin authority keypair path")
   .option(
     "-aak, --admin-account-keypair <keypair>",
     "admin account keypair path"
@@ -381,7 +381,7 @@ const adminAuthorityKeypair = options.adminAuthorityKeypair
   ? keypairFromFilePath(options.adminAuthorityKeypair)
   : anchor.web3.Keypair.generate();
 
-// Admin storage keypair, referenced internally
+// Admin account keypair, referenced internally
 // Keypair technically only necessary the first time this is initialized
 const adminAccountKeypair = options.adminAccountKeypair
   ? keypairFromFilePath(options.adminAccountKeypair)
@@ -586,7 +586,7 @@ const main = async () => {
       const txHash = await cliVars.provider.sendAndConfirm(tx);
       await cliVars.provider.connection.confirmTransaction(txHash);
       console.log(
-        `createUserTx = ${txHash}, userStorageAccount = ${derivedAddress}`
+        `createUserTx = ${txHash}, userAccount = ${derivedAddress}`
       );
       break;
     }

--- a/solana-programs/anchor/audius-data/scripts/seed-tx.sh
+++ b/solana-programs/anchor/audius-data/scripts/seed-tx.sh
@@ -6,7 +6,7 @@ set -x
 
 ANCHOR_PROGRAM_DIR="$PROTOCOL_DIR/solana-programs/anchor/audius-data"
 OWNER_KEYPAIR_PATH="$HOME/.config/solana/id.json"
-ADMIN_KEYPAIR_PATH="$PWD/adminKeypair.json"
+ADMIN_AUTHORITY_KEYPAIR_PATH="$PWD/adminAuthorityKeypair.json"
 ADMIN_ACCOUNT_KEYPAIR_PATH="$PWD/adminAccountKeypair.json"
 USER_KEYPAIR_PATH="$PWD/userKeypair.json"
 AUDIUS_DATA_PROGRAM_ID=$(solana-keygen pubkey $PWD/target/deploy/audius_data-keypair.json)
@@ -24,19 +24,19 @@ echo "Registering content nodes!"
 # Register content nodes
 yarn run ts-node cli/main.ts -f initContentNode \
     -k "$OWNER_KEYPAIR_PATH" \
-    --admin-keypair "$ADMIN_KEYPAIR_PATH" \
+    --admin-authority-keypair "$ADMIN_AUTHORITY_KEYPAIR_PATH" \
     --admin-account-keypair "$ADMIN_ACCOUNT_KEYPAIR_PATH" \
     --cn-sp-id 1
 
 yarn run ts-node cli/main.ts -f initContentNode \
     -k "$OWNER_KEYPAIR_PATH" \
-    --admin-keypair "$ADMIN_KEYPAIR_PATH" \
+    --admin-authority-keypair "$ADMIN_AUTHORITY_KEYPAIR_PATH" \
     --admin-account-keypair "$ADMIN_ACCOUNT_KEYPAIR_PATH" \
     --cn-sp-id 2
 
 yarn run ts-node cli/main.ts -f initContentNode \
     -k "$OWNER_KEYPAIR_PATH" \
-    --admin-keypair "$ADMIN_KEYPAIR_PATH" \
+    --admin-authority-keypair "$ADMIN_AUTHORITY_KEYPAIR_PATH" \
     --admin-account-keypair "$ADMIN_ACCOUNT_KEYPAIR_PATH" \
     --cn-sp-id 3
 
@@ -44,7 +44,7 @@ echo "Init user"
 
 yarn run ts-node cli/main.ts -f initUser \
     -k "$OWNER_KEYPAIR_PATH" \
-    --admin-keypair "$ADMIN_KEYPAIR_PATH" \
+    --admin-authority-keypair "$ADMIN_AUTHORITY_KEYPAIR_PATH" \
     --admin-account-keypair "$ADMIN_ACCOUNT_KEYPAIR_PATH" \
     --user-replica-set 1,2,3 \
     --user-id 1 \

--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -147,28 +147,28 @@
     admin_authority_keypair_publickey=$(solana-keygen pubkey adminAuthorityKeypair.json)
     admin_authority_keypair_privatekey=$(cat adminAuthorityKeypair.json)
     admin_account_keypair_publickey=$(solana-keygen pubkey adminAccountKeypair.json)
-    admin_storage_keypair_privatekey=$(cat adminAccountKeypair.json)
+    admin_account_keypair_privatekey=$(cat adminAccountKeypair.json)
 
     # initialize Content/URSM nodes - initContentNode uses deterministic 
     # addresses and pkeys from eth-contracts ganache chain.
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_privatekey" \
         --cn-sp-id 1 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_privatekey" \
         --cn-sp-id 2 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_privatekey" \
         --cn-sp-id 3 \
         --network "$SOLANA_HOST"
 
@@ -184,7 +184,7 @@ cat <<EOF
     "anchorAdminPublicKey": "$admin_authority_keypair_publickey",
     "anchorAdminPrivateKey": "$admin_authority_keypair_privatekey",
     "anchorAdminStoragePublicKey": "$admin_account_keypair_publickey",
-    "anchorAdminStoragePrivateKey": "$admin_storage_keypair_privatekey",
+    "anchorAdminStoragePrivateKey": "$admin_account_keypair_privatekey",
     "trackListenCountAddress": "$track_listen_count_address",
     "audiusEthRegistryAddress": "$audius_eth_registry_address",
     "validSigner": "$valid_signer",

--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -142,33 +142,33 @@
     yarn run ts-node cli/main.ts --function initAdmin --owner-keypair $owner_wallet_path --network $SOLANA_HOST
 
     # Propagate local variables
-    admin_keypair_path="$PWD/adminKeypair.json"
-    admin_storage_keypair_path="$PWD/adminStorageKeypair.json"
-    admin_keypair_publickey=$(solana-keygen pubkey adminKeypair.json)
-    admin_keypair_privatekey=$(cat adminKeypair.json)
-    admin_storage_keypair_publickey=$(solana-keygen pubkey adminStorageKeypair.json)
-    admin_storage_keypair_privatekey=$(cat adminStorageKeypair.json)
+    admin_authority_keypair_path="$PWD/adminAuthorityKeypair.json"
+    admin_storage_keypair_path="$PWD/adminAccountKeypair.json"
+    admin_authority_keypair_publickey=$(solana-keygen pubkey adminAuthorityKeypair.json)
+    admin_authority_keypair_privatekey=$(cat adminAuthorityKeypair.json)
+    admin_account_keypair_publickey=$(solana-keygen pubkey adminAccountKeypair.json)
+    admin_storage_keypair_privatekey=$(cat adminAccountKeypair.json)
 
     # initialize Content/URSM nodes - initContentNode uses deterministic 
     # addresses and pkeys from eth-contracts ganache chain.
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_path"\
-        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --admin-authority-keypair "$admin_authority_keypair_path"\
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 1 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_path"\
-        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --admin-authority-keypair "$admin_authority_keypair_path"\
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 2 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
-        --admin-keypair "$admin_keypair_path"\
-        --admin-storage-keypair "$admin_storage_keypair_path" \
+        --admin-authority-keypair "$admin_authority_keypair_path"\
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 3 \
         --network "$SOLANA_HOST"
 
@@ -177,12 +177,13 @@
 # Back up 2 directories to audius-protocol/solana-programs
 cd ../../
 
+# TODO follow up PR on cleaning up anchor admin storage naming
 cat <<EOF
 {
     "anchorProgramId": "$anchor_program_id",
-    "anchorAdminPublicKey": "$admin_keypair_publickey",
-    "anchorAdminPrivateKey": "$admin_keypair_privatekey",
-    "anchorAdminStoragePublicKey": "$admin_storage_keypair_publickey",
+    "anchorAdminPublicKey": "$admin_authority_keypair_publickey",
+    "anchorAdminPrivateKey": "$admin_authority_keypair_privatekey",
+    "anchorAdminStoragePublicKey": "$admin_account_keypair_publickey",
     "anchorAdminStoragePrivateKey": "$admin_storage_keypair_privatekey",
     "trackListenCountAddress": "$track_listen_count_address",
     "audiusEthRegistryAddress": "$audius_eth_registry_address",

--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -154,21 +154,21 @@
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_path" \
         --cn-sp-id 1 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_path" \
         --cn-sp-id 2 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_storage_keypair_path" \
+        --admin-account-keypair "$admin_account_keypair_path" \
         --cn-sp-id 3 \
         --network "$SOLANA_HOST"
 

--- a/solana-programs/start.sh
+++ b/solana-programs/start.sh
@@ -143,7 +143,7 @@
 
     # Propagate local variables
     admin_authority_keypair_path="$PWD/adminAuthorityKeypair.json"
-    admin_storage_keypair_path="$PWD/adminAccountKeypair.json"
+    admin_account_keypair_path="$PWD/adminAccountKeypair.json"
     admin_authority_keypair_publickey=$(solana-keygen pubkey adminAuthorityKeypair.json)
     admin_authority_keypair_privatekey=$(cat adminAuthorityKeypair.json)
     admin_account_keypair_publickey=$(solana-keygen pubkey adminAccountKeypair.json)
@@ -154,21 +154,21 @@
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_account_keypair_privatekey" \
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 1 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_account_keypair_privatekey" \
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 2 \
         --network "$SOLANA_HOST"
 
     yarn run ts-node cli/main.ts --function initContentNode \
         --owner-keypair "$owner_wallet_path" \
         --admin-authority-keypair "$admin_authority_keypair_path"\
-        --admin-account-keypair "$admin_account_keypair_privatekey" \
+        --admin-account-keypair "$admin_storage_keypair_path" \
         --cn-sp-id 3 \
         --network "$SOLANA_HOST"
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Currently, solana-programs container is broken and doesn't seed the first solana transactions. This change fixes that but leaves the rest of the naming aside for https://github.com/AudiusProject/audius-protocol/pull/3011/files.


### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

solana-programs start works.

### How will this change be monitored? Are there sufficient logs?
No monitoring.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->