### PR TITLE
[CON-234] Enable write quorum

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -497,13 +497,13 @@ const config = convict({
     default: 5000 // 5000ms = 5s (prod default)
   },
   enforceWriteQuorum: {
-    doc: 'Boolean flag indicating whether or not primary should reject write on 2/3 replication across replica set',
+    doc: 'Boolean flag indicating whether or not primary should reject write until 2/3 replication across replica set',
     format: Boolean,
     env: 'enforceWriteQuorum',
-    default: false
+    default: true
   },
   manualSyncsDisabled: {
-    doc: 'Disables issuing of manual syncs in order to test SnapbackSM Recurring Sync logic.',
+    doc: 'Disables issuing of manual syncs in order to test state machine Recurring Sync logic.',
     format: 'BooleanCustom',
     env: 'manualSyncsDisabled',
     default: false

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -77,8 +77,8 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db: ${e}`)
       }
 
-      // This call is not await-ed to avoid delaying or erroring
-      issueAndWaitForSecondarySyncRequests(req)
+      // Await 2/3 write quorum (replicating data to at least 1 secondary)
+      await issueAndWaitForSecondarySyncRequests(req)
 
       return successResponse({
         metadataMultihash: multihash,
@@ -176,7 +176,8 @@ module.exports = function (app) {
 
         await transaction.commit()
 
-        await issueAndWaitForSecondarySyncRequests(req)
+        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+        issueAndWaitForSecondarySyncRequests(req, true)
 
         return successResponse()
       } catch (e) {

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -741,8 +741,8 @@ module.exports = function (app) {
         return errorResponseServerError(e)
       }
 
-      // Must be awaitted and cannot be try-catched, ensuring that error from inside this rejects request
-      await issueAndWaitForSecondarySyncRequests(req)
+      // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+      issueAndWaitForSecondarySyncRequests(req, true)
 
       return successResponse({ dirCID })
     })

--- a/creator-node/src/routes/playlists.js
+++ b/creator-node/src/routes/playlists.js
@@ -78,8 +78,8 @@ module.exports = function (app) {
         )
       }
 
-      // This call is not await-ed to avoid delaying or erroring
-      issueAndWaitForSecondarySyncRequests(req)
+      // Await 2/3 write quorum (replicating data to at least 1 secondary)
+      await issueAndWaitForSecondarySyncRequests(req)
 
       return successResponse({
         metadataMultihash: multihash,
@@ -171,7 +171,8 @@ module.exports = function (app) {
 
         await transaction.commit()
 
-        await issueAndWaitForSecondarySyncRequests(req)
+        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+        issueAndWaitForSecondarySyncRequests(req, true)
 
         return successResponse()
       } catch (e) {

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -297,8 +297,8 @@ module.exports = function (app) {
         return errorResponseServerError(`Could not save to db db: ${e}`)
       }
 
-      // This call is not await-ed to avoid delaying or erroring
-      issueAndWaitForSecondarySyncRequests(req)
+      // Await 2/3 write quorum (replicating data to at least 1 secondary)
+      await issueAndWaitForSecondarySyncRequests(req)
 
       return successResponse({
         metadataMultihash: multihash,
@@ -576,7 +576,8 @@ module.exports = function (app) {
 
         await transaction.commit()
 
-        await issueAndWaitForSecondarySyncRequests(req)
+        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+        issueAndWaitForSecondarySyncRequests(req, true)
 
         metricEndTimerFn({ code: 200 })
         return successResponse()

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -71,7 +71,7 @@ const MetricLabels = Object.freeze({
     reconfigType: [
       'one_secondary', // Only one secondary was replaced in the user's replica set
       'multiple_secondaries', // Both secondaries were replaced in the user's replica set
-      'primary_and_or_secondaries', // A secondary gets promoted to new primary and one or both secondaries get replaced with new random nodes,
+      'primary_and_or_secondaries', // A secondary gets promoted to new primary and one or both secondaries get replaced with new random nodes
       'null' // No change was made to the user's replica set because the job short-circuited before selecting or was unable to select new node(s)
     ]
   },


### PR DESCRIPTION
### Description

- Change `enforceWriteQuorum` env var default from false to true
- Make file consumers of the issueAndWaitForSecondarySyncRequests not await it because discovery only indexes metadata, so write quorum isn't needed on files
  - This applies to the routes: `/image_upload`, `/audius_users`, `/playlists`, `/tracks`
  - TODO: Can we confirm that data from these routes being unreplicated won't block indexing on discovery? Some of them were previously awaited but it seemed unnecessary since they didn't have metadata (but they do update the DB)
- Make metadata consumers of the issueAndWaitForSecondarySyncRequests middleware await it so that the middleware can actually block the request from succeeding until a 2/3 write quorum is reached
  - This makes writes await replication in all scenarios, but the write can still succeed if replication fails and write quorum is disabled
  - This applies to the routes: `/audius_users/metadata`, `/playlists/metadata`, `/tracks/metadata`
- Change order of precedence for enforcing client header vs server env var:
  - If client passes `Enforce-Write-Quorum` header as `false`, disable write quorum regardless of the `enforceWriteQuorum` env var
  - If client passes `Enforce-Write-Quorum` header as `true`, enable write quorum regardless of the `enforceWriteQuorum` env var
  - If client doesn't pass `Enforce-Write-Quorum` header, write quorum = `enforceWriteQuorum` env var



### Tests
Before each test: disable snapback (set disableSnapback env var to true) and refactored state monitoring (set stateMonitoringQueueRateLimitJobsPerInterval env var to 0) so that we can test only seeing manual syncs and not recurring
1. Default happy path with enforceWriteQuorum=false (now changed to default=true), default processSync behavior:
    * POST request to /audius_users/metadata when uploading track shows Enforce-Write-Quorum=undefined (still enqueued+awaited manual sync just didn't enforce failing the POST request if the sync failed)
    * Successfully logged completion before returning 200:
      * `issueAndWaitForSecondarySyncRequests - At least one secondary successfully replicated content for user 0xd7903b72f7e92f68ab14e61ef65689a201c4d741 in 534ms","time":"2022-07-08T00:20:17.617Z"
"requestMethod":"POST","requestHostname":"cn4_creator-node_1","requestUrl":"/audius_users/metadata","requestWallet":"0xd7903b72f7e92f68ab14e61ef65689a201c4d741","requestBlockchainUserId":"2","duration":627,"statusCode":200`
2. Expected failure case – enforceWriteQuorum=true, processSync temporarily changed to always throw:
    * Progress bar looks super glitchy – it bounced back and forth
    * Primary eventually returned 500 for the metadata POST request with the expected error:
      * `Error processing request: Error: issueAndWaitForSecondarySyncRequests Error - Failed to reach 2/3 write quorum for user`
      * This caused the UI to show the heavy load error. **TODO: Is this what we want? Should we try to issue a reconfig so they can write to a different RS?**
3. TODO: Enforce-Write-Quorum header = true, enforceWriteQuorum=false: should make the header take precedence (await and throw if 2/3 quorum isn't reached)
4. TODO: Enforce-Write-Quorum header = false, enforceWriteQuorum=true: should make the header take precedence (await but don't throw if 2/3 quorum isn't reached)
5. TODO: manualSyncsDisabled=true: should throw instead of return if enforceWriteQuorum=true
6. TODO: Missing req.session or req.session.wallet should throw instead of return if enforceWriteQuorum=true
7. TODO: Node is not primary or invalid creatorNodeEndpoints should throw instead of return if enforceWriteQuorum=true



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
TODO: Search for success/failure logs and possibly add a metric