### PR TITLE
[CON-229] - Fix content caching

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
-					max_size=10g inactive=30m use_temp_path=off;
+					max_size=10g inactive=60m use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
     server {
@@ -39,6 +39,7 @@ http {
             proxy_cache_background_update on;
 
             # Cache only 200 responses for 30m before considered stale
+            proxy_cache_valid any 0m;
             proxy_cache_valid 200 30m;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
-					max_size=10g inactive=60m use_temp_path=off;
+					max_size=10g inactive=30m use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
     server {
@@ -39,7 +39,6 @@ http {
             proxy_cache_background_update on;
 
             # Cache only 200 responses for 30m before considered stale
-            proxy_cache_valid any 0m;
             proxy_cache_valid 200 30m;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -355,14 +355,6 @@ const getCID = async (req, res) => {
     }
   }
 
-  // If client has provided filename, set filename in header to be auto-populated in download prompt.
-  if (req.query.filename) {
-    res.setHeader('Content-Disposition', contentDisposition(req.query.filename))
-  }
-
-  // Set the CID cache-control so that client caches the response for 30 days
-  res.setHeader('cache-control', 'public, max-age=2592000, immutable')
-
   /**
    * If the file is found on file system, stream from file system
    */
@@ -380,6 +372,7 @@ const getCID = async (req, res) => {
         stage: `STREAM_FROM_FILE_SYSTEM_COMPLETE`,
         time: `${Date.now() - startMs}ms`
       })
+      _setHeadersForStreaming(req, res)
       logGetCIDDecisionTree(decisionTree, req)
       return fsStream
     } catch (e) {
@@ -480,6 +473,7 @@ const getCID = async (req, res) => {
       time: `${Date.now() - startMs}ms`
     })
 
+    _setHeadersForStreaming()
     logGetCIDDecisionTree(decisionTree, req)
     return fsStream
   } catch (e) {
@@ -585,6 +579,21 @@ const _verifyContentMatchesHash = async function (req, resizeResp, dirCID) {
     logger.error(errMsg)
     throw new Error(errMsg)
   }
+}
+
+/**
+ * Sets headers for streaming
+ * @param {Object} req
+ * @param {Object} res
+ */
+function _setHeadersForStreaming(req, res) {
+  // If client has provided filename, set filename in header to be auto-populated in download prompt.
+  if (req.query.filename) {
+    res.setHeader('Content-Disposition', contentDisposition(req.query.filename))
+  }
+
+  // Set the CID cache-control so that client caches the response for 30 days
+  res.setHeader('cache-control', 'public, max-age=2592000, immutable')
 }
 
 /**


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

We only want to cache on 404, but for some reason, content was still cached. Turns out it is because we were setting the `cache-control` header to `public, max-age=2592000` even if content was not servable (e.g. 404-ing). The keyword `public` implies that content can be cached on client or server side.

So, this PR is to only set the the download/cache headers if content is definitely served.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Before, if the `ipfs/<cid>` route was getting a 404, it would result in a cache miss, then a cache hit.

After, all 404s will only result in a cache miss.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

We will still monitor nginx logs in the logs file, and can observe the `x-cache-status` header


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->