### PR TITLE
[CON-149] Test more of snapback

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3574,6 +3574,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -4489,6 +4495,21 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4503,6 +4524,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -5201,6 +5228,15 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -7633,6 +7669,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -9544,6 +9586,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11002,6 +11053,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pbkdf2": {
@@ -14028,6 +14085,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
+    "chai": "4.3.6",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.25.3",
@@ -86,6 +87,7 @@
     "proxyquire": "^2.1.3",
     "sequelize-cli": "^5.3.0",
     "sinon": "^7.0.0",
+    "sinon-chai": "3.7.0",
     "standard": "12.0.1",
     "supertest": "^3.3.0",
     "typescript": "^4.4.4"

--- a/creator-node/src/snapbackSM/StateMachineConstants.js
+++ b/creator-node/src/snapbackSM/StateMachineConstants.js
@@ -2,5 +2,7 @@ module.exports = {
   // Max number of attempts to select new replica set in reconfig
   MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS: 5,
   // Max number of attempts to fetch clock statuses from /users/batch_clock_status
-  MAX_USER_BATCH_CLOCK_FETCH_RETRIES: 5
+  MAX_USER_BATCH_CLOCK_FETCH_RETRIES: 5,
+  // Retry delay (in millis) between requests during monitoring
+  SYNC_MONITORING_RETRY_DELAY_MS: 15000
 }

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -504,7 +504,7 @@ class SnapbackSM {
         secondary1,
         secondary2,
         primary,
-        unhealthyReplicas,
+        unhealthyReplicasSet: unhealthyReplicas,
         healthyNodes,
         replicaSetNodesToUserClockStatusesMap
       })
@@ -525,8 +525,8 @@ class SnapbackSM {
         // If for some reason any node in the new replica set is not registered on chain as a valid SP and is
         // selected as part of the new replica set, do not issue reconfig
         if (!this.peerSetManager.endpointToSPIdMap[endpt]) {
+          response.errorMsg = `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} phase=${phase} unable to find valid SPs from new replica set=[${newReplicaSetEndpoints}] | new replica set spIds=[${newReplicaSetSPIds}] | reconfig type=[${reconfigType}] | endpointToSPIdMap=${this.peerSetManager.endpointToSPIdMap} | endpt=${endpt}. Skipping reconfig.`
           this.logError(response.errorMsg)
-          response.errorMsg = `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} phase=${phase} unable to find valid SPs from new replica set=[${newReplicaSetEndpoints}] | new replica set spIds=[${newReplicaSetSPIds}] | reconfig type=[${reconfigType}]. Skipping reconfig.`
           return response
         }
         newReplicaSetSPIds.push(this.peerSetManager.endpointToSPIdMap[endpt])

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -15,11 +15,9 @@ const SecondarySyncHealthTracker = require('./secondarySyncHealthTracker')
 const { generateTimestampAndSignature } = require('../apiSigning')
 const {
   MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS,
-  MAX_USER_BATCH_CLOCK_FETCH_RETRIES
+  MAX_USER_BATCH_CLOCK_FETCH_RETRIES,
+  SYNC_MONITORING_RETRY_DELAY_MS
 } = require('./StateMachineConstants')
-
-// Retry delay between requests during monitoring
-const SyncMonitoringRetryDelayMs = 15000
 
 // Timeout for fetching batch clock values
 const BATCH_CLOCK_STATUS_REQUEST_TIMEOUT = 10000 // 10s
@@ -1607,7 +1605,7 @@ class SnapbackSM {
       }
 
       // Delay between retries
-      await Utils.timeout(SyncMonitoringRetryDelayMs, false)
+      await Utils.timeout(SYNC_MONITORING_RETRY_DELAY_MS, false)
     }
 
     const monitoringTimeMs = Date.now() - startTimeMs


### PR DESCRIPTION
### Description

- Increase snapbackSM branch coverage: 54.61% -> 69.5%
- Increase snapbackSM line coverage: 63.25% -> 76%
- Increase total Content Node branch coverage: 53.23% -> 54.44%
- Increase total Content Node line coverage: 66.63% -> 67.86%
- Add coverage for `issueSyncRequestsToSecondaries`, `processStateMachineOperation`, `additionalSyncIsRequired`, and `computeUserSecondarySyncSuccessRatesMap`
- Add Chai library for more flexible and easier-to-understand assertions

### Tests
Before
<img width="813" alt="before_total" src="https://user-images.githubusercontent.com/4657956/169109331-5bd1c5e3-5d38-4e46-8ac3-9603a9332687.png">
<img width="805" alt="before_snapback" src="https://user-images.githubusercontent.com/4657956/169109347-8afb95dc-f86c-4cf4-bccd-3f52a62a4121.png">


After
<img width="809" alt="after_total" src="https://user-images.githubusercontent.com/4657956/169109381-a85b436e-3f7e-4ea2-b90a-4317777e2063.png">
<img width="814" alt="after_snapback" src="https://user-images.githubusercontent.com/4657956/169109409-05f7f1b8-9422-450c-a5bc-bd81498f1b4a.png">



### How will this change be monitored? Are there sufficient logs?
N/A