### PR TITLE
Fix redis chunk add use

### DIFF
--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -371,7 +371,7 @@ class BlacklistManager {
   static async _addToRedisChunkHelper(redisKey, data) {
     const redisAddMaxItemsSize = 100000
     try {
-      logger.error(
+      logger.info(
         `About to call _addToRedisChunkHelper for ${redisKey} with data of length ${data.length}`
       )
       for (let i = 0; i < data.length; i += redisAddMaxItemsSize) {

--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -421,7 +421,7 @@ class BlacklistManager {
           for (const cid of cids) {
             const redisCIDKey = this.getRedisBlacklistSegmentToTrackIdKey(cid)
             try {
-              await this._addToRedisChunkHelper(redisCIDKey, trackId)
+              await this._addToRedisChunkHelper(redisCIDKey, [trackId])
             } catch (e) {
               errors.push(
                 `Unable to add ${redisCIDKey}:${trackId}: ${e.toString()}`


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

In this usage of the chunking method, the track id was not passed in in an array, causing the iteration logic to not occur. This PR is to put the track id into an array. 

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

No functionality changes, just bug fix

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

There are logs surrounding this method. We can check the error logs if it occurs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->