### PR TITLE
Wait 10 seconds after trying health check instead of before

### DIFF
--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -274,7 +274,6 @@ const performHealthCheckWithRetry = async (
   let attempts = retries
   while (attempts > 0) {
     try {
-      await wait(10000)
       await performHealthCheck(service, serviceNumber)
       console.log(
         `Successful health check for ${service}${serviceNumber || ''}`.happy
@@ -283,6 +282,7 @@ const performHealthCheckWithRetry = async (
     } catch (e) {
       console.log(`${e}`)
     }
+    await wait(10000)
     attempts -= 1
   }
   const serviceNumberString = serviceNumber ? `, spId=${serviceNumber}` : ''


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Moves the wait for health check in service commands to be _after_ the first check (if it fails), since we might want to run health check outside the main `A up` and don't necessarily need to wait 10 seconds

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->