### PR TITLE
Comment out coveralls upload from content-node tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,8 @@ jobs:
             export spOwnerWallet='yes'
             export isCIBuild=true
             npm run test:coverage:ci
-      - coveralls/upload:
-          path_to_lcov: ./creator-node/coverage/lcov.info
+      # - coveralls/upload:
+      #     path_to_lcov: ./creator-node/coverage/lcov.info
 
   test-discovery-provider:
     docker:


### PR DESCRIPTION
### Description
We have coveralls since uploading to Coveralls which shows the little red X in github checks. Comment out for now until we can fix. 

<!-- What is the purpose of this PR? What is the current behavior? New behavior? Relevant links and/or information pertaining to PR? -->

### Tests
Verified on this branch that it no longer publishes to coveralls
<!-- List the manual tests and repro instructions to verify that this PR works as anticipated. Include log analysis if possible. If this change impacts clients, make sure that you have tested the clients! -->

### How will this change be monitored? Are there sufficient logs?
Coveralls doesn't fail the git status checks anymore
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->