### PR TITLE
[INF-80] Add health check to Dockerfile

### DIFF
--- a/creator-node/Dockerfile
+++ b/creator-node/Dockerfile
@@ -25,7 +25,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositor
     apk add postgresql-libs=11.12-r0 && \
     apk add python3 && \
     apk add python3-dev && \
-    apk add py3-pip
+    apk add py3-pip && \
+    apk add curl
 
 # Install openresty with public key
 RUN echo 'http://mirror.leaseweb.com/alpine/v3.13/community' >> /etc/apk/repositories && \
@@ -85,6 +86,9 @@ ENV GIT_SHA=$git_sha
 ENV logglyDisable=$audius_loggly_disable
 ENV logglyToken=$audius_loggly_token
 ENV logglyTags=$audius_loggly_tags
+
+HEALTHCHECK --interval=5s --timeout=5s \
+    CMD curl -f http://localhost:4000/health_check || exit 1
 
 # CMD ["sh", "-c", "/usr/bin/wait && exec node src/index.js"]
 CMD ["bash", "scripts/start.sh"]

--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -30,6 +30,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositor
     apk add docker && \
     apk add nodejs && \
     apk add npm && \
+    apk add curl && \
     apk add --virtual .build-deps gcc musl-dev postgresql-dev=11.12-r0
 
 COPY requirements.txt requirements.txt
@@ -105,5 +106,8 @@ ENV audius_loggly_tags=$audius_loggly_tags
 
 ENV PROMETHEUS_MULTIPROC_DIR /prometheus_data
 RUN mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
+
+HEALTHCHECK --interval=5s --timeout=5s \
+    CMD curl -f http://localhost:5000/health_check || exit 1
 
 CMD ["bash", "scripts/start.sh"]

--- a/identity-service/Dockerfile
+++ b/identity-service/Dockerfile
@@ -25,7 +25,8 @@ RUN apk update && \
     apk add rsyslog && \
     apk add python3 && \
     apk add python3-dev && \
-    apk add py3-pip
+    apk add py3-pip && \
+    apk add curl
 
 EXPOSE 7000
 
@@ -38,5 +39,8 @@ ENV GIT_SHA=$git_sha
 ENV logglyDisable=$audius_loggly_disable
 ENV logglyToken=$audius_loggly_token
 ENV logglyTags=$audius_loggly_tags
+
+HEALTHCHECK --interval=5s --timeout=5s \
+    CMD curl -f http://localhost:7000/health_check || exit 1
 
 CMD ["bash", "scripts/start.sh"]


### PR DESCRIPTION
### Description

Installs curl and adds a health check to the Dockerfile directly so that we don't need to have health checks managed by docker-compose

### Tests

Tested by bringing up the docker container
```sh
ubuntu@cheran-gcp:~$ docker ps | grep healthy
30fc8d0c274d   cn1_creator-node                                                              "bash scripts/start.…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:4000->4000/tcp, :::4000->4000/tcp, 0.0.0.0:9230->9230/tcp, :::9230->9230/tcp               cn1_creator-node_1
ffbab9abfc3d   dn1_web-server                                                                "bash scripts/start.…"   3 minutes ago        Up 3 minutes (healthy)        0.0.0.0:5000->5000/tcp, :::5000->5000/tcp                                                          dn1_web-server_1
ed3fea2045e5   postgres:11.1                                                                 "docker-entrypoint.s…"   3 minutes ago        Up 3 minutes (healthy)        0.0.0.0:5432->5432/tcp, :::5432->5432/tcp
```

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->