### PR TITLE
Lower cache size to 4gb

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -20,7 +20,7 @@ http {
     # manager, regardless whether or not it has expired.
     # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
     proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
-					max_size=10g inactive=12h use_temp_path=off;
+					max_size=4g inactive=12h use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
     server {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Lower the cache max size from 10g -> 4gb since the min requirement for sps is 16gb

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
No new tests as this is just reducing the size of the cache

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Check nginx access and error logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->