### PR TITLE
[CON-150] Break apart determineNewReplicaSet + cleanup

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -487,7 +487,7 @@ class SnapbackSM {
       } = newReplicaSet
       newReplicaSetEndpoints = [newPrimary, newSecondary1, newSecondary2]
 
-      console.log(
+      this.log(
         `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} newReplicaSetEndpoints=${JSON.stringify(
           newReplicaSetEndpoints
         )}`

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -1106,7 +1106,6 @@ class SnapbackSM {
           'retrieveClockStatusesForUsersAcrossReplicaSet() Error',
           { error: e.message }
         )
-        console.log(e.stack)
         throw new Error(
           'processStateMachineOperation():retrieveClockStatusesForUsersAcrossReplicaSet() Error'
         )

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -487,6 +487,12 @@ class SnapbackSM {
       } = newReplicaSet
       newReplicaSetEndpoints = [newPrimary, newSecondary1, newSecondary2]
 
+      console.log(
+        `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} newReplicaSetEndpoints=${JSON.stringify(
+          newReplicaSetEndpoints
+        )}`
+      )
+
       // If snapback is not enabled, Log reconfig op without issuing.
       if (!issueReconfig) {
         this.log(
@@ -570,13 +576,11 @@ class SnapbackSM {
    *  - if two secondaries are unhealthy -> {primary: current primary, secondary1: new healthy node, secondary2: new healthy node}
    *  - ** if one primary is unhealthy -> {primary: higher clock value of the two secondaries, secondary1: the healthy secondary, secondary2: new healthy node}
    *  - ** if one primary and one secondary are unhealthy -> {primary: the healthy secondary, secondary1: new healthy node, secondary2: new healthy node}
-   *  - if entire replica set is unhealthy -> {primary: null, secondary1: null, secondary2: null, eissueReconfig: false}
+   *  - if entire replica set is unhealthy -> {primary: null, secondary1: null, secondary2: null, issueReconfig: false}
    *
-   * ** - If in the case a primary is ever unhealthy, we do not want to pre-emptively issue a reconfig and cycle out the primary. See
-   * `peerSetManager` instance variable for more information.
+   * ** - If in the case a primary is ever unhealthy, we do not want to pre-emptively issue a reconfig and cycle out the primary. See `peerSetManager` instance variable for more information.
    *
-   * Also, there is the notion of `issueReconfig` flag. This value is used to determine whether or not to issue a reconfig based on the
-   * curretly enabled reconfig mode. See `RECONFIG_MODE` variable for more information.
+   * Also, there is the notion of `issueReconfig` flag. This value is used to determine whether or not to issue a reconfig based on the curretly enabled reconfig mode. See `RECONFIG_MODE` variable for more information.
    *
    * @param {Object} param
    * @param {string} param.primary current user's primary endpoint
@@ -603,14 +607,6 @@ class SnapbackSM {
     healthyNodes,
     replicaSetNodesToUserClockStatusesMap
   }) {
-    const response = {
-      newPrimary: null,
-      newSecondary1: null,
-      newSecondary2: null,
-      issueReconfig: false,
-      reconfigType: null
-    }
-
     const currentReplicaSet = [primary, secondary1, secondary2]
     const healthyReplicaSet = new Set(
       currentReplicaSet.filter((node) => !unhealthyReplicasSet.has(node))
@@ -622,60 +618,129 @@ class SnapbackSM {
       wallet
     )
 
-    let newPrimary
     if (unhealthyReplicasSet.size === 1) {
-      if (unhealthyReplicasSet.has(primary)) {
-        // If snapbackSM has already checked this primary and it failed the health check, select the higher clock
-        // value of the two secondaries as the new primary, leave the other as the first secondary, and select a new second secondary
-        let currentHealthySecondary
-        ;[newPrimary, currentHealthySecondary] =
-          replicaSetNodesToUserClockStatusesMap[secondary1][wallet] >=
-          replicaSetNodesToUserClockStatusesMap[secondary2][wallet]
-            ? [secondary1, secondary2]
-            : [secondary2, secondary1]
-        response.newPrimary = newPrimary
-        response.newSecondary1 = currentHealthySecondary
-        response.newSecondary2 = newReplicaNodes[0]
-        response.issueReconfig = this.isReconfigEnabled(
-          RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
-        )
-        response.reconfigType = RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
-      } else {
-        // If one secondary is unhealthy, select a new secondary
-        const currentHealthySecondary = !unhealthyReplicasSet.has(secondary1)
-          ? secondary1
-          : secondary2
-        response.newPrimary = primary
-        response.newSecondary1 = currentHealthySecondary
-        response.newSecondary2 = newReplicaNodes[0]
-        response.issueReconfig = this.isReconfigEnabled(
-          RECONFIG_MODES.ONE_SECONDARY.key
-        )
-        response.reconfigType = RECONFIG_MODES.ONE_SECONDARY.key
-      }
+      return this.determineNewReplicaSetWhenOneNodeIsUnhealthy(
+        wallet,
+        primary,
+        secondary1,
+        secondary2,
+        unhealthyReplicasSet,
+        replicaSetNodesToUserClockStatusesMap,
+        newReplicaNodes[0]
+      )
     } else if (unhealthyReplicasSet.size === 2) {
-      if (unhealthyReplicasSet.has(primary)) {
-        // If primary + secondary is unhealthy, use other healthy secondary as primary and 2 random secondaries
-        response.newPrimary = !unhealthyReplicasSet.has(secondary1)
-          ? secondary1
-          : secondary2
-        response.issueReconfig = this.isReconfigEnabled(
-          RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
-        )
-        response.reconfigType = RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
-      } else {
-        // If both secondaries are unhealthy, keep original primary and select two random secondaries
-        response.newPrimary = primary
-        response.issueReconfig = this.isReconfigEnabled(
-          RECONFIG_MODES.MULTIPLE_SECONDARIES.key
-        )
-        response.reconfigType = RECONFIG_MODES.MULTIPLE_SECONDARIES.key
-      }
-      response.newSecondary1 = newReplicaNodes[0]
-      response.newSecondary2 = newReplicaNodes[1]
+      return this.determineNewReplicaSetWhenTwoNodeAreUnhealthy(
+        primary,
+        secondary1,
+        secondary2,
+        unhealthyReplicasSet,
+        newReplicaNodes
+      )
     }
 
-    return response
+    // Can't replace all 3 replicas because there would be no replica to sync from
+    return {
+      newPrimary: null,
+      newSecondary1: null,
+      newSecondary2: null,
+      issueReconfig: false,
+      reconfigType: null
+    }
+  }
+
+  /**
+   * Determines new replica set when one node in the current replica set is unhealthy.
+   * @param {*} wallet wallet address of user whose replica set contains 1 unhealthy node to be replaced
+   * @param {*} primary user's current primary endpoint
+   * @param {*} secondary1 user's current first secondary endpoint
+   * @param {*} secondary2 user's current second secondary endpoint
+   * @param {*} unhealthyReplicasSet a set of endpoints of unhealthy replica set nodes
+   * @param {*} replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to (map of user wallet strings to clock value of secondary for user)
+   * @param {*} newReplicaNode endpoint of node that will replace the unhealthy node
+   * @returns reconfig info to update the user's replica set to replace the 1 unhealthy node
+   */
+  determineNewReplicaSetWhenOneNodeIsUnhealthy(
+    wallet,
+    primary,
+    secondary1,
+    secondary2,
+    unhealthyReplicasSet,
+    replicaSetNodesToUserClockStatusesMap,
+    newReplicaNode
+  ) {
+    // If snapbackSM has already checked this primary and it failed the health check, select the higher clock
+    // value of the two secondaries as the new primary, leave the other as the first secondary, and select a new second secondary
+    if (unhealthyReplicasSet.has(primary)) {
+      const [newPrimary, currentHealthySecondary] =
+        replicaSetNodesToUserClockStatusesMap[secondary1][wallet] >=
+        replicaSetNodesToUserClockStatusesMap[secondary2][wallet]
+          ? [secondary1, secondary2]
+          : [secondary2, secondary1]
+      return {
+        newPrimary,
+        newSecondary1: currentHealthySecondary,
+        newSecondary2: newReplicaNode,
+        issueReconfig: this.isReconfigEnabled(
+          RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+        ),
+        reconfigType: RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+      }
+    }
+
+    // If one secondary is unhealthy, select a new secondary
+    const currentHealthySecondary = !unhealthyReplicasSet.has(secondary1)
+      ? secondary1
+      : secondary2
+    return {
+      newPrimary: primary,
+      newSecondary1: currentHealthySecondary,
+      newSecondary2: newReplicaNode,
+      issueReconfig: this.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key),
+      reconfigType: RECONFIG_MODES.ONE_SECONDARY.key
+    }
+  }
+
+  /**
+   * Determines new replica set when two nodes in the current replica set are unhealthy.
+   * @param {*} primary user's current primary endpoint
+   * @param {*} secondary1 user's current first secondary endpoint
+   * @param {*} secondary2 user's current second secondary endpoint
+   * @param {*} unhealthyReplicasSet a set of endpoints of unhealthy replica set nodes
+   * @param {*} newReplicaNodes array of endpoints of nodes that will replace the unhealthy nodes
+   * @returns reconfig info to update the user's replica set to replace the 1 unhealthy nodes
+   */
+  determineNewReplicaSetWhenTwoNodeAreUnhealthy(
+    primary,
+    secondary1,
+    secondary2,
+    unhealthyReplicasSet,
+    newReplicaNodes
+  ) {
+    // If primary + secondary is unhealthy, use other healthy secondary as primary and 2 random secondaries
+    if (unhealthyReplicasSet.has(primary)) {
+      return {
+        newPrimary: !unhealthyReplicasSet.has(secondary1)
+          ? secondary1
+          : secondary2,
+        newSecondary1: newReplicaNodes[0],
+        newSecondary2: newReplicaNodes[1],
+        issueReconfig: this.isReconfigEnabled(
+          RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+        ),
+        reconfigType: RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+      }
+    }
+
+    // If both secondaries are unhealthy, keep original primary and select two random secondaries
+    return {
+      newPrimary: primary,
+      newSecondary1: newReplicaNodes[0],
+      newSecondary2: newReplicaNodes[1],
+      issueReconfig: this.isReconfigEnabled(
+        RECONFIG_MODES.MULTIPLE_SECONDARIES.key
+      ),
+      reconfigType: RECONFIG_MODES.MULTIPLE_SECONDARIES.key
+    }
   }
 
   /**
@@ -746,19 +811,15 @@ class SnapbackSM {
     return Array.from(newReplicaNodesSet)
   }
 
-  // TODO: We should not do this pattern of passing a param for the sole purpose of modifying it (will revisit during refactor)
   /**
    * Given map(replica node => userWallets[]), retrieves clock values for every (node, userWallet) pair
    * @param {Object} replicaSetNodesToUserWalletsMap map of <replica set node : wallets>
-   * @param {Set<string>} unhealthyPeers set of unhealthy peer endpoints
    *
-   * @returns {Object} map(replica node => map(wallet => clockValue))
+   * @returns {Object} { replicasToUserClockStatusMap: map(replica node => map(wallet => clockValue)), unhealthyPeers: Set<string> }
    */
-  async retrieveClockStatusesForUsersAcrossReplicaSet(
-    replicasToWalletsMap,
-    unhealthyPeers
-  ) {
+  async retrieveClockStatusesForUsersAcrossReplicaSet(replicasToWalletsMap) {
     const replicasToUserClockStatusMap = {}
+    const unhealthyPeers = new Set()
 
     /** In parallel for every replica, fetch clock status for all users on that replica */
     const replicas = Object.keys(replicasToWalletsMap)
@@ -817,7 +878,10 @@ class SnapbackSM {
       })
     )
 
-    return replicasToUserClockStatusMap
+    return {
+      replicasToUserClockStatusMap,
+      unhealthyPeers
+    }
   }
 
   /**
@@ -1022,11 +1086,14 @@ class SnapbackSM {
       // Retrieve clock statuses for all users and their current replica sets
       let replicaSetNodesToUserClockStatusesMap
       try {
-        replicaSetNodesToUserClockStatusesMap =
-          await this.retrieveClockStatusesForUsersAcrossReplicaSet(
-            replicaSetNodesToUserWalletsMap,
-            unhealthyPeers
-          )
+        const {
+          replicasToUserClockStatusMap,
+          unhealthyPeers: clockUnhealthyPeers
+        } = await this.retrieveClockStatusesForUsersAcrossReplicaSet(
+          replicaSetNodesToUserWalletsMap
+        )
+        replicaSetNodesToUserClockStatusesMap = replicasToUserClockStatusMap
+        unhealthyPeers = new Set([...unhealthyPeers, ...clockUnhealthyPeers])
         this._addToStateMachineQueueDecisionTree(
           decisionTree,
           jobId,
@@ -1039,6 +1106,7 @@ class SnapbackSM {
           'retrieveClockStatusesForUsersAcrossReplicaSet() Error',
           { error: e.message }
         )
+        console.log(e.stack)
         throw new Error(
           'processStateMachineOperation():retrieveClockStatusesForUsersAcrossReplicaSet() Error'
         )

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -264,36 +264,6 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
 
-    nock(constants.primaryEndpoint)
-      .persist()
-      .get(() => true)
-      .reply(500)
-
-    nock(constants.secondary1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.secondary2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.healthyNode1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode3Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
     const { newPrimary, newSecondary1, newSecondary2, issueReconfig } = await snapback.determineNewReplicaSet({
       primary: constants.primaryEndpoint,
       secondary1: constants.secondary1Endpoint,
@@ -305,11 +275,11 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     })
 
     // Check to make sure that the new replica set is what we expect it to be
-    assert.strictEqual(newPrimary, constants.secondary2Endpoint)
-    assert.ok(healthyNodes.includes(newSecondary1))
-    assert.ok(healthyNodes.includes(newSecondary2))
-    assert.strictEqual(issueReconfig, false)
-    assert.ok(!snapback.isReconfigEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key))
+    expect(newPrimary).to.equal(constants.secondary2Endpoint)
+    expect(healthyNodes).to.include(newSecondary1)
+    expect(healthyNodes).to.include(newSecondary2)
+    expect(issueReconfig).to.be.false
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.RECONFIG_DISABLED.key)).to.be.false
   })
 
   it('if entire replica set is unhealthy, return falsy replica set', async function () {
@@ -331,10 +301,10 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     })
 
     // Check to make sure that the return is falsy
-    assert.strictEqual(newPrimary, null)
-    assert.strictEqual(newSecondary1, null)
-    assert.strictEqual(newSecondary2, null)
-    assert.strictEqual(issueReconfig, false)
+    expect(newPrimary).to.be.null
+    expect(newSecondary1).to.be.null
+    expect(newSecondary2).to.be.null
+    expect(issueReconfig).to.be.false
   })
 
   it('if one secondary is unhealthy, return new secondary', async function () {
@@ -346,31 +316,6 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
-
-    nock(constants.secondary1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.secondary2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.healthyNode1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode3Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
 
     // Pass in size 1 of `unhealthyReplicasSet`
     const { newPrimary, newSecondary1, newSecondary2, issueReconfig } = await snapback.determineNewReplicaSet({
@@ -385,11 +330,11 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Check to make sure that the new replica set is what we expect it to be
     // Primary is the same, secondary1 is the same, secondary2 is replaced
-    assert.strictEqual(newPrimary, constants.primaryEndpoint)
-    assert.strictEqual(newSecondary1, constants.secondary1Endpoint)
-    assert.ok(healthyNodes.includes(newSecondary2))
-    assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
+    expect(newPrimary).to.equal(constants.primaryEndpoint)
+    expect(newSecondary1).to.equal(constants.secondary1Endpoint)
+    expect(healthyNodes).to.include(newSecondary2)
+    expect(issueReconfig).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key)).to.be.true
   })
 
   it('if both secondaries are unhealthy, return two new secondaries ', async function () {
@@ -401,31 +346,6 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
-
-    nock(constants.secondary1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.secondary2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.healthyNode1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode3Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
 
     // Pass in size 1 of `unhealthyReplicasSet`
     const { newPrimary, newSecondary1, newSecondary2, issueReconfig } = await snapback.determineNewReplicaSet({
@@ -440,12 +360,12 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Check to make sure that the new replica set is what we expect it to be
     // Primary is the same, secondary1 and secondary2 are replaced
-    assert.strictEqual(newPrimary, constants.primaryEndpoint)
-    assert.ok(healthyNodes.includes(newSecondary1))
-    assert.ok(healthyNodes.includes(newSecondary2))
-    assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
+    expect(newPrimary).to.equal(constants.primaryEndpoint)
+    expect(healthyNodes).to.include(newSecondary1)
+    expect(healthyNodes).to.include(newSecondary2)
+    expect(issueReconfig).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key)).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key)).to.be.true
   })
 
   it('if one primary is unhealthy, return a secondary promoted to primary, existing secondary1, and new secondary2', async function () {
@@ -456,36 +376,6 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
-
-    nock(constants.primaryEndpoint)
-      .persist()
-      .get(() => true)
-      .reply(500)
-
-    nock(constants.secondary1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.secondary2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.healthyNode1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode3Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
 
     // Pass in size 1 of `unhealthyReplicasSet`
     const { newPrimary, newSecondary1, newSecondary2, issueReconfig } = await snapback.determineNewReplicaSet({
@@ -499,13 +389,13 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     })
 
     // Check to make sure that the new replica set is what we expect it to be
-    assert.strictEqual(newPrimary, constants.secondary1Endpoint)
-    assert.strictEqual(newSecondary1, constants.secondary2Endpoint)
-    assert.ok(healthyNodes.includes(newSecondary2))
-    assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    expect(newPrimary).to.equal(constants.secondary1Endpoint)
+    expect(newSecondary1).to.equal(constants.secondary2Endpoint)
+    expect(healthyNodes).to.include(newSecondary2)
+    expect(issueReconfig).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key)).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key)).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)).to.be.true
   })
 
   it('if primary+secondary are unhealthy, return a secondary promoted to a primary, and 2 new secondaries', async function () {
@@ -516,36 +406,6 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
 
     // Mock `selectRandomReplicaSetNodes` to return the healthy nodes
     snapback.selectRandomReplicaSetNodes = async () => { return healthyNodes }
-
-    nock(constants.primaryEndpoint)
-      .persist()
-      .get(() => true)
-      .reply(500)
-
-    nock(constants.secondary1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.secondary2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: { clockValue: 10 } })
-
-    nock(constants.healthyNode1Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode2Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
-
-    nock(constants.healthyNode3Endpoint)
-      .persist()
-      .get(() => true)
-      .reply(200, { data: healthCheckVerboseResponse })
 
     const { newPrimary, newSecondary1, newSecondary2, issueReconfig } = await snapback.determineNewReplicaSet({
       primary: constants.primaryEndpoint,
@@ -558,13 +418,13 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     })
 
     // Check to make sure that the new replica set is what we expect it to be
-    assert.strictEqual(newPrimary, constants.secondary2Endpoint)
-    assert.ok(healthyNodes.includes(newSecondary1))
-    assert.ok(healthyNodes.includes(newSecondary2))
-    assert.strictEqual(issueReconfig, true)
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key))
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key))
-    assert.ok(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key))
+    expect(newPrimary).to.equal(constants.secondary2Endpoint)
+    expect(healthyNodes).to.include(newSecondary1)
+    expect(healthyNodes).to.include(newSecondary2)
+    expect(issueReconfig).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.ONE_SECONDARY.key)).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.MULTIPLE_SECONDARIES.key)).to.be.true
+    expect(snapback.isReconfigEnabled(RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key)).to.be.true
   })
 })
 
@@ -1174,7 +1034,8 @@ describe('test SnapbackSM -- retrieveClockStatusesForUsersAcrossReplicaSet', fun
       'http://healthyCn2.co': {
         'wallet1': 10,
         'wallet2': 20
-      }
+      },
+      'http://unhealthyCn.co': {}
     }
 
     const { SnapbackSM: mockSnapback } = proxyquire(
@@ -1206,22 +1067,16 @@ describe('test SnapbackSM -- retrieveClockStatusesForUsersAcrossReplicaSet', fun
       'http://healthyCn2.co': ['wallet1', 'wallet2'],
       'http://unhealthyCn.co': ['wallet1', 'wallet2']
     }
-    const unhealthyPeers = new Set()
-    const replicaToClockValueMap = await snapback.retrieveClockStatusesForUsersAcrossReplicaSet(
-      replicasToWalletsMap,
+    const {
+      replicasToUserClockStatusMap,
       unhealthyPeers
-    )
+    } = await snapback.retrieveClockStatusesForUsersAcrossReplicaSet(replicasToWalletsMap)
 
-    // Each wallet should have the expected clock value
-    assert.strictEqual(Object.keys(replicaToClockValueMap).length, 3)
-    assert.ok(Object.keys(replicaToClockValueMap).every((replica) => {
-      const actualClockValues = replicaToClockValueMap[replica]
-      const expectedClockValues = expectedReplicaToClockValueMap[replica] || {}
-      assert.deepStrictEqual(actualClockValues, expectedClockValues)
-      return true
-    }))
-    assert.strictEqual(unhealthyPeers.size, 1)
-    assert.ok(unhealthyPeers.has('http://unhealthyCn.co'))
+    // Each wallet should have the expected clock value, and the unhealthy node should've caused an error
+    expect(Object.keys(replicasToUserClockStatusMap)).to.have.lengthOf(3)
+    expect(replicasToUserClockStatusMap).to.deep.equal(expectedReplicaToClockValueMap)
+    expect(unhealthyPeers).to.have.property('size', 1)
+    expect(unhealthyPeers).to.include('http://unhealthyCn.co')
   })
 })
 
@@ -1531,7 +1386,10 @@ describe('test SnapbackSM -- processStateMachineOperation', function () {
     const buildReplicaSetNodesToUserWalletsMapStub = sinon.stub().returns(replicaSetNodesToUserWalletsMap)
     const updateEndpointToSpIdMapStub = sinon.stub().resolves()
     const retrieveClockStatusesForUsersAcrossReplicaSetStub = sinon.stub().resolves(
-      replicaSetNodesToUserClockStatusesMap
+      {
+        replicasToUserClockStatusMap: replicaSetNodesToUserClockStatusesMap,
+        unhealthyPeers: new Set()
+      }
     )
     const computeUserSecondarySyncSuccessRatesMapStub = sinon.stub().resolves(userSecondarySyncSuccessRatesMap)
 
@@ -1558,16 +1416,12 @@ describe('test SnapbackSM -- processStateMachineOperation', function () {
     const jobId = 1
     await snapback.processStateMachineOperation(jobId)
 
-    sinon.assert.calledOnce(getNodeUsersStub)
-    sinon.assert.calledOnceWithExactly(getUnhealthyPeersStub, nodeUsers)
-    sinon.assert.calledOnceWithExactly(buildReplicaSetNodesToUserWalletsMapStub, nodeUsers)
-    sinon.assert.calledOnce(updateEndpointToSpIdMapStub)
-    sinon.assert.calledOnceWithExactly(
-      retrieveClockStatusesForUsersAcrossReplicaSetStub,
-      replicaSetNodesToUserWalletsMap,
-      unhealthyPeers
-    )
-    sinon.assert.calledOnceWithExactly(computeUserSecondarySyncSuccessRatesMapStub, nodeUsers)
+    expect(getNodeUsersStub).to.have.been.calledOnce
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(nodeUsers)
+    expect(buildReplicaSetNodesToUserWalletsMapStub).to.have.been.calledOnceWithExactly(nodeUsers)
+    expect(updateEndpointToSpIdMapStub).to.have.been.calledOnce
+    expect(retrieveClockStatusesForUsersAcrossReplicaSetStub).to.have.been.calledOnceWithExactly(replicaSetNodesToUserWalletsMap)
+    expect(computeUserSecondarySyncSuccessRatesMapStub).to.have.been.calledOnceWithExactly(nodeUsers)
   })
 })
 


### PR DESCRIPTION
### Description

- Break apart `determineNewReplicaSet`
- Refactor `retrieveClockStatusesForUsersAcrossReplicaSet` to not take in a param and modify it
- Clean up some unnecessary `nock` usage in tests and change some built-in assertions to more human-readable Chai assertions

### Tests
Tests pass. `determineNewReplicaSet` was already covered, so we can be pretty sure it's still working as expected.

### How will this change be monitored? Are there sufficient logs?
Look for any unexpected replica sets ("`new replica set=`") in logs containing `issueUpdateReplicaSetOp`.