### PR TITLE
More state machine cleanup

### DIFF
--- a/creator-node/default-config.json
+++ b/creator-node/default-config.json
@@ -42,5 +42,6 @@
   "disableSnapback": true,
   "mergePrimaryAndSecondaryEnabled": false,
   "stateMonitoringQueueRateLimitInterval": 60000,
-  "stateMonitoringQueueRateLimitJobsPerInterval": 3
+  "stateMonitoringQueueRateLimitJobsPerInterval": 3,
+  "issueAndWaitForSecondarySyncRequestsPollingDurationMs": 5000
 }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -10,6 +10,7 @@ const {
   C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS,
   STATE_MONITORING_QUEUE_INIT_DELAY_MS
 } = require('../stateMachineConstants')
+const { makeQueue, registerQueueEvents } = require('../stateMachineUtils')
 const processJob = require('../processJob')
 const { logger: baseLogger, createChildLogger } = require('../../../logging')
 const { getLatestUserIdFromDiscovery } = require('./stateMonitoringUtils')
@@ -34,22 +35,40 @@ const cNodeEndpointToSpIdMapQueueLogger = createChildLogger(baseLogger, {
 class StateMonitoringManager {
   async init(discoveryNodeEndpoint, prometheusRegistry) {
     // Create and start queue to fetch cNodeEndpoint->spId mapping
-    const cNodeEndpointToSpIdMapQueue = this.makeCNodeToEndpointSpIdMapQueue(
-      config.get('redisHost'),
-      config.get('redisPort')
-    )
+    const cNodeEndpointToSpIdMapQueue = makeQueue({
+      redisHost: config.get('redisHost'),
+      redisPort: config.get('redisPort'),
+      name: QUEUE_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+      removeOnComplete: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+      removeOnFail: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP,
+      lockDuration: C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS,
+      limiter: {
+        max: 1,
+        duration: config.get('fetchCNodeEndpointToSpIdMapIntervalMs')
+      }
+    })
     await this.startEndpointToSpIdMapQueue(
       cNodeEndpointToSpIdMapQueue,
       prometheusRegistry
     )
 
     // Create and start queue to monitor state for syncs and reconfigs
-    const stateMonitoringQueue = this.makeMonitoringQueue(
-      config.get('redisHost'),
-      config.get('redisPort')
-    )
+    const stateMonitoringQueue = makeQueue({
+      redisHost: config.get('redisHost'),
+      redisPort: config.get('redisPort'),
+      name: QUEUE_NAMES.STATE_MONITORING,
+      removeOnComplete: QUEUE_HISTORY.STATE_MONITORING,
+      removeOnFail: QUEUE_HISTORY.STATE_MONITORING,
+      lockDuration: STATE_MONITORING_QUEUE_MAX_JOB_RUNTIME_MS,
+      limiter: {
+        // Bull doesn't allow either of these to be set to 0
+        max: config.get('stateMonitoringQueueRateLimitJobsPerInterval') || 1,
+        duration: config.get('stateMonitoringQueueRateLimitInterval') || 1
+      }
+    })
     this.registerMonitoringQueueEventHandlersAndJobProcessors({
       monitoringQueue: stateMonitoringQueue,
+      cNodeEndpointToSpIdMapQueue,
       monitorStateJobFailureCallback: this.enqueueMonitorStateJobAfterFailure,
       processMonitorStateJob:
         this.makeProcessMonitorStateJob(prometheusRegistry).bind(this),
@@ -66,64 +85,11 @@ class StateMonitoringManager {
     }
   }
 
-  makeMonitoringQueue(redisHost, redisPort) {
-    // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
-    return new BullQueue(QUEUE_NAMES.STATE_MONITORING, {
-      redis: {
-        host: redisHost,
-        port: redisPort
-      },
-      defaultJobOptions: {
-        removeOnComplete: QUEUE_HISTORY.STATE_MONITORING,
-        removeOnFail: QUEUE_HISTORY.STATE_MONITORING
-      },
-      settings: {
-        // Should be sufficiently larger than expected job runtime
-        lockDuration: STATE_MONITORING_QUEUE_MAX_JOB_RUNTIME_MS,
-        // We never want to re-process stalled jobs
-        maxStalledCount: 0
-      },
-      limiter: {
-        // Bull doesn't allow either of these to be set to 0
-        max: config.get('stateMonitoringQueueRateLimitJobsPerInterval') || 1,
-        duration: config.get('stateMonitoringQueueRateLimitInterval') || 1
-      }
-    })
-  }
-
-  makeCNodeToEndpointSpIdMapQueue(redisHost, redisPort) {
-    cNodeEndpointToSpIdMapQueueLogger.info(
-      `Initting queue to update cNodeEndpointToSpIdMap every ${
-        config.get('fetchCNodeEndpointToSpIdMapIntervalMs') / 1000
-      } seconds`
-    )
-    // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
-    return new BullQueue(QUEUE_NAMES.C_NODE_ENDPOINT_TO_SP_ID_MAP, {
-      redis: {
-        host: redisHost,
-        port: redisPort
-      },
-      defaultJobOptions: {
-        removeOnComplete: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP,
-        removeOnFail: QUEUE_HISTORY.C_NODE_ENDPOINT_TO_SP_ID_MAP
-      },
-      settings: {
-        // Should be sufficiently larger than expected job runtime
-        lockDuration: C_NODE_ENDPOINT_TO_SP_ID_MAP_QUEUE_MAX_JOB_RUNTIME_MS,
-        // We never want to re-process stalled jobs
-        maxStalledCount: 0
-      },
-      limiter: {
-        max: 1,
-        duration: config.get('fetchCNodeEndpointToSpIdMapIntervalMs')
-      }
-    })
-  }
-
   /**
    * Registers event handlers for logging and job success/failure.
    * @param {Object} params
    * @param {Object} params.monitoringQueue the monitoring queue to register events for
+   * @param {Object} params.cNodeEndpointToSpIdMapQueue the queue that fetches the cNodeEndpoint->spId map
    * @param {Function<failedJob>} params.monitorStateJobFailureCallback the function to call when a monitorState job fails
    * @param {Function<job>} params.processMonitorStateJob the function to call when processing a job from the queue to monitor state
    * @param {Function<job>} params.processFindSyncRequestsJob the function to call when processing a job from the queue to find sync requests that potentially need to be issued
@@ -131,31 +97,18 @@ class StateMonitoringManager {
    */
   registerMonitoringQueueEventHandlersAndJobProcessors({
     monitoringQueue,
+    cNodeEndpointToSpIdMapQueue,
     monitorStateJobFailureCallback,
     processMonitorStateJob,
     processFindSyncRequestsJob,
     processFindReplicaSetUpdatesJob
   }) {
     // Add handlers for logging
-    monitoringQueue.on('global:waiting', (jobId) => {
-      const logger = createChildLogger(monitoringQueueLogger, { jobId })
-      logger.info('Job active')
-    })
-    monitoringQueue.on('global:active', (jobId, jobPromise) => {
-      const logger = createChildLogger(monitoringQueueLogger, { jobId })
-      logger.info('Job active')
-    })
-    monitoringQueue.on('global:lock-extension-failed', (jobId, err) => {
-      const logger = createChildLogger(monitoringQueueLogger, { jobId })
-      logger.error(`Job lock extension failed. Error: ${err}`)
-    })
-    monitoringQueue.on('global:stalled', (jobId) => {
-      const logger = createChildLogger(monitoringQueueLogger, { jobId })
-      logger.error('Job stalled')
-    })
-    monitoringQueue.on('global:error', (error) => {
-      monitoringQueueLogger.error(`Queue Job Error - ${error}`)
-    })
+    registerQueueEvents(monitoringQueue, monitoringQueueLogger)
+    registerQueueEvents(
+      cNodeEndpointToSpIdMapQueue,
+      cNodeEndpointToSpIdMapQueueLogger
+    )
 
     // Log when a job fails to complete and re-enqueue another monitoring job
     monitoringQueue.on('failed', (job, err) => {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -1,5 +1,3 @@
-const BullQueue = require('bull')
-
 const config = require('../../../config')
 const {
   QUEUE_HISTORY,
@@ -8,6 +6,7 @@ const {
   STATE_RECONCILIATION_QUEUE_MAX_JOB_RUNTIME_MS,
   MANUAL_SYNC_QUEUE_MAX_JOB_RUNTIME_MS
 } = require('../stateMachineConstants')
+const { makeQueue, registerQueueEvents } = require('../stateMachineUtils')
 const processJob = require('../processJob')
 const { logger: baseLogger, createChildLogger } = require('../../../logging')
 const handleSyncRequestJobProcessor = require('./issueSyncRequest.jobProcessor')
@@ -28,7 +27,7 @@ const manualSyncLogger = createChildLogger(baseLogger, {
  */
 class StateReconciliationManager {
   async init(prometheusRegistry) {
-    const stateReconciliationQueue = this.makeQueue({
+    const stateReconciliationQueue = makeQueue({
       redisHost: config.get('redisHost'),
       redisPort: config.get('redisPort'),
       name: QUEUE_NAMES.STATE_RECONCILIATION,
@@ -37,7 +36,7 @@ class StateReconciliationManager {
       lockDuration: STATE_RECONCILIATION_QUEUE_MAX_JOB_RUNTIME_MS
     })
 
-    const manualSyncQueue = this.makeQueue({
+    const manualSyncQueue = makeQueue({
       redisHost: config.get('redisHost'),
       redisPort: config.get('redisPort'),
       name: QUEUE_NAMES.MANUAL_SYNC,
@@ -67,38 +66,11 @@ class StateReconciliationManager {
     }
   }
 
-  makeQueue({
-    redisHost,
-    redisPort,
-    name,
-    removeOnComplete,
-    removeOnFail,
-    lockDuration
-  }) {
-    // Settings config from https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#advanced-settings
-    return new BullQueue(name, {
-      redis: {
-        host: redisHost,
-        port: redisPort
-      },
-      defaultJobOptions: {
-        removeOnComplete: removeOnComplete,
-        removeOnFail: removeOnFail
-      },
-      settings: {
-        // Should be sufficiently larger than expected job runtime
-        lockDuration: lockDuration,
-        // We never want to re-process stalled jobs
-        maxStalledCount: 0
-      }
-    })
-  }
-
   /**
    * Registers event handlers for logging and job success/failure.
    * @param {Object} params.queue the queue to register events for
-   * @param {Function<queue, successfulJob, jobResult>} params.jobSuccessCallback the function to call when a job succeeds
-   * @param {Function<queue, failedJob>} params.jobFailureCallback the function to call when a job fails
+   * @param {Object} params.stateReconciliationQueue the state reconciliation queue
+   * @param {Object} params.manualSyncQueue the manual sync queue
    * @param {Function<job>} params.processManualSync the function to call when processing a manual sync job from the queue
    * @param {Function<job>} params.processRecurringSync the function to call when processing a recurring sync job from the queue
    * @param {Function<job>} params.processUpdateReplicaSet the function to call when processing an update-replica-set job from the queue
@@ -111,28 +83,8 @@ class StateReconciliationManager {
     processUpdateReplicaSet
   }) {
     // Add handlers for logging
-    stateReconciliationQueue.on('global:waiting', (jobId) => {
-      const logger = createChildLogger(reconciliationLogger, { jobId })
-      logger.info('Job waiting')
-    })
-    stateReconciliationQueue.on('global:active', (jobId, jobPromise) => {
-      const logger = createChildLogger(reconciliationLogger, { jobId })
-      logger.info('Job active')
-    })
-    stateReconciliationQueue.on(
-      'global:lock-extension-failed',
-      (jobId, err) => {
-        const logger = createChildLogger(stateReconciliationQueue, { jobId })
-        logger.error(`Job lock extension failed. Error: ${err}`)
-      }
-    )
-    stateReconciliationQueue.on('global:stalled', (jobId) => {
-      const logger = createChildLogger(stateReconciliationQueue, { jobId })
-      logger.error('Job stalled')
-    })
-    stateReconciliationQueue.on('global:error', (error) => {
-      reconciliationLogger.error(`Queue Job Error - ${error}`)
-    })
+    registerQueueEvents(stateReconciliationQueue, reconciliationLogger)
+    registerQueueEvents(manualSyncQueue, manualSyncLogger)
 
     // Log when a job fails to complete
     stateReconciliationQueue.on('failed', (job, err) => {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.js
@@ -20,9 +20,6 @@ const {
   SYNC_MODES
 } = require('../stateMachineConstants')
 const primarySyncFromSecondary = require('../../sync/primarySyncFromSecondary')
-const {
-  computeSyncModeForUserAndReplica
-} = require('../stateMonitoring/stateMonitoringUtils')
 
 const thisContentNodeEndpoint = config.get('creatorNodeEndpoint')
 const secondaryUserSyncDailyFailureCountThreshold = config.get(


### PR DESCRIPTION
### Description
- Extract making queues and common loggers into 2 functions and make sure they're applied to all state machine queues (this is especially important for debugging manual syncs since that queue didn't have the stalled logs)
- Lower the write quorum wait time on staging to 5 seconds


### Tests
Made sure existing tests pass and queues run correctly on local (these changes mostly impact the queue setup).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
As part of debugging manual sync jobs failing, check logs for: `json.queue:"manual-sync-queue" AND json.logLevel:"error"`