### PR TITLE
Add additional field to tip notification

### DIFF
--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -1156,7 +1156,7 @@ def solana_notifications():
                         const.notification_entity_id: user_tip.sender_user_id,
                         const.notification_entity_type: "user",
                         const.solana_notification_tip_amount: str(user_tip.amount),
-                        const.solana_notification_tip_signature: user_tip.signature
+                        const.solana_notification_tip_signature: user_tip.signature,
                     },
                 }
             )

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -1156,6 +1156,7 @@ def solana_notifications():
                         const.notification_entity_id: user_tip.sender_user_id,
                         const.notification_entity_type: "user",
                         const.solana_notification_tip_amount: str(user_tip.amount),
+                        const.solana_notification_tip_signature: user_tip.signature
                     },
                 }
             )

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -125,6 +125,7 @@ solana_notification_challenge_id = "challenge_id"
 solana_notification_threshold = "threshold"
 solana_notification_tip_rank = "rank"
 solana_notification_tip_amount = "amount"
+solana_notification_tip_signature = "tx_signature"
 
 solana_notification_reaction_type = "reaction_type"
 solana_notification_reaction_type_tip = "tip"


### PR DESCRIPTION
### Description

- The Tip notification was missing the tx_signature field; this is needed for identity to join between Reactions and Tips, where Reaction has the tip tx_signature as the 'reacted_to' field. 

### Tests
Tested on remote box
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->