### PR TITLE
[CON-168] Update cNodeEndpointToSpIdMap on a cron

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -53,6 +53,7 @@ skippedCIDsRetryQueueJobIntervalMs=30000 # 30sec in ms
 monitorStateJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 findSyncRequestsJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 findReplicaSetUpdatesJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+fetchCNodeEndpointToSpIdMapIntervalMs=10000 #10sec in ms
 
 # peerSetManager
 peerHealthCheckRequestTimeout=2000 # ms

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -448,6 +448,12 @@ const config = convict({
 
   /** sync / snapback configs */
 
+  fetchCNodeEndpointToSpIdMapIntervalMs: {
+    doc: 'interval (ms) to update the cNodeEndpoint->spId mapping',
+    format: 'nat',
+    env: 'fetchCNodeEndpointToSpIdMapIntervalMs',
+    default: 3_600_000 // 1hr
+  },
   stateMonitoringQueueRateLimitInterval: {
     doc: 'interval (ms) during which at most stateMonitoringQueueRateLimitJobsPerInterval jobs will run',
     format: 'nat',

--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -18,26 +18,16 @@ class StateMachineManager {
   async init(audiusLibs, prometheusRegistry) {
     this.updateEnabledReconfigModesSet()
 
-    // TODO: Decide on interval to run this on
-    try {
-      NodeToSpIdManager.updateCnodeEndpointToSpIdMap(audiusLibs.ethContracts)
-
-      // Update enabledReconfigModesSet after successful `updateCnodeEndpointToSpIdMap()` call
-      this.updateEnabledReconfigModesSet()
-    } catch (e) {
-      // Disable reconfig after failed update
-      this.updateEnabledReconfigModesSet(
-        /* override */ RECONFIG_MODES.RECONFIG_DISABLED.key
-      )
-      baseLogger.error(`updateEndpointToSpIdMap Error: ${e.message}`)
-    }
+    // TODO: Remove this and libs another way -- maybe init a new instance for each updateReplicaSet job
+    QueueInterfacer.init(audiusLibs)
 
     // Initialize queues
     const stateMonitoringManager = new StateMonitoringManager()
     const stateReconciliationManager = new StateReconciliationManager()
-    const stateMonitoringQueue = await stateMonitoringManager.init(
-      audiusLibs.discoveryProvider.discoveryProviderEndpoint
-    )
+    const { stateMonitoringQueue, cNodeEndpointToSpIdMapQueue } =
+      await stateMonitoringManager.init(
+        audiusLibs.discoveryProvider.discoveryProviderEndpoint
+      )
     const stateReconciliationQueue = await stateReconciliationManager.init()
 
     // Upon completion, make jobs record metrics and enqueue other jobs as necessary
@@ -58,12 +48,40 @@ class StateMachineManager {
       ).bind(this)
     )
 
-    // TODO: Remove this and libs another way -- maybe init a new instance for each updateReplicaSet job
-    QueueInterfacer.init(audiusLibs)
+    // Update the mapping in this StateMachineManager whenever a job successfully fetches it
+    cNodeEndpointToSpIdMapQueue.on(
+      'global:completed',
+      this.updateMapOnMapFetchJobComplete.bind(this)
+    )
 
     return {
       stateMonitoringQueue,
+      cNodeEndpointToSpIdMapQueue,
       stateReconciliationQueue
+    }
+  }
+
+  async updateMapOnMapFetchJobComplete(jobId, resultString) {
+    // Bull serializes the job result into redis, so we have to deserialize it into JSON
+    let jobResult = {}
+    try {
+      jobResult = JSON.parse(resultString) || {}
+    } catch (e) {
+      baseLogger.warn(
+        `Failed to parse cNodeEndpoint->spId map jobId ${jobId} result string: ${resultString}`
+      )
+      return
+    }
+
+    const { errorMsg } = jobResult
+    if (errorMsg?.length) {
+      // Disable reconfigs if there was an error fetching the mapping
+      this.updateEnabledReconfigModesSet(
+        /* override */ RECONFIG_MODES.RECONFIG_DISABLED.key
+      )
+    } else {
+      // Update the reconfig mode to the highest enabled mode if there was no error
+      this.updateEnabledReconfigModesSet()
     }
   }
 

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.js
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.js
@@ -1,8 +1,6 @@
 module.exports = {
-  // Max number of completed/failed jobs to keep in redis for the state monitoring queue
-  MONITORING_QUEUE_HISTORY: 20,
-  // Max number of completed/failed jobs to keep in redis for the state monitoring queue
-  RECONCILIATION_QUEUE_HISTORY: 300,
+  // Max millis to run a fetch cNodeEndpoint->spId mapping job for before marking it as stalled (1 minute)
+  C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS: 1000 * 60,
   // Max millis to run a StateMonitoringQueue job for before marking it as stalled (1 hour)
   STATE_MONITORING_QUEUE_MAX_JOB_RUNTIME_MS: 1000 * 60 * 60,
   // Millis to delay starting the first job in the StateMonitoringQueue (30 seconds)
@@ -29,9 +27,19 @@ module.exports = {
   SYNC_MONITORING_RETRY_DELAY_MS: 15_000,
   // Max number of attempts to select new replica set in reconfig
   MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS: 5,
+  QUEUE_HISTORY: Object.freeze({
+    // Max number of completed/failed jobs to keep in redis for the state monitoring queue
+    STATE_MONITORING: 20,
+    // Max number of completed/failed jobs to keep in redis for the cNodeEndpoint->spId map queue
+    C_NODE_ENDPOINT_TO_SP_ID_MAP: 100,
+    // Max number of completed/failed jobs to keep in redis for the state monitoring queue
+    STATE_RECONCILIATION: 300
+  }),
   QUEUE_NAMES: Object.freeze({
     // Name of StateMonitoringQueue
     STATE_MONITORING: 'state-monitoring-queue',
+    // Name of queue that only processes jobs to fetch the cNodeEndpoint->spId mapping,
+    C_NODE_ENDPOINT_TO_SP_ID_MAP: 'c-node-to-endpoint-sp-id-map-queue',
     // Name of StateReconciliationQueue
     STATE_RECONCILIATION: 'state-reconciliation-queue'
   }),
@@ -42,6 +50,8 @@ module.exports = {
     FIND_SYNC_REQUESTS: 'find-sync-requests',
     // Name of job in monitoring queue that determines replica set updates that should happen for users
     FIND_REPLICA_SET_UPDATES: 'find-replica-set-updates',
+    // Name of job that fetches the cNodeEndpoint->spId mapping and updates the local copy of it for other jobs to use
+    C_NODE_ENDPOINT_TO_SP_ID_MAP: 'update-c-node-to-endpoint-sp-id-map',
     // Name of job in reconciliation queue that issues a manual outgoing sync request to this node or to another node
     ISSUE_MANUAL_SYNC_REQUEST: 'issue-manual-sync-request',
     // Name of job in reconciliation queue that issues a recurring outgoing sync request to this node or to another node

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.js
@@ -1,0 +1,25 @@
+const QueueInterfacer = require('../QueueInterfacer')
+const NodeToSpIdManager = require('../CNodeToSpIdMapManager')
+
+/**
+ * Processes a job to update the cNodeEndpoint->spId map by reading the chain.
+ *
+ * @param {Object} param job data
+ * @param {Object} param.logger the logger that can be filtered by jobName and jobId
+ * @return {Object} the updated mapping, which will be used to update the enabled reconfig modes in stateMachineManager/index.js, and any error message that occurred
+ */
+module.exports = async function ({ logger }) {
+  let errorMsg = ''
+  try {
+    NodeToSpIdManager.updateCnodeEndpointToSpIdMap(
+      QueueInterfacer.getAudiusLibs().ethContracts
+    )
+  } catch (e) {
+    errorMsg = e.message || e.toString()
+    logger.error(`updateEndpointToSpIdMap Error: ${errorMsg}`)
+  }
+  return {
+    cNodeEndpointToSpIdMap: NodeToSpIdManager.getCNodeEndpointToSpIdMap(),
+    errorMsg
+  }
+}

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -177,7 +177,7 @@ const _findSyncsForUser = (
       continue
     }
 
-    // Secondary have too low of a success rate -- don't sync to it
+    // Secondary has too low of a success rate -- don't sync to it
     if (
       failureCount >= minFailedSyncRequestsBeforeReconfig &&
       successRate < minSecondaryUserSyncSuccessPercent

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -3,10 +3,11 @@ const _ = require('lodash')
 
 const config = require('../../../config')
 const {
-  MONITORING_QUEUE_HISTORY,
+  QUEUE_HISTORY,
   QUEUE_NAMES,
   JOB_NAMES,
   STATE_MONITORING_QUEUE_MAX_JOB_RUNTIME_MS,
+  C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS,
   STATE_MONITORING_QUEUE_INIT_DELAY_MS
 } = require('../stateMachineConstants')
 const processJob = require('../processJob')
@@ -15,9 +16,13 @@ const { getLatestUserIdFromDiscovery } = require('./stateMonitoringUtils')
 const monitorStateJobProcessor = require('./monitorState.jobProcessor')
 const findSyncRequestsJobProcessor = require('./findSyncRequests.jobProcessor')
 const findReplicaSetUpdatesJobProcessor = require('./findReplicaSetUpdates.jobProcessor')
+const fetchCNodeEndpointToSpIdMapJobProcessor = require('./fetchCNodeEndpointToSpIdMap.jobProcessor')
 
-const logger = createChildLogger(baseLogger, {
+const monitoringQueueLogger = createChildLogger(baseLogger, {
   queue: QUEUE_NAMES.STATE_MONITORING
+})
+const cNodeEndpointToSpIdMapQueueLogger = createChildLogger(baseLogger, {
+  queue: QUEUE_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP
 })
 
 /**
@@ -28,25 +33,35 @@ const logger = createChildLogger(baseLogger, {
  */
 class StateMonitoringManager {
   async init(discoveryNodeEndpoint) {
-    const queue = this.makeQueue(
+    // Create and start queue to fetch cNodeEndpoint->spId mapping
+    const cNodeEndpointToSpIdMapQueue = this.makeCNodeToEndpointSpIdMapQueue(
       config.get('redisHost'),
       config.get('redisPort')
     )
-    this.registerQueueEventHandlersAndJobProcessors({
-      queue,
+    await this.startEndpointToSpIdMapQueue(cNodeEndpointToSpIdMapQueue)
+
+    // Create and start queue to monitor state for syncs and reconfigs
+    const stateMonitoringQueue = this.makeMonitoringQueue(
+      config.get('redisHost'),
+      config.get('redisPort')
+    )
+    this.registerMonitoringQueueEventHandlersAndJobProcessors({
+      monitoringQueue: stateMonitoringQueue,
       monitorStateJobFailureCallback: this.enqueueMonitorStateJobAfterFailure,
       processMonitorStateJob: this.processMonitorStateJob.bind(this),
       processFindSyncRequestsJob: this.processFindSyncRequestsJob.bind(this),
       processFindReplicaSetUpdatesJob:
         this.processFindReplicaSetUpdatesJob.bind(this)
     })
+    await this.startMonitoringQueue(stateMonitoringQueue, discoveryNodeEndpoint)
 
-    await this.startQueue(queue, discoveryNodeEndpoint)
-
-    return queue
+    return {
+      stateMonitoringQueue,
+      cNodeEndpointToSpIdMapQueue
+    }
   }
 
-  makeQueue(redisHost, redisPort) {
+  makeMonitoringQueue(redisHost, redisPort) {
     // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
     return new BullQueue(QUEUE_NAMES.STATE_MONITORING, {
       redis: {
@@ -54,8 +69,8 @@ class StateMonitoringManager {
         port: redisPort
       },
       defaultJobOptions: {
-        removeOnComplete: MONITORING_QUEUE_HISTORY,
-        removeOnFail: MONITORING_QUEUE_HISTORY
+        removeOnComplete: QUEUE_HISTORY.STATE_MONITORING,
+        removeOnFail: QUEUE_HISTORY.STATE_MONITORING
       },
       settings: {
         // Should be sufficiently larger than expected job runtime
@@ -71,69 +86,120 @@ class StateMonitoringManager {
     })
   }
 
+  makeCNodeToEndpointSpIdMapQueue(redisHost, redisPort) {
+    cNodeEndpointToSpIdMapQueueLogger.info(
+      `Initting queue to update cNodeEndpointToSpIdMap every ${
+        config.get('fetchCNodeEndpointToSpIdMapIntervalMs') / 1000
+      } seconds`
+    )
+    // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
+    return new BullQueue(QUEUE_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP, {
+      redis: {
+        host: redisHost,
+        port: redisPort
+      },
+      defaultJobOptions: {
+        removeOnComplete: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+        removeOnFail: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP
+      },
+      settings: {
+        // Should be sufficiently larger than expected job runtime
+        lockDuration: C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS,
+        // We never want to re-process stalled jobs
+        maxStalledCount: 0
+      },
+      limiter: {
+        max: 1,
+        duration: config.get('fetchCNodeEndpointToSpIdMapIntervalMs')
+      }
+    })
+  }
+
   /**
    * Registers event handlers for logging and job success/failure.
-   * @param {Object} params.queue the queue to register events for
+   * @param {Object} params.monitoringQueue the monitoring queue to register events for
    * @param {Function<failedJob>} params.monitorStateJobFailureCallback the function to call when a monitorState job fails
    * @param {Function<job>} params.processMonitorStateJob the function to call when processing a job from the queue to monitor state
    * @param {Function<job>} params.processFindSyncRequestsJob the function to call when processing a job from the queue to find sync requests that potentially need to be issued
    * @param {Function<job>} params.processFindReplicaSetUpdatesJob the function to call when processing a job from the queue to find users' replica sets that are unhealthy and need to be updated
    */
-  registerQueueEventHandlersAndJobProcessors({
-    queue,
+  registerMonitoringQueueEventHandlersAndJobProcessors({
+    monitoringQueue,
     monitorStateJobFailureCallback,
     processMonitorStateJob,
     processFindSyncRequestsJob,
     processFindReplicaSetUpdatesJob
   }) {
     // Add handlers for logging
-    queue.on('global:waiting', (jobId) => {
-      logger.info(`Queue Job Waiting - ID ${jobId}`)
+    monitoringQueue.on('global:waiting', (jobId) => {
+      monitoringQueueLogger.info(`Queue Job Waiting - ID ${jobId}`)
     })
-    queue.on('global:active', (jobId, jobPromise) => {
-      logger.info(`Queue Job Active - ID ${jobId}`)
+    monitoringQueue.on('global:active', (jobId, jobPromise) => {
+      monitoringQueueLogger.info(`Queue Job Active - ID ${jobId}`)
     })
-    queue.on('global:lock-extension-failed', (jobId, err) => {
-      logger.error(
+    monitoringQueue.on('global:lock-extension-failed', (jobId, err) => {
+      monitoringQueueLogger.error(
         `Queue Job Lock Extension Failed - ID ${jobId} - Error ${err}`
       )
     })
-    queue.on('global:stalled', (jobId) => {
-      logger.error(`Queue Job Stalled - ID ${jobId}`)
+    monitoringQueue.on('global:stalled', (jobId) => {
+      monitoringQueueLogger.error(`Queue Job Stalled - ID ${jobId}`)
     })
-    queue.on('global:error', (error) => {
-      logger.error(`Queue Job Error - ${error}`)
+    monitoringQueue.on('global:error', (error) => {
+      monitoringQueueLogger.error(`Queue Job Error - ${error}`)
     })
 
     // Add handlers for when a job fails to complete (or completes with an error) or successfully completes
-    queue.on('completed', (job, result) => {
-      logger.info(
+    monitoringQueue.on('completed', (job, result) => {
+      monitoringQueueLogger.info(
         `Queue Job Completed - ID ${job?.id} - Result ${JSON.stringify(result)}`
       )
     })
-    queue.on('failed', (job, err) => {
-      logger.error(`Queue Job Failed - ID ${job?.id} - Error ${err}`)
+    monitoringQueue.on('failed', (job, err) => {
+      monitoringQueueLogger.error(
+        `Queue Job Failed - ID ${job?.id} - Error ${err}`
+      )
       if (job?.name === JOB_NAMES.MONITOR_STATE) {
-        monitorStateJobFailureCallback(queue, job)
+        monitorStateJobFailureCallback(monitoringQueue, job)
       }
     })
 
     // Register the logic that gets executed to process each new job from the queue
-    queue.process(
+    monitoringQueue.process(
       JOB_NAMES.MONITOR_STATE,
       1 /** concurrency */,
       processMonitorStateJob
     )
-    queue.process(
+    monitoringQueue.process(
       JOB_NAMES.FIND_SYNC_REQUESTS,
       1 /** concurrency */,
       processFindSyncRequestsJob
     )
-    queue.process(
+    monitoringQueue.process(
       JOB_NAMES.FIND_REPLICA_SET_UPDATES,
       1 /** concurrency */,
       processFindReplicaSetUpdatesJob
     )
+  }
+
+  /**
+   * Adds handlers for when a job fails to complete (or completes with an error) or successfully completes.
+   * Handlers enqueue another job to fetch the cNodeEndpoint->spId map again.
+   * @param {BullQueue} queue the cNodeToEndpointSpIdMap queue
+   */
+  makeCNodeToEndpointSpIdMapReEnqueueItself(queue) {
+    queue.on('completed', (job, result) => {
+      cNodeEndpointToSpIdMapQueueLogger.info(
+        `Queue Job Completed - ID ${job?.id} - Result ${JSON.stringify(result)}`
+      )
+      queue.add(JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP, /** data */ {})
+    })
+    queue.on('failed', (job, err) => {
+      cNodeEndpointToSpIdMapQueueLogger.error(
+        `Queue Job Failed - ID ${job?.id} - Error ${err}`
+      )
+      queue.add(JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP, /** data */ {})
+    })
   }
 
   /**
@@ -153,13 +219,13 @@ class StateMonitoringManager {
   }
 
   /**
-   * Clears the queue and adds a job that will start processing users
+   * Clears the monitoring queue and adds a job that will start processing users
    * starting from a random userId. Future jobs are added to the queue as a
    * result of this initial job succeeding or failing to complete.
    * @param {Object} queue the StateMonitoringQueue to consume jobs from
    * @param {string} discoveryNodeEndpoint the IP address or URL of a Discovery Node
    */
-  async startQueue(queue, discoveryNodeEndpoint) {
+  async startMonitoringQueue(queue, discoveryNodeEndpoint) {
     // Clear any old state if redis was running but the rest of the server restarted
     await queue.obliterate({ force: true })
 
@@ -188,6 +254,33 @@ class StateMonitoringManager {
     )
   }
 
+  /**
+   * Clears the cNodeEndpoint->spId map queue and adds an initial job.
+   * Future jobs are added to the queue as a result of this initial job succeeding/failing.
+   * @param {Object} queue the cNodeEndpoint->spId map queue to consume jobs from
+   */
+  async startEndpointToSpIdMapQueue(queue) {
+    // Clear any old state if redis was running but the rest of the server restarted
+    await queue.obliterate({ force: true })
+
+    queue.process(
+      JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+      1 /** concurrency */,
+      this.processFetchCNodeEndpointToSpIdMapJob
+    )
+
+    // Since we can't pass 0 to Bull's limiter.max, enforce a rate limit of 0 by
+    // pausing the queue and not enqueuing the first job
+    if (config.get('stateMonitoringQueueRateLimitJobsPerInterval') === 0) {
+      await queue.pause()
+      return
+    }
+
+    // Enqueue first job, which requeues itself upon completion or failure
+    await queue.add(JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP, /** data */ {})
+    this.makeCNodeToEndpointSpIdMapReEnqueueItself(queue)
+  }
+
   /*
    * Job processor boilerplate
    */
@@ -197,7 +290,7 @@ class StateMonitoringManager {
       JOB_NAMES.MONITOR_STATE,
       job,
       monitorStateJobProcessor,
-      logger
+      monitoringQueueLogger
     )
   }
 
@@ -206,7 +299,7 @@ class StateMonitoringManager {
       JOB_NAMES.FIND_SYNC_REQUESTS,
       job,
       findSyncRequestsJobProcessor,
-      logger
+      monitoringQueueLogger
     )
   }
 
@@ -215,7 +308,16 @@ class StateMonitoringManager {
       JOB_NAMES.FIND_REPLICA_SET_UPDATES,
       job,
       findReplicaSetUpdatesJobProcessor,
-      logger
+      monitoringQueueLogger
+    )
+  }
+
+  async processFetchCNodeEndpointToSpIdMapJob(job) {
+    return processJob(
+      JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+      job,
+      fetchCNodeEndpointToSpIdMapJobProcessor,
+      cNodeEndpointToSpIdMapQueueLogger
     )
   }
 }


### PR DESCRIPTION
### Description
Adds a new queue (`c-node-to-endpoint-sp-id-map-queue`) that reads the chain to update the cNodeEndpoint->spId mapping every 10 seconds locally and every 24 hours on staging/prod. This mapping should almost never change on prod, but locally it needs to be fetched more often because when CN1 is brought up and initially fetches the mapping, it's not aware of CN2/3/4. So we have to re-fetch shortly after CN2/3/4 are brought online.


### Tests
- Updated tests to pass
- Checked queue locally from `/health/bull` endpoint to make sure it was running the jobs at the correct interval and successfully returning the correct mapping


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check the `c-node-endpoint-to-sp-id-map-queue` queue from the `/health/bull` endpoint to make sure it's running the jobs at the correct interval on staging/prod (24 hours) and successfully returning the correct mapping in the job output.