### PR TITLE
[CON-224] - Re-enable nginx cache

### DIFF
--- a/creator-node/compose/docker-compose.yml
+++ b/creator-node/compose/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - manualSyncsDisabled=${manualSyncsDisabled}
       - devMode=${DEV_MODE}
       - spOwnerWallet=${spOwnerWallet}
-      - openRestyCacheCIDEnabled=${openRestyCacheCIDEnabled}
+      - contentCacheLayerEnabled=${contentCacheLayerEnabled}
     env_file:
       - ./env/base.env
     ports:

--- a/creator-node/compose/env/shellEnv1.sh
+++ b/creator-node/compose/env/shellEnv1.sh
@@ -4,4 +4,4 @@ export CREATOR_NODE_DB_HOST_PORT=4432
 export CREATOR_NODE_REDIS_HOST_PORT=4379
 export CREATOR_NODE_DEBUGGER_PORT=9230
 export SP_OWNER_WALLET_INDEX=1
-export openRestyCacheCIDEnabled=false
+export contentCacheLayerEnabled=true

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -25,8 +25,8 @@ http {
         # Match the paths /ipfs/<cid: string> and /content/<cid: string>.
         # If present in cache, serve. 
         # Else, hit upstream server + update cache + serve.
-        # ^~ : if request matches this route, do not attempt to bypass via the `/` pattern below
-        location ^~ /(ipfs|content) {
+        # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
+        location ~ (/ipfs/|/content/) {
             proxy_cache cidcache;
             proxy_pass http://127.0.0.1:3000;
 

--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -61,7 +61,7 @@ if [ -z "$dbUrl" ]; then
     /usr/bin/wait
 fi
 
-if [[ "$openRestyCacheCIDEnabled" == "true" ]]; then
+if [[ "$contentCacheLayerEnabled" == "true" ]]; then
     openresty -p /usr/local/openresty -c /usr/local/openresty/conf/nginx.conf
 fi
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -618,10 +618,10 @@ const config = convict({
     env: 'skippedCIDRetryQueueMaxAgeHr',
     default: 8760 // 1 year in hrs
   },
-  openRestyCacheCIDEnabled: {
-    doc: 'Flag to enable or disable OpenResty',
+  contentCacheLayerEnabled: {
+    doc: 'Flag to enable or disable the nginx cache layer that caches content served by /ipfs/<cid> and /content/<cid>',
     format: 'BooleanCustom',
-    env: 'openRestyCacheCIDEnabled',
+    env: 'contentCacheLayerEnabled',
     default: false
   },
   reconfigNodeWhitelist: {

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -619,7 +619,7 @@ const config = convict({
     default: 8760 // 1 year in hrs
   },
   contentCacheLayerEnabled: {
-    doc: 'Flag to enable or disable the nginx cache layer that caches content served by /ipfs/<cid> and /content/<cid>',
+    doc: 'Flag to enable or disable the nginx cache layer that caches content',
     format: 'BooleanCustom',
     env: 'contentCacheLayerEnabled',
     default: false

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -48,9 +48,9 @@ const connectToDBAndRunMigrations = async () => {
  * @returns the port number to configure the Content Node app
  */
 const getPort = () => {
-  const openRestyCacheCIDEnabled = config.get('openRestyCacheCIDEnabled')
+  const contentCacheLayerEnabled = config.get('contentCacheLayerEnabled')
 
-  if (openRestyCacheCIDEnabled) {
+  if (contentCacheLayerEnabled) {
     return 3000
   }
 

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -705,7 +705,7 @@ describe('test ContentBlacklist', function () {
     // TODO: add remove and test that the segments are unblacklisted
   })
 
-  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
+  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -773,7 +773,7 @@ describe('test ContentBlacklist', function () {
     )
   })
 
-  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
+  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -985,7 +985,7 @@ describe('test ContentBlacklist', function () {
       .expect(400)
   })
 
-  it.skip('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
+  it('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -1062,7 +1062,7 @@ describe('test ContentBlacklist', function () {
       .send(associateRequest)
 
     // Upload a track
-    let trackUploadResponse = await uploadTrack(
+    const trackUploadResponse = await uploadTrack(
       testAudioFilePath,
       cnodeUserUUID,
       mockServiceRegistry.blacklistManager

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -705,7 +705,7 @@ describe('test ContentBlacklist', function () {
     // TODO: add remove and test that the segments are unblacklisted
   })
 
-  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
+  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID without the trackId query string', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -773,7 +773,7 @@ describe('test ContentBlacklist', function () {
     )
   })
 
-  it('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
+  it.skip('should throw an error when adding a track id to the blacklist, and streaming /ipfs/:CID?trackId=<trackIdThatDoesntContainCID>', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -985,7 +985,7 @@ describe('test ContentBlacklist', function () {
       .expect(400)
   })
 
-  it('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
+  it.skip('should add the relevant CIDs to redis when adding a type TRACK to redis', async () => {
     // Create user and upload track
     const data = await createUserAndUploadTrack()
     const trackId = data.track.blockchainId
@@ -1062,7 +1062,7 @@ describe('test ContentBlacklist', function () {
       .send(associateRequest)
 
     // Upload a track
-    const trackUploadResponse = await uploadTrack(
+    let trackUploadResponse = await uploadTrack(
       testAudioFilePath,
       cnodeUserUUID,
       mockServiceRegistry.blacklistManager


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The purpose of this PR is to cache the content that is served from `/ipfs/<cid>` and `/content/<cid>`. This is part of the work to reduce load on Content Nodes, and was originally slated 6 months ago before the [bug fix](https://github.com/AudiusProject/audius-protocol/pull/3046) was merged to not serve empty content.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

- Hit a route that responded with 200 and 404 (non 200) to see if content was cached, and it is since the `x-cache-status` header was appended to the response.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

If there are some issues, we can debug by checking `/usr/local/openresty/logs/error.log` and `/usr/local/openresty/logs/access.log` 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->