### PR TITLE
[INF-93] disable rsyslog in favor of logspout for identity

### DIFF
--- a/identity-service/Dockerfile
+++ b/identity-service/Dockerfile
@@ -34,11 +34,13 @@ ARG git_sha
 ARG audius_loggly_disable
 ARG audius_loggly_token
 ARG audius_loggly_tags
+ARG audius_enable_rsyslog
 
 ENV GIT_SHA=$git_sha
 ENV logglyDisable=$audius_loggly_disable
 ENV logglyToken=$audius_loggly_token
 ENV logglyTags=$audius_loggly_tags
+ENV enableRsyslog=$audius_enable_rsyslog
 
 HEALTHCHECK --interval=5s --timeout=5s \
     CMD curl -f http://localhost:7000/health_check || exit 1

--- a/identity-service/scripts/start.sh
+++ b/identity-service/scripts/start.sh
@@ -2,12 +2,17 @@
 
 /usr/bin/wait
 
-if [[ -z "$logglyDisable" ]]; then
-    if [[ -n "$logglyToken" ]]; then
-        logglyTags=$(echo $logglyTags | python3 -c "print(' '.join(f'tag=\\\\\"{i}\\\\\"' for i in input().split(',')))")
-        mkdir -p /var/spool/rsyslog
-        mkdir -p /etc/rsyslog.d
-        cat >/etc/rsyslog.d/22-loggly.conf <<EOF
+# enable rsyslog if not explicitly disabled by Dockerfile ARGs
+: "${enableRsyslog:=true}"
+
+# $enableRsyslog should be true
+# $logglyDisable should be empty/null
+# $logglyToken should be a nonzero length string
+if $enableRsyslog && [[ -z "$logglyDisable" && -n "$logglyToken" ]]; then
+    logglyTags=$(echo $logglyTags | python3 -c "print(' '.join(f'tag=\\\\\"{i}\\\\\"' for i in input().split(',')))")
+    mkdir -p /var/spool/rsyslog
+    mkdir -p /etc/rsyslog.d
+    cat >/etc/rsyslog.d/22-loggly.conf <<EOF
 \$WorkDirectory /var/spool/rsyslog # where to place spool files
 \$ActionQueueFileName fwdRule1   # unique name prefix for spool files
 \$ActionQueueMaxDiskSpace 1g    # 1gb space limit (use as much as possible)
@@ -15,12 +20,11 @@ if [[ -z "$logglyDisable" ]]; then
 \$ActionQueueType LinkedList    # run asynchronously
 \$ActionResumeRetryCount -1    # infinite retries if host is down
 template(name="LogglyFormat" type="string"
- string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$logglyToken@41058 $logglyTags] %msg%\n")
+string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$logglyToken@41058 $logglyTags] %msg%\n")
 # Send messages to Loggly over TCP using the template.
 action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="514" template="LogglyFormat")
 EOF
-        rsyslogd
-    fi
+    rsyslogd
 fi
 
 node src/index.js | tee >(logger)


### PR DESCRIPTION
### Description

This PR is split off of #17 and handles changes solely for identity.

### Tests

We should verify this PR by looking at Loggly and ensuring parity with older logs.

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->