### PR TITLE
[CON-265] Add percentage based metrics to network monitoring

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -8,6 +8,7 @@ import {
     partiallySyncedUsersCountGauge,
     primaryUserCountGauge,
     unsyncedUsersCountGauge,
+    userCountGauge,
     usersWithAllFoundationNodeReplicaSetGauge,
 } from "../prometheus"
 import { getEnv } from "../utils"
@@ -19,6 +20,7 @@ import {
     getUnsyncedUsersCount,
     getUsersWithNullPrimaryClock,
     getUsersWithEntireReplicaSetInSpidSetCount,
+    getUserCount,
 } from "./queries"
 
 export const generateMetrics = async (run_id: number) => {
@@ -28,6 +30,8 @@ export const generateMetrics = async (run_id: number) => {
     console.log(`[${run_id}] generating metrics`)
 
     const endTimer = generatingMetricsDurationGauge.startTimer()
+
+    const userCount = await getUserCount()
 
     const allUserCount = await getAllUserCount(run_id)
 
@@ -50,6 +54,7 @@ export const generateMetrics = async (run_id: number) => {
         primaryUserCountGauge.set({ endpoint, run_id }, count)
     })
 
+    userCountGauge.set({ run_id }, userCount)
     fullySyncedUsersCountGauge.set({ run_id }, fullySyncedUsersCount)
     partiallySyncedUsersCountGauge.set({ run_id }, partiallySyncedUserCount)
     unsyncedUsersCountGauge.set({ run_id }, unsyncedUsersCount)
@@ -63,7 +68,8 @@ export const generateMetrics = async (run_id: number) => {
         fullySyncedUsersCount: fullySyncedUsersCount,
         partiallySyncedUsersCount: partiallySyncedUserCount,
         unsyncedUsersCount: unsyncedUsersCount,
-        usersWithNullPrimaryClock: usersWithNullPrimaryClock
+        usersWithNullPrimaryClock: usersWithNullPrimaryClock,
+        usersWithAllFoundationNodeReplicaSetCount: usersWithAllFoundationNodeReplicaSetCount,
     })
 
     try {

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -30,7 +30,7 @@ export const generateMetrics = async (run_id: number) => {
 
   const endTimer = generatingMetricsDurationGauge.startTimer();
 
-  const userCount = await getUserCount();
+  const userCount = await getUserCount(run_id);
 
   const allUserCount = await getAllUserCount(run_id);
 

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -1,108 +1,121 @@
-import axios from "axios"
+import axios from "axios";
 import {
-    allUserCountGauge,
-    fullySyncedUsersCountGauge,
-    gateway,
-    generatingMetricsDurationGauge,
-    nullPrimaryUsersCountGauge,
-    partiallySyncedUsersCountGauge,
-    primaryUserCountGauge,
-    unsyncedUsersCountGauge,
-    userCountGauge,
-    usersWithAllFoundationNodeReplicaSetGauge,
-} from "../prometheus"
-import { getEnv } from "../utils"
+  allUserCountGauge,
+  fullySyncedUsersCountGauge,
+  gateway,
+  generatingMetricsDurationGauge,
+  nullPrimaryUsersCountGauge,
+  partiallySyncedUsersCountGauge,
+  primaryUserCountGauge,
+  unsyncedUsersCountGauge,
+  userCountGauge,
+  usersWithAllFoundationNodeReplicaSetGauge,
+} from "../prometheus";
+import { getEnv } from "../utils";
 import {
-    getPrimaryUserCount,
-    getAllUserCount,
-    getFullySyncedUsersCount,
-    getPartiallySyncedUsersCount,
-    getUnsyncedUsersCount,
-    getUsersWithNullPrimaryClock,
-    getUsersWithEntireReplicaSetInSpidSetCount,
-    getUserCount,
-} from "./queries"
+  getPrimaryUserCount,
+  getAllUserCount,
+  getFullySyncedUsersCount,
+  getPartiallySyncedUsersCount,
+  getUnsyncedUsersCount,
+  getUsersWithNullPrimaryClock,
+  getUsersWithEntireReplicaSetInSpidSetCount,
+  getUserCount,
+} from "./queries";
 
 export const generateMetrics = async (run_id: number) => {
+  const { foundationNodes } = getEnv();
 
-    const { foundationNodes } = getEnv()
+  console.log(`[${run_id}] generating metrics`);
 
-    console.log(`[${run_id}] generating metrics`)
+  const endTimer = generatingMetricsDurationGauge.startTimer();
 
-    const endTimer = generatingMetricsDurationGauge.startTimer()
+  const userCount = await getUserCount();
 
-    const userCount = await getUserCount()
+  const allUserCount = await getAllUserCount(run_id);
 
-    const allUserCount = await getAllUserCount(run_id)
+  const primaryUserCount = await getPrimaryUserCount(run_id);
 
-    const primaryUserCount = await getPrimaryUserCount(run_id)
+  const fullySyncedUsersCount = await getFullySyncedUsersCount(run_id);
 
-    const fullySyncedUsersCount = await getFullySyncedUsersCount(run_id)
+  const partiallySyncedUserCount = await getPartiallySyncedUsersCount(run_id);
 
-    const partiallySyncedUserCount = await getPartiallySyncedUsersCount(run_id)
+  const unsyncedUsersCount = await getUnsyncedUsersCount(run_id);
 
-    const unsyncedUsersCount = await getUnsyncedUsersCount(run_id)
+  const usersWithNullPrimaryClock = await getUsersWithNullPrimaryClock(run_id);
 
-    const usersWithNullPrimaryClock = await getUsersWithNullPrimaryClock(run_id)
+  const usersWithAllFoundationNodeReplicaSetCount =
+    await getUsersWithEntireReplicaSetInSpidSetCount(run_id, foundationNodes);
 
-    const usersWithAllFoundationNodeReplicaSetCount = await getUsersWithEntireReplicaSetInSpidSetCount(run_id, foundationNodes)
+  allUserCount.forEach(({ endpoint, count }) => {
+    allUserCountGauge.set({ endpoint, run_id }, count);
+  });
+  primaryUserCount.forEach(({ endpoint, count }) => {
+    primaryUserCountGauge.set({ endpoint, run_id }, count);
+  });
 
-    allUserCount.forEach(({ endpoint, count }) => {
-        allUserCountGauge.set({ endpoint, run_id }, count)
-    })
-    primaryUserCount.forEach(({ endpoint, count }) => {
-        primaryUserCountGauge.set({ endpoint, run_id }, count)
-    })
+  userCountGauge.set({ run_id }, userCount);
+  fullySyncedUsersCountGauge.set({ run_id }, fullySyncedUsersCount);
+  partiallySyncedUsersCountGauge.set({ run_id }, partiallySyncedUserCount);
+  unsyncedUsersCountGauge.set({ run_id }, unsyncedUsersCount);
+  nullPrimaryUsersCountGauge.set({ run_id }, usersWithNullPrimaryClock);
+  usersWithAllFoundationNodeReplicaSetGauge.set(
+    { run_id },
+    usersWithAllFoundationNodeReplicaSetCount
+  );
 
-    userCountGauge.set({ run_id }, userCount)
-    fullySyncedUsersCountGauge.set({ run_id }, fullySyncedUsersCount)
-    partiallySyncedUsersCountGauge.set({ run_id }, partiallySyncedUserCount)
-    unsyncedUsersCountGauge.set({ run_id }, unsyncedUsersCount)
-    nullPrimaryUsersCountGauge.set({ run_id }, usersWithNullPrimaryClock)
-    usersWithAllFoundationNodeReplicaSetGauge.set({ run_id }, usersWithAllFoundationNodeReplicaSetCount)
+  // Record duration for generating metrics and export to prometheus
+  endTimer({ run_id: run_id });
 
-    // Record duration for generating metrics and export to prometheus
-    endTimer({ run_id: run_id })
-
+  if (userCount > 0) {
     await publishSlackReport({
-        fullySyncedUsersCount: fullySyncedUsersCount,
-        partiallySyncedUsersCount: partiallySyncedUserCount,
-        unsyncedUsersCount: unsyncedUsersCount,
-        usersWithNullPrimaryClock: usersWithNullPrimaryClock,
-        usersWithAllFoundationNodeReplicaSetCount: usersWithAllFoundationNodeReplicaSetCount,
-    })
+      fullySyncedUsersCount:
+        ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",
+      partiallySyncedUsersCount:
+        ((partiallySyncedUserCount / userCount) * 100).toFixed(2) + "%",
+      unsyncedUsersCount:
+        ((unsyncedUsersCount / userCount) * 100).toFixed(2) + "%",
+      usersWithNullPrimaryClock:
+        ((usersWithNullPrimaryClock / userCount) * 100).toFixed(2) + "%",
+      usersWithAllFoundationNodeReplicaSetCount:
+        ((usersWithAllFoundationNodeReplicaSetCount / userCount) * 100).toFixed(
+          2
+        ) + "%",
+    });
+  }
 
-    try {
-        // Finish by publishing metrics to prometheus push gateway
-        console.log(`[${run_id}] pushing metrics to gateway`);
-        await gateway.pushAdd({ jobName: 'network-monitoring' })
-    } catch (e) {
-        console.log(`[generateMetrics] error pushing metrics to pushgateway - ${(e as Error).message}`)
-    }
+  try {
+    // Finish by publishing metrics to prometheus push gateway
+    console.log(`[${run_id}] pushing metrics to gateway`);
+    await gateway.pushAdd({ jobName: "network-monitoring" });
+  } catch (e) {
+    console.log(
+      `[generateMetrics] error pushing metrics to pushgateway - ${
+        (e as Error).message
+      }`
+    );
+  }
 
-
-    console.log(`[${run_id}] finish generating metrics`);
-}
+  console.log(`[${run_id}] finish generating metrics`);
+};
 
 const publishSlackReport = async (metrics: Object) => {
+  const { slackUrl } = getEnv();
 
-    const { slackUrl } = getEnv()
+  let message = `\`\`\`${JSON.stringify(metrics, null, 2)}\`\`\``;
+  console.log(message);
 
-    if (slackUrl === '') {
-        return
-    }
+  if (slackUrl === "") {
+    return;
+  }
 
-    let message = `\`\`\`${JSON.stringify(metrics, null, 2)}\`\`\`` 
-    console.log(message)
-
-    try {
-        await axios.post(
-            slackUrl,
-            {
-                text: message,
-            }, 
-        )
-    } catch (e) {
-        console.log(`Error posting to slack in slack reporter ${(e as Error).toString()}`)
-    }
-}
+  try {
+    await axios.post(slackUrl, {
+      text: message,
+    });
+  } catch (e) {
+    console.log(
+      `Error posting to slack in slack reporter ${(e as Error).toString()}`
+    );
+  }
+};

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -10,14 +10,15 @@ import { sequelizeConn } from "../db"
  */ 
 
 // Get the current user count from discovery nodes
-export const getUserCount = async (): Promise<number> => {
+export const getUserCount = async (run_id: number): Promise<number> => {
 
     const usersResp: unknown[] = await sequelizeConn.query(`
     SELECT COUNT(*) as user_count
-    FROM users
-    WHERE is_current = TRUE
+    FROM network_monitoring_users
+    WHERE run_id = :run_id
     `, {
         type: QueryTypes.SELECT,
+        replacements: { run_id },
     })
 
     const usersCount = parseInt(((usersResp as { user_count: string }[])[0] || { user_count: '0' }).user_count)

--- a/discovery-provider/plugins/network-monitoring/src/prometheus.ts
+++ b/discovery-provider/plugins/network-monitoring/src/prometheus.ts
@@ -6,6 +6,12 @@ const { pushGatewayUrl } = getEnv()
 
 export const gateway = new client.Pushgateway(pushGatewayUrl)
 
+export const userCountGauge = new client.Gauge({
+    name: 'audius_nm_user_count',
+    help: 'the number of users on audius',
+    labelNames: ['run_id'],
+})
+
 export const allUserCountGauge = new client.Gauge({
     name: 'audius_nm_all_user_count',
     help: 'the count of users with this content node in their replica set',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds the metric `userCount` which is just the total number of users on Audius during that run. Having this metric will let us calculate percentages for things in grafana.

This PR also adds the number of users entirely on foundation nodes into the slack report which was something I forgot to do in my original PR.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Ran a network monitoring job locally

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This will be monitored with slack, prometheus and grafana

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->