### PR TITLE
Fix redis expiry test inconsistency

### DIFF
--- a/creator-node/test/redis.test.js
+++ b/creator-node/test/redis.test.js
@@ -74,9 +74,9 @@ describe('test Redis client', function () {
 
     assert.equal(await WalletWriteLock.syncIsInProgress(wallet), true)
 
-    // Confirm lock auto-expired after expected expiration time
+    // Confirm lock auto-expired after expected expiration time (plus a small buffer)
     
-    await utils.timeout(expirationSec * 2 * 1000)
+    await utils.timeout(expirationSec * 1000 + 100)
 
     assert.equal(await WalletWriteLock.isHeld(wallet), false)
   })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

There seems to be some inconsistency in redis test on key expiry (see failed [CI run here](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/24895/workflows/920ba488-28c3-4a2b-9136-1d92f4fa36d6/jobs/296818))
Attempts to address this by adding larger gap before checking

Some docs on potential causes of expire latency:
https://redis.io/docs/reference/optimization/latency/#latency-generated-by-expires
https://ably.com/blog/redis-keys-do-not-expire-atomically


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->