### PR TITLE
Remove retrieve peers from db

### DIFF
--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -1,6 +1,5 @@
 import logging
 
-from src.models.users.user import User
 from src.tasks.celery_app import celery
 from src.utils.eth_contracts_helpers import fetch_all_registered_content_nodes
 from src.utils.prometheus_metric import save_duration_metric


### PR DESCRIPTION
### Description
Remove query to retrieve peers from db as it's not needed because we do not rely on ipfs anymore
Notes: on prod dn2 it's the 5th most expensive query over the last week and 3rd most on dn3 when viewing load by time 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->