### PR TITLE
Add rollup-plugin-terser to minify libs bundle

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -4803,11 +4803,20 @@
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
       "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
       "requires": {
+        "@types/bn.js": "^4.11.5",
         "bn.js": "^5.0.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "bn.js": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
@@ -6709,12 +6718,23 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "requires": {
+        "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
         "elliptic": "^6.5.2",
         "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "ethereumjs-wallet": {
@@ -8522,6 +8542,34 @@
         }
       }
     },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
@@ -8771,6 +8819,12 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -8947,6 +9001,12 @@
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
         }
       }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -10733,6 +10793,29 @@
         }
       }
     },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        }
+      }
+    },
     "rpc-websockets": {
       "version": "7.4.17",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.17.tgz",
@@ -11826,6 +11909,61 @@
         }
       }
     },
+    "terser": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
+      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.8.0-beta.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^7.0.0"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -12423,6 +12561,7 @@
       "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.1.tgz",
       "integrity": "sha512-HOyDPj+4cNyeNPwgSeUkhtS0F+Pxc2obcm4oRYPW5ku6jnTO34pjaij0us+zoY3QEusR8FfAKVK1kFPZnS7Dzw==",
       "requires": {
+        "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
         "web3-core-helpers": "1.7.1",
@@ -12431,6 +12570,14 @@
         "web3-utils": "1.7.1"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "@types/node": {
           "version": "12.20.47",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
@@ -12845,6 +12992,7 @@
       "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.1.tgz",
       "integrity": "sha512-HpnbkPYkVK3lOyos2SaUjCleKfbF0SP3yjw7l551rAAi5sIz/vwlEzdPWd0IHL7ouxXbO0tDn7jzWBRcD3sTbA==",
       "requires": {
+        "@types/bn.js": "^4.11.5",
         "web3-core": "1.7.1",
         "web3-core-helpers": "1.7.1",
         "web3-core-method": "1.7.1",
@@ -12854,6 +13002,14 @@
         "web3-utils": "1.7.1"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "ethereumjs-util": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",

--- a/libs/package.json
+++ b/libs/package.json
@@ -103,6 +103,7 @@
     "prettier-config-standard": "^5.0.0",
     "rollup": "2.70.1",
     "rollup-plugin-dts": "4.2.0",
+    "rollup-plugin-terser": "7.0.2",
     "sinon": "9.0.2",
     "standard": "16.0.4",
     "ts-mocha": "9.0.2",

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -3,6 +3,7 @@ import babel from '@rollup/plugin-babel'
 import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
+import { terser } from 'rollup-plugin-terser'
 import dts from 'rollup-plugin-dts'
 
 import pkg from './package.json'
@@ -21,7 +22,8 @@ const commonConfig = {
     babel({ babelHelpers: 'bundled', extensions }),
     json(),
     resolve({ extensions, preferBuiltins: true }),
-    typescript()
+    typescript(),
+    terser()
   ],
   external: [
     ...Object.keys(pkg.dependencies),
@@ -30,7 +32,7 @@ const commonConfig = {
     'ethereumjs-wallet',
     'ethers/lib/utils',
     'ethers/lib/index',
-    'hashids/cjs',
+    'hashids/cjs'
   ]
 }
 
@@ -38,28 +40,29 @@ const commonTypeConfig = {
   plugins: [dts()]
 }
 
-export default [{
-  input: 'src/index.js',
-  output: [
-    { file: pkg.main, format: 'cjs', exports: 'auto', sourcemap: true }
-  ],
-  ...commonConfig
-},
-{
-  input: './src/types.ts',
-  output: [{ file: pkg.types, format: 'cjs' }],
-  ...commonTypeConfig
-},
-{
-  input: 'src/core.ts',
-  output: [
-    { file: pkg.core, format: 'cjs', exports: 'auto', sourcemap: true }
-  ],
-  ...commonConfig
-},
-{
-  input: './src/core.ts',
-  output: [{ file: pkg.coreTypes, format: 'cjs' }],
-  ...commonTypeConfig
-},
+export default [
+  {
+    input: 'src/index.js',
+    output: [
+      { file: pkg.main, format: 'cjs', exports: 'auto', sourcemap: true }
+    ],
+    ...commonConfig
+  },
+  {
+    input: './src/types.ts',
+    output: [{ file: pkg.types, format: 'cjs' }],
+    ...commonTypeConfig
+  },
+  {
+    input: 'src/core.ts',
+    output: [
+      { file: pkg.core, format: 'cjs', exports: 'auto', sourcemap: true }
+    ],
+    ...commonConfig
+  },
+  {
+    input: './src/core.ts',
+    output: [{ file: pkg.coreTypes, format: 'cjs' }],
+    ...commonTypeConfig
+  }
 ]


### PR DESCRIPTION
### Description

* Adds `rollup-plugin-terser` to minify the libs bundle, reducing bundle size from 2.1 MB to 888 KB

### Tests

Testing by linking libs into client and ensuring everything still works. Note that this does impact sourcemaps, it seems chrome can no longer open nested libs files in the dev tools, but I don't think that's too much of a problem

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->