### PR TITLE
Set update track is available cadence to every 12 hours 

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -531,7 +531,7 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": timedelta(minutes=10),
+                "schedule": timedelta(minutes=2),
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -531,7 +531,7 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": crontab(minute=0, hour=0),  # daily at midnight
+                "schedule": timedelta(minutes=10),
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -531,7 +531,7 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": timedelta(minutes=2),
+                "schedule": crontab(),  # run every minute
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -531,7 +531,7 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": crontab(),  # run every minute
+                "schedule": timedelta(hours=12),  # run every 12 hours
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -256,8 +256,8 @@ def update_track_is_available(self) -> None:
         raise e
     finally:
         if have_lock:
+            update_lock.release()
             redis.set(
                 UPDATE_TRACK_IS_AVAILABLE_FINISH_REDIS_KEY,
                 datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f %Z"),
             )
-            update_lock.release()

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -48,13 +48,6 @@ def fetch_unavailable_track_ids_in_network(session: Any, redis: Any) -> None:
 
         for i in range(0, len(unavailable_track_ids), BATCH_SIZE):
             unavailable_track_ids_batch = unavailable_track_ids[i : i + BATCH_SIZE]
-            logger.info(
-                f"update_track_is_available.py | vicky | Adding batch to key={spID_unavailable_tracks_key}"
-            )
-            # logger.info(*unavailable_track_ids_batch)
-            for id in range(len(unavailable_track_ids_batch)):
-                logger.info(f"vicky | {unavailable_track_ids_batch[id]}")
-
             redis.sadd(spID_unavailable_tracks_key, *unavailable_track_ids_batch)
 
             # Aggregate a set of unavailable tracks
@@ -220,8 +213,6 @@ def get_unavailable_tracks_redis_key(spID: int) -> str:
 # ####### CELERY TASKS ####### #
 @celery.task(name="update_track_is_available", bind=True)
 def update_track_is_available(self) -> None:
-
-    logger.info("update_track | vicky | starting task")
     """Recurring task that updates whether tracks are available on the network"""
 
     db = update_track_is_available.db

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -51,7 +51,9 @@ def fetch_unavailable_track_ids_in_network(session: Any, redis: Any) -> None:
             logger.info(
                 f"update_track_is_available.py | vicky | Adding batch to key={spID_unavailable_tracks_key}"
             )
-            logger.info(*unavailable_track_ids_batch)
+            # logger.info(*unavailable_track_ids_batch)
+            for id in range(len(unavailable_track_ids_batch)):
+                logger.info(f"vicky | {unavailable_track_ids_batch[id]}")
 
             redis.sadd(spID_unavailable_tracks_key, *unavailable_track_ids_batch)
 

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 UPDATE_TRACK_IS_AVAILABLE_LOCK = "update_track_is_available_lock"
 
 BATCH_SIZE = 1000
-DEFAULT_LOCK_TIMEOUT_SECONDS = 86400  # 24 hour -- the max duration of 1 worker
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30  # 30 seconds
 REQUESTS_TIMEOUT_SECONDS = 300  # 5 minutes
 
 
@@ -220,6 +220,8 @@ def get_unavailable_tracks_redis_key(spID: int) -> str:
 # ####### CELERY TASKS ####### #
 @celery.task(name="update_track_is_available", bind=True)
 def update_track_is_available(self) -> None:
+
+    logger.info("update_track | vicky | starting task")
     """Recurring task that updates whether tracks are available on the network"""
 
     db = update_track_is_available.db

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -48,6 +48,11 @@ def fetch_unavailable_track_ids_in_network(session: Any, redis: Any) -> None:
 
         for i in range(0, len(unavailable_track_ids), BATCH_SIZE):
             unavailable_track_ids_batch = unavailable_track_ids[i : i + BATCH_SIZE]
+            logger.info(
+                f"update_track_is_available.py | vicky | Adding batch to key={spID_unavailable_tracks_key}"
+            )
+            logger.info(*unavailable_track_ids_batch)
+
             redis.sadd(spID_unavailable_tracks_key, *unavailable_track_ids_batch)
 
             # Aggregate a set of unavailable tracks


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Looks like `crontab` doesn't work for midnight jobs after some debugging? Since this cadence is arbitrary and this job only took 2 seconds on staging (granted will be much longer on prod), let's just use `timedelta` to run every 12 hours instead.

health check
```
    "last_track_unavailability_job_end_time": "2022-06-08 18:57:03.178968 UTC",
    "last_track_unavailability_job_start_time": "2022-06-08 18:57:01.293707 UTC",
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Using `timedelta` on local and staging worked as expected

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Can check discovery health check for the start and end timestamps for the job 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->