### PR TITLE
Add Elasticsearch index block diffs to health check

### DIFF
--- a/discovery-provider/compose/docker-compose.redis.yml
+++ b/discovery-provider/compose/docker-compose.redis.yml
@@ -31,6 +31,17 @@ services:
     networks:
       - audius_dev
 
+  # kibana:
+  #   image: docker.elastic.co/kibana/kibana:8.1.0
+  #   container_name: kibana
+  #   environment:
+  #     ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+  #     SERVER_HOSTS: 0.0.0.0
+  #   ports:
+  #     - '5601:5601'
+  #   depends_on:
+  #     - elasticsearch
+
 volumes:
   esdata:
 

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -8,7 +8,6 @@ esclient = None
 if es_url:
     esclient = Elasticsearch(es_url)
 
-
 # uses aliases
 ES_PLAYLISTS = "playlists"
 ES_REPOSTS = "reposts"
@@ -16,6 +15,7 @@ ES_SAVES = "saves"
 ES_TRACKS = "tracks"
 ES_USERS = "users"
 
+ES_INDEXES = [ES_PLAYLISTS, ES_REPOSTS, ES_SAVES, ES_TRACKS, ES_USERS]
 
 def listify(things):
     if isinstance(things, list):


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Add some index block diffs to the health check so we can easily see if an ES index is caught up or not.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Manually tested against DP pointed to a sandbox snapshot.

```
"elasticsearch": {
"playlists": {
"blocknumber": 27233637,
"db_block_difference": 0
},
"reposts": {
"blocknumber": 27233637,
"db_block_difference": 0
},
"saves": {
"blocknumber": 27233631,
"db_block_difference": 6
},
"tracks": {
"blocknumber": 27233525,
"db_block_difference": 112
},
"users": {
"blocknumber": 27233622,
"db_block_difference": 15
}
},

```

### How will this change be monitored? Are there sufficient logs?
Check verbose health check.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->