### PR TITLE
Oops fix reconciliation prometheusRegistry too

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -29,7 +29,9 @@ class StateMachineManager {
         audiusLibs.discoveryProvider.discoveryProviderEndpoint,
         prometheusRegistry
       )
-    const stateReconciliationQueue = await stateReconciliationManager.init()
+    const stateReconciliationQueue = await stateReconciliationManager.init(
+      prometheusRegistry
+    )
 
     // Upon completion, make jobs record metrics and enqueue other jobs as necessary
     stateMonitoringQueue.on(


### PR DESCRIPTION
Same thing as [last PR](https://github.com/AudiusProject/audius-protocol/pull/3369) but for the reconciliation queue instead of just the monitoring queue. Whoops.