### PR TITLE
Install deps before running mad dog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ jobs:
               cd /home/ubuntu/audius-protocol/mad-dog;
               git pull;
               git checkout $CIRCLE_BRANCH;
+              A run init-repos up;
               A up;
               npm run start << parameters.mad-dog-type >> verbose;
               exit;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,12 @@ jobs:
             # Run A up on remote box
             GCLOUD_IP_ADDRESS=$(gcloud compute instances describe $GCLOUD_VM_NAME --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
             ssh -o "StrictHostKeyChecking no" -i ~/.ssh/google_compute_engine -tt ubuntu@$GCLOUD_IP_ADDRESS \<< EOF
-              cd /home/ubuntu/audius-protocol/mad-dog;
+              cd /home/ubuntu/audius-protocol;
               git pull;
               git checkout $CIRCLE_BRANCH;
+              cd ./service-commands;
+              npm i
+              cd ../mad-dog;
               A run init-repos up;
               A up;
               npm run start << parameters.mad-dog-type >> verbose;


### PR DESCRIPTION
### Description

Mad dog is failing on https://github.com/AudiusProject/audius-protocol/pull/3170 because it cannot find a newly installed node module due to the fact that the audius/circleci-gcloud-bake image is created nightly from master.

Unfortuntely, simply adding `A run init-repos up` before the test run doesn't work because the new dependency exists in service-commands as well. So we need to do a regular npm install in service commands before we can run `A` commands

These installs should be fast because most of the dependencies are already installed in the image

### Tests

Mad dog passes with these changes applied to the other branch

### How will this change be monitored? Are there sufficient logs?

Green ci flow