### PR TITLE
Create a CN-like metric registry for DN's Prometheus metrics

### DIFF
--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -3,11 +3,7 @@ from datetime import datetime
 
 import pytz
 from src.monitors import monitor_names, monitors
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 
 logger = logging.getLogger(__name__)
 MONITORS = monitors.MONITORS
@@ -36,9 +32,7 @@ def celery_tasks_prometheus_exporter():
     active_tasks = all_tasks["active_tasks"]
     registered_tasks = all_tasks["registered_celery_tasks"]
 
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS)
 
     active_task_names = []
     for task in active_tasks:

--- a/discovery-provider/src/queries/get_celery_tasks.py
+++ b/discovery-provider/src/queries/get_celery_tasks.py
@@ -3,7 +3,11 @@ from datetime import datetime
 
 import pytz
 from src.monitors import monitor_names, monitors
-from src.utils.prometheus_metric import PrometheusMetric, PrometheusType
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 
 logger = logging.getLogger(__name__)
 MONITORS = monitors.MONITORS
@@ -33,10 +37,7 @@ def celery_tasks_prometheus_exporter():
     registered_tasks = all_tasks["registered_celery_tasks"]
 
     metric = PrometheusMetric(
-        "celery_task_active_duration_seconds",
-        "How long the currently running celery task has been running",
-        labelnames=["task_name"],
-        metric_type=PrometheusType.GAUGE,
+        PrometheusRegistry[PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS]
     )
 
     active_task_names = []

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -467,7 +467,7 @@ def health_check_prometheus_exporter():
     )
 
     PrometheusMetric(
-        PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT
+        PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM
     ).save(health_results["web"]["blocknumber"])
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -24,7 +24,11 @@ from src.utils import db_session, helpers, redis_connection, web3_provider
 from src.utils.config import shared_config
 from src.utils.elasticdsl import ES_INDEXES, esclient
 from src.utils.helpers import redis_get_or_restore, redis_set_and_dump
-from src.utils.prometheus_metric import PrometheusMetric, PrometheusType
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.redis_constants import (
     LAST_REACTIONS_INDEX_TIME_KEY,
     LAST_SEEN_NEW_REACTION_TIME_KEY,
@@ -463,15 +467,11 @@ def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
     PrometheusMetric(
-        "health_check_block_difference_current",
-        "Difference between the latest block and the latest indexed block",
-        metric_type=PrometheusType.GAUGE,
+        PrometheusRegistry[PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT]
     ).save(health_results["block_difference"])
 
     PrometheusMetric(
-        "health_check_latest_indexed_block_num_current",
-        "Latest indexed block number",
-        metric_type=PrometheusType.GAUGE,
+        PrometheusRegistry[PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT]
     ).save(health_results["web"]["blocknumber"])
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -24,11 +24,7 @@ from src.utils import db_session, helpers, redis_connection, web3_provider
 from src.utils.config import shared_config
 from src.utils.elasticdsl import ES_INDEXES, esclient
 from src.utils.helpers import redis_get_or_restore, redis_set_and_dump
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 from src.utils.redis_constants import (
     LAST_REACTIONS_INDEX_TIME_KEY,
     LAST_SEEN_NEW_REACTION_TIME_KEY,
@@ -466,14 +462,12 @@ def get_elasticsearch_health_info(
 def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
-    PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT]
-    ).save(health_results["block_difference"])
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT).save(
+        health_results["block_difference"]
+    )
 
     PrometheusMetric(
-        PrometheusRegistry[
-            PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT
-        ]
+        PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT
     ).save(health_results["web"]["blocknumber"])
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -462,7 +462,7 @@ def get_elasticsearch_health_info(
 def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT).save(
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE).save(
         health_results["block_difference"]
     )
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -471,7 +471,9 @@ def health_check_prometheus_exporter():
     ).save(health_results["block_difference"])
 
     PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT]
+        PrometheusRegistry[
+            PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT
+        ]
     ).save(health_results["web"]["blocknumber"])
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -462,11 +462,11 @@ def get_elasticsearch_health_info(
 def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE).save(
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_LATEST).save(
         health_results["block_difference"]
     )
 
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM).save(
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_INDEXED_BLOCK_NUM_LATEST).save(
         health_results["web"]["blocknumber"]
     )
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -466,9 +466,9 @@ def health_check_prometheus_exporter():
         health_results["block_difference"]
     )
 
-    PrometheusMetric(
-        PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM
-    ).save(health_results["web"]["blocknumber"])
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM).save(
+        health_results["web"]["blocknumber"]
+    )
 
 
 PrometheusMetric.register_collector(

--- a/discovery-provider/src/tasks/aggregates/__init__.py
+++ b/discovery-provider/src/tasks/aggregates/__init__.py
@@ -75,7 +75,7 @@ def update_aggregate_table(
     current_checkpoint,
 ):
     metric = PrometheusMetric(
-        PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS
+        PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_DURATION_SECONDS
     )
 
     # get name of the caller function

--- a/discovery-provider/src/tasks/aggregates/__init__.py
+++ b/discovery-provider/src/tasks/aggregates/__init__.py
@@ -7,7 +7,11 @@ from redis import Redis
 from sqlalchemy import text
 from sqlalchemy.orm.session import Session
 from src.models.indexing.block import Block
-from src.utils.prometheus_metric import PrometheusMetric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.update_indexing_checkpoints import (
     get_last_indexed_checkpoint,
     save_indexed_checkpoint,
@@ -75,9 +79,7 @@ def update_aggregate_table(
     current_checkpoint,
 ):
     metric = PrometheusMetric(
-        "update_aggregate_table_latency_seconds",
-        "Runtimes for src.task.aggregates:update_aggregate_table()",
-        ("table_name", "task_name"),
+        PrometheusRegistry[PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS]
     )
 
     # get name of the caller function

--- a/discovery-provider/src/tasks/aggregates/__init__.py
+++ b/discovery-provider/src/tasks/aggregates/__init__.py
@@ -7,11 +7,7 @@ from redis import Redis
 from sqlalchemy import text
 from sqlalchemy.orm.session import Session
 from src.models.indexing.block import Block
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 from src.utils.update_indexing_checkpoints import (
     get_last_indexed_checkpoint,
     save_indexed_checkpoint,
@@ -79,7 +75,7 @@ def update_aggregate_table(
     current_checkpoint,
 ):
     metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS]
+        PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS
     )
 
     # get name of the caller function

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -53,7 +53,6 @@ from src.utils.indexing_errors import IndexingError
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
-    PrometheusRegistry,
     save_duration_metric,
 )
 from src.utils.redis_cache import (
@@ -566,9 +565,7 @@ def index_blocks(self, db, blocks_list):
     block_order_range = range(len(blocks_list) - 1, -1, -1)
     latest_block_timestamp = None
     changed_entity_ids_map = {}
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS)
     for i in block_order_range:
         start_time = time.time()
         metric.reset_timer()

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -50,7 +50,12 @@ from src.utils.index_blocks_performance import (
     sweep_old_index_blocks_ms,
 )
 from src.utils.indexing_errors import IndexingError
-from src.utils.prometheus_metric import PrometheusMetric, save_duration_metric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+    save_duration_metric,
+)
 from src.utils.redis_cache import (
     remove_cached_playlist_ids,
     remove_cached_track_ids,
@@ -562,9 +567,7 @@ def index_blocks(self, db, blocks_list):
     latest_block_timestamp = None
     changed_entity_ids_map = {}
     metric = PrometheusMetric(
-        "index_blocks_duration_seconds",
-        "Runtimes for src.task.index:index_blocks()",
-        ("scope",),
+        PrometheusRegistry[PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS]
     )
     for i in block_order_range:
         start_time = time.time()

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -15,7 +15,11 @@ from src.queries.update_historical_metrics import (
 from src.tasks.celery_app import celery
 from src.utils.get_all_other_nodes import get_all_other_nodes
 from src.utils.helpers import redis_get_or_restore, redis_set_and_dump
-from src.utils.prometheus_metric import PrometheusMetric, save_duration_metric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.redis_metrics import (
     METRICS_INTERVAL,
     datetime_format_secondary,
@@ -414,9 +418,7 @@ def update_metrics(self):
                 f"index_metrics.py | update_metrics | {self.request.id} | Acquired update_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_duration_seconds",
-                "Runtimes for src.task.index_metrics:celery.task()",
-                ("task_name",),
+                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
             )
             sweep_metrics(db, redis)
             refresh_metrics_matviews(db)
@@ -458,9 +460,7 @@ def aggregate_metrics(self):
                 f"index_metrics.py | aggregate_metrics | {self.request.id} | Acquired aggregate_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_duration_seconds",
-                "Runtimes for src.task.index_metrics:celery.task()",
-                ("task_name",),
+                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
             )
             consolidate_metrics_from_other_nodes(self, db, redis)
             metric.save_time({"task_name": "aggregate_metrics"})
@@ -503,9 +503,7 @@ def synchronize_metrics(self):
                 f"index_metrics.py | synchronize_metrics | {self.request.id} | Acquired synchronize_metrics_lock"
             )
             metric = PrometheusMetric(
-                "index_metrics_duration_seconds",
-                "Runtimes for src.task.index_metrics:celery.task()",
-                ("task_name",),
+                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
             )
             synchronize_all_node_metrics(self, db)
             metric.save_time({"task_name": "synchronize_metrics"})

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -19,6 +19,7 @@ from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
     PrometheusRegistry,
+    save_duration_metric,
 )
 from src.utils.redis_metrics import (
     METRICS_INTERVAL,

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -18,7 +18,6 @@ from src.utils.helpers import redis_get_or_restore, redis_set_and_dump
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
-    PrometheusRegistry,
     save_duration_metric,
 )
 from src.utils.redis_metrics import (
@@ -419,7 +418,7 @@ def update_metrics(self):
                 f"index_metrics.py | update_metrics | {self.request.id} | Acquired update_metrics_lock"
             )
             metric = PrometheusMetric(
-                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
+                PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS
             )
             sweep_metrics(db, redis)
             refresh_metrics_matviews(db)
@@ -461,7 +460,7 @@ def aggregate_metrics(self):
                 f"index_metrics.py | aggregate_metrics | {self.request.id} | Acquired aggregate_metrics_lock"
             )
             metric = PrometheusMetric(
-                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
+                PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS
             )
             consolidate_metrics_from_other_nodes(self, db, redis)
             metric.save_time({"task_name": "aggregate_metrics"})
@@ -504,7 +503,7 @@ def synchronize_metrics(self):
                 f"index_metrics.py | synchronize_metrics | {self.request.id} | Acquired synchronize_metrics_lock"
             )
             metric = PrometheusMetric(
-                PrometheusRegistry[PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS]
+                PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS
             )
             synchronize_all_node_metrics(self, db)
             metric.save_time({"task_name": "synchronize_metrics"})

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -20,7 +20,11 @@ from src.tasks.celery_app import celery
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.config import shared_config
-from src.utils.prometheus_metric import PrometheusMetric, save_duration_metric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.redis_cache import set_json_cached_key
 from src.utils.redis_constants import trending_tracks_last_completion_redis_key
 from src.utils.session_manager import SessionManager
@@ -105,9 +109,7 @@ TRENDING_PARAMS = "trending_params"
 def update_view(session: Session, mat_view_name: str):
     start_time = time.time()
     metric = PrometheusMetric(
-        "update_trending_view_duration_seconds",
-        "Runtimes for src.task.index_trending:update_view()",
-        ("mat_view_name",),
+        PrometheusRegistry[PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS]
     )
     session.execute(f"REFRESH MATERIALIZED VIEW {mat_view_name}")
     update_time = time.time() - start_time
@@ -126,8 +128,7 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
     logger.info("index_trending.py | starting indexing")
     update_start = time.time()
     metric = PrometheusMetric(
-        "index_trending_duration_seconds",
-        "Runtimes for src.task.index_trending:index_trending()",
+        PrometheusRegistry[PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS]
     )
     with db.scoped_session() as session:
         genres = get_genres(session)

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -24,6 +24,7 @@ from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
     PrometheusRegistry,
+    save_duration_metric,
 )
 from src.utils.redis_cache import set_json_cached_key
 from src.utils.redis_constants import trending_tracks_last_completion_redis_key

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -23,7 +23,6 @@ from src.utils.config import shared_config
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
-    PrometheusRegistry,
     save_duration_metric,
 )
 from src.utils.redis_cache import set_json_cached_key
@@ -110,7 +109,7 @@ TRENDING_PARAMS = "trending_params"
 def update_view(session: Session, mat_view_name: str):
     start_time = time.time()
     metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS]
+        PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS
     )
     session.execute(f"REFRESH MATERIALIZED VIEW {mat_view_name}")
     update_time = time.time() - start_time
@@ -128,9 +127,7 @@ def update_view(session: Session, mat_view_name: str):
 def index_trending(self, db: SessionManager, redis: Redis, timestamp):
     logger.info("index_trending.py | starting indexing")
     update_start = time.time()
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS)
     with db.scoped_session() as session:
         genres = get_genres(session)
 

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -18,7 +18,11 @@ from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.utils import helpers, multihash
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.prometheus_metric import PrometheusMetric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.track_event_constants import (
     track_event_types_arr,
     track_event_types_lookup,
@@ -41,9 +45,7 @@ def track_state_update(
     """Return tuple containing int representing number of Track model state changes found in transaction and set of processed track IDs."""
     begin_track_state_update = datetime.now()
     metric = PrometheusMetric(
-        "track_state_update_duration_seconds",
-        "Runtimes for src.task.tracks:track_state_update()",
-        ("scope",),
+        PrometheusRegistry[PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS]
     )
 
     blockhash = update_task.web3.toHex(block_hash)

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -18,11 +18,7 @@ from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.utils import helpers, multihash
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 from src.utils.track_event_constants import (
     track_event_types_arr,
     track_event_types_lookup,
@@ -44,9 +40,7 @@ def track_state_update(
 ) -> Tuple[int, Set]:
     """Return tuple containing int representing number of Track model state changes found in transaction and set of processed track IDs."""
     begin_track_state_update = datetime.now()
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS)
 
     blockhash = update_task.web3.toHex(block_hash)
     num_total_changes = 0

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -7,7 +7,12 @@ from src.models.indexing.ursm_content_node import URSMContentNode
 from src.models.tracks.track import Track
 from src.models.users.user import User
 from src.tasks.celery_app import celery
-from src.utils.prometheus_metric import PrometheusMetric, save_duration_metric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+    save_duration_metric,
+)
 from src.utils.redis_constants import (
     ALL_UNAVAILABLE_TRACKS_REDIS_KEY,
     UPDATE_TRACK_IS_AVAILABLE_FINISH_REDIS_KEY,
@@ -231,9 +236,9 @@ def update_track_is_available(self) -> None:
     have_lock = update_lock.acquire(blocking=False)
     if have_lock:
         metric = PrometheusMetric(
-            "update_track_is_available_duration_seconds",
-            "Runtimes for src.task.update_track_is_available:celery.task()",
-            ("task_name", "success"),
+            PrometheusRegistry[
+                PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS
+            ]
         )
         try:
             # TODO: we can deprecate this manual redis timestamp tracker once we confirm

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -10,7 +10,6 @@ from src.tasks.celery_app import celery
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
-    PrometheusRegistry,
     save_duration_metric,
 )
 from src.utils.redis_constants import (
@@ -236,9 +235,7 @@ def update_track_is_available(self) -> None:
     have_lock = update_lock.acquire(blocking=False)
     if have_lock:
         metric = PrometheusMetric(
-            PrometheusRegistry[
-                PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS
-            ]
+            PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS
         )
         try:
             # TODO: we can deprecate this manual redis timestamp tracker once we confirm

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -21,7 +21,11 @@ from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.utils import helpers
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.prometheus_metric import PrometheusMetric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.user_event_constants import user_event_types_arr, user_event_types_lookup
 
 logger = logging.getLogger(__name__)
@@ -41,9 +45,7 @@ def user_state_update(
     """Return tuple containing int representing number of User model state changes found in transaction and set of processed user IDs."""
     begin_user_state_update = datetime.now()
     metric = PrometheusMetric(
-        "user_state_update_duration_seconds",
-        "Runtimes for src.task.users:user_state_update()",
-        ("scope",),
+        PrometheusRegistry[PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS]
     )
 
     blockhash = update_task.web3.toHex(block_hash)
@@ -150,9 +152,7 @@ def process_user_txs_serial(
     skipped_tx_count,
 ):
     metric = PrometheusMetric(
-        "user_state_update_duration_seconds",
-        "Runtimes for src.task.users:user_state_update()",
-        ("scope",),
+        PrometheusRegistry[PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS]
     )
     processed_entries = 0
     for user_tx in user_txs:

--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -21,11 +21,7 @@ from src.tasks.ipld_blacklist import is_blacklisted_ipld
 from src.utils import helpers
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 from src.utils.user_event_constants import user_event_types_arr, user_event_types_lookup
 
 logger = logging.getLogger(__name__)
@@ -44,9 +40,7 @@ def user_state_update(
 ) -> Tuple[int, Set]:
     """Return tuple containing int representing number of User model state changes found in transaction and set of processed user IDs."""
     begin_user_state_update = datetime.now()
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS)
 
     blockhash = update_task.web3.toHex(block_hash)
     num_total_changes = 0
@@ -151,9 +145,7 @@ def process_user_txs_serial(
     user_ids,
     skipped_tx_count,
 ):
-    metric = PrometheusMetric(
-        PrometheusRegistry[PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS]
-    )
+    metric = PrometheusMetric(PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS)
     processed_entries = 0
     for user_tx in user_txs:
         try:

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -79,6 +79,7 @@ class PrometheusMetricNames:
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
+    TRACK_STATE_UPDATE_DURATION_SECONDS = "track_state_update_duration_seconds"
 
 
 PrometheusRegistry = {
@@ -136,6 +137,11 @@ PrometheusRegistry = {
     PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS}",
         "Runtimes for src.task.users:user_state_update()",
+        ("scope",),
+    ),
+    PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS}",
+        "Runtimes for src.task.tracks:track_state_update()",
         ("scope",),
     ),
 }

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -65,34 +65,31 @@ METRIC_PREFIX = "audius_dn"
 
 
 class PrometheusMetricNames:
-    FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
+    CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
     CELERY_TASK_COMPLETED_DURATION_SECONDS = "celery_task_completed_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
-    CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
+    FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
     HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT = "health_check_block_difference_current"
     HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT = (
         "health_check_latest_indexed_block_num_current"
     )
-    UPDATE_TRENDING_VIEW_DURATION_SECONDS = "update_trending_view_duration_seconds"
-    INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
-    INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
-    USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
-    TRACK_STATE_UPDATE_DURATION_SECONDS = "track_state_update_duration_seconds"
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
+    INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
+    INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
+    TRACK_STATE_UPDATE_DURATION_SECONDS = "track_state_update_duration_seconds"
+    UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS = "update_aggregate_table_latency_seconds"
     UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS = (
         "update_track_is_available_duration_seconds"
     )
-    UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS = "update_aggregate_table_latency_seconds"
+    UPDATE_TRENDING_VIEW_DURATION_SECONDS = "update_trending_view_duration_seconds"
+    USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
 
 
 PrometheusRegistry = {
-    PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS}",
-        "Runtimes for flask routes",
-        (
-            "route",
-            "code",
-        ),
+    PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",
+        "How long the currently running celery task has been running",
+        ("task_name",),
     ),
     PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS}",
@@ -110,10 +107,13 @@ PrometheusRegistry = {
             "success",
         ),
     ),
-    PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Gauge(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",
-        "How long the currently running celery task has been running",
-        ("task_name",),
+    PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS}",
+        "Runtimes for flask routes",
+        (
+            "route",
+            "code",
+        ),
     ),
     PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT}",
@@ -123,44 +123,44 @@ PrometheusRegistry = {
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT}",
         "Latest indexed block number",
     ),
-    PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS}",
-        "Runtimes for src.task.index_trending:update_view()",
-        ("mat_view_name",),
-    ),
-    PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS}",
-        "Runtimes for src.task.index_trending:index_trending()",
+    PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS}",
+        "Runtimes for src.task.index:index_blocks()",
+        ("scope",),
     ),
     PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS}",
         "Runtimes for src.task.index_metrics:celery.task()",
         ("task_name",),
     ),
-    PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS}",
-        "Runtimes for src.task.users:user_state_update()",
-        ("scope",),
+    PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS}",
+        "Runtimes for src.task.index_trending:index_trending()",
     ),
     PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS}",
         "Runtimes for src.task.tracks:track_state_update()",
         ("scope",),
     ),
-    PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS}",
-        "Runtimes for src.task.index:index_blocks()",
-        ("scope",),
+    PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS}",
+        "Runtimes for src.task.aggregates:update_aggregate_table()",
+        ("table_name", "task_name"),
     ),
     PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS}",
         "Runtimes for src.task.update_track_is_available:celery.task()",
         ("task_name", "success"),
     ),
-    PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS}",
-        "Runtimes for src.task.aggregates:update_aggregate_table()",
-        ("table_name", "task_name"),
+    PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS}",
+        "Runtimes for src.task.index_trending:update_view()",
+        ("mat_view_name",),
+    ),
+    PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS}",
+        "Runtimes for src.task.users:user_state_update()",
+        ("scope",),
     ),
 }
 

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -65,11 +65,6 @@ def save_duration_metric(metric_group):
     return decorator
 
 
-class PrometheusType:
-    HISTOGRAM = "histogram"
-    GAUGE = "gauge"
-
-
 METRIC_PREFIX = "audius_dn"
 
 
@@ -77,6 +72,13 @@ class PrometheusMetricNames:
     FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
     CELERY_TASK_COMPLETED_DURATION_SECONDS = "celery_task_completed_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
+    CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
+    HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT = "health_check_block_difference_current"
+    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT = "health_check_latest_indexed_block_num_current"
+    UPDATE_TRENDING_VIEW_DURATION_SECONDS = "update_trending_view_duration_seconds"
+    INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
+    INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
+    USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
 
 
 PrometheusRegistry = {
@@ -103,6 +105,38 @@ PrometheusRegistry = {
             "func_name",
             "success",
         ),
+    ),
+    PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",
+        "How long the currently running celery task has been running",
+        ("task_name",),
+    ),
+    PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT}",
+        "Difference between the latest block and the latest indexed block",
+    ),
+    PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT}",
+        "Latest indexed block number",
+    ),
+    PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS}",
+        "Runtimes for src.task.index_trending:update_view()",
+        ("mat_view_name",),
+    ),
+    PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_TRENDING_DURATION_SECONDS}",
+        "Runtimes for src.task.index_trending:index_trending()",
+    ),
+    PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS}",
+        "Runtimes for src.task.index_metrics:celery.task()",
+        ("task_name",),
+    ),
+    PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.USER_STATE_UPDATE_DURATION_SECONDS}",
+        "Runtimes for src.task.users:user_state_update()",
+        ("scope",),
     ),
 }
 

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -72,9 +72,7 @@ class PrometheusMetricNames:
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
     FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
     HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE = "health_check_latest_block_difference"
-    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM = (
-        "health_check_latest_indexed_block_num"
-    )
+    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM = "health_check_latest_indexed_block_num"
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -71,8 +71,8 @@ class PrometheusMetricNames:
     CELERY_TASK_DURATION_SECONDS = "celery_task_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
     FLASK_ROUTE_DURATION_SECONDS = "flask_route_duration_seconds"
-    HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE = "health_check_latest_block_difference"
-    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM = "health_check_latest_indexed_block_num"
+    HEALTH_CHECK_BLOCK_DIFFERENCE_LATEST = "health_check_block_difference_latest"
+    HEALTH_CHECK_INDEXED_BLOCK_NUM_LATEST = "health_check_indexed_block_num_latest"
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
@@ -115,12 +115,12 @@ PrometheusRegistry = {
             "route",
         ),
     ),
-    PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE: Gauge(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE}",
+    PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_LATEST: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_LATEST}",
         "Difference between the latest block and the latest indexed block",
     ),
-    PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM: Gauge(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM}",
+    PrometheusMetricNames.HEALTH_CHECK_INDEXED_BLOCK_NUM_LATEST: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_INDEXED_BLOCK_NUM_LATEST}",
         "Latest indexed block number",
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -70,7 +70,7 @@ class PrometheusMetricNames:
     CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
     CELERY_TASK_DURATION_SECONDS = "celery_task_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
-    FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
+    FLASK_ROUTE_DURATION_SECONDS = "flask_route_duration_seconds"
     HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE = "health_check_latest_block_difference"
     HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM = "health_check_latest_indexed_block_num"
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
@@ -107,8 +107,8 @@ PrometheusRegistry = {
             "success",
         ),
     ),
-    PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS}",
+    PrometheusMetricNames.FLASK_ROUTE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.FLASK_ROUTE_DURATION_SECONDS}",
         "Runtimes for flask routes",
         (
             "code",

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -77,7 +77,7 @@ class PrometheusMetricNames:
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
     TRACK_STATE_UPDATE_DURATION_SECONDS = "track_state_update_duration_seconds"
-    UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS = "update_aggregate_table_latency_seconds"
+    UPDATE_AGGREGATE_TABLE_DURATION_SECONDS = "update_aggregate_table_duration_seconds"
     UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS = (
         "update_track_is_available_duration_seconds"
     )
@@ -142,8 +142,8 @@ PrometheusRegistry = {
         "Runtimes for src.task.tracks:track_state_update()",
         ("scope",),
     ),
-    PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS}",
+    PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_DURATION_SECONDS}",
         "Runtimes for src.task.aggregates:update_aggregate_table()",
         (
             "table_name",

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -117,7 +117,7 @@ PrometheusRegistry = {
             "route",
         ),
     ),
-    PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT: Gauge(
+    PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE}",
         "Difference between the latest block and the latest indexed block",
     ),

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -17,15 +17,11 @@ def save_duration_metric(metric_group):
         @wraps(func)
         def wrapper(*args, **kwargs):
             histogram_metric = PrometheusMetric(
-                PrometheusRegistry[
-                    PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS
-                ]
+                PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS
             )
 
             gauge_metric = PrometheusMetric(
-                PrometheusRegistry[
-                    PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS
-                ]
+                PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS
             )
             try:
                 # safely return this result under all circumstances

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -67,6 +67,32 @@ METRIC_PREFIX = "audius_dn"
 
 
 class PrometheusMetricNames:
+    """
+    Attempt to group metrics with high_level prefixes like:
+    * `flask_`
+    * `celery_task_`
+
+    Antepenultimate Suffixes:
+    * `_active` when measuring runtimes of actively running processes that are yet to be
+      completed
+    * `_last` when the last completed runtime is needed (duration in seconds)
+    * (default: do not use) `_completed` is always implied if the other two are missing.
+      Used when measuring runtimes of completed processes.
+
+    Penultimate Suffixes:
+    * `_duration` when measuring task duration or runtimes
+
+    Ultimate Suffixes:
+    * `_seconds` always the base unit (never microseconds, milliseconds, etc)
+    * `_latest` when looking at a snapshot of unit-less data
+    * `_total`, when accumulating a count, in addition to the unit if applicable
+    * `_info` for a pseudo-metric that provides metadata about the running binary
+
+    See the following resources for related information:
+    * [Creator Node's docs](https://github.com/AudiusProject/audius-protocol/blob/master/creator-node/src/services/prometheusMonitoring/README.md)
+    * [Official docs](https://prometheus.io/docs/practices/naming)
+    """
+
     CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
     CELERY_TASK_DURATION_SECONDS = "celery_task_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -16,13 +16,15 @@ def save_duration_metric(metric_group):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            histogram_metric = PrometheusMetric(
-                PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS
-            )
-
-            gauge_metric = PrometheusMetric(
-                PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS
-            )
+            if metric_group == "celery_task":
+                histogram_metric = PrometheusMetric(
+                    PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS
+                )
+                gauge_metric = PrometheusMetric(
+                    PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS
+                )
+            else:
+                raise NameError(f"Metric Group '{metric_group}' not found.")
             try:
                 # safely return this result under all circumstances
                 result = func(*args, **kwargs)

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -172,7 +172,7 @@ class PrometheusMetric:
         self.reset_timer()
 
         if name not in PrometheusRegistry:
-            raise TypeError(f"Metric name '{name}' not found")
+            raise NameError(f"Metric name '{name}' not found")
         self.metric = PrometheusRegistry[name]
 
     def reset_timer(self):
@@ -191,9 +191,9 @@ class PrometheusMetric:
         if labels:
             this_metric = this_metric.labels(**labels)
 
-        if isinstance(self.metric, Histogram):
+        if isinstance(this_metric, Histogram):
             this_metric.observe(value)
-        elif isinstance(self.metric, Gauge):
+        elif isinstance(this_metric, Gauge):
             this_metric.set(value)
 
     @classmethod

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -74,7 +74,9 @@ class PrometheusMetricNames:
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
     CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
     HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT = "health_check_block_difference_current"
-    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT = "health_check_latest_indexed_block_num_current"
+    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT = (
+        "health_check_latest_indexed_block_num_current"
+    )
     UPDATE_TRENDING_VIEW_DURATION_SECONDS = "update_trending_view_duration_seconds"
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -82,11 +82,13 @@ class PrometheusMetricNames:
     Penultimate Suffixes:
     * `_duration` when measuring task duration or runtimes
 
-    Ultimate Suffixes:
+    Suffixes:
     * `_seconds` always the base unit (never microseconds, milliseconds, etc)
     * `_latest` when looking at a snapshot of unit-less data
-    * `_total`, when accumulating a count, in addition to the unit if applicable
     * `_info` for a pseudo-metric that provides metadata about the running binary
+
+    Ultimate Suffixes:
+    * `_total`, when accumulating a count, in addition to above suffixes if applicable
 
     See the following resources for related information:
     * [Creator Node's docs](https://github.com/AudiusProject/audius-protocol/blob/master/creator-node/src/services/prometheusMonitoring/README.md)

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -113,6 +113,34 @@ class PrometheusMetricNames:
     USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
 
 
+"""
+Metric Types:
+
+* Prometheus Gauges: Prometheus Gauges (not to be confused with the Grafana Panel Type
+  which is a UI element which looks like a speedometer) will export a single metric
+  which is useful for point-in-time collection.
+* Prometheus Histograms: Histograms are far more common, especially when timing how long
+  code runs, since a single metric endpoint will be exploded to create 11 additional
+  metrics (sum, count, and 9 statistical buckets).
+    * When looking at the raw /prometheus_metrics endpoint for
+      `audius_dn_update_aggregate_table_latency_seconds_bucket`, you can see how a
+      single metric explodes into multiple statistical helpers.
+
+Labels:
+
+Only use labels when labeling across **low-cardinality** of options.
+
+As a general guideline, try to keep the cardinality of your metrics below 10, and for
+metrics that exceed that, aim to limit them to a handful across your whole system.
+The vast majority of your metrics should have no labels.
+
+A few example labels:
+
+* `scope` is used when measuring a larger unit of work that may have subtasks we want to
+  measure runtimes for.
+    * `{scope=”full”}` is reserved for the larger base unit of work
+* `task_name` when similar CeleryTasks use the same helper code from different callers
+"""
 PrometheusRegistry = {
     PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -113,8 +113,8 @@ PrometheusRegistry = {
         f"{METRIC_PREFIX}_{PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS}",
         "Runtimes for flask routes",
         (
-            "route",
             "code",
+            "route",
         ),
     ),
     PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT: Gauge(
@@ -147,12 +147,18 @@ PrometheusRegistry = {
     PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS}",
         "Runtimes for src.task.aggregates:update_aggregate_table()",
-        ("table_name", "task_name"),
+        (
+            "table_name",
+            "task_name",
+        ),
     ),
     PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS}",
         "Runtimes for src.task.update_track_is_available:celery.task()",
-        ("task_name", "success"),
+        (
+            "success",
+            "task_name",
+        ),
     ),
     PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS}",

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -18,7 +18,7 @@ def save_duration_metric(metric_group):
         def wrapper(*args, **kwargs):
             if metric_group == "celery_task":
                 histogram_metric = PrometheusMetric(
-                    PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS
+                    PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS
                 )
                 gauge_metric = PrometheusMetric(
                     PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS
@@ -68,12 +68,12 @@ METRIC_PREFIX = "audius_dn"
 
 class PrometheusMetricNames:
     CELERY_TASK_ACTIVE_DURATION_SECONDS = "celery_task_active_duration_seconds"
-    CELERY_TASK_COMPLETED_DURATION_SECONDS = "celery_task_completed_duration_seconds"
+    CELERY_TASK_DURATION_SECONDS = "celery_task_duration_seconds"
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
     FLASK_ROUTE_LATENCY_SECONDS = "flask_route_latency_seconds"
-    HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT = "health_check_block_difference_current"
-    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT = (
-        "health_check_latest_indexed_block_num_current"
+    HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE = "health_check_latest_block_difference"
+    HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM = (
+        "health_check_latest_indexed_block_num"
     )
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
@@ -93,8 +93,8 @@ PrometheusRegistry = {
         "How long the currently running celery task has been running",
         ("task_name",),
     ),
-    PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS: Histogram(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_COMPLETED_DURATION_SECONDS}",
+    PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS}",
         "How long a celery_task took to complete",
         (
             "func_name",
@@ -118,11 +118,11 @@ PrometheusRegistry = {
         ),
     ),
     PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT: Gauge(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_CURRENT}",
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_BLOCK_DIFFERENCE}",
         "Difference between the latest block and the latest indexed block",
     ),
-    PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT: Gauge(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM_CURRENT}",
+    PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM: Gauge(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_LATEST_INDEXED_BLOCK_NUM}",
         "Latest indexed block number",
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -82,6 +82,11 @@ class PrometheusMetricNames:
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     USER_STATE_UPDATE_DURATION_SECONDS = "user_state_update_duration_seconds"
     TRACK_STATE_UPDATE_DURATION_SECONDS = "track_state_update_duration_seconds"
+    INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
+    UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS = (
+        "update_track_is_available_duration_seconds"
+    )
+    UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS = "update_aggregate_table_latency_seconds"
 
 
 PrometheusRegistry = {
@@ -145,6 +150,21 @@ PrometheusRegistry = {
         f"{METRIC_PREFIX}_{PrometheusMetricNames.TRACK_STATE_UPDATE_DURATION_SECONDS}",
         "Runtimes for src.task.tracks:track_state_update()",
         ("scope",),
+    ),
+    PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS}",
+        "Runtimes for src.task.index:index_blocks()",
+        ("scope",),
+    ),
+    PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS}",
+        "Runtimes for src.task.update_track_is_available:celery.task()",
+        ("task_name", "success"),
+    ),
+    PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS: Histogram(
+        f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_AGGREGATE_TABLE_LATENCY_SECONDS}",
+        "Runtimes for src.task.aggregates:update_aggregate_table()",
+        ("table_name", "task_name"),
     ),
 }
 

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -26,11 +26,7 @@ from src.models.metrics.aggregate_monthly_unique_users_metrics import (
 )
 from src.utils.config import shared_config
 from src.utils.helpers import get_ip, redis_get_or_restore, redis_set_and_dump
-from src.utils.prometheus_metric import (
-    PrometheusMetric,
-    PrometheusMetricNames,
-    PrometheusRegistry,
-)
+from src.utils.prometheus_metric import PrometheusMetric, PrometheusMetricNames
 from src.utils.query_params import app_name_param, stringify_query_params
 from werkzeug.wrappers.response import Response as wResponse
 
@@ -656,9 +652,7 @@ def record_metrics(func):
         except Exception as e:
             logger.error("Error while recording metrics: %s", e.message)
 
-        metric = PrometheusMetric(
-            PrometheusRegistry[PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS]
-        )
+        metric = PrometheusMetric(PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS)
 
         result = func(*args, **kwargs)
 

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -26,7 +26,11 @@ from src.models.metrics.aggregate_monthly_unique_users_metrics import (
 )
 from src.utils.config import shared_config
 from src.utils.helpers import get_ip, redis_get_or_restore, redis_set_and_dump
-from src.utils.prometheus_metric import PrometheusMetric
+from src.utils.prometheus_metric import (
+    PrometheusMetric,
+    PrometheusMetricNames,
+    PrometheusRegistry,
+)
 from src.utils.query_params import app_name_param, stringify_query_params
 from werkzeug.wrappers.response import Response as wResponse
 
@@ -653,12 +657,7 @@ def record_metrics(func):
             logger.error("Error while recording metrics: %s", e.message)
 
         metric = PrometheusMetric(
-            "flask_route_latency_seconds",
-            "Runtimes for flask routes",
-            (
-                "route",
-                "code",
-            ),
+            PrometheusRegistry[PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS]
         )
 
         result = func(*args, **kwargs)

--- a/discovery-provider/src/utils/redis_metrics.py
+++ b/discovery-provider/src/utils/redis_metrics.py
@@ -652,7 +652,7 @@ def record_metrics(func):
         except Exception as e:
             logger.error("Error while recording metrics: %s", e.message)
 
-        metric = PrometheusMetric(PrometheusMetricNames.FLASK_ROUTE_LATENCY_SECONDS)
+        metric = PrometheusMetric(PrometheusMetricNames.FLASK_ROUTE_DURATION_SECONDS)
 
         result = func(*args, **kwargs)
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -127,8 +127,8 @@ Try to keep the number of personal dashboards low to maintain navigability.
 
 Our dashboards use common set of Variables (Dashboard `Settings` -> `Variables`):
 
-* `env`: `label_values(audius_dn_flask_route_latency_seconds_count, environment)`
-* `host`: `label_values(audius_dn_flask_route_latency_seconds_count{environment=~"$env"}, host)`
+* `env`: `label_values(audius_dn_flask_route_duration_seconds_count, environment)`
+* `host`: `label_values(audius_dn_flask_route_duration_seconds_count{environment=~"$env"}, host)`
 
 To simplify the process of setting up dashboards each time, we can navigate to the `Audius - Boilerplate` dashboard's `Settings` -> `Save As...` dialog to copy the boilerplate.
 
@@ -176,7 +176,7 @@ Notice how we restrict the `environment` and `host` labels associated with the m
 
 A common pattern for histograms is to display the average latency of a recorded metric like the example below:
 
-> `max by (route) (rate(audius_dn_flask_route_latency_seconds_sum{environment=~"$env", host=~"$host"}[5m]) / rate(audius_dn_flask_route_latency_seconds_count{environment=~"$env", host=~"$host"}[5m]))`
+> `max by (route) (rate(audius_dn_flask_route_duration_seconds_sum{environment=~"$env", host=~"$host"}[5m]) / rate(audius_dn_flask_route_duration_seconds_count{environment=~"$env", host=~"$host"}[5m]))`
 
 The bulk of the query comes from official docs on [calculating averages from histograms](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations) while including PromQL filters for `environment` and `host`.
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -159,7 +159,7 @@ When additional complexity is required, visit the [official Prometheus documenta
 
 Gauges are the easiest pattern since they simply display the value of a metric that was displayed at scrape time:
 
-> `audius_dn_health_check_latest_block_difference{environment=~"$env", host=~"$host"}`
+> `audius_dn_health_check_block_difference_latest{environment=~"$env", host=~"$host"}`
 
 Notice how we restrict the `environment` and `host` labels associated with the metric to match the Dashboard Variables discussed in the previous section.
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -159,7 +159,7 @@ When additional complexity is required, visit the [official Prometheus documenta
 
 Gauges are the easiest pattern since they simply display the value of a metric that was displayed at scrape time:
 
-> `audius_dn_health_check_block_difference_current{environment=~"$env", host=~"$host"}`
+> `audius_dn_health_check_latest_block_difference{environment=~"$env", host=~"$host"}`
 
 Notice how we restrict the `environment` and `host` labels associated with the metric to match the Dashboard Variables discussed in the previous section.
 

--- a/monitoring/grafana/dashboards/audius-boilerplate.json
+++ b/monitoring/grafana/dashboards/audius-boilerplate.json
@@ -40,7 +40,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -49,7 +49,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -63,7 +63,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -72,7 +72,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
@@ -408,7 +408,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -419,7 +419,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -430,7 +430,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -441,7 +441,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -452,7 +452,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,
@@ -563,7 +563,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -574,7 +574,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -585,7 +585,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -596,7 +596,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -607,7 +607,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,
@@ -693,7 +693,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -704,7 +704,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -715,7 +715,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -726,7 +726,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -737,7 +737,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_eth\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
@@ -202,7 +202,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"}",
+            "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
             "legendFormat": "{{host}}",
             "range": true,
             "refId": "A"
@@ -263,7 +263,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "max(audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "max(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
             "legendFormat": "Max",
             "range": true,
             "refId": "A"
@@ -273,7 +273,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "avg(audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "avg(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
             "hide": false,
             "legendFormat": "Average",
             "range": true,
@@ -284,7 +284,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "min(audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "min(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
             "hide": false,
             "legendFormat": "Min",
             "range": true,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
@@ -202,7 +202,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
+            "expr": "audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"}",
             "legendFormat": "{{host}}",
             "range": true,
             "refId": "A"
@@ -263,7 +263,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "max(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "max(audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"})",
             "legendFormat": "Max",
             "range": true,
             "refId": "A"
@@ -273,7 +273,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "avg(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "avg(audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"})",
             "hide": false,
             "legendFormat": "Average",
             "range": true,
@@ -284,7 +284,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "min(audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"})",
+            "expr": "min(audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"})",
             "hide": false,
             "legendFormat": "Min",
             "range": true,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-blockchain-indexing.json
@@ -760,7 +760,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -769,7 +769,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -784,7 +784,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -793,7 +793,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-celery-task-details.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-celery-task-details.json
@@ -189,7 +189,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -198,7 +198,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -213,7 +213,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -222,7 +222,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-celery-task-details.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-celery-task-details.json
@@ -122,7 +122,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -133,7 +133,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -144,7 +144,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -155,7 +155,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -166,7 +166,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\", func_name=\"$task_name\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,
@@ -237,7 +237,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_celery_task_completed_duration_seconds_bucket, func_name)",
+          "definition": "label_values(audius_dn_celery_task_duration_seconds_bucket, func_name)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -246,7 +246,7 @@
           "name": "task_name",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_celery_task_completed_duration_seconds_bucket, func_name)",
+            "query": "label_values(audius_dn_celery_task_duration_seconds_bucket, func_name)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-celery-tasks.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-celery-tasks.json
@@ -906,7 +906,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -915,7 +915,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -930,7 +930,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -939,7 +939,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
@@ -344,7 +344,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "sum(rate(audius_dn_flask_route_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])) / sum(rate(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
+            "expr": "sum(rate(audius_dn_flask_route_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])) / sum(rate(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
             "legendFormat": "average",
             "range": true,
             "refId": "A"
@@ -354,7 +354,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "max by (route) (rate(audius_dn_flask_route_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
+            "expr": "max by (route) (rate(audius_dn_flask_route_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
             "hide": false,
             "legendFormat": "{{route}}",
             "range": true,
@@ -416,7 +416,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "sum(rate(audius_dn_flask_route_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])) / sum(rate(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
+            "expr": "sum(rate(audius_dn_flask_route_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])) / sum(rate(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
             "legendFormat": "average",
             "range": true,
             "refId": "A"
@@ -521,7 +521,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "(sum by (code) (rate(audius_dn_flask_route_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])))",
+            "expr": "(sum by (code) (rate(audius_dn_flask_route_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m])))",
             "hide": false,
             "legendFormat": "__auto",
             "range": true,
@@ -1061,7 +1061,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -1070,7 +1070,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -1085,7 +1085,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -1094,7 +1094,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
@@ -729,7 +729,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
+            "expr": "audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"}",
             "legendFormat": "{{host}}",
             "range": true,
             "refId": "A"

--- a/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
@@ -729,7 +729,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"}",
+            "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
             "legendFormat": "{{host}}",
             "range": true,
             "refId": "A"

--- a/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
+++ b/monitoring/grafana/dashboards/audius-discovery-provider-overview.json
@@ -839,7 +839,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -850,7 +850,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -861,7 +861,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -872,7 +872,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -883,7 +883,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"update_task\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,
@@ -994,7 +994,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.5, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p50",
             "range": true,
@@ -1005,7 +1005,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.90, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p90",
             "range": true,
@@ -1016,7 +1016,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p95",
             "range": true,
@@ -1027,7 +1027,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p99",
             "range": true,
@@ -1038,7 +1038,7 @@
               "type": "prometheus"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_completed_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.999, sum(rate(audius_dn_celery_task_duration_seconds_bucket{environment=~\"$env\", host=~\"$host\",func_name=\"index_solana_plays\"}[5m])) by (le))",
             "hide": false,
             "legendFormat": "p999",
             "range": true,

--- a/monitoring/grafana/dashboards/audius-network-monitoring.json
+++ b/monitoring/grafana/dashboards/audius-network-monitoring.json
@@ -918,7 +918,7 @@
       "list": [
         {
           "allValue": ".*",
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "hide": 0,
           "includeAll": true,
           "label": "Environment",
@@ -926,7 +926,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/dheeraj-content-node-dashboard-test.json
+++ b/monitoring/grafana/dashboards/dheeraj-content-node-dashboard-test.json
@@ -344,7 +344,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -353,7 +353,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/joaquin-network-monitoring-v2.json
+++ b/monitoring/grafana/dashboards/joaquin-network-monitoring-v2.json
@@ -401,7 +401,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -410,7 +410,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "r2_nnDL7z"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -434,7 +434,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/joaquin-playground.json
+++ b/monitoring/grafana/dashboards/joaquin-playground.json
@@ -1002,7 +1002,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "audius_dn_update_aggregate_table_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}",
+                "expr": "audius_dn_update_aggregate_table_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -1094,7 +1094,7 @@
             "pluginVersion": "8.4.1",
             "targets": [
               {
-                "expr": "rate(audius_dn_update_aggregate_table_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_update_aggregate_table_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m])",
+                "expr": "rate(audius_dn_update_aggregate_table_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_update_aggregate_table_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{table_name}}",

--- a/monitoring/grafana/dashboards/joaquin-playground.json
+++ b/monitoring/grafana/dashboards/joaquin-playground.json
@@ -318,7 +318,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
+                "expr": "audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"}",
                 "interval": "",
                 "legendFormat": "{{host}}",
                 "refId": "A"
@@ -409,7 +409,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
+                "expr": "audius_dn_health_check_block_difference_latest{environment=~\"$env\", host=~\"$host\"}",
                 "interval": "",
                 "legendFormat": "{{host}}",
                 "refId": "A"

--- a/monitoring/grafana/dashboards/joaquin-playground.json
+++ b/monitoring/grafana/dashboards/joaquin-playground.json
@@ -409,7 +409,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "audius_dn_health_check_latest_indexed_block_num_current{environment=~\"$env\", host=~\"$host\"}",
+                "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
                 "interval": "",
                 "legendFormat": "{{host}}",
                 "refId": "A"

--- a/monitoring/grafana/dashboards/joaquin-playground.json
+++ b/monitoring/grafana/dashboards/joaquin-playground.json
@@ -708,7 +708,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "max by (route) (rate(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
+                "expr": "max by (route) (rate(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
                 "interval": "",
                 "legendFormat": "{{host}}{{route}}",
                 "refId": "A"
@@ -801,7 +801,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "max by (route) (rate(audius_dn_flask_route_latency_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
+                "expr": "max by (route) (rate(audius_dn_flask_route_duration_seconds_sum{environment=~\"$env\", host=~\"$host\"}[5m]) / rate(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\", host=~\"$host\"}[5m]))",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -895,7 +895,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "max by (host, route, code) (rate(audius_dn_flask_route_latency_seconds_count{code!=\"200\", code!=\"\", environment=~\"$env\", host=~\"$host\"}[5m]))",
+                "expr": "max by (host, route, code) (rate(audius_dn_flask_route_duration_seconds_count{code!=\"200\", code!=\"\", environment=~\"$env\", host=~\"$host\"}[5m]))",
                 "interval": "",
                 "legendFormat": "{{host}}{{route}} ({{code}})",
                 "refId": "A"
@@ -2150,7 +2150,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -2159,7 +2159,7 @@
           "name": "env",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count, environment)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count, environment)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,
@@ -2173,7 +2173,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "definition": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+          "definition": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
           "description": "",
           "hide": 0,
           "includeAll": true,
@@ -2182,7 +2182,7 @@
           "name": "host",
           "options": [],
           "query": {
-            "query": "label_values(audius_dn_flask_route_latency_seconds_count{environment=~\"$env\"}, host)",
+            "query": "label_values(audius_dn_flask_route_duration_seconds_count{environment=~\"$env\"}, host)",
             "refId": "StandardVariableQuery"
           },
           "refresh": 1,

--- a/monitoring/grafana/dashboards/joaquin-playground.json
+++ b/monitoring/grafana/dashboards/joaquin-playground.json
@@ -318,7 +318,7 @@
                   "type": "prometheus"
                 },
                 "exemplar": true,
-                "expr": "audius_dn_health_check_block_difference_current{environment=~\"$env\", host=~\"$host\"}",
+                "expr": "audius_dn_health_check_latest_block_difference{environment=~\"$env\", host=~\"$host\"}",
                 "interval": "",
                 "legendFormat": "{{host}}",
                 "refId": "A"


### PR DESCRIPTION
### Description

* Consolidate where metrics are created/defined.
* Change pattern to this: 328e8c3ca5c3cb35741a77f6fbff535d19518b08.
* Follow standardized naming scheme.
* Update related dashboards with new metric names.

Release checklist:

- [ ] Deploy new dashboards

### Tests

Ensure existing dashboards continue to populate with new data.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

#eng-infrastructure