### PR TITLE
tag search on elasticsearch

### DIFF
--- a/discovery-provider/es-indexer/src/helpers/splitTags.ts
+++ b/discovery-provider/es-indexer/src/helpers/splitTags.ts
@@ -1,0 +1,7 @@
+export function splitTags(tags: string | null): string[] {
+  if (!tags) return []
+  return tags
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
+}

--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,7 +1,7 @@
 export const indexNames = {
-  playlists: 'playlists6',
+  playlists: 'playlists7',
   reposts: 'reposts2',
   saves: 'saves2',
-  tracks: 'tracks6',
-  users: 'users6',
+  tracks: 'tracks7',
+  users: 'users7',
 }

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -1,6 +1,7 @@
 import { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types'
 import { keyBy, merge } from 'lodash'
 import { dialPg } from '../conn'
+import { splitTags } from '../helpers/splitTags'
 import { indexNames } from '../indexNames'
 import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { PlaylistDoc } from '../types/docs'
@@ -77,7 +78,10 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
           properties: {
             mood: { type: 'keyword' },
             genre: { type: 'keyword' },
-            tags: { type: 'keyword' },
+            tags: {
+              type: 'keyword',
+              normalizer: 'lower_asciifolding',
+            },
             play_count: { type: 'integer' },
             repost_count: { type: 'integer' },
             save_count: { type: 'integer' },
@@ -215,7 +219,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
         and track_id in (${idList})`
     const allTracks = await pg.query(q)
     for (let t of allTracks.rows) {
-      t.tags = t.tags?.split(',').filter(Boolean)
+      t.tags = splitTags(t.tags)
     }
     return keyBy(allTracks.rows, 'track_id')
   }

--- a/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
@@ -1,5 +1,6 @@
 import { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types'
 import { merge } from 'lodash'
+import { splitTags } from '../helpers/splitTags'
 import { indexNames } from '../indexNames'
 import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { TrackDoc } from '../types/docs'
@@ -58,9 +59,9 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
           },
         },
         length: { type: 'integer' },
-        tags: {
-          type: 'text',
-          analyzer: 'comma_analyzer',
+        tag_list: {
+          type: 'keyword',
+          normalizer: 'lower_asciifolding',
         },
         genre: { type: 'keyword' },
         mood: { type: 'keyword' },
@@ -186,7 +187,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
     row.suggest = [row.title, row.user.handle, row.user.name]
       .filter((x) => x)
       .join(' ')
-    row.tags = row.tags
+    row.tag_list = splitTags(row.tags)
     row.repost_count = row.reposted_by.length
     row.favorite_count = row.saved_by.length
     row.duration = Math.ceil(

--- a/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
@@ -1,6 +1,7 @@
 import { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types'
 import { groupBy, keyBy, merge } from 'lodash'
 import { dialPg } from '../conn'
+import { splitTags } from '../helpers/splitTags'
 import { indexNames } from '../indexNames'
 import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { UserDoc } from '../types/docs'
@@ -61,7 +62,7 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
           properties: {
             mood: { type: 'keyword' },
             genre: { type: 'keyword' },
-            tags: { type: 'keyword' },
+            tags: { type: 'keyword', normalizer: 'lower_asciifolding' },
           },
         },
       },
@@ -172,7 +173,7 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
     `
     const allTracks = await pg.query(q)
     for (let t of allTracks.rows) {
-      t.tags = t.tags?.split(',').filter(Boolean)
+      t.tags = splitTags(t.tags)
     }
     const grouped = groupBy(allTracks.rows, 'owner_id')
     return grouped

--- a/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
+++ b/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
@@ -5,6 +5,12 @@ import {
 
 export const sharedIndexSettings: IndicesIndexSettings = {
   analysis: {
+    normalizer: {
+      lower_asciifolding: {
+        type: 'custom',
+        filter: ['asciifolding', 'lowercase'],
+      },
+    },
     analyzer: {
       standard_asciifolding: {
         type: 'custom',

--- a/discovery-provider/es-indexer/src/types/docs.ts
+++ b/discovery-provider/es-indexer/src/types/docs.ts
@@ -41,7 +41,7 @@ export type TrackDoc = TrackRow & {
   saved_by: number[]
   routes: string[]
   permalink: string
-  tags: string // comma separated
+  tag_list: string[]
   repost_count: number
   favorite_count: number
   play_count: any // todo: is it a string or number?  pg returns string

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -182,9 +182,9 @@ def search_tags_es(q: str, kind="all", current_user_id=None, limit=0, offset=0):
         return match
 
     if do_tracks:
-        mdsl.extend([{"index": ES_TRACKS}, tag_match("tags")])
+        mdsl.extend([{"index": ES_TRACKS}, tag_match("tag_list")])
         if current_user_id:
-            dsl = tag_match("tags")
+            dsl = tag_match("tag_list")
             dsl["query"]["bool"]["must"].append(be_saved(current_user_id))
             mdsl.extend([{"index": ES_TRACKS}, dsl])
 

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -216,6 +216,13 @@ def search_tags_es(q: str, kind="all", current_user_id=None, limit=0, offset=0):
             response["followed_users"] = pluck_hits(mfound["responses"].pop(0))
 
     finalize_response(response, limit, current_user_id)
+
+    # attempt to match legacy tag search response
+    # which doesn't have the encoded track.user_id field
+    for k in ["tracks", "saved_tracks"]:
+        for track in response[k]:
+            del track["user_id"]
+
     return response
 
 

--- a/discovery-provider/src/queries/search_queries.py
+++ b/discovery-provider/src/queries/search_queries.py
@@ -35,7 +35,7 @@ from src.queries.search_config import (
     user_handle_exact_match_boost,
     user_name_weight,
 )
-from src.queries.search_es import search_es_full
+from src.queries.search_es import search_es_full, search_tags_es
 from src.queries.search_track_tags import search_track_tags
 from src.queries.search_user_tags import search_user_tags
 from src.utils.db_session import get_db_read_replica
@@ -97,6 +97,11 @@ def search_tags():
     results = {}
 
     (limit, offset) = get_pagination_vars()
+
+    if os.getenv("audius_elasticsearch_search_enabled"):
+        hits = search_tags_es(search_str, kind, current_user_id, limit, offset)
+        return api_helpers.success_response(hits)
+
     db = get_db_read_replica()
     with db.scoped_session() as session:
         if searchKind in [SearchKind.all, SearchKind.tracks]:

--- a/discovery-provider/src/tasks/index_materialized_views.py
+++ b/discovery-provider/src/tasks/index_materialized_views.py
@@ -10,15 +10,11 @@ DEFAULT_UPDATE_TIMEOUT = 60 * 60 * 6  # 6 hours
 
 
 def update_views(self, db):
+    if os.getenv("audius_elasticsearch_search_enabled"):
+        return
+
     with db.scoped_session() as session:
         start_time = time.time()
-        if os.getenv("audius_elasticsearch_search_enabled"):
-            session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY tag_track_user")
-            logger.info(
-                f"index_materialized_views.py | Finished updating tag_track_user in: {time.time() - start_time} sec."
-            )
-            return
-
         logger.info("index_materialized_views.py | Updating materialized views")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_lexeme_dict")
         session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY track_lexeme_dict")

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -7,6 +7,9 @@ from src.utils.spl_audio import to_wei
 es_url = os.getenv("audius_elasticsearch_url")
 esclient = None
 if es_url:
+    # for now just printing this out to see if celery might be re-init client over and over
+    # in future will check if esclient exists before creating
+    print(f"elasticsearch init client pid {os.getpid()}")
     esclient = Elasticsearch(es_url)
 
 # uses aliases

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -6,10 +6,7 @@ from src.utils.spl_audio import to_wei
 
 es_url = os.getenv("audius_elasticsearch_url")
 esclient = None
-if es_url:
-    # for now just printing this out to see if celery might be re-init client over and over
-    # in future will check if esclient exists before creating
-    print(f"elasticsearch init client pid {os.getpid()}")
+if es_url and not esclient:
     esclient = Elasticsearch(es_url)
 
 # uses aliases


### PR DESCRIPTION
### Description

Tag search endpoint uses elasticsearch

Actually some TODOs:

* [x] update es mapping to use `lower_keyword` for tags.  Also track.tags comma tokenizer thing is somewhat confusing, so will introduce a new filed `tag_list` that splits tags in the indexer and uses `lower_keyword`.  This will require bumping users and tracks index.
* [x] disable matview tag refresh when es search enabled

### Tests


```
export DEV=http://1.2.3.4:5000

curl -H "X-User-ID: 1" "$DEV/search/tags?kind=all&limit=15&offset=0&query=hybrid&user_tag_count=1"  | jq '.data.followed_users'
```
