### PR TITLE
Start remote-dev with a clean `git status`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ jobs:
               A run init-repos up;
               A up;
               A down;
+              cd "$PROTOCOL_DIR";
+              git checkout -f;
               exit;
             EOF
 


### PR DESCRIPTION
### Description

Have `--fast` launched nodes start with a clean `git status` output.

### Tests

Manually run these commands on first boot.

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->