### PR TITLE
Ci node modules fix

### DIFF
--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -79,6 +79,9 @@ RUN python3 -m pip install --upgrade pip && \
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install -r requirements.txt --no-cache-dir
 
+COPY es-indexer es-indexer
+RUN cd es-indexer && npm install && npm run build
+
 COPY . .
 
 COPY --from=contracts /usr/src/app/build/contracts/ build/contracts/

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -112,11 +112,13 @@ fi
 
 
 # start es-indexer
-if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
-  # npm run catchup creates triggers + populate indexes - this blocks server / celery start
-  # npm start gets backgrounded and goes into listen mode
-  cd es-indexer && npm run catchup && npm start &
-fi
+(
+    if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
+    # npm run catchup creates triggers + populate indexes - this blocks server / celery start
+    # npm start gets backgrounded and goes into listen mode
+    cd es-indexer && npm run catchup && npm start &
+    fi
+)
 
 # start api server + celery workers
 if [[ "$audius_discprov_dev_mode" == "true" ]]; then

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -112,10 +112,11 @@ fi
 
 
 # start es-indexer
+cd es-indexer && npm i && cd -
 if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
   # npm run catchup creates triggers + populate indexes - this blocks server / celery start
   # npm start gets backgrounded and goes into listen mode
-  cd es-indexer && npm i && npm run build && npm run catchup && npm start &
+  cd es-indexer && npm run build && npm run catchup && npm start &
 fi
 
 # start api server + celery workers

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -112,11 +112,10 @@ fi
 
 
 # start es-indexer
-cd es-indexer && npm i && cd -
 if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
   # npm run catchup creates triggers + populate indexes - this blocks server / celery start
   # npm start gets backgrounded and goes into listen mode
-  cd es-indexer && npm run build && npm run catchup && npm start &
+  cd es-indexer && npm run catchup && npm start &
 fi
 
 # start api server + celery workers

--- a/discovery-provider/scripts/test.sh
+++ b/discovery-provider/scripts/test.sh
@@ -22,6 +22,8 @@ pip3 install -r requirements.txt
 sleep 5
 set +e
 
+cd es-indexer && npm i && cd -
+
 if [ -n "${VERBOSE}" ]; then
   set -x
 fi

--- a/discovery-provider/scripts/up.sh
+++ b/discovery-provider/scripts/up.sh
@@ -58,6 +58,7 @@ fi
 (
     # mv ./node_modules away, temporarily
     cd ${PROTOCOL_DIR}/discovery-provider/es-indexer
+    npm i
     mv node_modules /tmp/dn-node_modules
 )
 


### PR DESCRIPTION
### Description

A few different test fixes:

* `scripts/test.sh` does `npm i` in `es-indexer` so that tests that call es-indexer will work
* `scripts/up.sh` does `npm i` in `es-indexer` to ensure node_modules stashing works
* fixes `test_search.py` to not rely on timeouts


### Tests

ran the tests


