### PR TITLE
[PAY-126] [PAY-114] Add supporters/supporting API

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -6,6 +6,7 @@ from flask_restx import reqparse
 from src import api_helpers
 from src.models import ChallengeType
 from src.queries.get_challenges import ChallengeResponse
+from src.queries.get_support_for_user import SupportResponse
 from src.queries.get_undisbursed_challenges import UndisbursedChallengeResponse
 from src.utils.config import shared_config
 from src.utils.helpers import decode_string_id, encode_int_id
@@ -286,6 +287,12 @@ def extend_undisbursed_challenge(undisbursed_challenge: UndisbursedChallengeResp
         new_undisbursed_challenge["user_id"]
     )
     return new_undisbursed_challenge
+
+
+def extend_support(support: SupportResponse):
+    new_support = support.copy()
+    new_support["user"] = extend_user(support["user"])
+    return new_support
 
 
 def abort_bad_path_param(param, namespace):

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -289,10 +289,20 @@ def extend_undisbursed_challenge(undisbursed_challenge: UndisbursedChallengeResp
     return new_undisbursed_challenge
 
 
-def extend_support(support: SupportResponse):
-    new_support = support.copy()
-    new_support["user"] = extend_user(support["user"])
-    return new_support
+def extend_supporter(support: SupportResponse):
+    return {
+        "rank": support["rank"],
+        "amount": support["amount"],
+        "sender": extend_user(support["user"]),
+    }
+
+
+def extend_supporting(support: SupportResponse):
+    return {
+        "rank": support["rank"],
+        "amount": support["amount"],
+        "receiver": extend_user(support["user"]),
+    }
 
 
 def abort_bad_path_param(param, namespace):

--- a/discovery-provider/src/api/v1/models/support.py
+++ b/discovery-provider/src/api/v1/models/support.py
@@ -1,0 +1,13 @@
+from flask_restx import fields
+
+from .common import ns
+from .users import user_model
+
+support = ns.model(
+    "support",
+    {
+        "rank": fields.Integer(required=True),
+        "user": fields.Nested(user_model, required=True),
+        "amount": fields.String(required=True),
+    },
+)

--- a/discovery-provider/src/api/v1/models/support.py
+++ b/discovery-provider/src/api/v1/models/support.py
@@ -3,11 +3,21 @@ from flask_restx import fields
 from .common import ns
 from .users import user_model
 
-support = ns.model(
-    "support",
+supporter_response = ns.model(
+    "supporter",
     {
         "rank": fields.Integer(required=True),
-        "user": fields.Nested(user_model, required=True),
         "amount": fields.String(required=True),
+        "sender": fields.Nested(user_model, required=True),
+    },
+)
+
+
+supporting_response = ns.model(
+    "supporting",
+    {
+        "rank": fields.Integer(required=True),
+        "amount": fields.String(required=True),
+        "receiver": fields.Nested(user_model, required=True),
     },
 )

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -906,6 +906,7 @@ get_supporters_response = make_response(
 
 @ns.route("/<string:id>/supporters")
 class GetSupporters(Resource):
+    @record_metrics
     @ns.doc(
         id="""Get User Supporters""",
         description="""Gets the supporters of the given user""",
@@ -930,6 +931,7 @@ get_supporting_response = make_response(
 
 @ns.route("/<string:id>/supporting")
 class GetSupporting(Resource):
+    @record_metrics
     @ns.doc(
         id="""Get User Supporting""",
         description="""Gets the users that the given user supports""",

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -931,8 +931,8 @@ get_supporting_response = make_response(
 @ns.route("/<string:id>/supporting")
 class GetSupporting(Resource):
     @ns.doc(
-        id="""Get User Supporters""",
-        description="""Gets the supporters of the given user""",
+        id="""Get User Supporting""",
+        description="""Gets the users that the given user supports""",
         params={"id": "A User ID"},
     )
     @ns.expect(pagination_parser)

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -10,7 +10,8 @@ from src.api.v1.helpers import (
     extend_activity,
     extend_challenge_response,
     extend_favorite,
-    extend_support,
+    extend_supporter,
+    extend_supporting,
     extend_track,
     extend_user,
     format_limit,
@@ -25,7 +26,7 @@ from src.api.v1.helpers import (
     success_response,
 )
 from src.api.v1.models.common import favorite
-from src.api.v1.models.support import support
+from src.api.v1.models.support import supporter_response, supporting_response
 from src.api.v1.models.users import (
     associated_wallets,
     challenge_response,
@@ -899,7 +900,7 @@ class GetChallenges(Resource):
 
 
 get_supporters_response = make_response(
-    "get_supporters", ns, fields.List(fields.Nested(support))
+    "get_supporters", ns, fields.List(fields.Nested(supporter_response))
 )
 
 
@@ -918,8 +919,13 @@ class GetSupporters(Resource):
         decoded_id = decode_with_abort(id, ns)
         args["user_id"] = decoded_id
         support = get_support_received_by_user(args)
-        support = list(map(extend_support, support))
+        support = list(map(extend_supporter, support))
         return success_response(support)
+
+
+get_supporting_response = make_response(
+    "get_supporting", ns, fields.List(fields.Nested(supporting_response))
+)
 
 
 @ns.route("/<string:id>/supporting")
@@ -930,12 +936,12 @@ class GetSupporting(Resource):
         params={"id": "A User ID"},
     )
     @ns.expect(pagination_parser)
-    @ns.marshal_with(get_supporters_response)
+    @ns.marshal_with(get_supporting_response)
     @cache(ttl_sec=5)
     def get(self, id: str):
         args = pagination_parser.parse_args()
         decoded_id = decode_with_abort(id, ns)
         args["user_id"] = decoded_id
         support = get_support_sent_by_user(args)
-        support = list(map(extend_support, support))
+        support = list(map(extend_supporting, support))
         return success_response(support)

--- a/discovery-provider/src/queries/get_support_for_user.py
+++ b/discovery-provider/src/queries/get_support_for_user.py
@@ -1,0 +1,119 @@
+from typing import Any, Dict, List, Tuple, TypedDict
+
+from sqlalchemy import Integer, column, text
+from src.models import AggregateUserTips
+from src.queries.query_helpers import get_users_by_id
+from src.utils.db_session import get_db_read_replica
+
+sql_support_received = text(
+    """
+SELECT
+    RANK() OVER (ORDER BY amount DESC) AS rank
+    , sender_user_id
+    , receiver_user_id
+    , amount
+FROM aggregate_user_tips
+WHERE receiver_user_id = :receiver_user_id
+ORDER BY amount DESC
+LIMIT :limit
+OFFSET :offset;
+"""
+).columns(
+    column("rank", Integer),
+    AggregateUserTips.sender_user_id,
+    AggregateUserTips.receiver_user_id,
+    AggregateUserTips.amount,
+)
+
+
+sql_support_sent = text(
+    """
+SELECT rank, sender_user_id, receiver_user_id, amount 
+FROM (
+    SELECT 
+        B.sender_user_id
+        , B.receiver_user_id
+        , B.amount
+        , RANK() OVER (PARTITION BY B.receiver_user_id ORDER BY B.amount DESC) AS rank
+    FROM aggregate_user_tips A
+    JOIN aggregate_user_tips B ON A.receiver_user_id = B.receiver_user_id
+    WHERE A.sender_user_id = :sender_user_id
+) rankings
+WHERE sender_user_id = :sender_user_id
+ORDER BY amount DESC, receiver_user_id ASC
+LIMIT :limit
+OFFSET :offset;
+"""
+).columns(
+    column("rank", Integer),
+    AggregateUserTips.sender_user_id,
+    AggregateUserTips.receiver_user_id,
+    AggregateUserTips.amount,
+)
+
+
+class SupportResponse(TypedDict):
+    rank: int
+    amount: int
+    user: Any
+
+
+def query_result_to_support_response(
+    results, users: Dict[int, Any], user_is_sender: bool
+) -> List[SupportResponse]:
+    return [
+        {
+            "rank": row[0],
+            "amount": row[1].amount,
+            "user": users[
+                row[1].sender_user_id if user_is_sender else row[1].receiver_user_id
+            ],
+        }
+        for row in results
+    ]
+
+
+def get_support_received_by_user(args) -> List[SupportResponse]:
+    support: List[SupportResponse] = []
+    receiver_user_id = args.get("user_id")
+    current_user_id = args.get("current_user_id")
+    limit = args.get("limit", 100)
+    offset = args.get("offset", 0)
+
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        query = (
+            session.query("rank", AggregateUserTips)
+            .from_statement(sql_support_received)
+            .params(receiver_user_id=receiver_user_id, limit=limit, offset=offset)
+        )
+        rows: List[Tuple[int, AggregateUserTips]] = query.all()
+
+        user_ids = [row[1].sender_user_id for row in rows]
+        users = get_users_by_id(session, user_ids, current_user_id)
+
+        support = query_result_to_support_response(rows, users, user_is_sender=True)
+    return support
+
+
+def get_support_sent_by_user(args) -> List[SupportResponse]:
+    support: List[SupportResponse] = []
+    sender_user_id = args.get("user_id")
+    current_user_id = args.get("current_user_id")
+    limit = args.get("limit")
+    offset = args.get("offset")
+
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        query = (
+            session.query("rank", AggregateUserTips)
+            .from_statement(sql_support_sent)
+            .params(sender_user_id=sender_user_id, limit=limit, offset=offset)
+        )
+        rows: List[Tuple[int, AggregateUserTips]] = query.all()
+
+        user_ids = [row[1].receiver_user_id for row in rows]
+        users = get_users_by_id(session, user_ids, current_user_id)
+
+        support = query_result_to_support_response(rows, users, user_is_sender=False)
+    return support


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Adds `v1/users/<id>/supporters` and `v1/users/<id>/supporting` routes to the Discovery Node API

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested on remote using seed commands

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Ideas? Added `@record_metrics` to the endpoints

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->