### PR TITLE
[CON-183] Fix libs logger issue in CN by consuming latest typed libs

### DIFF
--- a/libs/src/services/contracts/ContractClient.ts
+++ b/libs/src/services/contracts/ContractClient.ts
@@ -150,7 +150,7 @@ export class ContractClient {
       this.providerSelector?.getUnhealthySize() ===
       this.providerSelector?.getServicesSize()
     ) {
-      this.logger.log(
+      this.logger.warn(
         'No healthy providers available - resetting ProviderSelection and selecting.'
       )
       this.providerSelector?.clearUnhealthy()
@@ -202,7 +202,7 @@ export class ContractClient {
           onRetry: (err) => {
             if (err) {
               // eslint-disable-next-line @typescript-eslint/no-base-to-string
-              this.logger.log(`Retry error for ${methodName} : ${err}`)
+              this.logger.warn(`Retry error for ${methodName} : ${err}`)
             }
           }
         }

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -3,11 +3,6 @@ export type Nullable<T> = T | null
 
 export interface Logger {
   /**
-   * Write a 'log' level log.
-   */
-  log: (message: any, ...optionalParams: any[]) => any
-
-  /**
    * Write a 'info' level log.
    */
   info: (message: any, ...optionalParams: any[]) => any


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR remove `.log()` from the logger type and removes any `logger.log()` calls in favor of something more descriptive. 

This is fixing the type error from content node of "`_this2.logger.log()` is not a function" because bunyan doesn't have a logger (thank you @dylanjeffers for helping debug)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

tested locally by running locally

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

These changes will be monitored on loggly

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->