### PR TITLE
Fix CN nodejs version

### DIFF
--- a/creator-node/Dockerfile
+++ b/creator-node/Dockerfile
@@ -16,7 +16,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositor
         curl \
         docker=20.10.3-r1 \
         libpq=11.12-r0 \
-        nodejs=14.19.0-r0 \
+        nodejs=14.20.0-r0 \
         npm \
         postgresql-client=11.12-r0 \
         postgresql-contrib=11.12-r0 \


### PR DESCRIPTION
### Description
```
------
 > [audius-protocol_creator-node base 4/8] RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories &&     apk update &&     apk add         bash=5.1.16-r0         curl         docker=20.10.3-r1         libpq=11.12-r0         nodejs=14.19.0-r0         npm         postgresql-client=11.12-r0         postgresql-contrib=11.12-r0         postgresql-libs=11.12-r0         postgresql=11.12-r0         py3-pip         python3         python3-dev         redis=6.0.16-r0         rsyslog=8.2012.0-r3         sudo=1.9.5p2-r0:
#0 0.369 fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
#0 0.551 fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
#0 0.718 fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
#0 0.979 v3.13.10-95-g246565436f [https://dl-cdn.alpinelinux.org/alpine/v3.13/main]
#0 0.979 v3.13.10-90-ga8ff23e970 [https://dl-cdn.alpinelinux.org/alpine/v3.13/community]
#0 0.979 v3.10.9-43-g3feb769ea3 [http://dl-cdn.alpinelinux.org/alpine/v3.10/main]
#0 0.979 OK: 19569 distinct packages available
#0 1.490 ERROR: unable to select packages:
#0 1.497   nodejs-14.20.0-r0:
#0 1.565     breaks: world[nodejs=14.19.0-r0]
#0 1.565     satisfies: npm-14.20.0-r0[nodejs]
------
failed to solve: executor failed running [/bin/sh -c echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories &&     apk update &&     apk add         bash=5.1.16-r0         curl         docker=20.10.3-r1         libpq=11.12-r0         nodejs=14.19.0-r0         npm         postgresql-client=11.12-r0         postgresql-contrib=11.12-r0         postgresql-libs=11.12-r0         postgresql=11.12-r0         py3-pip         python3         python3-dev         redis=6.0.16-r0         rsyslog=8.2012.0-r3         sudo=1.9.5p2-r0]: exit code: 2
```


### Tests
`audius-compose up`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA