### PR TITLE
Fix mad-dog to GCP invalid name errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,7 @@ jobs:
 
             # pick first ten characters and lowercase all of them
             CIRCLE_BRANCH_CLEANED="${CIRCLE_BRANCH:0:10}" | awk '{print tolower($0)}
-            CIRCLE_SHA_CLEANED="${CIRCLE_SHA1:0:10}" | awk '{print tolower($0)} 
-            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED-$CIRCLE_SHA_CLEANED-$(date +%s)
+            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED-$(date +%s)
             echo "GCLOUD_VM_NAME" $GCLOUD_VM_NAME
 
             export PROTOCOL_DIR=/home/circleci/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account $GCLOUD_SERVICE_ACCOUNT_EMAIL --key-file=-
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH-$GIT_SHA-$(date +%s)
+            GCLOUD_VM_NAME=mad-dog-test-${CIRCLE_BRANCH,,}-$GIT_SHA-$(date +%s)
             echo "GCLOUD_VM_NAME" $GCLOUD_VM_NAME
 
             export PROTOCOL_DIR=/home/circleci/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,11 @@ jobs:
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account $GCLOUD_SERVICE_ACCOUNT_EMAIL --key-file=-
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            GCLOUD_VM_NAME=mad-dog-test-${CIRCLE_BRANCH,,}-$GIT_SHA-$(date +%s)
+
+            # pick first ten characters and lowercase all of them
+            CIRCLE_BRANCH_CLEANED="${CIRCLE_BRANCH:0:10}" | awk '{print tolower($0)}
+            CIRCLE_SHA_CLEANED="${CIRCLE_SHA1:0:10}" | awk '{print tolower($0)} 
+            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED-$CIRCLE_SHA_CLEANED-$(date +%s)
             echo "GCLOUD_VM_NAME" $GCLOUD_VM_NAME
 
             export PROTOCOL_DIR=/home/circleci/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ jobs:
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
             # pick first ten characters and lowercase all of them
-            CIRCLE_BRANCH_CLEANED="${CIRCLE_BRANCH:0:10}" | awk '{print tolower($0)}
-            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED-$(date +%s)
+            CIRCLE_BRANCH_CLEANED="${CIRCLE_BRANCH:0:10}" | awk '{print tolower($0)}'
+            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED$(date +%s)
             echo "GCLOUD_VM_NAME" $GCLOUD_VM_NAME
 
             export PROTOCOL_DIR=/home/circleci/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,7 @@ jobs:
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
-            # pick first ten characters and lowercase all of them
-            CIRCLE_BRANCH_CLEANED="${CIRCLE_BRANCH:0:10}" | awk '{print tolower($0)}'
-            GCLOUD_VM_NAME=mad-dog-test-$CIRCLE_BRANCH_CLEANED$(date +%s)
+            GCLOUD_VM_NAME=mad-dog-test-$(date +%s)
             echo "GCLOUD_VM_NAME" $GCLOUD_VM_NAME
 
             export PROTOCOL_DIR=/home/circleci/project


### PR DESCRIPTION
### Description
In CI, GCP fails to create an instance if the name contains uppercase characters. Was useful for debugging, but this isn't really even necessary anymore since the instance will be deleted right after and the logs contain the name of the instance. For now we should be able to delete

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Testing on CI with this branch which contains uppercase characters.
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
CI jobs won't pass in this branch if this code doesn't work
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->