### PR TITLE
Skip fetching all CIDs for all tracks

### DIFF
--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -231,37 +231,6 @@ class BlacklistManager {
     const segmentCIDs = new Set()
     const trackIdToSegments = {}
 
-    // Retrieve CIDs from the track metadata and build mapping of <trackId: segments>
-    for (const track of tracks) {
-      if (!track.metadataJSON || !track.metadataJSON.track_segments) continue
-
-      // If the current track is from the track BL and not user BL, create mapping
-      if (explicitTrackIds.has(track.blockchainId)) {
-        trackIdToSegments[track.blockchainId] = []
-      }
-
-      for (const segment of track.metadataJSON.track_segments) {
-        if (!segment.multihash) continue
-
-        segmentCIDs.add(segment.multihash)
-        if (trackIdToSegments[track.blockchainId]) {
-          trackIdToSegments[track.blockchainId].push(segment.multihash)
-        }
-      }
-    }
-
-    // also retrieves the CID's directly from the files table so we get copy320
-    if (allTrackIds.length > 0) {
-      const files = await models.File.findAll({
-        where: { trackBlockchainId: allTrackIds }
-      })
-      for (const file of files) {
-        if (file.type === 'track' || file.type === 'copy320') {
-          segmentCIDs.add(file.multihash)
-        }
-      }
-    }
-
     return { segmentCIDs: [...segmentCIDs], trackIdToSegments }
   }
 

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -711,7 +711,7 @@ describe('test ContentBlacklist', function () {
     // TODO: add remove and test that the segments are unblacklisted
   })
 
-  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
+  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -779,7 +779,7 @@ describe('test ContentBlacklist', function () {
     )
   })
 
-  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
+  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -991,7 +991,7 @@ describe('test ContentBlacklist', function () {
       .expect(400)
   })
 
-  it('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
+  it.skip('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fetching all CIDs for all tracks was causing the content node process to OOM (and also take an absurdly long time to come up during init). This is a fix meant to carry us through until this codepath is fully refactored.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on CN2 and CN3 on production. The tests that were commented in this PR are part of the functionality that no longer works because of these changes


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Can hit the /ipfs/ route for CIDs and test whether content is served

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->