### PR TITLE
Fix primarySyncFromSecondary circular dep by moving initAudiusLibs to separate file

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -2230,7 +2230,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -2245,12 +2245,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2259,27 +2259,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3754,7 +3754,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3952,7 +3952,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -4210,7 +4210,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-layout": {
       "version": "1.2.2",
@@ -4481,7 +4481,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001241",
@@ -5181,7 +5181,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
     },
     "css-to-react-native": {
       "version": "3.0.0",
@@ -7121,7 +7121,7 @@
     "fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha1-XFVDRisiru79NtBbNOUceMuG0xM="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -11513,7 +11513,7 @@
     "qr.js": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
     },
     "qrcode.react": {
       "version": "1.0.1",

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -6,8 +6,8 @@ const axios = require('axios')
 
 const config = require('./config')
 const Utils = require('./utils')
-const { libs } = require('@audius/sdk')
-const LibsUtils = libs.Utils
+const { libs: audiusLibs } = require('@audius/sdk')
+const LibsUtils = audiusLibs.Utils
 const DiskManager = require('./diskManager')
 const { logger: genericLogger } = require('./logging')
 const { sendResponse, errorResponseBadRequest } = require('./apiHelpers')
@@ -104,7 +104,7 @@ async function copyMultihashToFs(multihash, srcPath, logContext) {
  *    creating directories
  * 2. attempt to fetch the CID from a variety of sources
  * 3. return boolean failure content retrieval or content verification failure
- * @param {Object} serviceRegistry
+ * @param {Object} libs
  * @param {Object} logger
  * @param {String} multihash CID
  * @param {String} expectedStoragePath file system path similar to `/file_storage/Qm1`
@@ -117,7 +117,7 @@ async function copyMultihashToFs(multihash, srcPath, logContext) {
  * @return {Boolean} true if success, false if error
  */
 async function saveFileForMultihashToFS(
-  serviceRegistry,
+  libs,
   logger,
   multihash,
   expectedStoragePath,
@@ -315,7 +315,6 @@ async function saveFileForMultihashToFS(
     // If file is not found on disk, check nodes on the rest of the network
     if (!fileFound) {
       try {
-        const libs = serviceRegistry.libs
         const found = await findCIDInNetwork(
           expectedStoragePath,
           multihash,
@@ -399,7 +398,7 @@ async function saveFileForMultihashToFS(
       await removeFile(expectedStoragePath)
       if (numRetries > 0) {
         return saveFileForMultihashToFS(
-          serviceRegistry,
+          libs,
           logger,
           multihash,
           expectedStoragePath,

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -526,15 +526,13 @@ async function getOwnEndpoint({ libs }) {
  * @returns {Array} - array of strings of replica set
  */
 async function getCreatorNodeEndpoints({
-  serviceRegistry,
+  libs,
   logger,
   wallet,
   blockNumber,
   ensurePrimary,
   myCnodeEndpoint
 }) {
-  const { libs } = serviceRegistry
-
   logger.info(`Starting getCreatorNodeEndpoints for wallet ${wallet}`)
   const start = Date.now()
 

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -1,0 +1,84 @@
+const { libs: AudiusLibs } = require('@audius/sdk')
+
+const config = require('../config')
+const { logger: genericLogger } = require('../logging')
+
+/**
+ * Creates, initializes, and returns an audiusLibs instance
+ *
+ * Configures dataWeb3 to be internal to libs, logged in with delegatePrivateKey in order to write chain TX
+ */
+module.exports = async (logger = genericLogger) => {
+  /**
+   * Define all config variables
+   */
+  const ethProviderUrl = config.get('ethProviderUrl')
+  const ethNetworkId = config.get('ethNetworkId')
+  const discoveryProviderWhitelistConfig = config.get(
+    'discoveryProviderWhitelist'
+  )
+  const identityService = config.get('identityService')
+  const discoveryNodeUnhealthyBlockDiff = config.get(
+    'discoveryNodeUnhealthyBlockDiff'
+  )
+  const ethTokenAddress = config.get('ethTokenAddress')
+  const ethRegistryAddress = config.get('ethRegistryAddress')
+  const ethOwnerWallet = config.get('ethOwnerWallet')
+  const dataRegistryAddress = config.get('dataRegistryAddress')
+  const dataProviderUrl = config.get('dataProviderUrl')
+  const delegatePrivateKey = config.get('delegatePrivateKey')
+  const creatorNodeIsDebug = config.get('creatorNodeIsDebug')
+
+  const discoveryProviderWhitelist = discoveryProviderWhitelistConfig
+    ? new Set(discoveryProviderWhitelistConfig.split(','))
+    : null
+
+  /**
+   * Configure ethWeb3
+   */
+  const ethWeb3 = await AudiusLibs.Utils.configureWeb3(
+    ethProviderUrl,
+    ethNetworkId,
+    /* requiresAccount */ false
+  )
+  if (!ethWeb3) {
+    throw new Error(
+      'Failed to init audiusLibs due to ethWeb3 configuration error'
+    )
+  }
+
+  /**
+   * Create AudiusLibs instance
+   */
+  const audiusLibs = new AudiusLibs({
+    ethWeb3Config: AudiusLibs.configEthWeb3(
+      ethTokenAddress,
+      ethRegistryAddress,
+      ethWeb3,
+      ethOwnerWallet
+    ),
+    web3Config: AudiusLibs.configInternalWeb3(
+      dataRegistryAddress,
+      // pass as array
+      [dataProviderUrl],
+      // TODO - formatting this private key here is not ideal
+      delegatePrivateKey.replace('0x', '')
+    ),
+    discoveryProviderConfig: {
+      whitelist: discoveryProviderWhitelist,
+      unhealthyBlockDiff: discoveryNodeUnhealthyBlockDiff
+    },
+    // If an identity service config is present, set up libs with the connection, otherwise do nothing
+    identityServiceConfig: identityService
+      ? AudiusLibs.configIdentityService(identityService)
+      : undefined,
+    isDebug: creatorNodeIsDebug,
+    isServer: true,
+    preferHigherPatchForPrimary: true,
+    preferHigherPatchForSecondaries: true,
+    logger
+  })
+
+  await audiusLibs.init()
+  return audiusLibs
+}

--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -10,7 +10,7 @@ const DBManager = require('../../dbManager')
 const { getCreatorNodeEndpoints } = require('../../middlewares')
 const { saveFileForMultihashToFS } = require('../../fileManager')
 const SyncHistoryAggregator = require('../../snapbackSM/syncHistoryAggregator')
-const { serviceRegistry } = require('../../serviceRegistry')
+const initAudiusLibs = require('../initAudiusLibs')
 const asyncRetry = require('../../utils/asyncRetry')
 
 const EXPORT_REQ_TIMEOUT_MS = 10000 // 10000ms = 10s
@@ -28,20 +28,25 @@ module.exports = async function primarySyncFromSecondary({
   secondary,
   logContext = DEFAULT_LOG_CONTEXT
 }) {
-  await serviceRegistry.initLibs()
-
-  // This is used only for logging record endpoint of requesting node
-  const selfEndpoint = config.get('creatorNodeEndpoint') || null
-
   const logPrefix = `[primarySyncFromSecondary][Wallet: ${wallet}][Secondary: ${secondary}]`
   const logger = genericLogger.child(logContext)
   logger.info(`[primarySyncFromSecondary] [Wallet: ${wallet}] Beginning...`)
   const start = Date.now()
 
+  // This is used only for logging record endpoint of requesting node
+  const selfEndpoint = config.get('creatorNodeEndpoint') || null
+
   // object to track if the function errored, returned at the end of the function
   let error = null
 
   try {
+    let libs
+    try {
+      libs = await initAudiusLibs()
+    } catch (e) {
+      throw new Error(`InitAudiusLibs Error - ${e.message}`)
+    }
+
     await WalletWriteLock.acquire(
       wallet,
       WalletWriteLock.VALID_ACQUIRERS.PrimarySyncFromSecondary
@@ -52,7 +57,7 @@ module.exports = async function primarySyncFromSecondary({
       wallet,
       selfEndpoint,
       logger,
-      logPrefix
+      libs
     })
 
     // Keep importing data from secondary until full clock range has been retrieved
@@ -70,6 +75,7 @@ module.exports = async function primarySyncFromSecondary({
       await saveFilesToDisk({
         files: fetchedCNodeUser.files,
         userReplicaSet,
+        libs,
         logger
       })
 
@@ -170,7 +176,7 @@ async function fetchExportFromSecondary({
  * - `saveFileForMultihashToFS` will exit early if files already exist on disk
  * - Performed in batches to limit concurrent load
  */
-async function saveFilesToDisk({ files, userReplicaSet, logger }) {
+async function saveFilesToDisk({ files, userReplicaSet, libs, logger }) {
   const FileSaveMaxConcurrency = config.get('nodeSyncFileSaveMaxConcurrency')
 
   try {
@@ -196,7 +202,7 @@ async function saveFilesToDisk({ files, userReplicaSet, logger }) {
       await Promise.all(
         trackFilesSlice.map(async (trackFile) => {
           const succeeded = await saveFileForMultihashToFS(
-            serviceRegistry,
+            libs,
             logger,
             trackFile.multihash,
             trackFile.storagePath,
@@ -237,7 +243,7 @@ async function saveFilesToDisk({ files, userReplicaSet, logger }) {
           let succeeded
           if (nonTrackFile.type === 'image' && nonTrackFile.fileName !== null) {
             succeeded = await saveFileForMultihashToFS(
-              serviceRegistry,
+              libs,
               logger,
               multihash,
               nonTrackFile.storagePath,
@@ -246,7 +252,7 @@ async function saveFilesToDisk({ files, userReplicaSet, logger }) {
             )
           } else {
             succeeded = await saveFileForMultihashToFS(
-              serviceRegistry,
+              libs,
               logger,
               multihash,
               nonTrackFile.storagePath,
@@ -443,10 +449,10 @@ async function filterOutAlreadyPresentDBEntries({
   return filteredEntries
 }
 
-async function getUserReplicaSet({ wallet, selfEndpoint, logger }) {
+async function getUserReplicaSet({ wallet, selfEndpoint, libs, logger }) {
   try {
     let userReplicaSet = await getCreatorNodeEndpoints({
-      serviceRegistry,
+      libs,
       logger,
       wallet,
       blockNumber: null,

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -27,7 +27,7 @@ module.exports = async function (
   blockNumber = null,
   forceResync = false
 ) {
-  const { nodeConfig, redis } = serviceRegistry
+  const { nodeConfig, redis, libs } = serviceRegistry
 
   const FileSaveMaxConcurrency = nodeConfig.get(
     'nodeSyncFileSaveMaxConcurrency'
@@ -160,7 +160,7 @@ module.exports = async function (
       try {
         const myCnodeEndpoint = await getOwnEndpoint(serviceRegistry)
         userReplicaSet = await getCreatorNodeEndpoints({
-          serviceRegistry,
+          libs,
           logger: logger,
           wallet: fetchedWalletPublicKey,
           blockNumber,
@@ -353,7 +353,7 @@ module.exports = async function (
           await Promise.all(
             trackFilesSlice.map(async (trackFile) => {
               const success = await saveFileForMultihashToFS(
-                serviceRegistry,
+                libs,
                 logger,
                 trackFile.multihash,
                 trackFile.storagePath,
@@ -399,7 +399,7 @@ module.exports = async function (
                   nonTrackFile.fileName !== null
                 ) {
                   success = await saveFileForMultihashToFS(
-                    serviceRegistry,
+                    libs,
                     logger,
                     multihash,
                     nonTrackFile.storagePath,
@@ -408,7 +408,7 @@ module.exports = async function (
                   )
                 } else {
                   success = await saveFileForMultihashToFS(
-                    serviceRegistry,
+                    libs,
                     logger,
                     multihash,
                     nonTrackFile.storagePath,

--- a/creator-node/src/services/sync/skippedCIDsRetryService.js
+++ b/creator-node/src/services/sync/skippedCIDsRetryService.js
@@ -11,11 +11,9 @@ const LogPrefix = '[SkippedCIDsRetryQueue]'
  * TODO - consider moving queue/jobs off main process. Will require re-factoring of job processing / dependencies
  */
 class SkippedCIDsRetryQueue {
-  constructor(nodeConfig, libs, serviceRegistry) {
-    if (!nodeConfig || !libs || !serviceRegistry) {
-      throw new Error(
-        `${LogPrefix} Cannot start without nodeConfig, libs, and serviceRegistry`
-      )
+  constructor(nodeConfig, libs) {
+    if (!nodeConfig || !libs) {
+      throw new Error(`${LogPrefix} Cannot start without nodeConfig, libs`)
     }
 
     this.queue = new Bull('skipped-cids-retry-queue', {
@@ -41,7 +39,7 @@ class SkippedCIDsRetryQueue {
 
     this.queue.process(async (job, done) => {
       try {
-        await this.process(CIDMaxAgeMs, libs, serviceRegistry)
+        await this.process(CIDMaxAgeMs, libs)
       } catch (e) {
         this.logError(`Failed to process job || Error: ${e.message}`)
       }
@@ -76,7 +74,7 @@ class SkippedCIDsRetryQueue {
    * Attempt to re-fetch all previously skipped files
    * Only process files with age <= maxAge
    */
-  async process(CIDMaxAgeMs, libs, serviceRegistry) {
+  async process(CIDMaxAgeMs, libs) {
     const startTimestampMs = Date.now()
     const oldestFileCreatedAtDate = new Date(startTimestampMs - CIDMaxAgeMs)
 
@@ -99,7 +97,7 @@ class SkippedCIDsRetryQueue {
     for await (const file of skippedFiles) {
       // Returns boolean success indicator
       const success = await saveFileForMultihashToFS(
-        serviceRegistry,
+        libs,
         logger,
         file.multihash,
         file.storagePath,

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1327,7 +1327,8 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
     primarySyncFromSecondaryStub = proxyquire(
       '../src/services/sync/primarySyncFromSecondary',
       {
-        '../../serviceRegistry': { serviceRegistry: serviceRegistryMock }
+        '../../serviceRegistry': { serviceRegistry: serviceRegistryMock },
+        '../initAudiusLibs': async () => libsMock
       }
     )
   })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

**Problem**
circular dependency between `primarySyncFromSecondary` and `serviceRegistry`: `primarySyncFromSecondary` imports `serviceRegistry`, which imports `stateMachineManager`, which eventually imports `issueSyncRequest.jobProcessor` which imports `primarySyncFromSecondary`

**Solution**
- Move `serviceRegistry._initAudiusLibs()` to separate file
- update `serviceRegistry` to consume above
- update `saveFileForMultihashToFS()` and `getCreatorNodeEndpoints()` to accept `libs` instead of `serviceRegistry`
- same changes to other files

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Existing test coverage
TODO maddog regression test

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Error log containing `[primarySyncFromSecondary]` and `InitAudiusLibs Error`
Logs containing `circular dependency` or `initAudiusLibs`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->