### PR TITLE
Increase materialized view timeout to 6 hours

### DIFF
--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -5,7 +5,7 @@ from src.tasks.celery_app import celery
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_UPDATE_TIMEOUT = 60 * 30  # 30 minutes
+DEFAULT_UPDATE_TIMEOUT = 60 * 60 * 6  # 6 hours
 
 
 def update_views(self, db):


### PR DESCRIPTION
### Description
Currently the lock for the materialized view worker frequently expires on DP3 after 30 minutes. This is just a bandaid to increase that to 6 hours. Longer term we should not have jobs that run this long unbounded.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Calculated the new timeout in seconds is equal to the desired timeout.

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
We can see if multiple tasks are running in the /celery_workers_check endpoint

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->