### PR TITLE
Add unsubscribe link to welcomeDownload.html

### DIFF
--- a/identity-service/src/notifications/emails/downloadMobileApp.html
+++ b/identity-service/src/notifications/emails/downloadMobileApp.html
@@ -563,7 +563,9 @@
                   style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">Tired
                   of seeing these emails?</span> <a href="https://audius.co/settings"
                   style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Update
-                  your notification preferences</a>
+                  your notification preferences</a>  <span
+                  style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">or</span> <a href="%unsubscribe_url%"
+                  style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Unsubscribe</a>
               </td>
             </tr>
           </table>

--- a/identity-service/src/notifications/emails/recovery.html
+++ b/identity-service/src/notifications/emails/recovery.html
@@ -645,7 +645,7 @@
                   <tr>
                     <td valign="top" id="utilityBar" colspan="3">
                       <div>
-                        <a href='http://mailgun/unsubscribe/%recipient.id%' class="utilityLink">unsubscribe from this list</a><span
+                        <a href="%unsubscribe_url%" class="utilityLink">unsubscribe from this list</a><span
                           class="mobileHide">
                       </div>
                     </td>

--- a/identity-service/src/notifications/emails/welcome.html
+++ b/identity-service/src/notifications/emails/welcome.html
@@ -619,7 +619,9 @@
                   style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">Tired
                   of seeing these emails?</span> <a href="https://audius.co/settings"
                   style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Update
-                  your notification preferences</a>
+                  your notification preferences</a> <span
+                  style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">or</span> <a href="%unsubscribe_url%"
+                  style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Unsubscribe</a>
               </td>
             </tr>
           </table>

--- a/identity-service/src/notifications/emails/welcomeDownload.html
+++ b/identity-service/src/notifications/emails/welcomeDownload.html
@@ -670,7 +670,7 @@
                   style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">Tired
                   of seeing these emails?</span> <a href="https://audius.co/settings"
                   style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Update
-                  your notification preferences</a>  <span
+                  your notification preferences</a> <span
                   style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">or</span> <a href="%unsubscribe_url%"
                   style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Unsubscribe</a>
               </td>

--- a/identity-service/src/notifications/emails/welcomeDownload.html
+++ b/identity-service/src/notifications/emails/welcomeDownload.html
@@ -670,7 +670,9 @@
                   style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">Tired
                   of seeing these emails?</span> <a href="https://audius.co/settings"
                   style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Update
-                  your notification preferences</a>
+                  your notification preferences</a>  <span
+                  style="font-family: 'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color:#858199;;font-weight:normal;">or</span> <a href="%unsubscribe_url%"
+                  style="font-family:'Gilroy', Helvetica, Arial, sans-serif;font-size: 12px;color: #858199;text-decoration:underline;font-weight:normal">Unsubscribe</a>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
### Description
Add unsubscribe link to all emails in identity. Fixed the recovery email unsubscribe link which took you nowhere.

Link to mailgun docs - https://help.mailgun.com/hc/en-us/articles/203306610-Do-I-control-the-unsubscribe-handling-or-does-Mailgun-

Updated UI
<img width="597" alt="Hello_Dheeraj_-_dheerajmanju1_gmail_com_-_Gmail" src="https://user-images.githubusercontent.com/295938/172024523-110484d3-ca11-4857-aef6-f916e387c776.png">

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Ran via the mailgun template test, got the email in my inbox, clicked through "Unsubscribe" and verified it took me to a page where I could unsubscribe.

<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
Mailgun's dashboard has analytics for unsubscribes
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->