### PR TITLE
Support notif for track added to playlist

### DIFF
--- a/discovery-provider/src/models/models.py
+++ b/discovery-provider/src/models/models.py
@@ -365,6 +365,7 @@ class Track(Base):
             f"track_id={self.track_id},"
             f"is_current={self.is_current},"
             f"is_delete={self.is_delete},"
+            f"is_unlisted={self.is_unlisted},"
             f"owner_id={self.owner_id},"
             f"route_id={self.route_id},"
             f"title={self.title},"

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -47,7 +47,7 @@ from src.utils.spl_audio import to_wei_string
 logger = logging.getLogger(__name__)
 bp = Blueprint("notifications", __name__)
 
-max_block_diff = 10000
+max_block_diff = int(shared_config["discprov"]["notifications_max_block_diff"])
 max_slot_diff = int(shared_config["discprov"]["notifications_max_slot_diff"])
 
 

--- a/discovery-provider/src/queries/response_name_constants.py
+++ b/discovery-provider/src/queries/response_name_constants.py
@@ -84,6 +84,7 @@ notification_type_remix_create = "RemixCreate"
 notification_type_remix_cosign = "RemixCosign"
 notification_type_playlist_update = "PlaylistUpdate"
 notification_type_tier_change = "TierChange"
+notification_type_track_added_to_playlist = "TrackAddedToPlaylist"
 
 notification_blocknumber = "blocknumber"
 notification_initiator = "initiator"


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add a notification for users who have their track added to a playlist. Finished + tested these changes from @raymondjacobson. Identity / client changes WIP.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Manually tested on local services. 
Notifications response:
```
{
"blocknumber": 4445, 
"initiator": 1, 
"metadata": {
    "entity_id": 2, 
    "entity_owner_id": 2, 
    "entity_type": "track"
}, 
"timestamp": "2022-06-07T17:52:20 Z", 
"type": "TrackAddedToPlaylist"
}
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check `/notifications` response. Validate TrackAddedToPlaylist entry.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->