### PR TITLE
Disable recurring sync processing in snapback

### DIFF
--- a/creator-node/src/snapbackSM/snapbackSM.js
+++ b/creator-node/src/snapbackSM/snapbackSM.js
@@ -286,16 +286,18 @@ class SnapbackSM {
       )
 
       // Initialize recurringSyncQueue job processor
-      this.recurringSyncQueue.process(
-        this.MaxRecurringRequestSyncJobConcurrency,
-        async (job) => {
-          try {
-            await this.processSyncOperation(job, SyncType.Recurring)
-          } catch (e) {
-            this.logError(`RecurringSyncQueue processing error ${e}`)
+      if (!this.nodeConfig.get('disableSnapback')) {
+        this.recurringSyncQueue.process(
+          this.MaxRecurringRequestSyncJobConcurrency,
+          async (job) => {
+            try {
+              await this.processSyncOperation(job, SyncType.Recurring)
+            } catch (e) {
+              this.logError(`RecurringSyncQueue processing error ${e}`)
+            }
           }
-        }
-      )
+        )
+      }
       this.inittedJobProcessors = true
     }
 

--- a/creator-node/test/snapbackSM.test.js
+++ b/creator-node/test/snapbackSM.test.js
@@ -103,6 +103,7 @@ describe('test SnapbackSM -- determineNewReplicaSet, sync queue, and reconfig mo
     const MaxRecurringRequestSyncJobConcurrency = 1
     nodeConfig.set('maxManualRequestSyncJobConcurrency', MaxManualRequestSyncJobConcurrency)
     nodeConfig.set('maxRecurringRequestSyncJobConcurrency', MaxRecurringRequestSyncJobConcurrency)
+    nodeConfig.set('disableSnapback', false)
 
     // Mock out the initial call to sync
     nock(constants.secondary1Endpoint)


### PR DESCRIPTION
### Description
Make the `disableSnapback` env var prevent the snapback recurring sync queue from processing jobs.

### Tests
Updated a relevant snapback test to pass (it failed at first due to the change, which is good). Checked locally to make sure the `recurring-sync-queue` queue doesn't process jobs with `disableSnapback` set to `true`.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Make sure the `recurring-sync-queue` queue doesn't process jobs on any staging nodes (check this from the `/health/bull` dashboard).