### PR TITLE
Add location endpoint to discovery

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -340,11 +340,8 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         # DB connections check
         db_connections_json, db_connections_error = _get_db_conn_state()
         health_results["db_connections"] = db_connections_json
-        health_results["country"] = shared_config["serviceLocation"]["serviceCountry"]
-        health_results["latitude"] = shared_config["serviceLocation"]["serviceLatitude"]
-        health_results["longitude"] = shared_config["serviceLocation"][
-            "serviceLongitude"
-        ]
+        location = get_location()
+        health_results.update(location)
 
         if db_connections_error:
             return health_results, db_connections_error
@@ -377,6 +374,20 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     )
 
     return health_results, is_unhealthy
+
+
+class LocationResponse(TypedDict):
+    country: str
+    latitude: str
+    longitude: str
+
+
+def get_location() -> LocationResponse:
+    return {
+        "country": shared_config["serviceLocation"]["serviceCountry"],
+        "latitude": shared_config["serviceLocation"]["serviceLatitude"],
+        "longitude": shared_config["serviceLocation"]["serviceLongitude"],
+    }
 
 
 def get_elasticsearch_health_info(

--- a/discovery-provider/src/queries/health_check.py
+++ b/discovery-provider/src/queries/health_check.py
@@ -6,7 +6,11 @@ from src.api_helpers import success_response
 from src.queries.get_alembic_version import get_alembic_version
 from src.queries.get_celery_tasks import convert_epoch_to_datetime, get_celery_tasks
 from src.queries.get_db_seed_restore_status import get_db_seed_restore_status
-from src.queries.get_health import get_health, get_latest_ipld_indexed_block
+from src.queries.get_health import (
+    get_health,
+    get_latest_ipld_indexed_block,
+    get_location,
+)
 from src.queries.get_latest_play import get_latest_play
 from src.queries.get_sol_plays import get_latest_sol_play_check_info
 from src.queries.queries import parse_bool_param
@@ -158,3 +162,9 @@ def db_seed_restore_check():
     has_restored, seed_hash = get_db_seed_restore_status()
     response = {"has_restored": has_restored, "seed_hash": seed_hash}
     return success_response(response, sign_response=False)
+
+
+@bp.route("/location", methods=["GET"])
+def location():
+    location = get_location()
+    return success_response(location, sign_response=False)


### PR DESCRIPTION
### Description
Adds separate `/location` endpoint to the discovery node.
The verbose health check takes a while and the location is not relevant to the node's health check, so this breaks it out. 
The location is used by the protocol dashboard to fetch their country for country flags next to the nodes.  

### Tests
Ran locally and was able to hit `/health_check?verbose=true` and `/location` and see the country, lat, and long in both

### How will this change be monitored? Are there sufficient logs?


Fixes PLAT-136