### PR TITLE
Notification Fixes

### DIFF
--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -126,10 +126,11 @@ solana_notification_threshold = "threshold"
 solana_notification_tip_rank = "rank"
 solana_notification_tip_amount = "amount"
 solana_notification_tip_signature = "tx_signature"
+solana_notification_tip_sender_id = "tip_sender_id"
 
 solana_notification_reaction_type = "reaction_type"
 solana_notification_reaction_type_tip = "tip"
-solana_notification_reaction_reacted_to = "reacted_to"
+solana_notification_reaction_reacted_to_entity = "reacted_to_entity"
 solana_notification_reaction_reaction_value = "reaction_value"
 
 

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -211,7 +211,8 @@ const formatTipSend = (notification) => ({
   ...getCommonNotificationsFields(notification),
   type: notification.type,
   amount: notification.metadata.amount,
-  recipientId: notification.entityId
+  entityId: notification.entityId,
+  entityType: Entity.User
 })
 
 const formatTipReceive = (notification) => ({
@@ -219,31 +220,35 @@ const formatTipReceive = (notification) => ({
   type: notification.type,
   amount: notification.metadata.amount,
   reactionValue: notification.metadata.reactionValue,
-  senderId: notification.entityId,
-  tipTxSignature: notification.metadata.tipTxSignature
+  entityId: notification.entityId,
+  tipTxSignature: notification.metadata.tipTxSignature,
+  entityType: Entity.User
 })
 
 const formatSupportingRankUp = (notification) => ({
   ...getCommonNotificationsFields(notification),
   type: notification.type,
-  supportedUserId: notification.metadata.supportedUserId,
-  rank: notification.entityId
+  entityId: notification.metadata.supportedUserId,
+  rank: notification.entityId,
+  entityType: Entity.User
 })
 
 const formatSupporterRankUp = (notification) => ({
   ...getCommonNotificationsFields(notification),
   type: notification.type,
-  supportingUser: notification.metadata.supportingUserId,
-  rank: notification.entityId
+  entityId: notification.metadata.supportingUserId,
+  rank: notification.entityId,
+  entityType: Entity.User
 })
 
 const formatReaction = (notification) => ({
   ...getCommonNotificationsFields(notification),
   type: notification.type,
-  reactingUser: notification.entityId,
+  entityId: notification.entityId,
   reactionType: notification.metadata.reactionType,
   reactionValue: notification.metadata.reactionValue,
-  reactedTo: notification.metadata.reactedTo
+  reactedTo: notification.metadata.reactedTo,
+  entityType: Entity.User
 })
 
 const getCommonNotificationsFields = (notification) => ({


### PR DESCRIPTION
### Description

- Adds reacted_to_entity in reaction notification, including amount and recipient
- Properly pad amounts
- Alter shape of Identity notifications to be more consistent with what client expects

### Tests

- Tested on stage

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->