### PR TITLE
Move trusted notifier init back to await-ed init

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -79,6 +79,13 @@ class ServiceRegistry {
     // Transcode handoff requires libs. Set libs in AsyncProcessingQueue after libs init is complete
     this.asyncProcessingQueue = new AsyncProcessingQueue(this.libs)
 
+    this.trustedNotifierManager = new TrustedNotifierManager(
+      config,
+      this.libs
+    )
+
+    await this.trustedNotifierManager.init()
+
     this.synchronousServicesInitialized = true
 
     logInfoWithDuration(
@@ -100,14 +107,6 @@ class ServiceRegistry {
     // If error occurs in initializing these services, do not continue with app start up.
     try {
       await this.blacklistManager.init()
-
-      this.trustedNotifierManager = new TrustedNotifierManager(
-        config,
-        this.libs
-      )
-
-      await this.trustedNotifierManager.init()
-
       await this.monitoringQueue.start()
       await this.sessionExpirationQueue.start()
     } catch (e) {

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -79,10 +79,7 @@ class ServiceRegistry {
     // Transcode handoff requires libs. Set libs in AsyncProcessingQueue after libs init is complete
     this.asyncProcessingQueue = new AsyncProcessingQueue(this.libs)
 
-    this.trustedNotifierManager = new TrustedNotifierManager(
-      config,
-      this.libs
-    )
+    this.trustedNotifierManager = new TrustedNotifierManager(config, this.libs)
 
     await this.trustedNotifierManager.init()
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This was mistakenly moved outside initServices() in serviceRegistry. The reason this is a problem is the result of serviceRegistry right after initServices get set in express as global variables as app.set(...) and the notifier service was not initialized at the time it was set which was causing problems.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Pushed out hotfix onto cn3 and verified it works


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Planning to expose trusted notifier id and wallet in a follow up PR, merging this just to unblock prod deploy

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->