### PR TITLE
[CON-145] Add cancel token and test coverage to getNodeUsers

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3947,7 +3947,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -4205,7 +4205,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-layout": {
       "version": "1.2.2",
@@ -4508,6 +4508,15 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "chai": "4.3.6",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.25.3",

--- a/creator-node/src/snapbackSM/StateMachineConstants.js
+++ b/creator-node/src/snapbackSM/StateMachineConstants.js
@@ -4,5 +4,11 @@ module.exports = {
   // Max number of attempts to fetch clock statuses from /users/batch_clock_status
   MAX_USER_BATCH_CLOCK_FETCH_RETRIES: 5,
   // Retry delay (in millis) between requests during monitoring
-  SYNC_MONITORING_RETRY_DELAY_MS: 15000
+  SYNC_MONITORING_RETRY_DELAY_MS: 15_000,
+  // Millis to timeout request for getting users who have a node as their primary/secondary
+  GET_NODE_USERS_TIMEOUT_MS: 60_000,
+  // Millis to forcibly cancel getNodeUsers request (if axios timeout doesn't work)
+  GET_NODE_USERS_CANCEL_TOKEN_MS: 70_000,
+  // Max number of users to fetch if no maximum is given
+  GET_NODE_USERS_DEFAULT_PAGE_SIZE: 100_000
 }

--- a/creator-node/test/peerSetManager.test.js
+++ b/creator-node/test/peerSetManager.test.js
@@ -1,11 +1,20 @@
 const assert = require('assert')
+const proxyquire = require('proxyquire')
+const chai = require('chai')
+const _ = require('lodash')
+const nock = require('nock')
+const sinon = require('sinon')
+const { CancelToken } = require('axios').default
 
 const PeerSetManager = require('../src/snapbackSM/peerSetManager')
+const Utils = require('../src/utils')
 
-describe('test peerSetManager', () => {
+const { expect } = chai
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+describe('test peerSetManager -- determinePeerHealth', () => {
   let peerSetManager
-
-  const primaryEndpoint = 'http://primary.audius.co'
 
   const baseVerboseHealthCheckResp = {
     version: '0.3.37',
@@ -50,7 +59,7 @@ describe('test peerSetManager', () => {
     })
   })
 
-  it('[determinePeerHealth] should throw error if storage path vars are improper', () => {
+  it('should throw error if storage path vars are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp
     }
@@ -75,7 +84,7 @@ describe('test peerSetManager', () => {
     }
   })
 
-  it('[determinePeerHealth] should throw error if memory vars are improper', () => {
+  it('should throw error if memory vars are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp
     }
@@ -101,7 +110,7 @@ describe('test peerSetManager', () => {
     }
   })
 
-  it('[determinePeerHealth] should throw error if the file descriptors are improper', () => {
+  it('should throw error if the file descriptors are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp
     }
@@ -125,7 +134,7 @@ describe('test peerSetManager', () => {
     }
   })
 
-  it('[determinePeerHealth] should throw error if latest sync history vars are improper', () => {
+  it('should throw error if latest sync history vars are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp
     }
@@ -158,7 +167,7 @@ describe('test peerSetManager', () => {
     }
   })
 
-  it('[determinePeerHealth] should throw error if rolling sync history vars are improper', () => {
+  it('should throw error if rolling sync history vars are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp
     }
@@ -191,15 +200,28 @@ describe('test peerSetManager', () => {
     }
   })
 
-  it('[determinePeerHealth] should pass if verbose health check resp is proper', () => {
+  it('should pass if verbose health check resp is proper', () => {
     try {
       peerSetManager.determinePeerHealth(baseVerboseHealthCheckResp)
     } catch (e) {
       assert.fail(`Should have succeeded: ${e.toString()}`)
     }
   })
+})
 
-  it('[isPrimaryHealthy] should mark primary as healthy if responds with 200 from health check', async () => {
+describe('test peerSetManager -- isPrimaryHealthy', () => {
+  let peerSetManager
+
+  const primaryEndpoint = 'http://primary.audius.co'
+
+  beforeEach(() => {
+    peerSetManager = new PeerSetManager({
+      discoveryProviderEndpoint: 'https://discovery_endpoint.audius.co',
+      creatorNodeEndpoint: 'https://content_node_endpoint.audius.co'
+    })
+  })
+
+  it('should mark primary as healthy if responds with 200 from health check', async () => {
     // Mock method
     peerSetManager.isNodeHealthy = async () => { return true }
 
@@ -209,7 +231,7 @@ describe('test peerSetManager', () => {
     assert.strictEqual(peerSetManager.primaryToEarliestFailedHealthCheckTimestamp[primaryEndpoint], undefined)
   })
 
-  it('[isPrimaryHealthy] should mark primary as healthy if responds with 500 from health check and has not been visited yet', async () => {
+  it('should mark primary as healthy if responds with 500 from health check and has not been visited yet', async () => {
     peerSetManager.isNodeHealthy = async () => { return false }
 
     const isHealthy = await peerSetManager.isPrimaryHealthy(primaryEndpoint)
@@ -218,7 +240,7 @@ describe('test peerSetManager', () => {
     assert.ok(peerSetManager.primaryToEarliestFailedHealthCheckTimestamp[primaryEndpoint])
   })
 
-  it('[isPrimaryHealthy] should mark primary as unhealthy if responds with 500 from health check and the primary has surpassed the allowed threshold time to be unhealthy', async () => {
+  it('should mark primary as unhealthy if responds with 500 from health check and the primary has surpassed the allowed threshold time to be unhealthy', async () => {
     // Set `maxNumberSecondsPrimaryRemainsUnhealthy` to 0 to mock threshold going over
     peerSetManager = new PeerSetManager({
       discoveryProviderEndpoint: 'https://discovery_endpoint.audius.co',
@@ -238,7 +260,7 @@ describe('test peerSetManager', () => {
     assert.ok(peerSetManager.primaryToEarliestFailedHealthCheckTimestamp[primaryEndpoint])
   })
 
-  it('[isPrimaryHealthy] removes primary from map if it goes from unhealthy and back to healthy', async () => {
+  it('removes primary from map if it goes from unhealthy and back to healthy', async () => {
     peerSetManager.isNodeHealthy = async () => { return false }
 
     let isHealthy = await peerSetManager.isPrimaryHealthy(primaryEndpoint)
@@ -253,5 +275,296 @@ describe('test peerSetManager', () => {
 
     assert.strictEqual(isHealthy, true)
     assert.ok(!peerSetManager.primaryToEarliestFailedHealthCheckTimestamp[primaryEndpoint])
+  })
+})
+
+describe('test peerSetManager -- getNodeUsers', () => {
+  const DISCOVERY_NODE_ENDPOINT = 'https://discovery_endpoint.audius.co'
+  const CREATOR_NODE_ENDPOINT = 'https://content_node_endpoint.audius.co'
+  const users = []
+  _.range(1, 20).forEach((userId) => {
+    users.push({
+      'user_id': userId,
+      'wallet': `wallet${userId}`,
+      'primary': 'http://cn1.co',
+      'secondary1': 'http://cn2.co',
+      'secondary2': 'http://cn3.co',
+      'primarySpID': 1,
+      'secondary1SpID': 2,
+      'secondary2SpID': 3
+    })
+  })
+
+  it('uses correct params for axios request when not given pagination params', async () => {
+    const GET_NODE_USERS_TIMEOUT_MS = 100
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 5_000
+    const GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+    let method, baseURL, url, params, timeout, cancelToken, otherParams
+    const axios = async (req) => {
+      ;({
+        method,
+        baseURL,
+        url,
+        params,
+        timeout,
+        cancelToken,
+        ...otherParams
+      } = req)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axios.CancelToken = cancelTokenStub
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        'axios': axios,
+        './StateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    await peerSetManager.getNodeUsers()
+
+    expect(method).to.equal('get')
+    expect(baseURL).to.equal(DISCOVERY_NODE_ENDPOINT)
+    expect(url).to.equal('v1/full/users/content_node/all')
+    expect(params).to.deep.equal({
+      creator_node_endpoint: CREATOR_NODE_ENDPOINT,
+      prev_user_id: 0,
+      max_users: GET_NODE_USERS_DEFAULT_PAGE_SIZE
+    })
+    expect(timeout).to.equal(GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.not.have.been.called
+    expect(otherParams).to.be.empty
+  })
+
+  it('uses correct params for axios request when given pagination params', async () => {
+    const GET_NODE_USERS_TIMEOUT_MS = 100
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 5_000
+    const GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+    const prevUserId = 1
+    const maxUsers = 25
+
+    let method, baseURL, url, params, timeout, cancelToken, otherParams
+    const axios = async (req) => {
+      ;({
+        method,
+        baseURL,
+        url,
+        params,
+        timeout,
+        cancelToken,
+        ...otherParams
+      } = req)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axios.CancelToken = cancelTokenStub
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        'axios': axios,
+        './StateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    await peerSetManager.getNodeUsers(prevUserId, maxUsers)
+
+    expect(method).to.equal('get')
+    expect(baseURL).to.equal(DISCOVERY_NODE_ENDPOINT)
+    expect(url).to.equal('v1/full/users/content_node/all')
+    expect(params).to.deep.equal({
+      creator_node_endpoint: CREATOR_NODE_ENDPOINT,
+      prev_user_id: prevUserId,
+      max_users: maxUsers
+    })
+    expect(timeout).to.equal(GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.not.have.been.called
+    expect(otherParams).to.be.empty
+  })
+
+  it('throws when one or more users is missing a required field', async () => {
+    const axios = async (_) => {
+      return {
+        data:
+        {
+          data:
+          [
+            ...users,
+            {
+              'user_id': 'userId with missing secondary2SpID',
+              'wallet': `wallet`,
+              'primary': 'http://cn1.co',
+              'secondary1': 'http://cn2.co',
+              'secondary2': 'http://cn3.co',
+              'primarySpID': 1,
+              'secondary1SpID': 2
+            }
+          ]
+        }
+      }
+    }
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        'axios': axios
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    return expect(peerSetManager.getNodeUsers()).to.eventually
+      .be.rejectedWith('getNodeUsers() Error: Unexpected response format during getNodeUsers() call')
+      .and.be.an.instanceOf(Error)
+  })
+
+  it('uses cancel token to cancel axios request after delay (using stubbed axios)', async () => {
+    const GET_NODE_USERS_TIMEOUT_MS = 5_000
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 100
+    const GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+    let timeout, cancelToken
+    const axios = async (req) => {
+      ;({
+        timeout,
+        cancelToken
+      } = req)
+
+      // Wait long enough for the cancel token to cancel the axios request
+      await Utils.timeout(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axios.CancelToken = cancelTokenStub
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        'axios': axios,
+        './StateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    await peerSetManager.getNodeUsers()
+
+    expect(timeout).to.equal(GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.have.been.calledOnceWithExactly(
+      `getNodeUsers took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out`
+    )
+  })
+
+  it('uses cancel token to cancel axios request after delay (using real axios with delayConnection)', async () => {
+    const GET_NODE_USERS_TIMEOUT_MS = 5_000
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 100
+    const GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        './StateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/v1/full/users/content_node/all')
+      .query({
+        creator_node_endpoint: CREATOR_NODE_ENDPOINT,
+        prev_user_id: 0,
+        max_users: GET_NODE_USERS_DEFAULT_PAGE_SIZE
+      })
+      .delay(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+      .reply(200, { data: users })
+
+    return expect(peerSetManager.getNodeUsers()).to.eventually
+      .be.rejectedWith(
+        `getNodeUsers() Error: Cancel: getNodeUsers took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out - connected discprov [${DISCOVERY_NODE_ENDPOINT}]`
+      )
+      .and.be.an.instanceOf(Error)
+  })
+
+  it('uses cancel token to cancel axios request after delay (using real axios with delayBody)', async () => {
+    const GET_NODE_USERS_TIMEOUT_MS = 5_000
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 100
+    const GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+    const MockedPeerSetManager = proxyquire(
+      '../src/snapbackSM/peerSetManager.js',
+      {
+        './StateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    const peerSetManager = new MockedPeerSetManager({
+      discoveryProviderEndpoint: DISCOVERY_NODE_ENDPOINT,
+      creatorNodeEndpoint: CREATOR_NODE_ENDPOINT
+    })
+
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/v1/full/users/content_node/all')
+      .query({
+        creator_node_endpoint: CREATOR_NODE_ENDPOINT,
+        prev_user_id: 0,
+        max_users: GET_NODE_USERS_DEFAULT_PAGE_SIZE
+      })
+      .delayBody(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+      .reply(200, { data: users })
+
+    return expect(peerSetManager.getNodeUsers()).to.eventually
+      .be.rejectedWith(
+        `getNodeUsers() Error: Cancel: getNodeUsers took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out - connected discprov [${DISCOVERY_NODE_ENDPOINT}]`
+      )
+      .and.be.an.instanceOf(Error)
   })
 })


### PR DESCRIPTION
### Description
- Add cancel token to getNodeUsers in snapback. It looks like an issue with the state-machine queue getting stuck is caused by axios hanging and not timing out or succeeding/failing. Related issues:
  - https://github.com/axios/axios/issues/2527
  - https://github.com/axios/axios/issues/124
- Add test coverage for getNodeUsers and group other peerSetManager tests into `describe` blocks

### Tests
- Ran `A up` locally and made sure it wasn't causing any errors
- Added tests that mock the request taking long enough to make the cancel token kick in, and verify that the request/function fails as expected in that scenario. Logs: 
<img width="1728" alt="Screen Shot 2022-05-23 at 8 33 12 AM" src="https://user-images.githubusercontent.com/4657956/169855254-6baecd8d-e198-4513-bd56-c20305763181.png">


### How will this change be monitored? Are there sufficient logs?
- Search logs for `getNodeUsers request canceled` or `getNodeUsers took more than` to see when the cancel token had to be used
- Search for `getNodeUsers` to see general failures/successes