### PR TITLE
[CON-138] Lower retry attempts for issuing new replica set

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -18,7 +18,7 @@ const { generateTimestampAndSignature } = require('../apiSigning')
 const SyncMonitoringRetryDelayMs = 15000
 
 // Max number of attempts to select new replica set in reconfig
-const MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS = 100
+const MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS = 5
 
 // Timeout for fetching batch clock values
 const BATCH_CLOCK_STATUS_REQUEST_TIMEOUT = 10000 // 10s


### PR DESCRIPTION
### Description
Simple change to give up on issuing a new replica set after 5 attempts instead of trying 100 times.

### Tests
This is overly time consuming to test for how small of a change it is. Will make sure CircleCI passes and add an extra reviewer.

### How will this change be monitored? Are there sufficient logs?
Search for `Not enough healthy nodes found to issue new replica set after 100 attempts` in the logs. It should no longer appear and instead log `Not enough healthy nodes found to issue new replica set after 5 attempts`.