### PR TITLE
Removing unnecessary sql check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -212,11 +212,6 @@ const healthCheck = async (
     logger.warn('Health check with no libs')
   }
 
-  // we have a /db_check route for more granular detail, but the service health check should
-  // also check that the db connection is good. having this in the health_check
-  // allows us to get auto restarts from liveness probes etc if the db connection is down
-  await sequelize.query('SELECT 1')
-
   if (
     !response.numberOfCPUs ||
     response.numberOfCPUs < MIN_NUBMER_OF_CPUS ||


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

We noticed that there were too many clients open on psql. And a lot of these queries were the select(1) from db. This is to remove this unnecessary check.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

This connection wasnt used anywhere, and the /db_check checks the db more in depth. We should use the /db_check route instead for db health.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Check /db_check for db health and /health_check for other server health

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->