### PR TITLE
Add xmlhttprequest dependency

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -13325,8 +13325,7 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
+      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/libs/package.json
+++ b/libs/package.json
@@ -64,7 +64,8 @@
     "secp256k1": "4.0.2",
     "semver": "6.3.0",
     "stream-browserify": "3.0.0",
-    "web3": "1.7.1"
+    "web3": "1.7.1",
+    "xmlhttprequest": "1.8.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.18.2",


### PR DESCRIPTION
### Description

Add xmlhttprequest dependency to fix error:
```
Failed to compile.

./node_modules/@audius/sdk/dist/legacy.js
Module not found: Can't resolve 'xmlhttprequest' in '/Users/saliou/Documents/Audius/audius-client/packages/web/node_modules/@audius/sdk/dist'
```


### Tests

testing with local client using the sdk with this change


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->