### PR TITLE
Dont need to .length a length

### DIFF
--- a/creator-node/src/services/stateMachineManager/CNodeToSpIdMapManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeToSpIdMapManager.js
@@ -44,7 +44,7 @@ class CNodeToSpIdMapManager {
       throw new Error(errorMessage)
     }
 
-    logger.info(`updateEndpointToSpIdMap Success. Size: ${mapLength.length}`)
+    logger.info(`updateEndpointToSpIdMap Success. Size: ${mapLength}`)
   }
 }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

saw this log
```
[2022-06-27T19:07:40.478Z]  INFO: audius_creator_node/13166 on 5bb7a1ff2882: updateEndpointToSpIdMap Success. Size: undefined (logLevel=info)
```

realized that we didnt need to `.length` a length var 😉 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

- no additional tests needed
- manual test log output
```
[2022-06-27T19:13:28.911Z]  INFO: audius_creator_node/13786 on 5bb7a1ff2882: updateEndpointToSpIdMap Success. Size: 4 (logLevel=info)
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

monitoring the same log

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->