### PR TITLE
[PAY-433] Fixed Ray's broken prod account

### DIFF
--- a/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
+++ b/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
@@ -6,6 +6,7 @@ Create Date: 2022-07-21 15:24:49.790954
 
 """
 from alembic import op
+from sqlalchemy.orm import sessionmaker
 
 # revision identifiers, used by Alembic.
 revision = 'ab56e2d974a6'
@@ -13,9 +14,15 @@ down_revision = '08becec375f3'
 branch_labels = None
 depends_on = None
 
+Session = sessionmaker()
 
 def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    res = session.execute("select wallet from users where user_id = 987591")
+    oldWallet = res.fetchall()[0][0]
     op.execute("update users set wallet = '0x1111111111222222222233333333334444444444' where user_id = 987591;")
+    op.execute("update user_bank_accounts set ethereum_address = '0x1111111111222222222233333333334444444444' where ethereum_address = '{}';".format(oldWallet))
 
 
 def downgrade():

--- a/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
+++ b/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
@@ -1,0 +1,22 @@
+"""fix_ray_account
+
+Revision ID: ab56e2d974a6
+Revises: 08becec375f3
+Create Date: 2022-07-21 15:24:49.790954
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'ab56e2d974a6'
+down_revision = '08becec375f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("update users set wallet = '0x1111111111222222222233333333334444444444' where user_id = 987591;")
+
+
+def downgrade():
+    pass

--- a/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
+++ b/discovery-provider/alembic/versions/ab56e2d974a6_fix_ray_account.py
@@ -6,7 +6,6 @@ Create Date: 2022-07-21 15:24:49.790954
 
 """
 from alembic import op
-from sqlalchemy.orm import sessionmaker
 
 # revision identifiers, used by Alembic.
 revision = 'ab56e2d974a6'
@@ -14,15 +13,9 @@ down_revision = '08becec375f3'
 branch_labels = None
 depends_on = None
 
-Session = sessionmaker()
 
 def upgrade():
-    bind = op.get_bind()
-    session = Session(bind=bind)
-    res = session.execute("select wallet from users where user_id = 987591")
-    oldWallet = res.fetchall()[0][0]
     op.execute("update users set wallet = '0x1111111111222222222233333333334444444444' where user_id = 987591;")
-    op.execute("update user_bank_accounts set ethereum_address = '0x1111111111222222222233333333334444444444' where ethereum_address = '{}';".format(oldWallet))
 
 
 def downgrade():


### PR DESCRIPTION
### Description
Ray had created a test user (named "hardforktest1", user_id: 987591) and mistakenly used the same wallet address as in his nomal prod account. This breaks our assumption that users have a 1-1 relationship to wallets which tip indexing relies on. This migration changes the wallet address of hardforktest1 to a garbage value.

### Tests
Tested on remote dev box: created fake user in users table, then ran migration and visually confirmed the wallet value changed.
Before:
<img width="678" alt="Screen Shot 2022-07-21 at 11 33 13 AM" src="https://user-images.githubusercontent.com/3893871/180260523-4b6f9098-880a-4790-b04a-ed94fc26b74e.png">
After:
<img width="676" alt="Screen Shot 2022-07-21 at 11 35 24 AM" src="https://user-images.githubusercontent.com/3893871/180260526-d6953bae-c2fd-4c6c-9bbb-0ebfd7447ed5.png">

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Once the migration is run I will confirm with Ray that he is able to send tips. Should also keep an eye out for any unexpected behavior on his prod account.