### PR TITLE
[CON-195] Update health check for new queues

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -50,7 +50,9 @@ minimumFailedSyncRequestsBeforeReconfig=5
 maxSyncMonitoringDurationInMs=10000 # 10sec
 syncRequestMaxUserFailureCountBeforeSkip=3
 skippedCIDsRetryQueueJobIntervalMs=30000 # 30sec in ms
-snapbackMaxLastSuccessfulRunDelayMs=300000 # 5min in ms
+monitorStateJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+findSyncRequestsJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+findReplicaSetUpdatesJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 
 # peerSetManager
 peerHealthCheckRequestTimeout=2000 # ms

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -180,20 +180,24 @@ const healthCheck = async (
     shouldHandleTranscode,
     asyncProcessingQueue: asyncProcessingQueueJobs,
     solDelegatePublicKeyBase58,
-    latestMonitorStateJobStart: parseDateOrNull(latestMonitorStateJobStart),
-    latestMonitorStateJobSuccess: parseDateOrNull(latestMonitorStateJobSuccess),
-    latestFindSyncRequestsJobStart: parseDateOrNull(
-      latestFindSyncRequestsJobStart
-    ),
-    latestFindSyncRequestsJobSuccess: parseDateOrNull(
-      latestFindSyncRequestsJobSuccess
-    ),
-    latestFindReplicaSetUpdatesJobStart: parseDateOrNull(
-      latestFindReplicaSetUpdatesJobStart
-    ),
-    latestFindReplicaSetUpdatesJobSuccess: parseDateOrNull(
-      latestFindReplicaSetUpdatesJobSuccess
-    )
+    stateMachineJobs: {
+      latestMonitorStateJobStart: parseDateOrNull(latestMonitorStateJobStart),
+      latestMonitorStateJobSuccess: parseDateOrNull(
+        latestMonitorStateJobSuccess
+      ),
+      latestFindSyncRequestsJobStart: parseDateOrNull(
+        latestFindSyncRequestsJobStart
+      ),
+      latestFindSyncRequestsJobSuccess: parseDateOrNull(
+        latestFindSyncRequestsJobSuccess
+      ),
+      latestFindReplicaSetUpdatesJobStart: parseDateOrNull(
+        latestFindReplicaSetUpdatesJobStart
+      ),
+      latestFindReplicaSetUpdatesJobSuccess: parseDateOrNull(
+        latestFindReplicaSetUpdatesJobSuccess
+      )
+    }
   }
 
   // If optional `randomBytesToSign` query param provided, node will include string in signed object

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -70,8 +70,12 @@ const healthCheck = async (
     dailySyncFailCount,
     latestSyncSuccessTimestamp,
     latestSyncFailTimestamp,
-    stateMachineQueueLatestJobSuccess,
-    stateMachineQueueLatestJobStart
+    latestMonitorStateJobStart,
+    latestMonitorStateJobSuccess,
+    latestFindSyncRequestsJobStart,
+    latestFindSyncRequestsJobSuccess,
+    latestFindReplicaSetUpdatesJobStart,
+    latestFindReplicaSetUpdatesJobSuccess
   ] = await getMonitors([
     MONITORS.DATABASE_CONNECTIONS,
     MONITORS.DATABASE_SIZE,
@@ -90,8 +94,12 @@ const healthCheck = async (
     MONITORS.DAILY_SYNC_FAIL_COUNT,
     MONITORS.LATEST_SYNC_SUCCESS_TIMESTAMP,
     MONITORS.LATEST_SYNC_FAIL_TIMESTAMP,
-    MONITORS.LATEST_STATE_MACHINE_QUEUE_SUCCESS,
-    MONITORS.LATEST_STATE_MACHINE_QUEUE_START
+    MONITORS.LATEST_MONITOR_STATE_JOB_START,
+    MONITORS.LATEST_MONITOR_STATE_JOB_SUCCESS,
+    MONITORS.LATEST_FIND_SYNC_REQUESTS_JOB_START,
+    MONITORS.LATEST_FIND_SYNC_REQUESTS_JOB_SUCCESS,
+    MONITORS.LATEST_FIND_REPLICA_SET_UPDATES_JOB_START,
+    MONITORS.LATEST_FIND_REPLICA_SET_UPDATES_JOB_SUCCESS
   ])
 
   let currentSnapbackReconfigMode
@@ -172,12 +180,20 @@ const healthCheck = async (
     shouldHandleTranscode,
     asyncProcessingQueue: asyncProcessingQueueJobs,
     solDelegatePublicKeyBase58,
-    stateMachineQueueLatestJobSuccess: stateMachineQueueLatestJobSuccess
-      ? new Date(parseInt(stateMachineQueueLatestJobSuccess)).toISOString()
-      : null,
-    stateMachineQueueLatestJobStart: stateMachineQueueLatestJobStart
-      ? new Date(parseInt(stateMachineQueueLatestJobStart)).toISOString()
-      : null
+    latestMonitorStateJobStart: parseDateOrNull(latestMonitorStateJobStart),
+    latestMonitorStateJobSuccess: parseDateOrNull(latestMonitorStateJobSuccess),
+    latestFindSyncRequestsJobStart: parseDateOrNull(
+      latestFindSyncRequestsJobStart
+    ),
+    latestFindSyncRequestsJobSuccess: parseDateOrNull(
+      latestFindSyncRequestsJobSuccess
+    ),
+    latestFindReplicaSetUpdatesJobStart: parseDateOrNull(
+      latestFindReplicaSetUpdatesJobStart
+    ),
+    latestFindReplicaSetUpdatesJobSuccess: parseDateOrNull(
+      latestFindReplicaSetUpdatesJobSuccess
+    )
   }
 
   // If optional `randomBytesToSign` query param provided, node will include string in signed object
@@ -211,6 +227,10 @@ const healthCheck = async (
   }
 
   return response
+}
+
+const parseDateOrNull = (date) => {
+  return date ? new Date(parseInt(date)).toISOString() : null
 }
 
 // TODO remove verbose health check after fully deprecated

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -230,12 +230,14 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      latestMonitorStateJobStart: null,
-      latestMonitorStateJobSuccess: null,
-      latestFindSyncRequestsJobStart: null,
-      latestFindSyncRequestsJobSuccess: null,
-      latestFindReplicaSetUpdatesJobStart: null,
-      latestFindReplicaSetUpdatesJobSuccess: null
+      stateMachineJobs: {
+        latestMonitorStateJobStart: null,
+        latestMonitorStateJobSuccess: null,
+        latestFindSyncRequestsJobStart: null,
+        latestFindSyncRequestsJobSuccess: null,
+        latestFindReplicaSetUpdatesJobStart: null,
+        latestFindReplicaSetUpdatesJobSuccess: null
+      }
     })
   })
 
@@ -334,12 +336,14 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      latestMonitorStateJobStart: null,
-      latestMonitorStateJobSuccess: null,
-      latestFindSyncRequestsJobStart: null,
-      latestFindSyncRequestsJobSuccess: null,
-      latestFindReplicaSetUpdatesJobStart: null,
-      latestFindReplicaSetUpdatesJobSuccess: null
+      stateMachineJobs: {
+        latestMonitorStateJobStart: null,
+        latestMonitorStateJobSuccess: null,
+        latestFindSyncRequestsJobStart: null,
+        latestFindSyncRequestsJobSuccess: null,
+        latestFindReplicaSetUpdatesJobStart: null,
+        latestFindReplicaSetUpdatesJobSuccess: null
+      }
     })
   })
 
@@ -427,12 +431,14 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      latestMonitorStateJobStart: null,
-      latestMonitorStateJobSuccess: null,
-      latestFindSyncRequestsJobStart: null,
-      latestFindSyncRequestsJobSuccess: null,
-      latestFindReplicaSetUpdatesJobStart: null,
-      latestFindReplicaSetUpdatesJobSuccess: null
+      stateMachineJobs: {
+        latestMonitorStateJobStart: null,
+        latestMonitorStateJobSuccess: null,
+        latestFindSyncRequestsJobStart: null,
+        latestFindSyncRequestsJobSuccess: null,
+        latestFindReplicaSetUpdatesJobStart: null,
+        latestFindReplicaSetUpdatesJobSuccess: null
+      }
     })
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
@@ -561,12 +567,14 @@ describe('Test Health Check Verbose', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      latestMonitorStateJobStart: null,
-      latestMonitorStateJobSuccess: null,
-      latestFindSyncRequestsJobStart: null,
-      latestFindSyncRequestsJobSuccess: null,
-      latestFindReplicaSetUpdatesJobStart: null,
-      latestFindReplicaSetUpdatesJobSuccess: null
+      stateMachineJobs: {
+        latestMonitorStateJobStart: null,
+        latestMonitorStateJobSuccess: null,
+        latestFindSyncRequestsJobStart: null,
+        latestFindSyncRequestsJobSuccess: null,
+        latestFindReplicaSetUpdatesJobStart: null,
+        latestFindReplicaSetUpdatesJobSuccess: null
+      }
     })
   })
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -230,8 +230,12 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      stateMachineQueueLatestJobSuccess: null,
-      stateMachineQueueLatestJobStart: null
+      latestMonitorStateJobStart: null,
+      latestMonitorStateJobSuccess: null,
+      latestFindSyncRequestsJobStart: null,
+      latestFindSyncRequestsJobSuccess: null,
+      latestFindReplicaSetUpdatesJobStart: null,
+      latestFindReplicaSetUpdatesJobSuccess: null
     })
   })
 
@@ -330,8 +334,12 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      stateMachineQueueLatestJobSuccess: null,
-      stateMachineQueueLatestJobStart: null
+      latestMonitorStateJobStart: null,
+      latestMonitorStateJobSuccess: null,
+      latestFindSyncRequestsJobStart: null,
+      latestFindSyncRequestsJobSuccess: null,
+      latestFindReplicaSetUpdatesJobStart: null,
+      latestFindReplicaSetUpdatesJobSuccess: null
     })
   })
 
@@ -419,8 +427,12 @@ describe('Test Health Check', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      stateMachineQueueLatestJobSuccess: null,
-      stateMachineQueueLatestJobStart: null
+      latestMonitorStateJobStart: null,
+      latestMonitorStateJobSuccess: null,
+      latestFindSyncRequestsJobStart: null,
+      latestFindSyncRequestsJobSuccess: null,
+      latestFindReplicaSetUpdatesJobStart: null,
+      latestFindReplicaSetUpdatesJobSuccess: null
     })
 
     assert.deepStrictEqual(res.meetsMinRequirements, false)
@@ -549,8 +561,12 @@ describe('Test Health Check Verbose', function () {
         }
       },
       solDelegatePublicKeyBase58: SOL_PUBLIC_KEY_BASE58,
-      stateMachineQueueLatestJobSuccess: null,
-      stateMachineQueueLatestJobStart: null
+      latestMonitorStateJobStart: null,
+      latestMonitorStateJobSuccess: null,
+      latestFindSyncRequestsJobStart: null,
+      latestFindSyncRequestsJobSuccess: null,
+      latestFindReplicaSetUpdatesJobStart: null,
+      latestFindReplicaSetUpdatesJobSuccess: null
     })
   })
 

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -116,51 +116,65 @@ const healthCheckController = async (req) => {
     randomBytesToSign
   )
 
-  const {
-    latestMonitorStateJobSuccess,
-    latestFindSyncRequestsJobSuccess,
-    latestFindReplicaSetUpdatesJobSuccess
-  } = response
-  if (enforceStateMachineQueueHealth && latestMonitorStateJobSuccess) {
+  if (enforceStateMachineQueueHealth) {
+    const { stateMachineJobs } = response
+    const {
+      latestMonitorStateJobSuccess,
+      latestFindSyncRequestsJobSuccess,
+      latestFindReplicaSetUpdatesJobSuccess
+    } = stateMachineJobs
+    const stateMachineErrors = []
+
     // Enforce time since last successful monitor-state job
-    response.monitorStateJobLastSuccessfulRunDelayMs =
-      MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    const monitorStateDelta =
-      Date.now() - new Date(latestMonitorStateJobSuccess).getTime()
-    if (
-      monitorStateDelta > MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    ) {
-      return errorResponseServerError(
-        `monitor-state job not healthy - last successful run ${monitorStateDelta}ms ago not within healthy threshold of ${MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
-      )
+    if (latestMonitorStateJobSuccess) {
+      response.stateMachineJobs.monitorStateJobLastSuccessfulRunDelayMs =
+        MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      const monitorStateDelta =
+        Date.now() - new Date(latestMonitorStateJobSuccess).getTime()
+      if (
+        monitorStateDelta > MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      ) {
+        stateMachineErrors.push(
+          `monitor-state job not healthy - last successful run ${monitorStateDelta}ms ago not within healthy threshold of ${MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+        )
+      }
     }
 
     // Enforce time since last successful find-sync-requests job
-    response.findSyncRequestsJobLastSuccessfulRunDelayMs =
-      FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    const findSyncRequestsDelta =
-      Date.now() - new Date(latestFindSyncRequestsJobSuccess).getTime()
-    if (
-      findSyncRequestsDelta >
-      FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    ) {
-      return errorResponseServerError(
-        `find-sync-requests job not healthy - last successful run ${findSyncRequestsDelta}ms ago not within healthy threshold of ${FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
-      )
+    if (latestFindSyncRequestsJobSuccess) {
+      response.stateMachineJobs.findSyncRequestsJobLastSuccessfulRunDelayMs =
+        FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      const findSyncRequestsDelta =
+        Date.now() - new Date(latestFindSyncRequestsJobSuccess).getTime()
+      if (
+        findSyncRequestsDelta >
+        FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      ) {
+        stateMachineErrors.push(
+          `find-sync-requests job not healthy - last successful run ${findSyncRequestsDelta}ms ago not within healthy threshold of ${FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+        )
+      }
     }
 
     // Enforce time since last successful find-replica-set-updates job
-    response.findReplicaSetUpdatesJobLastSuccessfulRunDelayMs =
-      FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    const findReplicaSetUpdatesDelta =
-      Date.now() - new Date(latestFindReplicaSetUpdatesJobSuccess).getTime()
-    if (
-      findReplicaSetUpdatesDelta >
-      FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    ) {
-      return errorResponseServerError(
-        `find-replica-set-updates job not healthy - last successful run ${findReplicaSetUpdatesDelta}ms ago not within healthy threshold of ${FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
-      )
+    if (latestFindReplicaSetUpdatesJobSuccess) {
+      response.stateMachineJobs.findReplicaSetUpdatesJobLastSuccessfulRunDelayMs =
+        FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      const findReplicaSetUpdatesDelta =
+        Date.now() - new Date(latestFindReplicaSetUpdatesJobSuccess).getTime()
+      if (
+        findReplicaSetUpdatesDelta >
+        FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+      ) {
+        stateMachineErrors.push(
+          `find-replica-set-updates job not healthy - last successful run ${findReplicaSetUpdatesDelta}ms ago not within healthy threshold of ${FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+        )
+      }
+    }
+
+    // Return errors
+    if (stateMachineErrors.length) {
+      return errorResponseServerError(JSON.stringify(stateMachineErrors))
     }
   }
 

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -33,9 +33,14 @@ const router = express.Router()
 const MAX_HEALTH_CHECK_TIMESTAMP_AGE_MS = 300000
 const numberOfCPUs = os.cpus().length
 
-const SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS = config.get(
-  'snapbackMaxLastSuccessfulRunDelayMs'
+const MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS = config.get(
+  'monitorStateJobLastSuccessfulRunDelayMs'
 )
+const FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS = config.get(
+  'findSyncRequestsJobLastSuccessfulRunDelayMs'
+)
+const FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS =
+  config.get('findReplicaSetUpdatesJobLastSuccessfulRunDelayMs')
 
 // Helper Functions
 /**
@@ -111,15 +116,50 @@ const healthCheckController = async (req) => {
     randomBytesToSign
   )
 
-  const { stateMachineQueueLatestJobSuccess } = response
-  if (enforceStateMachineQueueHealth && stateMachineQueueLatestJobSuccess) {
-    response.snapbackMaxLastSuccessfulRunDelayMs =
-      SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
-    const delta =
-      Date.now() - new Date(stateMachineQueueLatestJobSuccess).getTime()
-    if (delta > SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS) {
+  const {
+    latestMonitorStateJobSuccess,
+    latestFindSyncRequestsJobSuccess,
+    latestFindReplicaSetUpdatesJobSuccess
+  } = response
+  if (enforceStateMachineQueueHealth && latestMonitorStateJobSuccess) {
+    // Enforce time since last successful monitor-state job
+    response.monitorStateJobLastSuccessfulRunDelayMs =
+      MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    const monitorStateDelta =
+      Date.now() - new Date(latestMonitorStateJobSuccess).getTime()
+    if (
+      monitorStateDelta > MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    ) {
       return errorResponseServerError(
-        `StateMachineQueue not healthy - last successful run ${delta}ms ago not within healthy threshold of ${SNAPBACK_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+        `monitor-state job not healthy - last successful run ${monitorStateDelta}ms ago not within healthy threshold of ${MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+      )
+    }
+
+    // Enforce time since last successful find-sync-requests job
+    response.findSyncRequestsJobLastSuccessfulRunDelayMs =
+      FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    const findSyncRequestsDelta =
+      Date.now() - new Date(latestFindSyncRequestsJobSuccess).getTime()
+    if (
+      findSyncRequestsDelta >
+      FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    ) {
+      return errorResponseServerError(
+        `find-sync-requests job not healthy - last successful run ${findSyncRequestsDelta}ms ago not within healthy threshold of ${FIND_SYNC_REQUESTS_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
+      )
+    }
+
+    // Enforce time since last successful find-replica-set-updates job
+    response.findReplicaSetUpdatesJobLastSuccessfulRunDelayMs =
+      FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    const findReplicaSetUpdatesDelta =
+      Date.now() - new Date(latestFindReplicaSetUpdatesJobSuccess).getTime()
+    if (
+      findReplicaSetUpdatesDelta >
+      FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS
+    ) {
+      return errorResponseServerError(
+        `find-replica-set-updates job not healthy - last successful run ${findReplicaSetUpdatesDelta}ms ago not within healthy threshold of ${FIND_REPLICA_SET_UPDATES_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS}ms`
       )
     }
   }

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -666,11 +666,23 @@ const config = convict({
     env: 'audiusContentInfraSetup',
     default: ''
   },
-  snapbackMaxLastSuccessfulRunDelayMs: {
-    doc: 'Max time delay since last snapback successful run (milliseconds)',
+  monitorStateJobLastSuccessfulRunDelayMs: {
+    doc: 'Max time delay since last monitor-state job successfully ran (milliseconds)',
     format: 'nat',
-    env: 'snapbackMaxLastSuccessfulRunDelayMs',
-    default: 5 * 60 * 60 * 1000 // 5 hrs
+    env: 'monitorStateJobLastSuccessfulRunDelayMs',
+    default: 10 * 60 * 1000 // 10 mins
+  },
+  findSyncRequestsJobLastSuccessfulRunDelayMs: {
+    doc: 'Max time delay since last find-sync-requests job successfully ran (milliseconds)',
+    format: 'nat',
+    env: 'findSyncRequestsJobLastSuccessfulRunDelayMs',
+    default: 10 * 60 * 1000 // 10 mins
+  },
+  findReplicaSetUpdatesJobLastSuccessfulRunDelayMs: {
+    doc: 'Max time delay since last find-replica-set-updates job successfully ran (milliseconds)',
+    format: 'nat',
+    env: 'findReplicaSetUpdatesJobLastSuccessfulRunDelayMs',
+    default: 10 * 60 * 1000 // 10 mins
   },
   disableSnapback: {
     doc: 'True to not run any snapback queues (old state machine and old syncs)',

--- a/creator-node/src/monitors/monitors.js
+++ b/creator-node/src/monitors/monitors.js
@@ -34,8 +34,12 @@ const {
   getDailySyncFailCount,
   getLatestSyncSuccessTimestamp,
   getLatestSyncFailTimestamp,
-  getStateMachineQueueLatestJobSuccess,
-  getStateMachineQueueLatestJobStart
+  getLatestMonitorStateJobStart,
+  getLatestMonitorStateJobSuccess,
+  getLatestFindSyncRequestsJobStart,
+  getLatestFindSyncRequestsJobSuccess,
+  getLatestFindReplicaSetUpdatesJobStart,
+  getLatestFindReplicaSetUpdatesJobSuccess
 } = require('./stateMachine')
 const redis = require('../redis')
 
@@ -220,17 +224,39 @@ const LATEST_SYNC_FAIL_TIMESTAMP = {
   type: 'string'
 }
 
-const LATEST_STATE_MACHINE_QUEUE_SUCCESS = {
-  name: 'stateMachineQueueLatestJobSuccess',
-  func: getStateMachineQueueLatestJobSuccess,
-  ttl: 5, // 5 /* mins */ * 60 /* s */,
+const LATEST_MONITOR_STATE_JOB_START = {
+  name: 'latestMonitorStateJobStart',
+  func: getLatestMonitorStateJobStart,
   type: 'string'
 }
 
-const LATEST_STATE_MACHINE_QUEUE_START = {
-  name: 'stateMachineQueueLatestJobStart',
-  func: getStateMachineQueueLatestJobStart,
-  ttl: 5, // 5 /* mins */ * 60 /* s */,
+const LATEST_MONITOR_STATE_JOB_SUCCESS = {
+  name: 'latestMonitorStateJobSuccess',
+  func: getLatestMonitorStateJobSuccess,
+  type: 'string'
+}
+
+const LATEST_FIND_SYNC_REQUESTS_JOB_START = {
+  name: 'latestFindSyncRequestsJobStart',
+  func: getLatestFindSyncRequestsJobStart,
+  type: 'string'
+}
+
+const LATEST_FIND_SYNC_REQUESTS_JOB_SUCCESS = {
+  name: 'latestFindSyncRequestsJobSuccess',
+  func: getLatestFindSyncRequestsJobSuccess,
+  type: 'string'
+}
+
+const LATEST_FIND_REPLICA_SET_UPDATES_JOB_START = {
+  name: 'latestFindReplicaSetUpdatesJobStart',
+  func: getLatestFindReplicaSetUpdatesJobStart,
+  type: 'string'
+}
+
+const LATEST_FIND_REPLICA_SET_UPDATES_JOB_SUCCESS = {
+  name: 'latestFindReplicaSetUpdatesJobSuccess',
+  func: getLatestFindReplicaSetUpdatesJobSuccess,
   type: 'string'
 }
 
@@ -260,8 +286,12 @@ const MONITORS = {
   DAILY_SYNC_FAIL_COUNT,
   LATEST_SYNC_SUCCESS_TIMESTAMP,
   LATEST_SYNC_FAIL_TIMESTAMP,
-  LATEST_STATE_MACHINE_QUEUE_SUCCESS,
-  LATEST_STATE_MACHINE_QUEUE_START
+  LATEST_MONITOR_STATE_JOB_START,
+  LATEST_MONITOR_STATE_JOB_SUCCESS,
+  LATEST_FIND_SYNC_REQUESTS_JOB_START,
+  LATEST_FIND_SYNC_REQUESTS_JOB_SUCCESS,
+  LATEST_FIND_REPLICA_SET_UPDATES_JOB_START,
+  LATEST_FIND_REPLICA_SET_UPDATES_JOB_SUCCESS
 }
 
 const getMonitorRedisKey = (monitor) =>

--- a/creator-node/src/monitors/stateMachine.js
+++ b/creator-node/src/monitors/stateMachine.js
@@ -2,6 +2,9 @@ const redis = require('../redis')
 
 const SyncHistoryAggregator = require('../snapbackSM/syncHistoryAggregator')
 const { SYNC_STATES } = require('../snapbackSM/syncHistoryAggregator')
+const {
+  JOB_NAMES
+} = require('../services/stateMachineManager/stateMachineConstants')
 
 /**
  * Get the total number of syncs that met 'status' per wallet per day for the given number of days
@@ -67,12 +70,28 @@ const getLatestSyncFailTimestamp = async () => {
   return fail
 }
 
-const getStateMachineQueueLatestJobSuccess = async () => {
-  return redis.get('stateMachineQueueLatestJobSuccess')
+const getLatestMonitorStateJobStart = async () => {
+  return redis.get(`latestJobStart_${JOB_NAMES.MONITOR_STATE}`)
 }
 
-const getStateMachineQueueLatestJobStart = async () => {
-  return redis.get('stateMachineQueueLatestJobStart')
+const getLatestMonitorStateJobSuccess = async () => {
+  return redis.get(`latestJobSuccess_${JOB_NAMES.MONITOR_STATE}`)
+}
+
+const getLatestFindSyncRequestsJobStart = async () => {
+  return redis.get(`latestJobStart_${JOB_NAMES.FIND_SYNC_REQUESTS}`)
+}
+
+const getLatestFindSyncRequestsJobSuccess = async () => {
+  return redis.get(`latestJobSuccess_${JOB_NAMES.FIND_SYNC_REQUESTS}`)
+}
+
+const getLatestFindReplicaSetUpdatesJobStart = async () => {
+  return redis.get(`latestJobStart_${JOB_NAMES.FIND_REPLICA_SET_UPDATES}`)
+}
+
+const getLatestFindReplicaSetUpdatesJobSuccess = async () => {
+  return redis.get(`latestJobSuccess_${JOB_NAMES.FIND_REPLICA_SET_UPDATES}`)
 }
 
 module.exports = {
@@ -82,6 +101,10 @@ module.exports = {
   getDailySyncFailCount,
   getLatestSyncSuccessTimestamp,
   getLatestSyncFailTimestamp,
-  getStateMachineQueueLatestJobSuccess,
-  getStateMachineQueueLatestJobStart
+  getLatestMonitorStateJobStart,
+  getLatestMonitorStateJobSuccess,
+  getLatestFindSyncRequestsJobStart,
+  getLatestFindSyncRequestsJobSuccess,
+  getLatestFindReplicaSetUpdatesJobStart,
+  getLatestFindReplicaSetUpdatesJobSuccess
 }

--- a/creator-node/src/services/stateMachineManager/processJob.js
+++ b/creator-node/src/services/stateMachineManager/processJob.js
@@ -1,4 +1,5 @@
-import { createChildLogger } from '../../logging'
+const { createChildLogger } = require('../../logging')
+const redis = require('../../redis')
 
 /**
  * Higher order function to wrap a job processor with a logger and a try-catch.
@@ -17,7 +18,9 @@ module.exports = async function (jobName, job, jobProcessor, parentLogger) {
 
   let result
   try {
+    await redis.set(`latestJobStart_${jobName}`, Date.now())
     result = await jobProcessor({ logger: jobLogger, ...jobData })
+    await redis.set(`latestJobSuccess_${jobName}`, Date.now())
   } catch (error) {
     jobLogger.error(`Error processing job: ${error}`)
     result = { error: error.message || `${error}` }

--- a/creator-node/test/processJob.test.js
+++ b/creator-node/test/processJob.test.js
@@ -29,6 +29,9 @@ describe('test processJob() util function', function () {
       {
         '../../logging': {
           createChildLogger
+        },
+        '../../redis': {
+          set: sandbox.stub()
         }
       }
     )


### PR DESCRIPTION
### Description

- Remove `snapbackMaxLastSuccessfulRunDelayMs` env var
- Add an env var for each of the 3 state monitoring queue jobs: `monitorStateJobLastSuccessfulRunDelayMs`, `findSyncRequestsJobLastSuccessfulRunDelayMs`, and `findReplicaSetUpdatesJobLastSuccessfulRunDelayMs`
- Record last job start and success for each state machine queue job in redis
- Make `health_check?enforceStateMachineQueueHealth=true` route enforce env vars for max time since last successful job run for each state monitoring job


**Health Check Response When Healthy**
<img width="706" alt="Screen Shot 2022-06-27 at 1 51 30 PM" src="https://user-images.githubusercontent.com/4657956/176033461-74ad8af0-e2af-4136-ba23-e4912bee283e.png">


**Health Check Response When Unhealthy**
<img width="1606" alt="Screen Shot 2022-06-27 at 2 04 07 PM" src="https://user-images.githubusercontent.com/4657956/176035257-29055aab-8cb0-4916-af6a-851d484603d9.png">


### Tests
Updated health check tests to reflect new vars, and checked the route locally with a disabled and enabled queue (verified that disabling the monitoring queue makes the health check fail after 10 minutes since no jobs run).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
This updates the route that's already used by pingdom health checks on staging. We can monitor those health checks (they've been unhealthy since they used to reflect snapback, which is disabled on staging) and then add the same pingdom checks to prod.