### PR TITLE
Added xmlhttprequest to internal browser bundle

### DIFF
--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -49,7 +49,8 @@ const browserInternal = [
   'graceful-fs',
   'node-localstorage',
   'abi-decoder',
-  'web3'
+  'web3',
+  'xmlhttprequest'
 ]
 
 const browserConfig = {


### PR DESCRIPTION
### Description
Ran into a build issue in a project using the SDK:
```
Module not found: Error: Can't resolve 'url' in '/Users/Reed/audius/faucet/node_modules/xmlhttprequest/lib'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }
```
which was resolved by adding xmlhttprequest to the SDK's internal bundle so that it would be polyfilled. Webpack 5 removed node.js polyfills.

### Tests
npm linked local libs to the project that was importing @audius/sdk which fixed the build.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
