### PR TITLE
Make contracts docker containers build only on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,6 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run:
           name: Docker build << parameters.repo >>
-          no_output_timeout: 90m
           command: |
             cd << parameters.repo >>
             docker build -t audius/<< parameters.repo >>:$IMAGE_TAG -t audius/<< parameters.repo>>:$(git rev-parse HEAD) --build-arg git_sha=$(git rev-parse HEAD) --build-arg audius_loggly_disable=$audius_loggly_disable --build-arg audius_loggly_token=$audius_loggly_token --build-arg audius_loggly_tags=$audius_loggly_tags --build-arg BUILD_NUM=$CIRCLE_BUILD_NUM .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,6 +653,7 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run:
           name: Docker build << parameters.repo >>
+          no_output_timeout: 90m
           command: |
             cd << parameters.repo >>
             docker build -t audius/<< parameters.repo >>:$IMAGE_TAG -t audius/<< parameters.repo>>:$(git rev-parse HEAD) --build-arg git_sha=$(git rev-parse HEAD) --build-arg audius_loggly_disable=$audius_loggly_disable --build-arg audius_loggly_token=$audius_loggly_token --build-arg audius_loggly_tags=$audius_loggly_tags --build-arg BUILD_NUM=$CIRCLE_BUILD_NUM .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -713,12 +713,18 @@ workflows:
       - docker-build-and-push:
           name: build-contracts
           repo: contracts
+          filters:
+            branches:
+              only: /(^master$)/
 
       - test-eth-contracts:
           name: test-eth-contracts
       - docker-build-and-push:
           name: build-eth-contracts
           repo: eth-contracts
+          filters:
+            branches:
+              only: /(^master$)/
 
       - test-creator-node:
           name: test-creator-node
@@ -745,6 +751,9 @@ workflows:
       - docker-build-and-push:
           name: build-solana-programs
           repo: solana-programs
+          filters:
+            branches:
+              only: /(^master$)/
 
       - test-mad-dog-e2e:
           context:


### PR DESCRIPTION
### Description
I was able to ssh into a CircleCI VM and force the build by hand and it succeeded after over an hour and it's been cached now. However, given that we don't use contracts containers from branches for any purpose, I propose moving contract container builds to only run on master.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Tested on CircleCI
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
Checks provide monitoring on CircleCI
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->