### PR TITLE
Fix max_slot_result None check

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_tips.py
+++ b/discovery-provider/src/tasks/index_aggregate_tips.py
@@ -39,8 +39,8 @@ INSERT INTO aggregate_user_tips (
 
 def _update_aggregate_tips(session: Session):
 
-    max_slot_result = session.query(func.max(UserTip.slot)).one_or_none()
-    max_slot = int(max_slot_result[0]) if max_slot_result is not None else 0
+    max_slot_result = session.query(func.max(UserTip.slot)).one()
+    max_slot = int(max_slot_result[0]) if max_slot_result[0] is not None else 0
     update_aggregate_table(
         logger,
         session,


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

`func.max()` will always return a row, but the value of the row might be `None`

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

No tests - only affects databases with 0 UserTips

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->