### PR TITLE
Use logInfo/logError, and set flag to bottom of fn

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -97,7 +97,7 @@ class ServiceRegistry {
   }
 
   setupBullMonitoring(app, stateMonitoringQueue, stateReconciliationQueue) {
-    logger.info('Setting up Bull queue monitoring...')
+    this.logInfo('Setting up Bull queue monitoring...')
 
     const serverAdapter = new ExpressAdapter()
     const { stateMachineQueue, manualSyncQueue, recurringSyncQueue } =
@@ -172,9 +172,6 @@ class ServiceRegistry {
     )
     await this.skippedCIDsRetryQueue.init()
 
-    this.servicesThatRequireServerInitialized = true
-    this.logInfo(`All services that require server successfully initialized!`)
-
     try {
       this.setupBullMonitoring(
         app,
@@ -182,8 +179,13 @@ class ServiceRegistry {
         stateReconciliationQueue
       )
     } catch (e) {
-      logger.error(`Failed to initialize bull monitoring UI: ${e.message || e}`)
+      this.logError(
+        `Failed to initialize bull monitoring UI: ${e.message || e}`
+      )
     }
+
+    this.servicesThatRequireServerInitialized = true
+    this.logInfo(`All services that require server successfully initialized!`)
   }
 
   logInfo(msg) {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The bull queue monitoring requires the server, so we should probably set the flag at the end of the fn. Also this PR updates the log calls to use `logInfo` and `logError`

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

No tests, just simple log change and reordering of fns.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

The existing monitoring should be sufficient.
<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->