### PR TITLE
Fix Solana global slot logic

### DIFF
--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -126,35 +126,34 @@ class SolanaClientManager:
             "solana_client_manager.py | get_signatures_for_address | All requests failed",
         )
 
-    def get_block_height(
+    def get_slot(
         self, retries=DEFAULT_MAX_RETRIES, encoding="json"
     ) -> Optional[int]:
-        def _get_block_height(client: Client, index):
+        def _get_slot(client: Client, index):
             endpoint = self.endpoints[index]
             num_retries = retries
             while num_retries > 0:
                 try:
-                    logger.info("solana_client_manager.py | get_block_height")
-                    response = client.get_block_height()
+                    response = client.get_slot(Commitment("finalized"))
                     return response["result"]
                 except Exception as e:
                     logger.error(
-                        f"solana_client_manager.py | get_block_height, {e}",
+                        f"solana_client_manager.py | get_slot, {e}",
                         exc_info=True,
                     )
                 num_retries -= 1
                 time.sleep(DELAY_SECONDS)
                 logger.error(
-                    f"solana_client_manager.py | get_block_height | Retrying with endpoint {endpoint}"
+                    f"solana_client_manager.py | get_slot | Retrying with endpoint {endpoint}"
                 )
             raise Exception(
-                f"solana_client_manager.py | get_block_height | Failed with endpoint {endpoint}"
+                f"solana_client_manager.py | get_slot | Failed with endpoint {endpoint}"
             )
 
         return _try_all(
             self.clients,
-            _get_block_height,
-            "solana_client_manager.py | get_block_height | All requests failed to fetch",
+            _get_slot,
+            "solana_client_manager.py | get_slot | All requests failed to fetch",
         )
 
 

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -126,9 +126,7 @@ class SolanaClientManager:
             "solana_client_manager.py | get_signatures_for_address | All requests failed",
         )
 
-    def get_slot(
-        self, retries=DEFAULT_MAX_RETRIES, encoding="json"
-    ) -> Optional[int]:
+    def get_slot(self, retries=DEFAULT_MAX_RETRIES, encoding="json") -> Optional[int]:
         def _get_slot(client: Client, index):
             endpoint = self.endpoints[index]
             num_retries = retries

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -519,9 +519,9 @@ def process_solana_rewards_manager(
 
     # Get the latests slot available globally before fetching txs to keep track of indexing progress
     try:
-        latest_global_slot = solana_client_manager.get_block_height()
+        latest_global_slot = solana_client_manager.get_slot()
     except:
-        logger.error("index_rewards_manager.py | Failed to get block height")
+        logger.error("index_rewards_manager.py | Failed to get slot")
 
     # List of signatures that will be populated as we traverse recent operations
     transaction_signatures = get_transaction_signatures(

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -537,7 +537,7 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis: Redi
 
     # Get the latests slot available globally before fetching txs to keep track of indexing progress
     try:
-        latest_global_slot = solana_client_manager.get_block_height()
+        latest_global_slot = solana_client_manager.get_slot()
     except:
         logger.error("index_solana_plays.py | Failed to get block height")
 

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -417,7 +417,7 @@ def process_user_bank_txs():
 
     # Get the latests slot available globally before fetching txs to keep track of indexing progress
     try:
-        latest_global_slot = solana_client_manager.get_block_height()
+        latest_global_slot = solana_client_manager.get_slot()
     except:
         logger.error("index_user_bank.py | Failed to get block height")
 


### PR DESCRIPTION
### Description

Two issues with our global slot approach:
- We were calling getBlockHeight instead of getSlot - the block # lags behind slot # due to the way blocks are inconsistently produced on Solana
- We weren't storing out global slot on supporter rank ups or on listen milestones

### Tests

- Tested on my remote and on stage DN2

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->