### PR TITLE
Remove redundant header setting/unsetting

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -539,9 +539,6 @@ const getDirCID = async (req, res) => {
     redisClient.set(cacheKey, storagePath, 'EX', FILE_CACHE_EXPIRY_SECONDS)
   }
 
-  // Set the CID cache-control so that client cache the response for 30 days
-  res.setHeader('cache-control', 'public, max-age=2592000, immutable')
-
   // Attempt to stream file to client
   try {
     req.logger.info(`Retrieving ${storagePath} directly from filesystem`)
@@ -562,8 +559,6 @@ const getDirCID = async (req, res) => {
       `Error calling findCIDInNetwork for path ${storagePath}`,
       e
     )
-    // Unset the cache-control header so that a bad response is not cached
-    res.removeHeader('cache-control')
     return sendResponse(req, res, errorResponseServerError(e.message))
   }
 }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Since the stream fn actually sets and unsets the header, these manual setting/unsetting shouldn't be necessary anymore

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- Deployed this hash to stage cn5 and it looks good https://creatornode5.staging.audius.co/ipfs/QmWut8nyZmVftG2ASeLzssULBbbXLnb59ZmTKencJH7nU2/original.jpg

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

For making dir cid requests, check to see if `cache-control` is properly set on 200s and non-200s (e.g. should be set on 200s, not set on 200s)

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->