### PR TITLE
[PAY-370] Dedupe reaction notifications

### DIFF
--- a/identity-service/src/notifications/processNotifications/reactionNotification.js
+++ b/identity-service/src/notifications/processNotifications/reactionNotification.js
@@ -2,14 +2,39 @@ const models = require('../../models')
 const { notificationTypes } = require('../constants')
 
 async function processReactionNotifications (notifications, tx) {
+  const notifsToReturn = []
+
   for (const notification of notifications) {
     const { slot, initiator: reactorId, metadata: { reaction_value: reactionValue, reacted_to_entity: reactedToEntity, reaction_type: reactionType } } = notification
 
     // TODO: unhardcode assumptions about the userId receiving the notification, when
     // we have additional reaction types.
 
-    await models.SolanaNotification.findOrCreate({
+    const existingNotification = await models.SolanaNotification.findOne({
       where: {
+        type: notificationTypes.Reaction,
+        userId: reactedToEntity.tip_sender_id, // The user receiving the reaction is the user who sent the tip
+        entityId: reactorId, // The user who sent the reaction
+        metadata: {
+          reactionType,
+          reactedToEntity
+        }
+      },
+      transaction: tx
+    })
+
+    // In the case that the notification already exists, avoid returning it to prevent
+    // sending it a second time. Just update the original reaction value.
+    if (existingNotification) {
+      // Have to recreate the metadata object for save to work properly
+      existingNotification.metadata = {
+        ...existingNotification.metadata,
+        reactionValue
+      }
+      await existingNotification.save({ transaction: tx })
+    } else {
+      notifsToReturn.push(notification)
+      await models.SolanaNotification.create({
         slot,
         type: notificationTypes.Reaction,
         userId: reactedToEntity.tip_sender_id, // The user receiving the reaction is the user who sent the tip
@@ -20,10 +45,14 @@ async function processReactionNotifications (notifications, tx) {
           reactionValue
         }
       },
-      transaction: tx
-    })
+      {
+        transaction: tx
+      }
+      )
+    }
   }
-  return notifications
+
+  return notifsToReturn
 }
 
 module.exports = processReactionNotifications


### PR DESCRIPTION
### Description
- Only show a single reaction notification per tip

### Tests
- Tested on remote box, sent multiple reactions, saw we weren't creating new notification rows
- Will test push notifs on stage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->