### PR TITLE
[INF-93] Follow up code cleanliness for Bunyan changes

### DIFF
--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -10,11 +10,13 @@ function RawStdOutWithLevelName() {
   return {
     write: (log) => {
       // duplicate log object before sending to stdout
-      const clonedLog = Object.assign({}, log)
+      const clonedLog = { ...log }
 
       // add new level (string) to level key
       clonedLog.logLevel = bunyan.nameFromLevel[clonedLog.level]
 
+      // stringify() uses the safeCycles() replacer, which returns '[Circular]'
+      // when circular references are detected
       const logLine = JSON.stringify(clonedLog, bunyan.safeCycles()) + '\n'
       process.stdout.write(logLine)
     }
@@ -27,7 +29,7 @@ const logger = bunyan.createLogger({
   streams: [
     {
       level: logLevel,
-      stream: new RawStdOutWithLevelName(),
+      stream: RawStdOutWithLevelName(),
       type: 'raw'
     }
   ]

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -17,6 +17,7 @@ function RawStdOutWithLevelName() {
 
       // stringify() uses the safeCycles() replacer, which returns '[Circular]'
       // when circular references are detected
+      // related code: https://github.com/trentm/node-bunyan/blob/0ff1ae29cc9e028c6c11cd6b60e3b90217b66a10/lib/bunyan.js#L1155-L1200
       const logLine = JSON.stringify(clonedLog, bunyan.safeCycles()) + '\n'
       process.stdout.write(logLine)
     }


### PR DESCRIPTION
### Description

* Create a copy of the log object by using the format: `const clonedLog = { ...log }`
* Add comments to Bunyan's code to clarify `safeCycles()`'s functionality for `JSON.stringify()`'s `replacer`.
* Remove the `new` keyword for cleaner object references.

This is a follow up PR for the comments on #3136 to match current coding practices.


### Tests

Locally running logs.

### How will this change be monitored? Are there sufficient logs?

Loggly logs.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->