### PR TITLE
Print errors while creating GCP instances

### DIFF
--- a/service-commands/scripts/create-instance.sh
+++ b/service-commands/scripts/create-instance.sh
@@ -118,8 +118,7 @@ case "$provider" in
 			--boot-disk-size $disk_size \
 			--boot-disk-type $disk_type \
 			--machine-type $machine_type \
-			$spot_flag \
-			2> /dev/null
+			$spot_flag
 		if [[ "$image" = "$GCP_DEV_IMAGE" ]]; then
 			gcloud compute instances add-tags $name --tags=fast
 		fi


### PR DESCRIPTION
### Description
We were throwing away the output from the gcloud create instance command, print that out in case there's an error.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested locally and verified it prints errors if invalid. Here's an example
```
➜  audius-docker-compose git:(main) A create-instance --machine-type n2-custom-8-16384 "<test>"
Provider: gcp
OS Image: project=ubuntu-os-cloud,family=ubuntu-2004-lts
Disk Size: 256
Machine Type: n2-custom-8-16384
Name: <test>
Spot Instance: false
Account: <email>
Project: <project>
Confirm Options? [y/N] y
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid value for field 'resource.name': '<test>'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'


```
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->