### PR TITLE
Batch track metadata notification fetches

### DIFF
--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -239,11 +239,18 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
 
   const uniqueTrackIds = [...new Set(trackIdsToFetch)]
 
-  let tracks = await audius.Track.getTracks(
-    /** limit */ uniqueTrackIds.length,
-    /** offset */ 0,
-    /** idsArray */ uniqueTrackIds
-  )
+  let tracks = []
+  const trackBatchSize = 100
+  for (let trackBatchOffset = 0; trackBatchOffset < uniqueTrackIds.length; trackBatchOffset += trackBatchSize) {
+    const trackBatch = uniqueTrackIds.slice(trackBatchOffset, trackBatchOffset + trackBatchSize)
+    const tracksResponse = await audius.Track.getTracks(
+      /** limit */ trackBatch.length,
+      /** offset */ 0,
+      /** idsArray */ trackBatch
+    )
+    tracks.push(...tracksResponse)
+  }
+
   if (!Array.isArray(tracks)) {
     logger.error(`fetchNotificationMetadata | Unable to fetch track ids ${uniqueTrackIds.join(',')}`)
   }

--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -239,8 +239,9 @@ async function fetchNotificationMetadata (audius, userIds = [], notifications, f
 
   const uniqueTrackIds = [...new Set(trackIdsToFetch)]
 
-  let tracks = []
-  const trackBatchSize = 100
+  const tracks = []
+  // Batch track fetches to avoid large request lines
+  const trackBatchSize = 100 // use default limit
   for (let trackBatchOffset = 0; trackBatchOffset < uniqueTrackIds.length; trackBatchOffset += trackBatchSize) {
     const trackBatch = uniqueTrackIds.slice(trackBatchOffset, trackBatchOffset + trackBatchSize)
     const tracksResponse = await audius.Track.getTracks(

--- a/identity-service/test/sendNotifications/index.js
+++ b/identity-service/test/sendNotifications/index.js
@@ -300,4 +300,60 @@ describe('Test Send Notifications', function () {
         queueNotif.types.some(t => t === deviceType.Mobile)
     }))
   })
+
+  it('should batch track metadata fetches', async function () {
+    // User 1 creates tracks 500 tracks 
+
+    // ======================================= Set subscribers for create notifications =======================================
+    await models.Subscription.bulkCreate([
+      { subscriberId: 3, userId: 1 } // User 3 subscribes to user 1
+    ])
+
+    const tx1 = await models.sequelize.transaction()
+
+    let mockNotifications = []
+    for (let i = 1; i <= 500; i++) {
+      const mockNotification = {
+        'blocknumber': 1,
+        'initiator': 1,
+        'metadata': {
+          'entity_id': i,
+          'entity_owner_id': 1,
+          'entity_type': 'track'
+        },
+        'timestamp': '2020-10-27T15:14:20 Z',
+        'type': 'Create'
+      }
+      mockNotifications.push(mockNotification)
+    }
+    await processNotifications(mockNotifications, tx1)
+    await sendNotifications(mockAudiusLibs, mockNotifications, tx1)
+    await tx1.commit()
+
+    let pushNotifications = pushNotificationQueue.PUSH_NOTIFICATIONS_BUFFER
+
+    assert.deepStrictEqual(pushNotifications.length, 0)
+
+    // Wait 60 seconds to debounce tracks / album notifications
+    await new Promise(resolve => setTimeout(resolve, 5 * 1000))
+    const tx2 = await models.sequelize.transaction()
+    await sendNotifications(mockAudiusLibs, [], tx2)
+    await tx2.commit()
+
+    pushNotifications = pushNotificationQueue.PUSH_NOTIFICATIONS_BUFFER
+    assert.deepStrictEqual(pushNotifications.length, mockNotifications.length)
+
+    for (const notification of pushNotifications) {
+      assert.deepStrictEqual(notification.notificationParams.title, 'New Artist Update')
+      assert.deepStrictEqual(notification.types, ['mobile', 'browser'])
+    }
+
+    const user3Message = 'user 1 released a new track Title, Track id: '
+
+    const user3Notifs = pushNotifications.filter(n => n.userId === 3)
+    assert.deepStrictEqual(user3Notifs.length, mockNotifications.length)
+    for (let i = 1; i <= mockNotifications.length; i++) {
+      assert.deepStrictEqual(user3Notifs.some(n => n.notificationParams.message === user3Message + i), true)
+    }
+  })
 })

--- a/identity-service/test/sendNotifications/index.js
+++ b/identity-service/test/sendNotifications/index.js
@@ -302,7 +302,7 @@ describe('Test Send Notifications', function () {
   })
 
   it('should batch track metadata fetches', async function () {
-    // User 1 creates tracks 500 tracks
+    // User 1 creates 500 tracks
 
     // ======================================= Set subscribers for create notifications =======================================
     await models.Subscription.bulkCreate([

--- a/identity-service/test/sendNotifications/index.js
+++ b/identity-service/test/sendNotifications/index.js
@@ -302,7 +302,7 @@ describe('Test Send Notifications', function () {
   })
 
   it('should batch track metadata fetches', async function () {
-    // User 1 creates tracks 500 tracks 
+    // User 1 creates tracks 500 tracks
 
     // ======================================= Set subscribers for create notifications =======================================
     await models.Subscription.bulkCreate([


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

While oncall, I saw repeatedly failing getTracks calls in identity. The problem was large request lines.
```
Failed to make Discovery Provider request, attempt #56, error undefined, request: {"endpoint":"tracks","queryParams":{"limit":825,"offset":0,"id":[1010155,1009092,1008536,1006575
```

The failure looks like a getTracks request and testing out getTracks requests of various sizes showed similar behavior where a large request fails across DPs.
```
await audiusLibs.Track.getTracks(1, 0, [1010155,1009092,1008536,1006575,1005979,1004040,1003166,1002312,1000521,998842,997053,995835,993672,992021,991205,988384,986632,986628,984389,983886,982682,978171,977159,
```

Modifying the DP gunicorn limit is probably not the best solution and I ended up seeing another limit hit from nginx. https://github.com/AudiusProject/audius-protocol/pull/3060

The only call to getTracks is in fetchNotificationMetadata. This change splits this big request into batches of 100 leaves plenty of room.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Added test case for large batch of track notifications.

### How will this change be monitored? Are there sufficient logs?

Check for error log above. Confirm track notifications make progress.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->