### PR TITLE
Clean up state machine and add timing logs

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -487,7 +487,6 @@ class SnapbackSM {
       `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} unhealthy replica set=[${unhealthyReplicas}] numHealthyNodes=${healthyNodes.length}`
     )
 
-    const unhealthyReplicasSet = new Set(unhealthyReplicas)
     const response = { errorMsg: null, issuedReconfig: false }
     let newReplicaSetEndpoints = []
     const newReplicaSetSPIds = []
@@ -506,7 +505,7 @@ class SnapbackSM {
         secondary1,
         secondary2,
         primary,
-        unhealthyReplicasSet,
+        unhealthyReplicas,
         healthyNodes,
         replicaSetNodesToUserClockStatusesMap
       })

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -292,7 +292,7 @@ class SnapbackSM {
     const latestUserId = await this.getLatestUserId()
     this.lastProcessedUserId = _.random(0, latestUserId)
     this.usersPerJob = this.nodeConfig.get('snapbackUsersPerJob')
-    
+
     // Enqueue first job after a delay. This job requeues itself upon completion or failure
     await this.stateMachineQueue.add(
       /** data */ { startTime: Date.now() },

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -617,7 +617,7 @@ class SnapbackSM {
     secondary1,
     secondary2,
     wallet,
-    unhealthyReplicasSet,
+    unhealthyReplicasSet = new Set(),
     healthyNodes,
     replicaSetNodesToUserClockStatusesMap
   }) {

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -102,10 +102,8 @@ class SnapbackSM {
     this.debug = true
 
     // Start at a random userId to avoid biased processing of early users
-    this.lastProcessedUserId = Utils.randomIntFromIntervalInclusive(
-      0,
-      10_000_000
-    )
+    const latestUserId = await this.getLatestUserId()
+    this.lastProcessedUserId = _.random(0, latestUserId)
     this.usersPerJob = this.nodeConfig.get('snapbackUsersPerJob')
 
     this.endpoint = this.nodeConfig.get('creatorNodeEndpoint')
@@ -442,7 +440,12 @@ class SnapbackSM {
       startTime: Date.now()
     }
 
+    const startTimeMs = Date.now()
     const jobInfo = await queue.add(jobProps)
+    const timeElapsedMs = Date.now() - startTimeMs
+    this.log(
+      `enqueueSync waited ${timeElapsedMs}ms for sync type ${syncType} Bull job to be added to queue for user wallet ${userWallet}`
+    )
 
     // Record sync in syncDeDuplicator
     this.syncDeDuplicator.recordSync(
@@ -531,10 +534,15 @@ class SnapbackSM {
         newReplicaSetSPIds.push(this.peerSetManager.endpointToSPIdMap[endpt])
       }
 
+      const startTimeMs = Date.now()
       await this.audiusLibs.contracts.UserReplicaSetManagerClient.updateReplicaSet(
         userId,
         newReplicaSetSPIds[0], // primary
         newReplicaSetSPIds.slice(1) // [secondary1, secondary2]
+      )
+      const timeElapsedMs = Date.now() - startTimeMs
+      this.log(
+        `[issueUpdateReplicaSetOp] updateReplicaSet took ${timeElapsedMs}ms for userId=${userId} wallet=${wallet} `
       )
 
       response.issuedReconfig = true
@@ -1234,7 +1242,9 @@ class SnapbackSM {
           (this.currentModuloSlice + 1) % this.moduloBase
       } else {
         // The next job should start processing where this one ended or loop back around to the first user
-        const lastProcessedUser = nodeUsers.pop() || { user_id: 0 }
+        const lastProcessedUser = nodeUsers[nodeUsers.length - 1] || {
+          user_id: 0
+        }
         this.lastProcessedUserId = lastProcessedUser.user_id
       }
     }
@@ -1398,7 +1408,7 @@ class SnapbackSM {
   async _aggregateOps(nodeUser, unhealthyPeers, userSecondarySyncMetrics) {
     const requiredUpdateReplicaSetOps = []
     const potentialSyncRequests = []
-    const unhealthyReplicas = []
+    const unhealthyReplicas = new Set()
 
     const {
       wallet,
@@ -1442,14 +1452,14 @@ class SnapbackSM {
           this.logError(
             `processStateMachineOperation(): Secondary ${secondary} for user ${wallet} mismatched spID. Expected ${secondaryInfo.spId}, found ${this.peerSetManager.endpointToSPIdMap[secondary]}. Marking replica as unhealthy.`
           )
-          unhealthyReplicas.push(secondary)
+          unhealthyReplicas.add(secondary)
 
           // Error case 2 - already marked unhealthy
         } else if (unhealthyPeers.has(secondary)) {
           this.logError(
             `processStateMachineOperation(): Secondary ${secondary} for user ${wallet} in unhealthy peer set. Marking replica as unhealthy.`
           )
-          unhealthyReplicas.push(secondary)
+          unhealthyReplicas.add(secondary)
 
           // Error case 3 - low user sync success rate
         } else if (
@@ -1459,7 +1469,7 @@ class SnapbackSM {
           this.logError(
             `processStateMachineOperation(): Secondary ${secondary} for user ${wallet} has userSyncSuccessRate of ${successRate}, which is below threshold of ${this.MinimumSecondaryUserSyncSuccessPercent}. ${successCount} Successful syncs vs ${failureCount} Failed syncs. Marking replica as unhealthy.`
           )
-          unhealthyReplicas.push(secondary)
+          unhealthyReplicas.add(secondary)
 
           // Success case
         } else {
@@ -1470,7 +1480,7 @@ class SnapbackSM {
       /**
        * If any unhealthy replicas found for user, enqueue an updateReplicaSetOp for later processing
        */
-      if (unhealthyReplicas.length > 0) {
+      if (unhealthyReplicas.size > 0) {
         requiredUpdateReplicaSetOps.push({ ...nodeUser, unhealthyReplicas })
       }
 
@@ -1496,7 +1506,7 @@ class SnapbackSM {
           this.peerSetManager.endpointToSPIdMap[replica.endpoint] !==
           replica.spId
         ) {
-          unhealthyReplicas.push(replica.endpoint)
+          unhealthyReplicas.add(replica.endpoint)
         } else if (unhealthyPeers.has(replica.endpoint)) {
           // Else, continue with conducting extra health check if the current observed node is a primary, and
           // add to `unhealthyReplicas` if observed node is a secondary
@@ -1508,12 +1518,12 @@ class SnapbackSM {
           }
 
           if (addToUnhealthyReplicas) {
-            unhealthyReplicas.push(replica.endpoint)
+            unhealthyReplicas.add(replica.endpoint)
           }
         }
       }
 
-      if (unhealthyReplicas.length > 0) {
+      if (unhealthyReplicas.size > 0) {
         requiredUpdateReplicaSetOps.push({ ...nodeUser, unhealthyReplicas })
       }
     }
@@ -1876,6 +1886,43 @@ class SnapbackSM {
     // Update class variables for external access
     this.highestEnabledReconfigMode = highestEnabledReconfigMode
     this.enabledReconfigModesSet = enabledReconfigModesSet
+  }
+
+  /**
+   *
+   * @returns the ID of the newest user on Audius
+   */
+  async getLatestUserId() {
+    const discoveryNodeEndpoint =
+      this.audiusLibs.discoveryProvider.discoveryProviderEndpoint
+    if (!discoveryNodeEndpoint) {
+      throw new Error('No discovery provider currently selected, exiting')
+    }
+
+    // Will throw error on non-200 response
+    let latestUserId = 0
+    try {
+      // Request all users that have this node as a replica (either primary or secondary)
+      const resp = await Utils.asyncRetry({
+        asyncFnLabel: 'fetch all users with this node in replica',
+        asyncFn: async () => {
+          return axios({
+            method: 'get',
+            baseURL: discoveryNodeEndpoint,
+            url: `latest/user`,
+            timeout: 10_000 // 10s
+          })
+        },
+        logger
+      })
+      latestUserId = resp.data.data
+    } catch (e) {
+      throw new Error(
+        `getLatestUserId() Error: ${e.toString()} - connected discovery node: [${discoveryNodeEndpoint}]`
+      )
+    }
+
+    return latestUserId
   }
 }
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -101,11 +101,6 @@ class SnapbackSM {
     // Toggle to switch logs
     this.debug = true
 
-    // Start at a random userId to avoid biased processing of early users
-    const latestUserId = await this.getLatestUserId()
-    this.lastProcessedUserId = _.random(0, latestUserId)
-    this.usersPerJob = this.nodeConfig.get('snapbackUsersPerJob')
-
     this.endpoint = this.nodeConfig.get('creatorNodeEndpoint')
     this.spID = this.nodeConfig.get('spID')
     this.delegatePrivateKey = this.nodeConfig.get('delegatePrivateKey')
@@ -293,6 +288,11 @@ class SnapbackSM {
       }
     )
 
+    // Start at a random userId to avoid biased processing of early users
+    const latestUserId = await this.getLatestUserId()
+    this.lastProcessedUserId = _.random(0, latestUserId)
+    this.usersPerJob = this.nodeConfig.get('snapbackUsersPerJob')
+    
     // Enqueue first job after a delay. This job requeues itself upon completion or failure
     await this.stateMachineQueue.add(
       /** data */ { startTime: Date.now() },

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -31,10 +31,6 @@ class Utils {
   static getRandomInt(max) {
     return Math.floor(Math.random() * max)
   }
-
-  static randomIntFromIntervalInclusive(min, max) {
-    return Math.floor(Math.random() * (max - min + 1) + min)
-  }
 }
 
 /**

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -114,6 +114,10 @@ describe('test SnapbackSM', function () {
     }
 
     const snapback = new SnapbackSM(nodeConfig, getLibsMock())
+
+    // Mock `getLatestUserId` to return userId=0
+    snapback.getLatestUserId = async () => { return 0 }
+    
     await snapback.init()
 
     // Enqueue recurring requestSync jobs
@@ -557,9 +561,6 @@ describe('test SnapbackSM', function () {
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
 
-    // Mock `getLatestUserId` to return userId=0
-    snapback.getLatestUserId = async () => { return 0 }
-
     // Mark primary as unhealthy
     nock(constants.primaryEndpoint)
       .persist()
@@ -675,7 +676,7 @@ describe('test SnapbackSM', function () {
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
-    assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://cnOriginallySpId3ReregisteredAsSpId4.co')
+    assert.ok(requiredUpdateReplicaSetOps[0].unhealthyReplicas.has('http://cnOriginallySpId3ReregisteredAsSpId4.co'))
     assert.strictEqual(potentialSyncRequests.length, 0)
   })
 
@@ -708,7 +709,7 @@ describe('test SnapbackSM', function () {
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
     // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
-    assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://cnOriginallySpId3ReregisteredAsSpId4.co')
+    assert.ok(requiredUpdateReplicaSetOps[0].unhealthyReplicas.has('http://cnOriginallySpId3ReregisteredAsSpId4.co'))
     assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')
   })
 
@@ -806,7 +807,7 @@ describe('test SnapbackSM', function () {
     const userSecondarySyncMetricsMap = await snapback.computeUserSecondarySyncSuccessRatesMap(nodeUsers)
     const { requiredUpdateReplicaSetOps, potentialSyncRequests } = await snapback.aggregateReconfigAndPotentialSyncOps(nodeUsers, unhealthyPeers, userSecondarySyncMetricsMap)
 
-    assert.strictEqual(requiredUpdateReplicaSetOps[0].unhealthyReplicas[0], 'http://deregisteredCN.co')
+    assert.ok(requiredUpdateReplicaSetOps[0].unhealthyReplicas.has('http://deregisteredCN.co'))
     assert.strictEqual(potentialSyncRequests[0].endpoint, 'http://cnWithSpId2.co')
   })
 })

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -602,7 +602,7 @@ describe('test SnapbackSM', function () {
       constants.primaryEndpoint,
       constants.secondary1Endpoint,
       constants.secondary2Endpoint,
-      [constants.primaryEndpoint] /* unhealthyReplicas */,
+      new Set([constants.primaryEndpoint]) /* unhealthyReplicas */,
       healthyNodes /* healthyNodes */,
       replicaSetNodesToUserClockStatusesMapCopy
     )

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -557,6 +557,9 @@ describe('test SnapbackSM', function () {
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
 
+    // Mock `getLatestUserId` to return userId=0
+    snapback.getLatestUserId = async () => { return 0 }
+
     // Mark primary as unhealthy
     nock(constants.primaryEndpoint)
       .persist()


### PR DESCRIPTION
### Description

- Change custom random function to lodash's random function, and change the max from the magic number of 10M to the actual current newest user dynamically fetched from the `/latest/user` endpoint
- Change unhealthyReplicas from Array to Set since the logs showed that duplicate endpoints were being pushed to the array
- Add time loggings for updateReplicaSet and for awaiting Queue#add since that's a suspected bottleneck (there's a correlation between Redis memory usage and time spent on code that calls Queue#add)
    - See https://github.com/OptimalBits/bull/blob/develop/lib/commands/addJob-6.lua for Redis calls during Queue#add
    - See related issues https://github.com/OptimalBits/bull/issues/629 and https://github.com/OptimalBits/bull/issues/2054 

### Tests
I ran Content Node locally to verify that I saw the loggings and that the random number was between 0 and the number of users registered.

### How will this change be monitored? Are there sufficient logs?

- Search for "enqueueSync waited" in the logs to see how long Queue#add is taking
- Search for "[issueUpdateReplicaSetOp] updateReplicaSet took" to see how long the updateReplicaSet step is taking
- Look for any uptick in errors starting with "SnapbackSM: "