### PR TITLE
ES: reindex all playlists on interval

### DIFF
--- a/discovery-provider/es-indexer/src/indexers/BaseIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/BaseIndexer.ts
@@ -120,10 +120,13 @@ export abstract class BaseIndexer<RowType> {
 
   async indexIds(ids: Array<number>) {
     if (!ids.length) return
-    let sql = this.baseSelect()
-    sql += ` and ${this.tableName}.${this.idColumn} in (${ids.join(',')}) `
-    const result = await dialPg().query(sql)
-    await this.indexRows(result.rows)
+    const chunks = chunk(ids, this.batchSize)
+    for (let chunk of chunks) {
+      let sql = this.baseSelect()
+      sql += ` and ${this.tableName}.${this.idColumn} in (${chunk.join(',')}) `
+      const result = await dialPg().query(sql)
+      await this.indexRows(result.rows)
+    }
   }
 
   async catchup(checkpoint?: BlocknumberCheckpoint) {

--- a/discovery-provider/es-indexer/src/listener.ts
+++ b/discovery-provider/es-indexer/src/listener.ts
@@ -51,7 +51,6 @@ const handlers = {
     if (!row.play_item_id) return // when could this happen?
     pending.trackIds.add(row.play_item_id)
   },
-  // TODO: can we do trigger on agg playlist matview?
   saves: (save: SaveRow) => {
     pending.saves.push(save)
     if (save.save_type == 'track') {

--- a/discovery-provider/es-indexer/src/main.ts
+++ b/discovery-provider/es-indexer/src/main.ts
@@ -6,6 +6,7 @@ import { TrackIndexer } from './indexers/TrackIndexer'
 import { UserIndexer } from './indexers/UserIndexer'
 import { PendingUpdates, startListener, takePending } from './listener'
 import { logger } from './logger'
+import { performance } from 'perf_hooks'
 import { setupTriggers } from './setup'
 import {
   ensureSaneCluterSettings,
@@ -82,8 +83,10 @@ async function start() {
   while (true) {
     const pending = takePending()
     if (pending) {
+      let before = performance.now()
       await processPending(pending)
-      logger.info('processed new updates')
+      const processPendingMs = (performance.now() - before).toFixed(0)
+      logger.info({ processPendingMs }, 'processPending finished')
     }
     // free up event loop + batch queries to postgres
     await new Promise((r) => setTimeout(r, 500))

--- a/discovery-provider/es-indexer/src/types/db.ts
+++ b/discovery-provider/es-indexer/src/types/db.ts
@@ -5,25 +5,25 @@
 export interface AggregateDailyAppNameMetricRow {
   'application_name': string;
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregateDailyTotalUsersMetricRow {
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregateDailyUniqueUsersMetricRow {
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'summed_count'?: number | null;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregateIntervalPlayRow {
   'created_at'?: Date | null;
@@ -35,44 +35,44 @@ export interface AggregateIntervalPlayRow {
 export interface AggregateMonthlyAppNameMetricRow {
   'application_name': string;
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregateMonthlyPlayRow {
   'count': number;
   'play_item_id': number;
-  'timestamp': Date;
+  'timestamp'?: Date;
 }
 export interface AggregateMonthlyTotalUsersMetricRow {
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregateMonthlyUniqueUsersMetricRow {
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
   'summed_count'?: number | null;
   'timestamp': Date;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface AggregatePlaylistRow {
   'is_album'?: boolean | null;
-  'playlist_id'?: number | null;
-  'repost_count'?: string | null;
-  'save_count'?: string | null;
+  'playlist_id': number;
+  'repost_count'?: number | null;
+  'save_count'?: number | null;
 }
 export interface AggregatePlayRow {
   'count'?: string | null;
-  'play_item_id'?: number | null;
+  'play_item_id': number;
 }
 export interface AggregateTrackRow {
-  'repost_count': number;
-  'save_count': number;
+  'repost_count'?: number;
+  'save_count'?: number;
   'track_id': number;
 }
 export interface AggregateUserRow {
@@ -97,7 +97,7 @@ export interface AlbumLexemeDictRow {
   'owner_id'?: number | null;
   'playlist_id'?: number | null;
   'playlist_name'?: string | null;
-  'repost_count'?: string | null;
+  'repost_count'?: number | null;
   'row_number'?: string | null;
   'user_name'?: string | null;
   'word'?: string | null;
@@ -108,11 +108,11 @@ export interface AlembicVersionRow {
 export interface AppNameMetricRow {
   'application_name': string;
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: string;
   'ip'?: string | null;
-  'timestamp': Date;
-  'updated_at': Date;
+  'timestamp'?: Date;
+  'updated_at'?: Date;
 }
 export interface AppNameMetricsAllTimeRow {
   'count'?: string | null;
@@ -141,12 +141,6 @@ export interface AudiusDataTxRow {
   'slot': number;
 }
 export interface BlockRow {
-  'blockhash': string;
-  'is_current'?: boolean | null;
-  'number'?: number | null;
-  'parenthash'?: string | null;
-}
-export interface BlocksCopyRow {
   'blockhash': string;
   'is_current'?: boolean | null;
   'number'?: number | null;
@@ -184,9 +178,9 @@ export interface ChallengeRow {
   'type': challengetype;
 }
 export interface EthBlockRow {
-  'created_at': Date;
+  'created_at'?: Date;
   'last_scanned_block'?: number;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface FollowRow {
   'blockhash'?: string | null;
@@ -258,7 +252,7 @@ export interface PlaylistLexemeDictRow {
   'owner_id'?: number | null;
   'playlist_id'?: number | null;
   'playlist_name'?: string | null;
-  'repost_count'?: string | null;
+  'repost_count'?: number | null;
   'row_number'?: string | null;
   'user_name'?: string | null;
   'word'?: string | null;
@@ -285,24 +279,27 @@ export interface PlaylistRow {
   'updated_at': Date;
 }
 export interface PlayRow {
-  'created_at': Date;
+  'city'?: string | null;
+  'country'?: string | null;
+  'created_at'?: Date;
   'id'?: number;
   'play_item_id': number;
+  'region'?: string | null;
   'signature'?: string | null;
   'slot'?: number | null;
   'source'?: string | null;
-  'updated_at': Date;
+  'updated_at'?: Date;
   'user_id'?: number | null;
 }
 export interface PlaysArchiveRow {
   'archived_at'?: Date | null;
-  'created_at': Date;
+  'created_at'?: Date;
   'id': number;
   'play_item_id': number;
   'signature'?: string | null;
   'slot'?: number | null;
   'source'?: string | null;
-  'updated_at': Date;
+  'updated_at'?: Date;
   'user_id'?: number | null;
 }
 export interface ReactionRow {
@@ -316,7 +313,7 @@ export interface ReactionRow {
   'tx_signature'?: string | null;
 }
 export interface RelatedArtistRow {
-  'created_at': Date;
+  'created_at'?: Date;
   'related_artist_user_id': number;
   'score': number;
   'user_id': number;
@@ -344,13 +341,13 @@ export interface RewardManagerTxRow {
 }
 export interface RouteMetricRow {
   'count': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: string;
   'ip'?: string | null;
-  'query_string': string;
+  'query_string'?: string;
   'route_path': string;
-  'timestamp': Date;
-  'updated_at': Date;
+  'timestamp'?: Date;
+  'updated_at'?: Date;
   'version': string;
 }
 export interface RouteMetricsAllTimeRow {
@@ -390,11 +387,11 @@ export interface SaveRow {
 export interface SkippedTransactionRow {
   'blockhash': string;
   'blocknumber': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'id'?: number;
-  'level': skippedtransactionlevel;
+  'level'?: skippedtransactionlevel;
   'txhash': string;
-  'updated_at': Date;
+  'updated_at'?: Date;
 }
 export interface SplTokenTxRow {
   'created_at'?: Date;
@@ -460,6 +457,7 @@ export interface TrackRow {
   'field_visibility'?: any | null;
   'file_type'?: string | null;
   'genre'?: string | null;
+  'is_available'?: boolean;
   'is_current': boolean;
   'is_delete': boolean;
   'is_unlisted'?: boolean;
@@ -524,18 +522,18 @@ export interface UrsmContentNodeRow {
 }
 export interface UserBalanceChangeRow {
   'blocknumber': number;
-  'created_at': Date;
+  'created_at'?: Date;
   'current_balance': string;
   'previous_balance': string;
-  'updated_at': Date;
+  'updated_at'?: Date;
   'user_id'?: number;
 }
 export interface UserBalanceRow {
   'associated_sol_wallets_balance'?: string;
   'associated_wallets_balance'?: string;
   'balance': string;
-  'created_at': Date;
-  'updated_at': Date;
+  'created_at'?: Date;
+  'updated_at'?: Date;
   'user_id'?: number;
   'waudio'?: string | null;
 }
@@ -563,7 +561,7 @@ export interface UserEventRow {
   'blocknumber'?: number | null;
   'id'?: number;
   'is_current': boolean;
-  'is_mobile_user': boolean;
+  'is_mobile_user'?: boolean;
   'referrer'?: number | null;
   'slot'?: number | null;
   'user_id': number;
@@ -582,7 +580,7 @@ export interface UserListeningHistoryRow {
 }
 export interface UserTipRow {
   'amount': string;
-  'created_at': Date;
+  'created_at'?: Date;
   'receiver_user_id': number;
   'sender_user_id': number;
   'signature': string;
@@ -595,12 +593,12 @@ export interface UserRow {
   'blocknumber'?: number | null;
   'cover_photo'?: string | null;
   'cover_photo_sizes'?: string | null;
-  'created_at': Date;
+  'created_at'?: Date;
   'creator_node_endpoint'?: string | null;
   'handle'?: string | null;
   'handle_lc'?: string | null;
   'has_collectibles'?: boolean;
-  'is_creator': boolean;
+  'is_creator'?: boolean;
   'is_current': boolean;
   'is_deactivated'?: boolean;
   'is_verified'?: boolean;
@@ -615,7 +613,7 @@ export interface UserRow {
   'secondary_ids'?: any | null;
   'slot'?: number | null;
   'txhash'?: string;
-  'updated_at': Date;
+  'updated_at'?: Date;
   'user_authority_account'?: string | null;
   'user_id': number;
   'user_storage_account'?: string | null;


### PR DESCRIPTION
### Description

`total_play_count` is computed in `PlaylistIndexer.ts`... it doesn't exist in postgres anywhere.

To keep this value current there are two options:
* when a track play comes thru, lookup all playlists track is on and mark them stale (`playlists containing track x` can be cheaply done in ES)
* on an interval re-index all playlists (this PR so far)

Possible downsides of re-index all:
* if you add to the pendingUpdates batch... that batch will take 3 minutes and block ongoing indexing
* if you do it outside the pendingUpdates batch, you might be able to hit an ES MVCC error?  Need to look at this more to see if this is possible.  If not, doing outside of pendingUpdates might be a good option.

That said, the API can compute this dynamically per-request.  We don't use this field for ranking.  So maybe this is unnecessary.


### Tests

ran locally