### PR TITLE
Fix various bugs with tips endpoint

### DIFF
--- a/discovery-provider/alembic/versions/a83814aeb4a1_add_updated_at_to_usertip.py
+++ b/discovery-provider/alembic/versions/a83814aeb4a1_add_updated_at_to_usertip.py
@@ -1,0 +1,23 @@
+"""Add updated_at to UserTip
+
+Revision ID: a83814aeb4a1
+Revises: 0d2067242dd5
+Create Date: 2022-05-14 03:11:26.246894
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a83814aeb4a1"
+down_revision = "0d2067242dd5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user_tips", sa.Column("updated_at", sa.DateTime(), nullable=False))
+
+
+def downgrade():
+    op.drop_column("user_tips", "updated_at")

--- a/discovery-provider/src/api/v1/tips.py
+++ b/discovery-provider/src/api/v1/tips.py
@@ -94,6 +94,13 @@ full_tips_parser.add_argument(
     description="The minimum Solana slot to pull tips from",
 )
 full_tips_parser.add_argument(
+    "max_slot",
+    type=int,
+    required=False,
+    default=0,
+    description="The maximum Solana slot to pull tips from",
+)
+full_tips_parser.add_argument(
     "tx_signatures",
     required=False,
     description="A list of transaction signatures of tips to fetch",

--- a/discovery-provider/src/models/aggregate_user_tips.py
+++ b/discovery-provider/src/models/aggregate_user_tips.py
@@ -1,19 +1,12 @@
 from sqlalchemy import BigInteger, Column, Integer, PrimaryKeyConstraint
 
-from .models import Base
+from .models import Base, RepresentableMixin
 
 
-class AggregateUserTips(Base):
+class AggregateUserTips(Base, RepresentableMixin):
     __tablename__ = "aggregate_user_tips"
     sender_user_id = Column(Integer, nullable=False)
     receiver_user_id = Column(Integer, nullable=False, index=True)
     amount = Column(BigInteger, nullable=False)
 
     PrimaryKeyConstraint(sender_user_id, receiver_user_id)
-
-    def __repr__(self):
-        return f"<AggregateUserTips\
-sender_user_id={self.sender_user_id},\
-receiver_user_id={self.receiver_user_id},\
-amount={self.amount},\
->"

--- a/discovery-provider/src/models/user_tip.py
+++ b/discovery-provider/src/models/user_tip.py
@@ -8,10 +8,10 @@ from sqlalchemy import (
     func,
 )
 
-from .models import Base
+from .models import Base, RepresentableMixin
 
 
-class UserTip(Base):
+class UserTip(Base, RepresentableMixin):
     __tablename__ = "user_tips"
     signature = Column(String, nullable=False)
     slot = Column(Integer, nullable=False, index=True)
@@ -19,15 +19,8 @@ class UserTip(Base):
     receiver_user_id = Column(Integer, nullable=False, index=True)
     amount = Column(BigInteger, nullable=False)
     created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
 
     PrimaryKeyConstraint(signature)
-
-    def __repr__(self):
-        return f"<UserTip\
-signature={self.signature},\
-slot={self.slot},\
-sender_user_id={self.sender_user_id},\
-receiver_user_id={self.receiver_user_id},\
-amount={self.amount},\
-created_at={self.created_at}\
->"

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -142,6 +142,7 @@ def process_transfer_instruction(
     tx_sig: str,
     slot: int,
     challenge_event_bus: ChallengeEventBus,
+    timestamp: datetime.datetime,
 ):
     # Accounts to refresh balance
     logger.info(
@@ -231,6 +232,7 @@ def process_transfer_instruction(
             sender_user_id=sender_user_id,
             receiver_user_id=receiver_user_id,
             slot=slot,
+            created_at=timestamp,
         )
         session.add(user_tip)
         challenge_event_bus.dispatch(ChallengeEvent.send_tip, slot, sender_user_id)
@@ -356,6 +358,7 @@ def process_user_bank_tx_details(
             tx_sig=tx_sig,
             slot=result["slot"],
             challenge_event_bus=challenge_event_bus,
+            timestamp=timestamp,
         )
 
 

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -234,6 +234,7 @@ def process_transfer_instruction(
             slot=slot,
             created_at=timestamp,
         )
+        logger.debug(f"index_user_bank.py | Creating tip {user_tip}")
         session.add(user_tip)
         challenge_event_bus.dispatch(ChallengeEvent.send_tip, slot, sender_user_id)
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

- Fixes spacing on `__repr__` functions in models
- Adds `updated_at` to `UserTIp` model
- Makes `created_at` on `UserTip` model use the timestamp from the chain
- Adds `max_slot` to `v1/full/tips` endpoint for better indexed pagination
- Removes second offset/limit to fix a bug where the offset would be applied twice and undercut the limit
- Fixes crash when no tips are returned from the query
- Add debug logging for visibility when tips are created

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested on remote

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->