### PR TITLE
Extend ES indexer test

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_es_indexer.py
+++ b/discovery-provider/integration_tests/tasks/test_es_indexer.py
@@ -55,11 +55,16 @@ def clean_up_es():
 
 
 def test_es_indexer_catchup(app):
+    """
+    Tests initial catchup.
+    """
+
     with app.app_context():
         db = get_db()
 
     populate_mock_db(db, basic_entities)
-
+    
+    # run indexer until timeout and validate catchup completed
     try:
         output = subprocess.run(
             ["npm", "run", "dev"],
@@ -81,6 +86,10 @@ def test_es_indexer_catchup(app):
 
 
 def test_es_indexer_processing(app):
+    """
+    Tests indexing after initial catchup.
+    """
+
     with app.app_context():
         db = get_db()
     try:
@@ -91,9 +100,12 @@ def test_es_indexer_processing(app):
             text=True,
             stdout=subprocess.PIPE,
         )
-        time.sleep(4)
+        time.sleep(3)
+        
+        # add new records
         populate_mock_db(db, basic_entities)
-        proc.communicate(timeout=2)
+    
+        proc.communicate(timeout=5) # timeout indexer
     except subprocess.TimeoutExpired as timeout:
         if "processed new updates" not in timeout.output.decode("utf-8"):
             raise Exception("Elasticsearch failed to process updates")

--- a/discovery-provider/integration_tests/tasks/test_es_indexer.py
+++ b/discovery-provider/integration_tests/tasks/test_es_indexer.py
@@ -63,7 +63,7 @@ def test_es_indexer_catchup(app):
         db = get_db()
 
     populate_mock_db(db, basic_entities)
-    
+
     # run indexer until timeout and validate catchup completed
     try:
         output = subprocess.run(
@@ -101,11 +101,11 @@ def test_es_indexer_processing(app):
             stdout=subprocess.PIPE,
         )
         time.sleep(3)
-        
+
         # add new records
         populate_mock_db(db, basic_entities)
-    
-        proc.communicate(timeout=5) # timeout indexer
+
+        proc.communicate(timeout=5)  # timeout indexer
     except subprocess.TimeoutExpired as timeout:
         if "processed new updates" not in timeout.output.decode("utf-8"):
             raise Exception("Elasticsearch failed to process updates")


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This should fix some intermittent errors in the catchup test. Looks like not all items are indexed by the time the tests end. I'll keep an eye out if this still happens.

```
        search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
>       assert len(search_res) == 6
E       assert 2 == 6
E         +2
E         -6
```

### Tests
Extended test duration.
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check CI test status.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->