### PR TITLE
[CON-131] Refactor state machine redis metrics to reduce calls

### DIFF
--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -27,19 +27,6 @@ const CHALLENGE_TTL_SECONDS = 120
 const CHALLENGE_PREFIX = 'userLoginChallenge:'
 
 module.exports = function (app) {
-  app.get(
-    '/theo/enqueue',
-    handleResponse(async (req, res, next) => {
-      const serviceRegistry = app.get('serviceRegistry')
-      await serviceRegistry.snapbackSM.stateMachineQueue.add(
-        /** data */ { startTime: Date.now() },
-        /** opts */ {}
-      )
-
-      return successResponse()
-    })
-  )
-
   /**
    * Creates CNodeUser table entry if one doesn't already exist
    */

--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -27,6 +27,19 @@ const CHALLENGE_TTL_SECONDS = 120
 const CHALLENGE_PREFIX = 'userLoginChallenge:'
 
 module.exports = function (app) {
+  app.get(
+    '/theo/enqueue',
+    handleResponse(async (req, res, next) => {
+      const serviceRegistry = app.get('serviceRegistry')
+      await serviceRegistry.snapbackSM.stateMachineQueue.add(
+        /** data */ { startTime: Date.now() },
+        /** opts */ {}
+      )
+
+      return successResponse()
+    })
+  )
+
   /**
    * Creates CNodeUser table entry if one doesn't already exist
    */

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1413,24 +1413,16 @@ class SnapbackSM {
   }
 
   async computeUserSecondarySyncSuccessRatesMap(nodeUsers) {
-    let walletsToSecondariesMapping = {}
+    // Map each nodeUser to truthy secondaries (ignore empty secondaries that result from incomplete replica sets)
+    const walletsToSecondariesMapping = {}
     for (const nodeUser of nodeUsers) {
       const { wallet, secondary1, secondary2 } = nodeUser
-      const secondaries = [{ endpoint: secondary1 }, { endpoint: secondary2 }]
-
-      // Get only truthy secondaries (ignore empty secondary endpoints that result from incomplete replica sets)
-      const secondaryEndpoints = secondaries
-        .filter((secondary) => secondary.endpoint)
-        .map((secondary) => secondary.endpoint)
-
-      walletsToSecondariesMapping = {
-        ...walletsToSecondariesMapping,
-        [wallet]: secondaryEndpoints
-      }
+      const secondaries = [secondary1, secondary2].filter(Boolean)
+      walletsToSecondariesMapping[wallet] = secondaries
     }
 
     const userSecondarySyncMetricsMap =
-      await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+      await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRatesForToday(
         walletsToSecondariesMapping
       )
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -235,16 +235,16 @@ class SnapbackSM {
     )
 
     // Enqueue stateMachineQueue jobs on a cron, after an initial delay
-    await this.stateMachineQueue.add(
-      /** data */ { startTime: Date.now() },
-      /** opts */ { delay: STATE_MACHINE_QUEUE_INIT_DELAY_MS }
-    )
-    await this.stateMachineQueue.add(
-      /** data */ { startTime: Date.now() },
-      /** opts */ {
-        repeat: { every: this.snapbackJobInterval }
-      }
-    )
+    // await this.stateMachineQueue.add(
+    //   /** data */ { startTime: Date.now() },
+    //   /** opts */ { delay: STATE_MACHINE_QUEUE_INIT_DELAY_MS }
+    // )
+    // await this.stateMachineQueue.add(
+    //   /** data */ { startTime: Date.now() },
+    //   /** opts */ {
+    //     repeat: { every: this.snapbackJobInterval }
+    //   }
+    // )
 
     this.log(
       `SnapbackSM initialized with manualSyncsDisabled=${this.manualSyncsDisabled}. Added initial stateMachineQueue job; jobs will be enqueued every ${this.snapbackJobInterval}ms`
@@ -977,11 +977,38 @@ class SnapbackSM {
         )
       }
 
+      // Retrieve success metrics for all users syncing to their secondaries
+      let userSecondarySyncMetricsMap = {}
+      try {
+        userSecondarySyncMetricsMap =
+          await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+        this._addToStateMachineQueueDecisionTree(
+          decisionTree,
+          'computeUserSecondarySyncSuccessRatesMap() Success',
+          {
+            userSecondarySyncMetricsMapLength: Object.keys(
+              userSecondarySyncMetricsMap
+            ).length
+          }
+        )
+      } catch (e) {
+        this._addToStateMachineQueueDecisionTree(
+          decisionTree,
+          'computeUserSecondarySyncSuccessRatesMap() Error',
+          { error: e.message }
+        )
+        console.log(e.stack) // TODO: Remove before publishing PR draft
+        throw new Error(
+          'processStateMachineOperation():computeUserSecondarySyncSuccessRatesMap() Error'
+        )
+      }
+
       // Find sync requests that need to be issued and ReplicaSets that need to be updated
       const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
         await this.aggregateReconfigAndPotentialSyncOps(
           nodeUsers,
-          unhealthyPeers
+          unhealthyPeers,
+          userSecondarySyncMetricsMap
         )
       this._addToStateMachineQueueDecisionTree(
         decisionTree,
@@ -1187,6 +1214,7 @@ class SnapbackSM {
    *
    * @param {Object} nodeUser { primary, secondary1, secondary2, primarySpID, secondary1SpID, secondary2SpID, user_id, wallet }
    * @param {Set<string>} unhealthyPeers set of unhealthy peers
+   * @param {string (wallet): Object{ string (secondary endpoint): Object{ successRate: number (0-1), successCount: number, failureCount: number }}} userSecondarySyncMetricsMap mapping of nodeUser's wallet (string) to metrics for their sync success to secondaries
    * @returns
    * {
    *  requiredUpdateReplicaSetOps: {Object[]} array of {...nodeUsers, unhealthyReplicas: {string[]} endpoints of unhealthy rset nodes }
@@ -1194,7 +1222,11 @@ class SnapbackSM {
    * }
    * @notice this will issue sync to healthy secondary and update replica set away from unhealthy secondary
    */
-  async aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers) {
+  async aggregateReconfigAndPotentialSyncOps(
+    nodeUsers,
+    unhealthyPeers,
+    userSecondarySyncMetricsMap
+  ) {
     // Parallelize calling this._aggregateOps on chunks of 500 nodeUsers at a time
     const nodeUserBatches = _.chunk(
       nodeUsers,
@@ -1204,7 +1236,11 @@ class SnapbackSM {
     for (const nodeUserBatch of nodeUserBatches) {
       const resultBatch = await Promise.allSettled(
         nodeUserBatch.map((nodeUser) =>
-          this._aggregateOps(nodeUser, unhealthyPeers)
+          this._aggregateOps(
+            nodeUser,
+            unhealthyPeers,
+            userSecondarySyncMetricsMap[nodeUser.wallet]
+          )
         )
       )
       results.push(...resultBatch)
@@ -1249,8 +1285,9 @@ class SnapbackSM {
    * Used to determine the `requiredUpdateReplicaSetOps` and `potentialSyncRequests` for a given nodeUser.
    * @param {Object} nodeUser { primary, secondary1, secondary2, primarySpID, secondary1SpID, secondary2SpID, user_id, wallet}
    * @param {Set<string>} unhealthyPeers set of unhealthy peers
+   * @param {string (secondary endpoint): Object{ successRate: number (0-1), successCount: number, failureCount: number }} userSecondarySyncMetrics mapping of each secondary to the success metrics the nodeUser has had syncing to it
    */
-  async _aggregateOps(nodeUser, unhealthyPeers) {
+  async _aggregateOps(nodeUser, unhealthyPeers, userSecondarySyncMetrics) {
     const requiredUpdateReplicaSetOps = []
     const potentialSyncRequests = []
     const unhealthyReplicas = []
@@ -1284,11 +1321,27 @@ class SnapbackSM {
       /**
        * For each secondary, enqueue `potentialSyncRequest` if healthy else add to `unhealthyReplicas`
        */
-      const userSecondarySyncMetrics =
+      // TODO: Theo remove before submitting non-draft PR
+      const userSecondarySyncMetricsExpected =
         await this._computeUserSecondarySyncSuccessRates(
           nodeUser,
           secondariesEndpoint
         )
+      try {
+        if (
+          !_.isEqual(userSecondarySyncMetrics, userSecondarySyncMetricsExpected)
+        ) {
+          logger.error(`[theo] ERROR MISMATCHED METRICS`)
+          logger.error(
+            `[theo] expected: ${JSON.stringify(
+              userSecondarySyncMetricsExpected
+            )}, got: ${JSON.stringify(userSecondarySyncMetrics)}`
+          )
+          throw new Error('mismatched')
+        }
+      } catch (e) {
+        logger.error(`[theo] Mismatched redis results error: ${e}`)
+      }
       for (const secondaryInfo of secondariesInfo) {
         const secondary = secondaryInfo.endpoint
 
@@ -1380,6 +1433,31 @@ class SnapbackSM {
     }
 
     return { requiredUpdateReplicaSetOps, potentialSyncRequests }
+  }
+
+  async computeUserSecondarySyncSuccessRatesMap(nodeUsers) {
+    let walletsToSecondariesMapping = {}
+    for (const nodeUser of nodeUsers) {
+      const { wallet, secondary1, secondary2 } = nodeUser
+      const secondaries = [{ endpoint: secondary1 }, { endpoint: secondary2 }]
+
+      // Get only truthy secondaries (ignore empty secondary endpoints that result from incomplete replica sets)
+      const secondaryEndpoints = secondaries
+        .filter((secondary) => secondary.endpoint)
+        .map((secondary) => secondary.endpoint)
+
+      walletsToSecondariesMapping = {
+        ...walletsToSecondariesMapping,
+        [wallet]: secondaryEndpoints
+      }
+    }
+
+    const userSecondarySyncMetricsMap =
+      await SecondarySyncHealthTracker.batchComputeUserSecondarySyncSuccessRates(
+        walletsToSecondariesMapping
+      )
+
+    return userSecondarySyncMetricsMap
   }
 
   // Wrapper fn

--- a/creator-node/test/secondarySyncHealthTracker.test.js
+++ b/creator-node/test/secondarySyncHealthTracker.test.js
@@ -20,7 +20,7 @@ describe('test secondarySyncHealthTracker', function () {
   })
 
   it(
-    '[computeUsersSecondarySyncSuccessRates] should return 100% success rate for 1 success and 0 failures',
+    '[computeUsersSecondarySyncSuccessRatesForToday] should return 100% success rate for 1 success and 0 failures',
     async function () {
       const wallet = 'testWallet1'
       const secondary = 'http://secondary1.co'
@@ -32,7 +32,7 @@ describe('test secondarySyncHealthTracker', function () {
         [wallet]: [[secondary]]
       }
       const userSecondarySyncMetricsMap =
-        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRatesForToday(
           walletsToSecondariesMapping
         )
 
@@ -49,7 +49,7 @@ describe('test secondarySyncHealthTracker', function () {
   })
 
   it(
-    '[computeUsersSecondarySyncSuccessRates] should return 50% success rate for 1 success and 1 failure',
+    '[computeUsersSecondarySyncSuccessRatesForToday] should return 50% success rate for 1 success and 1 failure',
     async function () {
       const wallet = 'testWallet1'
       const secondary = 'http://secondary1.co'
@@ -62,7 +62,7 @@ describe('test secondarySyncHealthTracker', function () {
         [wallet]: [[secondary]]
       }
       const userSecondarySyncMetricsMap =
-        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRatesForToday(
           walletsToSecondariesMapping
         )
 
@@ -79,7 +79,7 @@ describe('test secondarySyncHealthTracker', function () {
   })
 
   it(
-    '[computeUsersSecondarySyncSuccessRates] should return 0% success rate for 0 successes and 1 failure',
+    '[computeUsersSecondarySyncSuccessRatesForToday] should return 0% success rate for 0 successes and 1 failure',
     async function () {
       const wallet = 'testWallet1'
       const secondary = 'http://secondary1.co'
@@ -91,7 +91,7 @@ describe('test secondarySyncHealthTracker', function () {
         [wallet]: [[secondary]]
       }
       const userSecondarySyncMetricsMap =
-        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRatesForToday(
           walletsToSecondariesMapping
         )
 
@@ -108,7 +108,7 @@ describe('test secondarySyncHealthTracker', function () {
   })
 
   it(
-    '[computeUsersSecondarySyncSuccessRates] only returns wallets and secondaries requested',
+    '[computeUsersSecondarySyncSuccessRatesForToday] only returns wallets and secondaries requested',
     async function () {
       const wallet = 'testWallet1'
       const wallet2 = 'testWallet2'
@@ -131,7 +131,7 @@ describe('test secondarySyncHealthTracker', function () {
         [wallet2]: [[secondary], [secondary3]]
       }
       const userSecondarySyncMetricsMap =
-        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRatesForToday(
           walletsToSecondariesMapping
         )
 

--- a/creator-node/test/secondarySyncHealthTracker.test.js
+++ b/creator-node/test/secondarySyncHealthTracker.test.js
@@ -1,0 +1,166 @@
+const assert = require('assert')
+
+const SecondarySyncHealthTracker = require('../src/snapbackSM/secondarySyncHealthTracker')
+const { getLibsMock } = require('./lib/libsMock')
+const { getApp } = require('./lib/app')
+
+describe('test secondarySyncHealthTracker', function () {
+  let app, server
+
+  beforeEach(async function () {
+    const appInfo = await getApp(getLibsMock())
+    app = appInfo.app
+    server = appInfo.server
+
+    await app.get('redisClient').flushdb()
+  })
+
+  afterEach(async function () {
+    await server.close()
+  })
+
+  it(
+    '[computeUsersSecondarySyncSuccessRates] should return 100% success rate for 1 success and 0 failures',
+    async function () {
+      const wallet = 'testWallet1'
+      const secondary = 'http://secondary1.co'
+      const syncType = 'testSyncType'
+
+      await SecondarySyncHealthTracker.recordSuccess(secondary, wallet, syncType)
+
+      const walletsToSecondariesMapping = {
+        [wallet]: [[secondary]]
+      }
+      const userSecondarySyncMetricsMap =
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+          walletsToSecondariesMapping
+        )
+
+      const expectedUserSecondarySyncMetricsMap = {
+        [wallet]: {
+          [secondary]: {
+            successCount: 1,
+            failureCount: 0,
+            successRate: 1
+          }
+        }
+      }
+      assert.deepEqual(userSecondarySyncMetricsMap, expectedUserSecondarySyncMetricsMap)
+  })
+
+  it(
+    '[computeUsersSecondarySyncSuccessRates] should return 50% success rate for 1 success and 1 failure',
+    async function () {
+      const wallet = 'testWallet1'
+      const secondary = 'http://secondary1.co'
+      const syncType = 'testSyncType'
+
+      await SecondarySyncHealthTracker.recordSuccess(secondary, wallet, syncType)
+      await SecondarySyncHealthTracker.recordFailure(secondary, wallet, syncType)
+
+      const walletsToSecondariesMapping = {
+        [wallet]: [[secondary]]
+      }
+      const userSecondarySyncMetricsMap =
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+          walletsToSecondariesMapping
+        )
+
+      const expectedUserSecondarySyncMetricsMap = {
+        [wallet]: {
+          [secondary]: {
+            successCount: 1,
+            failureCount: 1,
+            successRate: 0.5
+          }
+        }
+      }
+      assert.deepEqual(userSecondarySyncMetricsMap, expectedUserSecondarySyncMetricsMap)
+  })
+
+  it(
+    '[computeUsersSecondarySyncSuccessRates] should return 0% success rate for 0 successes and 1 failure',
+    async function () {
+      const wallet = 'testWallet1'
+      const secondary = 'http://secondary1.co'
+      const syncType = 'testSyncType'
+
+      await SecondarySyncHealthTracker.recordFailure(secondary, wallet, syncType)
+
+      const walletsToSecondariesMapping = {
+        [wallet]: [[secondary]]
+      }
+      const userSecondarySyncMetricsMap =
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+          walletsToSecondariesMapping
+        )
+
+      const expectedUserSecondarySyncMetricsMap = {
+        [wallet]: {
+          [secondary]: {
+            successCount: 0,
+            failureCount: 1,
+            successRate: 0
+          }
+        }
+      }
+      assert.deepEqual(userSecondarySyncMetricsMap, expectedUserSecondarySyncMetricsMap)
+  })
+
+  it(
+    '[computeUsersSecondarySyncSuccessRates] only returns wallets and secondaries requested',
+    async function () {
+      const wallet = 'testWallet1'
+      const wallet2 = 'testWallet2'
+      const wallet3 = 'testWallet3'
+      const secondary = 'http://secondary1.co'
+      const secondary2 = 'http://secondary2.co'
+      const secondary3 = 'http://secondary3.co'
+      const syncType = 'testSyncType'
+
+      for (const currSecondary of [secondary, secondary2, secondary3]) {
+        await SecondarySyncHealthTracker.recordSuccess(currSecondary, wallet, syncType)
+        await SecondarySyncHealthTracker.recordSuccess(currSecondary, wallet, syncType)
+        await SecondarySyncHealthTracker.recordFailure(currSecondary, wallet2, syncType)
+        await SecondarySyncHealthTracker.recordSuccess(currSecondary, wallet3, syncType)
+        await SecondarySyncHealthTracker.recordFailure(currSecondary, wallet3, syncType)
+      }
+
+      const walletsToSecondariesMapping = {
+        [wallet]: [[secondary], [secondary2]],
+        [wallet2]: [[secondary], [secondary3]]
+      }
+      const userSecondarySyncMetricsMap =
+        await SecondarySyncHealthTracker.computeUsersSecondarySyncSuccessRates(
+          walletsToSecondariesMapping
+        )
+
+      const expectedUserSecondarySyncMetricsMap = {
+        [wallet]: {
+          [secondary]: {
+            successCount: 2,
+            failureCount: 0,
+            successRate: 1
+          },
+          [secondary2]: {
+            successCount: 2,
+            failureCount: 0,
+            successRate: 1
+          }
+        },
+        [wallet2]: {
+          [secondary]: {
+            successCount: 0,
+            failureCount: 1,
+            successRate: 0
+          },
+          [secondary3]: {
+            successCount: 0,
+            failureCount: 1,
+            successRate: 0
+          }
+        }
+      }
+      assert.deepEqual(userSecondarySyncMetricsMap, expectedUserSecondarySyncMetricsMap)
+  })
+})

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -668,7 +668,8 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://cnOriginallySpId3ReregisteredAsSpId4.co')
@@ -712,7 +713,8 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://cnOriginallySpId3ReregisteredAsSpId4.co')
@@ -756,7 +758,8 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
@@ -790,7 +793,8 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
     assert.strictEqual(potentialSyncRequests.length, 0)
@@ -832,7 +836,8 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers)
+    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://deregisteredCN.co')
     assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -679,18 +679,6 @@ describe('test SnapbackSM', function () {
   it('[aggregateReconfigAndPotentialSyncOps] if the self node is the primary and a secondary spId is different from what is on chain, issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
 
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          successRate: 100
-        },
-        'http://cnOriginallySpId3ReregisteredAsSpId4.co': {
-          successRate: 100
-        }
-      }
-    }
-
     // Mock that one of the nodes got reregistered from spId 3 to spId 4
     snapback.peerSetManager.endpointToSPIdMap = {
       'http://some_healthy_primary.co': 1,
@@ -723,18 +711,6 @@ describe('test SnapbackSM', function () {
 
   it('[aggregateReconfigAndPotentialSyncOps] if the self node (primary) is the same as the SP with a different spId, do not issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
-
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          successRate: 100
-        },
-        'http://cnWithSpId3.co': {
-          successRate: 100
-        }
-      }
-    }
 
     // Mock that one of the nodes got reregistered from spId 3 to spId 4
     snapback.peerSetManager.endpointToSPIdMap = {
@@ -802,18 +778,6 @@ describe('test SnapbackSM', function () {
 
   it('[aggregateReconfigAndPotentialSyncOps] if any replica set node is not in the map, issue reconfig', async function () {
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
-
-    // Mock these as very nodes that completed only successful syncs
-    snapback._computeUserSecondarySyncSuccessRates = async () => {
-      return {
-        'http://cnWithSpId2.co': {
-          successRate: 100
-        },
-        'http://deregisteredCN.co': {
-          successRate: 100
-        }
-      }
-    }
 
     // Mock the deregistered node to not have any spId
     snapback.peerSetManager.endpointToSPIdMap = {

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -668,7 +668,7 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
@@ -713,7 +713,7 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
@@ -758,7 +758,7 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
@@ -793,7 +793,7 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     assert.strictEqual(requiredUpdateReplicaSetOps.length, 0)
@@ -836,7 +836,7 @@ describe('test SnapbackSM', function () {
 
     const unhealthyPeers = new Set()
 
-    const userSecondarySyncMetricsMap = await this.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+    const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://deregisteredCN.co')


### PR DESCRIPTION
### Description
- Change fetching sync metrics via 1 redis call per nodeUser to instead fetching sync metrics for all users at once
- Fix bug that caused sync outcomes to be read improperly, which caused the sync success rate to always be 100%
- Add tests for redis batching + making sure that bug doesn't come back. Increased Content Node coverage:
    - line coverage 64.00% -> 66.85%
    - branch coverage 50.85% -> 52.78%

### Tests
The latest commit has integration tests, and if you go back to the first commit there are logs that help with manually verifying functionality -- it performs the original redis check and throws an error with the message `[theo] ERROR MISMATCHED METRICS` if the original metric doesn't match the metric pulled from the new unified redis call.

Steps I followed to test:
1. Use the first commit in this PR (it has extra logs for testing) locally and then on staging
2. Hit the endpoint <node url>/theo/enqueue
3. Search the Docker logs to make sure the state machine operation completed and look for any logs with `[theo]` in them:
    - `docker container ps | grep "cn"`
    - `docker container logs <container for the CN you're looking for> |& less`
    - Type `[theo]` <Enter> (there shouldn't be any hits)
    - Type `processStateMachineOperation` <Enter> (the decision tree should be complete with no failures)

### How will this change be monitored? Are there sufficient logs?
Search for "processStateMachineOperation()" in logs to monitor the decision tree for new errors. `userSecondarySyncMetricsMapLength` should equal `nodeUsersLength`