### PR TITLE
[CON-178] Add eth web3 get content node infos call

### DIFF
--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -2,7 +2,7 @@ import logging
 
 from src.models import User
 from src.tasks.celery_app import celery
-from src.utils.eth_contracts_helpers import fetch_all_registered_content_nodes
+from src.utils.eth_contracts_helpers import fetch_all_registered_content_node_endpoints
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def retrieve_peers_from_eth_contracts(self):
     eth_web3 = update_network_peers.eth_web3
     redis = update_network_peers.redis
     eth_abi_values = update_network_peers.eth_abi_values
-    return fetch_all_registered_content_nodes(
+    return fetch_all_registered_content_node_endpoints(
         eth_web3, shared_config, redis, eth_abi_values
     )
 

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -10,8 +10,8 @@ from src.queries.skipped_transactions import add_node_level_skipped_transaction
 from src.tasks.users import invalidate_old_user, lookup_user_record
 from src.utils import helpers
 from src.utils.eth_contracts_helpers import (
-    content_node_service_type,
-    sp_factory_registry_key,
+    CONTENT_NODE_SERVICE_TYPE,
+    SP_FACTORY_REGISTRY_KEY,
 )
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
@@ -280,7 +280,7 @@ def get_endpoint_from_id(update_task, sp_factory_inst, sp_id):
             sp_factory_inst = get_sp_factory_inst(update_task)
 
         cn_endpoint_info = sp_factory_inst.functions.getServiceEndpointInfo(
-            content_node_service_type, sp_id
+            CONTENT_NODE_SERVICE_TYPE, sp_id
         ).call()
         logger.info(
             f"index.py | user_replica_set.py | spID={sp_id} fetched {cn_endpoint_info}"
@@ -301,7 +301,7 @@ def get_sp_factory_inst(update_task):
         address=eth_registry_address, abi=get_eth_abi_values()["Registry"]["abi"]
     )
     sp_factory_address = eth_registry_instance.functions.getContract(
-        sp_factory_registry_key
+        SP_FACTORY_REGISTRY_KEY
     ).call()
     sp_factory_inst = eth_web3.eth.contract(
         address=sp_factory_address,

--- a/discovery-provider/src/utils/cid_metadata_client.py
+++ b/discovery-provider/src/utils/cid_metadata_client.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import aiohttp
 from src.tasks.metadata import track_metadata_format, user_metadata_format
-from src.utils.eth_contracts_helpers import fetch_all_registered_content_nodes
+from src.utils.eth_contracts_helpers import fetch_all_registered_content_node_endpoints
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class CIDMetadataClient:
         # in the celery worker
         if eth_web3 and shared_config and redis and eth_abi_values:
             self._cnode_endpoints = list(
-                fetch_all_registered_content_nodes(
+                fetch_all_registered_content_node_endpoints(
                     eth_web3, shared_config, redis, eth_abi_values
                 )
             )


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

This PR 
- adds a function called `fetch_all_registered_content_node_info()` that fetches registered Content Node info on the chain.
- refactors the fn `fetch_all_registered_content_nodes(0` to `fetch_all_registered_content_node_endpoints()` to more accurately reflect the return response
- slight refactoring on hard-coded instances and eth web3 values so that the sp factory instance can be initialized

This PR is a subtask to CON-112

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

🌚  no direct tests... we can add if we think we want tests for this

### How will this change be monitored? Are there sufficient logs?

This will be consumed in CON-112, so the logs will be monitored then. Other changes include general refactors and no changes to functionality. So, however the fns were monitored prior will apply following this PR merge.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->