### PR TITLE
[CON-233] Add queue history for all remaining queues

### DIFF
--- a/creator-node/src/AsyncProcessingQueue.js
+++ b/creator-node/src/AsyncProcessingQueue.js
@@ -45,7 +45,7 @@ class AsyncProcessingQueue {
       },
       defaultJobOptions: {
         removeOnComplete: ASYNC_PROCESSING_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: ASYNC_PROCESSING_QUEUE_HISTORY
       }
     })
 

--- a/creator-node/src/AsyncProcessingQueue.js
+++ b/creator-node/src/AsyncProcessingQueue.js
@@ -27,6 +27,8 @@ const PROCESS_STATES = Object.freeze({
   FAILED: 'FAILED'
 })
 
+const ASYNC_PROCESSING_QUEUE_HISTORY = 500
+
 /**
  * This queue accepts jobs (any function) that needs to be processed asynchonously.
  * Once the job is complete, the response is added to redis. The response can be
@@ -42,7 +44,7 @@ class AsyncProcessingQueue {
         port: config.get('redisPort')
       },
       defaultJobOptions: {
-        removeOnComplete: true,
+        removeOnComplete: ASYNC_PROCESSING_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/ImageProcessingQueue.js
+++ b/creator-node/src/ImageProcessingQueue.js
@@ -29,7 +29,7 @@ class ImageProcessingQueue {
       },
       defaultJobOptions: {
         removeOnComplete: IMAGE_PROCESSING_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: IMAGE_PROCESSING_QUEUE_HISTORY
       }
     })
 

--- a/creator-node/src/ImageProcessingQueue.js
+++ b/creator-node/src/ImageProcessingQueue.js
@@ -18,6 +18,8 @@ const MAX_CONCURRENCY =
     ? imageProcessingMaxConcurrency
     : os.cpus().length
 
+const IMAGE_PROCESSING_QUEUE_HISTORY = 500
+
 class ImageProcessingQueue {
   constructor() {
     this.queue = new Bull('image-processing-queue', {
@@ -26,7 +28,7 @@ class ImageProcessingQueue {
         host: config.get('redisHost')
       },
       defaultJobOptions: {
-        removeOnComplete: true,
+        removeOnComplete: IMAGE_PROCESSING_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -32,7 +32,7 @@ class TranscodingQueue {
       },
       defaultJobOptions: {
         removeOnComplete: TRANSCODING_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: TRANSCODING_QUEUE_HISTORY
       }
     })
     this.logStatus('Initialized TranscodingQueue')

--- a/creator-node/src/TranscodingQueue.js
+++ b/creator-node/src/TranscodingQueue.js
@@ -21,6 +21,8 @@ const PROCESS_NAMES = Object.freeze({
   transcode320: 'transcode_320'
 })
 
+const TRANSCODING_QUEUE_HISTORY = 500
+
 class TranscodingQueue {
   constructor() {
     this.queue = new Bull('transcoding-queue', {
@@ -29,7 +31,7 @@ class TranscodingQueue {
         host: config.get('redisHost')
       },
       defaultJobOptions: {
-        removeOnComplete: true,
+        removeOnComplete: TRANSCODING_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/monitors/MonitoringQueue.js
+++ b/creator-node/src/monitors/MonitoringQueue.js
@@ -30,7 +30,7 @@ class MonitoringQueue {
       },
       defaultJobOptions: {
         removeOnComplete: MONITORING_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: MONITORING_QUEUE_HISTORY
       }
     })
 

--- a/creator-node/src/monitors/MonitoringQueue.js
+++ b/creator-node/src/monitors/MonitoringQueue.js
@@ -10,6 +10,8 @@ const PROCESS_NAMES = Object.freeze({
   monitor: 'monitor'
 })
 
+const MONITORING_QUEUE_HISTORY = 500
+
 /**
  * A persistent cron-style queue that periodically monitors various
  * health metrics and caches values in redis.
@@ -27,7 +29,7 @@ class MonitoringQueue {
         host: config.get('redisHost')
       },
       defaultJobOptions: {
-        removeOnComplete: true,
+        removeOnComplete: MONITORING_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/services/sync/skippedCIDsRetryService.js
+++ b/creator-node/src/services/sync/skippedCIDsRetryService.js
@@ -7,6 +7,8 @@ const { saveFileForMultihashToFS } = require('../../fileManager')
 
 const LogPrefix = '[SkippedCIDsRetryQueue]'
 
+const RETRY_QUEUE_HISTORY = 500
+
 /**
  * TODO - consider moving queue/jobs off main process. Will require re-factoring of job processing / dependencies
  */
@@ -23,7 +25,7 @@ class SkippedCIDsRetryQueue {
       },
       defaultJobOptions: {
         // these required since completed/failed jobs data set can grow infinitely until memory exhaustion
-        removeOnComplete: true,
+        removeOnComplete: RETRY_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/services/sync/skippedCIDsRetryService.js
+++ b/creator-node/src/services/sync/skippedCIDsRetryService.js
@@ -26,7 +26,7 @@ class SkippedCIDsRetryQueue {
       defaultJobOptions: {
         // these required since completed/failed jobs data set can grow infinitely until memory exhaustion
         removeOnComplete: RETRY_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: RETRY_QUEUE_HISTORY
       }
     })
 

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -3,6 +3,8 @@ const Bull = require('bull')
 const { logger } = require('../../logging')
 const secondarySyncFromPrimary = require('./secondarySyncFromPrimary')
 
+const SYNC_QUEUE_HISTORY = 500
+
 /**
  * SyncQueue - handles enqueuing and processing of Sync jobs on secondary
  * sync job = this node (secondary) will sync data for a user from their primary
@@ -24,7 +26,7 @@ class SyncQueue {
         port: this.nodeConfig.get('redisPort')
       },
       defaultJobOptions: {
-        removeOnComplete: true,
+        removeOnComplete: SYNC_QUEUE_HISTORY,
         removeOnFail: true
       }
     })

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -27,7 +27,7 @@ class SyncQueue {
       },
       defaultJobOptions: {
         removeOnComplete: SYNC_QUEUE_HISTORY,
-        removeOnFail: true
+        removeOnFail: SYNC_QUEUE_HISTORY
       }
     })
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds queue history (both onComplete and onFail) to every queue that didn't already have it 
* ImageProcessingQueue
* AsyncProcessingQueue
* SyncQueue
* SkippedCIDRetryQueue
* MonitoringQueue
* TranscodingQueue

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

We'll be able to monitor these changes on the bull dashboards

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->