### PR TITLE
[PAY-256] Fix back to back tip nonce error

### DIFF
--- a/libs/src/services/solanaWeb3Manager/transfer.js
+++ b/libs/src/services/solanaWeb3Manager/transfer.js
@@ -86,7 +86,7 @@ async function getAccountNonce ({
     mintKey,
     claimableTokenProgramKey
   })
-  const accInfo = await connection.getAccountInfoAndContext(transferNonceAccount)
+  const accInfo = await connection.getAccountInfoAndContext(transferNonceAccount, 'confirmed')
   if (accInfo.value) {
     const nonceAccount = borsh.deserialize(NonceAccountSchema, NonceAccount, accInfo.value.data)
     nonce = nonceAccount.nonce


### PR DESCRIPTION
### Description
- Back to back tips would break because we would fetch an out of date nonce.
- Solution: use more permissive commitment level for fetching nonce account



### Tests

Tested locally
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->