### PR TITLE
Remove local log files + alleviate discovery disk pressure

### DIFF
--- a/discovery-provider/.gitignore
+++ b/discovery-provider/.gitignore
@@ -44,11 +44,6 @@ build/
 # redis dumps
 *_dump
 
-# logs
-beat.log
-worker.log
-server.log
-
 # build in service-commands up
 compose/env/tmp*/
 

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -85,10 +85,10 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
         echo "Finished running migrations"
     fi
 
-    ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) server.log &
+    ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) worker.log &
-        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) beat.log &
+        watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &
     fi
 else
     ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &

--- a/service-commands/src/commands/service-commands.json
+++ b/service-commands/src/commands/service-commands.json
@@ -13,7 +13,7 @@
       "sudo rm -rf discovery-provider/.venv",
       "sudo rm -rf discovery-provider/.mypy_cache",
       "sudo rm -f discovery-provider/*.log",
-      "docker image prune -f --filter 'dangling=true' --filter 'until=360h'"
+      "docker image prune --filter 'dangling=true' --filter 'until=360h' --force"
     ]
   },
   "network": {


### PR DESCRIPTION
### Description
These files were added because it seemed like we might need these to get logs from docker. Turns out that might not be the case. 

This actually fixes another bug where the watchmedo constantly spews discovery logs about 
```
{"levelno": 10, "level": "DEBUG", "msg": "in-event <InotifyEvent: src_path=b'/audius-discovery-provider/worker.log', wd=1, mask=IN_MODIFY, cookie=0, name=worker.log>", "timestamp": "2022-05-04 13:04:19,680"}
``` 
<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested the system locally by bringing up everything and checking the logs. I will also put this on stage and test that loggly transport works.
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
If this change doesn't work there wouldn't have been any local discovery logs
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->