### PR TITLE
Use logglyTags for CN nodes (logspout)

### DIFF
--- a/logspout/start.sh
+++ b/logspout/start.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
 
-# start with `logspout` Loggly tag, and add ${audius_loggly_tags} if present
+# start with `logspout` Loggly tag, and add ${audius_loggly_tags} or ${logglyTags} if present
 tag_csv=logspout
 if [[ "${audius_loggly_tags}" ]]; then
    tag_csv=${tag_csv},${audius_loggly_tags}
+elif [[ "${logglyTags}" ]]; then
+   tag_csv=${tag_csv},${logglyTags}
 fi
 
 # set hostname to ${audius_discprov_url}, else ${creatorNodeEndpoint}


### PR DESCRIPTION
### Description

Currently we're only adding discovery provider formatted tags and ignoring content node tags. This will ensure we use both sets of tags for our Loggly logspout integration.

### Tests

Confirm accurate logs in Loggly.

### How will this change be monitored? Are there sufficient logs?

Confirm accurate logs in Loggly.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->