### PR TITLE
Increase write quorum timeout to 1m

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -494,7 +494,7 @@ const config = convict({
     doc: 'Duration for which to poll secondaries for content replication in `issueAndWaitForSecondarySyncRequests` function',
     format: 'nat',
     env: 'issueAndWaitForSecondarySyncRequestsPollingDurationMs',
-    default: 5000 // 5000ms = 5s (prod default)
+    default: 60000 // 60000ms = 1m (prod default)
   },
   enforceWriteQuorum: {
     doc: 'Boolean flag indicating whether or not primary should reject write until 2/3 replication across replica set',


### PR DESCRIPTION
### Description
Increase timeout for write quorum to wait 1 minute for a sync to complete to at least 1 secondary. This will impact the buckets for the `audius_cn_write_quorum_duration_seconds` metric, so I confirmed with @jonaylor89 that this will be OK for Prometheus since it's NoSQL.


### Tests
N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Timeouts in the logs should show 1 minute (or stop timing out) instead of 5 seconds. The log message `"Failed to reach 2/3 write quorum for user <WALLET> in <TIME>ms"` should have a <TIME> larger than 5000.