### PR TITLE
Revert "CON-180 Re-enable coveralls on content node (#3220)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,8 +362,8 @@ jobs:
             export spOwnerWallet='yes'
             export isCIBuild=true
             npm run test:coverage:ci
-      - coveralls/upload:
-          path_to_lcov: ./creator-node/coverage/lcov.info
+      # - coveralls/upload:
+      #     path_to_lcov: ./creator-node/coverage/lcov.info
 
   test-discovery-provider:
     docker:


### PR DESCRIPTION
This reverts commit 9eb7cb61f6f4dda879ddef1f9ca8ca08580f665c.

### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->