### PR TITLE
[CON-118] (Content Node) Paginate getNodeUsers in snapback

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -44,6 +44,7 @@ const healthCheck = async (
   const maxStorageUsedPercent = config.get('maxStorageUsedPercent')
 
   // SnapbackSM information
+  const snapbackUsersPerJob = config.get('snapbackUsersPerJob')
   const snapbackModuloBase = config.get('snapbackModuloBase')
   const manualSyncsDisabled = config.get('manualSyncsDisabled')
 
@@ -154,6 +155,7 @@ const healthCheck = async (
     currentSnapbackReconfigMode,
     manualSyncsDisabled,
     snapbackModuloBase,
+    snapbackUsersPerJob,
     transcodeActive,
     transcodeWaiting,
     transcodeQueueIsAvailable: isAvailable,

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -135,6 +135,7 @@ describe('Test Health Check', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
     config.set('maxStorageUsedPercent', 95)
+    config.set('snapbackUsersPerJob', 2)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -195,6 +196,7 @@ describe('Test Health Check', function () {
       currentSnapbackReconfigMode: 'RECONFIG_DISABLED',
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
+      snapbackUsersPerJob: 2,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -233,6 +235,7 @@ describe('Test Health Check', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
     config.set('maxStorageUsedPercent', 95)
+    config.set('snapbackUsersPerJob', 2)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -288,6 +291,7 @@ describe('Test Health Check', function () {
       currentSnapbackReconfigMode: 'RECONFIG_DISABLED',
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
+      snapbackUsersPerJob: 2,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -373,6 +377,7 @@ describe('Test Health Check', function () {
       currentSnapbackReconfigMode: 'RECONFIG_DISABLED',
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
+      snapbackUsersPerJob: 2,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -442,6 +447,7 @@ describe('Test Health Check Verbose', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
     config.set('maxStorageUsedPercent', 95)
+    config.set('snapbackUsersPerJob', 2)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 
@@ -497,6 +503,7 @@ describe('Test Health Check Verbose', function () {
       currentSnapbackReconfigMode: 'RECONFIG_DISABLED',
       manualSyncsDisabled: false,
       snapbackModuloBase: 18,
+      snapbackUsersPerJob: 2,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -535,6 +542,7 @@ describe('Test Health Check Verbose', function () {
     config.set('serviceLatitude', '37.7749')
     config.set('serviceLongitude', '-122.4194')
     config.set('maxStorageUsedPercent', 95)
+    config.set('snapbackUsersPerJob', 2)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -496,6 +496,12 @@ const config = convict({
     env: 'snapbackModuloBase',
     default: 48
   },
+  snapbackUsersPerJob: {
+    doc: 'Maximum number of users to process in each SnapbackSM job',
+    format: 'nat',
+    env: 'snapbackUsersPerJob',
+    default: 1000
+  },
   maxManualRequestSyncJobConcurrency: {
     doc: 'Max bull queue concurrency for manual sync request jobs',
     format: 'nat',

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -110,8 +110,7 @@ class PeerSetManager {
    * Retrieve users with this node as replica (primary or secondary).
    * Makes single request to discovery node to retrieve all users, optionally paginated
    *
-   * @notice Discovery Nodes will ignore these params if they're updated to the version which added pagination
-   *
+   * @notice Discovery Nodes will ignore these params if they're not updated to the version which added pagination
    * @param prevUserId user_id is used for pagination, where each paginated request returns
    *                   maxUsers number of users starting at a user with id=user_id
    * @param maxUsers the maximum number of users to fetch
@@ -156,7 +155,7 @@ class PeerSetManager {
     logger.info(`getNodeUsers() nodeUsers.length: ${nodeUsers.length}`)
 
     // Ensure every object in response array contains all required fields
-    nodeUsers.forEach((nodeUser) => {
+    for (const nodeUser of nodeUsers) {
       const requiredFields = [
         'user_id',
         'wallet',
@@ -176,7 +175,7 @@ class PeerSetManager {
           'getNodeUsers() Error: Unexpected response format during getNodeUsers() call'
         )
       }
-    })
+    }
 
     return nodeUsers
   }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1230,7 +1230,8 @@ class SnapbackSM {
 
       if (useModulo) {
         // Increment and adjust current slice by this.moduloBase
-        this.currentModuloSlice = (this.currentModuloSlice + 1) % this.moduloBase
+        this.currentModuloSlice =
+          (this.currentModuloSlice + 1) % this.moduloBase
       } else {
         // The next job should start processing where this one ended or loop back around to the first user
         const lastProcessedUser = nodeUsers.pop() || { user_id: 0 }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -936,8 +936,8 @@ class SnapbackSM {
           this.usersPerJob
         )
 
-        // Backwards compatibility -- if DN hasn't updated to support pagination,
-        // then we have to manually paginate the full set of users
+        // Backwards compatibility -- DN will return all users if it doesn't have pagination.
+        // In that case, we have to manually paginate the full set of users
         if (nodeUsers.length > this.usersPerJob) {
           useModulo = true
           nodeUsers = this.sliceUsers(nodeUsers)

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -31,6 +31,10 @@ class Utils {
   static getRandomInt(max) {
     return Math.floor(Math.random() * max)
   }
+
+  static randomIntFromIntervalInclusive(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min)
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

- Add pagination to Discovery Node for `/v1/full/users/content_node` route and SQL query
- Update Content Node to use the pagination
- Expose new config option `snapbackUsersPerJob` via health check

### Tests
Verified query by execing into Postgres container and running it. Also hit the endpoint manually with different params, and ran Snapback locally, and tested on staging (e.g. https://discoveryprovider2.staging.audius.co/v1/full/users/content_node/all?creator_node_endpoint=https://creatornode11.staging.audius.co&prev_user_id=0&max_users=100)

### How will this change be monitored? Are there sufficient logs?
- Search for `v1/full/users/content_node/all` in Discovery Node logs
- Look through Content Node logs containing `processStateMachineOperation` or `StateMachineQueue`