### PR TITLE
[PLAT-146] Make health check respond when web3 is unhealthy

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -219,7 +219,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         latest_indexed_block_hash_bytes = redis.get(
             most_recent_indexed_block_hash_redis_key
         )
-        if latest_indexed_block_hash is not None:
+        if latest_indexed_block_hash_bytes is not None:
             latest_indexed_block_hash = latest_indexed_block_hash_bytes.decode("utf-8")
     else:
         # Get latest blockchain state from web3

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -200,10 +200,10 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         else default_healthy_block_diff
     )
 
-    latest_block_num = None
-    latest_block_hash = None
-    latest_indexed_block_num = None
-    latest_indexed_block_hash = None
+    latest_block_num: Optional[int] = None
+    latest_block_hash: Optional[str] = None
+    latest_indexed_block_num: Optional[int] = None
+    latest_indexed_block_hash: Optional[str] = None
 
     if use_redis_cache:
         # get latest blockchain state from redis cache, or fallback to chain if None
@@ -216,9 +216,11 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         if latest_indexed_block_num is not None:
             latest_indexed_block_num = int(latest_indexed_block_num)
 
-        latest_indexed_block_hash = redis.get(most_recent_indexed_block_hash_redis_key)
+        latest_indexed_block_hash_bytes = redis.get(
+            most_recent_indexed_block_hash_redis_key
+        )
         if latest_indexed_block_hash is not None:
-            latest_indexed_block_hash = latest_indexed_block_hash.decode("utf-8")
+            latest_indexed_block_hash = latest_indexed_block_hash_bytes.decode("utf-8")
     else:
         # Get latest blockchain state from web3
         try:
@@ -324,7 +326,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "infra_setup": infra_setup,
     }
 
-    if latest_block_num != None and latest_indexed_block_num != None:
+    if latest_block_num is not None and latest_indexed_block_num is not None:
         block_difference = abs(latest_block_num - latest_indexed_block_num)
     else:
         # If we cannot get a reading from chain about what the latest block is,


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Refactor health check on discovery such that it will not crash if web3 is unavailable.
Doing this work made me think that in the future, we probably want to have discovery node report only its latest block and have clients determine whether it is an acceptable number of blocks behind given its view of the world. It would be easy for a discovery node to get network-partitioned from the chain layer it's communicating with and then report 0 blocks behind indefinitely. I get around this in this PR by making the block diff = maximum_healthy + 1.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->


Local stack, if missing reports
```
block_difference: 101,
web: {
  blockhash: null,
  blocknumber: null
}
```

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Health checks / pingdom

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->