### PR TITLE
[PLAT-149] Enforce wallet fetch ordering in discovery auth_middleware

### DIFF
--- a/discovery-provider/src/utils/auth_middleware.py
+++ b/discovery-provider/src/utils/auth_middleware.py
@@ -50,6 +50,9 @@ def auth_middleware(**kwargs):
                             User.wallet == wallet.lower(),
                             User.is_current == True,
                         )
+                        # In the case that multiple wallets match (not enforced on the data layer),
+                        # pick the user id that is lowest (created first).
+                        .order_by(User.user_id.asc())
                         .first()
                     )
                     if user:

--- a/discovery-provider/src/utils/auth_middleware.py
+++ b/discovery-provider/src/utils/auth_middleware.py
@@ -1,9 +1,12 @@
 import functools
+import logging
 
 from eth_account.messages import encode_defunct
 from flask.globals import request
 from src.models.models import User
 from src.utils import db_session, web3_provider
+
+logger = logging.getLogger(__name__)
 
 MESSAGE_HEADER = "Encoded-Data-Message"
 SIGNATURE_HEADER = "Encoded-Data-Signature"
@@ -57,6 +60,9 @@ def auth_middleware(**kwargs):
                     )
                     if user:
                         authed_user_id = user.user_id
+                        logger.info(
+                            f"auth_middleware.py | authed_user_id: {authed_user_id}"
+                        )
             return func(*args, **kwargs, authed_user_id=authed_user_id)
 
         return inner_wrap


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Fixes auth_middleware query to enforce ordering in results when two users clash with the same wallet.
Rare occurrence and the culprit of that is user error (running audiusLibs.contracts.addUser when already authenticated with an audius account / wallet).

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested on stage discovery 1! Hidden tracks show as expected. Will re-test when it lands on prod in the next release with my user account

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Hidden tracks viewable


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->