### PR TITLE
Fetch CN spID config after it has been set

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateMachineUtils.js
@@ -20,7 +20,6 @@ const {
 const MAX_BATCH_CLOCK_STATUS_BATCH_SIZE = config.get(
   'maxBatchClockStatusBatchSize'
 )
-const SP_ID = config.get('spID')
 const DELEGATE_PRIVATE_KEY = config.get('delegatePrivateKey')
 
 /**
@@ -35,6 +34,8 @@ const retrieveClockStatusesForUsersAcrossReplicaSet = async (
 ) => {
   const replicasToUserClockStatusMap = {}
   const unhealthyPeers = new Set()
+
+  const spID = config.get('spID')
 
   /** In parallel for every replica, fetch clock status for all users on that replica */
   const replicas = Object.keys(replicasToWalletsMap)
@@ -65,10 +66,10 @@ const retrieveClockStatusesForUsersAcrossReplicaSet = async (
 
         // Sign request to other CN to bypass rate limiting
         const { timestamp, signature } = generateTimestampAndSignature(
-          { spID: SP_ID },
+          { spID: spID },
           DELEGATE_PRIVATE_KEY
         )
-        axiosReqParams.params = { spID: SP_ID, timestamp, signature }
+        axiosReqParams.params = { spID: spID, timestamp, signature }
 
         let batchClockStatusResp = []
         let errorMsg
@@ -110,7 +111,7 @@ const retrieveClockStatusesForUsersAcrossReplicaSet = async (
  * Signs request with spID to bypass rate limits
  */
 const retrieveClockValueForUserFromReplica = async (replica, wallet) => {
-  const spID = SP_ID
+  const spID = config.get('spID')
 
   const { timestamp, signature } = generateTimestampAndSignature(
     { spID },


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

spID value was 0 because it was fetched before it was set. Updated to only fetch inside function call instead of at top of file to always get latest value

Currently we see errors like
```
{"name":"audius_creator_node","hostname":"b2bbeffbdeff","pid":13,"requestID":"iJObYqi7Cz","requestMethod":"GET","requestHostname":"127.0.0.1","requestUrl":"/users/clock_status/0x2d7f378c77239e652834b750fc18d6711699a5e6","requestQueryParams":"spID=0&timestamp=2022-06-29T22:38:43.574Z&signature=0x34af4918dcf7bb39d7b1d28953b96fafd3697f217f616caf5cdd37721650b27950465e96b3a9f18f7428ff1faf737cd138cfaf889359a0af71634057213eb9eb1b","level":30,"msg":"Begin processing request","time":"2022-06-29T22:38:43.638Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","hostname":"b2bbeffbdeff","pid":13,"level":30,"msg":"starting timeout of 250","time":"2022-06-29T22:38:43.667Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","hostname":"b2bbeffbdeff","pid":13,"requestID":"gwTGfZ2N2C","requestMethod":"GET","requestHostname":"127.0.0.1","requestUrl":"/users/clock_status/0x65131c815e972fc533b0cde092f3dd8095bf4f7c","requestQueryParams":"spID=0&timestamp=2022-06-29T22:38:43.525Z&signature=0x1efcb4d392a7ae652c13fe4967736d1e53465d7433e52548e04879d886f9988a1aaa3f20fda54370f4a2468fefea9a6a74c72acd3b7cdc28ffe71975b346613e1c","level":20,"msg":"Requester is not a valid SP. Continuing with rate limit: Error: SpID 0 is not registered as valid SP on L1 ServiceProviderFactory or missing field endpoint=","time":"2022-06-29T22:38:43.733Z","v":0,"logLevel":"debug"}
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally, confirmed that spID now is correctly set

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Search for "spID=0" in logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->