### PR TITLE
Improve state machine debugging & fix bugs

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -12,6 +12,7 @@ redisPort=6379
 # Put CNs to debug mode if we're running locally.
 # Can be overriden.
 creatorNodeIsDebug=true
+disableSnapback=false
 
 WAIT_HOSTS=
 

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -217,7 +217,7 @@ class ServiceRegistry {
                 json[key] =
                   value.length > 100
                     ? `[Truncated array with ${value.length} elements]`
-                    : value
+                    : this.truncateBull(value, newDepth)
               } else {
                 const length = Object.keys(value).length
                 json[key] =

--- a/creator-node/src/services/stateMachineManager/makeCompletedJobEnqueueOtherJobs.js
+++ b/creator-node/src/services/stateMachineManager/makeCompletedJobEnqueueOtherJobs.js
@@ -70,6 +70,9 @@ module.exports = function makeCompletedJobEnqueueOtherJobs(
     try {
       const monitoringBulkAddResult = await monitoringQueue.addBulk(
         monitoringJobs.map((job) => {
+          if (!job?.jobName || !job?.jobData) {
+            logger.error(`Job ${JSON.stringify(job)} is missing name or data!`)
+          }
           return { name: job.jobName, data: job.jobData }
         })
       )
@@ -86,6 +89,9 @@ module.exports = function makeCompletedJobEnqueueOtherJobs(
     try {
       const reconciliationBulkAddResult = await reconciliationQueue.addBulk(
         reconciliationJobs.map((job) => {
+          if (!job?.jobName || !job?.jobData) {
+            logger.error(`Job ${JSON.stringify(job)} is missing name or data!`)
+          }
           // Inject enabledReconfigModesSet into update-replica-set jobs as an array.
           // It gets `this` from being bound to ./index.js
           if (job.jobName === JOB_NAMES.UPDATE_REPLICA_SET) {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
@@ -304,10 +304,9 @@ const _findReplicaSetUpdatesForUser = async (
 
 /**
  * Transforms data type from ((K1,V1) => (K2,V2)) to (K1,V1[K2]), where K1 is the node endpoint,
- * V1 is the mapping, and K2 is the wallet to filter by. Default to clock value of -1 whenever the given
- * wallet isn't present in a node's mapping.
+ * V1 is the mapping, and K2 is the wallet to filter by. Also filters out nodes that don't have a value for the wallet.
  * @param {Object} replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to (map of user wallet strings to clock value of secondary for user)
- * @param {string} wallet the wallet to filter clock values for (other wallets will be exlucded from the output)
+ * @param {string} wallet the wallet to filter clock values for (other wallets will be excluded from the output)
  * @returns mapping of node endpoint (string) to clock value (number) on that node for the given wallet
  */
 const _transformAndFilterNodeToClockValuesMapping = (
@@ -315,8 +314,12 @@ const _transformAndFilterNodeToClockValuesMapping = (
   wallet
 ) => {
   return Object.fromEntries(
-    Object.entries(replicaSetNodesToUserClockStatusesMap).map(
-      ([node, clockValueMapping]) => [node, clockValueMapping[wallet] || -1]
-    )
+    Object.entries(replicaSetNodesToUserClockStatusesMap)
+      .map(([node, clockValueMapping]) => [
+        node,
+        clockValueMapping[wallet] || -1
+      ])
+      // Only include nodes that have clock values -- this means only the nodes in the user's replica set
+      .filter(([, clockValue]) => clockValue !== -1)
   )
 }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -53,13 +53,13 @@ const getNewOrExistingSyncReq = ({
     syncType === SyncType.Manual
       ? JOB_NAMES.ISSUE_MANUAL_SYNC_REQUEST
       : JOB_NAMES.ISSUE_RECURRING_SYNC_REQUEST
-  const jobProps = {
+  const jobData = {
     syncType,
     syncRequestParameters
   }
   const syncReqToEnqueue = {
     jobName,
-    jobProps
+    jobData
   }
 
   // Record sync in syncDeDuplicator
@@ -67,7 +67,7 @@ const getNewOrExistingSyncReq = ({
     syncType,
     userWallet,
     secondaryEndpoint,
-    jobProps
+    jobData
   )
 
   return { syncReqToEnqueue }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -27,7 +27,7 @@ const reconfigNodeWhitelist = config.get('reconfigNodeWhitelist')
  * @param {number} param.secondary1 the current secondary1 endpoint of the user whose replica set will be reconfigured
  * @param {number} param.secondary2 the current secondary2 endpoint of the user whose replica set will be reconfigured
  * @param {string[]} param.unhealthyReplicas the endpoints of the user's replica set that are currently unhealthy
- * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of secondary endpoint strings to clock value of secondary for user whose replica set should be updated
+ * @param {Object} param.replicaSetNodesToUserClockStatusesMap map of user's node endpoint strings to clock value of node for user whose replica set should be updated
  * @param {string[]} param.enabledReconfigModes array of which reconfig modes are enabled
  */
 module.exports = async function ({
@@ -104,7 +104,7 @@ module.exports = async function ({
     logger.error(
       `ERROR issuing update replica set op: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | Error: ${e.toString()}`
     )
-    errorMsg = `${e}`
+    errorMsg = e.toString()
   }
 
   return {

--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -305,10 +305,12 @@ class SnapbackSM {
     this.usersPerJob = this.nodeConfig.get('snapbackUsersPerJob')
 
     // Enqueue first job after a delay. This job requeues itself upon completion or failure
-    await this.stateMachineQueue.add(
-      /** data */ { startTime: Date.now() },
-      /** opts */ { delay: STATE_MACHINE_QUEUE_INIT_DELAY_MS }
-    )
+    if (!this.nodeConfig.get('disableSnapback')) {
+      await this.stateMachineQueue.add(
+        /** data */ { startTime: Date.now() },
+        /** opts */ { delay: STATE_MACHINE_QUEUE_INIT_DELAY_MS }
+      )
+    }
 
     this.log(
       `SnapbackSM initialized with manualSyncsDisabled=${this.manualSyncsDisabled}. Added initial stateMachineQueue job with ${STATE_MACHINE_QUEUE_INIT_DELAY_MS}ms delay; a new will be enqueued after each previous job finishes`

--- a/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
+++ b/creator-node/test/findReplicaSetUpdates.jobProcessor.test.js
@@ -83,7 +83,8 @@ describe('test findReplicaSetUpdates job processor', function () {
     },
     [secondary2]: {
       [wallet]: 10
-    }
+    },
+    unusedNode: {}
   }
 
   const CLOCK_STATUSES_MAP_FILTERED_TO_WALLET = {


### PR DESCRIPTION
### Description

- Fix truncation not recursing all the way down for arrays
- Filter out nodes in the node => clockValue mapping. The monitorState job only fetches clock values for the user's replica set, so all other nodes were showing in the bull dashboard as -1 when they actually had higher values. This didn't cause bugs but made debugging confusing
- Add list of nodes that were attempted to be selected for new replica set (and their clock value) to the replica update-replica-set job's results (for debugging purposes)
- Fix find-sync-requests returning `jobProps` field instead of `jobData`, and add a check so this type of issue will be caught in the future
- Add `disableSnapback` config option to easily turn off snapback and revert to turning it back on if needed



### Tests
Made sure the state machine queues are running locally and existing tests pass. Also updated one test to make sure filtering irrelevant nodes is working.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

- Monitor the /health/bull endpoint and search logs for the error "Failed to bulk-enqueue" or "missing name or data"
- Make sure the snapback queues (state-machine, manual-sync-queue, recurring-sync-queue) are empty or non-empty based on whether `disableSnapback` is set to true or false, respectively