### PR TITLE
[C-655] Make localStorage configurable in libs & sdk

### DIFF
--- a/libs/src/libs.js
+++ b/libs/src/libs.js
@@ -42,7 +42,7 @@ class AudiusLibs {
    * @param {string} url
    * @param {boolean?} useHedgehogLocalStorage whether or not to read hedgehog entropy in local storage
    */
-  static configIdentityService(url, useHedgehogLocalStorage = true) {
+  static configIdentityService (url, useHedgehogLocalStorage = true) {
     return { url, useHedgehogLocalStorage }
   }
 
@@ -50,7 +50,7 @@ class AudiusLibs {
    * Configures an identity service wrapper
    * @param {string} url
    */
-  static configComstock(url) {
+  static configComstock (url) {
     return { url }
   }
 
@@ -65,7 +65,7 @@ class AudiusLibs {
    * @param {function} monitoringCallbacks.request
    * @param {function} monitoringCallbacks.healthCheck
    */
-  static configCreatorNode(
+  static configCreatorNode (
     fallbackUrl,
     lazyConnect = false,
     passList = null,
@@ -89,7 +89,7 @@ class AudiusLibs {
    * @param {?string} walletOverride wallet address to force use instead of the first wallet on the provided web3
    * @param {?number} walletIndex if using a wallet returned from web3, pick the wallet at this index
    */
-  static async configExternalWeb3(
+  static async configExternalWeb3 (
     registryAddress,
     web3Provider,
     networkId,
@@ -115,7 +115,7 @@ class AudiusLibs {
    * @param {string} registryAddress
    * @param {string | Web3 | Array<string>} providers web3 provider endpoint(s)
    */
-  static configInternalWeb3(registryAddress, providers, privateKey) {
+  static configInternalWeb3 (registryAddress, providers, privateKey) {
     let providerList
     if (typeof providers === 'string') {
       providerList = providers.split(',')
@@ -148,7 +148,7 @@ class AudiusLibs {
    * @param {string?} claimDistributionContractAddress
    * @param {string?} wormholeContractAddress
    */
-  static configEthWeb3(
+  static configEthWeb3 (
     tokenAddress,
     registryAddress,
     providers,
@@ -188,7 +188,7 @@ class AudiusLibs {
    * @param {string} config.ethBridgeAddress
    * @param {string} config.ethTokenBridgeAddress
    */
-  static configWormhole({
+  static configWormhole ({
     rpcHosts,
     solBridgeAddress,
     solTokenBridgeAddress,
@@ -232,7 +232,7 @@ class AudiusLibs {
    * @param {PublicKey|string} audiusDataProgramId program ID for the audius-data Anchor program
    * @param {Idl} audiusDataIdl IDL for the audius-data Anchor program.
    */
-  static configSolanaWeb3({
+  static configSolanaWeb3 ({
     solanaClusterEndpoint,
     mintAddress,
     solanaTokenAddress,
@@ -284,7 +284,7 @@ class AudiusLibs {
    * @param {string} config.programId Program ID of the audius data program
    * @param {string} config.adminAccount Public Key of admin account
    */
-  static configSolanaAudiusData({ programId, adminAccount }) {
+  static configSolanaAudiusData ({ programId, adminAccount }) {
     return {
       programId,
       adminAccount
@@ -301,7 +301,7 @@ class AudiusLibs {
    *  })
    *  await audius.init()
    */
-  constructor({
+  constructor ({
     web3Config,
     ethWeb3Config,
     solanaWeb3Config,

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -34,6 +34,7 @@ import {
   IDENTITY_SERVICE_ENDPOINT,
   WORMHOLE_ADDRESS
 } from './constants'
+import { LocalStorage } from '../utils/localStorage'
 
 type Web3Config = {
   providers: string[]
@@ -60,6 +61,10 @@ type SdkConfig = {
    * Configuration for the IdentityService client
    */
   identityServiceConfig?: IdentityService
+  /**
+   * Optional custom local storage
+   */
+  localStorage?: LocalStorage
   /**
    * Configuration for Web3
    */
@@ -98,7 +103,7 @@ const initializeServices = (config: SdkConfig) => {
     identityServiceConfig
   } = config
 
-  const userStateManager = new UserStateManager()
+  const userStateManager = new UserStateManager({ localStorage })
 
   const identityService = new IdentityService({
     identityServiceEndpoint: IDENTITY_SERVICE_ENDPOINT,
@@ -126,6 +131,7 @@ const initializeServices = (config: SdkConfig) => {
   const discoveryProvider = new DiscoveryProvider({
     ethContracts,
     userStateManager,
+    localStorage,
     ...discoveryProviderConfig
   })
 

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -34,7 +34,7 @@ import {
   IDENTITY_SERVICE_ENDPOINT,
   WORMHOLE_ADDRESS
 } from './constants'
-import { LocalStorage } from '../utils/localStorage'
+import type { LocalStorage } from '../utils/localStorage'
 
 type Web3Config = {
   providers: string[]

--- a/libs/src/service-selection/ServiceSelection.test.ts
+++ b/libs/src/service-selection/ServiceSelection.test.ts
@@ -249,7 +249,7 @@ describe('ServiceSelection withBackupCriteria', () => {
 describe('ServiceSelection withShortCircuit', () => {
   const shortcircuit = 'https://shortcircuit.audius.co'
   class ServiceSelectionWithShortCircuit extends ServiceSelection {
-    override shortcircuit() {
+    override async shortcircuit() {
       return shortcircuit
     }
   }

--- a/libs/src/service-selection/ServiceSelection.ts
+++ b/libs/src/service-selection/ServiceSelection.ts
@@ -149,7 +149,7 @@ export class ServiceSelection {
     }
 
     // If a short circuit is provided, take it. Don't check it, just use it.
-    const shortcircuit = this.shortcircuit()
+    const shortcircuit = await this.shortcircuit()
     this.decisionTree.push({
       stage: DECISION_TREE_STATE.CHECK_SHORT_CIRCUIT,
       val: shortcircuit
@@ -325,7 +325,7 @@ export class ServiceSelection {
   }
 
   /** A short-circuit. If overriden, can be used to skip selection (which could be slow) */
-  shortcircuit(): null | string {
+  async shortcircuit(): Promise<null | string> {
     return null
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -36,13 +36,14 @@ export type DiscoveryProviderConfig = {
   ethContracts: EthContracts
   web3Manager?: Web3Manager
   reselectTimeout?: number
-  selectionCallback?: DiscoveryProviderSelectionConfig['selectionCallback']
-  monitoringCallbacks?: DiscoveryProviderSelectionConfig['monitoringCallbacks']
   selectionRequestTimeout?: number
   selectionRequestRetries?: number
   unhealthySlotDiffPlays?: number
   unhealthyBlockDiff?: number
-}
+} & Pick<
+  DiscoveryProviderSelectionConfig,
+  'selectionCallback' | 'monitoringCallbacks' | 'localStorage'
+>
 
 export type UserProfile = {
   userId: number
@@ -105,6 +106,7 @@ export class DiscoveryProvider {
     monitoringCallbacks,
     selectionRequestTimeout = REQUEST_TIMEOUT_MS,
     selectionRequestRetries = MAX_MAKE_REQUEST_RETRY_COUNT,
+    localStorage,
     unhealthySlotDiffPlays,
     unhealthyBlockDiff
   }: DiscoveryProviderConfig) {
@@ -124,6 +126,7 @@ export class DiscoveryProvider {
         monitoringCallbacks,
         requestTimeout: selectionRequestTimeout,
         unhealthySlotDiffPlays: unhealthySlotDiffPlays,
+        localStorage: localStorage,
         unhealthyBlockDiff: this.unhealthyBlockDiff
       },
       this.ethContracts
@@ -151,7 +154,9 @@ export class DiscoveryProvider {
       const userAccount = await this.getUserAccount(
         this.web3Manager.getWalletAddress()
       )
-      if (userAccount) this.userStateManager.setCurrentUser(userAccount)
+      if (userAccount) {
+        await this.userStateManager.setCurrentUser(userAccount)
+      }
     }
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.ts
@@ -426,7 +426,7 @@ describe('DiscoveryProviderSelection', () => {
       })
 
     const s = new DiscoveryProviderSelection(
-      {},
+      { localStorage },
       mockEthContracts([healthy1], '1.2.3')
     )
     const service = await s.select()
@@ -476,7 +476,7 @@ describe('DiscoveryProviderSelection', () => {
       })
 
     const s = new DiscoveryProviderSelection(
-      {},
+      { localStorage },
       mockEthContracts([healthy1, healthy2, initiallyUnhealthy], '1.2.3')
     )
     const firstService = await s.select()

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -134,7 +134,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
 
   /** Sets a cached discovery provider in localstorage */
   async setCached(endpoint: string) {
-    await localStorage.setItem(
+    await this.localStorage.setItem(
       DISCOVERY_PROVIDER_TIMESTAMP,
       JSON.stringify({ endpoint, timestamp: Date.now() })
     )

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -15,17 +15,9 @@ import semver from 'semver'
 import type { EthContracts } from '../ethContracts'
 import type { AxiosResponse } from 'axios'
 import type { Maybe, Nullable } from '../../utils'
+import { LocalStorage } from '../../utils/localStorage'
 
 const PREVIOUS_VERSIONS_TO_CHECK = 5
-
-let localStorage: Storage
-if (typeof window === 'undefined' || window === null) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const LocalStorage = require('node-localstorage').LocalStorage
-  localStorage = new LocalStorage('./local-storage')
-} else {
-  localStorage = window.localStorage
-}
 
 export type DiscoveryProviderSelectionConfig = Omit<
   ServiceSelectionConfig,
@@ -39,6 +31,7 @@ export type DiscoveryProviderSelectionConfig = Omit<
   }
   unhealthySlotDiffPlays?: number
   unhealthyBlockDiff?: number
+  localStorage?: LocalStorage
 }
 
 export class DiscoveryProviderSelection extends ServiceSelection {
@@ -57,6 +50,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
   unhealthyBlockDiff: number
   _regressedMode: boolean
   validVersions: Nullable<string[]>
+  localStorage?: LocalStorage
 
   constructor(
     config: DiscoveryProviderSelectionConfig,
@@ -86,6 +80,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
     this.unhealthySlotDiffPlays = config.unhealthySlotDiffPlays ?? null
     this.unhealthyBlockDiff =
       config.unhealthyBlockDiff ?? DEFAULT_UNHEALTHY_BLOCK_DIFF
+    this.localStorage = config.localStorage
 
     // Whether or not we are running in `regressed` mode, meaning we were
     // unable to select a discovery provider that was up-to-date. Clients may
@@ -97,10 +92,10 @@ export class DiscoveryProviderSelection extends ServiceSelection {
   }
 
   /** Retrieves a cached discovery provider from localstorage */
-  getCached() {
-    if (localStorage) {
+  async getCached() {
+    if (this.localStorage) {
       try {
-        const discProvTimestamp = localStorage.getItem(
+        const discProvTimestamp = await this.localStorage.getItem(
           DISCOVERY_PROVIDER_TIMESTAMP
         )
         if (discProvTimestamp) {
@@ -131,22 +126,22 @@ export class DiscoveryProviderSelection extends ServiceSelection {
   }
 
   /** Clears any cached discovery provider from localstorage */
-  clearCached() {
-    if (localStorage) {
-      localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
+  async clearCached() {
+    if (this.localStorage) {
+      await this.localStorage.removeItem(DISCOVERY_PROVIDER_TIMESTAMP)
     }
   }
 
   /** Sets a cached discovery provider in localstorage */
-  setCached(endpoint: string) {
-    localStorage.setItem(
+  async setCached(endpoint: string) {
+    await localStorage.setItem(
       DISCOVERY_PROVIDER_TIMESTAMP,
       JSON.stringify({ endpoint, timestamp: Date.now() })
     )
   }
 
   /** Allows the selection take a shortcut if there's a cached provider */
-  override shortcircuit() {
+  override async shortcircuit() {
     return this.getCached()
   }
 

--- a/libs/src/userStateManager.ts
+++ b/libs/src/userStateManager.ts
@@ -1,7 +1,5 @@
 import { CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY } from './constants'
-
-const supportsLocalStorage = () =>
-  typeof window !== 'undefined' && window && window.localStorage
+import { LocalStorage } from './utils/localStorage'
 
 export type CurrentUser = {
   user_id: string
@@ -12,6 +10,10 @@ export type CurrentUser = {
   is_creator: boolean
 }
 
+type UserStateManagerConfig = {
+  localStorage?: LocalStorage
+}
+
 /**
  * Singleton class to store the current user if initialized.
  * Some instances of AudiusLibs and services require a current user to
@@ -19,20 +21,25 @@ export type CurrentUser = {
  */
 export class UserStateManager {
   currentUser: CurrentUser | null
+  localStorage?: LocalStorage
 
-  constructor() {
+  constructor({ localStorage }: UserStateManagerConfig) {
     // Should reflect the same fields as discovery node's /users?handle=<handle>
     this.currentUser = null
+    this.localStorage = localStorage
   }
 
   /**
    * Sets this.currentUser with currentUser
    * @param {Object} currentUser fields to override this.currentUser with
    */
-  setCurrentUser(currentUser: CurrentUser) {
+  async setCurrentUser(currentUser: CurrentUser) {
     this.currentUser = currentUser
-    if (supportsLocalStorage()) {
-      window.localStorage.setItem(CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY, 'true')
+    if (this.localStorage) {
+      await this.localStorage.setItem(
+        CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY,
+        'true'
+      )
     }
   }
 
@@ -44,10 +51,10 @@ export class UserStateManager {
     return this.currentUser ? this.currentUser.user_id : null
   }
 
-  clearUser() {
+  async clearUser() {
     this.currentUser = null
-    if (supportsLocalStorage()) {
-      window.localStorage.removeItem(CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY)
+    if (this.localStorage) {
+      await this.localStorage.removeItem(CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY)
     }
   }
 }

--- a/libs/src/utils/localStorage.ts
+++ b/libs/src/utils/localStorage.ts
@@ -2,7 +2,7 @@
  * Local storage interface that supports async storage implementations
  */
 export type LocalStorage = {
-  getItem?: (key: string) => Promise<string> | string
+  getItem?: (key: string) => Promise<string | null> | string | null
   setItem?: (key: string, value: string) => Promise<void> | void
   removeItem?: (key: string) => Promise<void> | void
 }

--- a/libs/src/utils/localStorage.ts
+++ b/libs/src/utils/localStorage.ts
@@ -1,0 +1,22 @@
+/**
+ * Local storage interface that supports async storage implementations
+ */
+export type LocalStorage = {
+  getItem?: (key: string) => Promise<string> | string
+  setItem?: (key: string, value: string) => Promise<void> | void
+  removeItem?: (key: string) => Promise<void> | void
+}
+
+/**
+ * Fallback for localStorage that works in node and the browser
+ * @returns localStorage
+ */
+export const getPlatformLocalStorage = () => {
+  if (typeof window === 'undefined' || window === null) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const LocalStorage = require('node-localstorage').LocalStorage
+    return new LocalStorage('./local-storage')
+  } else {
+    return window.localStorage
+  }
+}


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Allows `localStorage` to be passed into libs and the sdk, using `getPlatformLocalStorage()` as a back up that works for both node and the browser

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Unit tests pass, need to do some further testing before merging

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->