### PR TITLE
[PAY-414] Fix unsending reactions

### DIFF
--- a/identity-service/src/notifications/processNotifications/reactionNotification.js
+++ b/identity-service/src/notifications/processNotifications/reactionNotification.js
@@ -24,14 +24,19 @@ async function processReactionNotifications (notifications, tx) {
     })
 
     // In the case that the notification already exists, avoid returning it to prevent
-    // sending it a second time. Just update the original reaction value.
+    // sending it a second time. Just update or delete the original reaction value.
     if (existingNotification) {
-      // Have to recreate the metadata object for save to work properly
-      existingNotification.metadata = {
-        ...existingNotification.metadata,
-        reactionValue
+      if (parseInt(reactionValue) === 0) {
+        // Destroy reaction if undoing reaction value
+        await existingNotification.destroy({ transaction: tx })
+      } else {
+        // Have to recreate the metadata object for save to work properly
+        existingNotification.metadata = {
+          ...existingNotification.metadata,
+          reactionValue
+        }
+        await existingNotification.save({ transaction: tx })
       }
-      await existingNotification.save({ transaction: tx })
     } else {
       notifsToReturn.push(notification)
       await models.SolanaNotification.create({

--- a/identity-service/src/routes/reactions.js
+++ b/identity-service/src/routes/reactions.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
     if (!senderWallet || !reactedTo || reactionValue === undefined) return errorResponseBadRequest(`Missing argument: ${JSON.stringify({ senderWallet, reactedTo, reactionValue })}`)
 
     const parsedReaction = parseInt(reactionValue)
-    if (parsedReaction === NaN) return errorResponseBadRequest('Invalid reaction type')
+    if (isNaN(parsedReaction)) return errorResponseBadRequest('Invalid reaction type')
 
     const libs = req.app.get('audiusLibs')
 

--- a/identity-service/src/routes/reactions.js
+++ b/identity-service/src/routes/reactions.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
     if (!senderWallet || !reactedTo || reactionValue === undefined) return errorResponseBadRequest(`Missing argument: ${JSON.stringify({ senderWallet, reactedTo, reactionValue })}`)
 
     const parsedReaction = parseInt(reactionValue)
-    if (!parsedReaction) return errorResponseBadRequest('Invalid reaction type')
+    if (parsedReaction === undefined) return errorResponseBadRequest('Invalid reaction type')
 
     const libs = req.app.get('audiusLibs')
 

--- a/identity-service/src/routes/reactions.js
+++ b/identity-service/src/routes/reactions.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
     if (!senderWallet || !reactedTo || reactionValue === undefined) return errorResponseBadRequest(`Missing argument: ${JSON.stringify({ senderWallet, reactedTo, reactionValue })}`)
 
     const parsedReaction = parseInt(reactionValue)
-    if (parsedReaction === undefined) return errorResponseBadRequest('Invalid reaction type')
+    if (parsedReaction === NaN) return errorResponseBadRequest('Invalid reaction type')
 
     const libs = req.app.get('audiusLibs')
 


### PR DESCRIPTION
### Description

- Fixes an error with parseInt
- Properly deletes Reaction notifications if a reaction is unsent

**Note** this also requires a small client change to complete the issue - currently waiting for better WIFI before putting up a PR.

### Tests

Tested on staging.
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->