### PR TITLE
Leave tags mat view on with search flag enabled

### DIFF
--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -10,16 +10,20 @@ DEFAULT_UPDATE_TIMEOUT = 60 * 60 * 6  # 6 hours
 
 
 def update_views(self, db):
-    if os.getenv("audius_elasticsearch_search_enabled"):
-        return
     with db.scoped_session() as session:
         start_time = time.time()
+        if os.getenv("audius_elasticsearch_search_enabled"):
+            session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
+            logger.info(
+                f"index_materialized_views.py | Finished updating tag_track_user in: {time.time() - start_time} sec."
+            )
+            return
+
         logger.info("index_materialized_views.py | Updating materialized views")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY track_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY playlist_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY album_lexeme_dict")
-        session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
 
     logger.info(
         f"index_materialized_views.py | Finished updating materialized views in: {time.time() - start_time} sec."


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

With this search flag enabled, we can disable mat views but not yet tags mat view. We will do that https://linear.app/audius/issue/PLAT-154/search-tags.

Fast follow up from https://github.com/AudiusProject/audius-protocol/pull/3093/files.

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->
Tested on sandbox and verified only tag matview is refreshed.
```
{"levelno": 20, "level": "INFO", "msg": "index_materialized_views.py | Finished updating tag_track_user in: 61.29243063926697 sec.", "timestamp": "2022-05-27 20:08:45,323"}
```


### How will this change be monitored? Are there sufficient logs?

Checking the log above.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->