### PR TITLE
Rate limit local queue logging

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -41,7 +41,11 @@ class StateMonitoringManager {
         this.processFindReplicaSetUpdatesJob.bind(this)
     })
 
-    await this.startQueue(queue, discoveryNodeEndpoint)
+    // Don't start this queue on local dev because jobs process quickly with 0 users, which spams the logs
+    if (!config.get('creatorNodeIsDebug')) {
+      await this.startQueue(queue, discoveryNodeEndpoint)
+    }
+
     return queue
   }
 

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -148,12 +148,22 @@ class SnapbackSM {
 
     // State machine queue processes all user operations
     // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
-    this.stateMachineQueue = this.createBullQueue('state-machine', {
-      // Should be sufficiently larger than expected job runtime
-      lockDuration: MAX_SNAPBACK_JOB_RUNTIME_MS,
-      // We never want to re-process stalled jobs
-      maxStalledCount: 0
-    })
+    this.stateMachineQueue = this.createBullQueue(
+      'state-machine',
+      {
+        // Should be sufficiently larger than expected job runtime
+        lockDuration: MAX_SNAPBACK_JOB_RUNTIME_MS,
+        // We never want to re-process stalled jobs
+        maxStalledCount: 0
+      },
+      // Rate limit to 1 job every 3 minutes locally to prevent log spam during development
+      this.nodeConfig.get('creatorNodeIsDebug')
+        ? {
+            max: 1,
+            duration: 3000 * 60
+          }
+        : {}
+    )
 
     // Sync queues handle issuing sync request from primary -> secondary
     this.manualSyncQueue = this.createBullQueue('manual-sync-queue')
@@ -322,7 +332,7 @@ class SnapbackSM {
   }
 
   // Initialize bull queue instance with provided name and settings
-  createBullQueue(queueName, settings = {}) {
+  createBullQueue(queueName, settings = {}, limiter = {}) {
     return new Bull(queueName, {
       redis: {
         port: this.nodeConfig.get('redisPort'),
@@ -333,7 +343,8 @@ class SnapbackSM {
         removeOnComplete: SNAPBACK_QUEUE_HISTORY,
         removeOnFail: SNAPBACK_QUEUE_HISTORY
       },
-      settings
+      settings,
+      ...(!_.isEmpty(limiter) && { limiter })
     })
   }
 


### PR DESCRIPTION
### Description
- Rate limit SnapbackSM to one job per every 3 minutes on local dev to prevent the jobs from spamming the logs. This happens because there are no users locally, so processing is extremely fast
- Disable the monitoring queue on local dev to also prevent log spam. This works by just not adding the first monitoring job to the queue, so then no future monitoring or reconciliation jobs are added

### Tests
I ran `A up` locally to verify SnapbackSM was rate limited and monitoring jobs were not occurring:
`state-machine` should be running 1 job every 3 minutes
`state-monitoring-queue` and `state-reconciliation-queue` should not have any jobs


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Go to the `/health/bull` endpoint and see how quickly the jobs are progressing on staging:
`state-machine` should be running as fast as it can (no rate limit)
`state-monitoring-queue` should be processing jobs (it's broken if there are no jobs in this queue on staging)