### PR TITLE
[CON-262] Add more test coverage for /export

### DIFF
--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -1,6 +1,13 @@
 const models = require('../../models')
 const { Transaction } = require('sequelize')
 
+/**
+ * Exports all db data (not files) associated with walletPublicKey[] as JSON.
+ *
+ * @return {
+ *  cnodeUsersDict - Map Object containing all db data keyed on cnodeUserUUID
+ * }
+ */
 const exportComponentService = async ({
   walletPublicKeys,
   requestedClockRangeMin,

--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -1,0 +1,139 @@
+const models = require('../../models')
+const { Transaction } = require('sequelize')
+
+const exportComponentService = async ({
+  walletPublicKeys,
+  requestedClockRangeMin,
+  requestedClockRangeMax,
+  logger
+}) => {
+  const transaction = await models.sequelize.transaction({
+    isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+  })
+
+  try {
+    // Fetch cnodeUser for each walletPublicKey.
+    const cnodeUsers = await models.CNodeUser.findAll({
+      where: { walletPublicKey: walletPublicKeys },
+      transaction,
+      raw: true
+    })
+    const cnodeUserUUIDs = cnodeUsers.map(
+      (cnodeUser) => cnodeUser.cnodeUserUUID
+    )
+
+    // Fetch all data for cnodeUserUUIDs: audiusUsers, tracks, files, clockRecords.
+
+    const [audiusUsers, tracks, files, clockRecords] = await Promise.all([
+      models.AudiusUser.findAll({
+        where: {
+          cnodeUserUUID: cnodeUserUUIDs,
+          clock: {
+            [models.Sequelize.Op.gte]: requestedClockRangeMin,
+            [models.Sequelize.Op.lte]: requestedClockRangeMax
+          }
+        },
+        order: [['clock', 'ASC']],
+        transaction,
+        raw: true
+      }),
+      models.Track.findAll({
+        where: {
+          cnodeUserUUID: cnodeUserUUIDs,
+          clock: {
+            [models.Sequelize.Op.gte]: requestedClockRangeMin,
+            [models.Sequelize.Op.lte]: requestedClockRangeMax
+          }
+        },
+        order: [['clock', 'ASC']],
+        transaction,
+        raw: true
+      }),
+      models.File.findAll({
+        where: {
+          cnodeUserUUID: cnodeUserUUIDs,
+          clock: {
+            [models.Sequelize.Op.gte]: requestedClockRangeMin,
+            [models.Sequelize.Op.lte]: requestedClockRangeMax
+          }
+        },
+        order: [['clock', 'ASC']],
+        transaction,
+        raw: true
+      }),
+      models.ClockRecord.findAll({
+        where: {
+          cnodeUserUUID: cnodeUserUUIDs,
+          clock: {
+            [models.Sequelize.Op.gte]: requestedClockRangeMin,
+            [models.Sequelize.Op.lte]: requestedClockRangeMax
+          }
+        },
+        order: [['clock', 'ASC']],
+        transaction,
+        raw: true
+      })
+    ])
+
+    /** Bundle all data into cnodeUser objects to maximize import speed. */
+    const cnodeUsersDict = {}
+    cnodeUsers.forEach((cnodeUser) => {
+      // Add cnodeUserUUID data fields
+      cnodeUser.audiusUsers = []
+      cnodeUser.tracks = []
+      cnodeUser.files = []
+      cnodeUser.clockRecords = []
+
+      cnodeUsersDict[cnodeUser.cnodeUserUUID] = cnodeUser
+      const curCnodeUserClockVal = cnodeUser.clock
+
+      // Resets cnodeUser clock value to requestedClockRangeMax to ensure consistency with clockRecords data
+      // Also ensures secondary knows there is more data to sync
+      if (cnodeUser.clock > requestedClockRangeMax) {
+        // since clockRecords are returned by clock ASC, clock val at last index is largest clock val
+        cnodeUser.clock = requestedClockRangeMax
+        logger.info(
+          `nodeSync.js#export - cnodeUser clock val ${curCnodeUserClockVal} is higher than requestedClockRangeMax, reset to ${requestedClockRangeMax}`
+        )
+      }
+
+      // Validate clock values or throw an error
+      const maxClockRecordId = Math.max(
+        ...clockRecords.map((record) => record.clock)
+      )
+      if (cnodeUser.clock !== maxClockRecordId) {
+        throw new Error(
+          `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecordId}`
+        )
+      }
+
+      cnodeUser.clockInfo = {
+        requestedClockRangeMin,
+        requestedClockRangeMax,
+        localClockMax: cnodeUser.clock
+      }
+    })
+
+    audiusUsers.forEach((audiusUser) => {
+      cnodeUsersDict[audiusUser.cnodeUserUUID].audiusUsers.push(audiusUser)
+    })
+    tracks.forEach((track) => {
+      cnodeUsersDict[track.cnodeUserUUID].tracks.push(track)
+    })
+    files.forEach((file) => {
+      cnodeUsersDict[file.cnodeUserUUID].files.push(file)
+    })
+    clockRecords.forEach((clockRecord) => {
+      cnodeUsersDict[clockRecord.cnodeUserUUID].clockRecords.push(clockRecord)
+    })
+
+    await transaction.commit()
+
+    return cnodeUsersDict
+  } catch (e) {
+    await transaction.rollback()
+    throw new Error(e)
+  }
+}
+
+module.exports = exportComponentService

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -7,7 +7,7 @@ const {
 } = require('../apiHelpers')
 const config = require('../config')
 const retry = require('async-retry')
-const { Transaction } = require('sequelize')
+const exportComponentService = require('../components/replicaSet/exportComponentService')
 
 module.exports = function (app) {
   /**
@@ -34,160 +34,27 @@ module.exports = function (app) {
       const requestedClockRangeMax =
         requestedClockRangeMin + (maxExportClockValueRange - 1)
 
-      let cnodeUsersDict = {}
-
       try {
-        await retry(
+        const cnodeUsersDict = await retry(
           async () => {
-            const transaction = await models.sequelize.transaction({
-              isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+            return exportComponentService({
+              walletPublicKeys,
+              requestedClockRangeMin,
+              requestedClockRangeMax,
+              logger: req.logger
             })
-
-            try {
-              // Fetch cnodeUser for each walletPublicKey.
-              const cnodeUsers = await models.CNodeUser.findAll({
-                where: { walletPublicKey: walletPublicKeys },
-                transaction,
-                raw: true
-              })
-              const cnodeUserUUIDs = cnodeUsers.map(
-                (cnodeUser) => cnodeUser.cnodeUserUUID
-              )
-
-              // Fetch all data for cnodeUserUUIDs: audiusUsers, tracks, files, clockRecords.
-
-              const [audiusUsers, tracks, files, clockRecords] =
-                await Promise.all([
-                  models.AudiusUser.findAll({
-                    where: {
-                      cnodeUserUUID: cnodeUserUUIDs,
-                      clock: {
-                        [models.Sequelize.Op.gte]: requestedClockRangeMin,
-                        [models.Sequelize.Op.lte]: requestedClockRangeMax
-                      }
-                    },
-                    order: [['clock', 'ASC']],
-                    transaction,
-                    raw: true
-                  }),
-                  models.Track.findAll({
-                    where: {
-                      cnodeUserUUID: cnodeUserUUIDs,
-                      clock: {
-                        [models.Sequelize.Op.gte]: requestedClockRangeMin,
-                        [models.Sequelize.Op.lte]: requestedClockRangeMax
-                      }
-                    },
-                    order: [['clock', 'ASC']],
-                    transaction,
-                    raw: true
-                  }),
-                  models.File.findAll({
-                    where: {
-                      cnodeUserUUID: cnodeUserUUIDs,
-                      clock: {
-                        [models.Sequelize.Op.gte]: requestedClockRangeMin,
-                        [models.Sequelize.Op.lte]: requestedClockRangeMax
-                      }
-                    },
-                    order: [['clock', 'ASC']],
-                    transaction,
-                    raw: true
-                  }),
-                  models.ClockRecord.findAll({
-                    where: {
-                      cnodeUserUUID: cnodeUserUUIDs,
-                      clock: {
-                        [models.Sequelize.Op.gte]: requestedClockRangeMin,
-                        [models.Sequelize.Op.lte]: requestedClockRangeMax
-                      }
-                    },
-                    order: [['clock', 'ASC']],
-                    transaction,
-                    raw: true
-                  })
-                ])
-
-              /** Bundle all data into cnodeUser objects to maximize import speed. */
-              cnodeUsersDict = {}
-              cnodeUsers.forEach((cnodeUser) => {
-                // Add cnodeUserUUID data fields
-                cnodeUser.audiusUsers = []
-                cnodeUser.tracks = []
-                cnodeUser.files = []
-                cnodeUser.clockRecords = []
-
-                cnodeUsersDict[cnodeUser.cnodeUserUUID] = cnodeUser
-                const curCnodeUserClockVal = cnodeUser.clock
-
-                // Resets cnodeUser clock value to requestedClockRangeMax to ensure consistency with clockRecords data
-                // Also ensures secondary knows there is more data to sync
-                if (cnodeUser.clock > requestedClockRangeMax) {
-                  // since clockRecords are returned by clock ASC, clock val at last index is largest clock val
-                  cnodeUser.clock = requestedClockRangeMax
-                  req.logger.info(
-                    `nodeSync.js#export - cnodeUser clock val ${curCnodeUserClockVal} is higher than requestedClockRangeMax, reset to ${requestedClockRangeMax}`
-                  )
-                }
-
-                // Validate clock values or throw an error
-                const maxClockRecordId = Math.max(
-                  ...clockRecords.map((record) => record.clock)
-                )
-                if (cnodeUser.clock !== maxClockRecordId) {
-                  throw new Error(
-                    `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecordId}`
-                  )
-                }
-
-                cnodeUser.clockInfo = {
-                  requestedClockRangeMin,
-                  requestedClockRangeMax,
-                  localClockMax: cnodeUser.clock
-                }
-              })
-
-              audiusUsers.forEach((audiusUser) => {
-                cnodeUsersDict[audiusUser.cnodeUserUUID].audiusUsers.push(
-                  audiusUser
-                )
-              })
-              tracks.forEach((track) => {
-                cnodeUsersDict[track.cnodeUserUUID].tracks.push(track)
-              })
-              files.forEach((file) => {
-                cnodeUsersDict[file.cnodeUserUUID].files.push(file)
-              })
-              clockRecords.forEach((clockRecord) => {
-                cnodeUsersDict[clockRecord.cnodeUserUUID].clockRecords.push(
-                  clockRecord
-                )
-              })
-
-              req.logger.info(
-                `Successful export for wallets ${walletPublicKeys} to source endpoint ${
-                  sourceEndpoint || '(not provided)'
-                } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
-                  Date.now() - start
-                } ms`
-              )
-
-              await transaction.commit()
-            } catch (e) {
-              req.logger.error(
-                `Error in /export for wallets ${walletPublicKeys} to source endpoint ${
-                  sourceEndpoint || '(not provided)'
-                } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
-                  Date.now() - start
-                } ms ||`,
-                e
-              )
-              await transaction.rollback()
-            }
           },
           {
             retries: 3
           }
+        )
+
+        req.logger.info(
+          `Successful export for wallets ${walletPublicKeys} to source endpoint ${
+            sourceEndpoint || '(not provided)'
+          } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
+            Date.now() - start
+          } ms`
         )
 
         return successResponse({ cnodeUsers: cnodeUsersDict })

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -702,7 +702,7 @@ describe('test nodesync', async function () {
       })
     })
 
-    describe('Confirm export throws ann error with inconsitent data', async function () {
+    describe('Confirm export throws an error with inconsitent data', async function () {
       beforeEach(setupDepsAndApp)
 
       beforeEach(createUserAndTrack)

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -707,7 +707,7 @@ describe('test nodesync', async function () {
 
       beforeEach(createUserAndTrack)
 
-      it.only('Inconsistent clock values', async function () {
+      it('Inconsistent clock values', async function () {
         // Mock findOne DB function for cnodeUsers and ClockRecords
         // Have them return inconsistent values
         const clockRecordsFindAllStub = sandbox.stub().resolves([


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR splits the `/export` route into two functions, one for handling the request and one for performing business logic called `exportComponentService`. 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

A new test was added for the `exportComponentService` to make sure that the correct error is thrown when the database returns inconsistent clock values.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

The current logs are sufficient for monitoring these changes.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->