### PR TITLE
[INF-122] Export search queries metrics to Prometheus

### DIFF
--- a/discovery-provider/src/api/v1/search.py
+++ b/discovery-provider/src/api/v1/search.py
@@ -12,6 +12,7 @@ from src.api.v1.helpers import (
 from src.api.v1.models.search import search_model
 from src.queries.search_queries import search
 from src.utils.redis_cache import cache
+from src.utils.redis_metrics import record_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class FullSearch(Resource):
     @full_ns.expect(full_search_parser)
     @full_ns.marshal_with(search_full_response)
     @cache(ttl_sec=5)
+    @record_metrics
     def get(self):
         args = full_search_parser.parse_args()
         offset = format_offset(args)
@@ -69,6 +71,7 @@ class FullSearchAutocomplete(Resource):
     @full_ns.expect(full_search_parser)
     @full_ns.marshal_with(search_autocomplete_response)
     @cache(ttl_sec=5)
+    @record_metrics
     def get(self):
         """
         Get Users/Tracks/Playlists/Albums that best match the search query

--- a/discovery-provider/src/api/v1/search.py
+++ b/discovery-provider/src/api/v1/search.py
@@ -28,6 +28,7 @@ search_full_response = make_full_response(
 
 @full_ns.route("/full")
 class FullSearch(Resource):
+    @record_metrics
     @full_ns.doc(
         id="Search",
         description="""Get Users/Tracks/Playlists/Albums that best match the search query""",
@@ -36,7 +37,6 @@ class FullSearch(Resource):
     @full_ns.expect(full_search_parser)
     @full_ns.marshal_with(search_full_response)
     @cache(ttl_sec=5)
-    @record_metrics
     def get(self):
         args = full_search_parser.parse_args()
         offset = format_offset(args)
@@ -64,6 +64,7 @@ search_autocomplete_response = make_full_response(
 
 @full_ns.route("/autocomplete")
 class FullSearchAutocomplete(Resource):
+    @record_metrics
     @full_ns.doc(
         id="Search Autocomplete",
         responses={200: "Success", 400: "Bad request", 500: "Server error"},
@@ -71,7 +72,6 @@ class FullSearchAutocomplete(Resource):
     @full_ns.expect(full_search_parser)
     @full_ns.marshal_with(search_autocomplete_response)
     @cache(ttl_sec=5)
-    @record_metrics
     def get(self):
         """
         Get Users/Tracks/Playlists/Albums that best match the search query

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -669,7 +669,9 @@ def record_metrics(func):
             )
 
         route = route.split("?")[0]
-        if "/v1/full/" in route or "/users/intersection/" in route:
+        if "/v1/full/search/autocomplete" in route:
+            route = "/".join(route.split("/")[:5])
+        elif "/v1/full/" in route or "/users/intersection/" in route:
             route = "/".join(route.split("/")[:4])
         elif "/v1/users/" in route and ("/followers" in route or "/following" in route):
             route = "/".join(route.split("/")[:3] + ["*"] + route.split("/")[-1:])


### PR DESCRIPTION
### Description

`src/api/v1/search.py` did not use the `@record_metrics` decorator previously. Without this decorator, we were not exporting metrics for latency and request counts for search queries.

We are now exporting these metrics in advance of our search rework.

### Tests

```
audius_dn_flask_route_latency_seconds_sum{code="200",route="/playlists"} 0.059265851974487305
audius_dn_flask_route_latency_seconds_sum{code="200",route="/v1/full/search"} 0.2101149559020996
audius_dn_flask_route_latency_seconds_sum{code="200",route="/v1/full/search/autocomplete"} 0.12108540534973145
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.005",route="/playlists"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.01",route="/playlists"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.025",route="/playlists"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.05",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.075",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.1",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.25",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.5",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.75",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="1.0",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="2.5",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="5.0",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="7.5",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="10.0",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="+Inf",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_count{code="200",route="/playlists"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.005",route="/v1/full/search"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.01",route="/v1/full/search"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.025",route="/v1/full/search"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.05",route="/v1/full/search"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.075",route="/v1/full/search"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.1",route="/v1/full/search"} 1.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.25",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.5",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.75",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="1.0",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="2.5",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="5.0",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="7.5",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="10.0",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="+Inf",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_count{code="200",route="/v1/full/search"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.005",route="/v1/full/search/autocomplete"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.01",route="/v1/full/search/autocomplete"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.025",route="/v1/full/search/autocomplete"} 0.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.05",route="/v1/full/search/autocomplete"} 1.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.075",route="/v1/full/search/autocomplete"} 1.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.1",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.25",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.5",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="0.75",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="1.0",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="2.5",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="5.0",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="7.5",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="10.0",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_bucket{code="200",le="+Inf",route="/v1/full/search/autocomplete"} 2.0
audius_dn_flask_route_latency_seconds_count{code="200",route="/v1/full/search/autocomplete"} 2.0
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

The above metrics should be observed via `/prometheus_metrics`.