### PR TITLE
Use loggly's recommended MaxMessageSize of 64k

### DIFF
--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -12,6 +12,7 @@ if [[ -z "$logglyDisable" ]]; then
         logglyTags=$(echo $logglyTags | python3 -c "print(' '.join(f'tag=\\\\\"{i}\\\\\"' for i in input().split(',')))")
         mkdir -p /var/spool/rsyslog
         mkdir -p /etc/rsyslog.d
+        sed -i '1s|^|$MaxMessageSize 64k\n|' /etc/rsyslog.conf
         cat >/etc/rsyslog.d/22-loggly.conf <<EOF
 \$WorkDirectory /var/spool/rsyslog # where to place spool files
 \$ActionQueueFileName fwdRule1   # unique name prefix for spool files


### PR DESCRIPTION
### Description

Use the suggested MaxMessageSize of 64kb:

* [solarwinds.com](https://documentation.solarwinds.com/en/success_center/loggly/content/admin/rsyslog-manual-configuration.htm)
* [rsyslog.com](https://www.rsyslog.com/doc/master/configuration/global/index.html)

### Tests

After running `A run creator-node restart`, `docker logs cn1_creator-node_1 --since 1s --follow` still worked as expected and the change was confirmed in `rsyslog.conf`.

```
❯ docker exec -ti cn1_creator-node_1 bash -c "head -n 2 /etc/rsyslog.conf"
$MaxMessageSize 64k
# rsyslog configuration file
```

### How will this change be monitored? Are there sufficient logs?

We should now be able to import messages longer than 8k, which was the default.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->