### PR TITLE
Declare last_tx

### DIFF
--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -532,6 +532,9 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis: Redi
     # Current batch
     page_count = 0
 
+    # The last transaction processed
+    last_tx = None
+
     # Get the latests slot available globally before fetching txs to keep track of indexing progress
     try:
         latest_global_slot = solana_client_manager.get_block_height()


### PR DESCRIPTION
### Description

Fixes:

```
{"levelno": 40, "level": "ERROR", "msg": "index_solana_plays.py | Fatal error in main loop\nTraceback (most recent call last):\n  File \"/audius-discovery-provider/src/tasks/index_solana_plays.py\", line 665, in index_solana_plays\n    process_solana_plays(solana_client_manager, redis)\n  File \"/audius-discovery-provider/src/tasks/index_solana_plays.py\", line 632, in process_solana_plays\n    if last_tx:\nUnboundLocalError: local variable 'last_tx' referenced before assignment", "timestamp": "2022-05-13 17:14:45,243"}
```

Which occurs when there are no plays to process.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested locally on remote

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->