### PR TITLE
Test monitorState and findSyncRequests job processors

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -45,23 +45,30 @@ module.exports = function ({
   let errors = []
   for (const user of users) {
     const {
-      syncReqsToEnqueues: userSyncReqsToEnqueue,
+      syncReqsToEnqueue: userSyncReqsToEnqueue,
       duplicateSyncReqs: userDuplicateSyncReqs,
       errors: userErrors
     } = _findSyncsForUser(
       user,
       thisContentNodeEndpoint,
       unhealthyPeersSet,
-      userSecondarySyncMetricsMap[user.wallet],
+      userSecondarySyncMetricsMap[user.wallet] || {
+        [user.secondary1]: { successRate: 1, failureCount: 0 },
+        [user.secondary2]: { successRate: 1, failureCount: 0 }
+      },
       minSecondaryUserSyncSuccessPercent,
       minFailedSyncRequestsBeforeReconfig,
       replicaSetNodesToUserClockStatusesMap
     )
-    if (userSyncReqsToEnqueue) {
+    console.log(
+      `duplicate: ${userDuplicateSyncReqs}; reqs: ${userSyncReqsToEnqueue}`
+    )
+    if (userSyncReqsToEnqueue?.length) {
+      console.log('userSyncReqsToEnqueue was true')
       syncReqsToEnqueue = syncReqsToEnqueue.concat(userSyncReqsToEnqueue)
-    } else if (userDuplicateSyncReqs) {
+    } else if (userDuplicateSyncReqs?.length) {
       duplicateSyncReqs = duplicateSyncReqs.concat(userDuplicateSyncReqs)
-    } else if (userErrors) errors = errors.concat(userErrors)
+    } else if (userErrors?.length) errors = errors.concat(userErrors)
   }
 
   return {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -60,11 +60,7 @@ module.exports = function ({
       minFailedSyncRequestsBeforeReconfig,
       replicaSetNodesToUserClockStatusesMap
     )
-    console.log(
-      `duplicate: ${userDuplicateSyncReqs}; reqs: ${userSyncReqsToEnqueue}`
-    )
     if (userSyncReqsToEnqueue?.length) {
-      console.log('userSyncReqsToEnqueue was true')
       syncReqsToEnqueue = syncReqsToEnqueue.concat(userSyncReqsToEnqueue)
     } else if (userDuplicateSyncReqs?.length) {
       duplicateSyncReqs = duplicateSyncReqs.concat(userDuplicateSyncReqs)

--- a/creator-node/test/StateMonitoringManager.test.js
+++ b/creator-node/test/StateMonitoringManager.test.js
@@ -39,11 +39,11 @@ describe('test StateMonitoringManager initialization, events, and re-enqueuing',
 
   function getProcessJobMock() {
     const loggerStub = {
-      info: sinon.stub(),
-      warn: sinon.stub(),
-      error: sinon.stub()
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
     }
-    const createChildLogger = sinon.stub().returns(loggerStub)
+    const createChildLogger = sandbox.stub().returns(loggerStub)
     const processJobMock = proxyquire(
       '../src/services/stateMachineManager/processJob.js',
       {

--- a/creator-node/test/findSyncRequests.jobProcessor.test.js
+++ b/creator-node/test/findSyncRequests.jobProcessor.test.js
@@ -1,0 +1,498 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai')
+const sinon = require('sinon')
+const { expect } = chai
+const proxyquire = require('proxyquire')
+
+const { getApp } = require('./lib/app')
+const { getLibsMock } = require('./lib/libsMock')
+
+const config = require('../src/config')
+const {
+  SyncType,
+  QUEUE_NAMES
+} = require('../src/services/stateMachineManager/stateMachineConstants')
+
+chai.use(require('sinon-chai'))
+
+describe('test findSyncRequests job processor', function () {
+  let server, sandbox, originalContentNodeEndpoint
+  beforeEach(async function () {
+    const appInfo = await getApp(getLibsMock())
+    await appInfo.app.get('redisClient').flushdb()
+    server = appInfo.server
+    sandbox = sinon.createSandbox()
+    config.set('spID', 1)
+    originalContentNodeEndpoint = config.get('creatorNodeEndpoint')
+  })
+
+  afterEach(async function () {
+    await server.close()
+    sandbox.restore()
+    config.set('creatorNodeEndpoint', originalContentNodeEndpoint)
+  })
+
+  const primary = 'http://primary_cn.co'
+  const secondary1 = 'http://secondary_to_sync_to.co'
+  const secondary2 = 'http://secondary_already_synced.co'
+  const primarySpID = 1
+  const secondary1SpID = 2
+  const secondary2SpID = 3
+  const user_id = 1
+  const wallet = '0x123456789'
+  const users = [
+    {
+      primary,
+      secondary1,
+      secondary2,
+      primarySpID,
+      secondary1SpID,
+      secondary2SpID,
+      user_id,
+      wallet
+    }
+  ]
+
+  function getJobProcessorStub(
+    getNewOrExistingSyncReqStub,
+    getCNodeEndpointToSpIdMapStub
+  ) {
+    return proxyquire(
+      '../src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js',
+      {
+        '../../../config': config,
+        '../stateReconciliation/stateReconciliationUtils': {
+          getNewOrExistingSyncReq: getNewOrExistingSyncReqStub
+        },
+        '../CNodeToSpIdMapManager': {
+          getCNodeEndpointToSpIdMap: getCNodeEndpointToSpIdMapStub
+        }
+      }
+    )
+  }
+
+  it('returns correct syncs (happy path)', function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1
+    // spIds in mapping must match those in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID,
+      [secondary2]: secondary2SpID
+    }
+    const unhealthyPeers = []
+    // Clock value of secondary1 being less than primary means we'll sync from primary to secondary1
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    const userSecondarySyncMetricsMap = {}
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub successfully finding a new sync to enqueue from primary1 to secondary1
+    const expectedSyncReqToEnqueue = 'expectedSyncReqToEnqueue'
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      const { userWallet, secondaryEndpoint, primaryEndpoint, syncType } = args
+      if (
+        userWallet === wallet &&
+        secondaryEndpoint === secondary1 &&
+        primaryEndpoint === primary &&
+        syncType === SyncType.Recurring
+      ) {
+        return { syncReqToEnqueue: expectedSyncReqToEnqueue }
+      }
+      throw new Error(
+        'getNewOrExistingSyncReq was not expected to be called with the given args'
+      )
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: sync to user1 to secondary1 because its clock value is behind
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [],
+      errors: [],
+      jobsToEnqueue: {
+        [QUEUE_NAMES.STATE_RECONCILIATION]: [expectedSyncReqToEnqueue]
+      }
+    })
+    expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
+      userWallet: wallet,
+      secondaryEndpoint: secondary1,
+      primaryEndpoint: primary,
+      syncType: SyncType.Recurring
+    })
+  })
+
+  it("doesn't enqueue duplicate syncs", function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1
+    const primary = 'http://primary_cn.co'
+    const secondary1 = 'http://secondary_to_sync_to.co'
+    const secondary2 = 'http://secondary_already_synced.co'
+    const primarySpID = 1
+    const secondary1SpID = 2
+    const secondary2SpID = 3
+    const user_id = 1
+    const wallet = '0x123456789'
+    // spIds in mapping must match those in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID,
+      [secondary2]: secondary2SpID
+    }
+    const users = [
+      {
+        primary,
+        secondary1,
+        secondary2,
+        primarySpID,
+        secondary1SpID,
+        secondary2SpID,
+        user_id,
+        wallet
+      }
+    ]
+    const unhealthyPeers = []
+    // Clock value of secondary1 being less than primary means we'll sync from primary to secondary1
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    const userSecondarySyncMetricsMap = {}
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub having a duplicate sync so that no new sync will be enqueued
+    const expectedDuplicateSyncReq = 'expectedDuplicateSyncReq'
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      const { userWallet, secondaryEndpoint, primaryEndpoint, syncType } = args
+      if (
+        userWallet === wallet &&
+        secondaryEndpoint === secondary1 &&
+        primaryEndpoint === primary &&
+        syncType === SyncType.Recurring
+      ) {
+        return { duplicateSyncReq: expectedDuplicateSyncReq }
+      }
+      throw new Error(
+        'getNewOrExistingSyncReq was not expected to be called with the given args'
+      )
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: sync to user1 to secondary1 doesn't happen because a duplicate is already in the queue
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [expectedDuplicateSyncReq],
+      errors: [],
+      jobsToEnqueue: {}
+    })
+    expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
+      userWallet: wallet,
+      secondaryEndpoint: secondary1,
+      primaryEndpoint: primary,
+      syncType: SyncType.Recurring
+    })
+  })
+
+  it("doesn't sync to unhealthy secondaries", function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1 (except being healthy)
+    // spIds in mapping must match those in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID,
+      [secondary2]: secondary2SpID
+    }
+    // Mark secondary1 as healthy so it won't sync to it
+    const unhealthyPeers = [secondary1]
+    // Clock value of secondary1 being less than primary means we would sync from primary to secondary1 if secondary1 is healthy
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    const userSecondarySyncMetricsMap = {}
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub finding syncs never being called because it should short-circuit first when seeing secondary1 is unhealthy
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error('getNewOrExistingSyncReq was not expected to be called')
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: no syncs because secondary1 would normally sync but it's unhealthy
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [],
+      errors: [],
+      jobsToEnqueue: {}
+    })
+    expect(getNewOrExistingSyncReqStub).to.not.have.been.called
+  })
+
+  it("doesn't sync if spId is mismatched in cNodeEndpointToSpId mapping", function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1 (except spId matching)
+    // Make secondary1's spId in mapping NOT match the spId in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID + 100,
+      [secondary2]: secondary2SpID
+    }
+    const unhealthyPeers = []
+    // Clock value of secondary1 being less than primary means we would sync from primary to secondary1 if spId matched
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    const userSecondarySyncMetricsMap = {}
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub finding syncs never being called because it should short-circuit first when seeing secondary1 spId mismatches
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error('getNewOrExistingSyncReq was not expected to be called')
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: no syncs because secondary1 would normally sync but its spId mismatches
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [],
+      errors: [],
+      jobsToEnqueue: {}
+    })
+    expect(getNewOrExistingSyncReqStub).to.not.have.been.called
+  })
+
+  it("doesn't sync if success rate is too low", function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1 (except success rate)
+    // spIds in mapping must match those in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID,
+      [secondary2]: secondary2SpID
+    }
+    const unhealthyPeers = []
+    // Clock value of secondary1 being less than primary means we would sync from primary to secondary1 if success rate were higher
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    // Make success rate lower than threshold
+    const userSecondarySyncMetricsMap = {
+      [wallet]: {
+        [secondary1]: { successRate: 0, failureCount: 100 },
+        [secondary2]: { successRate: 1, failureCount: 0 }
+      }
+    }
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub  finding syncs never being called because it should short-circuit first when seeing low secondary1 success rate
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error('getNewOrExistingSyncReq was not expected to be called')
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: no syncs because secondary1 would normally sync but its success rate is low
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [],
+      errors: [],
+      jobsToEnqueue: {}
+    })
+    expect(getNewOrExistingSyncReqStub).to.not.have.been.called
+  })
+
+  it('catches errors from finding syncs', function () {
+    // Set variables that satisfy conditions for user1 to be synced from primary1 to secondary1
+    // spIds in mapping must match those in the `users` variable
+    const cNodeEndpointToSpIdMap = {
+      [primary]: primarySpID,
+      [secondary1]: secondary1SpID,
+      [secondary2]: secondary2SpID
+    }
+    const unhealthyPeers = []
+    // Clock value of secondary1 being less than primary means we'll sync from primary to secondary1
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: {
+        [wallet]: 10
+      },
+      [secondary1]: {
+        [wallet]: 9
+      },
+      [secondary2]: {
+        [wallet]: 10
+      }
+    }
+    const userSecondarySyncMetricsMap = {}
+    // This node must be the primary in order to sync
+    config.set('creatorNodeEndpoint', primary)
+    // Stub error when trying to find a new sync to enqueue from primary1 to secondary1
+    const expectedErrorMsg = 'expectedErrorMsg'
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error(expectedErrorMsg)
+    })
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    const logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+
+    const findSyncRequestsJobProcessor = getJobProcessorStub(
+      getNewOrExistingSyncReqStub,
+      getCNodeEndpointToSpIdMapStub
+    )
+
+    // Verify job outputs the correct results: sync to user1 to secondary1 because its clock value is behind
+    expect(
+      findSyncRequestsJobProcessor({
+        logger,
+        users,
+        unhealthyPeers,
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      })
+    ).to.deep.equal({
+      duplicateSyncReqs: [],
+      errors: [
+        `Error getting new or existing sync request for user ${wallet} and secondary ${secondary1} - ${expectedErrorMsg}`
+      ],
+      jobsToEnqueue: {}
+    })
+    expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
+      userWallet: wallet,
+      secondaryEndpoint: secondary1,
+      primaryEndpoint: primary,
+      syncType: SyncType.Recurring
+    })
+  })
+})

--- a/creator-node/test/monitorState.jobProcessor.test.js
+++ b/creator-node/test/monitorState.jobProcessor.test.js
@@ -2,18 +2,24 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const { expect } = chai
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 const proxyquire = require('proxyquire')
 const _ = require('lodash')
 
-const config = require('../src/config')
 const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')
 
-describe.skip('test monitorState job processor', function () {
+const config = require('../src/config')
+const {
+  QUEUE_NAMES,
+  JOB_NAMES
+} = require('../src/services/stateMachineManager/stateMachineConstants')
+
+chai.use(require('sinon-chai'))
+
+describe('test monitorState job processor', function () {
   let server,
     sandbox,
+    logger,
     originalContentNodeEndpoint,
     getNodeUsersStub,
     getUnhealthyPeersStub,
@@ -43,7 +49,6 @@ describe.skip('test monitorState job processor', function () {
     getCNodeEndpointToSpIdMapStub = null
   })
 
-  const JOB_ID = 9
   const LAST_PROCESSED_USER_ID = 5
   const NUM_USERS_TO_PROCESS = 4
   const DISCOVERY_NODE_ENDPOINT = 'http://default_dn1.co'
@@ -132,7 +137,6 @@ describe.skip('test monitorState job processor', function () {
   // Return the promise created from running processStateMonitoringJob with the given params
   // and with each step mocked to the given steps (or default mocked steps above)
   function processStateMonitoringJob({
-    jobId = JOB_ID,
     lastProcessedUserId = LAST_PROCESSED_USER_ID,
     discoveryNodeEndpoint = DISCOVERY_NODE_ENDPOINT,
     contentNodeEndpoint = CONTENT_NODE_ENDPOINT,
@@ -142,7 +146,55 @@ describe.skip('test monitorState job processor', function () {
     config.set('creatorNodeEndpoint', contentNodeEndpoint)
     config.set('snapbackUsersPerJob', numUsersToProcess)
     const jobFunc = makeProcessStateMonitoringJob({ ...steps })
-    return jobFunc(jobId, lastProcessedUserId, discoveryNodeEndpoint, 0, 0)
+    logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+    return jobFunc({ logger, lastProcessedUserId, discoveryNodeEndpoint })
+  }
+
+  function verifyJobResult({
+    jobResult,
+    lastProcessedUserId,
+    users = USERS,
+    unhealthyPeers = UNHEALTHY_PEERS,
+    replicaSetNodesToUserClockStatusesMap = REPLICAS_TO_USER_CLOCK_STATUS_MAP,
+    userSecondarySyncMetricsMap = USER_SECONDARY_SYNC_SUCCESS_RATES_MAP
+  }) {
+    const monitorJobs = jobResult.jobsToEnqueue[QUEUE_NAMES.STATE_MONITORING]
+
+    // Verify that there are 3 jobs all being added to the state monitoring queue
+    expect(monitorJobs).to.have.lengthOf(3)
+
+    // Verify jobResult enqueues the correct monitorState job starting at the expected userId
+    expect(monitorJobs).to.deep.include({
+      jobName: JOB_NAMES.MONITOR_STATE,
+      jobData: {
+        lastProcessedUserId,
+        discoveryNodeEndpoint: DISCOVERY_NODE_ENDPOINT
+      }
+    })
+    // Verify jobResult enqueues the correct findSyncRequests job
+    expect(monitorJobs).to.deep.include({
+      jobName: JOB_NAMES.FIND_SYNC_REQUESTS,
+      jobData: {
+        users,
+        unhealthyPeers: Array.from(unhealthyPeers),
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      }
+    })
+    // Verify jobResult enqueues the correct findReplicaSetUpdates job
+    expect(monitorJobs).to.deep.include({
+      jobName: JOB_NAMES.FIND_REPLICA_SET_UPDATES,
+      jobData: {
+        users,
+        unhealthyPeers: Array.from(unhealthyPeers),
+        replicaSetNodesToUserClockStatusesMap,
+        userSecondarySyncMetricsMap
+      }
+    })
   }
 
   it('should process the correct number of users and resolve successfully', async function () {
@@ -167,19 +219,15 @@ describe.skip('test monitorState job processor', function () {
     })
 
     // Verify that the state monitoring job processed `usersToProcess` users
-    return expect(
-      processStateMonitoringJob({
-        lastProcessedUserId,
-        numUsersToProcess,
-        steps: { users }
-      })
-    ).to.eventually.be.fulfilled.and.deep.equal({
+    const jobResult = await processStateMonitoringJob({
+      lastProcessedUserId,
+      numUsersToProcess,
+      steps: { users }
+    })
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: lastProcessedUserId + numUsersToProcess - 1,
-      jobFailed: false,
-      users,
-      unhealthyPeers: UNHEALTHY_PEERS,
-      replicaSetNodesToUserClockStatusesMap: REPLICAS_TO_USER_CLOCK_STATUS_MAP,
-      userSecondarySyncMetricsMap: USER_SECONDARY_SYNC_SUCCESS_RATES_MAP
+      users
     })
   })
 
@@ -196,13 +244,10 @@ describe.skip('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: 0,
-      jobFailed: false,
-      users: [],
-      unhealthyPeers: UNHEALTHY_PEERS,
-      replicaSetNodesToUserClockStatusesMap: REPLICAS_TO_USER_CLOCK_STATUS_MAP,
-      userSecondarySyncMetricsMap: USER_SECONDARY_SYNC_SUCCESS_RATES_MAP
+      users: []
     })
   })
 
@@ -227,13 +272,9 @@ describe.skip('test monitorState job processor', function () {
     expect(
       computeUserSecondarySyncSuccessRatesMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
-    expect(jobResult).to.deep.equal({
-      lastProcessedUserId: USER_ID,
-      jobFailed: false,
-      users: USERS,
-      unhealthyPeers: UNHEALTHY_PEERS,
-      replicaSetNodesToUserClockStatusesMap: REPLICAS_TO_USER_CLOCK_STATUS_MAP,
-      userSecondarySyncMetricsMap: USER_SECONDARY_SYNC_SUCCESS_RATES_MAP
+    verifyJobResult({
+      jobResult,
+      lastProcessedUserId: USER_ID
     })
   })
 
@@ -261,12 +302,9 @@ describe.skip('test monitorState job processor', function () {
     expect(
       computeUserSecondarySyncSuccessRatesMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: USER_ID,
-      jobFailed: true,
-      users: USERS,
-      unhealthyPeers: UNHEALTHY_PEERS,
-      replicaSetNodesToUserClockStatusesMap: REPLICAS_TO_USER_CLOCK_STATUS_MAP,
       userSecondarySyncMetricsMap: {}
     })
   })
@@ -293,11 +331,9 @@ describe.skip('test monitorState job processor', function () {
       retrieveClockStatusesForUsersAcrossReplicaSetStub
     ).to.have.been.calledOnceWithExactly(REPLICA_SET_NODES_TO_USER_WALLETS_MAP)
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: USER_ID,
-      jobFailed: true,
-      users: USERS,
-      unhealthyPeers: UNHEALTHY_PEERS,
       replicaSetNodesToUserClockStatusesMap: {},
       userSecondarySyncMetricsMap: {}
     })
@@ -324,11 +360,9 @@ describe.skip('test monitorState job processor', function () {
     expect(retrieveClockStatusesForUsersAcrossReplicaSetStub).to.not.have.been
       .called
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: USER_ID,
-      jobFailed: true,
-      users: USERS,
-      unhealthyPeers: UNHEALTHY_PEERS,
       replicaSetNodesToUserClockStatusesMap: {},
       userSecondarySyncMetricsMap: {}
     })
@@ -351,10 +385,9 @@ describe.skip('test monitorState job processor', function () {
     expect(retrieveClockStatusesForUsersAcrossReplicaSetStub).to.not.have.been
       .called
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: USER_ID,
-      jobFailed: true,
-      users: USERS,
       unhealthyPeers: new Set(),
       replicaSetNodesToUserClockStatusesMap: {},
       userSecondarySyncMetricsMap: {}
@@ -378,9 +411,9 @@ describe.skip('test monitorState job processor', function () {
     expect(retrieveClockStatusesForUsersAcrossReplicaSetStub).to.not.have.been
       .called
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called
-    expect(jobResult).to.deep.equal({
+    verifyJobResult({
+      jobResult,
       lastProcessedUserId: LAST_PROCESSED_USER_ID,
-      jobFailed: true,
       users: [{ user_id: LAST_PROCESSED_USER_ID }],
       unhealthyPeers: new Set(),
       replicaSetNodesToUserClockStatusesMap: {},

--- a/creator-node/test/processJob.test.js
+++ b/creator-node/test/processJob.test.js
@@ -19,11 +19,11 @@ describe('test processJob() util function', function () {
   it('handles error when processing job', async function () {
     // Mock the logger that processJob() uses
     const loggerStub = {
-      info: sinon.stub(),
-      warn: sinon.stub(),
-      error: sinon.stub()
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
     }
-    const createChildLogger = sinon.stub().returns(loggerStub)
+    const createChildLogger = sandbox.stub().returns(loggerStub)
     const processJob = proxyquire(
       '../src/services/stateMachineManager/processJob.js',
       {
@@ -37,7 +37,7 @@ describe('test processJob() util function', function () {
     const jobName = 'jobName'
     const job = { id: 1, data: {} }
     const errorMsg = 'test error message'
-    const jobProcessor = sinon.stub().rejects(new Error(errorMsg))
+    const jobProcessor = sandbox.stub().rejects(new Error(errorMsg))
     const parentLogger = {}
 
     // Verify that errors are caught and logged when processing job


### PR DESCRIPTION
### Description
- Test job processors:
  - monitorState: update 8/8 failing tests
  - findSyncRequests: add 6 new tests

- Fix a typo and bugs that were breaking syncs and duplicates: destructured `syncRequestsToEnqueue` with an extra "s" at the end of the variable name and checked for truthy arrays instead of empty arrays

### Tests

- monitorState.jobProcessor.js: 92.11% line coverage
- findSyncRequests.jobProcessor.js: 91.8% line coverage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A -- tests