### PR TITLE
Add content verification + retries for metadata writes

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -45,9 +45,7 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
     const fileIsEmpty = fileSize === 0
     // there is one case where an empty file could be valid, check for that CID explicitly
     if (fileIsEmpty && cid !== EMPTY_FILE_CID) {
-      throw new Error(
-        `File has no content, content length is 0: ${cid}`
-      )
+      throw new Error(`File has no content, content length is 0: ${cid}`)
     }
 
     const expectedCid = await LibsUtils.fileHasher.generateNonImageCid(
@@ -63,11 +61,7 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
   } catch (e) {
     await removeFile(dstPath)
     if (numRetries > 0) {
-      return saveFileFromBufferToDisk(
-        req,
-        buffer,
-        numRetries - 1
-      )
+      return saveFileFromBufferToDisk(req, buffer, numRetries - 1)
     }
     throw new Error(
       `saveFileFromBufferToDisk - Error during content verification for cid ${cid} ${e.message}`

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -55,7 +55,7 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
     if (cid !== expectedCID) {
       // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
       throw new Error(
-        `File contents don't their expected CID. CID: ${cid} expected CID: ${expectedCID}`
+        `File contents don't match their expected CID. CID: ${cid} expected CID: ${expectedCID}`
       )
     }
   } catch (e) {
@@ -387,7 +387,7 @@ async function saveFileForMultihashToFS(
         })
         // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
         throw new Error(
-          `File contents don't their expected CID. CID: ${multihash} expected CID: ${expectedCid}`
+          `File contents don't match their expected CID. CID: ${multihash} expected CID: ${expectedCid}`
         )
       }
       decisionTree.push({

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -48,14 +48,14 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
       throw new Error(`File has no content, content length is 0: ${cid}`)
     }
 
-    const expectedCid = await LibsUtils.fileHasher.generateNonImageCid(
+    const expectedCID = await LibsUtils.fileHasher.generateNonImageCid(
       dstPath,
       genericLogger.child(req.logContext)
     )
-    if (cid !== expectedCid) {
+    if (cid !== expectedCID) {
       // delete this file because the next time we run sync and we see it on disk, we'll assume we have it and it's correct
       throw new Error(
-        `File contents don't their expected CID. CID: ${cid} expected CID: ${expectedCid}`
+        `File contents don't their expected CID. CID: ${cid} expected CID: ${expectedCID}`
       )
     }
   } catch (e) {
@@ -64,7 +64,7 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
       return saveFileFromBufferToDisk(req, buffer, numRetries - 1)
     }
     throw new Error(
-      `saveFileFromBufferToDisk - Error during content verification for cid ${cid} ${e.message}`
+      `saveFileFromBufferToDisk - Error during content verification for multihash ${cid} ${e.message}`
     )
   }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
When writing files to disk from metadata uploads, we never validate the contents of the file. This adds content verification + retries similar to how the saveFileForMultihashToFS does.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested by running A seed create-user and making sure the metadata object is stored on disk and stored via the /ipfs route. Also forced the retry logic by forcing failure inside the try clause if numRetries > 3 to make sure it correctly retries and eventually succeeds correctly. 


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
We can search the logs for "Error during content verification for multihash". Note, this log is the same as the saveFileForMultihashToFS error log since they represent the same underlying issue.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->