### PR TITLE
[PLAT-181] Sort by transactionIndex instead of hash

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -18,6 +18,7 @@ url =
 env =
 trending_refresh_seconds = 3600
 infra_setup =
+indexing_transaction_index_sort_order_start_block =
 
 [flask]
 debug = true

--- a/discovery-provider/src/tasks/sort_block_transactions.py
+++ b/discovery-provider/src/tasks/sort_block_transactions.py
@@ -1,0 +1,11 @@
+def sort_block_transactions(block, indexing_transaction_index_sort_order_start_block):
+    # Sort transactions by transactionIndex after we have hit
+    # indexing_transaction_index_sort_order_start_block.
+    if block.number > indexing_transaction_index_sort_order_start_block:
+        sorted_txs = sorted(
+            block.transactions,
+            key=lambda entry: entry["transactionIndex"],
+        )
+    else:
+        sorted_txs = sorted(block.transactions, key=lambda entry: entry["hash"])
+    return sorted_txs

--- a/discovery-provider/src/tasks/sort_block_transactions_unit_test.py
+++ b/discovery-provider/src/tasks/sort_block_transactions_unit_test.py
@@ -1,0 +1,49 @@
+from src.tasks.sort_block_transactions import sort_block_transactions
+
+
+def makeTestTransaction(hash, transactionIndex):
+    return {"hash": hash, "transactionIndex": transactionIndex}
+
+
+class TestBlock:
+    def __init__(self, number, transactions):
+        self.number = number
+        self.transactions = transactions
+
+
+def test_sort_by_hash():
+    block = TestBlock(
+        100,
+        [
+            {"hash": "0xaaa", "transactionIndex": 1},
+            {"hash": "0xddd", "transactionIndex": 2},
+            {"hash": "0xccc", "transactionIndex": 3},
+            {"hash": "0xbbb", "transactionIndex": 4},
+        ],
+    )
+    sorted_txs = sort_block_transactions(block, 200)
+    assert sorted_txs == [
+        {"hash": "0xaaa", "transactionIndex": 1},
+        {"hash": "0xbbb", "transactionIndex": 4},
+        {"hash": "0xccc", "transactionIndex": 3},
+        {"hash": "0xddd", "transactionIndex": 2},
+    ]
+
+
+def test_sort_by_transaction_index():
+    block = TestBlock(
+        100,
+        [
+            {"hash": "0xaaa", "transactionIndex": 1},
+            {"hash": "0xddd", "transactionIndex": 3},
+            {"hash": "0xccc", "transactionIndex": 2},
+            {"hash": "0xbbb", "transactionIndex": 4},
+        ],
+    )
+    sorted_txs = sort_block_transactions(block, 50)
+    assert sorted_txs == [
+        {"hash": "0xaaa", "transactionIndex": 1},
+        {"hash": "0xccc", "transactionIndex": 2},
+        {"hash": "0xddd", "transactionIndex": 3},
+        {"hash": "0xbbb", "transactionIndex": 4},
+    ]


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Switches sort by hash to sort by transactionIndex.

We would like this to happen in unison across all nodes. Given release cycle, July 11 seems like a good date. This translates to `392727` blocks ahead for prod (5.5s production rate).

The target blocks for this activation are:
prod: 28344410
staging: as soon as code is merged, pick block number ~100 ahead.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

This should be watched closely on staging for side effects.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This should be watched closely on staging for side effects.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->