### PR TITLE
Create a separate workflow for hold jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,6 +758,12 @@ workflows:
           context:
             - GCP2
           mad-dog-type: test
+
+  # in order to run a job in hold-workflows
+  # 1. go to the CircleCI dashboard
+  # 2. go to your branch of choice
+  # 3. click "Trigger Pipeline"
+  # 4. Add boolean paramter "full_ci" and set to true
   hold-workflows:
     when: << pipeline.parameters.full_ci >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,26 +753,26 @@ workflows:
             - GCP2
           mad-dog-type: test
 
-      # Commenting this out since we almost never run this job, and it ruins our nice green check marks.
-      # - hold-test-mad-dog-e2e-full:
-      #     type: approval
-      # - test-mad-dog-e2e:
-      #     context:
-      #       - GCP2
-      #     name: test-mad-dog-e2e-full
-      #     mad-dog-type: test-nightly
-      #     requires:
-      #       - hold-test-mad-dog-e2e-full
+  hold-jobs:
+    jobs:
+      - hold-test-mad-dog-e2e-full:
+          type: approval
+      - test-mad-dog-e2e:
+          context:
+            - GCP2
+          name: test-mad-dog-e2e-full
+          mad-dog-type: test-nightly
+          requires:
+            - hold-test-mad-dog-e2e-full
 
-      # Commenting this out since we almost never need to build this manually, and it ruins our nice green check marks.
-      # - hold-build-logspout:
-      #     type: approval
-      # - docker-build-and-push:
-      #     name: build-logspout
-      #     repo: logspout
-      #     logspout-tag: "true"
-      #     requires:
-      #       - hold-build-logspout
+      - hold-build-logspout:
+          type: approval
+      - docker-build-and-push:
+          name: build-logspout
+          repo: logspout
+          logspout-tag: "true"
+          requires:
+            - hold-build-logspout
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,43 +721,43 @@ workflows:
     jobs:
       - test-libs:
           name: test-libs
-      # - docker-build-and-push:
-      #     name: build-libs
-      #     repo: libs
+      - docker-build-and-push:
+          name: build-libs
+          repo: libs
 
-      # - test-contracts:
-      #     name: test-contracts
+      - test-contracts:
+          name: test-contracts
 
-      # - test-eth-contracts:
-      #     name: test-eth-contracts
+      - test-eth-contracts:
+          name: test-eth-contracts
 
-      # - test-creator-node:
-      #     name: test-creator-node
-      # - docker-build-and-push:
-      #     name: build-creator-node
-      #     repo: creator-node
+      - test-creator-node:
+          name: test-creator-node
+      - docker-build-and-push:
+          name: build-creator-node
+          repo: creator-node
 
-      # - test-discovery-provider:
-      #     name: test-discovery-provider
-      # - docker-build-and-push-updated:
-      #     name: build-discovery-provider
-      #     repo: discovery-provider
+      - test-discovery-provider:
+          name: test-discovery-provider
+      - docker-build-and-push-updated:
+          name: build-discovery-provider
+          repo: discovery-provider
 
-      # - test-identity-service:
-      #     name: test-identity-service
-      # - docker-build-and-push:
-      #     name: build-identity-service
-      #     repo: identity-service
+      - test-identity-service:
+          name: test-identity-service
+      - docker-build-and-push:
+          name: build-identity-service
+          repo: identity-service
 
-      # - test-solana-programs:
-      #     name: test-solana-programs
-      # - test-solana-programs-anchor:
-      #     name: test-solana-programs-anchor
+      - test-solana-programs:
+          name: test-solana-programs
+      - test-solana-programs-anchor:
+          name: test-solana-programs-anchor
 
-      # - test-mad-dog-e2e:
-      #     context:
-      #       - GCP2
-      #     mad-dog-type: test
+      - test-mad-dog-e2e:
+          context:
+            - GCP2
+          mad-dog-type: test
   hold-workflows:
     when: << pipeline.parameters.full_ci >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,9 +758,11 @@ workflows:
       #     context:
       #       - GCP2
       #     mad-dog-type: test
+  hold-workflows:
+    when: << pipeline.parameters.full_ci >>
+    jobs:
       - hold-test-mad-dog-e2e-full:
           type: approval
-          when: << pipeline.parameters.full_ci >>
       - test-mad-dog-e2e:
           context:
             - GCP2
@@ -768,18 +770,14 @@ workflows:
           mad-dog-type: test-nightly
           requires:
             - hold-test-mad-dog-e2e-full
-          when: << pipeline.parameters.full_ci >>
-
       - hold-build-logspout:
           type: approval
-          when: << pipeline.parameters.full_ci >>
       - docker-build-and-push:
           name: build-logspout
           repo: logspout
           logspout-tag: "true"
           requires:
             - hold-build-logspout
-          when: << pipeline.parameters.full_ci >>
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,12 @@ commands:
           steps:
             - run: ./diff.sh << parameters.service >> || (echo "no diff" && circleci-agent step halt)
 
+# global parameters
+parameters:
+  full_ci:
+    type: boolean
+    default: false
+
 jobs:
   bake-gcp-dev-image:
     docker:
@@ -752,11 +758,9 @@ workflows:
       #     context:
       #       - GCP2
       #     mad-dog-type: test
-
-  hold-jobs:
-    jobs:
       - hold-test-mad-dog-e2e-full:
           type: approval
+          when: << pipeline.parameters.full_ci >>
       - test-mad-dog-e2e:
           context:
             - GCP2
@@ -764,15 +768,18 @@ workflows:
           mad-dog-type: test-nightly
           requires:
             - hold-test-mad-dog-e2e-full
+          when: << pipeline.parameters.full_ci >>
 
       - hold-build-logspout:
           type: approval
+          when: << pipeline.parameters.full_ci >>
       - docker-build-and-push:
           name: build-logspout
           repo: logspout
           logspout-tag: "true"
           requires:
             - hold-build-logspout
+          when: << pipeline.parameters.full_ci >>
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,43 +715,43 @@ workflows:
     jobs:
       - test-libs:
           name: test-libs
-      - docker-build-and-push:
-          name: build-libs
-          repo: libs
+      # - docker-build-and-push:
+      #     name: build-libs
+      #     repo: libs
 
-      - test-contracts:
-          name: test-contracts
+      # - test-contracts:
+      #     name: test-contracts
 
-      - test-eth-contracts:
-          name: test-eth-contracts
+      # - test-eth-contracts:
+      #     name: test-eth-contracts
 
-      - test-creator-node:
-          name: test-creator-node
-      - docker-build-and-push:
-          name: build-creator-node
-          repo: creator-node
+      # - test-creator-node:
+      #     name: test-creator-node
+      # - docker-build-and-push:
+      #     name: build-creator-node
+      #     repo: creator-node
 
-      - test-discovery-provider:
-          name: test-discovery-provider
-      - docker-build-and-push-updated:
-          name: build-discovery-provider
-          repo: discovery-provider
+      # - test-discovery-provider:
+      #     name: test-discovery-provider
+      # - docker-build-and-push-updated:
+      #     name: build-discovery-provider
+      #     repo: discovery-provider
 
-      - test-identity-service:
-          name: test-identity-service
-      - docker-build-and-push:
-          name: build-identity-service
-          repo: identity-service
+      # - test-identity-service:
+      #     name: test-identity-service
+      # - docker-build-and-push:
+      #     name: build-identity-service
+      #     repo: identity-service
 
-      - test-solana-programs:
-          name: test-solana-programs
-      - test-solana-programs-anchor:
-          name: test-solana-programs-anchor
+      # - test-solana-programs:
+      #     name: test-solana-programs
+      # - test-solana-programs-anchor:
+      #     name: test-solana-programs-anchor
 
-      - test-mad-dog-e2e:
-          context:
-            - GCP2
-          mad-dog-type: test
+      # - test-mad-dog-e2e:
+      #     context:
+      #       - GCP2
+      #     mad-dog-type: test
 
   hold-jobs:
     jobs:


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Addressing [this](https://github.com/AudiusProject/audius-protocol/pull/3235) PR, I've moved all the hold jobs into a separate workflow that's enabled by manually triggering a build from the CIrcleCI dashboard on a particular branch with the "full_ci" parameter enabled.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Example workflow with the full_ci parameter enabled https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/23775/workflows/412df710-c098-4ee6-a21d-c933f9033450


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
CI feature, will show up in Circle if it passed

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->