### PR TITLE
Use a default for updated_at column

### DIFF
--- a/discovery-provider/alembic/versions/a83814aeb4a1_add_updated_at_to_usertip.py
+++ b/discovery-provider/alembic/versions/a83814aeb4a1_add_updated_at_to_usertip.py
@@ -16,7 +16,15 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("user_tips", sa.Column("updated_at", sa.DateTime(), nullable=False))
+    op.add_column(
+        "user_tips",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+    )
 
 
 def downgrade():


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fixes a bug in the migration if there are already tips in the DB:

```
psycopg2.errors.NotNullViolation: column “updated_at” contains null values
```

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Down/upped alembic migration on remote. Will test on master

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->