### PR TITLE
Run image bake without monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -750,10 +750,45 @@ workflows:
   # test, build and push all commits
   test-build-and-push:
     jobs:
-      - bake-gcp-dev-image:
+      - test-libs:
+          name: test-libs
+      - docker-build-and-push:
+          name: build-libs
+          repo: libs
+
+      - test-contracts:
+          name: test-contracts
+
+      - test-eth-contracts:
+          name: test-eth-contracts
+
+      - test-creator-node:
+          name: test-creator-node
+      - docker-build-and-push:
+          name: build-creator-node
+          repo: creator-node
+
+      - test-discovery-provider:
+          name: test-discovery-provider
+      - docker-build-and-push-updated:
+          name: build-discovery-provider
+          repo: discovery-provider
+
+      - test-identity-service:
+          name: test-identity-service
+      - docker-build-and-push:
+          name: build-identity-service
+          repo: identity-service
+
+      - test-solana-programs:
+          name: test-solana-programs
+      - test-solana-programs-anchor:
+          name: test-solana-programs-anchor
+
+      - test-mad-dog-e2e:
           context:
             - GCP2
-          name: bake-gcp-dev-image
+          mad-dog-type: test
 
   # in order to run a job in hold-workflows
   # 1. go to the CircleCI dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
               # commands to prime the VM for the bake
               A run init-repos up;
               A up;
-              A run monitoring up;
               A down;
               cd audius-protocol/;
               git checkout -f;
@@ -751,45 +750,10 @@ workflows:
   # test, build and push all commits
   test-build-and-push:
     jobs:
-      - test-libs:
-          name: test-libs
-      - docker-build-and-push:
-          name: build-libs
-          repo: libs
-
-      - test-contracts:
-          name: test-contracts
-
-      - test-eth-contracts:
-          name: test-eth-contracts
-
-      - test-creator-node:
-          name: test-creator-node
-      - docker-build-and-push:
-          name: build-creator-node
-          repo: creator-node
-
-      - test-discovery-provider:
-          name: test-discovery-provider
-      - docker-build-and-push-updated:
-          name: build-discovery-provider
-          repo: discovery-provider
-
-      - test-identity-service:
-          name: test-identity-service
-      - docker-build-and-push:
-          name: build-identity-service
-          repo: identity-service
-
-      - test-solana-programs:
-          name: test-solana-programs
-      - test-solana-programs-anchor:
-          name: test-solana-programs-anchor
-
-      - test-mad-dog-e2e:
+      - bake-gcp-dev-image:
           context:
             - GCP2
-          mad-dog-type: test
+          name: bake-gcp-dev-image
 
   # in order to run a job in hold-workflows
   # 1. go to the CircleCI dashboard


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Image bake has been failing in CI for a few days, it's been stuck on "Too long with no output (exceeded 10m0s): context deadline exceeded" after `A run monitoring up;`. I removed `A run monitoring up;` and it seems to be passing now, not sure why it's causing bake to fail.

Example of failing bake https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/25197/workflows/b8b7d08d-f618-4bf5-9328-27afd6c57afb/jobs/300858. This has been happening for several days, not just a one off


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Working bake in this CI run https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/25235/workflows/5f1c3f53-2f7a-4e64-84ec-ea7d5d3ec602/jobs/300918

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Image bake will fail in CI

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->