### PR TITLE
use a different context for cd commands

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -112,12 +112,14 @@ fi
 
 
 # start es-indexer
-cd es-indexer && npm i && cd -
-if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
-  # npm run catchup creates triggers + populate indexes - this blocks server / celery start
-  # npm start gets backgrounded and goes into listen mode
-  cd es-indexer && npm run build && npm run catchup && npm start &
-fi
+(
+    cd es-indexer && npm i && cd -
+    if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
+    # npm run catchup creates triggers + populate indexes - this blocks server / celery start
+    # npm start gets backgrounded and goes into listen mode
+    cd es-indexer && npm run build && npm run catchup && npm start &
+    fi
+)
 
 # start api server + celery workers
 if [[ "$audius_discprov_dev_mode" == "true" ]]; then


### PR DESCRIPTION
### Description

Using `()` allows us to safely use `cd` without possibly affecting downstream commands.