### PR TITLE
Fix types

### DIFF
--- a/libs/src/services/solanaAudiusData/index.ts
+++ b/libs/src/services/solanaAudiusData/index.ts
@@ -96,7 +96,7 @@ export class SolanaAudiusData {
    * Encodes and derives the user account, bump seed, and base authority
    */
   async getUserIdSeed(userId: BN) {
-    // @ts-ignore
+    // @ts-expect-error
     const userIdSeed = userId.toArrayLike(Uint8Array, 'le', 4)
     const {
       baseAuthorityAccount,
@@ -391,9 +391,9 @@ export class SolanaAudiusData {
       message: userSolKeypair.publicKey.toBytes(),
       replicaSet: [params.cn1SpId, params.cn2SpId, params.cn3SpId],
       replicaSetBumps: spSeedAddresses.map(({ bumpSeed }) => bumpSeed),
-      cn1: spSeedAddresses[0]!.derivedAddress,
-      cn2: spSeedAddresses[1]!.derivedAddress,
-      cn3: spSeedAddresses[2]!.derivedAddress,
+      cn1: (spSeedAddresses[0] as SeedAddress).derivedAddress,
+      cn2: (spSeedAddresses[1] as SeedAddress).derivedAddress,
+      cn3: (spSeedAddresses[2] as SeedAddress).derivedAddress,
       metadata: params.metadata
     })
     return await this.sendTx(tx)

--- a/libs/src/services/solanaWeb3Manager/utils.d.ts
+++ b/libs/src/services/solanaWeb3Manager/utils.d.ts
@@ -1,4 +1,4 @@
-class SolanaUtils {
+export default class SolanaUtils {
   static signBytes: (bytes: any, ethPrivateKey: any) => any
   static prepareInstructionForRelay: (instruction: any) => any
   static constructTransferId: (challengeId: any, specifier: any) => string
@@ -29,5 +29,3 @@ class SolanaUtils {
   // Safely create pubkey from nullable val
   static newPublicKeyNullable: (val: any) => any
 }
-
-module.exports = SolanaUtils


### PR DESCRIPTION
### Description
Fixes types errors that prevents running ts-node on init scripts
ie. `ts-node initScripts/mainnet.js staging-config-live.json setversion discovery-node 0.3.58` had the following error before
```
TSError: ⨯ Unable to compile TypeScript:
src/services/solanaAudiusData/index.ts:55:34 - error TS2339: Property 'newPublicKeyNullable' does not exist on type 'typeof import("/home/ubuntu/audius-protocol/libs/src/services/solanaWeb3Manager/utils")'.

55     this.programId = SolanaUtils.newPublicKeyNullable(programId)
                                    ~~~~~~~~~~~~~~~~~~~~
src/services/solanaAudiusData/index.ts:56:37 - error TS2339: Property 'newPublicKeyNullable' does not exist on type 'typeof import("/home/ubuntu/audius-protocol/libs/src/services/solanaWeb3Manager/utils")'.

56     this.adminAccount = SolanaUtils.newPublicKeyNullable(adminAccount)
                                       ~~~~~~~~~~~~~~~~~~~~
src/services/solanaAudiusData/index.ts:94:43 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(ArrayType: BufferConstructor, endian?: Endianness | undefined, length?: number | undefined): Buffer', gave the following error.
    Argument of type 'Uint8ArrayConstructor' is not assignable to parameter of type 'BufferConstructor'.
      Type 'Uint8ArrayConstructor' is missing the following properties from type 'BufferConstructor': isBuffer, isEncoding, byteLength, concat, and 5 more.
  Overload 2 of 2, '(ArrayType: any[], endian?: Endianness | undefined, length?: number | undefined): any[]', gave the following error.
    Argument of type 'Uint8ArrayConstructor' is not assignable to parameter of type 'any[]'.
      Type 'Uint8ArrayConstructor' is missing the following properties from type 'any[]': pop, push, concat, join, and 28 more.

94     const userIdSeed = userId.toArrayLike(Uint8Array, 'le', 4)
                                             ~~~~~~~~~~

src/services/solanaAudiusData/index.ts:219:36 - error TS2345: Argument of type '{ adminAccount?: anchor.web3.PublicKey | undefined; baseAuthorityAccount?: anchor.web3.PublicKey | undefined; bumpSeed?: number | undefined; userId: anchor.BN; ... 10 more ...; program: AudiusData.AudiusDataProgram; }' is not assignable to parameter of type 'InitUserParams'.
  Types of property 'ethAddress' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

219     const tx = AudiusData.initUser({
                                       ~
220       payer: this.solanaWeb3Manager.feePayerKey,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
222       ...params
    ~~~~~~~~~~~~~~~
223     })
    ~~~~~
src/services/solanaAudiusData/index.ts:377:12 - error TS2532: Object is possibly 'undefined'.

377       cn1: spSeedAddresses[0].derivedAddress,
               ~~~~~~~~~~~~~~~~~~
src/services/solanaAudiusData/index.ts:378:12 - error TS2532: Object is possibly 'undefined'.

378       cn2: spSeedAddresses[1].derivedAddress,
               ~~~~~~~~~~~~~~~~~~
src/services/solanaAudiusData/index.ts:379:12 - error TS2532: Object is possibly 'undefined'.

379       cn3: spSeedAddresses[2].derivedAddress,
               ~~~~~~~~~~~~~~~~~~
src/services/solanaAudiusData/index.ts:426:7 - error TS2783: 'adminAccount' is specified more than once, so this usage will be overwritten.

426       adminAccount: this.adminAccount,
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  src/services/solanaAudiusData/index.ts:427:7
    427       ...params
              ~~~~~~~~~
    This spread always overwrites this property.

    at createTSError (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:843:12)
    at reportTSError (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:847:19)
    at getOutput (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:1057:36)
    at Object.compile (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:1411:41)
    at Module.m._compile (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:1596:30)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Object.require.extensions.<computed> [as .ts] (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:1600:12)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/home/ubuntu/audius-protocol/libs/src/index.js:4:30)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Object.require.extensions.<computed> [as .js] (/home/ubuntu/.nvm/versions/node/v14.18.1/lib/node_modules/ts-node/src/index.ts:1587:43)
    at Module.load (internal/modules/cjs/loader.js:950:32) {
  diagnosticCodes: [
    2339, 2339, 2769,
    2345, 2532, 2532,
    2532, 2783
  ]
}
```

### Tests
Was able to run the script and run npm build

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->