### PR TITLE
CON-200 Make snapbackMaxLastSuccessfulRunDelayMs configurable

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -49,6 +49,7 @@ minimumFailedSyncRequestsBeforeReconfig=5
 maxSyncMonitoringDurationInMs=10000 # 10sec
 syncRequestMaxUserFailureCountBeforeSkip=3
 skippedCIDsRetryQueueJobIntervalMs=30000 # 30sec in ms
+snapbackMaxLastSuccessfulRunDelayMs=300000 # 5min in ms
 
 # peerSetManager
 peerHealthCheckRequestTimeout=2000 # ms

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -33,8 +33,9 @@ const router = express.Router()
 const MAX_HEALTH_CHECK_TIMESTAMP_AGE_MS = 300000
 const numberOfCPUs = os.cpus().length
 
-// Max # of millis that we consider healthy since the last successful Snapback job
-const SNAPBACK_HEALTHY_LAST_RUN_MS = 1000 * 60 * 60 // 1 hour
+const SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS = config.get(
+  'snapbackMaxLastSuccessfulRunDelayMs'
+)
 
 // Helper Functions
 /**
@@ -114,9 +115,9 @@ const healthCheckController = async (req) => {
   if (enforceStateMachineQueueHealth && stateMachineQueueLatestJobSuccess) {
     const delta =
       Date.now() - new Date(stateMachineQueueLatestJobSuccess).getTime()
-    if (delta > SNAPBACK_HEALTHY_LAST_RUN_MS) {
+    if (delta > SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS) {
       return errorResponseServerError(
-        `StateMachineQueue not healthy - last successful run ${delta}ms ago not within healthy threshold of ${SNAPBACK_HEALTHY_LAST_RUN_MS}ms`
+        `StateMachineQueue not healthy - last successful run ${delta}ms ago not within healthy threshold of ${SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
       )
     }
   }

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -113,6 +113,8 @@ const healthCheckController = async (req) => {
 
   const { stateMachineQueueLatestJobSuccess } = response
   if (enforceStateMachineQueueHealth && stateMachineQueueLatestJobSuccess) {
+    response.snapbackMaxLastSuccessfulRunDelayMs =
+      SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
     const delta =
       Date.now() - new Date(stateMachineQueueLatestJobSuccess).getTime()
     if (delta > SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS) {

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -665,6 +665,12 @@ const config = convict({
     format: String,
     env: 'audiusContentInfraSetup',
     default: ''
+  },
+  snapbackMaxLastSuccessfulRunDelayMs: {
+    doc: 'Max time delay since last snapback successful run (milliseconds)',
+    format: 'nat',
+    env: 'snapbackMaxLastSuccessfulRunDelayMs',
+    default: 5 * 60 * 60 * 1000 // 5 hrs
   }
   /**
    * unsupported options at the moment


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Previously, snapback health check used a hardcoded value, which is not sufficient for stage or prod nodes
Changing this to be configurable + increasing prod default value

Note - this is a temporary fix until larger stateMachine redesign ships

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Existing test coverage is sufficient
This is already live and working correctly on https://creatornode11.staging.audius.co/health_check?enforceStateMachineQueueHealth=true

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Any errors containing `StateMachineQueue not healthy - last successful run`
Slack alerts (via pingdom) for stateMachineQueue health, or directly checking `<endpoint>/health_check?enforceStateMachineQueueHealth=true`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->