### PR TITLE
Bump libs version v1.2.115

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.114",
+  "version": "1.2.115",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/libs",
-  "version": "1.2.114",
+  "version": "1.2.115",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Description
Bump libs version
Has changes from #2966

### Tests
Ran locally linked with client and identity 

### How will this change be monitored? Are there sufficient logs?
