### PR TITLE
[CON-149] Increase snapbackSM test coverage

### DIFF
--- a/creator-node/src/snapbackSM/StateMachineConstants.js
+++ b/creator-node/src/snapbackSM/StateMachineConstants.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Max number of attempts to select new replica set in reconfig
+  MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS: 2,
+  // Max number of attempts to fetch clock statuses from /users/batch_clock_status
+  MAX_USER_BATCH_CLOCK_FETCH_RETRIES: 5
+}


### PR DESCRIPTION
### Description

- Increase snapbackSM branch coverage: 41.13% -> 54.61%
- Increase snapbackSM line coverage: 50.5% -> 63.25%
- Increase total Content Node branch coverage: 52.14% -> 53.23%
- Increase total Content Node line coverage: 65.29% -> 66.63%
- Increase existing coverage of `requiredUpdateReplicaSetOps`
- Add coverage for `selectRandomReplicaSetNodes` and `retrieveClockStatusesForUsersAcrossReplicaSet`
- Minor refactor: move some constants into new StateMachineConstants.js file so they can be mocked

### Tests
Before
<img width="801" alt="before_total" src="https://user-images.githubusercontent.com/4657956/168850118-92b41b61-37b0-4178-a52d-627eff1b33ce.png">
<img width="729" alt="before_snapback" src="https://user-images.githubusercontent.com/4657956/168850031-3073ac22-c6ec-4c73-ad11-7daec0fa62f1.png">

After
<img width="813" alt="after_total" src="https://user-images.githubusercontent.com/4657956/168850179-7b336ca0-0219-465a-8125-fb75861b60ad.png">
<img width="805" alt="after_snapback" src="https://user-images.githubusercontent.com/4657956/168850218-c10801f5-2c61-44b1-8bc7-a1646ae4ef39.png">


### How will this change be monitored? Are there sufficient logs?
N/A