### PR TITLE
Make `verifyToken` endpoint expect either hashid or int user id (eventually just hashid)

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -1425,7 +1425,10 @@ class GetTokenVerification(Resource):
             ns.abort(400, "JWT payload could not be decoded.")
 
         wallet_user_id = get_user_with_wallet(wallet)
-        if not wallet_user_id or (wallet_user_id != payload["userId"] and wallet_user_id != decode_string_id(payload["userId"])):
+        if not wallet_user_id or (
+            wallet_user_id != payload["userId"]
+            and wallet_user_id != decode_string_id(payload["userId"])
+        ):
             ns.abort(
                 404,
                 "The JWT signature is invalid - the wallet does not match the user.",

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -76,7 +76,7 @@ from src.utils import web3_provider
 from src.utils.auth_middleware import auth_middleware
 from src.utils.config import shared_config
 from src.utils.db_session import get_db_read_replica
-from src.utils.helpers import encode_int_id
+from src.utils.helpers import decode_string_id, encode_int_id
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
@@ -1425,7 +1425,7 @@ class GetTokenVerification(Resource):
             ns.abort(400, "JWT payload could not be decoded.")
 
         wallet_user_id = get_user_with_wallet(wallet)
-        if not wallet_user_id or wallet_user_id != payload["userId"]:
+        if not wallet_user_id or (wallet_user_id != payload["userId"] and wallet_user_id != decode_string_id(payload["userId"])):
             ns.abort(
                 404,
                 "The JWT signature is invalid - the wallet does not match the user.",

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -45,7 +45,7 @@ export type DiscoveryProviderConfig = {
 }
 
 export type UserProfile = {
-  userId: number
+  userId: string
   email: string
   name: string
   handle: string


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Have verifyToken endpoint expect either hashid or integer user id. This is in anticipation of [this PR](https://github.com/AudiusProject/audius-client/pull/1557) on the client side being released. After both PRs are released, we should change this to just expect hashid user ids.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->