### PR TITLE
[INF-180] Add SOCKS5 proxy for use with client

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -203,7 +203,7 @@ def ps(protocol_dir):
         if service["Publishers"]:
             for publisher in service["Publishers"]:
                 if publisher["PublishedPort"]:
-                    ports[publisher["TargetPort"]] = publisher["PublishedPort"]
+                    ports[publisher["PublishedPort"]] = publisher["TargetPort"]
 
         if service["Service"] == "creator-node":
             name = f"{service['Service']}-{replica}"

--- a/dev-tools/startup/discovery-provider.sh
+++ b/dev-tools/startup/discovery-provider.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+export audius_enable_rsyslog=false
+
 export audius_discprov_url="http://$(hostname -i):5000"
 
 export audius_delegate_owner_wallet=$(printenv "DP${replica}_DELEGATE_OWNER_ADDRESS")

--- a/dev-tools/startup/socks5-proxy-pac.py
+++ b/dev-tools/startup/socks5-proxy-pac.py
@@ -14,21 +14,23 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-type", "application/x-ns-proxy-autoconfig")
         self.end_headers()
 
-        self.wfile.write(f"""
+        self.wfile.write(
+            f"""
         function FindProxyForURL(url, host) {{
             if (isInNet(host, "{IP_ADDRESS}", "255.255.0.0")) {{
-                return "SOCKS5 {self.headers.get("Host").split(":")[0]} 1080"
+                return "SOCKS5 {self.headers.get("Host").split(":")[0]}:1080"
             }}
 
             return "DIRECT";
         }}
-        """.encode())
+        """.encode()
+        )
 
 
 def main():
-    httpd = http.server.HTTPServer(('', 80), Handler)
+    httpd = http.server.HTTPServer(("", 80), Handler)
     httpd.serve_forever()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/dev-tools/startup/socks5-proxy-pac.py
+++ b/dev-tools/startup/socks5-proxy-pac.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import socket
+import http
+import http.server
+
+HOSTNAME = socket.gethostname()
+IP_ADDRESS = socket.gethostbyname(HOSTNAME)
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(http.HTTPStatus.OK)
+        self.send_header("Content-type", "application/x-ns-proxy-autoconfig")
+        self.end_headers()
+
+        self.wfile.write(f"""
+        function FindProxyForURL(url, host) {{
+            if (isInNet(host, "{IP_ADDRESS}", "255.255.0.0")) {{
+                return "SOCKS5 {self.headers.get("Host").split(":")[0]} 1080"
+            }}
+
+            return "DIRECT";
+        }}
+        """.encode())
+
+
+def main():
+    httpd = http.server.HTTPServer(('', 80), Handler)
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -81,10 +81,10 @@ if [ -z "$audius_db_url" ]; then
         sudo -u postgres pg_ctl init -D /db
         echo "host all all 0.0.0.0/0 md5" >>/db/pg_hba.conf
         echo "listen_addresses = '*'" >>/db/postgresql.conf
-        sudo -u postgres pg_ctl start -D /db -o "-c shared_buffers=512MB" -o "-c shared_preload_libraries=pg_stat_statements"
+        sudo -u postgres pg_ctl start -D /db -o "-c shared_preload_libraries=pg_stat_statements"
         sudo -u postgres createdb audius_discovery
     else
-        sudo -u postgres pg_ctl start -D /db -o "-c shared_buffers=512MB" -o "-c shared_preload_libraries=pg_stat_statements"
+        sudo -u postgres pg_ctl start -D /db -o "-c shared_preload_libraries=pg_stat_statements"
     fi
 
     sudo -u postgres psql -c "ALTER USER postgres PASSWORD '${postgres_password:-postgres}';"
@@ -108,6 +108,8 @@ if [ "$audius_db_run_migrations" != false ]; then
     export PYTHONPATH='.'
     alembic upgrade head
     echo "Finished running migrations"
+
+    sleep 20
 fi
 
 # start es-indexer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,7 +351,7 @@ services:
   # SOCKS5 proxy for use with client
 
   socks5-proxy:
-    image: serjs/go-socks5-proxy:latest
+    image: serjs/go-socks5-proxy:v0.0.3
     ports:
       - "1080:1080"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,6 +348,21 @@ services:
     deploy:
       mode: global
 
+  # SOCKS5 proxy for use with client
+
+  socks5-proxy:
+    image: serjs/go-socks5-proxy:latest
+    ports:
+      - "1080:1080"
+
+  socks5-proxy-pac:
+    image: python:3.10.5
+    command: python /tmp/dev-tools/startup/socks5-proxy-pac.py
+    ports:
+      - "8080:80"
+    volumes:
+      - ./dev-tools:/tmp/dev-tools
+
 volumes:
   poa-contracts-abis:
   eth-contracts-abis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
 
   build-audius-libs:
     build: libs
-    command: sh -c "cp scripts/AudiusClaimDistributor.json scripts/Wormhole.json eth-contracts/ABIs/ && npm run dev"
+    command: sh -c "cp scripts/AudiusClaimDistributor.json scripts/Wormhole.json eth-contracts/ABIs/"
     volumes:
       - audius-libs:/usr/src/app
       - poa-contracts-abis:/usr/src/app/data-contracts/ABIs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -357,7 +357,7 @@ services:
 
   socks5-proxy-pac:
     image: python:3.10.5
-    command: python /tmp/dev-tools/startup/socks5-proxy-pac.py
+    command: sh -c "head -n-1 /etc/hosts > /etc/hosts && python /tmp/dev-tools/startup/socks5-proxy-pac.py"
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
### Description
This PR adds a SOCKS5 proxy so that we can connect the audius-client to our local development stack 

To use the proxy from a mac:
```
networksetup -setautoproxyurl "Wi-Fi" "http://<instance ip>:8080/proxy.pac"
```

Change "Wi-Fi" to network interface name you find in system settings

Then on your local machine you can go to http://audius-protocol-creator-node-2:4000/health_check


### Tests
Pending working client


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA