### PR TITLE
INF Cleanup unused label

### DIFF
--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -252,11 +252,11 @@ def update_track_is_available(self) -> None:
             update_tracks_is_available_status(db, redis)
 
             metric.save_time(
-                {"task_name": "update_track_is_available", "success": "true"}
+                {"success": "true"}
             )
         except Exception as e:
             metric.save_time(
-                {"task_name": "update_track_is_available", "success": "false"}
+                {"success": "false"}
             )
             logger.error(
                 "update_track_is_available.py | Fatal error in main loop", exc_info=True

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -251,13 +251,9 @@ def update_track_is_available(self) -> None:
 
             update_tracks_is_available_status(db, redis)
 
-            metric.save_time(
-                {"success": "true"}
-            )
+            metric.save_time({"success": "true"})
         except Exception as e:
-            metric.save_time(
-                {"success": "false"}
-            )
+            metric.save_time({"success": "false"})
             logger.error(
                 "update_track_is_available.py | Fatal error in main loop", exc_info=True
             )

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -209,9 +209,7 @@ PrometheusRegistry = {
     PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRACK_IS_AVAILABLE_DURATION_SECONDS}",
         "Runtimes for src.task.update_track_is_available:celery.task()",
-        (
-            "success",
-        ),
+        ("success",),
     ),
     PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS}",

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -211,7 +211,6 @@ PrometheusRegistry = {
         "Runtimes for src.task.update_track_is_available:celery.task()",
         (
             "success",
-            "task_name",
         ),
     ),
     PrometheusMetricNames.UPDATE_TRENDING_VIEW_DURATION_SECONDS: Histogram(


### PR DESCRIPTION
### Description

Remove unused label that is consuming unneeded space/load on Prometheus.

However, once we have a use case for different labels, we can revisit this metric and add these labels back in.


### Tests

Run locally and confirmed that `update_track_is_available_duration_seconds` metrics are still being produced.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

#eng-infrastructure for any issues.