### PR TITLE
es-indexer: retry + load following IDs in batches

### DIFF
--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,9 +1,9 @@
 export const indexNames = {
-  follows: 'follows1',
-  playlists: 'playlists1',
-  plays: 'plays1',
-  reposts: 'reposts1',
-  saves: 'saves1',
-  tracks: 'tracks1',
-  users: 'users1',
+  follows: 'follows2',
+  playlists: 'playlists2',
+  plays: 'plays2',
+  reposts: 'reposts2',
+  saves: 'saves2',
+  tracks: 'tracks2',
+  users: 'users2',
 }

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -17,6 +17,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
       index: {
         number_of_shards: 1,
         number_of_replicas: 0,
+        refresh_interval: '5s',
       },
     },
     mappings: {
@@ -150,11 +151,13 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
         title,
         length,
         created_at,
-        aggregate_plays.count as play_count
+        coalesce(aggregate_track.repost_count, 0) as repost_count,
+        coalesce(aggregate_track.save_count, 0) as save_count,
+        coalesce(aggregate_plays.count, 0) as play_count
   
       from tracks
-      join aggregate_track using (track_id)
-      join aggregate_plays on tracks.track_id = aggregate_plays.play_item_id
+      left join aggregate_track using (track_id)
+      left join aggregate_plays on tracks.track_id = aggregate_plays.play_item_id
       where 
         is_current 
         and not is_delete 

--- a/discovery-provider/es-indexer/src/indexers/RepostIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/RepostIndexer.ts
@@ -16,6 +16,7 @@ export class RepostIndexer extends BaseIndexer<RepostDoc> {
       index: {
         number_of_shards: 1,
         number_of_replicas: 0,
+        refresh_interval: '5s',
       },
     },
     mappings: {

--- a/discovery-provider/es-indexer/src/indexers/SaveIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/SaveIndexer.ts
@@ -16,6 +16,7 @@ export class SaveIndexer extends BaseIndexer<SaveDoc> {
       index: {
         number_of_shards: 1,
         number_of_replicas: 0,
+        refresh_interval: '5s',
       },
     },
     mappings: {

--- a/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
@@ -8,6 +8,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
   tableName = 'tracks'
   idColumn = 'track_id'
   indexName = indexNames.tracks
+  batchSize = 500
 
   mapping: IndicesCreateRequest = {
     index: indexNames.tracks,

--- a/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
@@ -16,6 +16,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
       index: {
         number_of_shards: 1,
         number_of_replicas: 0,
+        refresh_interval: '5s',
 
         analysis: {
           normalizer: {
@@ -48,6 +49,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
         mood: { type: 'keyword' },
         is_delete: { type: 'boolean' },
         is_unlisted: { type: 'boolean' },
+        is_downloadable: { type: 'boolean' },
 
         // saves
         saved_by: { type: 'keyword' },
@@ -62,6 +64,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
             location: { type: 'keyword' },
             name: { type: 'text' }, // should it be keyword with a `searchable` treatment?
             follower_count: { type: 'integer' },
+            is_verified: { type: 'boolean' },
           },
         },
 
@@ -82,13 +85,17 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
     -- etl tracks
     select 
       tracks.*,
-      aggregate_plays.count as play_count,
+      (tracks.download->>'is_downloadable')::boolean as is_downloadable,
+      coalesce(aggregate_plays.count, 0) as play_count,
   
       json_build_object(
         'handle', users.handle,
         'name', users.name,
         'location', users.location,
-        'follower_count', follower_count
+        'follower_count', coalesce(follower_count, 0),
+        'is_verified', is_verified,
+        'balance', balance,
+        'associated_wallets_balance', associated_wallets_balance
       ) as artist,
   
       array(
@@ -122,11 +129,12 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
       ) as saved_by
     
     from tracks
-    join users on owner_id = user_id 
-    join aggregate_user on users.user_id = aggregate_user.user_id
-    join aggregate_plays on tracks.track_id = aggregate_plays.play_item_id
-      WHERE tracks.is_current = true 
-        AND users.is_current = true
+      join users on owner_id = user_id 
+      left join aggregate_user on users.user_id = aggregate_user.user_id
+      left join user_balances on users.user_id = user_balances.user_id
+      left join aggregate_plays on tracks.track_id = aggregate_plays.play_item_id
+    WHERE tracks.is_current = true 
+      AND users.is_current = true
     `
   }
 

--- a/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
@@ -17,6 +17,7 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
       index: {
         number_of_shards: 1,
         number_of_replicas: 0,
+        refresh_interval: '5s',
       },
     },
     mappings: {
@@ -56,10 +57,22 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
     return `
     -- etl users
     select 
-      *
+      users.*,
+      user_balances.balance,
+      user_balances.associated_wallets_balance,
+      user_balances.waudio,
+      user_balances.associated_sol_wallets_balance,
+      coalesce(track_count, 0) as track_count,
+      coalesce(playlist_count, 0) as playlist_count,
+      coalesce(album_count, 0) as album_count,
+      coalesce(follower_count, 0) as follower_count,
+      coalesce(following_count, 0) as following_count,
+      coalesce(repost_count, 0) as repost_count,
+      coalesce(track_save_count, 0) as track_save_count
     from
       users
-      join aggregate_user using (user_id)
+      left join aggregate_user on users.user_id = aggregate_user.user_id
+      left join user_balances on users.user_id = user_balances.user_id
     where 
       is_current = true
     `

--- a/discovery-provider/es-indexer/src/logger.ts
+++ b/discovery-provider/es-indexer/src/logger.ts
@@ -1,6 +1,7 @@
-import pino from 'pino'
+import pino, { stdTimeFunctions } from 'pino'
 
 export const logger = pino({
   name: `es-indexer`,
   base: undefined,
+  timestamp: stdTimeFunctions.isoTime,
 })


### PR DESCRIPTION
### Description

* Retry with linear backoff if indexing a batch encounters errors
* User indexer loads followers per-batch to make the cold start query cheaper
* Adds some new denormalized fields + mappings
* Rolls forward to v2 indexes.

### Tests

Built index on local ES