### PR TITLE
remove time.sleep from es tests

### DIFF
--- a/discovery-provider/es-indexer/package.json
+++ b/discovery-provider/es-indexer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "catchup": "node build/src/main.js --no-listen",
-    "catchup:ci": "ts-node --transpileOnly src/main.ts --no-listen",
+    "catchup:ci": "ts-node --transpileOnly src/main.ts --drop --no-listen",
     "dev": "ts-node src/main.ts",
     "nuke": "ts-node scripts/nuke.ts",
     "sql-ts": "ts-node scripts/sql-ts.ts",

--- a/discovery-provider/es-indexer/src/main.ts
+++ b/discovery-provider/es-indexer/src/main.ts
@@ -36,6 +36,7 @@ async function processPending(pending: PendingUpdates) {
 async function start() {
   const cliFlags = program
     .option('--no-listen', 'exit after catchup is complete')
+    .option('--drop', 'drop and recreate indexes')
     .parse()
     .opts()
 
@@ -46,7 +47,9 @@ async function start() {
 
   // create indexes
   const indexers = Object.values(indexer)
-  await Promise.all(indexers.map((ix) => ix.createIndex({ drop: false })))
+  await Promise.all(
+    indexers.map((ix) => ix.createIndex({ drop: cliFlags.drop }))
+  )
 
   // setup postgres trigger + listeners
   await setupTriggers()

--- a/discovery-provider/integration_tests/queries/test_search.py
+++ b/discovery-provider/integration_tests/queries/test_search.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import time
 from datetime import datetime
 
 import pytest
@@ -260,7 +259,6 @@ def setup_search(app_module):
         cwd="es-indexer",
         timeout=5,
     )
-    time.sleep(2)
 
 
 def test_get_tracks_external(app_module):

--- a/discovery-provider/integration_tests/tasks/test_es_indexer.py
+++ b/discovery-provider/integration_tests/tasks/test_es_indexer.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import subprocess
-import time
 
-import pytest
 from elasticsearch import Elasticsearch
 from integration_tests.utils import populate_mock_db
 from src.utils.db_session import get_db
@@ -48,12 +46,6 @@ basic_entities = {
 }
 
 
-@pytest.fixture(autouse=True)
-def clean_up_es():
-    esclient.delete_by_query(index="*", query={"match_all": {}})
-    yield
-
-
 def test_es_indexer_catchup(app):
     """
     Tests initial catchup.
@@ -74,6 +66,5 @@ def test_es_indexer_catchup(app):
         timeout=5,
     )
     esclient.indices.refresh(index="*")
-    time.sleep(2)
     search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
     assert len(search_res) == 6


### PR DESCRIPTION
### Description

ES delete_by_query is async unless you pass extra refresh=true
but instead will just have es-indexer drop and create indexes
which will ensure mapping is up to date also.

### Tests

ran tests
