### PR TITLE
Fix last_tx bug in Discovery index_solana_plays.py

### DIFF
--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -632,7 +632,7 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis: Redi
         )
         raise e
 
-    if last_tx:
+    if last_tx and transaction_signatures:
         redis.set(latest_sol_plays_slot_key, last_tx["slot"])
     elif latest_global_slot is not None:
         redis.set(latest_sol_plays_slot_key, latest_global_slot)


### PR DESCRIPTION
### Description

There was a bug here, predominantly exercised on staging due to low tx volume, where `last_tx` would be not None even though we processed no transactions, causing us to never set a global slot. This is the case when there is only one tx in the `transactions_array`, and that tx itself already exists in the db, causing us to bail out immediately and not process any transactions.

This wasn't an issue in the other Solana indexing tasks because `last_tx` corresponds to the last actually processed tx in those.  

### Tests

Tested on stage DN1.

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->