### PR TITLE
Simplify CN child logger pattern

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3947,7 +3947,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -4205,7 +4205,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-layout": {
       "version": "1.2.2",

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -1,6 +1,10 @@
 const config = require('./config')
 
-const { requestNotExcludedFromLogging, getDuration } = require('./logging')
+const {
+  requestNotExcludedFromLogging,
+  getDuration,
+  createChildLogger
+} = require('./logging')
 const { generateTimestampAndSignature } = require('./apiSigning')
 
 module.exports.handleResponse = (func) => {
@@ -62,7 +66,7 @@ module.exports.handleResponseWithHeartbeat = (func) => {
 
 const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
   const duration = getDuration(req)
-  let logger = req.logger.createChildLogger({
+  let logger = createChildLogger(req.logger, {
     duration,
     statusCode: resp.statusCode
   })
@@ -72,7 +76,7 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
       logger.info('Success')
     }
   } else {
-    logger = logger.createChildLogger({
+    logger = createChildLogger(logger, {
       errorMessage: resp.object.error
     })
     if (req && req.body) {
@@ -99,7 +103,7 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
 const sendResponseWithHeartbeatTerminator =
   (module.exports.sendResponseWithHeartbeatTerminator = (req, res, resp) => {
     const duration = getDuration(req)
-    let logger = req.logger.createChildLogger({
+    let logger = createChildLogger(req.logger, {
       duration,
       statusCode: resp.statusCode
     })
@@ -109,7 +113,7 @@ const sendResponseWithHeartbeatTerminator =
         logger.info('Success')
       }
     } else {
-      logger = logger.createChildLogger({
+      logger = createChildLogger(logger, {
         errorMessage: resp.object.error
       })
       if (req && req.body) {

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -65,7 +65,7 @@ module.exports.handleResponseWithHeartbeat = (func) => {
 
 const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
   const duration = getDuration(req)
-  let logger = req.logger.getChild({
+  let logger = req.logger.createChildLogger({
     duration,
     statusCode: resp.statusCode
   })
@@ -75,7 +75,7 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
       logger.info('Success')
     }
   } else {
-    logger = logger.getChild({
+    logger = logger.createChildLogger({
       errorMessage: resp.object.error
     })
     if (req && req.body) {
@@ -102,7 +102,7 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
 const sendResponseWithHeartbeatTerminator =
   (module.exports.sendResponseWithHeartbeatTerminator = (req, res, resp) => {
     const duration = getDuration(req)
-    let logger = req.logger.getChild({
+    let logger = req.logger.createChildLogger({
       duration,
       statusCode: resp.statusCode
     })
@@ -112,7 +112,7 @@ const sendResponseWithHeartbeatTerminator =
         logger.info('Success')
       }
     } else {
-      logger = logger.getChild({
+      logger = logger.createChildLogger({
         errorMessage: resp.object.error
       })
       if (req && req.body) {

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -3,7 +3,6 @@ const config = require('./config')
 const {
   requestNotExcludedFromLogging,
   getDuration,
-  setFieldsInChildLogger
 } = require('./logging')
 const { generateTimestampAndSignature } = require('./apiSigning')
 
@@ -66,7 +65,7 @@ module.exports.handleResponseWithHeartbeat = (func) => {
 
 const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
   const duration = getDuration(req)
-  let logger = setFieldsInChildLogger(req, {
+  let logger = req.logger.getChild({
     duration,
     statusCode: resp.statusCode
   })
@@ -76,7 +75,7 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
       logger.info('Success')
     }
   } else {
-    logger = logger.child({
+    logger = logger.getChild({
       errorMessage: resp.object.error
     })
     if (req && req.body) {
@@ -103,16 +102,17 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
 const sendResponseWithHeartbeatTerminator =
   (module.exports.sendResponseWithHeartbeatTerminator = (req, res, resp) => {
     const duration = getDuration(req)
-    let logger = setFieldsInChildLogger(req, {
+    let logger = req.logger.getChild({
       duration,
       statusCode: resp.statusCode
     })
+
     if (resp.statusCode === 200) {
       if (requestNotExcludedFromLogging(req.originalUrl)) {
         logger.info('Success')
       }
     } else {
-      logger = logger.child({
+      logger = logger.getChild({
         errorMessage: resp.object.error
       })
       if (req && req.body) {

--- a/creator-node/src/apiHelpers.js
+++ b/creator-node/src/apiHelpers.js
@@ -1,9 +1,6 @@
 const config = require('./config')
 
-const {
-  requestNotExcludedFromLogging,
-  getDuration,
-} = require('./logging')
+const { requestNotExcludedFromLogging, getDuration } = require('./logging')
 const { generateTimestampAndSignature } = require('./apiSigning')
 
 module.exports.handleResponse = (func) => {

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -100,6 +100,7 @@ function loggingMiddleware(req, res, next) {
  * Creates and returns a child logger for provided logger
  * @param {Object} logger bunyan parent logger instance
  * @param {Object} options optional object to define child logger properties. adds to JSON fields, allowing for better log filtering/querying
+ * @returns {Object} child logger instance with defined options
  */
 function createChildLogger(logger, options = {}) {
   return logger.child(options)

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -96,7 +96,11 @@ function loggingMiddleware(req, res, next) {
   next()
 }
 
-/** Creates and returns a childLogger */
+/**
+ * Creates and returns a bunyan childLogger
+ *
+ * Options object adds properties to the JSON logger, allowing for better log filtering/querying
+ */
 logger.createChildLogger = function (options = {}) {
   return logger.child(options)
 }

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -97,7 +97,7 @@ function loggingMiddleware(req, res, next) {
 }
 
 /** Creates and returns a childLogger */
-logger.getChild = function (options = {}) {
+logger.createChildLogger = function (options = {}) {
   return logger.child(options)
 }
 

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -97,11 +97,11 @@ function loggingMiddleware(req, res, next) {
 }
 
 /**
- * Creates and returns a bunyan childLogger
- *
- * Options object adds properties to the JSON logger, allowing for better log filtering/querying
+ * Creates and returns a child logger for provided logger
+ * @param {Object} logger bunyan parent logger instance
+ * @param {Object} options optional object to define child logger properties. adds to JSON fields, allowing for better log filtering/querying
  */
-logger.createChildLogger = function (options = {}) {
+function createChildLogger(logger, options = {}) {
   return logger.child(options)
 }
 
@@ -143,5 +143,6 @@ module.exports = {
   getRequestLoggingContext,
   getStartTime,
   getDuration,
+  createChildLogger,
   logInfoWithDuration
 }

--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -96,21 +96,9 @@ function loggingMiddleware(req, res, next) {
   next()
 }
 
-/**
- * Add fields to a child logger instance
- * @param {*} req
- * @param {Object} options fields to add to child logger
- * @returns a logger instance
- */
-function setFieldsInChildLogger(req, options = {}) {
-  const fields = Object.keys(options)
-
-  const childOptions = {}
-  fields.forEach((field) => {
-    childOptions[field] = options[field]
-  })
-
-  return req.logger.child(childOptions)
+/** Creates and returns a childLogger */
+logger.getChild = function (options = {}) {
+  return logger.child(options)
 }
 
 /**
@@ -151,6 +139,5 @@ module.exports = {
   getRequestLoggingContext,
   getStartTime,
   getDuration,
-  setFieldsInChildLogger,
   logInfoWithDuration
 }

--- a/creator-node/test/lib/reqMock.js
+++ b/creator-node/test/lib/reqMock.js
@@ -30,7 +30,8 @@ const logger = {
   },
   info: () => {},
   warn: () => {},
-  error: () => {}
+  error: () => {},
+  createChildLogger: () => ({ ...logger })
 }
 
 /**

--- a/creator-node/test/lib/reqMock.js
+++ b/creator-node/test/lib/reqMock.js
@@ -30,8 +30,7 @@ const logger = {
   },
   info: () => {},
   warn: () => {},
-  error: () => {},
-  createChildLogger: () => ({ ...logger })
+  error: () => {}
 }
 
 /**


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

- simplify `setFieldsInChildLogger` logic
- change name to `createChildLogger` for accuracy
- update calls

working example https://replit.com/@SidSethi/Child-logging#index.js

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

existing CN tests failed until final commit
Ensure logs called by `sendResponse` and `sendResponseWithHeartbeatTerminator` look correct:
- `sendResponse` is called by `handleResponse` which is used in `/health_check`
```
[2022-05-25T15:22:20.070Z]  INFO: audius_creator_node/67 on 0d34096fabb8: Success (requestID=8BX5ROjBy, requestMethod=GET, requestHostname=cn1_creator-node_1, requestUrl=/health_check, duration=34, statusCode=200, logLevel=info)
```
- `sendResponseWithHeartbeatTerminator` is called by `handleResponseWithHeartbeat` which is used in `/health_check/duration/heartbeat`
```
[2022-05-25T15:25:08.934Z]  INFO: audius_creator_node/67 on 0d34096fabb8: Error processing request: Missing required query parameters || Request Body: {} || Request Query Params: {} (requestID=tFyI9U9Lh7, requestMethod=GET, requestHostname=34.69.173.123, requestUrl=/health_check/duration/heartbeat, duration=1, statusCode=400, errorMessage="Missing required query parameters", logLevel=info)
```

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Monitor above logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->