### PR TITLE
INF-128 Remove on-hold jobs from main ci workflow to get dat ✅

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,6 +573,7 @@ jobs:
       #     paths:
       #       - solana-programs/track_listen_count/target
       #     key: track-listen-count-deps-{{ checksum "solana-programs/track_listen_count/Cargo.toml" }}
+
   test-solana-programs-anchor:
     resource_class: large # 4vcpu/8gb
     machine:
@@ -742,15 +743,6 @@ workflows:
           name: build-identity-service
           repo: identity-service
 
-      - hold-build-logspout:
-          type: approval
-      - docker-build-and-push:
-          name: build-logspout
-          repo: logspout
-          logspout-tag: "true"
-          requires:
-            - hold-build-logspout
-
       - test-solana-programs:
           name: test-solana-programs
       - test-solana-programs-anchor:
@@ -760,15 +752,27 @@ workflows:
           context:
             - GCP2
           mad-dog-type: test
-      - hold-test-mad-dog-e2e-full:
-          type: approval
-      - test-mad-dog-e2e:
-          context:
-            - GCP2
-          name: test-mad-dog-e2e-full
-          mad-dog-type: test-nightly
-          requires:
-            - hold-test-mad-dog-e2e-full
+
+      # Commenting this out since we almost never run this job, and it ruins our nice green check marks.
+      # - hold-test-mad-dog-e2e-full:
+      #     type: approval
+      # - test-mad-dog-e2e:
+      #     context:
+      #       - GCP2
+      #     name: test-mad-dog-e2e-full
+      #     mad-dog-type: test-nightly
+      #     requires:
+      #       - hold-test-mad-dog-e2e-full
+
+      # Commenting this out since we almost never need to build this manually, and it ruins our nice green check marks.
+      # - hold-build-logspout:
+      #     type: approval
+      # - docker-build-and-push:
+      #     name: build-logspout
+      #     repo: logspout
+      #     logspout-tag: "true"
+      #     requires:
+      #       - hold-build-logspout
 
   # test master at midnight daily
   test-nightly:


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
We have 2 jobs in our main CI workflow that are on-hold until manually approved. As a result we never get a green success marker on successful CI flows. Since we pretty much never need these jobs, I'm disabling them. Just commented out for now so infra can keep as reference and proceed as they see fit

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
See CI status for below commit

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->