### PR TITLE
Fix miscellaneous state machine bugs

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
@@ -87,16 +87,30 @@ module.exports = async function ({
 
     // Combine each promise's updateReplicaSetOps into a job
     for (const updateReplicaSetOp of updateReplicaSetOps) {
+      const { wallet } = updateReplicaSetOp
+      // Make a replicaSetNodesToUserClockStatusesMap that only has entries for the user
+      const replicaSetNodesToUserClockStatusesMapFiltered = {}
+      for (const node of Object.keys(replicaSetNodesToUserClockStatusesMap)) {
+        const userClockStatusesMap = replicaSetNodesToUserClockStatusesMap[node]
+        replicaSetNodesToUserClockStatusesMapFiltered[node] =
+          [wallet] in userClockStatusesMap
+            ? {
+                [wallet]: userClockStatusesMap[wallet]
+              }
+            : {}
+      }
+
       updateReplicaSetJobs.push({
         jobName: JOB_NAMES.UPDATE_REPLICA_SET,
         jobData: {
-          wallet: updateReplicaSetOp.wallet,
+          wallet,
           userId: updateReplicaSetOp.user_id,
           primary: updateReplicaSetOp.primary,
           secondary1: updateReplicaSetOp.secondary1,
           secondary2: updateReplicaSetOp.secondary2,
           unhealthyReplicas: Array.from(updateReplicaSetOp.unhealthyReplicas),
-          replicaSetNodesToUserClockStatusesMap
+          replicaSetNodesToUserClockStatusesMap:
+            replicaSetNodesToUserClockStatusesMapFiltered
         }
       })
     }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -201,9 +201,9 @@ const _findSyncsForUser = (
           primaryEndpoint: thisContentNodeEndpoint,
           syncType: SyncType.Recurring
         })
-        if (syncReqToEnqueue && !_.isEmpty(syncReqToEnqueue)) {
+        if (!_.isEmpty(syncReqToEnqueue)) {
           syncReqsToEnqueue.push(syncReqToEnqueue)
-        } else if (duplicateSyncReq && !_.isEmpty(duplicateSyncReq)) {
+        } else if (!_.isEmpty(duplicateSyncReq)) {
           duplicateSyncReqs.push(duplicateSyncReq)
         }
       } catch (e) {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const config = require('../../../config')
 const CNodeToSpIdMapManager = require('../CNodeToSpIdMapManager')
 const { SyncType, QUEUE_NAMES } = require('../stateMachineConstants')
@@ -199,8 +201,11 @@ const _findSyncsForUser = (
           primaryEndpoint: thisContentNodeEndpoint,
           syncType: SyncType.Recurring
         })
-        if (syncReqToEnqueue) syncReqsToEnqueue.push(syncReqToEnqueue)
-        else if (duplicateSyncReq) duplicateSyncReqs.push(duplicateSyncReq)
+        if (syncReqToEnqueue && !_.isEmpty(syncReqToEnqueue)) {
+          syncReqsToEnqueue.push(syncReqToEnqueue)
+        } else if (duplicateSyncReq && !_.isEmpty(duplicateSyncReq)) {
+          duplicateSyncReqs.push(duplicateSyncReq)
+        }
       } catch (e) {
         errors.push(
           `Error getting new or existing sync request for user ${wallet} and secondary ${secondary} - ${e.message}`

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -41,18 +41,6 @@ module.exports = async function (
   replicaSetNodesToUserClockStatusesMap,
   enabledReconfigModes
 ) {
-  _validateJobData(
-    logger,
-    primary,
-    secondary1,
-    secondary2,
-    wallet,
-    unhealthyReplicas,
-    healthyNodes,
-    replicaSetNodesToUserClockStatusesMap,
-    enabledReconfigModes
-  )
-
   /**
    * Fetch all the healthy nodes while disabling sync checks to select nodes for new replica set
    * Note: sync checks are disabled because there should not be any syncs occurring for a particular user
@@ -73,6 +61,18 @@ module.exports = async function (
     throw new Error(
       'Auto-selecting Content Nodes returned an empty list of healthy nodes.'
     )
+
+  _validateJobData(
+    logger,
+    primary,
+    secondary1,
+    secondary2,
+    wallet,
+    unhealthyReplicas,
+    healthyNodes,
+    replicaSetNodesToUserClockStatusesMap,
+    enabledReconfigModes
+  )
 
   let errorMsg = ''
   let issuedReconfig = false

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -144,7 +144,7 @@ module.exports = async function (
  * @param {string} param.wallet current user's wallet address
  * @param {Set<string>} param.unhealthyReplicasSet a set of endpoints of unhealthy replica set nodes
  * @param {string[]} param.healthyNodes array of healthy Content Node endpoints used for selecting new replica set
- * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to (map of user wallet strings to clock value of secondary for user)
+ * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to clock value of secondary for user whose replica set should be updated
  * @param {string[]} param.enabledReconfigModes array of which reconfig modes are enabled
  * @returns {Object}
  * {
@@ -179,7 +179,6 @@ const determineNewReplicaSet = async ({
 
   if (unhealthyReplicasSet.size === 1) {
     return determineNewReplicaSetWhenOneNodeIsUnhealthy(
-      wallet,
       primary,
       secondary1,
       secondary2,
@@ -272,17 +271,15 @@ const _validateJobData = (
 
 /**
  * Determines new replica set when one node in the current replica set is unhealthy.
- * @param {*} wallet wallet address of user whose replica set contains 1 unhealthy node to be replaced
  * @param {*} primary user's current primary endpoint
  * @param {*} secondary1 user's current first secondary endpoint
  * @param {*} secondary2 user's current second secondary endpoint
  * @param {*} unhealthyReplicasSet a set of endpoints of unhealthy replica set nodes
- * @param {*} replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to (map of user wallet strings to clock value of secondary for user)
+ * @param {*} replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to clock value of secondary for user whose replica set should be updated
  * @param {*} newReplicaNode endpoint of node that will replace the unhealthy node
  * @returns reconfig info to update the user's replica set to replace the 1 unhealthy node
  */
 const determineNewReplicaSetWhenOneNodeIsUnhealthy = (
-  wallet,
   primary,
   secondary1,
   secondary2,
@@ -295,8 +292,8 @@ const determineNewReplicaSetWhenOneNodeIsUnhealthy = (
   // value of the two secondaries as the new primary, leave the other as the first secondary, and select a new second secondary
   if (unhealthyReplicasSet.has(primary)) {
     const [newPrimary, currentHealthySecondary] =
-      replicaSetNodesToUserClockStatusesMap[secondary1][wallet] >=
-      replicaSetNodesToUserClockStatusesMap[secondary2][wallet]
+      replicaSetNodesToUserClockStatusesMap[secondary1] >=
+      replicaSetNodesToUserClockStatusesMap[secondary2]
         ? [secondary1, secondary2]
         : [secondary2, secondary1]
     return {

--- a/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
+++ b/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
@@ -87,15 +87,9 @@ describe('test findReplicaSetUpdates job processor', function () {
   }
 
   const CLOCK_STATUSES_MAP_FILTERED_TO_WALLET = {
-    [primary]: {
-      [wallet]: 10
-    },
-    [secondary1]: {
-      [wallet]: 10
-    },
-    [secondary2]: {
-      [wallet]: 10
-    }
+    [primary]: 10,
+    [secondary1]: 10,
+    [secondary2]: 10
   }
 
   function getJobProcessorStub(

--- a/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
+++ b/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
@@ -74,22 +74,24 @@ describe('test findReplicaSetUpdates job processor', function () {
 
   const DEFAULT_CLOCK_STATUSES_MAP = {
     [primary]: {
-      [wallet]: 10
+      [wallet]: 10,
+      randomWallet: 10
     },
     [secondary1]: {
-      [wallet]: 10
+      [wallet]: 10,
+      anotherWallet: 100
     },
     [secondary2]: {
       [wallet]: 10
     }
   }
 
-  const CLOCK_STATUSES_MAP_WHERE_SECONDARY1_IS_BEHIND = {
+  const CLOCK_STATUSES_MAP_FILTERED_TO_WALLET = {
     [primary]: {
       [wallet]: 10
     },
     [secondary1]: {
-      [wallet]: 9
+      [wallet]: 10
     },
     [secondary2]: {
       [wallet]: 10
@@ -118,7 +120,6 @@ describe('test findReplicaSetUpdates job processor', function () {
     cNodeEndpointToSpIdMap = DEFAULT_CNODE_ENDOINT_TO_SP_ID_MAP,
     userSecondarySyncMetricsMap = {},
     unhealthyPeers = [],
-    replicaSetNodesToUserClockStatusesMap = DEFAULT_CLOCK_STATUSES_MAP,
     isPrimaryHealthyInExtraHealthCheck = true
   }) {
     const getCNodeEndpointToSpIdMapStub = sandbox
@@ -138,7 +139,7 @@ describe('test findReplicaSetUpdates job processor', function () {
       logger,
       users,
       unhealthyPeers,
-      replicaSetNodesToUserClockStatusesMap,
+      replicaSetNodesToUserClockStatusesMap: DEFAULT_CLOCK_STATUSES_MAP,
       userSecondarySyncMetricsMap
     })
   }
@@ -163,8 +164,7 @@ describe('test findReplicaSetUpdates job processor', function () {
                   secondary2,
                   unhealthyReplicas: expectedUnhealthyReplicas,
                   replicaSetNodesToUserClockStatusesMap:
-                    jobProcessorArgs?.replicaSetNodesToUserClockStatusesMap ||
-                    DEFAULT_CLOCK_STATUSES_MAP
+                    CLOCK_STATUSES_MAP_FILTERED_TO_WALLET
                 }
               }
             ]


### PR DESCRIPTION
### Description

- Change `replicaSetNodesToUserClockStatusesMap` sent to updateReplicaSet job from a map of node => wallet => clockValue to just node => clockValue (it doesn't need all wallets - just the one for the user whose replica set is being updated)
- Fix validating healthyNodes before creating it in updateReplicaSet job
- Truncate large Bull job data and result objects - see https://github.com/felixmosh/bull-board/pull/414#issuecomment-1134874761 
- Fix empty sync request getting enqueued (it was a no-op but pollutes queue history)

### Tests

- Updated findReplicaSetUpdates test to make sure filtering other wallets works
- Ran `A up` locally to make sure truncating didn't break Bull Board ~~(will need more data from staging to verify actual functionality)~~ and tested with a max of 10 characters (instead of 10,000) to verify functionality


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Push out to stage CN11 and monitor the `/health/bull` endpoint. Look for failed jobs or data mismatching between jobs.