### PR TITLE
[PAY-401] Fix Solana Node registration script

### DIFF
--- a/identity-service/src/solanaNodeRegistration.js
+++ b/identity-service/src/solanaNodeRegistration.js
@@ -4,42 +4,45 @@ const config = require('./config.js')
 const JOB_FREQUENCY_MS = 15 /* min */ * 60 /* sec */ * 1000 /* msec */
 
 const registerNodes = async (audiusLibs, logger) => {
-  logger.info('Beginning node registration job')
-  const nodes = await audiusLibs.ServiceProvider.discoveryProvider.serviceSelector.getServices({ verbose: true })
-  const unregistered = []
-  for (const node of nodes) {
-    const isRegistered = await audiusLibs.solanaWeb3Manager.getIsDiscoveryNodeRegistered(node.delegateOwnerWallet)
-
-    if (!isRegistered) {
-      logger.info(`Node ${node.endpoint} is unregistered!`)
-      unregistered.push(node)
-    }
-  }
-
-  if (unregistered.length) {
-    logger.info(`Found unregistered nodes: ${JSON.stringify(unregistered.map(n => n.endpoint))}}`)
-  } else {
-    logger.info(`All nodes successfully registered on Solana!`)
-    return
-  }
-
-  for (const node of unregistered) {
-    logger.info(`Attempting to register node: ${node.endpoint}`)
-    try {
-      const res = await audiusLibs.Rewards.createSenderPublic({
-        senderEthAddress: node.delegateOwnerWallet,
-        operatorEthAddress: node.owner,
-        senderEndpoint: node.endpoint
-      })
-
-      if (!res.error) {
-        logger.info(`Registered ${node.endpoint}`)
-      } else {
-        logger.error(`Error registering: ${node.endpoint}`)
+  try {
+    logger.info('Beginning node registration job')
+    const nodes = await audiusLibs.ServiceProvider.discoveryProvider.serviceSelector.getServices({ verbose: true })
+    const unregistered = []
+    for (const node of nodes) {
+      const isRegistered = await audiusLibs.solanaWeb3Manager.getIsDiscoveryNodeRegistered(node.delegateOwnerWallet)
+      if (!isRegistered) {
+        logger.info(`Node ${node.endpoint} is unregistered!`)
+        unregistered.push(node)
       }
-    } catch (e) {
-      logger.error(`Got error creating for node: ${e.endpoint}`)
     }
+
+    if (unregistered.length) {
+      logger.info(`Found unregistered nodes: ${JSON.stringify(unregistered.map(n => n.endpoint))}}`)
+    } else {
+      logger.info(`All nodes successfully registered on Solana!`)
+      return
+    }
+
+    for (const node of unregistered) {
+      logger.info(`Attempting to register node: ${node.endpoint}`)
+      try {
+        const res = await audiusLibs.Rewards.createSenderPublic({
+          senderEthAddress: node.delegateOwnerWallet,
+          operatorEthAddress: node.owner,
+          senderEndpoint: node.endpoint
+        })
+
+        if (!res.error) {
+          logger.info(`Registered ${node.endpoint}`)
+        } else {
+          logger.error(`Error registering: ${node.endpoint}: ${res.error}`)
+        }
+      } catch (e) {
+        logger.error(`Got error creating for node: ${node.endpoint}, ${e.message}`)
+      }
+    }
+  } catch (e) {
+    logger.error(`Caught error in register nodes: ${e.message}`)
   }
 }
 

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -602,10 +602,14 @@ class Rewards extends Base {
     if (endpoints) {
       attestEndpoints = sampleSize(endpoints, numAttestations)
     } else {
-      attestEndpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes({quorumSize: numAttestations, useWhitelist: false, filter: async (node) => {
-        const isRegistered = await this.solanaWeb3Manager.getIsDiscoveryNodeRegistered(node.delegateOwnerWallet)
-        return isRegistered
-      }})
+      attestEndpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes({
+        quorumSize: numAttestations,
+        useWhitelist: false,
+        filter: async (node) => {
+          const isRegistered = await this.solanaWeb3Manager.getIsDiscoveryNodeRegistered(node.delegateOwnerWallet)
+          return isRegistered
+        }
+      })
     }
 
     if (attestEndpoints.length < numAttestations) {

--- a/libs/src/api/rewards.js
+++ b/libs/src/api/rewards.js
@@ -252,7 +252,7 @@ class Rewards extends Base {
       endpoints = sampleSize(endpoints, quorumSize)
     } else {
       // If no endpoints array provided, select here
-      endpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes(quorumSize)
+      endpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes({ quorumSize })
     }
 
     if (endpoints.length < quorumSize) {
@@ -602,10 +602,10 @@ class Rewards extends Base {
     if (endpoints) {
       attestEndpoints = sampleSize(endpoints, numAttestations)
     } else {
-      attestEndpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes(numAttestations, [], async (node) => {
+      attestEndpoints = await this.ServiceProvider.getUniquelyOwnedDiscoveryNodes({quorumSize: numAttestations, useWhitelist: false, filter: async (node) => {
         const isRegistered = await this.solanaWeb3Manager.getIsDiscoveryNodeRegistered(node.delegateOwnerWallet)
         return isRegistered
-      })
+      }})
     }
 
     if (attestEndpoints.length < numAttestations) {

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -119,18 +119,20 @@ class ServiceProvider extends Base {
    * unique service operators.
    * Throws if unable to find a large enough list.
    * @param {number} quorumSize
-   * @param {any[]} discoveryProviders the verbose list of discovery providers to select from
+   * @param {any[]} discoveryNodes the verbose list of discovery nodes to select from
    * @param {(node: { delegateOwnerWallet: string }) => boolean} filter an optional filter step to remove certain nodes
    */
-  async getUniquelyOwnedDiscoveryNodes (quorumSize, discoveryProviders = [], filter = (node) => true) {
-    if (!discoveryProviders || discoveryProviders.length === 0) {
-      discoveryProviders = await this.discoveryProvider.serviceSelector.findAll({ verbose: true })
+  async getUniquelyOwnedDiscoveryNodes ({quorumSize, discoveryNodes = [], filter = (node) => true, useWhitelist = true }) {
+    if (!discoveryNodes || discoveryNodes.length === 0) {
+      // Whitelist logic: if useWhitelist is false, pass in null to override internal whitelist logic; if true, pass in undefined
+      // so service selector uses internal whitelist
+      discoveryNodes = await this.discoveryProvider.serviceSelector.findAll({ verbose: true, whitelist: useWhitelist ? undefined : null })
     }
 
-    discoveryProviders.filter(filter)
+    discoveryNodes.filter(filter)
 
     // Group nodes by owner
-    const grouped = discoveryProviders.reduce((acc, curr) => {
+    const grouped = discoveryNodes.reduce((acc, curr) => {
       if (curr.owner in acc) {
         acc[curr.owner].push(curr)
       } else {

--- a/libs/src/api/serviceProvider.js
+++ b/libs/src/api/serviceProvider.js
@@ -122,7 +122,7 @@ class ServiceProvider extends Base {
    * @param {any[]} discoveryNodes the verbose list of discovery nodes to select from
    * @param {(node: { delegateOwnerWallet: string }) => boolean} filter an optional filter step to remove certain nodes
    */
-  async getUniquelyOwnedDiscoveryNodes ({quorumSize, discoveryNodes = [], filter = (node) => true, useWhitelist = true }) {
+  async getUniquelyOwnedDiscoveryNodes ({ quorumSize, discoveryNodes = [], filter = (node) => true, useWhitelist = true }) {
     if (!discoveryNodes || discoveryNodes.length === 0) {
       // Whitelist logic: if useWhitelist is false, pass in null to override internal whitelist logic; if true, pass in undefined
       // so service selector uses internal whitelist

--- a/libs/src/services/solanaWeb3Manager/rewardsAttester.ts
+++ b/libs/src/services/solanaWeb3Manager/rewardsAttester.ts
@@ -773,10 +773,10 @@ export class RewardsAttester {
     endpoints = [...endpoints].filter((e) => !blockSet.has(e.endpoint))
 
     this.endpoints =
-      await this.libs.Rewards.ServiceProvider.getUniquelyOwnedDiscoveryNodes(
-        this.quorumSize,
-        endpoints
-      )
+      await this.libs.Rewards.ServiceProvider.getUniquelyOwnedDiscoveryNodes({
+        quorumSize: this.quorumSize,
+        discoveryNodes: endpoints
+      })
     this.logger.info(
       `Selected new discovery nodes in ${
         (Date.now() - startTime) / 1000

--- a/libs/tests/rewardsAttesterTest.js
+++ b/libs/tests/rewardsAttesterTest.js
@@ -29,8 +29,8 @@ function MockLibs(getSlot = () => 100, getBlockNumber = () => 100) {
     submitAndEvaluate: (args) => {},
     getUndisbursedChallenges: (args) => {},
     ServiceProvider: {
-      getUniquelyOwnedDiscoveryNodes: (quorumSize, nodes) => {
-        return nodes.slice(0, quorumSize)
+      getUniquelyOwnedDiscoveryNodes: ({ quorumSize, discoveryNodes }) => {
+        return discoveryNodes.slice(0, quorumSize)
       }
     }
   }


### PR DESCRIPTION
### Description
- Was seeing an error on prod identity trying to register solana nodes; the internal whitelist of a single DN would prevent Identity from selecting a quorum of nodes in `getUniquelyOwnedDiscoveryNodes`. This fixes that
- Add try catches to the bull queue code on identity; if there are errors here, as it is right now we get a vague redis parsing error.

TBH I think there's more going on here; but it's very hard to test this. This should strictly be better than what we have, and I'm hopeful the additional try catch logs should shed some more light on what's going on.


### Tests

Tested this on a local stack. Seems to work - I'm seeing a borsh IO error though, which should be unrelated to anything we touched. I'm not sure when / if ever we tried using create-sender locally, so I suspect that simply isn't working properly.


<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->