### PR TITLE
Add string-based `level` keys to Bunyan logger

### DIFF
--- a/creator-node/compose/env/commonEnv.sh
+++ b/creator-node/compose/env/commonEnv.sh
@@ -5,3 +5,4 @@ export delegatePrivateKey=DELEGATE_PRIVATE_KEY
 export creatorNodeEndpoint=CREATOR_NODE_ENDPOINT
 export spOwnerWallet=SP_OWNER_WALLET
 export COMPOSE_HTTP_TIMEOUT=200
+export printSequelizeLogs=true

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -262,7 +262,7 @@ const config = convict({
     doc: 'If we should print logs from sequelize',
     format: Boolean,
     env: 'printSequelizeLogs',
-    default: true
+    default: false
   },
 
   // Transcoding settings

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -3,13 +3,23 @@ const shortid = require('shortid')
 
 const config = require('./config')
 
+function stdOutWithLevelName() {}
+stdOutWithLevelName.prototype.write = function(data) {
+    var logObject = JSON.parse(data)
+
+    // Change log level number to name and write it out
+    logObject.levelno = logObject.level
+    logObject.level = bunyan.nameFromLevel[logObject.level]
+    process.stdout.write(JSON.stringify(logObject) + '\n')
+}
+
 const logLevel = config.get('logLevel') || 'info'
 const logger = bunyan.createLogger({
   name: 'audius_creator_node',
   streams: [
     {
       level: logLevel,
-      stream: process.stdout
+      stream: new stdOutWithLevelName()
     }
   ]
 })

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -3,29 +3,6 @@ const shortid = require('shortid')
 
 const config = require('./config')
 
-// taken from: https://github.com/trentm/node-bunyan/issues/194#issuecomment-396521385
-// since there is no official support for string-based "level" values
-// response from author: https://github.com/trentm/node-bunyan/issues/194#issuecomment-70397668
-function StdOutWithLevelName() {}
-StdOutWithLevelName.prototype.write = function (data) {
-  try {
-    // grab logs before sending to stdout
-    const logObject = JSON.parse(data)
-
-    // rename level (int) to levelno key
-    logObject.levelno = logObject.level
-
-    // add new level (string) to level key
-    logObject.level = bunyan.nameFromLevel[logObject.level]
-
-    // rewrite line to stdout
-    process.stdout.write(JSON.stringify(logObject) + '\n')
-  } catch (e) {
-    // write line as is, in case of parsing exception
-    process.stdout.write(data)
-  }
-}
-
 // taken from: https://github.com/trentm/node-bunyan/issues/194#issuecomment-347801909
 // since there is no official support for string-based "level" values
 // response from author: https://github.com/trentm/node-bunyan/issues/194#issuecomment-70397668
@@ -51,13 +28,10 @@ const logLevel = config.get('logLevel') || 'info'
 const logger = bunyan.createLogger({
   name: 'audius_creator_node',
   streams: [
-    // {
-    //   level: logLevel,
-    //   stream: new StdOutWithLevelName()
-    // },
     {
       level: logLevel,
-      stream: new RawStdOutWithLevelName()
+      stream: new RawStdOutWithLevelName(),
+      type: 'raw'
     }
   ]
 })

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -12,11 +12,8 @@ function RawStdOutWithLevelName() {
       // duplicate log object before sending to stdout
       const clonedLog = Object.assign({}, log)
 
-      // rename level (int) to levelno key
-      clonedLog.levelno = clonedLog.level
-
       // add new level (string) to level key
-      clonedLog.level = bunyan.nameFromLevel[clonedLog.levelno]
+      clonedLog.logLevel = bunyan.nameFromLevel[clonedLog.level]
 
       const logLine = JSON.stringify(clonedLog, bunyan.safeCycles()) + '\n'
       process.stdout.write(logLine)

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -3,14 +3,14 @@ const shortid = require('shortid')
 
 const config = require('./config')
 
-function stdOutWithLevelName() {}
-stdOutWithLevelName.prototype.write = function(data) {
-    var logObject = JSON.parse(data)
+function StdOutWithLevelName() {}
+StdOutWithLevelName.prototype.write = function (data) {
+  const logObject = JSON.parse(data)
 
-    // Change log level number to name and write it out
-    logObject.levelno = logObject.level
-    logObject.level = bunyan.nameFromLevel[logObject.level]
-    process.stdout.write(JSON.stringify(logObject) + '\n')
+  // Change log level number to name and write it out
+  logObject.levelno = logObject.level
+  logObject.level = bunyan.nameFromLevel[logObject.level]
+  process.stdout.write(JSON.stringify(logObject) + '\n')
 }
 
 const logLevel = config.get('logLevel') || 'info'
@@ -19,7 +19,7 @@ const logger = bunyan.createLogger({
   streams: [
     {
       level: logLevel,
-      stream: new stdOutWithLevelName()
+      stream: new StdOutWithLevelName()
     }
   ]
 })


### PR DESCRIPTION
### Description

Have Creator Node logs match the `level` keys of Discovery Provider logs within [`audius-protocol/discovery-provider/src/utils/helpers.py`](https://github.com/AudiusProject/audius-protocol/blob/1c613132530c52c66601a2fd99f1614e69ae5ae2/discovery-provider/src/utils/helpers.py#L207).

Previously, this was handled by [fluentd](https://github.com/AudiusProject/audius-k8s-manifests/blob/aac600fbfb123486f6ef07e8e323e2fa93b429a9/audius/logger/logger.yaml#L41).

Currently, Creator Node uses Bunyan for sending json-formatted logs that are parsable by log forwarders like Logspout. Bunyan, however, only outputs the `level` key as an integer while Discovery Provider outputs a string-based `level` key and integer-based `levelno` key.

Without standardizing on a string-based `level`-key, we would have to:

* Use two different queries for searching Loggly for `error`s within both CN and DP nodes. (`json.level:"50"` and `json.level:"error"`, respectively)
* Alternatively, we could change DP's `json.level` to also be integer-based and thus use a single query, but we would have to memorize the [level numbers](https://github.com/trentm/node-bunyan#levels).

#### Examples

The old logs used to use integers for the `level` key.

Old logs:

```bash
{
  "name": "audius_creator_node",
  "hostname": "56b9068c3287",
  "pid": 23,
  "level": 30,
  "msg": "NODESYNC.0xa601cdb1354755f8b6c2b0140029dd1e5943cd4d Saved all ClockRecord entries to DB",
  "time": "2022-05-23T06:02:23.072Z",
  "v": 0
}
```

The new logs redirects old `level` to `levelno` and sets `level` to be a string-based representation of the level (eg. info, warn, error, etc).

New logs:

```bash
{
  "name": "audius_creator_node",
  "hostname": "56b9068c3287",
  "pid": 23,
  "level": "info",
  "msg": "NODESYNC.0xa601cdb1354755f8b6c2b0140029dd1e5943cd4d Saved all ClockRecord entries to DB",
  "time": "2022-05-23T06:02:23.072Z",
  "v": 0,
  "levelno": 30
}
```

### Tests

Launch locally and staging.

### How will this change be monitored? Are there sufficient logs?

Loggly dashboards should show a string-based `level` value and integer-based `levelno` value.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->