### PR TITLE
Disable snapback, enable refactored state machine

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -12,7 +12,6 @@ redisPort=6379
 # Put CNs to debug mode if we're running locally.
 # Can be overriden.
 creatorNodeIsDebug=true
-disableSnapback=false
 
 WAIT_HOSTS=
 
@@ -37,8 +36,9 @@ spOwnerWalletIndex=
 
 
 # Sync / SnapbackSM configs
-stateMonitoringQueueRateLimitInterval=30000
-stateMonitoringQueueRateLimitJobsPerInterval=1
+disableSnapback=true
+stateMonitoringQueueRateLimitInterval=60000
+stateMonitoringQueueRateLimitJobsPerInterval=3
 snapbackModuloBase=3
 minimumDailySyncCount=5
 minimumRollingSyncCount=10

--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -38,5 +38,8 @@
   "dataNetworkId": "",
   "creatorNodeEndpoint": "",
   "nodeSyncFileSaveMaxConcurrency": 10,
-  "syncQueueMaxConcurrency": 50
+  "syncQueueMaxConcurrency": 50,
+  "disableSnapback": true,
+  "stateMonitoringQueueRateLimitInterval": 60000,
+  "stateMonitoringQueueRateLimitJobsPerInterval": 3
 }

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -458,7 +458,7 @@ const config = convict({
     doc: 'number of state monitoring jobs that can run in each interval (0 to pause queue)',
     format: 'nat',
     env: 'stateMonitoringQueueRateLimitJobsPerInterval',
-    default: 0
+    default: 3
   },
   debounceTime: {
     doc: 'sync debounce time in ms',
@@ -676,7 +676,7 @@ const config = convict({
     doc: 'True to not run any snapback queues (old state machine and old syncs)',
     format: Boolean,
     env: 'disableSnapback',
-    default: false
+    default: true
   }
   /**
    * unsupported options at the moment

--- a/creator-node/test/StateMonitoringManager.test.js
+++ b/creator-node/test/StateMonitoringManager.test.js
@@ -56,13 +56,18 @@ describe('test StateMonitoringManager initialization, events, and re-enqueuing',
   }
 
   it('creates the queue and registers its event handlers', async function () {
+    // Mock the latest userId, which is used during init as an upper bound
+    // to start the monitoring queue at a random user
+    const discoveryNodeEndpoint = 'https://discoveryNodeEndpoint.co'
+    nock(discoveryNodeEndpoint).get('/latest/user').reply(200, { data: 0 })
+
     // Initialize StateMonitoringManager and spy on its registerQueueEventHandlersAndJobProcessors function
     const stateMonitoringManager = new StateMonitoringManager()
     sandbox.spy(
       stateMonitoringManager,
       'registerQueueEventHandlersAndJobProcessors'
     )
-    const queue = await stateMonitoringManager.init('discoveryNodeEndpoint')
+    const queue = await stateMonitoringManager.init(discoveryNodeEndpoint)
 
     // Verify that the queue was successfully initialized and that its event listeners were registered
     expect(queue).to.exist.and.to.be.instanceOf(BullQueue)


### PR DESCRIPTION
### Description
Changes config defaults to disable snapback and enable the refactored state machine at a rate of 3 monitoring jobs per minute. Note that this change doesn't stop the manual sync queue, which snapback will continue to run regardless of the config options.


### Tests
These are the values that staging nodes have been using for a few days with no known issues. Check the monitoring steps below on staging.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check (on staging but also prod since this changes default configs for prod):
- Queues are healthy -- `/health/bull` endpoint shows:
  - `state-monitoring-queue` and `state-reconciliation-queue` queues are processing jobs that show inputs (jobData) and outputs (returnValue). Spot check some of each job type to make sure they look reasonable
  - `state-machine` and `recurring-sync-queue` queues are not processing any jobs
  - `manual-sync-queue` queue is processing jobs
- Search logs for errors with either refactored queue using this query: `json.log_level:"error" AND (json.queue:"state-monitoring-queue" OR json.queue:"state-reconciliation-queue")`
  - Errors starting with "Invalid type" likely mean something is passing data incorrectly to a job, preventing the job from running. Same for "Invalid sync data"
  - There will probably be some "Not enough healthy nodes found to issue new replica set" errors. Spot check them to make sure that they make sense (the other nodes had user state or were unhealthy so they couldn't be selected)
- `currentSnapbackReconfigMode` in the health check of each prod node should be set to `RECONFIG_DISABLED`