### PR TITLE
handle negative values in ranking field

### DIFF
--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -365,16 +365,11 @@ def personalize_dsl(dsl, current_user_id, must_saved):
 def default_function_score(dsl, ranking_field):
     return {
         "query": {
-            "function_score": {
+            "script_score": {
                 "query": {"bool": dsl},
-                "functions": [
-                    {
-                        "field_value_factor": {
-                            "field": ranking_field,
-                            "modifier": "ln2p",
-                        }
-                    },
-                ],
+                "script": {
+                    "source": f" Math.log(Math.max(doc['{ranking_field}'].value, 0) + 2)"
+                },
             }
         },
     }


### PR DESCRIPTION


### Description

negative follower_count was causing ES ranking to break:

```
field value function must not produce negative scores, but got: [-Infinity] for field value: [-2.0]
```

This uses a script_score script to clamp values to 0.

Really should not have negative values,
but trigger counters need to be fixed to avoid bad data in a later commit.


### Tests

```
/v1/full/search/autocomplete?limit=3&offset=0&query=a&user_id=aNzoj
```

works afterwards