### PR TITLE
Add check if download is none

### DIFF
--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -209,7 +209,8 @@ def get_tracks(args: GetTrackArgs):
         for track in tracks:
             if track["user"][0]["is_deactivated"] or track["is_delete"]:
                 track["track_segments"] = []
-                track["download"]["cid"] = None
+                if track["download"] is not None:
+                    track["download"]["cid"] = None
 
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 


### PR DESCRIPTION
### Description
Update the get tracks response to check for download dict before updating
validate that the query for a deleted track does not 500
This happened because legacy track records have the download column set to none instead of the default object. 

Not sure if I was supposed to keep the download field as `None` (which it was before) or set to the default json object

### Tests
Ran the system locally and validated the response did not 500

Fixes: PLAT-150