### PR TITLE
Test monitoring queue steps

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.js
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.js
@@ -53,5 +53,10 @@ module.exports = {
       key: 'ENTIRE_REPLICA_SET',
       value: 4
     }
+  }),
+  // Describes the type of sync operation
+  SyncType: Object.freeze({
+    Recurring: 'RECURRING', // Scheduled background sync to keep secondaries up to date
+    Manual: 'MANUAL' // Triggered by a user data write to primary
   })
 }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js
@@ -23,11 +23,11 @@ class StateMonitoringQueue {
       config.get('redisHost'),
       config.get('redisPort')
     )
-    this.registerQueueEventHandlers(
-      this.queue,
-      this.enqueueJobAfterSuccess,
-      this.enqueueJobAfterFailure
-    )
+    this.registerQueueEventHandlers({
+      queue: this.queue,
+      jobSuccessCallback: this.enqueueJobAfterSuccess,
+      jobFailureCallback: this.enqueueJobAfterFailure
+    })
     this.registerQueueJobProcessor(this.queue)
 
     await this.startQueue(
@@ -80,11 +80,15 @@ class StateMonitoringQueue {
 
   /**
    * Registers event handlers for logging and job success/failure.
-   * @param {Object} queue the queue to register events for
-   * @param {Function<queue, successfulJob, jobResult>} jobSuccessCallback the function to call when a job succeeds
-   * @param {Function<queue, failedJob>} jobFailureCallback the function to call when a job fails
+   * @param {Object} params.queue the queue to register events for
+   * @param {Function<queue, successfulJob, jobResult>} params.jobSuccessCallback the function to call when a job succeeds
+   * @param {Function<queue, failedJob>} params.jobFailureCallback the function to call when a job fails
    */
-  registerQueueEventHandlers(queue, jobSuccessCallback, jobFailureCallback) {
+  registerQueueEventHandlers({
+    queue,
+    jobSuccessCallback,
+    jobFailureCallback
+  }) {
     // Add handlers for logging
     queue.on('global:waiting', (jobId) => {
       this.log(`Queue Job Waiting - ID ${jobId}`)

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/stateMonitoringUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/stateMonitoringUtils.js
@@ -25,16 +25,12 @@ const MIN_SECONDARY_USER_SYNC_SUCCESS_PERCENT =
  * @returns the ID of the newest user on Audius
  */
 const getLatestUserIdFromDiscovery = async (discoveryNodeEndpoint) => {
-  if (!discoveryNodeEndpoint) {
-    throw new Error('No discovery provider currently selected, exiting')
-  }
-
   // Will throw error on non-200 response
   let latestUserId = 0
   try {
     // Request all users that have this node as a replica (either primary or secondary)
     const resp = await Utils.asyncRetry({
-      logLabel: 'fetch all users with this node in replica',
+      logLabel: 'fetch the ID of the newest user on Audius',
       asyncFn: async () => {
         return axios({
           method: 'get',
@@ -73,11 +69,6 @@ const getNodeUsers = async (
   prevUserId = 0,
   maxUsers = GET_NODE_USERS_DEFAULT_PAGE_SIZE
 ) => {
-  // Fetch discovery node currently connected to libs as this can change
-  if (!discoveryNodeEndpoint) {
-    throw new Error('No discovery provider currently selected, exiting')
-  }
-
   // Will throw error on non-200 response
   let nodeUsers
   try {
@@ -86,7 +77,7 @@ const getNodeUsers = async (
     setTimeout(
       () =>
         cancelTokenSource.cancel(
-          `getNodeUsers took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out`
+          `getNodeUsers() took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out`
         ),
       GET_NODE_USERS_CANCEL_TOKEN_MS
     )
@@ -113,13 +104,13 @@ const getNodeUsers = async (
     nodeUsers = resp.data.data
   } catch (e) {
     if (axios.isCancel(e)) {
-      logger.error(`getNodeUsers request canceled: ${e.message}`)
+      logger.error(`getNodeUsers() request canceled: ${e.message}`)
     }
     throw new Error(
-      `getNodeUsers Error: ${e.toString()} - connected discovery node [${discoveryNodeEndpoint}]`
+      `getNodeUsers() Error: ${e.toString()} - connected discovery node [${discoveryNodeEndpoint}]`
     )
   } finally {
-    logger.info(`getNodeUsers nodeUsers.length: ${nodeUsers?.length}`)
+    logger.info(`getNodeUsers() nodeUsers.length: ${nodeUsers?.length}`)
   }
 
   // Ensure every object in response array contains all required fields
@@ -140,7 +131,7 @@ const getNodeUsers = async (
     )
     if (!allRequiredFieldsPresent) {
       throw new Error(
-        'getNodeUsers Error: Unexpected response format during getNodeUsers call'
+        'getNodeUsers() Error: Unexpected response format during getNodeUsers() call'
       )
     }
   }

--- a/creator-node/test/StateMonitoringQueue.test.js
+++ b/creator-node/test/StateMonitoringQueue.test.js
@@ -43,9 +43,9 @@ describe('test StateMonitoringQueue initialization and logging', function () {
     expect(stateMonitoringQueue.queue).to.exist.and.to.be.instanceOf(BullQueue)
     expect(stateMonitoringQueue.registerQueueEventHandlers).to.have.been
       .calledOnce
-    expect(
-      stateMonitoringQueue.registerQueueEventHandlers.getCall(0).args[0]
-    ).to.have.deep.property('name', STATE_MONITORING_QUEUE_NAME)
+    expect(stateMonitoringQueue.registerQueueEventHandlers.getCall(0).args[0])
+      .to.have.property('queue')
+      .that.has.deep.property('name', STATE_MONITORING_QUEUE_NAME)
   })
 
   it('kicks off an initial job when initting', async function () {

--- a/creator-node/test/peerSetManager.test.js
+++ b/creator-node/test/peerSetManager.test.js
@@ -59,6 +59,10 @@ describe('test peerSetManager -- determinePeerHealth', () => {
     })
   })
 
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
   it('should throw error if storage path vars are improper', () => {
     let verboseHealthCheckResp = {
       ...baseVerboseHealthCheckResp

--- a/creator-node/test/stateMonitoringUtils.test.js
+++ b/creator-node/test/stateMonitoringUtils.test.js
@@ -1,0 +1,866 @@
+/* eslint-disable no-unused-expressions */
+const nock = require('nock')
+const chai = require('chai')
+const sinon = require('sinon')
+const { expect } = chai
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+const proxyquire = require('proxyquire')
+const _ = require('lodash')
+const { CancelToken } = require('axios').default
+
+const config = require('../src/config')
+const { getApp } = require('./lib/app')
+const { getLibsMock } = require('./lib/libsMock')
+const Utils = require('../src/utils')
+const {
+  getLatestUserIdFromDiscovery,
+  buildReplicaSetNodesToUserWalletsMap,
+  computeUserSecondarySyncSuccessRatesMap
+} = require('../src/services/stateMachineManager/stateMonitoring/stateMonitoringUtils')
+const {
+  SyncType
+} = require('../src/services/stateMachineManager/stateMachineConstants')
+const SecondarySyncHealthTracker = require('../src/snapbackSM/secondarySyncHealthTracker')
+
+describe('test getLatestUserIdFromDiscovery', function () {
+  const DISCOVERY_NODE_ENDPOINT = 'https://discovery_endpoint.audius.co'
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('returns correct value from discovery endpoint param', async function () {
+    const latestUserId = 123
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/latest/user')
+      .reply(200, { data: latestUserId })
+
+    return expect(
+      getLatestUserIdFromDiscovery(DISCOVERY_NODE_ENDPOINT)
+    ).to.eventually.be.fulfilled.and.equal(latestUserId)
+  })
+
+  it('throws when the axios request fails', async function () {
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/latest/user')
+      .times(5) // asyncRetry retries 5 times
+      .reply(500)
+
+    return expect(getLatestUserIdFromDiscovery(DISCOVERY_NODE_ENDPOINT))
+      .to.eventually.be.rejectedWith(
+        `getLatestUserIdFromDiscovery() Error: Error: Request failed with status code 500 - connected discovery node: [${DISCOVERY_NODE_ENDPOINT}]`
+      )
+      .and.be.an.instanceOf(Error)
+  })
+})
+
+describe('test getNodeUsers', function () {
+  const DISCOVERY_NODE_ENDPOINT = 'https://discovery_endpoint.audius.co'
+  const CONTENT_NODE_ENDPOINT = 'https://content_node_endpoint.audius.co'
+  const DEFAULT_GET_NODE_USERS_TIMEOUT_MS = 100
+  const DEFAULT_GET_NODE_USERS_CANCEL_TOKEN_MS = 5_000
+  const DEFAULT_GET_NODE_USERS_DEFAULT_PAGE_SIZE = 10
+
+  const users = []
+  _.range(1, 20).forEach((userId) => {
+    users.push({
+      user_id: userId,
+      wallet: `wallet${userId}`,
+      primary: 'http://cn1.co',
+      secondary1: 'http://cn2.co',
+      secondary2: 'http://cn3.co',
+      primarySpID: 1,
+      secondary1SpID: 2,
+      secondary2SpID: 3
+    })
+  })
+
+  function mockGetNodeUsers({
+    axios,
+    GET_NODE_USERS_TIMEOUT_MS = DEFAULT_GET_NODE_USERS_TIMEOUT_MS,
+    GET_NODE_USERS_CANCEL_TOKEN_MS = DEFAULT_GET_NODE_USERS_CANCEL_TOKEN_MS
+  }) {
+    const { getNodeUsers } = proxyquire(
+      '../src/services/stateMachineManager/stateMonitoring/stateMonitoringUtils.js',
+      {
+        axios,
+        '../stateMachineConstants': {
+          GET_NODE_USERS_TIMEOUT_MS,
+          GET_NODE_USERS_CANCEL_TOKEN_MS,
+          GET_NODE_USERS_DEFAULT_PAGE_SIZE:
+            DEFAULT_GET_NODE_USERS_DEFAULT_PAGE_SIZE
+        }
+      }
+    )
+    return getNodeUsers
+  }
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('uses correct params for axios request when not given pagination params', async function () {
+    let method, baseURL, url, params, timeout, cancelToken, otherParams
+    const axiosStub = async (req) => {
+      ;({ method, baseURL, url, params, timeout, cancelToken, ...otherParams } =
+        req)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axiosStub.CancelToken = cancelTokenStub
+
+    const getNodeUsers = mockGetNodeUsers({ axios: axiosStub })
+    await getNodeUsers(DISCOVERY_NODE_ENDPOINT, CONTENT_NODE_ENDPOINT)
+
+    expect(method).to.equal('get')
+    expect(baseURL).to.equal(DISCOVERY_NODE_ENDPOINT)
+    expect(url).to.equal('v1/full/users/content_node/all')
+    expect(params).to.deep.equal({
+      creator_node_endpoint: CONTENT_NODE_ENDPOINT,
+      prev_user_id: 0,
+      max_users: DEFAULT_GET_NODE_USERS_DEFAULT_PAGE_SIZE
+    })
+    expect(timeout).to.equal(DEFAULT_GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.not.have.been.called
+    expect(otherParams).to.be.empty
+  })
+
+  it('uses correct params for axios request when given pagination params', async function () {
+    const prevUserId = 1
+    const maxUsers = 25
+
+    let method, baseURL, url, params, timeout, cancelToken, otherParams
+    const axiosStub = async (req) => {
+      ;({ method, baseURL, url, params, timeout, cancelToken, ...otherParams } =
+        req)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axiosStub.CancelToken = cancelTokenStub
+
+    const getNodeUsers = mockGetNodeUsers({ axios: axiosStub })
+    await getNodeUsers(
+      DISCOVERY_NODE_ENDPOINT,
+      CONTENT_NODE_ENDPOINT,
+      prevUserId,
+      maxUsers
+    )
+
+    expect(method).to.equal('get')
+    expect(baseURL).to.equal(DISCOVERY_NODE_ENDPOINT)
+    expect(url).to.equal('v1/full/users/content_node/all')
+    expect(params).to.deep.equal({
+      creator_node_endpoint: CONTENT_NODE_ENDPOINT,
+      prev_user_id: prevUserId,
+      max_users: maxUsers
+    })
+    expect(timeout).to.equal(DEFAULT_GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.not.have.been.called
+    expect(otherParams).to.be.empty
+  })
+
+  it('throws when one or more users is missing a required field', async function () {
+    const axiosStub = async (_) => {
+      return {
+        data: {
+          data: [
+            ...users,
+            {
+              user_id: 'userId with missing secondary2SpID',
+              wallet: `wallet`,
+              primary: 'http://cn1.co',
+              secondary1: 'http://cn2.co',
+              secondary2: 'http://cn3.co',
+              primarySpID: 1,
+              secondary1SpID: 2
+            }
+          ]
+        }
+      }
+    }
+    const getNodeUsers = mockGetNodeUsers({ axios: axiosStub })
+
+    return expect(getNodeUsers(DISCOVERY_NODE_ENDPOINT, CONTENT_NODE_ENDPOINT))
+      .to.eventually.be.rejectedWith(
+        'getNodeUsers() Error: Unexpected response format during getNodeUsers() call'
+      )
+      .and.be.an.instanceOf(Error)
+  })
+
+  it('uses cancel token to cancel axios request after delay (using stubbed axios)', async function () {
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 50
+
+    let timeout, cancelToken
+    const axiosStub = async (req) => {
+      ;({ timeout, cancelToken } = req)
+
+      // Wait long enough for the cancel token to cancel the axios request
+      await Utils.timeout(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+
+      return { data: { data: users } }
+    }
+    const cancelTokenSourceMock = sinon.mock(CancelToken.source())
+    const cancelTokenCancelFunc = sinon.stub()
+    cancelTokenSourceMock.cancel = cancelTokenCancelFunc
+    const cancelTokenStub = { source: () => cancelTokenSourceMock }
+    axiosStub.CancelToken = cancelTokenStub
+    const getNodeUsers = mockGetNodeUsers({
+      axios: axiosStub,
+      GET_NODE_USERS_CANCEL_TOKEN_MS
+    })
+
+    await getNodeUsers(DISCOVERY_NODE_ENDPOINT, CONTENT_NODE_ENDPOINT)
+
+    expect(timeout).to.equal(DEFAULT_GET_NODE_USERS_TIMEOUT_MS)
+    expect(cancelToken).to.equal(cancelTokenSourceMock.token)
+    expect(cancelTokenCancelFunc).to.have.been.calledOnceWithExactly(
+      `getNodeUsers() took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out`
+    )
+  })
+
+  it('uses cancel token to cancel axios request after delay (using real axios with delayConnection)', async function () {
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 50
+
+    const realAxios = require('axios')
+    const getNodeUsers = mockGetNodeUsers({
+      axios: realAxios,
+      GET_NODE_USERS_CANCEL_TOKEN_MS
+    })
+
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/v1/full/users/content_node/all')
+      .query({
+        creator_node_endpoint: CONTENT_NODE_ENDPOINT,
+        prev_user_id: 0,
+        max_users: DEFAULT_GET_NODE_USERS_DEFAULT_PAGE_SIZE
+      })
+      .delay(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+      .times(5) // asyncRetry retries 5 times
+      .reply(200, { data: users })
+
+    return expect(getNodeUsers(DISCOVERY_NODE_ENDPOINT, CONTENT_NODE_ENDPOINT))
+      .to.eventually.be.rejectedWith(
+        `getNodeUsers() Error: Cancel: getNodeUsers() took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out - connected discovery node [${DISCOVERY_NODE_ENDPOINT}]`
+      )
+      .and.be.an.instanceOf(Error)
+  })
+
+  it('uses cancel token to cancel axios request after delay (using real axios with delayBody)', async function () {
+    const GET_NODE_USERS_CANCEL_TOKEN_MS = 50
+
+    const realAxios = require('axios')
+    const getNodeUsers = mockGetNodeUsers({
+      axios: realAxios,
+      GET_NODE_USERS_CANCEL_TOKEN_MS
+    })
+
+    nock(DISCOVERY_NODE_ENDPOINT)
+      .get('/v1/full/users/content_node/all')
+      .query({
+        creator_node_endpoint: CONTENT_NODE_ENDPOINT,
+        prev_user_id: 0,
+        max_users: DEFAULT_GET_NODE_USERS_DEFAULT_PAGE_SIZE
+      })
+      .delayBody(GET_NODE_USERS_CANCEL_TOKEN_MS + 1)
+      .times(5) // asyncRetry retries 5 times
+      .reply(200, { data: users })
+
+    return expect(getNodeUsers(DISCOVERY_NODE_ENDPOINT, CONTENT_NODE_ENDPOINT))
+      .to.eventually.be.rejectedWith(
+        `getNodeUsers() Error: Cancel: getNodeUsers() took more than ${GET_NODE_USERS_CANCEL_TOKEN_MS}ms and did not time out - connected discovery node [${DISCOVERY_NODE_ENDPOINT}]`
+      )
+      .and.be.an.instanceOf(Error)
+  })
+})
+
+describe('test buildReplicaSetNodesToUserWalletsMap', function () {
+  it('', function () {
+    const nodeUsersInput = [
+      {
+        user_id: '1',
+        wallet: 'wallet1',
+        primary: 'http://cn1.audius.co',
+        secondary1: 'http://cn2.audius.co',
+        secondary2: 'http://cn3.audius.co'
+      },
+      {
+        user_id: '2',
+        wallet: 'wallet2',
+        primary: 'http://cn2.audius.co',
+        secondary1: 'http://cn3.audius.co',
+        secondary2: 'http://cn4.audius.co'
+      },
+      {
+        user_id: '3',
+        wallet: 'wallet3',
+        primary: 'http://cn3.audius.co',
+        secondary1: 'http://cn4.audius.co',
+        secondary2: 'http://cn5.audius.co'
+      },
+      {
+        user_id: '4',
+        wallet: 'wallet4',
+        primary: 'http://cn3.audius.co',
+        secondary1: 'http://cn2.audius.co',
+        secondary2: 'http://cn1.audius.co'
+      }
+    ]
+    const expectedReplicaSetNodesToUserWalletsMapOutput = {
+      'http://cn1.audius.co': ['wallet1', 'wallet4'],
+      'http://cn2.audius.co': ['wallet1', 'wallet2', 'wallet4'],
+      'http://cn3.audius.co': ['wallet1', 'wallet2', 'wallet3', 'wallet4'],
+      'http://cn4.audius.co': ['wallet2', 'wallet3'],
+      'http://cn5.audius.co': ['wallet3']
+    }
+    expect(buildReplicaSetNodesToUserWalletsMap(nodeUsersInput)).to.deep.equal(
+      expectedReplicaSetNodesToUserWalletsMapOutput
+    )
+  })
+})
+
+describe('test computeUserSecondarySyncSuccessRatesMap', function () {
+  let server
+  beforeEach(async function () {
+    const appInfo = await getApp(getLibsMock())
+    server = appInfo.server
+    const app = appInfo.app
+    await app.get('redisClient').flushdb()
+  })
+
+  afterEach(async function () {
+    await server.close()
+  })
+
+  it('returns expected counts and percentages after recording successes and failures', async function () {
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      },
+      {
+        user_id: 2,
+        wallet: 'wallet2',
+        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordFailure(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordFailure(
+      [nodeUsers[0].secondary2],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+
+    const expectedUserSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        [nodeUsers[0].secondary1]: {
+          successRate: 0.75,
+          successCount: 3,
+          failureCount: 1
+        },
+        [nodeUsers[0].secondary2]: {
+          successRate: 0,
+          successCount: 0,
+          failureCount: 1
+        }
+      },
+      [nodeUsers[1].wallet]: {
+        [nodeUsers[1].secondary1]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        [nodeUsers[1].secondary2]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+
+    const userSecondarySyncMetricsMap =
+      await computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+
+    expect(userSecondarySyncMetricsMap).to.deep.equal(
+      expectedUserSecondarySyncMetricsMap
+    )
+  })
+})
+
+describe('test aggregateReconfigAndPotentialSyncOps', function () {
+  let server
+
+  beforeEach(async function () {
+    const appInfo = await getApp(getLibsMock())
+    server = appInfo.server
+    const app = appInfo.app
+    await app.get('redisClient').flushdb()
+    config.set('spID', 1)
+  })
+
+  afterEach(async function () {
+    await server.close()
+  })
+
+  function getAggregateReconfigAndPotentialSyncOps(config) {
+    const { aggregateReconfigAndPotentialSyncOps } = proxyquire(
+      '../src/services/stateMachineManager/stateMonitoring/stateMonitoringUtils.js',
+      {
+        '../../../config': config
+      }
+    )
+    return aggregateReconfigAndPotentialSyncOps
+  }
+
+  it('if the self node is the secondary and a primary spId is different from what is on chain, issue reconfig', async function () {
+    // Mock that one of the nodes got reregistered from spId 3 to spId 4
+    const endpointToSPIdMap = {
+      'http://cnOriginallySpId3ReregisteredAsSpId4.co': 4,
+      'http://cnWithSpId2.co': 2,
+      'http://cnWithSpId3.co': 3
+    }
+    const thisContentNodeEndpoint = 'http://cnWithSpId2.co'
+
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://cnWithSpId3.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.keys(['http://cnOriginallySpId3ReregisteredAsSpId4.co'])
+    expect(potentialSyncRequests).to.have.lengthOf(0)
+  })
+
+  it('if the self node is the primary and a secondary spId is different from what is on chain, issue reconfig', async function () {
+    // Mock that one of the nodes got reregistered from spId 3 to spId 4
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 1,
+      'http://cnWithSpId2.co': 2,
+      'http://cnOriginallySpId3ReregisteredAsSpId4.co': 4
+    }
+
+    const thisContentNodeEndpoint = 'http://some_healthy_primary.co'
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://cnOriginallySpId3ReregisteredAsSpId4.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.keys(['http://cnOriginallySpId3ReregisteredAsSpId4.co'])
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[0]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId2.co')
+  })
+
+  it('if the self node (primary) is the same as the SP with a different spId, do not issue reconfig', async function () {
+    // Mock that one of the nodes got reregistered from spId 3 to spId 4
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 4,
+      'http://cnWithSpId2.co': 2,
+      'http://cnWithSpId3.co': 3
+    }
+
+    const thisContentNodeEndpoint = 'http://some_healthy_primary.co'
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://cnWithSpId3.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    // Make sure that the CN with the different spId gets put into `requiredUpdateReplicaSetOps`
+    expect(requiredUpdateReplicaSetOps).to.have.lengthOf(0)
+    expect(potentialSyncRequests).to.have.lengthOf(2)
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[0]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId2.co')
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[1]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId3.co')
+  })
+
+  it('if the self node (secondary) is the same as the SP with a different spId, do not issue reconfig', async function () {
+    // Mock that one of the nodes got reregistered from spId 3 to spId 4
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 1,
+      'http://cnWithSpId2.co': 2,
+      'http://cnOriginallySpId3ReregisteredAsSpId4.co': 4
+    }
+
+    const thisContentNodeEndpoint =
+      'http://cnOriginallySpId3ReregisteredAsSpId4.co'
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://cnOriginallySpId3ReregisteredAsSpId4.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    expect(requiredUpdateReplicaSetOps).to.have.lengthOf(0)
+    expect(potentialSyncRequests).to.have.lengthOf(0)
+  })
+
+  it('if any replica set node is not in the map, issue reconfig', async function () {
+    // Mock the deregistered node to not have any spId
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 1,
+      'http://cnWithSpId2.co': 2
+    }
+
+    const thisContentNodeEndpoint = 'http://some_healthy_primary.co'
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://deregisteredCN.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://deregisteredCN.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.keys(['http://deregisteredCN.co'])
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[0]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId2.co')
+  })
+
+  it('if the self node (primary) and 1 secondary are healthy but not the other secondary, issue reconfig for the unhealthy secondary', async function () {
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 1,
+      'http://cnWithSpId2.co': 2,
+      'http://unhealthyCnWithSpId3.co': 3
+    }
+
+    const thisContentNodeEndpoint = 'http://some_healthy_primary.co'
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://unhealthyCnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+    const unhealthyPeers = new Set(['http://unhealthyCnWithSpId3.co'])
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        'http://unhealthyCnWithSpId3.co': {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    // Make sure that the unhealthy secondary put into `requiredUpdateReplicaSetOps`
+    expect(requiredUpdateReplicaSetOps).to.have.lengthOf(1)
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.property('size', 1)
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.keys(['http://unhealthyCnWithSpId3.co'])
+    expect(potentialSyncRequests).to.have.lengthOf(1)
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[0]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId2.co')
+  })
+
+  it('if the self node (primary) and and secondaries are healthy but sync success rate is low, issue reconfig', async function () {
+    config.set('minimumFailedSyncRequestsBeforeReconfig', 5)
+    config.set('minimumSecondaryUserSyncSuccessPercent', 25)
+    const endpointToSPIdMap = {
+      'http://some_healthy_primary.co': 1,
+      'http://cnWithSpId2.co': 2,
+      'http://cnWithSpId3.co': 3
+    }
+
+    const thisContentNodeEndpoint = 'http://some_healthy_primary.co'
+
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://some_healthy_primary.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+
+    const unhealthyPeers = new Set()
+    const userSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        'http://cnWithSpId2.co': {
+          successRate: 1,
+          successCount: 1,
+          failureCount: 0
+        },
+        'http://cnWithSpId3.co': {
+          successRate: 0.1,
+          successCount: 1,
+          failureCount: 9
+        }
+      }
+    }
+    const aggregateReconfigAndPotentialSyncOps =
+      getAggregateReconfigAndPotentialSyncOps(config)
+    const { requiredUpdateReplicaSetOps, potentialSyncRequests } =
+      await aggregateReconfigAndPotentialSyncOps(
+        nodeUsers,
+        unhealthyPeers,
+        userSecondarySyncMetricsMap,
+        endpointToSPIdMap,
+        thisContentNodeEndpoint
+      )
+
+    // Make sure that the CN with low sync success put into `requiredUpdateReplicaSetOps`
+    expect(requiredUpdateReplicaSetOps).to.have.lengthOf(1)
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.property('size', 1)
+    expect(requiredUpdateReplicaSetOps)
+      .to.have.nested.property('[0]')
+      .that.has.property('unhealthyReplicas')
+      .that.has.keys(['http://cnWithSpId3.co'])
+    expect(potentialSyncRequests).to.have.lengthOf(1)
+    expect(potentialSyncRequests)
+      .to.have.nested.property('[0]')
+      .that.has.property('endpoint')
+      .that.equals('http://cnWithSpId2.co')
+  })
+})


### PR DESCRIPTION
### Description

- Add SyncType to refactored constants
- Use named params for registering queue events
- Remove check to make getNodeUsers() and getLatestUserIdFromDiscovery() throw when no discovery node is given (this check is a remnant from when the DN was a class variable, but it's now a param that's passed. The axios call will fail anyway if it's empty)
- Add ~94% line coverage for stateMonitoringUtils.js:
  - `getLatestUserIdFromDiscovery()` – new tests
  - `getNodeUsers()` – same tests cleaned up and adapted to refactored context
  - `buildReplicaSetNodesToUserWalletsMap()` – new tests
  - `computeUserSecondarySyncSuccessRatesMap()` – same tests adapted to refactored context and changed to use chai instead of built-in assert
  - `aggregateReconfigAndPotentialSyncOps()` – same tests adapted to refactored context and changed to use chai instead of built-in assert

### Tests
<img width="838" alt="Screen Shot 2022-05-26 at 8 25 56 AM" src="https://user-images.githubusercontent.com/4657956/170520506-bffb419d-04a9-41b0-9ca2-ec6bd5de1fae.png">
<img width="824" alt="Screen Shot 2022-05-26 at 8 26 28 AM" src="https://user-images.githubusercontent.com/4657956/170520597-348f365a-fdb0-4e7f-9658-a0c63a3acd36.png">

### How will this change be monitored? Are there sufficient logs?
Keep an eye out in the logs for getNodeUsers and getLatestUserIdFromDiscovery failing with an empty discovery node (shouldn't happen):
- `getLatestUserIdFromDiscovery() Error:`
- `getNodeUsers() Error:`