### PR TITLE
[INF-122] Track metrics for dp4

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,17 +1,23 @@
-### Launch Prometheus & Grafana
+### Launch Prometheus & Grafana Locally
 
 ```bash
+docker-compose build
 docker-compose up -d prometheus grafana
 ./grafana/bin/create-data-sources.sh
 ./grafana/bin/upload-dashboards.sh
 ```
 
-Prometheus is accessible at port 9090, and Grafana at port 3000
+Ports:
 
-### Deploy Changes
+* Prometheus binds to :9090
+* Grafana binds to :3000
 
-Inside `monitoring-tools repo`
+### Deploy Production Changes
+
 ```bash
+ssh prometheus-grafana-metrics
+cd ~/audius-protocol/monitoring
 git checkout master
+
 ./deploy.sh
 ```

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -14,5 +14,6 @@ Visit `http://${REMOTE_DEV_HOST}:3000`.
 ```bash
 ssh prometheus-grafana-metrics
 cd ~/audius-protocol/monitoring
+git checkout master
 ./deploy.sh
 ```

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,19 +1,17 @@
-# Audius Network Monitoring
-### Launch Grafana
+### Launch Prometheus & Grafana
 
 ```bash
-docker-compose up -d grafana prometheus
+docker-compose up -d prometheus grafana
 ./grafana/bin/create-data-sources.sh
 ./grafana/bin/upload-dashboards.sh
 ```
 
-Visit `http://${REMOTE_DEV_HOST}:3000`.
+Prometheus is accessible at port 9090, and Grafana at port 3000
 
 ### Deploy Changes
 
+Inside `monitoring-tools repo`
 ```bash
-ssh prometheus-grafana-metrics
-cd ~/audius-protocol/monitoring
 git checkout master
 ./deploy.sh
 ```

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,4 +1,4 @@
-
+# Audius Network Monitoring
 ### Launch Grafana
 
 ```bash
@@ -8,3 +8,11 @@ docker-compose up -d grafana prometheus
 ```
 
 Visit `http://${REMOTE_DEV_HOST}:3000`.
+
+### Deploy Changes
+
+```bash
+ssh prometheus-grafana-metrics
+cd ~/audius-protocol/monitoring
+./deploy.sh
+```

--- a/monitoring/deploy.sh
+++ b/monitoring/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+git checkout master
+git pull
+docker-compose build
+
+docker-compose down
+docker-compose up -d

--- a/monitoring/deploy.sh
+++ b/monitoring/deploy.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-git checkout master
 git pull
 docker-compose build
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '3'
 
 services:
+  prometheus:
+    build: prometheus
+    user: 0:0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./data/prometheus:/prometheus
+
   grafana:
     build:
       context: grafana
@@ -17,13 +27,3 @@ services:
     restart: always
     volumes:
       - ./data/grafana:/var/lib/grafana
-
-  prometheus:
-    build: prometheus
-    user: 0:0
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./data/prometheus:/prometheus

--- a/monitoring/prometheus/generate-prom.js
+++ b/monitoring/prometheus/generate-prom.js
@@ -1,3 +1,5 @@
+// this script generates prometheus.yml dynamically
+// it uses audiusLibs to add known service providers to prometheus.yml
 
 const fs = require('fs');
 const dotenv = require('dotenv');
@@ -86,6 +88,19 @@ scrape_configs:
           service: 'audius'
           component: 'discover-provider'
           job: 'census'
+
+  # monitor canary nodes
+
+  - job_name: 'discoveryprovider4-audius-co'
+  scheme: https
+  metrics_path: '/prometheus_metrics'
+  static_configs:
+    - targets: ['discoveryprovider4.audius.co']
+      labels:
+        host: 'discoveryprovider4.audius.co'
+        environment: 'prod'
+        service: 'audius'
+        component: 'discover-provider'
 `)
 
   for (const env of ENVS) {

--- a/monitoring/prometheus/generate-prom.js
+++ b/monitoring/prometheus/generate-prom.js
@@ -92,15 +92,15 @@ scrape_configs:
   # monitor canary nodes
 
   - job_name: 'discoveryprovider4-audius-co'
-  scheme: https
-  metrics_path: '/prometheus_metrics'
-  static_configs:
-    - targets: ['discoveryprovider4.audius.co']
-      labels:
-        host: 'discoveryprovider4.audius.co'
-        environment: 'prod'
-        service: 'audius'
-        component: 'discover-provider'
+    scheme: https
+    metrics_path: '/prometheus_metrics'
+    static_configs:
+      - targets: ['discoveryprovider4.audius.co']
+        labels:
+          host: 'discoveryprovider4.audius.co'
+          environment: 'prod'
+          service: 'audius'
+          component: 'discover-provider'
 `)
 
   for (const env of ENVS) {


### PR DESCRIPTION
### Description

We currently only monitor nodes that are listed via audiusLibs. DP4 has useful metrics as a canary node.

This PR manually adds prod-dp4 to the list of nodes Prometheus listens to.

### Tests

Currently built, tested, and running on `prometheus-grafana-metrics`.

<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Who monitors the monitor? :thinking: 