### PR TITLE
Add coverage for CNodeHealthManager

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js
@@ -23,12 +23,12 @@ class StateMonitoringQueue {
       config.get('redisHost'),
       config.get('redisPort')
     )
-    this.registerQueueEventHandlers({
+    this.registerQueueEventHandlersAndJobProcessor({
       queue: this.queue,
       jobSuccessCallback: this.enqueueJobAfterSuccess,
-      jobFailureCallback: this.enqueueJobAfterFailure
+      jobFailureCallback: this.enqueueJobAfterFailure,
+      processJob: this.processJob
     })
-    this.registerQueueJobProcessor(this.queue)
 
     await this.startQueue(
       this.queue,
@@ -83,11 +83,13 @@ class StateMonitoringQueue {
    * @param {Object} params.queue the queue to register events for
    * @param {Function<queue, successfulJob, jobResult>} params.jobSuccessCallback the function to call when a job succeeds
    * @param {Function<queue, failedJob>} params.jobFailureCallback the function to call when a job fails
+   * @param {Function<job>} params.processJob the function to call when processing a job from the queue
    */
-  registerQueueEventHandlers({
+  registerQueueEventHandlersAndJobProcessor({
     queue,
     jobSuccessCallback,
-    jobFailureCallback
+    jobFailureCallback,
+    processJob
   }) {
     // Add handlers for logging
     queue.on('global:waiting', (jobId) => {
@@ -127,6 +129,9 @@ class StateMonitoringQueue {
       )
       jobFailureCallback(queue, job)
     })
+
+    // Register the logic that gets executed to process each new job from the queue
+    queue.process(1 /** concurrency */, processJob)
   }
 
   /**
@@ -173,55 +178,47 @@ class StateMonitoringQueue {
     })
   }
 
-  /**
-   * Registers the logic that gets executed to process each new job from the queue.
-   * @param {Object} queue the StateMonitoringQueue to consume jobs from
-   */
-  registerQueueJobProcessor(queue) {
-    // Initialize queue job processor (aka consumer)
-    queue.process(1 /** concurrency */, async (job) => {
-      const {
-        id: jobId,
-        data: {
-          lastProcessedUserId,
-          discoveryNodeEndpoint,
-          moduloBase,
-          currentModuloSlice
-        }
-      } = job
-
-      try {
-        this.log(`New job details: jobId=${jobId}, job=${JSON.stringify(job)}`)
-      } catch (e) {
-        this.logError(`Failed to log details for jobId=${jobId}: ${e}`)
-      }
-
-      // Default results of this job will be passed to the next job, so default to failure
-      let result = {
+  async processJob(job) {
+    const {
+      id: jobId,
+      data: {
         lastProcessedUserId,
-        jobFailed: true,
+        discoveryNodeEndpoint,
         moduloBase,
         currentModuloSlice
       }
-      try {
-        // TODO: Wire up metrics
-        // await redis.set('stateMachineQueueLatestJobStart', Date.now())
-        result = await processStateMonitoringJob(
-          jobId,
-          lastProcessedUserId,
-          discoveryNodeEndpoint,
-          moduloBase,
-          currentModuloSlice
-        )
-        // TODO: Wire up metrics
-        // await redis.set('stateMachineQueueLatestJobSuccess', Date.now())
-      } catch (e) {
-        this.logError(`Error processing jobId ${jobId}: ${e}`)
-        console.log(e.stack)
-      }
+    } = job
 
-      return result
-    })
+    try {
+      this.log(`New job details: jobId=${jobId}, job=${JSON.stringify(job)}`)
+    } catch (e) {
+      this.logError(`Failed to log details for jobId=${jobId}: ${e}`)
+    }
+
+    // Default results of this job will be passed to the next job, so default to failure
+    let result = {
+      lastProcessedUserId,
+      jobFailed: true,
+      moduloBase,
+      currentModuloSlice
+    }
+    try {
+      // TODO: Wire up metrics
+      // await redis.set('stateMachineQueueLatestJobStart', Date.now())
+      result = await processStateMonitoringJob(
+        jobId,
+        lastProcessedUserId,
+        discoveryNodeEndpoint,
+        moduloBase,
+        currentModuloSlice
+      )
+      // TODO: Wire up metrics
+      // await redis.set('stateMachineQueueLatestJobSuccess', Date.now())
+    } catch (e) {
+      this.logError(`Error processing jobId ${jobId}: ${e}`)
+    }
+
+    return result
   }
 
   /**

--- a/creator-node/test/CNodeHealthManager.test.js
+++ b/creator-node/test/CNodeHealthManager.test.js
@@ -1,0 +1,478 @@
+/* eslint-disable no-unused-expressions */
+const nock = require('nock')
+const chai = require('chai')
+const sinon = require('sinon')
+const { expect } = chai
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+const proxyquire = require('proxyquire')
+
+const CNodeHealthManager = require('../src/services/stateMachineManager/CNodeHealthManager')
+const config = require('../src/config')
+const Utils = require('../src/utils')
+
+describe('test CNodeHealthManager -- getUnhealthyPeers()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  const healthyCn1 = 'http://healthy_cn1.co'
+  const healthyCn2 = 'http://healthy_cn2.co'
+  const unhealthyCn3 = 'http://unhealthy_cn3.co'
+  const unhealthyCn4 = 'http://unhealthy_cn4.co'
+  const healthyNodes = [healthyCn1, healthyCn2]
+  const unhealthyNodes = [unhealthyCn3, unhealthyCn4]
+  const users = [
+    {
+      user_id: 1,
+      wallet: 'wallet1',
+      primary: healthyCn1,
+      secondary1: unhealthyCn3,
+      secondary2: unhealthyCn3
+    },
+    {
+      user_id: 2,
+      wallet: 'wallet2',
+      primary: unhealthyCn4,
+      secondary1: healthyCn2,
+      secondary2: healthyCn1
+    }
+  ]
+  const thisContentNodeEndpoint = 'http://healthy_cn1.co'
+
+  it('returns all unhealthy nodes with default performSimpleCheck', async function () {
+    // Stub functions that getUnhealthyPeers() will call
+    sandbox
+      .stub(CNodeHealthManager, '_computeContentNodePeerSet')
+      .returns(new Set([...healthyNodes, ...unhealthyNodes]))
+    const isNodeHealthyStub = sandbox.stub(CNodeHealthManager, 'isNodeHealthy')
+    isNodeHealthyStub.withArgs(sinon.match.in(healthyNodes)).resolves(true)
+    isNodeHealthyStub.withArgs(sinon.match.in(unhealthyNodes)).resolves(false)
+
+    // Verify that the correct unhealthy peers are returned
+    return expect(
+      CNodeHealthManager.getUnhealthyPeers(users, thisContentNodeEndpoint)
+    ).to.eventually.be.fulfilled.and.deep.equal(new Set(unhealthyNodes))
+  })
+
+  for (const performSimpleCheck of [true, false]) {
+    it(`returns all unhealthy nodes when performSimpleCheck=${performSimpleCheck}`, async function () {
+      // Stub functions that getUnhealthyPeers() will call
+      sandbox
+        .stub(CNodeHealthManager, '_computeContentNodePeerSet')
+        .returns(new Set([...healthyNodes, ...unhealthyNodes]))
+      const isNodeHealthyStub = sandbox.stub(
+        CNodeHealthManager,
+        'isNodeHealthy'
+      )
+      isNodeHealthyStub.withArgs(sinon.match.in(healthyNodes)).resolves(true)
+      isNodeHealthyStub.withArgs(sinon.match.in(unhealthyNodes)).resolves(false)
+
+      // Verify that the correct unhealthy peers are returned
+      return expect(
+        CNodeHealthManager.getUnhealthyPeers(
+          users,
+          thisContentNodeEndpoint,
+          performSimpleCheck
+        )
+      ).to.eventually.be.fulfilled.and.deep.equal(new Set(unhealthyNodes))
+    })
+  }
+})
+
+describe('test CNodeHealthManager -- isNodeHealthy()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('returns true when health check passes with performSimpleCheck=true', async function () {
+    // Stub functions that isNodeHealthy() will call
+    const node = 'http://some_content_node.co'
+    const verboseHealthCheckResp = { healthy: true }
+    const queryVerboseHealthCheckStub = sandbox
+      .stub(CNodeHealthManager, 'queryVerboseHealthCheck')
+      .resolves(verboseHealthCheckResp)
+    const determinePeerHealthStub = sandbox.stub(
+      CNodeHealthManager,
+      'determinePeerHealth'
+    )
+    const logErrorStub = sandbox.stub(CNodeHealthManager, 'logError')
+
+    // Verify that only the simple check was performed and returned healthy
+    const isHealthy = await CNodeHealthManager.isNodeHealthy(node, true)
+    expect(isHealthy).to.be.true
+    expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(node)
+    expect(determinePeerHealthStub).to.not.have.been.called
+    expect(logErrorStub).to.not.have.been.called
+  })
+
+  for (const performSimpleCheck of [true, false]) {
+    it(`returns false when health check fails with performSimpleCheck=${performSimpleCheck}`, async function () {
+      // Stub functions that isNodeHealthy() will call
+      const node = 'http://some_content_node.co'
+      const error = new Error('test error')
+      const queryVerboseHealthCheckStub = sandbox
+        .stub(CNodeHealthManager, 'queryVerboseHealthCheck')
+        .rejects(error)
+      const determinePeerHealthStub = sandbox.stub(
+        CNodeHealthManager,
+        'determinePeerHealth'
+      )
+      const logErrorStub = sandbox.stub(CNodeHealthManager, 'logError')
+
+      // Verify that only the simple check was performed and returned healthy
+      const isHealthy = await CNodeHealthManager.isNodeHealthy(
+        node,
+        performSimpleCheck
+      )
+      expect(isHealthy).to.be.false
+      expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(
+        node
+      )
+      expect(determinePeerHealthStub).to.not.have.been.called
+      expect(logErrorStub).to.have.been.called.calledOnceWithExactly(
+        `isNodeHealthy() peer=${node} is unhealthy: ${error.toString()}`
+      )
+    })
+  }
+
+  it('returns false when determinePeerHealth throws with performSimpleCheck=false', async function () {
+    // Stub functions that isNodeHealthy() will call
+    const node = 'http://some_content_node.co'
+    const determinePeerHealthError = new Error('test determinePeerHealthError')
+    const verboseHealthCheckResp = { healthy: false }
+    const queryVerboseHealthCheckStub = sandbox
+      .stub(CNodeHealthManager, 'queryVerboseHealthCheck')
+      .resolves(verboseHealthCheckResp)
+    const determinePeerHealthStub = sandbox
+      .stub(CNodeHealthManager, 'determinePeerHealth')
+      .throws(determinePeerHealthError)
+    const logErrorStub = sandbox.stub(CNodeHealthManager, 'logError')
+
+    // Verify that only the simple check was performed and returned healthy
+    const isHealthy = await CNodeHealthManager.isNodeHealthy(node, false)
+    expect(isHealthy).to.be.false
+    expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(node)
+    expect(determinePeerHealthStub).to.have.been.calledOnceWithExactly(
+      verboseHealthCheckResp
+    )
+    expect(logErrorStub).to.have.been.called.calledOnceWithExactly(
+      `isNodeHealthy() peer=${node} is unhealthy: ${determinePeerHealthError.toString()}`
+    )
+  })
+
+  it("returns true when determinePeerHealth doesn't throw with performSimpleCheck=false", async function () {
+    // Stub functions that isNodeHealthy() will call
+    const node = 'http://some_content_node.co'
+    const verboseHealthCheckResp = { healthy: true }
+    const queryVerboseHealthCheckStub = sandbox
+      .stub(CNodeHealthManager, 'queryVerboseHealthCheck')
+      .resolves(verboseHealthCheckResp)
+    const determinePeerHealthStub = sandbox.stub(
+      CNodeHealthManager,
+      'determinePeerHealth'
+    )
+    const logErrorStub = sandbox.stub(CNodeHealthManager, 'logError')
+
+    // Verify that only the simple check was performed and returned healthy
+    const isHealthy = await CNodeHealthManager.isNodeHealthy(node, false)
+    expect(isHealthy).to.be.true
+    expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(node)
+    expect(determinePeerHealthStub).to.have.been.calledOnceWithExactly(
+      verboseHealthCheckResp
+    )
+    expect(logErrorStub).to.not.have.been.called.called
+  })
+
+  it("returns true when determinePeerHealth doesn't throw with default performSimpleCheck", async function () {
+    // Stub functions that isNodeHealthy() will call
+    const node = 'http://some_content_node.co'
+    const verboseHealthCheckResp = { healthy: true }
+    const queryVerboseHealthCheckStub = sandbox
+      .stub(CNodeHealthManager, 'queryVerboseHealthCheck')
+      .resolves(verboseHealthCheckResp)
+    const determinePeerHealthStub = sandbox.stub(
+      CNodeHealthManager,
+      'determinePeerHealth'
+    )
+    const logErrorStub = sandbox.stub(CNodeHealthManager, 'logError')
+
+    // Verify that only the simple check was performed and returned healthy
+    const isHealthy = await CNodeHealthManager.isNodeHealthy(node)
+    expect(isHealthy).to.be.true
+    expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(node)
+    expect(determinePeerHealthStub).to.have.been.calledOnceWithExactly(
+      verboseHealthCheckResp
+    )
+    expect(logErrorStub).to.not.have.been.called.called
+  })
+})
+
+describe('test CNodeHealthManager -- queryVerboseHealthCheck()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    nock.disableNetConnect()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+
+  it('returns successful response', async function () {
+    const endpoint = 'http://healthy_cn.co'
+    const verboseHealthResp = {
+      healthy: 'true',
+      verboseData: 'data'
+    }
+    nock(endpoint)
+      .get('/health_check/verbose')
+      .reply(200, { data: verboseHealthResp })
+
+    await CNodeHealthManager.queryVerboseHealthCheck(endpoint)
+    expect(nock.isDone()).to.be.true
+  })
+})
+
+describe('test CNodeHealthManager -- determinePeerHealth()', function () {
+  // Set config vars for health thresholds
+  const minimumStoragePathSize = 100
+  const minimumMemoryAvailable = 100
+  const maxFileDescriptorsAllocatedPercentage = 50
+  const minimumDailySyncCount = 3
+  const minimumRollingSyncCount = 5
+  const minimumSuccessfulSyncCountPercentage = 50
+  config.set('minimumStoragePathSize', minimumStoragePathSize)
+  config.set('minimumMemoryAvailable', minimumMemoryAvailable)
+  config.set(
+    'maxFileDescriptorsAllocatedPercentage',
+    maxFileDescriptorsAllocatedPercentage
+  )
+  config.set('minimumDailySyncCount', minimumDailySyncCount)
+  config.set('minimumRollingSyncCount', minimumRollingSyncCount)
+  config.set(
+    'minimumSuccessfulSyncCountPercentage',
+    minimumSuccessfulSyncCountPercentage
+  )
+
+  function determinePeerHealth(verboseHealthCheckResp) {
+    const CNodeHealthManagerMock = proxyquire(
+      '../src/services/stateMachineManager/CNodeHealthManager.js',
+      {
+        './../../config': config
+      }
+    )
+    CNodeHealthManagerMock.determinePeerHealth(verboseHealthCheckResp)
+  }
+
+  it("doesn't throw if all data is healthy (empty data counts as healthy)", function () {
+    expect(() => determinePeerHealth({})).to.not.throw()
+  })
+
+  it('throws when low on storage space', function () {
+    const storagePathSize = 1000
+    const storagePathUsed = 990
+    const verboseHealthCheckResp = {
+      storagePathSize,
+      storagePathUsed
+    }
+    expect(() => determinePeerHealth(verboseHealthCheckResp)).to.throw(
+      `Almost out of storage=${
+        storagePathSize - storagePathUsed
+      }bytes remaining. Minimum storage required=${minimumStoragePathSize}bytes`
+    )
+  })
+
+  it('throws when low on memory', function () {
+    const usedMemory = 90
+    const totalMemory = 100
+    const verboseHealthCheckResp = {
+      usedMemory,
+      totalMemory
+    }
+    expect(() => determinePeerHealth(verboseHealthCheckResp)).to.throw(
+      `Running low on memory=${
+        totalMemory - usedMemory
+      }bytes remaining. Minimum memory required=${minimumMemoryAvailable}bytes`
+    )
+  })
+
+  it('throws when low on file descriptor space', function () {
+    const allocatedFileDescriptors = 99
+    const maxFileDescriptors = 100
+    const verboseHealthCheckResp = {
+      allocatedFileDescriptors,
+      maxFileDescriptors
+    }
+    expect(() => determinePeerHealth(verboseHealthCheckResp)).to.throw(
+      `Running low on file descriptors availability=${
+        (allocatedFileDescriptors / maxFileDescriptors) * 100
+      }% used. Max file descriptors allocated percentage allowed=${maxFileDescriptorsAllocatedPercentage}%`
+    )
+  })
+
+  it('throws when historical sync success rate for today is below threshold', function () {
+    const dailySyncSuccessCount = 1
+    const dailySyncFailCount = 9
+    const verboseHealthCheckResp = {
+      dailySyncSuccessCount,
+      dailySyncFailCount
+    }
+    expect(() => determinePeerHealth(verboseHealthCheckResp)).to.throw(
+      `Latest daily sync data shows that this node fails at a high rate of syncs. Successful syncs=${dailySyncSuccessCount} || Failed syncs=${dailySyncFailCount}. Minimum successful sync percentage=${minimumSuccessfulSyncCountPercentage}%`
+    )
+  })
+
+  it('throws when historical sync success rate for rolling 30-day window is below threshold', function () {
+    const thirtyDayRollingSyncSuccessCount = 1
+    const thirtyDayRollingSyncFailCount = 9
+    const verboseHealthCheckResp = {
+      thirtyDayRollingSyncSuccessCount,
+      thirtyDayRollingSyncFailCount
+    }
+    expect(() => determinePeerHealth(verboseHealthCheckResp)).to.throw(
+      `Rolling sync data shows that this node fails at a high rate of syncs. Successful syncs=${thirtyDayRollingSyncSuccessCount} || Failed syncs=${thirtyDayRollingSyncFailCount}. Minimum successful sync percentage=${minimumSuccessfulSyncCountPercentage}%`
+    )
+  })
+})
+
+describe('test CNodeHealthManager -- isPrimaryHealthy()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  const primary = 'http://cn1.co'
+  const gracePeriodSeconds = 1
+  config.set('maxNumberSecondsPrimaryRemainsUnhealthy', 1)
+
+  it('returns true (healthy) when healthy', async function () {
+    // Make isNodeHealthy return true
+    const isNodeHealthyStub = sandbox
+      .stub(CNodeHealthManager, 'isNodeHealthy')
+      .resolves(true)
+
+    const isHealthy = await CNodeHealthManager.isPrimaryHealthy(primary)
+    expect(isHealthy).to.be.true
+    expect(isNodeHealthyStub).to.have.been.calledOnceWithExactly(primary, true)
+  })
+
+  it('returns true when health check fails during grace period, then false when grace period ends, then true when health check starts passing again', async function () {
+    // Mock CNodeHealthManager to use the config with our shorter grace period
+    const CNodeHealthManagerMock = proxyquire(
+      '../src/services/stateMachineManager/CNodeHealthManager.js',
+      {
+        './../../config': config
+      }
+    )
+    // Make isNodeHealthy return false
+    const isNodeHealthyStub = sandbox
+      .stub(CNodeHealthManagerMock, 'isNodeHealthy')
+      .resolves(false)
+
+    // Verify that the node is marked as healthy during the grace period (even though it's unhealthy)
+    const isHealthy = await CNodeHealthManagerMock.isPrimaryHealthy(primary)
+    expect(isHealthy).to.be.true
+    const isHealthyDuringGracePeriod =
+      await CNodeHealthManagerMock.isPrimaryHealthy(primary)
+    expect(isHealthyDuringGracePeriod).to.be.true
+
+    // Verify that the node is unhealthy after the grace period ends
+    await Utils.timeout(gracePeriodSeconds * 1000 + 1)
+    const isHealthyAfterGracePeriod =
+      await CNodeHealthManagerMock.isPrimaryHealthy(primary)
+    expect(isHealthyAfterGracePeriod).to.be.false
+
+    // Verify that the node is healthy when the health check starts passing again
+    isNodeHealthyStub.returns(true)
+    const isHealthyWhenIsHealthCheckPassesAgain =
+      await CNodeHealthManagerMock.isPrimaryHealthy(primary)
+    expect(isHealthyWhenIsHealthCheckPassesAgain).to.be.true
+  })
+})
+
+describe('test CNodeHealthManager -- _computeContentNodePeerSet()', function () {
+  it('returns correct set of content nodes, filtering out empty endpoints and self', function () {
+    const thisContentNode = 'http://thisContentNode.co'
+    const users = [
+      {
+        primary: thisContentNode,
+        secondary1: 'http://cn1.co',
+        secondary2: 'http://cn2.co'
+      },
+      {
+        primary: thisContentNode,
+        secondary1: 'http://cn3.co',
+        secondary2: 'http://cn4.co'
+      },
+      {
+        primary: 'http://cn5.co',
+        secondary1: 'http://cn2.co',
+        secondary2: ''
+      }
+    ]
+    expect(
+      CNodeHealthManager._computeContentNodePeerSet(users, thisContentNode)
+    ).to.have.all.keys(
+      'http://cn1.co',
+      'http://cn2.co',
+      'http://cn3.co',
+      'http://cn4.co',
+      'http://cn5.co'
+    )
+  })
+})
+
+describe('test CNodeHealthManager logger', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('logs info and error with common prefix', function () {
+    // Initialize CNodeHealthManager with stubbed logger
+    const logInfoStub = sandbox.stub()
+    const logErrorStub = sandbox.stub()
+    const CNodeHealthManagerMock = proxyquire(
+      '../src/services/stateMachineManager/CNodeHealthManager.js',
+      {
+        './../../logging': {
+          logger: {
+            info: logInfoStub,
+            error: logErrorStub
+          }
+        }
+      }
+    )
+
+    // Verify that each log function passes the correct message to the logger
+    CNodeHealthManagerMock.log('test info msg')
+    expect(logInfoStub).to.have.been.calledOnceWithExactly(
+      'CNodeHealthManager: test info msg'
+    )
+    CNodeHealthManagerMock.logError('test error msg')
+    expect(logErrorStub).to.have.been.calledOnceWithExactly(
+      'CNodeHealthManager ERROR: test error msg'
+    )
+  })
+})

--- a/creator-node/test/StateMonitoringQueue.test.js
+++ b/creator-node/test/StateMonitoringQueue.test.js
@@ -16,7 +16,7 @@ const {
 const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')
 
-describe('test StateMonitoringQueue initialization and logging', function () {
+describe('test StateMonitoringQueue initialization, logging, and events', function () {
   let server, sandbox
   beforeEach(async function () {
     const appInfo = await getApp(getLibsMock())
@@ -36,16 +36,22 @@ describe('test StateMonitoringQueue initialization and logging', function () {
   })
 
   it('creates the queue and registers its event handlers', async function () {
-    // Initialize StateMonitoringQueue and spy on its registerQueueEventHandlers function
-    sandbox.spy(StateMonitoringQueue.prototype, 'registerQueueEventHandlers')
+    // Initialize StateMonitoringQueue and spy on its registerQueueEventHandlersAndJobProcessor function
+    sandbox.spy(
+      StateMonitoringQueue.prototype,
+      'registerQueueEventHandlersAndJobProcessor'
+    )
     const stateMonitoringQueue = new StateMonitoringQueue(config)
     await stateMonitoringQueue.init(getLibsMock())
 
     // Verify that the queue was successfully initialized and that its event listeners were registered
     expect(stateMonitoringQueue.queue).to.exist.and.to.be.instanceOf(BullQueue)
-    expect(stateMonitoringQueue.registerQueueEventHandlers).to.have.been
-      .calledOnce
-    expect(stateMonitoringQueue.registerQueueEventHandlers.getCall(0).args[0])
+    expect(stateMonitoringQueue.registerQueueEventHandlersAndJobProcessor).to
+      .have.been.calledOnce
+    expect(
+      stateMonitoringQueue.registerQueueEventHandlersAndJobProcessor.getCall(0)
+        .args[0]
+    )
       .to.have.property('queue')
       .that.has.deep.property('name', STATE_MONITORING_QUEUE_NAME)
   })
@@ -93,6 +99,84 @@ describe('test StateMonitoringQueue initialization and logging', function () {
     expect(isQueuePaused).to.be.true
     return expect(stateMonitoringQueue.queue.getJobs('delayed')).to.eventually
       .be.fulfilled.and.be.empty
+  })
+
+  it('processes jobs with expected data and returns the expected results', async function () {
+    // Mock StateMonitoringQueue to have processStateMonitoringJob return dummy data
+    const expectedResult = { jobFailed: false, test: 'test' }
+    const processStateMonitoringJobStub = sandbox
+      .stub()
+      .resolves(expectedResult)
+    const MockStateMonitoringQueue = proxyquire(
+      '../src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js',
+      {
+        './processStateMonitoringJob': processStateMonitoringJobStub
+      }
+    )
+
+    // Verify that StateMonitoringQueue returns our dummy data
+    const job = {
+      id: 9,
+      data: {
+        lastProcessedUserId: 2,
+        discoveryNodeEndpoint: 'http://test_endpoint.co',
+        moduloBase: 1,
+        currentModuloSlice: 2
+      }
+    }
+    await expect(
+      new MockStateMonitoringQueue().processJob(job)
+    ).to.eventually.be.fulfilled.and.deep.equal(expectedResult)
+    expect(processStateMonitoringJobStub).to.have.been.calledOnceWithExactly(
+      job.id,
+      job.data.lastProcessedUserId,
+      job.data.discoveryNodeEndpoint,
+      job.data.moduloBase,
+      job.data.currentModuloSlice
+    )
+  })
+
+  it('returns default result when processing a job fails or logging fails', async function () {
+    // Mock StateMonitoringQueue to have processStateMonitoringJob return dummy data
+    const logErrorStub = sandbox.stub()
+    const processStateMonitoringJobStub = sandbox.stub().rejects('test error')
+    const MockStateMonitoringQueue = proxyquire(
+      '../src/services/stateMachineManager/stateMonitoring/StateMonitoringQueue.js',
+      {
+        './processStateMonitoringJob': processStateMonitoringJobStub,
+        './../../../logging': {
+          logger: {
+            error: logErrorStub
+          }
+        }
+      }
+    )
+
+    // Verify that StateMonitoringQueue throws and returns default data
+    const job = {
+      id: 9,
+      data: {
+        lastProcessedUserId: 2,
+        discoveryNodeEndpoint: 'http://test_endpoint.co',
+        moduloBase: 1,
+        currentModuloSlice: 2
+      }
+    }
+    await expect(
+      new MockStateMonitoringQueue().processJob(job)
+    ).to.eventually.be.fulfilled.and.deep.equal({
+      lastProcessedUserId: job.data.lastProcessedUserId,
+      moduloBase: job.data.moduloBase,
+      currentModuloSlice: job.data.currentModuloSlice,
+      jobFailed: true
+    })
+    expect(logErrorStub).to.have.been.calledTwice
+    expect(logErrorStub.getCall(0).args[0]).to.equal(
+      `StateMonitoringQueue ERROR: Failed to log details for jobId=${job.id}: TypeError: logger.info is not a function`
+    )
+    expect(logErrorStub.getCall(1).args[0]).to.equal(
+      `StateMonitoringQueue ERROR: Error processing jobId ${job.id}: test error`
+    )
   })
 
   it('logs debug, info, warning, and error', function () {


### PR DESCRIPTION
### Description
Add tests for:
- CNodeHealthManager.js:
  - `getUnhealthyPeers()` – new tests
  - `getNodeUsers()` – new tests
  - `queryVerboseHealthCheck()` – new tests
  - `determinePeerHealth()` – new tests
  - `isPrimaryHealthy()` – new tests
  - `_computeContentNodePeerSet()` – new tests
- Queue job processor logic


### Tests
Made sure running locally didn't show any errors and verified that state machine manager tests are now very green!
<img width="838" alt="Screen Shot 2022-05-27 at 10 53 10 AM" src="https://user-images.githubusercontent.com/4657956/170764718-068d06e5-bade-4af4-9673-cd5bd0b96519.png">
<img width="837" alt="Screen Shot 2022-05-27 at 10 53 40 AM" src="https://user-images.githubusercontent.com/4657956/170764788-76204631-1a9c-434f-b827-d8e33c98c133.png">


### How will this change be monitored? Are there sufficient logs?
Nothing new to monitor -- just tests.