### PR TITLE
fix /celery_tasks_check

### DIFF
--- a/discovery-provider/src/queries/health_check.py
+++ b/discovery-provider/src/queries/health_check.py
@@ -155,8 +155,9 @@ def es_health():
 @bp.route("/celery_tasks_check", methods=["GET"])
 def celery_tasks_check():
     tasks = get_celery_tasks()
+    all_tasks = tasks.get("celery_tasks", [])
 
-    for task in tasks.get("celery_tasks", []):
+    for task in all_tasks.get("active_tasks", []):
         task["started_at_est_timestamp"] = convert_epoch_to_datetime(
             task.get("started_at")
         )


### PR DESCRIPTION
### Description

We are now including both active and registered tasks when getting all celery tasks ([code](https://github.com/AudiusProject/audius-protocol/blob/012150482a15b0105d1e12864a9372d6a0530b6a/discovery-provider/src/monitors/celery.py#L66-L69)).

This PR updates /celery_tasks_check to only look at the active tasks, as it used to.


### Tests

Release locally and ensure /celery_tasks_check is fixed.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Check /celery_tasks_check during staging and production releases.