### PR TITLE
Always require syncMode to be defined

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const axios = require('axios')
 const { logger } = require('../../../logging')
 const Utils = require('../../../utils')
-const { SyncType, JOB_NAMES } = require('../stateMachineConstants')
+const { SyncType, JOB_NAMES, SYNC_MODES } = require('../stateMachineConstants'),
 const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
 
 /**
@@ -21,6 +21,9 @@ const getNewOrExistingSyncReq = ({
   syncMode,
   immediate = false
 }) => {
+  if (!userWallet || !primaryEndpoint || !secondaryEndpoint || !syncType || !syncMode) {
+    throw new Error(`getNewOrExistingSyncReq missing parameter - userWallet: ${userWallet}, primaryEndpoint: ${primaryEndpoint}, secondaryEndpoint: ${secondaryEndpoint}, syncType: ${syncType}, syncMode: ${syncMode}`)
+  }
   /**
    * If duplicate sync already exists, do not add and instead return existing sync job info
    * Ignore syncMode when checking for duplicates, since it doesn't matter
@@ -99,6 +102,7 @@ const issueSyncRequestsUntilSynced = async (
     secondaryEndpoint: secondaryUrl,
     primaryEndpoint: primaryUrl,
     syncType: SyncType.Manual,
+    syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
     immediate: true
   })
   if (!_.isEmpty(duplicateSyncReq)) {
@@ -139,7 +143,8 @@ const issueSyncRequestsUntilSynced = async (
           userWallet: wallet,
           secondaryEndpoint: secondaryUrl,
           primaryEndpoint: primaryUrl,
-          syncType: SyncType.Manual
+          syncType: SyncType.Manual,
+          syncMode: SYNC_MODES.SyncSecondaryFromPrimary
         })
         if (!_.isEmpty(duplicateSyncReq)) {
           // Log duplicate and return

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const axios = require('axios')
 const { logger } = require('../../../logging')
 const Utils = require('../../../utils')
-const { SyncType, JOB_NAMES, SYNC_MODES } = require('../stateMachineConstants'),
+const { SyncType, JOB_NAMES, SYNC_MODES } = require('../stateMachineConstants')
 const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
 
 /**

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -21,8 +21,16 @@ const getNewOrExistingSyncReq = ({
   syncMode,
   immediate = false
 }) => {
-  if (!userWallet || !primaryEndpoint || !secondaryEndpoint || !syncType || !syncMode) {
-    throw new Error(`getNewOrExistingSyncReq missing parameter - userWallet: ${userWallet}, primaryEndpoint: ${primaryEndpoint}, secondaryEndpoint: ${secondaryEndpoint}, syncType: ${syncType}, syncMode: ${syncMode}`)
+  if (
+    !userWallet ||
+    !primaryEndpoint ||
+    !secondaryEndpoint ||
+    !syncType ||
+    !syncMode
+  ) {
+    throw new Error(
+      `getNewOrExistingSyncReq missing parameter - userWallet: ${userWallet}, primaryEndpoint: ${primaryEndpoint}, secondaryEndpoint: ${secondaryEndpoint}, syncType: ${syncType}, syncMode: ${syncMode}`
+    )
   }
   /**
    * If duplicate sync already exists, do not add and instead return existing sync job info

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.js
@@ -5,7 +5,8 @@ const {
   SyncType,
   RECONFIG_MODES,
   MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS,
-  QUEUE_NAMES
+  QUEUE_NAMES,
+  SYNC_MODES
 } = require('../stateMachineConstants')
 const { retrieveClockValueForUserFromReplica } = require('../stateMachineUtils')
 const CNodeToSpIdMapManager = require('../CNodeToSpIdMapManager')
@@ -536,7 +537,8 @@ const _issueUpdateReplicaSetOp = async (
         userWallet: wallet,
         primaryEndpoint: newPrimary,
         secondaryEndpoint: newSecondary1,
-        syncType: SyncType.Recurring
+        syncType: SyncType.Recurring,
+        syncMode: SYNC_MODES.SyncSecondaryFromPrimary
       })
     if (!_.isEmpty(duplicateSyncReq)) {
       logger.warn(
@@ -554,7 +556,8 @@ const _issueUpdateReplicaSetOp = async (
       userWallet: wallet,
       primaryEndpoint: newPrimary,
       secondaryEndpoint: newSecondary2,
-      syncType: SyncType.Recurring
+      syncType: SyncType.Recurring,
+      syncMode: SYNC_MODES.SyncSecondaryFromPrimary
     })
     if (!_.isEmpty(duplicateSyncReq2)) {
       logger.warn(

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -116,7 +116,7 @@ describe('test updateReplicaSet job processor', function () {
     )
   }
 
-  it('reconfigs one secondary when one secondary is unhealthy and reconfigs are enabled', async function () {
+  it.only('reconfigs one secondary when one secondary is unhealthy and reconfigs are enabled', async function () {
     // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
     const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
       return { syncReqToEnqueue: args }

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -11,7 +11,8 @@ const config = require('../src/config')
 const {
   SyncType,
   RECONFIG_MODES,
-  QUEUE_NAMES
+  QUEUE_NAMES,
+  SYNC_MODES
 } = require('../src/services/stateMachineManager/stateMachineConstants')
 
 chai.use(require('sinon-chai'))
@@ -174,12 +175,14 @@ describe('test updateReplicaSet job processor', function () {
             primaryEndpoint: primary,
             secondaryEndpoint: secondary2,
             syncType: SyncType.Recurring,
+            syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
             userWallet: wallet
           },
           {
             primaryEndpoint: primary,
             secondaryEndpoint: fourthHealthyNode,
             syncType: SyncType.Recurring,
+            syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
             userWallet: wallet
           }
         ]

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -116,7 +116,7 @@ describe('test updateReplicaSet job processor', function () {
     )
   }
 
-  it.only('reconfigs one secondary when one secondary is unhealthy and reconfigs are enabled', async function () {
+  it('reconfigs one secondary when one secondary is unhealthy and reconfigs are enabled', async function () {
     // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
     const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
       return { syncReqToEnqueue: args }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
SyncMode wasn't always passed in so issueSyncRequest.jobProcessor/_validateJobData threw an error ````Invalid type ("${typeof syncMode}") or value ("${syncMode}") of syncMode param````


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally by running mad-dog


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Added a new check in getNewOrExistingSyncReq in StateReconciliationUtils to make sure we error if syncMode is not passed in. Error message is "getNewOrExistingSyncReq missing parameter"

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->