### PR TITLE
Fix aggregate tip indexing bug

### DIFF
--- a/discovery-provider/src/tasks/index_aggregate_tips.py
+++ b/discovery-provider/src/tasks/index_aggregate_tips.py
@@ -195,8 +195,12 @@ def _update_aggregate_tips(session: Session, redis: Redis):
     prev_slot = get_last_indexed_checkpoint(session, AGGREGATE_TIPS)
     max_slot_result = session.query(func.max(UserTip.slot)).one()
     max_slot = int(max_slot_result[0]) if max_slot_result[0] is not None else 0
+
     if prev_slot == max_slot:
+        if latest_user_bank_slot is not None:
+            redis.set(latest_sol_aggregate_tips_slot_key, int(latest_user_bank_slot))
         return
+
     ranks_before = _get_ranks(session, prev_slot, max_slot)
     update_aggregate_table(
         logger,


### PR DESCRIPTION
### Description

- Found a bug where an early return in index_aggregate_tips would cause the userbank max slot to not be propagated properly

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->