### PR TITLE
INF-86 use new audius-infra ssh key for merging audius-sdk branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - setup_remote_docker
       - add_ssh_keys:
           fingerprints:
-            - "ee:b0:fd:fb:ba:c8:37:7a:f9:67:15:92:9f:02:97:3e"
+            - "d0:0b:a0:19:ac:46:58:e4:6c:ac:34:99:f6:1b:31:bb"
       - run:
           name: npm Auth
           command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc


### PR DESCRIPTION
### Description

Use the new audius-infra key for Github access.


### Tests

Manually testing our automated deploy script for Audius sdk.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->