### PR TITLE
Dm cli cleanup 05 10 22

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -117,11 +117,14 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
         echo "Finished running migrations"
     fi
 
-    # filter tail to server logs with `docker exec -it <disc-prov container> tail -f /var/log/discprov-server.log`
+    # filter tail to server/worker/beat logs with
+    # docker exec -it <container> tail -f /var/log/discprov-server.log
+    # docker exec -it <container> tail -f /var/log/discprov-worker.log
+    # docker exec -it <container> tail -f /var/log/discprov-beat.log
     ./scripts/dev-server.sh 2>&1 | tee >(logger -t server) &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
-        watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) & # docker exec -it <disc-prov container> tail -f /var/log/discprov-worker.log
-        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &                                                                         # docker exec -it <disc-prov container> tail -f /var/log/discprov-beat.log
+        watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t beat) &
     fi
 else
     ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -25,6 +25,7 @@ def create_instance(provider, image, disk_size, machine_type, name):
         check=False,
     )
 
+
 def create_instance_command_parser(subparser):
     parser_create_instance = subparser.add_parser(
         "create-instance",
@@ -79,6 +80,7 @@ def setup(
         ],
         check=False,
     )
+
 
 def setup_command_parser(subparser):
     parser_setup = subparser.add_parser(
@@ -151,12 +153,6 @@ def seed(options):
         check=False,
     )
 
-def seed_command_parser(subparser):
-    parser_setup = subparser.add_parser(
-        "seed",
-        help="seed data to the local machine",
-    )
-
 
 def main():
     parser = argparse.ArgumentParser(exit_on_error=False)
@@ -169,7 +165,6 @@ def main():
 
     create_instance_command_parser(subparser)
     setup_command_parser(subparser)
-    # seed_command_parser(subparser)
 
     try:
         # if no options are defined, print out the usage
@@ -198,9 +193,6 @@ def main():
                 args.client_git_ref,
                 args.name,
             )
-        # elif args.operation == "seed":
-        #     options = sys.argv[2:]
-        #     seed(options)
     except argparse.ArgumentError:
         if sys.argv[1] == "seed":
             options = sys.argv[2:]

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -25,59 +25,7 @@ def create_instance(provider, image, disk_size, machine_type, name):
         check=False,
     )
 
-
-def setup(
-    provider, service, user, config, fast, protocol_git_ref, client_git_ref, name
-):
-    """Setup a environment suitable for development on a remote machine"""
-    subprocess.run(
-        [
-            "bash",
-            f"{PROTOCOL_DIR}/service-commands/scripts/setup-instance.sh",
-            *(["-p", provider] if provider else []),
-            *(["-u", user] if user else []),
-            *(["-c", config] if config else []),
-            *(["-r", protocol_git_ref] if protocol_git_ref else []),
-            *(["-l", client_git_ref] if client_git_ref else []),
-            *(["-f"] if fast else []),
-            service,
-            name,
-        ],
-        check=False,
-    )
-
-
-def setup_js(options):
-    subprocess.run(
-        [
-            "node",
-            f"{PROTOCOL_DIR}/service-commands/scripts/setup.js",
-            *options,
-        ],
-        check=False,
-    )
-
-
-def seed(options):
-    subprocess.run(
-        [
-            "node",
-            f"{PROTOCOL_DIR}/service-commands/scripts/seed.js",
-            *options,
-        ],
-        check=False,
-    )
-
-
-def main():
-    parser = argparse.ArgumentParser(exit_on_error=False)
-
-    subparser = parser.add_subparsers(
-        title="operations",
-        dest="operation",
-        required=True,
-    )
-
+def create_instance_command_parser(subparser):
     parser_create_instance = subparser.add_parser(
         "create-instance",
         help="create instance on azure/gcp with specified options",
@@ -111,6 +59,28 @@ def main():
         help="name to assign to the created instance",
     )
 
+
+def setup(
+    provider, service, user, config, fast, protocol_git_ref, client_git_ref, name
+):
+    """Setup a environment suitable for development on a remote machine"""
+    subprocess.run(
+        [
+            "bash",
+            f"{PROTOCOL_DIR}/service-commands/scripts/setup-instance.sh",
+            *(["-p", provider] if provider else []),
+            *(["-u", user] if user else []),
+            *(["-c", config] if config else []),
+            *(["-r", protocol_git_ref] if protocol_git_ref else []),
+            *(["-l", client_git_ref] if client_git_ref else []),
+            *(["-f"] if fast else []),
+            service,
+            name,
+        ],
+        check=False,
+    )
+
+def setup_command_parser(subparser):
     parser_setup = subparser.add_parser(
         "setup",
         help="setup specified service on a remote machine",
@@ -159,7 +129,54 @@ def main():
         help="name of machine on which to setup the service",
     )
 
+
+def setup_js(options):
+    subprocess.run(
+        [
+            "node",
+            f"{PROTOCOL_DIR}/service-commands/scripts/setup.js",
+            *options,
+        ],
+        check=False,
+    )
+
+
+def seed(options):
+    subprocess.run(
+        [
+            "node",
+            f"{PROTOCOL_DIR}/service-commands/scripts/seed.js",
+            *options,
+        ],
+        check=False,
+    )
+
+def seed_command_parser(subparser):
+    parser_setup = subparser.add_parser(
+        "seed",
+        help="seed data to the local machine",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(exit_on_error=False)
+
+    subparser = parser.add_subparsers(
+        title="operations",
+        dest="operation",
+        required=True,
+    )
+
+    create_instance_command_parser(subparser)
+    setup_command_parser(subparser)
+    # seed_command_parser(subparser)
+
     try:
+        # if no options are defined, print out the usage
+        if len(sys.argv) == 1:
+            parser.print_help()
+            exit(0)
+
         args = parser.parse_args()
 
         if args.operation == "create-instance":
@@ -181,6 +198,9 @@ def main():
                 args.client_git_ref,
                 args.name,
             )
+        # elif args.operation == "seed":
+        #     options = sys.argv[2:]
+        #     seed(options)
     except argparse.ArgumentError:
         if sys.argv[1] == "seed":
             options = sys.argv[2:]

--- a/service-commands/scripts/A
+++ b/service-commands/scripts/A
@@ -155,7 +155,16 @@ def seed(options):
 
 
 def main():
-    parser = argparse.ArgumentParser(exit_on_error=False)
+    parser = argparse.ArgumentParser(
+        exit_on_error=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=
+"""
+Other commands:
+    `seed` - seed user data eg `A seed <operation>` or `A seed --help` for options
+    all other commands will pass through to service-commands/scripts/setup.js
+"""
+    )
 
     subparser = parser.add_subparsers(
         title="operations",


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->
Make default `A` prompt more useful. 

Currently we see this
```
ubuntu@dm-remote-dev-2:~$ A
usage: A [-h] {create-instance,setup} ...
A: error: the following arguments are required: operation
```

This would show up after this PR
```
ubuntu@dm-remote-dev:~/audius-protocol/service-commands/scripts$ A
usage: A [-h] {create-instance,setup} ...

optional arguments:
  -h, --help            show this help message and exit

operations:
  {create-instance,setup}
    create-instance     create instance on azure/gcp with specified options
    setup               setup specified service on a remote machine

Other commands:
    `seed` - seed user data eg `A seed <operation>` or `A seed --help` for options
    all other commands will pass through to service-commands/scripts/setup.js

```
### Tests
Tested this change locally using A
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
No monitoring, cli change only
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->