### PR TITLE
Initialize everything in ServiceRegistry constructor

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -47,11 +47,11 @@ class ServiceRegistry {
     this.skippedCIDsRetryQueue = null // Retries syncing CIDs that were unable to sync on first try
     this.syncQueue = null // Handles syncing data to users' replica sets
     this.asyncProcessingQueue = null // Handles all jobs that should be performed asynchornously. Currently handles track upload and track hand off
-    this.stateMonitoringQueue = null // ask theo
-    this.stateReconciliationQueue = null // ask theo
-    this.stateMachineQueue = null // ask theo
-    this.manualSyncQueue = null // Handles manual syncs, e.g. on track upload, image upload, etc. triggers a sync to the users' replica sets
-    this.recurringSyncQueue = null // Handles syncs that occur on a cadence, e.g. every hour attempts to sync user data
+    this.manualSyncQueue = null // Handles sync jobs triggered by client actions, e.g. track upload
+    this.recurringSyncQueue = null // Handles syncs that occur on a cadence, e.g. every hour
+    this.stateMonitoringQueue = null // // Handles jobs for finding replica set updates and syncs for one slice of users at a time
+    this.stateReconciliationQueue = null // Handles jobs for issuing sync requests and updating users' replica sets
+    this.stateMachineQueue = null // DEPRECATED -- being removed very soon. Handles sync jobs based on user state
 
     // Flags that indicate whether specific services have been initialized
     this.synchronousServicesInitialized = false

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -32,6 +32,9 @@ const PrometheusRegistry = require('./services/prometheusMonitoring/prometheusRe
  */
 class ServiceRegistry {
   constructor() {
+    // TODO: this is redundant and we should just rely on the import, but this is too tightly coupled with existing logic
+    this.nodeConfig = config
+
     // Some services are initialized to `null` and will be initialized in helper functions
 
     this.redis = redisClient // Redis Client

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -315,8 +315,6 @@ class ServiceRegistry {
       { logger, startTime: start },
       'ServiceRegistry || Initialized services that require server'
     )
-
-    console.log('done with everything god fucking', Object.keys(this))
   }
 
   logInfo(msg) {

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -50,13 +50,13 @@ class ServiceRegistry {
     this.monitoringQueue = new MonitoringQueue() // Recurring job to monitor node state & performance metrics
     this.sessionExpirationQueue = new SessionExpirationQueue() // Recurring job to clear expired session tokens from Redis and DB
     this.imageProcessingQueue = ImageProcessingQueue // Resizes all images on Audius
-    this.transcodingQueue = TranscodingQueue // Transcodesa and segments all tracks
+    this.transcodingQueue = TranscodingQueue // Transcodes and segments all tracks
     this.skippedCIDsRetryQueue = null // Retries syncing CIDs that were unable to sync on first try
     this.syncQueue = null // Handles syncing data to users' replica sets
-    this.asyncProcessingQueue = null // Handles all jobs that should be performed asynchornously. Currently handles track upload and track hand off
+    this.asyncProcessingQueue = null // Handles all jobs that should be performed asynchronously. Currently handles track upload and track hand off
     this.manualSyncQueue = null // Handles sync jobs triggered by client actions, e.g. track upload
     this.recurringSyncQueue = null // Handles syncs that occur on a cadence, e.g. every hour
-    this.stateMonitoringQueue = null // // Handles jobs for finding replica set updates and syncs for one slice of users at a time
+    this.stateMonitoringQueue = null // Handles jobs for finding replica set updates and syncs for one slice of users at a time
     this.stateReconciliationQueue = null // Handles jobs for issuing sync requests and updating users' replica sets
     this.stateMachineQueue = null // DEPRECATED -- being removed very soon. Handles sync jobs based on user state
 

--- a/mad-dog/src/index.js
+++ b/mad-dog/src/index.js
@@ -60,7 +60,6 @@ const services = [
 // The `additionalConfigs` is used for additional parameters for tests
 // * It is used to pass in `iterations` for the test_userReplicaSetNodes
 const makeTest = (name, testFn, { numUsers, numCreatorNodes, useZeroIndexedWallet, executeAllBatchSize = numUsers + 1, ...additionalConfigs }) => {
- logger.info(testFn)
  const wrappedTest = async ({ executeAll, executeOne }) => {
    try {
      const res = await testFn({


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Part of the task to handle graceful shut down include closing out jobs in all queues. To do this, we need to know which queues exist in the Content Node. No one knows before hand unless they (1) have all the queues memorized to heart, (2) scavenge through ServiceRegistry, and/or (3) look for all files with the word `Queue` appended to them. 

ServiceRegistry needed some love anyway 🤷‍♀️ 

This PR is to:
- expose **every** member variable in the constructor of the ServiceRegistry
- clean some some conflated initializations
- update comments

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

No tests, just reordering member variables + cleaning up initialize service calls


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

No new logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->