### PR TITLE
[PAY-272] Add API routes for individual user supporter/supporting

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -946,7 +946,7 @@ get_supporters_response = make_response(
 class GetSupporters(Resource):
     @record_metrics
     @ns.doc(
-        id="""Get User Supporters""",
+        id="""Get Supporters""",
         description="""Gets the supporters of the given user""",
         params={"id": "A User ID"},
     )
@@ -970,17 +970,17 @@ full_get_supporters_response = make_full_response(
 @full_ns.route("/<string:id>/supporters")
 class FullGetSupporters(Resource):
     @record_metrics
-    @ns.doc(
-        id="""Get User Supporters""",
+    @full_ns.doc(
+        id="""Get Supporters""",
         description="""Gets the supporters of the given user""",
         params={"id": "A User ID"},
     )
-    @ns.expect(pagination_with_current_user_parser)
-    @ns.marshal_with(full_get_supporters_response)
+    @full_ns.expect(pagination_with_current_user_parser)
+    @full_ns.marshal_with(full_get_supporters_response)
     @cache(ttl_sec=5)
     def get(self, id: str):
         args = pagination_with_current_user_parser.parse_args()
-        decoded_id = decode_with_abort(id, ns)
+        decoded_id = decode_with_abort(id, full_ns)
         current_user_id = get_current_user_id(args)
         args["user_id"] = decoded_id
         args["current_user_id"] = current_user_id
@@ -997,13 +997,13 @@ full_get_supporter_response = make_full_response(
 @full_ns.route("/<string:id>/supporters/<string:supporter_user_id>")
 class FullGetSupporter(Resource):
     @record_metrics
-    @ns.doc(
-        id="""Get User Supporter""",
+    @full_ns.doc(
+        id="""Get Supporter""",
         description="""Gets the specified supporter of the given user""",
         params={"id": "A User ID", "supporter_user_id": "A User ID of a supporter"},
     )
-    @ns.expect(current_user_parser)
-    @ns.marshal_with(full_get_supporter_response)
+    @full_ns.expect(current_user_parser)
+    @full_ns.marshal_with(full_get_supporter_response)
     @cache(ttl_sec=5)
     def get(self, id: str, supporter_user_id: str):
         args = current_user_parser.parse_args()
@@ -1026,10 +1026,10 @@ get_supporting_response = make_response(
 
 
 @ns.route("/<string:id>/supporting")
-class GetSupporting(Resource):
+class GetSupportings(Resource):
     @record_metrics
     @ns.doc(
-        id="""Get User Supporting""",
+        id="""Get Supportings""",
         description="""Gets the users that the given user supports""",
         params={"id": "A User ID"},
     )
@@ -1051,10 +1051,10 @@ full_get_supporting_response = make_full_response(
 
 
 @full_ns.route("/<string:id>/supporting")
-class FullGetSupporting(Resource):
+class FullGetSupportings(Resource):
     @record_metrics
     @full_ns.doc(
-        id="""Get User Supporting""",
+        id="""Get Supportings""",
         description="""Gets the users that the given user supports""",
         params={"id": "A User ID"},
     )
@@ -1070,6 +1070,40 @@ class FullGetSupporting(Resource):
         support = get_support_sent_by_user(args)
         support = list(map(extend_supporting, support))
         return success_response(support)
+
+
+full_get_supporting_response = make_full_response(
+    "full_get_supporting", full_ns, fields.Nested(supporting_response_full)
+)
+
+
+@full_ns.route("/<string:id>/supporting/<string:supported_user_id>")
+class FullGetSupporting(Resource):
+    @record_metrics
+    @full_ns.doc(
+        id="""Get Supporting""",
+        description="""Gets the support from the given user to the supported user""",
+        params={
+            "id": "A User ID",
+            "supported_user_id": "A User ID of a supported user",
+        },
+    )
+    @full_ns.expect(current_user_parser)
+    @full_ns.marshal_with(full_get_supporting_response)
+    @cache(ttl_sec=5)
+    def get(self, id: str, supported_user_id: str):
+        args = current_user_parser.parse_args()
+        decoded_id = decode_with_abort(id, full_ns)
+        current_user_id = get_current_user_id(args)
+        decoded_supported_user_id = decode_with_abort(supported_user_id, full_ns)
+        args["user_id"] = decoded_id
+        args["current_user_id"] = current_user_id
+        args["supported_user_id"] = decoded_supported_user_id
+        support = get_support_sent_by_user(args)
+        support = list(map(extend_supporting, support))
+        if not support:
+            abort_not_found(decoded_id, full_ns)
+        return success_response(support[0])
 
 
 verify_token_response = make_response(

--- a/discovery-provider/src/queries/get_support_for_user.py
+++ b/discovery-provider/src/queries/get_support_for_user.py
@@ -31,27 +31,27 @@ def query_result_to_support_response(
     ]
 
 
-sql_support_received = text(
-    """
-SELECT
-    RANK() OVER (ORDER BY amount DESC) AS rank
-    , sender_user_id
-    , receiver_user_id
-    , amount
-FROM aggregate_user_tips
-WHERE receiver_user_id = :receiver_user_id
-ORDER BY amount DESC
-LIMIT :limit
-OFFSET :offset;
-"""
-).columns(
-    column("rank", Integer),
-    AggregateUserTips.sender_user_id,
-    AggregateUserTips.receiver_user_id,
-    AggregateUserTips.amount,
-)
-
-# With supporter_user_id
+# Without supporter_user_id:
+# ----------------------------
+# SELECT
+#   rank() OVER (
+#     ORDER BY
+#       aggregate_user_tips.amount DESC
+#   ) AS rank,
+#   aggregate_user_tips.sender_user_id AS aggregate_user_tips_sender_user_id,
+#   aggregate_user_tips.receiver_user_id AS aggregate_user_tips_receiver_user_id,
+#   aggregate_user_tips.amount AS aggregate_user_tips_amount
+# FROM
+#   aggregate_user_tips
+# WHERE
+#   aggregate_user_tips.receiver_user_id = %(receiver_user_id_1) s
+# ORDER BY
+#   aggregate_user_tips.amount DESC
+# LIMIT
+#   %(param_1) s OFFSET %(param_2) s
+#
+#
+# With supporter_user_id:
 # ----------------------------
 # WITH rankings AS (
 #   SELECT

--- a/discovery-provider/src/queries/get_support_for_user.py
+++ b/discovery-provider/src/queries/get_support_for_user.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Tuple, TypedDict
 
-from sqlalchemy import Integer, column, func, text
+from sqlalchemy import func
 from sqlalchemy.orm import aliased
 from src.models import AggregateUserTips
 from src.queries.query_helpers import get_users_by_id, paginate_query
@@ -109,10 +109,7 @@ def get_support_received_by_user(args) -> List[SupportResponse]:
             )
             query = paginate_query(query)
 
-        logger.debug(f"get_support_for_user.py | {query}")
         rows: List[Tuple[int, AggregateUserTips]] = query.all()
-        logger.debug(f"get_support_for_user.py | {rows}")
-
         user_ids = [row[1].sender_user_id for row in rows]
         users = get_users_by_id(session, user_ids, current_user_id)
 
@@ -235,10 +232,8 @@ def get_support_sent_by_user(args) -> List[SupportResponse]:
                 AggregateUserTipsAlias.receiver_user_id.asc(),
             )
             query = paginate_query(query)
-        logger.debug(f"get_support_for_user.py | {query}")
-        rows: List[Tuple[int, AggregateUserTips]] = query.all()
-        logger.debug(f"get_support_for_user.py | {rows}")
 
+        rows: List[Tuple[int, AggregateUserTips]] = query.all()
         user_ids = [row[1].receiver_user_id for row in rows]
         users = get_users_by_id(session, user_ids, current_user_id)
 


### PR DESCRIPTION
### Description

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

- Adds route `/users/<id>/supporters/<supporter_user_id>` to get a specific supporter for a user
- Adds route `/users/<id>/supporting/<supported_user_id>` to get the support by a user to another user
- Both routes 404 if the supporter/supportee doesn't exist
- Updates the query to use SQLAlchemy to compose, added comments to show SQL version
- Fixes some minor full/non-full namespacing issues

### Tests

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

Tested manually on remote

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

TBD

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->