### PR TITLE
Add support for content nodes as prometheus targets

### DIFF
--- a/monitoring/prometheus/generateProm.js
+++ b/monitoring/prometheus/generateProm.js
@@ -11,7 +11,7 @@ const readFromFileAndWriteToStream = (stream, filename) => {
   stream.write("\n")
 }
 
-const generateJobYaml = (url, env, scheme = 'https', component = 'discovery-provider') => {
+const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-provider' }) => {
   url = url.replace("https://", "").replace("http://", "")
   sanitizedUrl = url.split(".").join("-")
 
@@ -67,7 +67,8 @@ const generateEnv = async (stream, env) => {
 
   for (const sp of serviceProviders) {
     const spEndpoint = sp.endpoint;
-    const yamlString = generateJobYaml(spEndpoint, env)
+    const serviceType = sp.type
+    const yamlString = generateJobYaml({ url: spEndpoint, env, component: serviceType })
     stream.write(yamlString);
     stream.write("\n")
   }

--- a/monitoring/prometheus/generateProm.js
+++ b/monitoring/prometheus/generateProm.js
@@ -52,7 +52,9 @@ const generateEnv = async (stream, env) => {
     preferHigherPatchForSecondaries: true
   })
   await audiusLibs.init()
-  const serviceProviders = await audiusLibs.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('discovery-node');
+  const discoveryNodes = await audiusLibs.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('discovery-node')
+  const contentNodes = await audiusLibs.ethContracts.ServiceProviderFactoryClient.getServiceProviderList('content-node')
+  const serviceProviders = [...discoveryNodes, ...contentNodes]
 
   // copy from environment-specific stubs
   readFromFileAndWriteToStream(stream, `${env}.yml`)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Previously prometheus.yml did not include content nodes as prometheus targets, this PR adds support for that.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Ran the script to generate prometheus.yml and verified it works.
`PROM_ENV=prod node generateProm.js`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Hosts should be visible in Grafana after adding these targets

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->