### PR TITLE
Add metric for find-syncs and fix reconciliation queue history

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -84,7 +84,7 @@ const MetricLabels = Object.freeze({
       'no_sync_secondary_data_matches_primary', // Sync not found because the secondary's clock value and filesHash match primary's
       'no_sync_unexpected_error', // Sync not found because some uncaught error was thrown
       'new_sync_request_enqueued_primary_to_secondary', // Sync was found from primary->secondary because all other conditions were met and primary clock value was greater than secondary
-      'new_sync_request_enqueued_secondary_to_primary', // Sync was found from secondary->primary because all other conditions were met and primary clock value was greater than secondary
+      'new_sync_request_enqueued_secondary_to_primary', // Sync was found from secondary->primary because all other conditions were met and secondary clock value was greater than primary
       'sync_request_already_enqueued', // Sync was found but a duplicate request has already been enqueued so no need to enqueue another
       'new_sync_request_unable_to_enqueue' // Sync was found but something prevented a new request from being created
     ]

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -76,10 +76,6 @@ const MetricLabels = Object.freeze({
     ]
   },
   [MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE]: {
-    // The primary node being synced from. Dynamic values because it can be any node
-    primary: [],
-    // The secondary node being synced to. Dynamic values because it can be any node
-    secondary: [],
     result: [
       'not_checked', // Default value -- means the logic short-circuited before checking if the primary should sync to the secondary. This can be expected if this node wasn't the user's primary
       'no_sync_already_marked_unhealthy', // Sync not found because the secondary was marked unhealthy before being passed to the find-sync-requests job

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -24,13 +24,21 @@ const MetricTypes = Object.freeze({
   // SUMMARY: promClient.Summary
 })
 
+/**
+ * Types for recording a metric value.
+ */
+const MetricRecordType = Object.freeze({
+  GAUGE_INC: 'GAUGE_INC',
+  HISTOGRAM_OBSERVE: 'HISTOGRAM_OBSERVE'
+})
+
 let MetricNames = {
   SYNC_QUEUE_JOBS_TOTAL_GAUGE: 'sync_queue_jobs_total',
   ROUTE_POST_TRACKS_DURATION_SECONDS_HISTOGRAM:
     'route_post_tracks_duration_seconds',
   ISSUE_SYNC_REQUEST_MONITORING_DURATION_SECONDS_HISTOGRAM:
     'issue_sync_request_monitoring_duration_seconds',
-  FIND_SYNCS_RESULTS_TOTAL_GAUGE: 'find_syncs_results_total'
+  FIND_SYNC_REQUEST_COUNTS_GAUGE: 'find_sync_request_counts'
 }
 // Add a histogram for each job in the state machine queues.
 // Some have custom labels below, and all of them use the label: uncaughtError=true/false
@@ -67,7 +75,7 @@ const MetricLabels = Object.freeze({
       'null' // No change was made to the user's replica set because the job short-circuited before selecting or was unable to select new node(s)
     ]
   },
-  [MetricNames.FIND_SYNCS_RESULTS_TOTAL_GAUGE]: {
+  [MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE]: {
     // The primary node being synced from. Dynamic values because it can be any node
     primary: [],
     // The secondary node being synced to. Dynamic values because it can be any node
@@ -156,12 +164,12 @@ const Metrics = Object.freeze({
       }
     ])
   ),
-  [MetricNames.FIND_SYNCS_RESULTS_TOTAL_GAUGE]: {
+  [MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE]: {
     metricType: MetricTypes.GAUGE,
     metricConfig: {
-      name: MetricNames.FIND_SYNCS_RESULTS_TOTAL_GAUGE,
+      name: MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE,
       help: "Counts for each find-sync-requests job's result when looking for syncs that should be requested from a primary to a secondary",
-      labelNames: MetricLabelNames[MetricNames.FIND_SYNCS_RESULTS_TOTAL_GAUGE]
+      labelNames: MetricLabelNames[MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE]
     }
   }
 })
@@ -170,4 +178,5 @@ module.exports.NamespacePrefix = NamespacePrefix
 module.exports.MetricTypes = MetricTypes
 module.exports.MetricNames = MetricNames
 module.exports.MetricLabels = MetricLabels
+module.exports.MetricRecordType = MetricRecordType
 module.exports.Metrics = Metrics

--- a/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.js
+++ b/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.js
@@ -94,8 +94,8 @@ module.exports = function (
         const metric = prometheusRegistry.getMetric(metricName)
         if (metricType === 'HISTOGRAM') {
           metric.observe(metricLabels, metricValue)
-        } else if (metricType === 'GAUGE') {
-          metric.set(metricValue)
+        } else if (metricType === 'GAUGE_INC') {
+          metric.inc(metricLabels, metricValue)
         } else {
           logger.error(`Unexpected metric type: ${metricType}`)
         }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -132,7 +132,7 @@ module.exports = async function ({
         // Log so we can find the primary+secondary for each result, but don't spam logs with the default result
         if (labelValue !== 'not_checked') {
           logger.info(
-            `Incrementing gauge for metric ${MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE} from primary=${primary} to secondary=${secondary} with result=${labelValue}`
+            `Recorded findSyncRequests from primary=${primary} to secondary=${secondary} with result=${labelValue}`
           )
         }
       }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -111,9 +111,6 @@ module.exports = function ({
       secondaryToResultCountMap
     )) {
       for (const [labelValue, metricValue] of Object.entries(resultCountMap)) {
-        logger.info(
-          `Incrementing gauge for metric ${MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE} from primary=${primary} to secondary=${secondary} with result=${labelValue}`
-        )
         metricsToRecord.push(
           makeGaugeIncToRecord(
             MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE,
@@ -121,6 +118,13 @@ module.exports = function ({
             { result: labelValue }
           )
         )
+
+        // Log so we can find the primary+secondary for each result, but don't spam logs with the default result
+        if (labelValue !== 'not_checked') {
+          logger.info(
+            `Incrementing gauge for metric ${MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE} from primary=${primary} to secondary=${secondary} with result=${labelValue}`
+          )
+        }
       }
     }
   }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -110,14 +110,18 @@ module.exports = function ({
     for (const [secondary, resultCountMap] of Object.entries(
       secondaryToResultCountMap
     )) {
-      for (const [labelValue, metricValue] of Object.entries(resultCountMap))
+      for (const [labelValue, metricValue] of Object.entries(resultCountMap)) {
+        logger.info(
+          `Incrementing gauge for metric ${MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE} from primary=${primary} to secondary=${secondary} with result=${labelValue}`
+        )
         metricsToRecord.push(
           makeGaugeIncToRecord(
             MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE,
             metricValue,
-            { primary, secondary, result: labelValue }
+            { result: labelValue }
           )
         )
+      }
     }
   }
   return {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.js
@@ -113,7 +113,7 @@ module.exports = function ({
       for (const [labelValue, metricValue] of Object.entries(resultCountMap))
         metricsToRecord.push(
           makeGaugeIncToRecord(
-            MetricNames.FIND_SYNCS_RESULTS_TOTAL_GAUGE,
+            MetricNames.FIND_SYNC_REQUEST_COUNTS_GAUGE,
             metricValue,
             { primary, secondary, result: labelValue }
           )

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -2,7 +2,7 @@ const BullQueue = require('bull')
 
 const config = require('../../../config')
 const {
-  RECONCILIATION_QUEUE_HISTORY,
+  QUEUE_HISTORY,
   QUEUE_NAMES,
   JOB_NAMES,
   STATE_RECONCILIATION_QUEUE_MAX_JOB_RUNTIME_MS
@@ -51,8 +51,8 @@ class StateReconciliationManager {
         port: redisPort
       },
       defaultJobOptions: {
-        removeOnComplete: RECONCILIATION_QUEUE_HISTORY,
-        removeOnFail: RECONCILIATION_QUEUE_HISTORY
+        removeOnComplete: QUEUE_HISTORY.RECONCILIATION_QUEUE_HISTORY,
+        removeOnFail: QUEUE_HISTORY.RECONCILIATION_QUEUE_HISTORY
       },
       settings: {
         // Should be sufficiently larger than expected job runtime

--- a/creator-node/test/findSyncRequests.jobProcessor.test.js
+++ b/creator-node/test/findSyncRequests.jobProcessor.test.js
@@ -143,21 +143,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'new_sync_request_enqueued'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }
@@ -261,21 +257,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'sync_request_already_enqueued'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }
@@ -348,21 +340,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'no_sync_already_marked_unhealthy'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }
@@ -429,21 +417,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'no_sync_sp_id_mismatch'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }
@@ -516,21 +500,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'no_sync_success_rate_too_low'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }
@@ -600,21 +580,17 @@ describe('test findSyncRequests job processor', function () {
       metricsToRecord: [
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_to_sync_to.co',
             result: 'no_sync_unexpected_error'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         },
         {
           metricLabels: {
-            primary: 'http://primary_cn.co',
-            secondary: 'http://secondary_already_synced.co',
             result: 'no_sync_secondary_clock_gte_primary'
           },
-          metricName: 'audius_cn_find_syncs_results_total',
+          metricName: 'audius_cn_find_sync_request_counts',
           metricType: 'GAUGE_INC',
           metricValue: 1
         }

--- a/creator-node/test/findSyncRequests.jobProcessor.test.js
+++ b/creator-node/test/findSyncRequests.jobProcessor.test.js
@@ -139,7 +139,29 @@ describe('test findSyncRequests job processor', function () {
       errors: [],
       jobsToEnqueue: {
         [QUEUE_NAMES.STATE_RECONCILIATION]: [expectedSyncReqToEnqueue]
-      }
+      },
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'new_sync_request_enqueued'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
       userWallet: wallet,
@@ -235,7 +257,29 @@ describe('test findSyncRequests job processor', function () {
     ).to.deep.equal({
       duplicateSyncReqs: [expectedDuplicateSyncReq],
       errors: [],
-      jobsToEnqueue: {}
+      jobsToEnqueue: {},
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'sync_request_already_enqueued'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
       userWallet: wallet,
@@ -300,7 +344,29 @@ describe('test findSyncRequests job processor', function () {
     ).to.deep.equal({
       duplicateSyncReqs: [],
       errors: [],
-      jobsToEnqueue: {}
+      jobsToEnqueue: {},
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'no_sync_already_marked_unhealthy'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.not.have.been.called
   })
@@ -359,7 +425,29 @@ describe('test findSyncRequests job processor', function () {
     ).to.deep.equal({
       duplicateSyncReqs: [],
       errors: [],
-      jobsToEnqueue: {}
+      jobsToEnqueue: {},
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'no_sync_sp_id_mismatch'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.not.have.been.called
   })
@@ -424,7 +512,29 @@ describe('test findSyncRequests job processor', function () {
     ).to.deep.equal({
       duplicateSyncReqs: [],
       errors: [],
-      jobsToEnqueue: {}
+      jobsToEnqueue: {},
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'no_sync_success_rate_too_low'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.not.have.been.called
   })
@@ -472,7 +582,7 @@ describe('test findSyncRequests job processor', function () {
       getCNodeEndpointToSpIdMapStub
     )
 
-    // Verify job outputs the correct results: sync to user1 to secondary1 because its clock value is behind
+    // Verify job outputs the correct results: sync to secondary1 errors, sync to secondary2 fails because it's already synced
     expect(
       findSyncRequestsJobProcessor({
         logger,
@@ -486,7 +596,29 @@ describe('test findSyncRequests job processor', function () {
       errors: [
         `Error getting new or existing sync request for user ${wallet} and secondary ${secondary1} - ${expectedErrorMsg}`
       ],
-      jobsToEnqueue: {}
+      jobsToEnqueue: {},
+      metricsToRecord: [
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_to_sync_to.co',
+            result: 'no_sync_unexpected_error'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        },
+        {
+          metricLabels: {
+            primary: 'http://primary_cn.co',
+            secondary: 'http://secondary_already_synced.co',
+            result: 'no_sync_secondary_clock_gte_primary'
+          },
+          metricName: 'audius_cn_find_syncs_results_total',
+          metricType: 'GAUGE_INC',
+          metricValue: 1
+        }
+      ]
     })
     expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
       userWallet: wallet,

--- a/creator-node/test/issueSyncRequest.jobProcessor.test.js
+++ b/creator-node/test/issueSyncRequest.jobProcessor.test.js
@@ -226,7 +226,7 @@ describe('test issueSyncRequest job processor', function () {
     })
     expect(result.metricsToRecord[0]).to.have.deep.property(
       'metricType',
-      'HISTOGRAM'
+      'HISTOGRAM_OBSERVE'
     )
     expect(result.metricsToRecord[0].metricValue).to.be.a('number')
     expect(getNewOrExistingSyncReqStub).to.not.have.been.called
@@ -337,7 +337,7 @@ describe('test issueSyncRequest job processor', function () {
     })
     expect(result.metricsToRecord[0]).to.have.deep.property(
       'metricType',
-      'HISTOGRAM'
+      'HISTOGRAM_OBSERVE'
     )
     expect(result.metricsToRecord[0].metricValue).to.be.a('number')
     expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({
@@ -420,7 +420,7 @@ describe('test issueSyncRequest job processor', function () {
     })
     expect(result.metricsToRecord[0]).to.have.deep.property(
       'metricType',
-      'HISTOGRAM'
+      'HISTOGRAM_OBSERVE'
     )
     expect(result.metricsToRecord[0].metricValue).to.be.a('number')
     expect(getNewOrExistingSyncReqStub).to.have.been.calledOnceWithExactly({


### PR DESCRIPTION
### Description
- Add prometheus gauge `audius_cn_find_sync_request_counts` for finding syncs. This will give us insight into when monitoring jobs find or don't find syncs for any of the following reasons:
  - `not_checked`: Default value -- means the logic short-circuited before checking if the primary should sync to the secondary. This can be expected if this node wasn't the user's primary
  - `no_sync_already_marked_unhealthy`; Sync not found because the secondary was marked unhealthy before being passed to the find-sync-requests job
   - `no_sync_sp_id_mismatch`: Sync not found because the secondary's spID mismatched what the chain reported
   - `no_sync_success_rate_too_low`: Sync not found because the success rate of syncing to this secondary is below the acceptable threshold
   - `no_sync_secondary_data_matches_primary`: Sync not found because the secondary's clock value was greater than or equal to the primary's clock value
   - `no_sync_unexpected_error`: Sync not found because some uncaught error was thrown
    - `new_sync_request_enqueued_primary_to_secondary`: Sync was found from primary->secondary because all other conditions were met and primary clock value was greater than secondary
    - `new_sync_request_enqueued_secondary_to_primary`: Sync was found from secondary->primary because all other conditions were met and secondary clock value was greater than primary
    - `sync_request_already_enqueued`: Sync was found but a duplicate request has already been enqueued so no need to enqueue another
    - `new_sync_request_unable_to_enqueue`: Sync was found but something prevented a new request from being created
- Fix reconciliation queue not deleting completed job history (this bug was introduced during a renaming)



### Tests
Updated tests to pass and verified that metrics were found locally with a user whose replica set needed updating due to me taking down a node in its replica set. Context + what the metric screenshots show in this case:
User's replica set was primary=cn4, secondaries=CN2 and CN3

1. I took CN2 offline
2. CN3 was first to notice the offline node and issued a reconfig
    - Verified by seeing this line in the screenshot of CN3 logs: `audius_cn_state_machine_update_replica_set_job_duration_seconds_bucket{le="30",uncaughtError="false",issuedReconfig="true",reconfigType="one_secondary"} 1`
3. Sync was successful (clock_status route showed its value updated on CN1)
4. CN4 looked for syncs and saw that it didn't need to sync to CN1 because its clock value was already updated
    - Verified by seeing this line in the screenshot of CN4 logs: `audius_cn_find_sync_request_counts{primary="http://cn4_creator-node_1:4003",secondary="http://cn1_creator-node_1:4000",result="no_sync_secondary_clock_gte_primary"} 3`
    - Note that this metric no longer has `primary` or `secondary` as labels because that would create too many time series -- see discussion below for details.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Monitor logs for `Metric label has invalid` or `Error processing job` errors
- Monitor the `/prometheus_metrics` endpoint to see what reasons syncs are being found or not found -- in the metric `audius_cn_find_sync_request_counts`
- Debug any unexpected metric results by searching the logs for `Recorded findSyncRequests from` to see which primary/secondary caused the metric to be incremented