### PR TITLE
Revert back to old logging property names so fluentd continues to work

### DIFF
--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -207,7 +207,6 @@ def tuple_to_model_dictionary(t, model):
 log_format = {
     "levelno": "levelno",
     "level": "levelname",
-    "logLevel": "levelname",
     "msg": "message",
     "timestamp": "asctime",
     "pathname": "pathname",

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -205,7 +205,8 @@ def tuple_to_model_dictionary(t, model):
 
 
 log_format = {
-    "level": "levelno",
+    "levelno": "levelno",
+    "level": "levelname",
     "logLevel": "levelname",
     "msg": "message",
     "timestamp": "asctime",


### PR DESCRIPTION
### Description
Changing the value of level broke the fluentd parser [here](https://github.com/AudiusProject/audius-k8s-manifests/blob/master/audius/logger/logger.yaml#L96) and since it's consumed by node operators, we should revert back to the old naming scheme since these new keys aren't strictly necessary.

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Put this commit on stage node and verified that loggly got the data in both k8s and docker compose setup.

K8s
<img width="286" alt="Cursor_and_Loggly___Search" src="https://user-images.githubusercontent.com/295938/171664313-e63c8794-7cc2-4e33-a5f5-1a9d5f1a1298.png">


Docker-compose
Note the level and levelno keys
<img width="337" alt="Loggly___Search" src="https://user-images.githubusercontent.com/295938/171664112-30505902-ef2b-432d-88ee-e979d1299323.png">

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
If logs show up on loggly, this feature is working
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->