### PR TITLE
Fix prometheusRegistry not being passed to state machine job processor

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -26,7 +26,8 @@ class StateMachineManager {
     const stateReconciliationManager = new StateReconciliationManager()
     const { stateMonitoringQueue, cNodeEndpointToSpIdMapQueue } =
       await stateMonitoringManager.init(
-        audiusLibs.discoveryProvider.discoveryProviderEndpoint
+        audiusLibs.discoveryProvider.discoveryProviderEndpoint,
+        prometheusRegistry
       )
     const stateReconciliationQueue = await stateReconciliationManager.init()
 

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -264,6 +264,7 @@ class StateMonitoringManager {
    * Clears the cNodeEndpoint->spId map queue and adds an initial job.
    * Future jobs are added to the queue as a result of this initial job succeeding/failing.
    * @param {Object} queue the cNodeEndpoint->spId map queue to consume jobs from
+   * @param {Object} prometheusRegistry the registry of metrics from src/services/prometheusMonitoring/prometheusRegistry.js
    */
   async startEndpointToSpIdMapQueue(queue, prometheusRegistry) {
     // Clear any old state if redis was running but the rest of the server restarted

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -38,7 +38,10 @@ class StateMonitoringManager {
       config.get('redisHost'),
       config.get('redisPort')
     )
-    await this.startEndpointToSpIdMapQueue(cNodeEndpointToSpIdMapQueue)
+    await this.startEndpointToSpIdMapQueue(
+      cNodeEndpointToSpIdMapQueue,
+      prometheusRegistry
+    )
 
     // Create and start queue to monitor state for syncs and reconfigs
     const stateMonitoringQueue = this.makeMonitoringQueue(
@@ -262,14 +265,16 @@ class StateMonitoringManager {
    * Future jobs are added to the queue as a result of this initial job succeeding/failing.
    * @param {Object} queue the cNodeEndpoint->spId map queue to consume jobs from
    */
-  async startEndpointToSpIdMapQueue(queue) {
+  async startEndpointToSpIdMapQueue(queue, prometheusRegistry) {
     // Clear any old state if redis was running but the rest of the server restarted
     await queue.obliterate({ force: true })
 
     queue.process(
       JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
       1 /** concurrency */,
-      this.processFetchCNodeEndpointToSpIdMapJob
+      this.makeProcessFetchCNodeEndpointToSpIdMapJob(prometheusRegistry).bind(
+        this
+      )
     )
 
     // Since we can't pass 0 to Bull's limiter.max, enforce a rate limit of 0 by
@@ -321,13 +326,15 @@ class StateMonitoringManager {
       )
   }
 
-  async processFetchCNodeEndpointToSpIdMapJob(job) {
-    return processJob(
-      JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
-      job,
-      fetchCNodeEndpointToSpIdMapJobProcessor,
-      cNodeEndpointToSpIdMapQueueLogger
-    )
+  makeProcessFetchCNodeEndpointToSpIdMapJob(prometheusRegistry) {
+    return async (job) =>
+      processJob(
+        JOB_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+        job,
+        fetchCNodeEndpointToSpIdMapJobProcessor,
+        cNodeEndpointToSpIdMapQueueLogger,
+        prometheusRegistry
+      )
   }
 }
 


### PR DESCRIPTION
### Description
I resolved merge conflicts on the last 2 PRs without re-testing, and they had a little error that completely broke the state machine queues. This fixes that by making sure `prometheusRegistry` is passed to all job processors.


### Tests
Tested locally to make sure jobs aren't failing anymore. They were failing when I deployed to staging because `prometheusRegistry` couldn't be found.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I'll deploy to staging shortly to make sure jobs start completing successfully again on the `/health/bull` endpoint.