### PR TITLE
[CON-230] - Bump nginx cache ttl

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
-					max_size=10g inactive=30m use_temp_path=off;
+					max_size=10g inactive=1y use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
     server {
@@ -38,8 +38,8 @@ http {
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
 
-            # Cache only 200 responses for 30m before considered stale
-            proxy_cache_valid 200 30m;
+            # Cache only 200 responses for some duration before considered stale
+            proxy_cache_valid 200 12h;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element
             # Other requests of the same cache element will either wait for a response to appear in the cache

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -15,6 +15,9 @@ http {
     client_max_body_size 0;
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
+    # Inactive = how long an item can remain in the cache without beign accessed
+    # If inactive period passes, content WILL BE DELETED from the cache by the cache
+    # manager, regardless whether or not it has expired.
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
 					max_size=10g inactive=12h use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
@@ -23,8 +26,7 @@ http {
         listen 4000;
 
         # Match the paths /ipfs/<cid: string> and /content/<cid: string>.
-        # If present in cache, serve. 
-        # Else, hit upstream server + update cache + serve.
+        # If present in cache, serve. Else, hit upstream server + update cache + serve.
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
         location ~ (/ipfs/|/content/) {
             proxy_cache cidcache;
@@ -39,6 +41,9 @@ http {
             proxy_cache_background_update on;
 
             # Cache only 200 responses for some duration before considered stale
+            # Stale implies content will be fetched from the upstream server, and NOT
+            # BE REMOVED in the cache.
+            # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
             proxy_cache_valid 200 12h;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -15,9 +15,10 @@ http {
     client_max_body_size 0;
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
-    # Inactive = how long an item can remain in the cache without beign accessed
+    # Inactive = how long an item can remain in the cache without being accessed
     # If inactive period passes, content WILL BE DELETED from the cache by the cache
     # manager, regardless whether or not it has expired.
+    # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
 					max_size=10g inactive=12h use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
@@ -40,10 +41,9 @@ http {
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
 
-            # Cache only 200 responses for some duration before considered stale
-            # Stale implies content will be fetched from the upstream server, and NOT
+            # Cache only responses with status code = 200 for some duration before considered stale.
+            # Stale implies content will be fetched from the upstream server. Stale content WILL NOT
             # BE REMOVED in the cache.
-            # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
             proxy_cache_valid 200 12h;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -43,7 +43,7 @@ http {
 
             # Cache only responses with status code = 200 for some duration before considered stale.
             # Stale implies content will be fetched from the upstream server. Stale content WILL NOT
-            # BE REMOVED in the cache.
+            # BE REMOVED from the cache.
             proxy_cache_valid 200 12h;
             
             # When enabled, only one request at a time will be allowed to populate a new cache element

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_package_path "/usr/local/openresty/conf/?.lua;;";
 
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
-					max_size=10g inactive=1y use_temp_path=off;
+					max_size=10g inactive=12h use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
     server {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Might as well bump the cache ttl to 12h from 30m, since the cn5 cache enabled soak is working out well.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
No change in functionality, just bumping the ttl

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Can still check the nginx access.log and error.log
Also if `x-cache-status` is in the response headers, then the nginx cache is enabled

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->