### PR TITLE
AUD-1172 Add Lo-Fi Genre

### DIFF
--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -64,6 +64,7 @@ genre_allowlist = {
     "Jungle",
     "Kids",
     "Latin",
+    "Lo-Fi",
     "Metal",
     "Moombahton",
     "Podcasts",


### PR DESCRIPTION
### Description

Adds `"Lo-Fi"` genre

### Tests

N/A - this is the only place genres are defined 

### How will this change be monitored? Are there sufficient logs?

N/A
