### PR TITLE
Kill running queries before migration

### DIFF
--- a/discovery-provider/alembic/versions/38642fb2948d_add_pg_triggers.py
+++ b/discovery-provider/alembic/versions/38642fb2948d_add_pg_triggers.py
@@ -28,7 +28,8 @@ def upgrade():
         """
         SELECT pg_cancel_backend(pid)
         FROM pg_stat_activity 
-        WHERE state != 'idle' AND query NOT ILIKE '%pg_stat_activity%';
+        WHERE state != 'idle' AND query NOT ILIKE '%pg_stat_activity%' and pid <> pg_backend_pid() 
+        ORDER BY query_start DESC;
         
         begin;
             WITH new_plays AS (

--- a/discovery-provider/alembic/versions/38642fb2948d_add_pg_triggers.py
+++ b/discovery-provider/alembic/versions/38642fb2948d_add_pg_triggers.py
@@ -26,6 +26,10 @@ def upgrade():
     connection = op.get_bind()
     connection.execute(
         """
+        SELECT pg_cancel_backend(pid)
+        FROM pg_stat_activity 
+        WHERE state != 'idle' AND query NOT ILIKE '%pg_stat_activity%';
+        
         begin;
             WITH new_plays AS (
                 SELECT


### PR DESCRIPTION
### Description

Running queries can hold up alembic migration for a long time, but celery is stopped already so should be safe to kill them.
