### PR TITLE
Use global slot for solana notifications

### DIFF
--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -41,6 +41,7 @@ from src.utils.config import shared_config
 from src.utils.redis_constants import (
     latest_sol_rewards_manager_db_tx_key,
     latest_sol_rewards_manager_program_tx_key,
+    latest_sol_rewards_manager_slot_key,
 )
 from src.utils.session_manager import SessionManager
 
@@ -500,12 +501,15 @@ def process_transaction_signatures(
                 "timestamp": last_tx["timestamp"],
             },
         )
+    return last_tx
 
 
 def process_solana_rewards_manager(
     solana_client_manager: SolanaClientManager, db: SessionManager, redis: Redis
 ):
     """Fetches the next set of reward manager transactions and updates the DB with Challenge Disbursements"""
+    # Get the latests slot available globally before fetching txs to keep track of indexing progress
+
     if not is_valid_rewards_manager_program:
         logger.error(
             "index_rewards_manager.py | no valid reward manager program passed"
@@ -514,6 +518,13 @@ def process_solana_rewards_manager(
     if not REWARDS_MANAGER_ACCOUNT:
         logger.error("index_rewards_manager.py | reward manager account missing")
         return
+
+    # Get the latests slot available globally before fetching txs to keep track of indexing progress
+    try:
+        latest_global_slot = solana_client_manager.get_block_height()
+    except:
+        logger.error("index_rewards_manager.py | Failed to get block height")
+
     # List of signatures that will be populated as we traverse recent operations
     transaction_signatures = get_transaction_signatures(
         solana_client_manager,
@@ -525,9 +536,13 @@ def process_solana_rewards_manager(
     )
     logger.info(f"index_rewards_manager.py | {transaction_signatures}")
 
-    process_transaction_signatures(
+    last_tx = process_transaction_signatures(
         solana_client_manager, db, redis, transaction_signatures
     )
+    if latest_global_slot is not None:
+        redis.set(latest_sol_rewards_manager_slot_key, latest_global_slot)
+    elif last_tx:
+        redis.set(latest_sol_rewards_manager_slot_key, last_tx["slot"])
 
 
 # ####### CELERY TASKS ####### #

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -537,10 +537,10 @@ def process_solana_rewards_manager(
     last_tx = process_transaction_signatures(
         solana_client_manager, db, redis, transaction_signatures
     )
-    if latest_global_slot is not None:
-        redis.set(latest_sol_rewards_manager_slot_key, latest_global_slot)
-    elif last_tx:
+    if last_tx:
         redis.set(latest_sol_rewards_manager_slot_key, last_tx["slot"])
+    elif latest_global_slot is not None:
+        redis.set(latest_sol_rewards_manager_slot_key, latest_global_slot)
 
 
 # ####### CELERY TASKS ####### #

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -508,8 +508,6 @@ def process_solana_rewards_manager(
     solana_client_manager: SolanaClientManager, db: SessionManager, redis: Redis
 ):
     """Fetches the next set of reward manager transactions and updates the DB with Challenge Disbursements"""
-    # Get the latests slot available globally before fetching txs to keep track of indexing progress
-
     if not is_valid_rewards_manager_program:
         logger.error(
             "index_rewards_manager.py | no valid reward manager program passed"

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -629,10 +629,10 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis: Redi
         )
         raise e
 
-    if latest_global_slot is not None:
-        redis.set(latest_sol_plays_slot_key, latest_global_slot)
-    elif last_tx:
+    if last_tx:
         redis.set(latest_sol_plays_slot_key, last_tx["slot"])
+    elif latest_global_slot is not None:
+        redis.set(latest_sol_plays_slot_key, latest_global_slot)
 
 
 @celery.task(name="index_solana_plays", bind=True)

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -41,3 +41,6 @@ latest_sol_spl_token_db_key = "latest_sol_program_tx:spl_token:db"
 # Used to get the latest processed slot of each indexing task, using the global slots instead of the per-program slots
 latest_sol_user_bank_slot_key = "latest_sol_slot:user_bank"
 latest_sol_aggregate_tips_slot_key = "latest_sol_slot:aggregate_tips"
+latest_sol_plays_slot_key = "latest_sol_slot:plays"
+latest_sol_listen_count_milestones_slot_key = "latest_sol_slot:listen_count_milestones"
+latest_sol_rewards_manager_slot_key = "latest_sol_slot:rewards_manager"


### PR DESCRIPTION
### Description

Use the global slot (block height) for tracking the solana indexing progress as it relates to notifications, otherwise notifications will be gated on the most recent transaction in each program

Related: #2993 

### Tests

Manually tested on remote

### How will this change be monitored? Are there sufficient logs?

Can check redis but also logging out the result of `get_max_slot()`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->