### PR TITLE
Default write quorum to off on prod

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -500,7 +500,7 @@ const config = convict({
     doc: 'Boolean flag indicating whether or not primary should reject write until 2/3 replication across replica set',
     format: Boolean,
     env: 'enforceWriteQuorum',
-    default: true
+    default: false
   },
   manualSyncsDisabled: {
     doc: 'Disables issuing of manual syncs in order to test state machine Recurring Sync logic.',


### PR DESCRIPTION
### Description
For rollout, write quorum should default to off on prod because we want to be able to turn write quorum on/off via Optimizely. If the write quorum env var defaults to true on prod, then we won't be able to turn it off in an emergency without waiting for SPs to update.


### Tests
N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A