### PR TITLE
Set service key to k8s when not present

### DIFF
--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -212,7 +212,7 @@ log_format = {
     "pathname": "pathname",
     "funcName": "funcName",
     "lineno": "lineno",
-    "service": os.getenv("audius_service"),
+    "service": os.getenv("audius_service", "k8s"),
 }
 
 formatter = JsonFormatter(log_format, ensure_ascii=False, mix_extra=True)

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -212,7 +212,7 @@ log_format = {
     "pathname": "pathname",
     "funcName": "funcName",
     "lineno": "lineno",
-    "service": os.getenv("audius_service", "k8s"),
+    "service": os.getenv("audius_service", "default"),
 }
 
 formatter = JsonFormatter(log_format, ensure_ascii=False, mix_extra=True)


### PR DESCRIPTION
### Description

We added a service key to our logger for logspout, but k8s doesn't set this key. Instead, we will default this key for k8s as "k8s".

### Tests

Confirm that DP1 is healthy and Loggly shows our logs.

### How will this change be monitored? Are there sufficient logs?

Confirm that DP1 is healthy and Loggly shows our logs.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->