### PR TITLE
Fix updateReplicaSet, add a few tests, and improve dashboard truncation

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -158,9 +158,21 @@ class ServiceRegistry {
     app.use('/health/bull', serverAdapter.getRouter())
   }
 
-  // Truncates large JSON data in Bull Board after 5 levels of nesting or 10,0000 characters.
-  // Replaces truncated data with [Array-Truncated], [Object-Truncated], or [String-Truncated].
-  // Taken from https://github.com/felixmosh/bull-board/pull/414#issuecomment-1134874761
+  /**
+   * Truncates large JSON data in Bull Board after any of the following is exceeded:
+   * - 5 levels of nesting
+   * - 10,000 characters (strings only)
+   * - 100 elements (arrays) or 100 keys (objects)
+   *
+   * Adapted from https://github.com/felixmosh/bull-board/pull/414#issuecomment-1134874761
+   *
+   * @param {Object} dataToTruncate the data that will be truncated as needed
+   * @param {number} [curDepth] the current depth of the object (this function is called recursively)
+   * @returns dataToTruncate with the following replacements when the above thresholds are exceeded:
+   * - [Truncated string of length <length>]
+   * - [Truncated array with <length> elements],
+   * - [Truncated object with <length> keys]
+   */
   truncateBull(dataToTruncate, curDepth = 0) {
     if (
       typeof dataToTruncate === 'object' &&
@@ -174,16 +186,23 @@ class ServiceRegistry {
         Object.entries(dataToTruncate).forEach(([key, value]) => {
           switch (typeof value) {
             case 'string':
-              json[key] = value.length > 10000 ? '[String-Truncated]' : value
+              json[key] =
+                value.length > 10_000
+                  ? `[Truncated string of length ${value.length}]`
+                  : value
               break
             case 'object':
               if (Array.isArray(value)) {
                 json[key] =
-                  JSON.stringify(value).length > 10000
-                    ? '[Array-Truncated]'
+                  value.length > 100
+                    ? `[Truncated array with ${value.length} elements]`
                     : value
               } else {
-                json[key] = this.truncateBull(value, newDepth)
+                const length = Object.keys(value).length
+                json[key] =
+                  length > 100
+                    ? `[Truncated object with ${length} keys]`
+                    : this.truncateBull(value, newDepth)
               }
               break
             default:
@@ -193,7 +212,9 @@ class ServiceRegistry {
         })
         return json
       }
-      return '[Object-Truncated]'
+      return `[Truncated object with ${
+        Object.keys(dataToTruncate).length
+      } keys]`
     }
     return dataToTruncate
   }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -529,7 +529,7 @@ const _issueUpdateReplicaSetOp = async (
       )
     }
 
-    // Enqueue a sync for new primary to new secondaries. If there is no diff, then this is a no-op.
+    // Enqueue a sync from new primary to new secondary1. If there is no diff, then this is a no-op.
     const { duplicateSyncReq, syncReqToEnqueue: syncToEnqueueToSecondary1 } =
       getNewOrExistingSyncReq({
         userWallet: wallet,
@@ -537,7 +537,15 @@ const _issueUpdateReplicaSetOp = async (
         secondaryEndpoint: newSecondary1,
         syncType: SyncType.Recurring
       })
+    if (!_.isEmpty(duplicateSyncReq)) {
+      logger.warn(
+        `[_issueUpdateReplicaSetOp] Reconfig had duplicate sync request to secondary1: ${duplicateSyncReq}`
+      )
+    } else if (!_.isEmpty(syncToEnqueueToSecondary1)) {
+      response.syncJobsToEnqueue.push(syncToEnqueueToSecondary1)
+    }
 
+    // Enqueue a sync from new primary to new secondary2. If there is no diff, then this is a no-op.
     const {
       duplicateSyncReq: duplicateSyncReq2,
       syncReqToEnqueue: syncToEnqueueToSecondary2
@@ -547,17 +555,8 @@ const _issueUpdateReplicaSetOp = async (
       secondaryEndpoint: newSecondary2,
       syncType: SyncType.Recurring
     })
-
-    if (!_.isEmpty(duplicateSyncReq)) {
-      logger.info(
-        `[_issueUpdateReplicaSetOp] Reconfig had duplicate sync request to secondary1: ${duplicateSyncReq}`
-      )
-    } else if (!_.isEmpty(syncToEnqueueToSecondary1)) {
-      response.syncJobsToEnqueue.push(syncToEnqueueToSecondary1)
-    }
-
     if (!_.isEmpty(duplicateSyncReq2)) {
-      logger.info(
+      logger.warn(
         `[_issueUpdateReplicaSetOp] Reconfig had duplicate sync request to secondary2: ${duplicateSyncReq2}`
       )
     } else if (!_.isEmpty(syncToEnqueueToSecondary2)) {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -27,10 +27,10 @@ const reconfigNodeWhitelist = config.get('reconfigNodeWhitelist')
  * @param {number} param.secondary1 the current secondary1 endpoint of the user whose replica set will be reconfigured
  * @param {number} param.secondary2 the current secondary2 endpoint of the user whose replica set will be reconfigured
  * @param {string[]} param.unhealthyReplicas the endpoints of the user's replica set that are currently unhealthy
- * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to (map of user wallet strings to clock value of secondary for user)
+ * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to clock value of secondary for user whose replica set should be updated
  * @param {string[]} param.enabledReconfigModes array of which reconfig modes are enabled
  */
-module.exports = async function (
+module.exports = async function ({
   logger,
   wallet,
   userId,
@@ -40,7 +40,7 @@ module.exports = async function (
   unhealthyReplicas,
   replicaSetNodesToUserClockStatusesMap,
   enabledReconfigModes
-) {
+}) {
   /**
    * Fetch all the healthy nodes while disabling sync checks to select nodes for new replica set
    * Note: sync checks are disabled because there should not be any syncs occurring for a particular user
@@ -56,7 +56,7 @@ module.exports = async function (
       }
     )
 
-  const healthyNodes = Object.keys(healthyServicesMap)
+  const healthyNodes = Object.keys(healthyServicesMap || {})
   if (healthyNodes.length === 0)
     throw new Error(
       'Auto-selecting Content Nodes returned an empty list of healthy nodes.'
@@ -79,7 +79,8 @@ module.exports = async function (
   let syncJobsToEnqueue = []
   let newReplicaSet = {}
   try {
-    newReplicaSet = await determineNewReplicaSet({
+    newReplicaSet = await _determineNewReplicaSet({
+      logger,
       wallet,
       primary,
       secondary1,
@@ -90,7 +91,7 @@ module.exports = async function (
       enabledReconfigModes
     })
     ;({ errorMsg, issuedReconfig, syncJobsToEnqueue } =
-      await issueUpdateReplicaSetOp(
+      await _issueUpdateReplicaSetOp(
         userId,
         wallet,
         primary,
@@ -103,6 +104,7 @@ module.exports = async function (
     logger.error(
       `ERROR issuing update replica set op: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | Error: ${e.toString()}`
     )
+    errorMsg = `${e}`
   }
 
   return {
@@ -112,16 +114,14 @@ module.exports = async function (
     healthyNodes,
     jobsToEnqueue: syncJobsToEnqueue?.length
       ? {
-          jobsToEnqueue: {
-            [QUEUE_NAMES.STATE_RECONCILIATION]: syncJobsToEnqueue
-          }
+          [QUEUE_NAMES.STATE_RECONCILIATION]: syncJobsToEnqueue
         }
       : {}
   }
 }
 
 /**
- * Logic to determine the new replica set. Used in reconfig op.
+ * Logic to determine the new replica set.
  *
  * The logic below is as follows:
  * 1. Select the unhealthy replica set nodes size worth of healthy nodes to prepare for issuing reconfig
@@ -132,9 +132,9 @@ module.exports = async function (
  *  - ** if one primary and one secondary are unhealthy -> {primary: the healthy secondary, secondary1: new healthy node, secondary2: new healthy node}
  *  - if entire replica set is unhealthy -> {primary: null, secondary1: null, secondary2: null, issueReconfig: false}
  *
- * ** - If in the case a primary is ever unhealthy, we do not want to pre-emptively issue a reconfig and cycle out the primary. See `peerSetManager` instance variable for more information.
+ * ** - If in the case a primary is ever unhealthy, we do not want to pre-emptively issue a reconfig and cycle out the primary. See `../CNodeHealthManager.js` for more information.
  *
- * Also, there is the notion of `issueReconfig` flag. This value is used to determine whether or not to issue a reconfig based on the curretly enabled reconfig mode. See `RECONFIG_MODE` variable for more information.
+ * Also, there is the notion of `issueReconfig` flag. This value is used to determine whether or not to issue a reconfig based on the currently enabled reconfig mode. See `RECONFIG_MODE` variable for more information.
  *
  * @param {Object} param
  * @param {Object} param.logger the logger that can be filtered by jobName and jobId
@@ -154,7 +154,7 @@ module.exports = async function (
  *  issueReconfig: {boolean} flag to issue reconfig or not
  * }
  */
-const determineNewReplicaSet = async ({
+const _determineNewReplicaSet = async ({
   logger,
   primary,
   secondary1,
@@ -169,7 +169,7 @@ const determineNewReplicaSet = async ({
   const healthyReplicaSet = new Set(
     currentReplicaSet.filter((node) => !unhealthyReplicasSet.has(node))
   )
-  const newReplicaNodes = await selectRandomReplicaSetNodes(
+  const newReplicaNodes = await _selectRandomReplicaSetNodes(
     healthyReplicaSet,
     unhealthyReplicasSet.size,
     healthyNodes,
@@ -178,7 +178,7 @@ const determineNewReplicaSet = async ({
   )
 
   if (unhealthyReplicasSet.size === 1) {
-    return determineNewReplicaSetWhenOneNodeIsUnhealthy(
+    return _determineNewReplicaSetWhenOneNodeIsUnhealthy(
       primary,
       secondary1,
       secondary2,
@@ -188,7 +188,7 @@ const determineNewReplicaSet = async ({
       enabledReconfigModes
     )
   } else if (unhealthyReplicasSet.size === 2) {
-    return determineNewReplicaSetWhenTwoNodesAreUnhealthy(
+    return _determineNewReplicaSetWhenTwoNodesAreUnhealthy(
       primary,
       secondary1,
       secondary2,
@@ -214,7 +214,7 @@ const _validateJobData = (
   secondary1,
   secondary2,
   wallet,
-  unhealthyReplicasSet,
+  unhealthyReplicas,
   healthyNodes,
   replicaSetNodesToUserClockStatusesMap,
   enabledReconfigModes
@@ -244,9 +244,9 @@ const _validateJobData = (
       `Invalid type ("${typeof wallet}") or value ("${wallet}") of wallet param`
     )
   }
-  if (!(unhealthyReplicasSet instanceof Set)) {
+  if (!(unhealthyReplicas instanceof Array)) {
     throw new Error(
-      `Invalid type ("${typeof unhealthyReplicasSet}") or value ("${unhealthyReplicasSet}") of unhealthyReplicasSet param`
+      `Invalid type ("${typeof unhealthyReplicas}") or value ("${unhealthyReplicas}") of unhealthyReplicasSet param`
     )
   }
   if (!(healthyNodes instanceof Array)) {
@@ -279,7 +279,7 @@ const _validateJobData = (
  * @param {*} newReplicaNode endpoint of node that will replace the unhealthy node
  * @returns reconfig info to update the user's replica set to replace the 1 unhealthy node
  */
-const determineNewReplicaSetWhenOneNodeIsUnhealthy = (
+const _determineNewReplicaSetWhenOneNodeIsUnhealthy = (
   primary,
   secondary1,
   secondary2,
@@ -333,7 +333,7 @@ const determineNewReplicaSetWhenOneNodeIsUnhealthy = (
  * @param {*} newReplicaNodes array of endpoints of nodes that will replace the unhealthy nodes
  * @returns reconfig info to update the user's replica set to replace the 1 unhealthy nodes
  */
-const determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
+const _determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
   primary,
   secondary1,
   secondary2,
@@ -383,18 +383,18 @@ const determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
  * @param {Object} logger a logger that can be filtered on jobName and jobId
  * @returns {string[]} a string[] of the new replica set nodes
  */
-const selectRandomReplicaSetNodes = async (
+const _selectRandomReplicaSetNodes = async (
   healthyReplicaSet,
   numberOfUnhealthyReplicas,
   healthyNodes,
   wallet,
   logger
 ) => {
-  const logStr = `[selectRandomReplicaSetNodes] wallet=${wallet} healthyReplicaSet=[${[
+  const logStr = `[_selectRandomReplicaSetNodes] wallet=${wallet} healthyReplicaSet=[${[
     ...healthyReplicaSet
-  ]}] numberOfUnhealthyReplicas=${numberOfUnhealthyReplicas} numberHealthyNodes=${
-    healthyNodes.length
-  } ||`
+  ]}] numberOfUnhealthyReplicas=${numberOfUnhealthyReplicas} healthyNodes=${[
+    ...healthyNodes
+  ]} ||`
 
   const newReplicaNodesSet = new Set()
   let selectNewReplicaSetAttemptCounter = 0
@@ -452,7 +452,7 @@ const selectRandomReplicaSetNodes = async (
  * @param {Object} newReplicaSet {newPrimary, newSecondary1, newSecondary2, issueReconfig, reconfigType}
  * @param {Object} logger a logger that can be filtered on jobName and jobId
  */
-const issueUpdateReplicaSetOp = async (
+const _issueUpdateReplicaSetOp = async (
   userId,
   wallet,
   primary,
@@ -462,7 +462,7 @@ const issueUpdateReplicaSetOp = async (
   logger
 ) => {
   const response = {
-    errorMsg: null,
+    errorMsg: '',
     issuedReconfig: false,
     syncJobsToEnqueue: []
   }
@@ -479,7 +479,7 @@ const issueUpdateReplicaSetOp = async (
     newReplicaSetEndpoints = [newPrimary, newSecondary1, newSecondary2]
 
     logger.info(
-      `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} newReplicaSetEndpoints=${JSON.stringify(
+      `[_issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} newReplicaSetEndpoints=${JSON.stringify(
         newReplicaSetEndpoints
       )}`
     )
@@ -487,7 +487,7 @@ const issueUpdateReplicaSetOp = async (
     // If snapback is not enabled, Log reconfig op without issuing.
     if (!issueReconfig) {
       logger.info(
-        `[issueUpdateReplicaSetOp] Reconfig [DISABLED]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | reconfig type=[${reconfigType}]`
+        `[_issueUpdateReplicaSetOp] Reconfig [DISABLED]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | reconfig type=[${reconfigType}]`
       )
       return response
     }
@@ -497,7 +497,7 @@ const issueUpdateReplicaSetOp = async (
       // If for some reason any node in the new replica set is not registered on chain as a valid SP and is
       // selected as part of the new replica set, do not issue reconfig
       if (!CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()[endpt]) {
-        response.errorMsg = `[issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} unable to find valid SPs from new replica set=[${newReplicaSetEndpoints}] | new replica set spIds=[${newReplicaSetSPIds}] | reconfig type=[${reconfigType}] | endpointToSPIdMap=${JSON.stringify(
+        response.errorMsg = `[_issueUpdateReplicaSetOp] userId=${userId} wallet=${wallet} unable to find valid SPs from new replica set=[${newReplicaSetEndpoints}] | new replica set spIds=[${newReplicaSetSPIds}] | reconfig type=[${reconfigType}] | endpointToSPIdMap=${JSON.stringify(
           CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()
         )} | endpt=${endpt}. Skipping reconfig.`
         logger.error(response.errorMsg)
@@ -518,7 +518,7 @@ const issueUpdateReplicaSetOp = async (
       )
       const timeElapsedMs = Date.now() - startTimeMs
       logger.info(
-        `[issueUpdateReplicaSetOp] updateReplicaSet took ${timeElapsedMs}ms for userId=${userId} wallet=${wallet} `
+        `[_issueUpdateReplicaSetOp] updateReplicaSet took ${timeElapsedMs}ms for userId=${userId} wallet=${wallet} `
       )
 
       response.issuedReconfig = true
@@ -538,24 +538,37 @@ const issueUpdateReplicaSetOp = async (
         syncType: SyncType.Recurring
       })
 
-    const { duplicateSyncReq: _, syncReqToEnqueue: syncToEnqueueToSecondary2 } =
-      getNewOrExistingSyncReq({
-        userWallet: wallet,
-        primaryEndpoint: newPrimary,
-        secondaryEndpoint: newSecondary2,
-        syncType: SyncType.Recurring
-      })
+    const {
+      duplicateSyncReq: duplicateSyncReq2,
+      syncReqToEnqueue: syncToEnqueueToSecondary2
+    } = getNewOrExistingSyncReq({
+      userWallet: wallet,
+      primaryEndpoint: newPrimary,
+      secondaryEndpoint: newSecondary2,
+      syncType: SyncType.Recurring
+    })
 
-    response.syncJobsToEnqueue.push(
-      syncToEnqueueToSecondary1,
-      syncToEnqueueToSecondary2
-    )
+    if (!_.isEmpty(duplicateSyncReq)) {
+      logger.info(
+        `[_issueUpdateReplicaSetOp] Reconfig had duplicate sync request to secondary1: ${duplicateSyncReq}`
+      )
+    } else if (!_.isEmpty(syncToEnqueueToSecondary1)) {
+      response.syncJobsToEnqueue.push(syncToEnqueueToSecondary1)
+    }
+
+    if (!_.isEmpty(duplicateSyncReq2)) {
+      logger.info(
+        `[_issueUpdateReplicaSetOp] Reconfig had duplicate sync request to secondary2: ${duplicateSyncReq2}`
+      )
+    } else if (!_.isEmpty(syncToEnqueueToSecondary2)) {
+      response.syncJobsToEnqueue.push(syncToEnqueueToSecondary2)
+    }
 
     logger.info(
-      `[issueUpdateReplicaSetOp] Reconfig [SUCCESS]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | reconfig type=[${reconfigType}]`
+      `[_issueUpdateReplicaSetOp] Reconfig [SUCCESS]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | reconfig type=[${reconfigType}]`
     )
   } catch (e) {
-    response.errorMsg = `[issueUpdateReplicaSetOp] Reconfig [ERROR]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | Error: ${e.toString()}`
+    response.errorMsg = `[_issueUpdateReplicaSetOp] Reconfig [ERROR]: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | Error: ${e.toString()}`
     logger.error(response.errorMsg)
     return response
   }

--- a/creator-node/test/StateReconciliationManager.test.js
+++ b/creator-node/test/StateReconciliationManager.test.js
@@ -143,12 +143,12 @@ describe('test StateReconciliationManager initialization, events, and job proces
   it('processes updateReplicaSet jobs with expected data and returns the expected results', async function () {
     // Mock StateReconciliationManager to have updateReplicaSet job processor return dummy data and mocked processJob util
     const expectedResult = { test: 'test' }
-    const issueSyncReqStub = sandbox.stub().resolves(expectedResult)
+    const updateReplicaSetStub = sandbox.stub().resolves(expectedResult)
     const { processJobMock, loggerStub } = getProcessJobMock()
     const MockStateReconciliationManager = proxyquire(
       '../src/services/stateMachineManager/stateReconciliation/index.js',
       {
-        './updateReplicaSet.jobProcessor': issueSyncReqStub,
+        './updateReplicaSet.jobProcessor': updateReplicaSetStub,
         '../processJob': processJobMock
       }
     )
@@ -178,7 +178,7 @@ describe('test StateReconciliationManager initialization, events, and job proces
     await expect(
       new MockStateReconciliationManager().processUpdateReplicaSetJob(job)
     ).to.eventually.be.fulfilled.and.deep.equal(expectedResult)
-    expect(issueSyncReqStub).to.have.been.calledOnceWithExactly({
+    expect(updateReplicaSetStub).to.have.been.calledOnceWithExactly({
       logger: loggerStub,
       wallet,
       userId,

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -64,7 +64,7 @@ describe('test updateReplicaSet job processor', function () {
   }
 
   function getJobProcessorStub({
-    audiusLibsStub,
+    healthyNodes,
     getNewOrExistingSyncReqStub,
     retrieveClockValueForUserFromReplicaStub,
     maxSelectNewReplicaSetAttempts = 100,
@@ -73,6 +73,20 @@ describe('test updateReplicaSet job processor', function () {
     const getCNodeEndpointToSpIdMapStub = sandbox
       .stub()
       .returns(cNodeEndpointToSpIdMap)
+    const updateReplicaSetStub = sandbox.stub().resolves()
+    const autoSelectCreatorNodesStub = sandbox
+      .stub()
+      .resolves({ services: healthyNodes })
+    const audiusLibsStub = {
+      ServiceProvider: {
+        autoSelectCreatorNodes: autoSelectCreatorNodesStub
+      },
+      contracts: {
+        UserReplicaSetManagerClient: {
+          updateReplicaSet: updateReplicaSetStub
+        }
+      }
+    }
     return proxyquire(
       '../src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js',
       {
@@ -112,20 +126,6 @@ describe('test updateReplicaSet job processor', function () {
       [secondary2]: '',
       [fourthHealthyNode]: ''
     }
-    const autoSelectCreatorNodesStub = sandbox
-      .stub()
-      .resolves({ services: healthyNodes })
-    const updateReplicaSetStub = sandbox.stub().resolves()
-    const audiusLibsStub = {
-      ServiceProvider: {
-        autoSelectCreatorNodes: autoSelectCreatorNodesStub
-      },
-      contracts: {
-        UserReplicaSetManagerClient: {
-          updateReplicaSet: updateReplicaSetStub
-        }
-      }
-    }
 
     // Mark secondary1 as unhealthy and fourthHealthyNode as not having any user state
     const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
@@ -138,7 +138,7 @@ describe('test updateReplicaSet job processor', function () {
     }
 
     const updateReplicaSetJobProcessor = getJobProcessorStub({
-      audiusLibsStub,
+      healthyNodes,
       getNewOrExistingSyncReqStub,
       retrieveClockValueForUserFromReplicaStub
     })
@@ -198,20 +198,6 @@ describe('test updateReplicaSet job processor', function () {
       [secondary2]: '',
       [fourthHealthyNode]: ''
     }
-    const autoSelectCreatorNodesStub = sandbox
-      .stub()
-      .resolves({ services: healthyNodes })
-    const updateReplicaSetStub = sandbox.stub().resolves()
-    const audiusLibsStub = {
-      ServiceProvider: {
-        autoSelectCreatorNodes: autoSelectCreatorNodesStub
-      },
-      contracts: {
-        UserReplicaSetManagerClient: {
-          updateReplicaSet: updateReplicaSetStub
-        }
-      }
-    }
 
     // Mark secondary1 as unhealthy and fourthHealthyNode as not having any user state
     const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
@@ -224,7 +210,7 @@ describe('test updateReplicaSet job processor', function () {
     }
 
     const updateReplicaSetJobProcessor = getJobProcessorStub({
-      audiusLibsStub,
+      healthyNodes,
       getNewOrExistingSyncReqStub,
       retrieveClockValueForUserFromReplicaStub
     })
@@ -269,20 +255,6 @@ describe('test updateReplicaSet job processor', function () {
       [secondary2]: '',
       [fourthHealthyNode]: ''
     }
-    const autoSelectCreatorNodesStub = sandbox
-      .stub()
-      .resolves({ services: healthyNodes })
-    const updateReplicaSetStub = sandbox.stub().resolves()
-    const audiusLibsStub = {
-      ServiceProvider: {
-        autoSelectCreatorNodes: autoSelectCreatorNodesStub
-      },
-      contracts: {
-        UserReplicaSetManagerClient: {
-          updateReplicaSet: updateReplicaSetStub
-        }
-      }
-    }
 
     // Mark all nodes in the replica set as unhealthy and fourthHealthyNode as not having any user state
     const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
@@ -295,7 +267,7 @@ describe('test updateReplicaSet job processor', function () {
     }
 
     const updateReplicaSetJobProcessor = getJobProcessorStub({
-      audiusLibsStub,
+      healthyNodes,
       getNewOrExistingSyncReqStub,
       retrieveClockValueForUserFromReplicaStub
     })

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -1,0 +1,330 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const nock = require('nock')
+
+const { getApp } = require('./lib/app')
+const { getLibsMock } = require('./lib/libsMock')
+
+const config = require('../src/config')
+const {
+  SyncType,
+  RECONFIG_MODES,
+  QUEUE_NAMES
+} = require('../src/services/stateMachineManager/stateMachineConstants')
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+const { expect } = chai
+
+describe('test updateReplicaSet job processor', function () {
+  let server, sandbox, originalContentNodeEndpoint, logger
+  beforeEach(async function () {
+    const appInfo = await getApp(getLibsMock())
+    await appInfo.app.get('redisClient').flushdb()
+    server = appInfo.server
+    sandbox = sinon.createSandbox()
+    config.set('spID', 1)
+    originalContentNodeEndpoint = config.get('creatorNodeEndpoint')
+    config.set('creatorNodeEndpoint', primary)
+    logger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub()
+    }
+    nock.disableNetConnect()
+  })
+
+  afterEach(async function () {
+    await server.close()
+    sandbox.restore()
+    config.set('creatorNodeEndpoint', originalContentNodeEndpoint)
+    logger = null
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+
+  const primary = 'http://primary_cn.co'
+  const secondary1 = 'http://secondary1.co'
+  const secondary2 = 'http://secondary2.co'
+  const fourthHealthyNode = 'http://healthy_cn4.co'
+  const primarySpID = 1
+  const secondary1SpID = 2
+  const secondary2SpID = 3
+  const fourthHealthyNodeSpID = 4
+  const userId = 1
+  const wallet = '0x123456789'
+
+  const DEFAULT_CNODE_ENDOINT_TO_SP_ID_MAP = {
+    [primary]: primarySpID,
+    [secondary1]: secondary1SpID,
+    [secondary2]: secondary2SpID,
+    [fourthHealthyNode]: fourthHealthyNodeSpID
+  }
+
+  function getJobProcessorStub({
+    audiusLibsStub,
+    getNewOrExistingSyncReqStub,
+    retrieveClockValueForUserFromReplicaStub,
+    maxSelectNewReplicaSetAttempts = 100,
+    cNodeEndpointToSpIdMap = DEFAULT_CNODE_ENDOINT_TO_SP_ID_MAP
+  }) {
+    const getCNodeEndpointToSpIdMapStub = sandbox
+      .stub()
+      .returns(cNodeEndpointToSpIdMap)
+    return proxyquire(
+      '../src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js',
+      {
+        '../../../config': config,
+        '../QueueInterfacer': {
+          getAudiusLibs: () => audiusLibsStub
+        },
+        './stateReconciliationUtils': {
+          getNewOrExistingSyncReq: getNewOrExistingSyncReqStub
+        },
+        '../stateMachineUtils': {
+          retrieveClockValueForUserFromReplica:
+            retrieveClockValueForUserFromReplicaStub
+        },
+        '../stateMachineConstants': {
+          SyncType,
+          RECONFIG_MODES,
+          MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS: maxSelectNewReplicaSetAttempts,
+          QUEUE_NAMES
+        },
+        '../CNodeToSpIdMapManager': {
+          getCNodeEndpointToSpIdMap: getCNodeEndpointToSpIdMapStub
+        }
+      }
+    )
+  }
+
+  it('reconfigs one secondary when one secondary is unhealthy and reconfigs are enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except secondary1
+    const healthyNodes = {
+      [primary]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: ''
+    }
+    const autoSelectCreatorNodesStub = sandbox
+      .stub()
+      .resolves({ services: healthyNodes })
+    const updateReplicaSetStub = sandbox.stub().resolves()
+    const audiusLibsStub = {
+      ServiceProvider: {
+        autoSelectCreatorNodes: autoSelectCreatorNodesStub
+      },
+      contracts: {
+        UserReplicaSetManagerClient: {
+          updateReplicaSet: updateReplicaSetStub
+        }
+      }
+    }
+
+    // Mark secondary1 as unhealthy and fourthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [secondary1]
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: 1,
+      [secondary1]: 1,
+      [secondary2]: 1,
+      [fourthHealthyNode]: -1
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      audiusLibsStub,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    // Verify job outputs the correct results: update secondary1 to randomHealthyNode
+    return expect(
+      updateReplicaSetJobProcessor({
+        logger,
+        wallet,
+        userId,
+        primary,
+        secondary1,
+        secondary2,
+        unhealthyReplicas,
+        replicaSetNodesToUserClockStatusesMap,
+        enabledReconfigModes: [RECONFIG_MODES.ONE_SECONDARY.key]
+      })
+    ).to.eventually.be.fulfilled.and.deep.equal({
+      errorMsg: '',
+      issuedReconfig: true,
+      newReplicaSet: {
+        newPrimary: primary,
+        newSecondary1: secondary2,
+        newSecondary2: fourthHealthyNode,
+        issueReconfig: true,
+        reconfigType: RECONFIG_MODES.ONE_SECONDARY.key
+      },
+      healthyNodes: [primary, secondary2, fourthHealthyNode],
+      jobsToEnqueue: {
+        [QUEUE_NAMES.STATE_RECONCILIATION]: [
+          {
+            primaryEndpoint: primary,
+            secondaryEndpoint: secondary2,
+            syncType: SyncType.Recurring,
+            userWallet: wallet
+          },
+          {
+            primaryEndpoint: primary,
+            secondaryEndpoint: fourthHealthyNode,
+            syncType: SyncType.Recurring,
+            userWallet: wallet
+          }
+        ]
+      }
+    })
+  })
+
+  it('reconfigs one secondary when one secondary is unhealthy but reconfigs are disabled', async function () {
+    // It should short-circuit before trying to sync -- no sync will be needed
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error('This was not supposed to be called')
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except secondary1
+    const healthyNodes = {
+      [primary]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: ''
+    }
+    const autoSelectCreatorNodesStub = sandbox
+      .stub()
+      .resolves({ services: healthyNodes })
+    const updateReplicaSetStub = sandbox.stub().resolves()
+    const audiusLibsStub = {
+      ServiceProvider: {
+        autoSelectCreatorNodes: autoSelectCreatorNodesStub
+      },
+      contracts: {
+        UserReplicaSetManagerClient: {
+          updateReplicaSet: updateReplicaSetStub
+        }
+      }
+    }
+
+    // Mark secondary1 as unhealthy and fourthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [secondary1]
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: 1,
+      [secondary1]: 1,
+      [secondary2]: 1,
+      [fourthHealthyNode]: -1
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      audiusLibsStub,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    // Verify job outputs the correct results: find update from secondary1 to randomHealthyNode but don't issue it
+    return expect(
+      updateReplicaSetJobProcessor({
+        logger,
+        wallet,
+        userId,
+        primary,
+        secondary1,
+        secondary2,
+        unhealthyReplicas,
+        replicaSetNodesToUserClockStatusesMap,
+        enabledReconfigModes: [RECONFIG_MODES.RECONFIG_DISABLED.key] // Disable reconfigs
+      })
+    ).to.eventually.be.fulfilled.and.deep.equal({
+      errorMsg: '',
+      issuedReconfig: false,
+      newReplicaSet: {
+        newPrimary: primary,
+        newSecondary1: secondary2,
+        newSecondary2: fourthHealthyNode,
+        issueReconfig: false,
+        reconfigType: RECONFIG_MODES.ONE_SECONDARY.key
+      },
+      healthyNodes: [primary, secondary2, fourthHealthyNode],
+      jobsToEnqueue: {}
+    })
+  })
+
+  it('returns falsy replica set when the whole replica set is unhealthy', async function () {
+    // It should short-circuit before trying to sync -- no sync will be needed
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      throw new Error('This was not supposed to be called')
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except secondary1
+    const healthyNodes = {
+      [primary]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: ''
+    }
+    const autoSelectCreatorNodesStub = sandbox
+      .stub()
+      .resolves({ services: healthyNodes })
+    const updateReplicaSetStub = sandbox.stub().resolves()
+    const audiusLibsStub = {
+      ServiceProvider: {
+        autoSelectCreatorNodes: autoSelectCreatorNodesStub
+      },
+      contracts: {
+        UserReplicaSetManagerClient: {
+          updateReplicaSet: updateReplicaSetStub
+        }
+      }
+    }
+
+    // Mark all nodes in the replica set as unhealthy and fourthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [primary, secondary1, secondary2]
+    const replicaSetNodesToUserClockStatusesMap = {
+      [primary]: 1,
+      [secondary1]: 1,
+      [secondary2]: 1,
+      [fourthHealthyNode]: -1
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      audiusLibsStub,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    // Verify job outputs the correct results: entire replica set is falsy because we can't sync if all nodes in the RS are unhealthy
+    return expect(
+      updateReplicaSetJobProcessor({
+        logger,
+        wallet,
+        userId,
+        primary,
+        secondary1,
+        secondary2,
+        unhealthyReplicas,
+        replicaSetNodesToUserClockStatusesMap,
+        enabledReconfigModes: [RECONFIG_MODES.ENTIRE_REPLICA_SET.key]
+      })
+    ).to.eventually.be.fulfilled.and.deep.equal({
+      errorMsg: '',
+      issuedReconfig: false,
+      newReplicaSet: {
+        newPrimary: null,
+        newSecondary1: null,
+        newSecondary2: null,
+        issueReconfig: false,
+        reconfigType: null
+      },
+      healthyNodes: [primary, secondary2, fourthHealthyNode],
+      jobsToEnqueue: {}
+    })
+  })
+})


### PR DESCRIPTION
### Description

- Make truncated data show length and truncate after 100 keys/elements instead of stringifying arrays and checking for 10,000 characters
  - 10,000 characters was still too large to be readable for some data, and not doing a keys/elements check means large nested properties cause the whole parent object to be truncated
- Fix updateReplicaSet job processor bugs:
  - Function taking regular params when it's passed an object
  - Validating unhealthyReplicas as a set instead of array
  - Not being passed reconfig modes array
  - Returning extra nested jobsToEnqueue
- Return updateReplicaSet error in job data (previously it was only logged but not viewable on the dashboard) and do other cleanup in that job processor
- Add basic tests for updateReplicaSet since basic errors like these should really be caught sooner


### Tests

- Existing tests pass and the new tests for the updateReplicaSet job processor also pass
- Simulated a replica set update locally and verified that it was able to run successfully:
  - Brought up the local stack (A up) and started the client
  - Signed up with a user
  - Verified cn3 was in the user's replica set from http://dn1_web-server_1:5000/v1/full/users/content_node/all?creator_node_endpoint=http://cn1_creator-node_1:4000 
  - Stopped cn3 (docker container stop cn3_creator-node_1)
  - Verified the flow of a monitor-state job showing cn3 in unhealthyPeers, then passing unhealthyPeers to find-sync-requests and find-replica-set-updates jobs. The latter triggered an update-replica-set job, which I verified had the correct inputs and outputs


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I'll be watching the dashboard (/health/bull endpoint) after releasing to stage CN11, looking for anomalies in update-replica-set jobs in the state-reconciliation-queue.