### PR TITLE
Add default logger + log boolean to CN asyncretry wrapper + renaming [Content Node]

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3941,7 +3941,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -4199,7 +4199,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-layout": {
       "version": "1.2.2",

--- a/creator-node/src/components/tracks/TrackTranscodeHandoffManager.js
+++ b/creator-node/src/components/tracks/TrackTranscodeHandoffManager.js
@@ -238,7 +238,7 @@ class TrackTranscodeHandoffManager {
           return resp
         }
       },
-      asyncFnLabel: 'polling transcode',
+      logLabel: 'polling transcode',
       options: {
         retries: POLLING_TRANSCODE_AND_SEGMENTS_RETRIES,
         minTimeout: POLLING_TRANSCODE_AND_SEGMENTS_MIN_TIMEOUT,
@@ -373,7 +373,7 @@ class TrackTranscodeHandoffManager {
           timeout: SEND_TRANSCODE_AND_SEGMENT_REQUEST_TIMEOUT_MS
         })
       },
-      asyncFnLabel: 'transcode and segment'
+      logLabel: 'transcode and segment'
     })
 
     return resp.data.data.uuid
@@ -431,7 +431,7 @@ class TrackTranscodeHandoffManager {
             timeout: FETCH_PROCESSING_STATUS_TIMEOUT_MS
           })
         },
-        asyncFnLabel: 'fetch track content processing status'
+        logLabel: 'fetch track content processing status'
       })
 
     return body.data
@@ -467,7 +467,7 @@ class TrackTranscodeHandoffManager {
           timeout: FETCH_STREAM_TIMEOUT_MS
         })
       },
-      asyncFnLabel: 'fetch segment'
+      logLabel: 'fetch segment'
     })
   }
 
@@ -501,7 +501,7 @@ class TrackTranscodeHandoffManager {
           timeout: FETCH_STREAM_TIMEOUT_MS
         })
       },
-      asyncFnLabel: 'fetch transcode'
+      logLabel: 'fetch transcode'
     })
   }
 
@@ -535,7 +535,7 @@ class TrackTranscodeHandoffManager {
           timeout: FETCH_STREAM_TIMEOUT_MS
         })
       },
-      asyncFnLabel: 'fetch m3u8'
+      logLabel: 'fetch m3u8'
     })
   }
 
@@ -560,7 +560,7 @@ class TrackTranscodeHandoffManager {
    * @param {Object} param
    * @param {Object} param.logger
    * @param {func} param.asyncFn the fn to asynchronously retry
-   * @param {string} param.asyncFnLabel the task label used to print on retry. used for debugging purposes
+   * @param {string} param.logLabel the task label used to print on retry. used for debugging purposes
    * @param {Object} param.options optional options. defaults to the params listed below if not explicitly passed in
    * @param {number} [param.options.factor=2] the exponential factor
    * @param {number} [param.options.retries=5] the max number of retries. defaulted to 5
@@ -572,7 +572,7 @@ class TrackTranscodeHandoffManager {
   static asyncRetryNotOn404({
     logger,
     asyncFn: inputAsyncFn,
-    asyncFnLabel,
+    logLabel,
     options = {}
   }) {
     const asyncFn = async (bail) => {
@@ -593,7 +593,7 @@ class TrackTranscodeHandoffManager {
       return resp
     }
 
-    return Utils.asyncRetry({ logger, asyncFn, asyncFnLabel, options })
+    return Utils.asyncRetry({ logger, asyncFn, logLabel, options })
   }
 }
 

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -127,7 +127,7 @@ class PeerSetManager {
     try {
       // Request all users that have this node as a replica (either primary or secondary)
       const resp = await Utils.asyncRetry({
-        asyncFnLabel: 'fetch all users with this node in replica',
+        logLabel: 'fetch all users with this node in replica',
         asyncFn: async () => {
           return axios({
             method: 'get',

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1909,7 +1909,7 @@ class SnapbackSM {
     try {
       // Request all users that have this node as a replica (either primary or secondary)
       const resp = await Utils.asyncRetry({
-        asyncFnLabel: 'fetch all users with this node in replica',
+        logLabel: 'fetch all users with this node in replica',
         asyncFn: async () => {
           return axios({
             method: 'get',

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -351,15 +351,16 @@ function currentNodeShouldHandleTranscode({
  *
  * options described here https://github.com/tim-kos/node-retry#retrytimeoutsoptions
  * @param {Object} param
- * @param {Object} param.logger
  * @param {func} param.asyncFn the fn to asynchronously retry
- * @param {string} param.logLabel used for debugging purposes
  * @param {Object} param.options optional options. defaults to the params listed below if not explicitly passed in
  * @param {number} [param.options.factor=2] the exponential factor
  * @param {number} [param.options.retries=5] the max number of retries. defaulted to 5
  * @param {number} [param.options.minTimeout=1000] minimum number of ms to wait after first retry. defaulted to 1000ms
  * @param {number} [param.options.maxTimeout=5000] maximum number of ms between two retries. defaulted to 5000ms
  * @param {func} [param.options.onRetry] fn that gets called per retry
+ * @param {Object} param.logger
+ * @param {Boolean} param.log enables/disables logging
+ * @param {string?} param.logLabel
  * @returns the fn response if success, or throws an error
  */
 function asyncRetry({

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -353,7 +353,7 @@ function currentNodeShouldHandleTranscode({
  * @param {Object} param
  * @param {Object} param.logger
  * @param {func} param.asyncFn the fn to asynchronously retry
- * @param {string} param.asyncFnLabel the task label used to print on retry. used for debugging purposes
+ * @param {string} param.logLabel used for debugging purposes
  * @param {Object} param.options optional options. defaults to the params listed below if not explicitly passed in
  * @param {number} [param.options.factor=2] the exponential factor
  * @param {number} [param.options.retries=5] the max number of retries. defaulted to 5
@@ -362,7 +362,13 @@ function currentNodeShouldHandleTranscode({
  * @param {func} [param.options.onRetry] fn that gets called per retry
  * @returns the fn response if success, or throws an error
  */
-function asyncRetry({ asyncFn, asyncFnLabel, options = {}, logger = genericLogger, log = true }) {
+function asyncRetry({
+  asyncFn,
+  options = {},
+  logger = genericLogger,
+  log = true,
+  logLabel = null
+}) {
   options = {
     retries: 5,
     factor: 2,
@@ -370,7 +376,9 @@ function asyncRetry({ asyncFn, asyncFnLabel, options = {}, logger = genericLogge
     maxTimeout: 5000,
     onRetry: (err, i) => {
       if (err && log) {
-        logger.warn(`${asyncFnLabel} ${i} retry error: `, err)
+        const logPrefix =
+          (logLabel ? `[${logLabel}] ` : '') + `[asyncRetry] [attempt #${i}]`
+        logger.warn(`${logPrefix}: `, err)
       }
     },
     ...options

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -7,6 +7,7 @@ const stream = require('stream')
 const retry = require('async-retry')
 const { promisify } = require('util')
 const pipeline = promisify(stream.pipeline)
+const { logger: genericLogger } = require('./logging.js')
 
 const models = require('./models')
 const redis = require('./redis')
@@ -361,14 +362,14 @@ function currentNodeShouldHandleTranscode({
  * @param {func} [param.options.onRetry] fn that gets called per retry
  * @returns the fn response if success, or throws an error
  */
-function asyncRetry({ logger, asyncFn, asyncFnLabel, options = {} }) {
+function asyncRetry({ asyncFn, asyncFnLabel, options = {}, logger = genericLogger, log = true }) {
   options = {
     retries: 5,
     factor: 2,
     minTimeout: 1000,
     maxTimeout: 5000,
     onRetry: (err, i) => {
-      if (err) {
+      if (err && log) {
         logger.warn(`${asyncFnLabel} ${i} retry error: `, err)
       }
     },

--- a/creator-node/test/utils.test.js
+++ b/creator-node/test/utils.test.js
@@ -58,7 +58,7 @@ describe('test src/utils.js', () => {
           },
           retries: 1
         },
-        asyncFnLabel:
+        logLabel:
           'test handleBackwardsCompatibility=false with 404 response'
       })
     } catch (e) {
@@ -90,7 +90,7 @@ describe('test src/utils.js', () => {
           },
           retries: 1
         },
-        asyncFnLabel: 'test 500 response'
+        logLabel: 'test 500 response'
       })
     } catch (e) {
       assert.strictEqual(didRetry, true)
@@ -121,7 +121,7 @@ describe('test src/utils.js', () => {
           },
           retries: 1
         },
-        asyncFnLabel: 'test 200 response'
+        logLabel: 'test 200 response'
       })
 
       assert.strictEqual(didRetry, false)


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

- Adds default logger for `asyncRetry` wrapper
- Adds log boolean to optionally disable `asyncRetry` logging
- renames `asyncFnLabel` to `logLabel` for naming consistency

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Existing regression tests

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Logs containing `asyncRetry`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->