### PR TITLE
[CON-214] - Removing clearing BL on init

### DIFF
--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -27,9 +27,6 @@ class BlacklistManager {
 
   static async init() {
     try {
-      // Clear existing redis keys
-      await this.deleteRedisKeys()
-
       const { trackIdsToBlacklist, userIdsToBlacklist, segmentsToBlacklist } =
         await this.getDataToBlacklist()
       await this.fetchCIDsAndAddToRedis({

--- a/creator-node/src/blacklistManager.js
+++ b/creator-node/src/blacklistManager.js
@@ -657,45 +657,6 @@ class BlacklistManager {
     return redis.smembers(redisKey)
   }
 
-  // Delete all existing redis keys
-  static async deleteRedisKeys() {
-    // Keep mapping of trackIds:cids
-    await redis.del(this.getRedisTrackIdKey())
-    await redis.del(this.getRedisUserIdKey())
-    await redis.del(this.getRedisSegmentCIDKey())
-    await redis.del(this.getInvalidTrackIdsKey())
-
-    BlacklistManager.deleteBlacklistCIDToTrackIdMappingInRedis('*')
-  }
-
-  // Deleting keys of a pattern: https://stackoverflow.com/a/36006360
-  static deleteBlacklistCIDToTrackIdMappingInRedis(pattern) {
-    // Create a readable stream (object mode)
-    const stream = redis.scanStream({
-      match: `${REDIS_MAP_BLACKLIST_SEGMENTCID_TO_TRACKID_KEY}:::${pattern}`
-    })
-    stream.on('data', function (keys) {
-      // `keys` is an array of strings representing key names
-      if (keys.length) {
-        const pipeline = redis.pipeline()
-        keys.forEach(function (key) {
-          pipeline.del(key)
-        })
-        pipeline.exec()
-      }
-    })
-    stream.on('end', function () {
-      logger.info(
-        `Done deleting ${REDIS_MAP_BLACKLIST_SEGMENTCID_TO_TRACKID_KEY} entries`
-      )
-    })
-    stream.on('error', function (e) {
-      logger.error(
-        `Could not delete ${REDIS_MAP_BLACKLIST_SEGMENTCID_TO_TRACKID_KEY} entries: ${e.toString()}`
-      )
-    })
-  }
-
   // Logger wrapper methods
 
   static logDebug(msg) {

--- a/creator-node/src/redis.js
+++ b/creator-node/src/redis.js
@@ -37,22 +37,17 @@ function getNodeSyncRedisKey(wallet) {
  * Deletes keys of a pattern: https://stackoverflow.com/a/36006360
  * @param {Object} param
  * @param {string} param.keyPattern the redis key pattern that matches keys to remove
- * @param {Object} param.redis the redis instance
  * @param {Object} param.logger the logger instance
  */
-function deleteKeyPatternInRedis({
-  keyPattern,
-  redis,
-  logger = genericLogger
-}) {
+function deleteKeyPatternInRedis({ keyPattern, logger = genericLogger }) {
   // Create a readable stream (object mode)
-  const stream = redis.scanStream({
+  const stream = redisClient.scanStream({
     match: keyPattern
   })
   stream.on('data', function (keys) {
     // `keys` is an array of strings representing key names
     if (keys.length) {
-      const pipeline = redis.pipeline()
+      const pipeline = redisClient.pipeline()
       keys.forEach(function (key) {
         pipeline.del(key)
       })

--- a/creator-node/test/blacklistManager.test.js
+++ b/creator-node/test/blacklistManager.test.js
@@ -6,24 +6,29 @@ const redis = require('../src/redis')
 
 const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')
+const { restartBlacklistManager } = require('./lib/blacklistManager')
+
+const CID_TO_DELIST = 'QmYkZMB1cdo8k1Lizco4YyiAMfUwCn9yUQaJn7T274uc5z'
 
 describe('test blacklistManager', () => {
-  let server, libsMock, userId
-
-  const CID = 'QmYkZMB1cdo8k1Lizco4YyiAMfUwCn9yUQaJn7T274uc5z'
+  let server, libsMock
 
   beforeEach(async () => {
     libsMock = getLibsMock()
 
-    const appInfo = await getApp(libsMock, BlacklistManager, null, userId)
+    const appInfo = await getApp(
+      libsMock,
+      BlacklistManager,
+      null,
+      1 /* userId */
+    )
     await BlacklistManager.init()
 
     server = appInfo.server
   })
 
   afterEach(async () => {
-    BlacklistManager.initialized = false
-    await redis.del(BlacklistManager.getRedisTrackIdToCIDsKey(1))
+    await restartBlacklistManager(redis)
     sinon.restore()
     await server.close()
   })
@@ -43,89 +48,170 @@ describe('test blacklistManager', () => {
   })
 
   it('[isServable] if cid is not in blacklist, serve', async () => {
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1), true)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1),
+      true
+    )
   })
 
   it('[isServable] if cid is in blacklist and trackId is invalid, do not serve', async () => {
     await BlacklistManager.addToRedis(
-      'BM.SET.BLACKLIST.SEGMENTCID', /* REDIS_SET_BLACKLIST_SEGMENTCID_KEY */
-      [CID]
+      'BM.SET.BLACKLIST.SEGMENTCID' /* REDIS_SET_BLACKLIST_SEGMENTCID_KEY */,
+      [CID_TO_DELIST]
     )
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, null), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 'abc'), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, -1), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 0.48), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1.48), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, []), false)
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, [1]), false)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, null),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 'abc'),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, -1),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 0.48),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1.48),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, []),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, [1]),
+      false
+    )
   })
 
   it('[isServable] cid belongs to track from input trackId, and the input trackId is valid + blacklisted, do not serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
     await BlacklistManager.addToRedis('BM.SET.BLACKLIST.TRACKID', [1])
-    await BlacklistManager.addToRedis('BM.MAP.BLACKLIST.SEGMENTCID.TRACKID', { '1': [CID] })
-    await BlacklistManager.addToRedis('BM.MAP.TRACKID.SEGMENTCIDS', { '1': [CID] })
+    await BlacklistManager.addToRedis('BM.MAP.BLACKLIST.SEGMENTCID.TRACKID', {
+      1: [CID_TO_DELIST]
+    })
+    await BlacklistManager.addToRedis('BM.MAP.TRACKID.SEGMENTCIDS', {
+      1: [CID_TO_DELIST]
+    })
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1), false)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1),
+      false
+    )
   })
 
   it('[isServable] cid is in blacklist, cid belongs to track from input trackId with redis check, and the input trackId is valid + not blacklisted, allow serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
-    await BlacklistManager.addToRedis('BM.MAP.TRACKID.SEGMENTCIDS', { '1': [CID] })
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
+    await BlacklistManager.addToRedis('BM.MAP.TRACKID.SEGMENTCIDS', {
+      1: [CID_TO_DELIST]
+    })
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1), true)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1),
+      true
+    )
   })
 
   it('[isServable] cid is in blacklist, cid does not belong to track from input trackId with redis check, and input track is invalid, do not serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
     await BlacklistManager.addToRedis('BM.SET.INVALID.TRACKIDS', [1234])
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1234), false)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1234),
+      false
+    )
   })
 
   it('[isServable] cid is in blacklist, cid does not belong to track from input trackId with redis check, and input track is invalid with db check, do not serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
 
     // Mock DB call to return nothing
-    sinon.stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb').callsFake(async () => {
-      return []
-    })
+    sinon
+      .stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb')
+      .callsFake(async () => {
+        return []
+      })
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1234), false)
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1234),
+      false
+    )
     assert.deepStrictEqual(await BlacklistManager.trackIdIsInvalid(1234), 1)
   })
 
   it('[isServable] cid is in blacklist, cid does not belong to track from input trackId with redis check, and input track is valid with db check, and cid is in track, allow serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
 
     // Mock DB call to return proper segment
-    sinon.stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb').callsFake(async () => {
-      return [{
-        metadataJSON: {
-          track_segments: [{ duration: 6, multihash: CID }]
-        }
-      }]
-    })
+    sinon
+      .stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb')
+      .callsFake(async () => {
+        return [
+          {
+            metadataJSON: {
+              track_segments: [{ duration: 6, multihash: CID_TO_DELIST }]
+            }
+          }
+        ]
+      })
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1), true)
-    assert.deepStrictEqual(await BlacklistManager.getAllCIDsFromTrackIdInRedis(1), [CID])
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1),
+      true
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.getAllCIDsFromTrackIdInRedis(1),
+      [CID_TO_DELIST]
+    )
   }).timeout(0)
 
   it('[isServable] cid is in blacklist, cid does not belong to track from input trackId with redis check, and input track is valid with db check, and cid is not in track, do not serve', async () => {
-    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [CID])
+    await BlacklistManager.addToRedis('BM.SET.BLACKLIST.SEGMENTCID', [
+      CID_TO_DELIST
+    ])
 
     // Mock DB call to return proper segment that is not the same as `CID`
-    sinon.stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb').callsFake(async () => {
-      return [{
-        metadataJSON: {
-          track_segments: [{ duration: 6, multihash: 'QmABC_tinashe_and_rei_ami' }]
-        }
-      }]
-    })
+    sinon
+      .stub(BlacklistManager, 'getAllCIDsFromTrackIdsInDb')
+      .callsFake(async () => {
+        return [
+          {
+            metadataJSON: {
+              track_segments: [
+                { duration: 6, multihash: 'QmABC_tinashe_and_rei_ami' }
+              ]
+            }
+          }
+        ]
+      })
 
-    assert.deepStrictEqual(await BlacklistManager.isServable(CID, 1), false)
-    assert.deepStrictEqual(await BlacklistManager.getAllCIDsFromTrackIdInRedis(1), ['QmABC_tinashe_and_rei_ami'])
+    assert.deepStrictEqual(
+      await BlacklistManager.isServable(CID_TO_DELIST, 1),
+      false
+    )
+    assert.deepStrictEqual(
+      await BlacklistManager.getAllCIDsFromTrackIdInRedis(1),
+      ['QmABC_tinashe_and_rei_ami']
+    )
   })
 })

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -19,6 +19,7 @@ const {
 } = require('./lib/dataSeeds')
 const { generateRandomCID } = require('./lib/utils')
 const { uploadTrack } = require('./lib/helpers')
+const { restartBlacklistManager } = require('./lib/blacklistManager')
 
 // Dummy keys from circle config.yml
 const DELEGATE_OWNER_WALLET = '0x1eC723075E67a1a2B6969dC5CfF0C6793cb36D25'
@@ -34,9 +35,8 @@ const trustedNotifierConfig = {
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
-describe('test ContentBlacklist', function () {
+describe.only('test ContentBlacklist', function () {
   let app, server, libsMock, mockServiceRegistry, userId
-  let ids = []
 
   beforeEach(async () => {
     libsMock = setupLibsMock(libsMock)
@@ -56,16 +56,10 @@ describe('test ContentBlacklist', function () {
 
   afterEach(async () => {
     // Reinitialize BlacklistManager and clear redis state
-    BlacklistManager.initialized = false
+    await restartBlacklistManager(redis)
 
     // clear TrustedNotifier wallet key
     mockServiceRegistry.trustedNotifierManager.trustedNotifierData.wallet = null
-
-    for (const id of ids) {
-      await redis.del(BlacklistManager.getRedisTrackIdToCIDsKey(id))
-    }
-
-    ids = []
 
     sinon.restore()
     await destroyUsers()
@@ -118,7 +112,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should return the proper userIds, trackIds, and segments', async () => {
-    ids = [43021]
+    const ids = [43021]
     const addUserData = generateTimestampAndSignature(
       {
         type: BlacklistManager.getTypes().user,
@@ -191,7 +185,7 @@ describe('test ContentBlacklist', function () {
     mockServiceRegistry.trustedNotifierManager.trustedNotifierData.wallet =
       trustedNotifierConfig.wallet
 
-    ids = [43021]
+    const ids = [43021]
     const addUserData = generateTimestampAndSignature(
       {
         type: BlacklistManager.getTypes().user,
@@ -261,7 +255,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should add user type and id to db and redis', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -289,7 +283,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should add track type and id to db and redis', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -318,7 +312,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should remove user type and id from db and redis', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -351,7 +345,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should remove track type and id from db and redis', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -384,7 +378,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should return success when removing a user that does not exist', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -412,7 +406,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should return success when removing a track that does not exist', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -440,7 +434,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should ignore duplicate add for track', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -476,7 +470,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should ignore duplicate add for user', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -512,7 +506,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should only blacklist partial user ids list if only some ids are found', async () => {
-    ids = [Utils.getRandomInt(MAX_ID), Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID), Utils.getRandomInt(MAX_ID)]
     libsMock.User.getUsers.returns([{ user_id: ids[0] }]) // only user @ index 0 is found
     const type = BlacklistManager.getTypes().user
     const { signature, timestamp } = generateTimestampAndSignature(
@@ -544,7 +538,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should only blacklist partial track ids list if only some ids are found', async () => {
-    ids = [Utils.getRandomInt(MAX_ID), Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID), Utils.getRandomInt(MAX_ID)]
     libsMock.Track.getTracks.returns([{ track_id: ids[0] }]) // only user @ index 0 is found
     const type = BlacklistManager.getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
@@ -630,7 +624,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it("should throw an error if delegate private key does not match that of the creator node's", async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const BAD_KEY =
       '0xBADKEY4d4a2412a443c17e1666764d3bba43e89e61129a35f9abc337ec170a5d'
@@ -647,7 +641,7 @@ describe('test ContentBlacklist', function () {
   })
 
   it('should throw an error if query params does not contain all necessary keys', async () => {
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
 
     await request(app)
@@ -685,7 +679,7 @@ describe('test ContentBlacklist', function () {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
-    ids = [trackId]
+    const ids = [trackId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().user
@@ -715,7 +709,7 @@ describe('test ContentBlacklist', function () {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
-    ids = [trackId]
+    const ids = [trackId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().track
@@ -731,9 +725,7 @@ describe('test ContentBlacklist', function () {
     // Hit /ipfs/:CID route for all track CIDs and ensure error response is returned because no trackId was passed
     await Promise.all(
       data.track.trackSegments.map((segment) =>
-        request(app)
-        .get(`/ipfs/${segment.multihash}`)
-        .expect(403)
+        request(app).get(`/ipfs/${segment.multihash}`).expect(403)
       )
     )
   })
@@ -742,7 +734,7 @@ describe('test ContentBlacklist', function () {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
-    ids = [trackId]
+    const ids = [trackId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().track
@@ -785,7 +777,7 @@ describe('test ContentBlacklist', function () {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
-    ids = [trackId]
+    const ids = [trackId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().track
@@ -818,7 +810,7 @@ describe('test ContentBlacklist', function () {
       trackId: 2,
       pubKey: '0x3f8f51ed837b15af580eb96cee740c723d340e7f'
     })
-    ids = [track1.track.blockchainId]
+    const ids = [track1.track.blockchainId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().track
@@ -860,7 +852,7 @@ describe('test ContentBlacklist', function () {
 
   it('should throw an error if user id does not exist', async () => {
     libsMock.User.getUsers.returns([])
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const resp1 = generateTimestampAndSignature(
       { type, values: ids },
@@ -897,7 +889,7 @@ describe('test ContentBlacklist', function () {
 
   it('should throw an error if track id does not exist', async () => {
     libsMock.Track.getTracks.returns([])
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().track
     const resp1 = generateTimestampAndSignature(
       { type, values: ids },
@@ -934,7 +926,7 @@ describe('test ContentBlacklist', function () {
 
   it('should throw an error if disc prov is unable to lookup ids', async () => {
     libsMock.User.getUsers.returns([])
-    ids = [Utils.getRandomInt(MAX_ID)]
+    const ids = [Utils.getRandomInt(MAX_ID)]
     const type = BlacklistManager.getTypes().user
     const resp1 = generateTimestampAndSignature(
       { type, values: ids },
@@ -997,7 +989,7 @@ describe('test ContentBlacklist', function () {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
-    ids = [trackId]
+    const ids = [trackId]
 
     // Blacklist trackId
     const type = BlacklistManager.getTypes().track

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -35,7 +35,7 @@ const trustedNotifierConfig = {
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
-describe.only('test ContentBlacklist', function () {
+describe('test ContentBlacklist', function () {
   let app, server, libsMock, mockServiceRegistry, userId
 
   beforeEach(async () => {

--- a/creator-node/test/lib/blacklistManager.js
+++ b/creator-node/test/lib/blacklistManager.js
@@ -1,0 +1,30 @@
+const BlacklistManager = require('../../src/blacklistManager')
+
+const { deleteKeyPatternInRedis } = require('./utils')
+
+/**
+ * Removes all BlacklistManager keys in redis
+ * @param {Object} redis
+ */
+async function restartBlacklistManager(redis) {
+  await redis.del(BlacklistManager.getRedisTrackIdKey())
+  await redis.del(BlacklistManager.getRedisUserIdKey())
+  await redis.del(BlacklistManager.getRedisSegmentCIDKey())
+  await redis.del(BlacklistManager.getInvalidTrackIdsKey())
+
+  deleteKeyPatternInRedis({
+    keyPattern: BlacklistManager.getRedisTrackIdToCIDsKey('*'),
+    redis
+  })
+
+  deleteKeyPatternInRedis({
+    keyPattern: BlacklistManager.getRedisBlacklistSegmentToTrackIdKey('*'),
+    redis
+  })
+
+  BlacklistManager.initialized = false
+}
+
+module.exports = {
+  restartBlacklistManager
+}

--- a/creator-node/test/lib/blacklistManager.js
+++ b/creator-node/test/lib/blacklistManager.js
@@ -1,6 +1,6 @@
 const BlacklistManager = require('../../src/blacklistManager')
 
-const { deleteKeyPatternInRedis } = require('./utils')
+const { deleteKeyPatternInRedis } = require('../../src/redis')
 
 /**
  * Removes all BlacklistManager keys in redis

--- a/creator-node/test/lib/blacklistManager.js
+++ b/creator-node/test/lib/blacklistManager.js
@@ -13,13 +13,11 @@ async function restartBlacklistManager(redis) {
   await redis.del(BlacklistManager.getInvalidTrackIdsKey())
 
   deleteKeyPatternInRedis({
-    keyPattern: BlacklistManager.getRedisTrackIdToCIDsKey('*'),
-    redis
+    keyPattern: BlacklistManager.getRedisTrackIdToCIDsKey('*')
   })
 
   deleteKeyPatternInRedis({
-    keyPattern: BlacklistManager.getRedisBlacklistSegmentToTrackIdKey('*'),
-    redis
+    keyPattern: BlacklistManager.getRedisBlacklistSegmentToTrackIdKey('*')
   })
 
   BlacklistManager.initialized = false

--- a/creator-node/test/lib/utils.js
+++ b/creator-node/test/lib/utils.js
@@ -1,4 +1,3 @@
-const { logger: genericLogger } = require('../../src/logging')
 const Utils = require('../../src/utils')
 
 const stringifiedDateFields = (obj) => {
@@ -46,44 +45,9 @@ const generateRandomCID = (numRandomDigits = 5, maxRandomNumber = 10000) => {
   )
 }
 
-/**
- * Deletes keys of a pattern: https://stackoverflow.com/a/36006360
- * @param {Object} param
- * @param {string} param.keyPattern the redis key pattern that matches keys to remove
- * @param {Object} param.redis the redis instance
- * @param {Object} param.logger the logger instance
- */
-function deleteKeyPatternInRedis({
-  keyPattern,
-  redis,
-  logger = genericLogger
-}) {
-  // Create a readable stream (object mode)
-  const stream = redis.scanStream({
-    match: keyPattern
-  })
-  stream.on('data', function (keys) {
-    // `keys` is an array of strings representing key names
-    if (keys.length) {
-      const pipeline = redis.pipeline()
-      keys.forEach(function (key) {
-        pipeline.del(key)
-      })
-      pipeline.exec()
-    }
-  })
-  stream.on('end', function () {
-    logger.info(`Done deleting ${keyPattern} entries`)
-  })
-  stream.on('error', function (e) {
-    logger.error(`Could not delete ${keyPattern} entries: ${e.toString()}`)
-  })
-}
-
 module.exports = {
   wait,
   stringifiedDateFields,
   functionThatThrowsWithMessage,
-  generateRandomCID,
-  deleteKeyPatternInRedis
+  generateRandomCID
 }

--- a/creator-node/test/lib/utils.js
+++ b/creator-node/test/lib/utils.js
@@ -51,6 +51,7 @@ const generateRandomCID = (numRandomDigits = 5, maxRandomNumber = 10000) => {
  * @param {Object} param
  * @param {string} param.keyPattern the redis key pattern that matches keys to remove
  * @param {Object} param.redis the redis instance
+ * @param {Object} param.logger the logger instance
  */
 function deleteKeyPatternInRedis({
   keyPattern,

--- a/creator-node/test/lib/utils.js
+++ b/creator-node/test/lib/utils.js
@@ -1,3 +1,4 @@
+const { logger: genericLogger } = require('../../src/logging')
 const Utils = require('../../src/utils')
 
 const stringifiedDateFields = (obj) => {
@@ -45,9 +46,43 @@ const generateRandomCID = (numRandomDigits = 5, maxRandomNumber = 10000) => {
   )
 }
 
+/**
+ * Deletes keys of a pattern: https://stackoverflow.com/a/36006360
+ * @param {Object} param
+ * @param {string} param.keyPattern the redis key pattern that matches keys to remove
+ * @param {Object} param.redis the redis instance
+ */
+function deleteKeyPatternInRedis({
+  keyPattern,
+  redis,
+  logger = genericLogger
+}) {
+  // Create a readable stream (object mode)
+  const stream = redis.scanStream({
+    match: keyPattern
+  })
+  stream.on('data', function (keys) {
+    // `keys` is an array of strings representing key names
+    if (keys.length) {
+      const pipeline = redis.pipeline()
+      keys.forEach(function (key) {
+        pipeline.del(key)
+      })
+      pipeline.exec()
+    }
+  })
+  stream.on('end', function () {
+    logger.info(`Done deleting ${keyPattern} entries`)
+  })
+  stream.on('error', function (e) {
+    logger.error(`Could not delete ${keyPattern} entries: ${e.toString()}`)
+  })
+}
+
 module.exports = {
   wait,
   stringifiedDateFields,
   functionThatThrowsWithMessage,
-  generateRandomCID
+  generateRandomCID,
+  deleteKeyPatternInRedis
 }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
There is no point to clear the BL on init. This operation is unnecessary adding time and complexity. If adding same keys, redis should override the existing values. Also, the BL is able to handle removing so changes can be made. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Fix tests to manually clear the BlacklistManager now

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Existing logs should be sufficient. 
<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->