### PR TITLE
add es-indexer/build to .dockerignore

### DIFF
--- a/discovery-provider/.dockerignore
+++ b/discovery-provider/.dockerignore
@@ -2,3 +2,5 @@ venv
 logs
 *.swp
 node_modules
+es-indexer/build
+


### PR DESCRIPTION
### Description

add es-indexer/build to .dockerignore

should fix permission issues on that folder.