### PR TITLE
bake dev images on demand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,6 +751,15 @@ workflows:
           requires:
             - hold-build-logspout
 
+      - hold-bake-gcp-dev-image:
+          type: approval
+      - bake-gcp-dev-image:
+          context:
+            - GCP2
+          name: bake-gcp-dev-image
+          requires:
+            - hold-bake-gcp-dev-image
+
       - test-solana-programs:
           name: test-solana-programs
       - test-solana-programs-anchor:


### PR DESCRIPTION
### Description

Bake a new dev image on demand. This allows us to merge breaking changes during the day without waiting until the next business day for a working remove-dev image.

### Tests

The build process should execute with new code, bake an image (without issues overwriting existing image names), and `A setup remote-dev --fast` should result in a working, up to date machine.

### How will this change be monitored? Are there sufficient logs?

See above.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->