### PR TITLE
Make exclusive try/except blocks for fetching ts

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -288,12 +288,20 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         last_track_unavailability_job_start_time = str(
             redis.get(UPDATE_TRACK_IS_AVAILABLE_START_REDIS_KEY).decode()
         )
+    except Exception as e:
+        logger.error(
+            f"Could not get latest track unavailability job start timestamp: {e}"
+        )
+        last_track_unavailability_job_start_time = None
+
+    try:
         last_track_unavailability_job_end_time = str(
             redis.get(UPDATE_TRACK_IS_AVAILABLE_FINISH_REDIS_KEY).decode()
         )
     except Exception as e:
-        logger.error(f"Could not get latest track unavailability job timestamps: {e}")
-        last_track_unavailability_job_start_time = None
+        logger.error(
+            f"Could not get latest track unavailability job end timestamp: {e}"
+        )
         last_track_unavailability_job_end_time = None
 
     # Get system information monitor values


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Upon testing, realized that if fetching the end timestamp fails, then the start would come up as `None`. This is to make the fetches exclusive

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Ran the health check locally and the timestamps were shown.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

No logs needed as the current update_track_is_available logs should be sufficient. Also added an exclusive exception log for each of the try/excepts.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->