### PR TITLE
Remove IPFS from DP start.sh

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -61,17 +61,6 @@ EOF
     fi
 fi
 
-if [ -z "$audius_ipfs_host" ]; then
-    if [ -z "$(ls -A /root/.ipfs)" ]; then
-        ipfs init --profile server
-    fi
-
-    ipfs daemon &
-    export audius_ipfs_host=localhost
-    export WAIT_HOSTS="localhost:5001"
-    /wait
-fi
-
 if [ -z "$audius_redis_url" ]; then
     redis-server --daemonize yes
     export audius_redis_url="redis://localhost:6379/00"


### PR DESCRIPTION
### Description

Removes IPFS from `start.sh` so that we don't see IPFS logs when starting DP

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->