### PR TITLE
use duration, not runtime, keyword for Prometheus metrics

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -557,7 +557,7 @@ def index_blocks(self, db, blocks_list):
     latest_block_timestamp = None
     changed_entity_ids_map = {}
     metric = PrometheusMetric(
-        "index_blocks_runtime_seconds",
+        "index_blocks_duration_seconds",
         "Runtimes for src.task.index:index_blocks()",
         ("scope",),
     )

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -412,7 +412,7 @@ def update_metrics(self):
                 f"index_metrics.py | update_metrics | {self.request.id} | Acquired update_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_runtime_seconds",
+                "index_metrics_duration_seconds",
                 "Runtimes for src.task.index_metrics:celery.task()",
                 ("task_name",),
             )
@@ -455,7 +455,7 @@ def aggregate_metrics(self):
                 f"index_metrics.py | aggregate_metrics | {self.request.id} | Acquired aggregate_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_runtime_seconds",
+                "index_metrics_duration_seconds",
                 "Runtimes for src.task.index_metrics:celery.task()",
                 ("task_name",),
             )
@@ -499,7 +499,7 @@ def synchronize_metrics(self):
                 f"index_metrics.py | synchronize_metrics | {self.request.id} | Acquired synchronize_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_runtime_seconds",
+                "index_metrics_duration_seconds",
                 "Runtimes for src.task.index_metrics:celery.task()",
                 ("task_name",),
             )

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -104,7 +104,7 @@ TRENDING_PARAMS = "trending_params"
 def update_view(session: Session, mat_view_name: str):
     start_time = time.time()
     metric = PrometheusMetric(
-        "update_trending_view_runtime_seconds",
+        "update_trending_view_duration_seconds",
         "Runtimes for src.task.index_trending:update_view()",
         ("mat_view_name",),
     )
@@ -125,7 +125,7 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
     logger.info("index_trending.py | starting indexing")
     update_start = time.time()
     metric = PrometheusMetric(
-        "index_trending_runtime_seconds",
+        "index_trending_duration_seconds",
         "Runtimes for src.task.index_trending:index_trending()",
     )
     with db.scoped_session() as session:

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -37,7 +37,7 @@ def track_state_update(
     """Return tuple containing int representing number of Track model state changes found in transaction and set of processed track IDs."""
     begin_track_state_update = datetime.now()
     metric = PrometheusMetric(
-        "track_state_update_runtime_seconds",
+        "track_state_update_duration_seconds",
         "Runtimes for src.task.tracks:track_state_update()",
         ("scope",),
     )

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -39,7 +39,7 @@ def user_state_update(
     """Return tuple containing int representing number of User model state changes found in transaction and set of processed user IDs."""
     begin_user_state_update = datetime.now()
     metric = PrometheusMetric(
-        "user_state_update_runtime_seconds",
+        "user_state_update_duration_seconds",
         "Runtimes for src.task.users:user_state_update()",
         ("scope",),
     )
@@ -148,7 +148,7 @@ def process_user_txs_serial(
     skipped_tx_count,
 ):
     metric = PrometheusMetric(
-        "user_state_update_runtime_seconds",
+        "user_state_update_duration_seconds",
         "Runtimes for src.task.users:user_state_update()",
         ("scope",),
     )


### PR DESCRIPTION
### Description

Match Prometheus' official leaning towards `duration` over `runtime` nomenclature.

### Tests

Grafana should still show the same metrics using updated panels:

* https://github.com/AudiusProject/load-test-tools/pull/16

### How will this change be monitored? Are there sufficient logs?

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->