### PR TITLE
update trending lock timeout to 24h

### DIFF
--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -269,7 +269,7 @@ def index_trending_task(self):
     redis = index_trending_task.redis
     web3 = index_trending_task.web3
     have_lock = False
-    update_lock = redis.lock("index_trending_lock", timeout=7200)
+    update_lock = redis.lock("index_trending_lock", timeout=86400)
     try:
         should_update_timestamp = get_should_update_trending(
             db, web3, redis, UPDATE_TRENDING_DURATION_DIFF_SEC


### PR DESCRIPTION
### Description

pg_dump will block the matview refresh...
and then multiple instances of this job will start running




### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

keep an eye on discovery blockdiff + postgres queries that are waiting for locks

