### PR TITLE
Handle exceptions from collectors

### DIFF
--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -32,7 +32,7 @@ def celery_tasks_prometheus_exporter():
     for task in tasks:
         try:
             metric.save_time(
-                {"task_name": task["task_name"]}, start_time=task["time_start"]
+                {"task_name": task["task_name"]}, start_time=task["started_at"]
             )
         except:
             logger.exception(f"Processing failed for task: {task}")

--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -32,7 +32,7 @@ def celery_tasks_prometheus_exporter():
     for task in tasks:
         try:
             metric.save_time({"task_name": task["name"]}, start_time=task["time_start"])
-        except Exception as e:
+        except:
             logger.exception(f"Processing failed for task: {task}")
 
 

--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -1,6 +1,9 @@
+import logging
+
 from src.monitors import monitor_names, monitors
 from src.utils.prometheus_metric import PrometheusMetric, PrometheusType
 
+logger = logging.getLogger(__name__)
 MONITORS = monitors.MONITORS
 
 
@@ -27,7 +30,10 @@ def celery_tasks_prometheus_exporter():
     )
 
     for task in tasks:
-        metric.save_time({"task_name": task["name"]}, start_time=task["time_start"])
+        try:
+            metric.save_time({"task_name": task["name"]}, start_time=task["time_start"])
+        except Exception as e:
+            logger.exception(f"Processing failed for task: {task}")
 
 
 PrometheusMetric.register_collector(

--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -31,7 +31,9 @@ def celery_tasks_prometheus_exporter():
 
     for task in tasks:
         try:
-            metric.save_time({"task_name": task["name"]}, start_time=task["time_start"])
+            metric.save_time(
+                {"task_name": task["task_name"]}, start_time=task["time_start"]
+            )
         except:
             logger.exception(f"Processing failed for task: {task}")
 

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -76,7 +76,7 @@ class PrometheusMetric:
 
     @classmethod
     def populate_collectors(cls):
-        for name, collector in enumerate(cls.registered_collectors):
+        for name, collector in cls.registered_collectors.items():
             try:
                 collector()
             except:

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -79,5 +79,5 @@ class PrometheusMetric:
         for name, collector in enumerate(cls.registered_collectors):
             try:
                 collector()
-            except Exception as e:
+            except:
                 logger.exception(f"Failure to collect '{name}'")

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -1,7 +1,10 @@
+import logging
 from time import time
 from typing import Callable, Dict
 
 from prometheus_client import Gauge, Histogram
+
+logger = logging.getLogger(__name__)
 
 
 class PrometheusType:
@@ -73,5 +76,8 @@ class PrometheusMetric:
 
     @classmethod
     def populate_collectors(cls):
-        for collector in cls.registered_collectors.values():
-            collector()
+        for name, collector in enumerate(cls.registered_collectors):
+            try:
+                collector()
+            except Exception as e:
+                logger.exception(f"Failure to collect '{name}'")


### PR DESCRIPTION
### Description

Our prometheus endpoints are currently seeing this:

```
{"error":["Something caused the server to crash."],"success":false}
```

Our logs are showing this:

```
{"levelno": 40, "level": "ERROR", "msg": "Non Audius-derived exception\nTraceback (most recent call last):\n  File \"/usr/lib/python3.9/site-packages/flask/app.py\", line 1838, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/usr/lib/python3.9/site-packages/flask/app.py\", line 1824, in dispatch_request\n    return self.view_functions[rule.endpoint](**req.view_args)\n  File \"/audius-discovery-provider/src/queries/prometheus_metrics_exporter.py\", line 43, in prometheus_metrics_exporter\n    PrometheusMetric.populate_collectors()\n  File \"/audius-discovery-provider/src/utils/prometheus_metric.py\", line 77, in populate_collectors\n    collector()\n  File \"/audius-discovery-provider/src/queries/get_celery_tasks.py\", line 30, in celery_tasks_prometheus_exporter\n    metric.save_time({\"task_name\": task[\"name\"]}, start_time=task[\"time_start\"])\nKeyError: 'name'", "timestamp": "2022-05-05 17:23:27,629"}
```

Let's wrap our collectors with try/except blocks to minimize future collector issues.

### Tests

Check that our prometheus endpoint continues to expose metrics:

* https://discoveryprovider2.staging.audius.co/prometheus_metrics
* https://discoveryprovider2.audius.co/prometheus_metrics

Check that our discovery provider metrics are still being displayed:

* http://grafana.audius.co/d/000000004/discovery-provider

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->