### PR TITLE
Default write quorum to on for local

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -54,6 +54,7 @@ monitorStateJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 findSyncRequestsJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 findReplicaSetUpdatesJobLastSuccessfulRunDelayMs=600000 # 10min in ms
 fetchCNodeEndpointToSpIdMapIntervalMs=10000 #10sec in ms
+enforceWriteQuorum=true
 
 # peerSetManager
 peerHealthCheckRequestTimeout=2000 # ms

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -500,7 +500,7 @@ const config = convict({
     doc: 'Boolean flag indicating whether or not primary should reject write until 2/3 replication across replica set',
     format: Boolean,
     env: 'enforceWriteQuorum',
-    default: true
+    default: false
   },
   manualSyncsDisabled: {
     doc: 'Disables issuing of manual syncs in order to test state machine Recurring Sync logic.',


### PR DESCRIPTION
### Description
Forgot in the last PR -- we also want write quorum to be enforced by default locally for testing. Only prod needs to default to off.

### Tests
N/A -- this is what it was set to before a few hours ago

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A