### PR TITLE
Make get_users_cnode cache configurable

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -19,6 +19,7 @@ env =
 trending_refresh_seconds = 3600
 infra_setup =
 indexing_transaction_index_sort_order_start_block =
+get_users_cnode_ttl_sec = 5
 
 [flask]
 debug = true

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -75,6 +75,7 @@ from src.queries.get_users_cnode import ReplicaType, get_users_cnode
 from src.queries.search_queries import SearchKind, search
 from src.utils import web3_provider
 from src.utils.auth_middleware import auth_middleware
+from src.utils.config import shared_config
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import encode_int_id
 from src.utils.redis_cache import cache
@@ -92,6 +93,9 @@ user_response = make_response("user_response", ns, fields.Nested(user_model))
 full_user_response = make_full_response(
     "full_user_response", full_ns, fields.List(fields.Nested(user_model_full))
 )
+
+# Cache TTL in seconds for the v1/full/users/content_node route
+GET_USERS_CNODE_TTL_SEC = shared_config["discprov"]["get_users_cnode_ttl_sec"]
 
 
 def get_single_user(user_id, current_user_id):
@@ -874,7 +878,7 @@ class UsersByContentNode(Resource):
         responses={200: "Success", 400: "Bad request", 500: "Server error"},
     )
     @full_ns.marshal_with(users_by_content_node_response)
-    @cache(ttl_sec=5 * 60)
+    @cache(ttl_sec=GET_USERS_CNODE_TTL_SEC)
     def get(self, replica_type):
         args = users_by_content_node_route_parser.parse_args()
 


### PR DESCRIPTION
### Description
Sets caching for the `/v1/full/users/content_node/all` route to be 5 seconds on local by default. See audius-docker-compose and audius-k8s PRs to make this 5 minutes on staging/prod:
- https://github.com/AudiusProject/audius-docker-compose/pull/32
- https://github.com/AudiusProject/audius-k8s/pull/403

#### Context
The state machine on Content Nodes uses this route with pagination queryparams to fetch a page of users who have the Content Node in their replica set.
##### Staging/Prod
If each staging/prod node has (very roughly) ~100K users and fetches in pages of 1000 users every 3 minutes (that's the current configuration), then 5 minutes is very conservative -- it gives enough time to make sure the state machine won't cycle back to the same users and fetch stale data that doesn't reflect updates it performed during its last iteration.
##### Local
Local has very few users, so its state machine currently cycles through before the 5 minutes and fetches stale data. This causes it to attempt to make the same state updates as its last iteration, but the updates are no-ops because they were already performed but not reflected by the Discovery Node yet.

### Tests
I checked the route with `A up` locally to make sure it's returning correct data.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor Content Node queues (`/health/bull` endpoint) in the `state-monitoring-queue` for errors in the `monitor-state` job, and look for jobs that fail to fetch users or return stale data (unlikely).