### PR TITLE
CON-180 Remove CI coverage status from READMEs

### DIFF
--- a/creator-node/README.md
+++ b/creator-node/README.md
@@ -1,5 +1,3 @@
-[![Coverage Status](https://coveralls.io/repos/github/AudiusProject/audius-protocol/badge.svg)](https://coveralls.io/github/AudiusProject/audius-protocol)
-
 An Audius Content Node (previously known as Creator Node) maintains the availability of content on Audius's decentralized network. The information stored includes Audius user metadata, images, and audio content. The content is backed by either aws S3 or a local directory.
 
 To blacklist content on an already running node:

--- a/eth-contracts/README.md
+++ b/eth-contracts/README.md
@@ -1,7 +1,5 @@
 # Audius Ethereum smart contracts
 
-[![Coverage Status](https://coveralls.io/repos/github/AudiusProject/audius-protocol/badge.svg)](https://coveralls.io/github/AudiusProject/audius-protocol)
-
 Audius has two sets of contracts - the one in this directory, which runs on Ethereum mainnet in
 production, and the one
 [here](https://github.com/AudiusProject/audius-protocol/tree/master/contracts) which runs on POA


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

Badge currently is not accurate since it shows the coverage % for the entire repo, as opposed to by service
Can add this later, but doesn't seem worthwhile to do now, so just removing

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

N/A

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->