### PR TITLE
Only track metrics for explicit routes

### DIFF
--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -43,7 +43,7 @@ function errorHandler(err, req, res, next) {
  * Example:
  * {
  *    regex: /(?:^\/ipfs\/(?:([^/]+?))\/?$|^\/content\/(?:([^/]+?))\/?$)/i,
- *    path: '/ipfs/#CID'
+ *    path: '/ipfs/:CID'
  * }
  * @param {Object} app
  */

--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -57,35 +57,38 @@ function _setupRouteDurationTracking(routers) {
   const routesWithoutRouteParams = []
   const routesWithRouteParams = []
   for (const layer of layers) {
-    const route = layer.route
-    if (Array.isArray(route.path)) {
-      route.path.forEach((p) => {
+    const path = layer.route.path
+    const method = Object.keys(layer.route.methods)[0]
+    const regex = layer.regexp
+
+    if (Array.isArray(path)) {
+      path.forEach((p) => {
         if (p.includes(':')) {
           routesWithRouteParams.push({
             path: p,
-            method: Object.keys(layer.route.methods)[0],
-            regex: layer.regexp
+            method,
+            regex
           })
         } else {
           routesWithoutRouteParams.push({
             path: p,
-            method: Object.keys(layer.route.methods)[0],
-            regex: layer.regexp
+            method,
+            regex
           })
         }
       })
     } else {
-      if (route.path.includes(':')) {
+      if (path.includes(':')) {
         routesWithRouteParams.push({
-          path: layer.route.path,
-          method: Object.keys(layer.route.methods)[0],
-          regex: layer.regexp
+          path,
+          method,
+          regex
         })
       } else {
         routesWithoutRouteParams.push({
-          path: layer.route.path,
-          method: Object.keys(layer.route.methods)[0],
-          regex: layer.regexp
+          path,
+          method,
+          regex
         })
       }
     }

--- a/creator-node/src/app.js
+++ b/creator-node/src/app.js
@@ -45,7 +45,7 @@ function errorHandler(err, req, res, next) {
  *    regex: /(?:^\/ipfs\/(?:([^/]+?))\/?$|^\/content\/(?:([^/]+?))\/?$)/i,
  *    path: '/ipfs/:CID'
  * }
- * @param {Object} app
+ * @param {Object[]} routers Array of Express routers
  */
 function _setupRouteDurationTracking(routers) {
   let layers = routers.map((route) => route.stack)

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -3,9 +3,7 @@ const express = require('express')
 const {
   handleResponse,
   successResponse,
-  errorResponseBadRequest,
   handleResponseWithHeartbeat,
-  sendResponse,
   errorResponseServerError
 } = require('../../apiHelpers')
 const {
@@ -25,8 +23,6 @@ const config = require('../../config')
 
 const router = express.Router()
 
-// 5 minutes in ms is the maximum age of a timestamp sent to /health_check/duration
-const MAX_HEALTH_CHECK_TIMESTAMP_AGE_MS = 300000
 const numberOfCPUs = os.cpus().length
 
 const MONITOR_STATE_JOB_MAX_LAST_SUCCESSFUL_RUN_DELAY_MS = config.get(

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -1,3 +1,4 @@
+const express = require('express')
 const { Buffer } = require('buffer')
 const fs = require('fs')
 const { promisify } = require('util')
@@ -22,165 +23,167 @@ const DBManager = require('../dbManager')
 
 const readFile = promisify(fs.readFile)
 
-module.exports = function (app) {
-  /**
-   * Create AudiusUser from provided metadata, and make metadata available to network
-   */
-  app.post(
-    '/audius_users/metadata',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const metadataJSON = req.body.metadata
-      const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
-      const cnodeUserUUID = req.session.cnodeUserUUID
-      const isValidMetadata = validateMetadata(req, metadataJSON)
-      if (!isValidMetadata) {
-        return errorResponseBadRequest('Invalid User Metadata')
+const router = express.Router()
+
+/**
+ * Create AudiusUser from provided metadata, and make metadata available to network
+ */
+router.post(
+  '/audius_users/metadata',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const metadataJSON = req.body.metadata
+    const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
+    const cnodeUserUUID = req.session.cnodeUserUUID
+    const isValidMetadata = validateMetadata(req, metadataJSON)
+    if (!isValidMetadata) {
+      return errorResponseBadRequest('Invalid User Metadata')
+    }
+
+    // Save file from buffer to disk
+    let multihash, dstPath
+    try {
+      const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
+      multihash = resp.cid
+      dstPath = resp.dstPath
+    } catch (e) {
+      return errorResponseServerError(
+        `saveFileFromBufferToDisk op failed: ${e}`
+      )
+    }
+
+    // Record metadata file entry in DB
+    const transaction = await models.sequelize.transaction()
+    let fileUUID
+    try {
+      const createFileQueryObj = {
+        multihash,
+        sourceFile: req.fileName,
+        storagePath: dstPath,
+        type: 'metadata' // TODO - replace with models enum
       }
+      const file = await DBManager.createNewDataRecord(
+        createFileQueryObj,
+        cnodeUserUUID,
+        models.File,
+        transaction
+      )
+      fileUUID = file.fileUUID
+      await transaction.commit()
+    } catch (e) {
+      await transaction.rollback()
+      return errorResponseServerError(`Could not save to db: ${e}`)
+    }
 
-      // Save file from buffer to disk
-      let multihash, dstPath
-      try {
-        const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
-        multihash = resp.cid
-        dstPath = resp.dstPath
-      } catch (e) {
-        return errorResponseServerError(
-          `saveFileFromBufferToDisk op failed: ${e}`
-        )
-      }
+    // Await 2/3 write quorum (replicating data to at least 1 secondary)
+    await issueAndWaitForSecondarySyncRequests(req)
 
-      // Record metadata file entry in DB
-      const transaction = await models.sequelize.transaction()
-      let fileUUID
-      try {
-        const createFileQueryObj = {
-          multihash,
-          sourceFile: req.fileName,
-          storagePath: dstPath,
-          type: 'metadata' // TODO - replace with models enum
-        }
-        const file = await DBManager.createNewDataRecord(
-          createFileQueryObj,
-          cnodeUserUUID,
-          models.File,
-          transaction
-        )
-        fileUUID = file.fileUUID
-        await transaction.commit()
-      } catch (e) {
-        await transaction.rollback()
-        return errorResponseServerError(`Could not save to db: ${e}`)
-      }
-
-      // Await 2/3 write quorum (replicating data to at least 1 secondary)
-      await issueAndWaitForSecondarySyncRequests(req)
-
-      return successResponse({
-        metadataMultihash: multihash,
-        metadataFileUUID: fileUUID
-      })
+    return successResponse({
+      metadataMultihash: multihash,
+      metadataFileUUID: fileUUID
     })
-  )
+  })
+)
 
-  /**
-   * Given audiusUser blockchainUserId, blockNumber, and metadataFileUUID, creates/updates AudiusUser DB entry
-   * and associates image file entries with audiusUser. Ends audiusUser creation/update process.
-   */
-  app.post(
-    '/audius_users',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const { blockchainUserId, blockNumber, metadataFileUUID } = req.body
+/**
+ * Given audiusUser blockchainUserId, blockNumber, and metadataFileUUID, creates/updates AudiusUser DB entry
+ * and associates image file entries with audiusUser. Ends audiusUser creation/update process.
+ */
+router.post(
+  '/audius_users',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const { blockchainUserId, blockNumber, metadataFileUUID } = req.body
 
-      if (!blockchainUserId || !blockNumber || !metadataFileUUID) {
-        return errorResponseBadRequest(
-          'Must include blockchainUserId, blockNumber, and metadataFileUUID.'
-        )
-      }
+    if (!blockchainUserId || !blockNumber || !metadataFileUUID) {
+      return errorResponseBadRequest(
+        'Must include blockchainUserId, blockNumber, and metadataFileUUID.'
+      )
+    }
 
-      const cnodeUser = req.session.cnodeUser
-      if (blockNumber < cnodeUser.latestBlockNumber) {
-        return errorResponseBadRequest(
-          `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
-        )
-      }
+    const cnodeUser = req.session.cnodeUser
+    if (blockNumber < cnodeUser.latestBlockNumber) {
+      return errorResponseBadRequest(
+        `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
+      )
+    }
 
-      const cnodeUserUUID = req.session.cnodeUserUUID
+    const cnodeUserUUID = req.session.cnodeUserUUID
 
-      // Fetch metadataJSON for metadataFileUUID.
-      const file = await models.File.findOne({
-        where: { fileUUID: metadataFileUUID, cnodeUserUUID }
-      })
-      if (!file) {
-        return errorResponseBadRequest(
-          `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
-        )
-      }
-      let metadataJSON
-      try {
-        const fileBuffer = await readFile(file.storagePath)
-        metadataJSON = JSON.parse(fileBuffer)
-      } catch (e) {
-        return errorResponseServerError(
-          `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}: ${e}.`
-        )
-      }
-
-      // Get coverArtFileUUID and profilePicFileUUID for multihashes in metadata object, if present.
-      let coverArtFileUUID, profilePicFileUUID
-      try {
-        ;[coverArtFileUUID, profilePicFileUUID] = await Promise.all([
-          validateStateForImageDirCIDAndReturnFileUUID(
-            req,
-            metadataJSON.cover_photo_sizes
-          ),
-          validateStateForImageDirCIDAndReturnFileUUID(
-            req,
-            metadataJSON.profile_picture_sizes
-          )
-        ])
-      } catch (e) {
-        return errorResponseBadRequest(e.message)
-      }
-
-      // Record AudiusUser entry + update CNodeUser entry in DB
-      const transaction = await models.sequelize.transaction()
-      try {
-        const createAudiusUserQueryObj = {
-          metadataFileUUID,
-          metadataJSON,
-          blockchainId: blockchainUserId,
-          coverArtFileUUID,
-          profilePicFileUUID
-        }
-        await DBManager.createNewDataRecord(
-          createAudiusUserQueryObj,
-          cnodeUserUUID,
-          models.AudiusUser,
-          transaction
-        )
-
-        // Update cnodeUser.latestBlockNumber
-        await cnodeUser.update(
-          { latestBlockNumber: blockNumber },
-          { transaction }
-        )
-
-        await transaction.commit()
-
-        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
-        issueAndWaitForSecondarySyncRequests(req, true)
-
-        return successResponse()
-      } catch (e) {
-        await transaction.rollback()
-        return errorResponseServerError(e.message)
-      }
+    // Fetch metadataJSON for metadataFileUUID.
+    const file = await models.File.findOne({
+      where: { fileUUID: metadataFileUUID, cnodeUserUUID }
     })
-  )
-}
+    if (!file) {
+      return errorResponseBadRequest(
+        `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
+      )
+    }
+    let metadataJSON
+    try {
+      const fileBuffer = await readFile(file.storagePath)
+      metadataJSON = JSON.parse(fileBuffer)
+    } catch (e) {
+      return errorResponseServerError(
+        `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}: ${e}.`
+      )
+    }
+
+    // Get coverArtFileUUID and profilePicFileUUID for multihashes in metadata object, if present.
+    let coverArtFileUUID, profilePicFileUUID
+    try {
+      ;[coverArtFileUUID, profilePicFileUUID] = await Promise.all([
+        validateStateForImageDirCIDAndReturnFileUUID(
+          req,
+          metadataJSON.cover_photo_sizes
+        ),
+        validateStateForImageDirCIDAndReturnFileUUID(
+          req,
+          metadataJSON.profile_picture_sizes
+        )
+      ])
+    } catch (e) {
+      return errorResponseBadRequest(e.message)
+    }
+
+    // Record AudiusUser entry + update CNodeUser entry in DB
+    const transaction = await models.sequelize.transaction()
+    try {
+      const createAudiusUserQueryObj = {
+        metadataFileUUID,
+        metadataJSON,
+        blockchainId: blockchainUserId,
+        coverArtFileUUID,
+        profilePicFileUUID
+      }
+      await DBManager.createNewDataRecord(
+        createAudiusUserQueryObj,
+        cnodeUserUUID,
+        models.AudiusUser,
+        transaction
+      )
+
+      // Update cnodeUser.latestBlockNumber
+      await cnodeUser.update(
+        { latestBlockNumber: blockNumber },
+        { transaction }
+      )
+
+      await transaction.commit()
+
+      // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+      issueAndWaitForSecondarySyncRequests(req, true)
+
+      return successResponse()
+    } catch (e) {
+      await transaction.rollback()
+      return errorResponseServerError(e.message)
+    }
+  })
+)
+
+module.exports = router

--- a/creator-node/src/routes/contact.js
+++ b/creator-node/src/routes/contact.js
@@ -1,17 +1,21 @@
+const express = require('express')
+
 const { handleResponse, successResponse } = require('../apiHelpers')
 
-module.exports = function (app) {
-  app.get(
-    '/contact',
-    handleResponse(async (req, res) => {
-      const trustedNotifierManager = req.app.get('trustedNotifierManager')
-      const email =
-        trustedNotifierManager.getTrustedNotifierData().email ||
-        'Email address unavailable at the moment'
-      const response = {
-        email
-      }
-      return successResponse(response)
-    })
-  )
-}
+const router = express.Router()
+
+router.get(
+  '/contact',
+  handleResponse(async (req, res) => {
+    const trustedNotifierManager = req.app.get('trustedNotifierManager')
+    const email =
+      trustedNotifierManager.getTrustedNotifierData().email ||
+      'Email address unavailable at the moment'
+    const response = {
+      email
+    }
+    return successResponse(response)
+  })
+)
+
+module.exports = router

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -1,9 +1,11 @@
+const express = require('express')
 const {
   handleResponse,
   successResponse,
   errorResponseServerError
 } = require('../apiHelpers')
 const config = require('../config.js')
+
 const path = require('path')
 const versionInfo = require(path.join(process.cwd(), '.version.json'))
 
@@ -13,128 +15,127 @@ const DiskManager = require('../diskManager')
 
 const MAX_DB_CONNECTIONS = config.get('dbConnectionPoolMax')
 
-module.exports = function (app) {
-  /**
-   * Exposes current and max db connection stats.
-   * Returns error if db connection threshold exceeded, else success.
-   */
-  app.get(
-    '/db_check',
-    handleResponse(async (req, res) => {
-      const verbose = req.query.verbose === 'true'
-      const maxConnections =
-        parseInt(req.query.maxConnections) || MAX_DB_CONNECTIONS
+const router = express.Router()
 
-      // Get number of open DB connections
-      const [numConnections, connectionInfo] = await getMonitors([
-        MONITORS.DATABASE_CONNECTIONS,
-        MONITORS.DATABASE_CONNECTION_INFO
-      ])
+/**
+ * Exposes current and max db connection stats.
+ * Returns error if db connection threshold exceeded, else success.
+ */
+router.get(
+  '/db_check',
+  handleResponse(async (req, res) => {
+    const verbose = req.query.verbose === 'true'
+    const maxConnections =
+      parseInt(req.query.maxConnections) || MAX_DB_CONNECTIONS
 
-      // Get detailed connection info
-      let activeConnections = null
-      let idleConnections = null
-      if (connectionInfo) {
-        activeConnections = connectionInfo.filter(
-          (conn) => conn.state === 'active'
-        ).length
-        idleConnections = connectionInfo.filter(
-          (conn) => conn.state === 'idle'
-        ).length
-      }
+    // Get number of open DB connections
+    const [numConnections, connectionInfo] = await getMonitors([
+      MONITORS.DATABASE_CONNECTIONS,
+      MONITORS.DATABASE_CONNECTION_INFO
+    ])
 
-      const resp = {
-        git: process.env.GIT_SHA,
-        connectionStatus: {
-          total: numConnections,
-          active: activeConnections,
-          idle: idleConnections
-        },
-        maxConnections: maxConnections
-      }
+    // Get detailed connection info
+    let activeConnections = null
+    let idleConnections = null
+    if (connectionInfo) {
+      activeConnections = connectionInfo.filter(
+        (conn) => conn.state === 'active'
+      ).length
+      idleConnections = connectionInfo.filter(
+        (conn) => conn.state === 'idle'
+      ).length
+    }
 
-      if (verbose) {
-        resp.connectionInfo = connectionInfo
-      }
+    const resp = {
+      git: process.env.GIT_SHA,
+      connectionStatus: {
+        total: numConnections,
+        active: activeConnections,
+        idle: idleConnections
+      },
+      maxConnections: maxConnections
+    }
 
-      return numConnections >= maxConnections
-        ? errorResponseServerError(resp)
-        : successResponse(resp)
+    if (verbose) {
+      resp.connectionInfo = connectionInfo
+    }
+
+    return numConnections >= maxConnections
+      ? errorResponseServerError(resp)
+      : successResponse(resp)
+  })
+)
+
+router.get(
+  '/version',
+  handleResponse(async (req, res) => {
+    if (config.get('isReadOnlyMode')) {
+      return errorResponseServerError()
+    }
+
+    const info = {
+      ...versionInfo,
+      country: config.get('serviceCountry'),
+      latitude: config.get('serviceLatitude'),
+      longitude: config.get('serviceLongitude')
+    }
+    return successResponse(info)
+  })
+)
+
+/**
+ * Exposes current and max disk usage stats.
+ * Returns error if max disk usage exceeded, else success.
+ */
+router.get(
+  '/disk_check',
+  handleResponse(async (req, res) => {
+    const maxUsageBytes = parseInt(req.query.maxUsageBytes)
+    const maxUsagePercent =
+      parseInt(req.query.maxUsagePercent) || config.get('maxStorageUsedPercent')
+
+    const storagePath = DiskManager.getConfigStoragePath()
+    const [total, used] = await getMonitors([
+      MONITORS.STORAGE_PATH_SIZE,
+      MONITORS.STORAGE_PATH_USED
+    ])
+    const available = total - used
+
+    const usagePercent = Math.round((used * 100) / total)
+
+    const resp = {
+      available: _formatBytes(available),
+      total: _formatBytes(total),
+      usagePercent: `${usagePercent}%`,
+      maxUsagePercent: `${maxUsagePercent}%`,
+      storagePath
+    }
+
+    if (maxUsageBytes) {
+      resp.maxUsage = _formatBytes(maxUsageBytes)
+    }
+
+    if (
+      usagePercent >= maxUsagePercent ||
+      (maxUsageBytes && total - available >= maxUsageBytes)
+    ) {
+      return errorResponseServerError(resp)
+    } else {
+      return successResponse(resp)
+    }
+  })
+)
+
+router.get(
+  '/ip_check',
+  handleResponse(async (req, res) => {
+    const { ip } = req
+
+    return successResponse({
+      ip: ip || ''
     })
-  )
-
-  app.get(
-    '/version',
-    handleResponse(async (req, res) => {
-      if (config.get('isReadOnlyMode')) {
-        return errorResponseServerError()
-      }
-
-      const info = {
-        ...versionInfo,
-        country: config.get('serviceCountry'),
-        latitude: config.get('serviceLatitude'),
-        longitude: config.get('serviceLongitude')
-      }
-      return successResponse(info)
-    })
-  )
-
-  /**
-   * Exposes current and max disk usage stats.
-   * Returns error if max disk usage exceeded, else success.
-   */
-  app.get(
-    '/disk_check',
-    handleResponse(async (req, res) => {
-      const maxUsageBytes = parseInt(req.query.maxUsageBytes)
-      const maxUsagePercent =
-        parseInt(req.query.maxUsagePercent) ||
-        config.get('maxStorageUsedPercent')
-
-      const storagePath = DiskManager.getConfigStoragePath()
-      const [total, used] = await getMonitors([
-        MONITORS.STORAGE_PATH_SIZE,
-        MONITORS.STORAGE_PATH_USED
-      ])
-      const available = total - used
-
-      const usagePercent = Math.round((used * 100) / total)
-
-      const resp = {
-        available: _formatBytes(available),
-        total: _formatBytes(total),
-        usagePercent: `${usagePercent}%`,
-        maxUsagePercent: `${maxUsagePercent}%`,
-        storagePath
-      }
-
-      if (maxUsageBytes) {
-        resp.maxUsage = _formatBytes(maxUsageBytes)
-      }
-
-      if (
-        usagePercent >= maxUsagePercent ||
-        (maxUsageBytes && total - available >= maxUsageBytes)
-      ) {
-        return errorResponseServerError(resp)
-      } else {
-        return successResponse(resp)
-      }
-    })
-  )
-
-  app.get(
-    '/ip_check',
-    handleResponse(async (req, res) => {
-      const { ip } = req
-
-      return successResponse({
-        ip: ip || ''
-      })
-    })
-  )
-}
+  })
+)
 
 function _formatBytes(bytes, decimals = 2) {
   if (bytes === 0) return '0 Bytes'
@@ -147,3 +148,5 @@ function _formatBytes(bytes, decimals = 2) {
 
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
+
+module.exports = router

--- a/creator-node/src/routes/index.js
+++ b/creator-node/src/routes/index.js
@@ -3,16 +3,15 @@
 const fs = require('fs')
 const path = require('path')
 
-module.exports = function (app) {
+module.exports = function () {
   const basename = path.basename(__filename)
 
-  fs.readdirSync(__dirname)
+  return fs
+    .readdirSync(__dirname)
     .filter((file) => {
       return (
         file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
       )
     })
-    .forEach((file) => {
-      require(path.join(__dirname, file))(app)
-    })
+    .map((file) => require(path.join(__dirname, file)))
 }

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -1,3 +1,5 @@
+const express = require('express')
+
 const models = require('../models')
 const {
   handleResponse,
@@ -9,91 +11,93 @@ const config = require('../config')
 const retry = require('async-retry')
 const exportComponentService = require('../components/replicaSet/exportComponentService')
 
-module.exports = function (app) {
-  /**
-   * Exports all db data (not files) associated with walletPublicKey[] as JSON.
-   *
-   * This route is only run on a user's primary, to export data to the user's secondaries.
-   *
-   * @return {
-   *  cnodeUsers Map Object containing all db data keyed on cnodeUserUUID
-   * }
-   */
-  app.get(
-    '/export',
-    handleResponse(async (req, res) => {
-      const start = Date.now()
+const router = express.Router()
 
-      const walletPublicKeys = req.query.wallet_public_key // array
-      const sourceEndpoint = req.query.source_endpoint // string
+/**
+ * Exports all db data (not files) associated with walletPublicKey[] as JSON.
+ *
+ * This route is only run on a user's primary, to export data to the user's secondaries.
+ *
+ * @return {
+ *  cnodeUsers Map Object containing all db data keyed on cnodeUserUUID
+ * }
+ */
+router.get(
+  '/export',
+  handleResponse(async (req, res) => {
+    const start = Date.now()
 
-      const maxExportClockValueRange = config.get('maxExportClockValueRange')
+    const walletPublicKeys = req.query.wallet_public_key // array
+    const sourceEndpoint = req.query.source_endpoint // string
 
-      // Define clock range (min and max) for export
-      const requestedClockRangeMin = parseInt(req.query.clock_range_min) || 0
-      const requestedClockRangeMax =
-        requestedClockRangeMin + (maxExportClockValueRange - 1)
+    const maxExportClockValueRange = config.get('maxExportClockValueRange')
 
-      try {
-        const cnodeUsersDict = await retry(
-          async () => {
-            return exportComponentService({
-              walletPublicKeys,
-              requestedClockRangeMin,
-              requestedClockRangeMax,
-              logger: req.logger
-            })
-          },
-          {
-            retries: 3
-          }
-        )
+    // Define clock range (min and max) for export
+    const requestedClockRangeMin = parseInt(req.query.clock_range_min) || 0
+    const requestedClockRangeMax =
+      requestedClockRangeMin + (maxExportClockValueRange - 1)
 
-        req.logger.info(
-          `Successful export for wallets ${walletPublicKeys} to source endpoint ${
-            sourceEndpoint || '(not provided)'
-          } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
-            Date.now() - start
-          } ms`
-        )
+    try {
+      const cnodeUsersDict = await retry(
+        async () => {
+          return exportComponentService({
+            walletPublicKeys,
+            requestedClockRangeMin,
+            requestedClockRangeMax,
+            logger: req.logger
+          })
+        },
+        {
+          retries: 3
+        }
+      )
 
-        return successResponse({ cnodeUsers: cnodeUsersDict })
-      } catch (e) {
-        req.logger.error(
-          `Error in /export for wallets ${walletPublicKeys} to source endpoint ${
-            sourceEndpoint || '(not provided)'
-          } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
-            Date.now() - start
-          } ms ||`,
-          e
-        )
-        return errorResponseServerError(e.message)
-      }
+      req.logger.info(
+        `Successful export for wallets ${walletPublicKeys} to source endpoint ${
+          sourceEndpoint || '(not provided)'
+        } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
+          Date.now() - start
+        } ms`
+      )
+
+      return successResponse({ cnodeUsers: cnodeUsersDict })
+    } catch (e) {
+      req.logger.error(
+        `Error in /export for wallets ${walletPublicKeys} to source endpoint ${
+          sourceEndpoint || '(not provided)'
+        } for clock value range [${requestedClockRangeMin},${requestedClockRangeMax}] || route duration ${
+          Date.now() - start
+        } ms ||`,
+        e
+      )
+      return errorResponseServerError(e.message)
+    }
+  })
+)
+
+/** Checks if node sync is in progress for wallet. */
+router.get(
+  '/sync_status/:walletPublicKey',
+  handleResponse(async (req, res) => {
+    const walletPublicKey = req.params.walletPublicKey
+
+    const redisClient = req.app.get('redisClient')
+    if (await redisClient.WalletWriteLock.syncIsInProgress(walletPublicKey)) {
+      return errorResponse(
+        423,
+        `Cannot change state of wallet ${walletPublicKey}. Node sync currently in progress.`
+      )
+    }
+
+    // Get & return latestBlockNumber for wallet
+    const cnodeUser = await models.CNodeUser.findOne({
+      where: { walletPublicKey }
     })
-  )
+    const latestBlockNumber = cnodeUser ? cnodeUser.latestBlockNumber : -1
+    const clockValue = cnodeUser ? cnodeUser.clock : -1
 
-  /** Checks if node sync is in progress for wallet. */
-  app.get(
-    '/sync_status/:walletPublicKey',
-    handleResponse(async (req, res) => {
-      const walletPublicKey = req.params.walletPublicKey
+    return successResponse({ walletPublicKey, latestBlockNumber, clockValue })
+  })
+)
 
-      const redisClient = req.app.get('redisClient')
-      if (await redisClient.WalletWriteLock.syncIsInProgress(walletPublicKey)) {
-        return errorResponse(
-          423,
-          `Cannot change state of wallet ${walletPublicKey}. Node sync currently in progress.`
-        )
-      }
-
-      // Get & return latestBlockNumber for wallet
-      const cnodeUser = await models.CNodeUser.findOne({
-        where: { walletPublicKey }
-      })
-      const latestBlockNumber = cnodeUser ? cnodeUser.latestBlockNumber : -1
-      const clockValue = cnodeUser ? cnodeUser.clock : -1
-
-      return successResponse({ walletPublicKey, latestBlockNumber, clockValue })
-    })
-  )
-}
+module.exports = router

--- a/creator-node/src/routes/playlists.js
+++ b/creator-node/src/routes/playlists.js
@@ -1,3 +1,4 @@
+const express = require('express')
 const fs = require('fs')
 const { promisify } = require('util')
 
@@ -21,161 +22,163 @@ const DBManager = require('../dbManager')
 
 const readFile = promisify(fs.readFile)
 
-module.exports = function (app) {
-  /**
-   * Create Playlist from provided metadata, and make metadata available to network
-   */
-  app.post(
-    '/playlists/metadata',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const metadataJSON = req.body.metadata
-      const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
-      const cnodeUserUUID = req.session.cnodeUserUUID
-      const isValidMetadata = validateMetadata(req, metadataJSON)
-      if (!isValidMetadata) {
-        return errorResponseBadRequest('Invalid Playlist Metadata')
+const router = express.Router()
+
+/**
+ * Create Playlist from provided metadata, and make metadata available to network
+ */
+router.post(
+  '/playlists/metadata',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const metadataJSON = req.body.metadata
+    const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
+    const cnodeUserUUID = req.session.cnodeUserUUID
+    const isValidMetadata = validateMetadata(req, metadataJSON)
+    if (!isValidMetadata) {
+      return errorResponseBadRequest('Invalid Playlist Metadata')
+    }
+
+    // Save file from buffer to disk
+    let multihash, dstPath
+    try {
+      const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
+      multihash = resp.cid
+      dstPath = resp.dstPath
+    } catch (e) {
+      return errorResponseServerError(
+        `saveFileFromBufferToDisk op failed: ${e}`
+      )
+    }
+
+    // Record metadata file entry in DB
+    const transaction = await models.sequelize.transaction()
+    let fileUUID
+    try {
+      const createFileQueryObj = {
+        multihash,
+        sourceFile: req.fileName,
+        storagePath: dstPath,
+        type: 'metadata'
       }
+      const file = await DBManager.createNewDataRecord(
+        createFileQueryObj,
+        cnodeUserUUID,
+        models.File,
+        transaction
+      )
+      fileUUID = file.fileUUID
+      await transaction.commit()
+    } catch (e) {
+      await transaction.rollback()
+      return errorResponseServerError(
+        `Could not save playlist metadata to db: ${e}`
+      )
+    }
 
-      // Save file from buffer to disk
-      let multihash, dstPath
-      try {
-        const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
-        multihash = resp.cid
-        dstPath = resp.dstPath
-      } catch (e) {
-        return errorResponseServerError(
-          `saveFileFromBufferToDisk op failed: ${e}`
-        )
-      }
+    // Await 2/3 write quorum (replicating data to at least 1 secondary)
+    await issueAndWaitForSecondarySyncRequests(req)
 
-      // Record metadata file entry in DB
-      const transaction = await models.sequelize.transaction()
-      let fileUUID
-      try {
-        const createFileQueryObj = {
-          multihash,
-          sourceFile: req.fileName,
-          storagePath: dstPath,
-          type: 'metadata'
-        }
-        const file = await DBManager.createNewDataRecord(
-          createFileQueryObj,
-          cnodeUserUUID,
-          models.File,
-          transaction
-        )
-        fileUUID = file.fileUUID
-        await transaction.commit()
-      } catch (e) {
-        await transaction.rollback()
-        return errorResponseServerError(
-          `Could not save playlist metadata to db: ${e}`
-        )
-      }
-
-      // Await 2/3 write quorum (replicating data to at least 1 secondary)
-      await issueAndWaitForSecondarySyncRequests(req)
-
-      return successResponse({
-        metadataMultihash: multihash,
-        metadataFileUUID: fileUUID
-      })
+    return successResponse({
+      metadataMultihash: multihash,
+      metadataFileUUID: fileUUID
     })
-  )
+  })
+)
 
-  /**
-   * Given playlist blockchainId, blockNumber, and metadataFileUUID, creates/updates Playlist DB entry
-   * and associates image file entries with playlist. Ends playlist creation/update process.
-   */
-  app.post(
-    '/playlists',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const { blockchainId, blockNumber, metadataFileUUID } = req.body
+/**
+ * Given playlist blockchainId, blockNumber, and metadataFileUUID, creates/updates Playlist DB entry
+ * and associates image file entries with playlist. Ends playlist creation/update process.
+ */
+router.post(
+  '/playlists',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const { blockchainId, blockNumber, metadataFileUUID } = req.body
 
-      if (!blockchainId || !blockNumber || !metadataFileUUID) {
-        return errorResponseBadRequest(
-          'Must include blockchainId, blockNumber, and metadataFileUUID.'
-        )
-      }
+    if (!blockchainId || !blockNumber || !metadataFileUUID) {
+      return errorResponseBadRequest(
+        'Must include blockchainId, blockNumber, and metadataFileUUID.'
+      )
+    }
 
-      const cnodeUser = req.session.cnodeUser
-      if (blockNumber < cnodeUser.latestBlockNumber) {
-        return errorResponseBadRequest(
-          `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
-        )
-      }
+    const cnodeUser = req.session.cnodeUser
+    if (blockNumber < cnodeUser.latestBlockNumber) {
+      return errorResponseBadRequest(
+        `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
+      )
+    }
 
-      const cnodeUserUUID = req.session.cnodeUserUUID
+    const cnodeUserUUID = req.session.cnodeUserUUID
 
-      // Fetch metadataJSON for metadataFileUUID.
-      const file = await models.File.findOne({
-        where: { fileUUID: metadataFileUUID, cnodeUserUUID }
-      })
-      if (!file) {
-        return errorResponseBadRequest(
-          `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
-        )
-      }
-      let metadataJSON
-      try {
-        const fileBuffer = await readFile(file.storagePath)
-        metadataJSON = JSON.parse(fileBuffer)
-      } catch (e) {
-        return errorResponseServerError(
-          `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}: ${e}.`
-        )
-      }
-
-      // Get playlistImageFileUUID for multihashes in metadata object, if present.
-      let playlistImageFileUUID
-      try {
-        playlistImageFileUUID =
-          await validateStateForImageDirCIDAndReturnFileUUID(
-            req,
-            metadataJSON.playlist_image_sizes_multihash
-          )
-      } catch (e) {
-        return errorResponseBadRequest(e.message)
-      }
-
-      // Record Playlist entry + update CNodeUser entry in DB
-      const transaction = await models.sequelize.transaction()
-      try {
-        const createPlaylistQueryObj = {
-          metadataFileUUID,
-          metadataJSON,
-          blockchainId,
-          playlistImageFileUUID
-        }
-        await DBManager.createNewDataRecord(
-          createPlaylistQueryObj,
-          cnodeUserUUID,
-          models.Playlist,
-          transaction
-        )
-
-        // Update cnodeUser.latestBlockNumber
-        await cnodeUser.update(
-          { latestBlockNumber: blockNumber },
-          { transaction }
-        )
-
-        await transaction.commit()
-
-        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
-        issueAndWaitForSecondarySyncRequests(req, true)
-
-        return successResponse()
-      } catch (e) {
-        await transaction.rollback()
-        return errorResponseServerError(e.message)
-      }
+    // Fetch metadataJSON for metadataFileUUID.
+    const file = await models.File.findOne({
+      where: { fileUUID: metadataFileUUID, cnodeUserUUID }
     })
-  )
-}
+    if (!file) {
+      return errorResponseBadRequest(
+        `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
+      )
+    }
+    let metadataJSON
+    try {
+      const fileBuffer = await readFile(file.storagePath)
+      metadataJSON = JSON.parse(fileBuffer)
+    } catch (e) {
+      return errorResponseServerError(
+        `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}: ${e}.`
+      )
+    }
+
+    // Get playlistImageFileUUID for multihashes in metadata object, if present.
+    let playlistImageFileUUID
+    try {
+      playlistImageFileUUID =
+        await validateStateForImageDirCIDAndReturnFileUUID(
+          req,
+          metadataJSON.playlist_image_sizes_multihash
+        )
+    } catch (e) {
+      return errorResponseBadRequest(e.message)
+    }
+
+    // Record Playlist entry + update CNodeUser entry in DB
+    const transaction = await models.sequelize.transaction()
+    try {
+      const createPlaylistQueryObj = {
+        metadataFileUUID,
+        metadataJSON,
+        blockchainId,
+        playlistImageFileUUID
+      }
+      await DBManager.createNewDataRecord(
+        createPlaylistQueryObj,
+        cnodeUserUUID,
+        models.Playlist,
+        transaction
+      )
+
+      // Update cnodeUser.latestBlockNumber
+      await cnodeUser.update(
+        { latestBlockNumber: blockNumber },
+        { transaction }
+      )
+
+      await transaction.commit()
+
+      // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+      issueAndWaitForSecondarySyncRequests(req, true)
+
+      return successResponse()
+    } catch (e) {
+      await transaction.rollback()
+      return errorResponseServerError(e.message)
+    }
+  })
+)
+
+module.exports = router

--- a/creator-node/src/routes/prometheusMetricsRoutes.js
+++ b/creator-node/src/routes/prometheusMetricsRoutes.js
@@ -1,12 +1,17 @@
+const express = require('express')
+
+const router = express.Router()
+
 /**
  * Exposes Prometheus metrics at `GET /prometheus_metrics`
  */
-module.exports = function (app) {
-  app.get('/prometheus_metrics', async (req, res) => {
-    const prometheusRegistry = req.app.get('serviceRegistry').prometheusRegistry
-    const metricData = await prometheusRegistry.getAllMetricData()
 
-    res.setHeader('Content-Type', prometheusRegistry.registry.contentType)
-    return res.end(metricData)
-  })
-}
+router.get('/prometheus_metrics', async (req, res) => {
+  const prometheusRegistry = req.app.get('serviceRegistry').prometheusRegistry
+  const metricData = await prometheusRegistry.getAllMetricData()
+
+  res.setHeader('Content-Type', prometheusRegistry.registry.contentType)
+  return res.end(metricData)
+})
+
+module.exports = router

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -1,3 +1,4 @@
+const express = require('express')
 const path = require('path')
 const fs = require('fs')
 const { Buffer } = require('buffer')
@@ -39,421 +40,441 @@ const TranscodingQueue = require('../TranscodingQueue')
 
 const readFile = promisify(fs.readFile)
 
-module.exports = function (app) {
-  /**
-   * Add a track transcode task into the worker queue. If the track file is uploaded properly (not transcoded), return successResponse
-   * @note this track content route is used in conjunction with the polling.
-   */
-  app.post(
-    '/track_content_async',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleTrackContentUpload,
-    handleResponse(async (req, res) => {
-      if (req.fileSizeError || req.fileFilterError) {
-        removeTrackFolder({ logContext: req.logContext }, req.fileDir)
-        return errorResponseBadRequest(req.fileSizeError || req.fileFilterError)
-      }
+const router = express.Router()
 
-      const AsyncProcessingQueue =
-        req.app.get('serviceRegistry').asyncProcessingQueue
+/**
+ * Add a track transcode task into the worker queue. If the track file is uploaded properly (not transcoded), return successResponse
+ * @note this track content route is used in conjunction with the polling.
+ */
+router.post(
+  '/track_content_async',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleTrackContentUpload,
+  handleResponse(async (req, res) => {
+    if (req.fileSizeError || req.fileFilterError) {
+      removeTrackFolder({ logContext: req.logContext }, req.fileDir)
+      return errorResponseBadRequest(req.fileSizeError || req.fileFilterError)
+    }
 
-      const selfTranscode = currentNodeShouldHandleTranscode({
-        transcodingQueueCanAcceptMoreJobs: await TranscodingQueue.isAvailable(),
-        spID: config.get('spID')
-      })
+    const AsyncProcessingQueue =
+      req.app.get('serviceRegistry').asyncProcessingQueue
 
-      if (selfTranscode) {
-        await AsyncProcessingQueue.addTrackContentUploadTask({
-          logContext: req.logContext,
-          req: {
-            fileName: req.fileName,
-            fileDir: req.fileDir,
-            fileDestination: req.file.destination,
-            cnodeUserUUID: req.session.cnodeUserUUID
-          }
-        })
-      } else {
-        await AsyncProcessingQueue.addTranscodeHandOffTask({
-          logContext: req.logContext,
-          req: {
-            fileName: req.fileName,
-            fileDir: req.fileDir,
-            fileNameNoExtension: req.fileNameNoExtension,
-            fileDestination: req.file.destination,
-            cnodeUserUUID: req.session.cnodeUserUUID,
-            headers: req.headers
-          }
-        })
-      }
-
-      return successResponse({ uuid: req.logContext.requestID })
+    const selfTranscode = currentNodeShouldHandleTranscode({
+      transcodingQueueCanAcceptMoreJobs: await TranscodingQueue.isAvailable(),
+      spID: config.get('spID')
     })
-  )
 
-  /**
-   * Delete all temporary transcode artifacts from track transcode handoff flow.
-   * This is called on the node that was handed off the transcode to clear the state from disk
-   */
-  app.post(
-    '/clear_transcode_and_segment_artifacts',
-    ensureValidSPMiddleware,
-    handleResponse(async (req, res) => {
-      const fileDir = req.body.fileDir
-      req.logger.info('Clearing filesystem fileDir', fileDir)
-      if (!fileDir.includes('tmp_track_artifacts')) {
-        return errorResponseBadRequest(
-          'Cannot remove track folder outside temporary track artifacts'
-        )
-      }
-      await removeTrackFolder({ logContext: req.logContext }, fileDir)
-
-      return successResponse()
-    })
-  )
-
-  /**
-   * Given that the requester is a valid SP, the current Content Node has enough storage,
-   * upload the track to the current node and add a transcode and segmenting job to the queue.
-   *
-   * This route is used on an available SP when the primary sends over a transcode and segment request
-   * to initiate the transcode handoff. This route does not run on the primary.
-   */
-  app.post(
-    '/transcode_and_segment',
-    ensureValidSPMiddleware,
-    ensureStorageMiddleware,
-    handleTrackContentUpload,
-    handleResponse(async (req, res) => {
-      const AsyncProcessingQueue =
-        req.app.get('serviceRegistry').asyncProcessingQueue
-
-      await AsyncProcessingQueue.addTranscodeAndSegmentTask({
+    if (selfTranscode) {
+      await AsyncProcessingQueue.addTrackContentUploadTask({
         logContext: req.logContext,
         req: {
           fileName: req.fileName,
           fileDir: req.fileDir,
-          uuid: req.logContext.requestID
+          fileDestination: req.file.destination,
+          cnodeUserUUID: req.session.cnodeUserUUID
         }
       })
+    } else {
+      await AsyncProcessingQueue.addTranscodeHandOffTask({
+        logContext: req.logContext,
+        req: {
+          fileName: req.fileName,
+          fileDir: req.fileDir,
+          fileNameNoExtension: req.fileNameNoExtension,
+          fileDestination: req.file.destination,
+          cnodeUserUUID: req.session.cnodeUserUUID,
+          headers: req.headers
+        }
+      })
+    }
 
-      return successResponse({ uuid: req.logContext.requestID })
+    return successResponse({ uuid: req.logContext.requestID })
+  })
+)
+
+/**
+ * Delete all temporary transcode artifacts from track transcode handoff flow.
+ * This is called on the node that was handed off the transcode to clear the state from disk
+ */
+router.post(
+  '/clear_transcode_and_segment_artifacts',
+  ensureValidSPMiddleware,
+  handleResponse(async (req, res) => {
+    const fileDir = req.body.fileDir
+    req.logger.info('Clearing filesystem fileDir', fileDir)
+    if (!fileDir.includes('tmp_track_artifacts')) {
+      return errorResponseBadRequest(
+        'Cannot remove track folder outside temporary track artifacts'
+      )
+    }
+    await removeTrackFolder({ logContext: req.logContext }, fileDir)
+
+    return successResponse()
+  })
+)
+
+/**
+ * Given that the requester is a valid SP, the current Content Node has enough storage,
+ * upload the track to the current node and add a transcode and segmenting job to the queue.
+ *
+ * This route is used on an available SP when the primary sends over a transcode and segment request
+ * to initiate the transcode handoff. This route does not run on the primary.
+ */
+router.post(
+  '/transcode_and_segment',
+  ensureValidSPMiddleware,
+  ensureStorageMiddleware,
+  handleTrackContentUpload,
+  handleResponse(async (req, res) => {
+    const AsyncProcessingQueue =
+      req.app.get('serviceRegistry').asyncProcessingQueue
+
+    await AsyncProcessingQueue.addTranscodeAndSegmentTask({
+      logContext: req.logContext,
+      req: {
+        fileName: req.fileName,
+        fileDir: req.fileDir,
+        uuid: req.logContext.requestID
+      }
     })
-  )
 
-  /**
-   * Given that the request is coming from a valid SP, serve the corresponding file
-   * from the transcode handoff
-   *
-   * This route is called from the primary to request the transcoded files after
-   * sending the first request for the transcode handoff. This route does not run on the primary.
-   */
-  app.get(
-    '/transcode_and_segment',
-    ensureValidSPMiddleware,
-    async (req, res) => {
-      const fileName = req.query.fileName
-      const fileType = req.query.fileType
-      const uuid = req.query.uuid
+    return successResponse({ uuid: req.logContext.requestID })
+  })
+)
 
-      if (!fileName || !fileType || !uuid) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseBadRequest(
-            `No provided filename=${fileName}, fileType=${fileType}, or uuid=${uuid}`
-          )
+/**
+ * Given that the request is coming from a valid SP, serve the corresponding file
+ * from the transcode handoff
+ *
+ * This route is called from the primary to request the transcoded files after
+ * sending the first request for the transcode handoff. This route does not run on the primary.
+ */
+router.get(
+  '/transcode_and_segment',
+  ensureValidSPMiddleware,
+  async (req, res) => {
+    const fileName = req.query.fileName
+    const fileType = req.query.fileType
+    const uuid = req.query.uuid
+
+    if (!fileName || !fileType || !uuid) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseBadRequest(
+          `No provided filename=${fileName}, fileType=${fileType}, or uuid=${uuid}`
+        )
+      )
+    }
+
+    const basePath = getTmpTrackUploadArtifactsPathWithInputUUID(uuid)
+    let pathToFile
+    if (fileType === 'transcode') {
+      pathToFile = path.join(basePath, fileName)
+    } else if (fileType === 'segment') {
+      pathToFile = path.join(basePath, 'segments', fileName)
+    } else if (fileType === 'm3u8') {
+      pathToFile = path.join(basePath, fileName)
+    }
+
+    try {
+      return await streamFromFileSystem(req, res, pathToFile)
+    } catch (e) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseServerError(
+          `Could not serve content, error=${e.toString()}`
+        )
+      )
+    }
+  }
+)
+
+/**
+ * Given track metadata object, save metadata to disk. Return metadata multihash if successful.
+ * If metadata is for a downloadable track, ensures transcoded master record exists in DB
+ */
+router.post(
+  '/tracks/metadata',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const metadataJSON = req.body.metadata
+
+    if (
+      !metadataJSON ||
+      !metadataJSON.owner_id ||
+      !metadataJSON.track_segments ||
+      !Array.isArray(metadataJSON.track_segments) ||
+      !metadataJSON.track_segments.length
+    ) {
+      return errorResponseBadRequest(
+        'Metadata object must include owner_id and non-empty track_segments array'
+      )
+    }
+
+    // If metadata indicates track is downloadable but doesn't provide a transcode CID,
+    //    ensure that a transcoded master record exists in DB
+    if (
+      metadataJSON.download &&
+      metadataJSON.download.is_downloadable &&
+      !metadataJSON.download.cid
+    ) {
+      const sourceFile = req.body.sourceFile
+      const trackId = metadataJSON.track_id
+      if (!sourceFile && !trackId) {
+        return errorResponseBadRequest(
+          'Cannot make downloadable - A sourceFile must be provided or the metadata object must include track_id'
         )
       }
 
-      const basePath = getTmpTrackUploadArtifactsPathWithInputUUID(uuid)
-      let pathToFile
-      if (fileType === 'transcode') {
-        pathToFile = path.join(basePath, fileName)
-      } else if (fileType === 'segment') {
-        pathToFile = path.join(basePath, 'segments', fileName)
-      } else if (fileType === 'm3u8') {
-        pathToFile = path.join(basePath, fileName)
-      }
+      // See if the track already has a transcoded master
+      if (trackId) {
+        const { blockchainId } = await models.Track.findOne({
+          attributes: ['blockchainId'],
+          where: {
+            blockchainId: trackId
+          },
+          order: [['clock', 'DESC']]
+        })
 
-      try {
-        return await streamFromFileSystem(req, res, pathToFile)
-      } catch (e) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseServerError(
-            `Could not serve content, error=${e.toString()}`
-          )
-        )
+        // Error if no DB entry for transcode found
+        const transcodedFile = await models.File.findOne({
+          attributes: ['multihash'],
+          where: {
+            cnodeUserUUID: req.session.cnodeUserUUID,
+            type: 'copy320',
+            trackBlockchainId: blockchainId
+          }
+        })
+        if (!transcodedFile) {
+          return errorResponseServerError('Failed to find transcoded file')
+        }
       }
     }
-  )
 
-  /**
-   * Given track metadata object, save metadata to disk. Return metadata multihash if successful.
-   * If metadata is for a downloadable track, ensures transcoded master record exists in DB
-   */
-  app.post(
-    '/tracks/metadata',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const metadataJSON = req.body.metadata
+    const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
+    const cnodeUserUUID = req.session.cnodeUserUUID
 
+    // Save file from buffer to disk
+    let multihash, dstPath
+    try {
+      const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
+      multihash = resp.cid
+      dstPath = resp.dstPath
+    } catch (e) {
+      return errorResponseServerError(
+        `/tracks/metadata saveFileFromBufferToDisk op failed: ${e}`
+      )
+    }
+
+    // Record metadata file entry in DB
+    const transaction = await models.sequelize.transaction()
+    let fileUUID
+    try {
+      const createFileQueryObj = {
+        multihash,
+        sourceFile: req.fileName,
+        storagePath: dstPath,
+        type: 'metadata' // TODO - replace with models enum
+      }
+      const file = await DBManager.createNewDataRecord(
+        createFileQueryObj,
+        cnodeUserUUID,
+        models.File,
+        transaction
+      )
+      fileUUID = file.fileUUID
+
+      await transaction.commit()
+    } catch (e) {
+      await transaction.rollback()
+      return errorResponseServerError(`Could not save to db db: ${e}`)
+    }
+
+    // Await 2/3 write quorum (replicating data to at least 1 secondary)
+    await issueAndWaitForSecondarySyncRequests(req)
+
+    return successResponse({
+      metadataMultihash: multihash,
+      metadataFileUUID: fileUUID
+    })
+  })
+)
+
+/**
+ * Given track blockchainTrackId, blockNumber, and metadataFileUUID, creates/updates Track DB track entry
+ * and associates segment & image file entries with track. Ends track creation/update process.
+ */
+router.post(
+  '/tracks',
+  authMiddleware,
+  ensurePrimaryMiddleware,
+  ensureStorageMiddleware,
+  handleResponse(async (req, res) => {
+    const {
+      blockchainTrackId,
+      blockNumber,
+      metadataFileUUID,
+      transcodedTrackUUID
+    } = req.body
+
+    // Input validation
+    if (!blockchainTrackId || !blockNumber || !metadataFileUUID) {
+      return errorResponseBadRequest(
+        'Must include blockchainTrackId, blockNumber, and metadataFileUUID.'
+      )
+    }
+
+    // Error on outdated blocknumber
+    const cnodeUser = req.session.cnodeUser
+    if (blockNumber < cnodeUser.latestBlockNumber) {
+      return errorResponseBadRequest(
+        `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
+      )
+    }
+    const cnodeUserUUID = req.session.cnodeUserUUID
+
+    // Fetch metadataJSON for metadataFileUUID, error if not found or malformatted
+    const file = await models.File.findOne({
+      where: { fileUUID: metadataFileUUID, cnodeUserUUID }
+    })
+    if (!file) {
+      return errorResponseBadRequest(
+        `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
+      )
+    }
+    let metadataJSON
+    try {
+      const fileBuffer = await readFile(file.storagePath)
+      metadataJSON = JSON.parse(fileBuffer)
       if (
         !metadataJSON ||
-        !metadataJSON.owner_id ||
         !metadataJSON.track_segments ||
         !Array.isArray(metadataJSON.track_segments) ||
         !metadataJSON.track_segments.length
       ) {
-        return errorResponseBadRequest(
-          'Metadata object must include owner_id and non-empty track_segments array'
-        )
-      }
-
-      // If metadata indicates track is downloadable but doesn't provide a transcode CID,
-      //    ensure that a transcoded master record exists in DB
-      if (
-        metadataJSON.download &&
-        metadataJSON.download.is_downloadable &&
-        !metadataJSON.download.cid
-      ) {
-        const sourceFile = req.body.sourceFile
-        const trackId = metadataJSON.track_id
-        if (!sourceFile && !trackId) {
-          return errorResponseBadRequest(
-            'Cannot make downloadable - A sourceFile must be provided or the metadata object must include track_id'
-          )
-        }
-
-        // See if the track already has a transcoded master
-        if (trackId) {
-          const { blockchainId } = await models.Track.findOne({
-            attributes: ['blockchainId'],
-            where: {
-              blockchainId: trackId
-            },
-            order: [['clock', 'DESC']]
-          })
-
-          // Error if no DB entry for transcode found
-          const transcodedFile = await models.File.findOne({
-            attributes: ['multihash'],
-            where: {
-              cnodeUserUUID: req.session.cnodeUserUUID,
-              type: 'copy320',
-              trackBlockchainId: blockchainId
-            }
-          })
-          if (!transcodedFile) {
-            return errorResponseServerError('Failed to find transcoded file')
-          }
-        }
-      }
-
-      const metadataBuffer = Buffer.from(JSON.stringify(metadataJSON))
-      const cnodeUserUUID = req.session.cnodeUserUUID
-
-      // Save file from buffer to disk
-      let multihash, dstPath
-      try {
-        const resp = await saveFileFromBufferToDisk(req, metadataBuffer)
-        multihash = resp.cid
-        dstPath = resp.dstPath
-      } catch (e) {
         return errorResponseServerError(
-          `/tracks/metadata saveFileFromBufferToDisk op failed: ${e}`
+          `Malformatted metadataJSON stored for metadataFileUUID ${metadataFileUUID}.`
         )
       }
+    } catch (e) {
+      return errorResponseServerError(
+        `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}.`
+      )
+    }
 
-      // Record metadata file entry in DB
-      const transaction = await models.sequelize.transaction()
-      let fileUUID
-      try {
-        const createFileQueryObj = {
-          multihash,
-          sourceFile: req.fileName,
-          storagePath: dstPath,
-          type: 'metadata' // TODO - replace with models enum
-        }
-        const file = await DBManager.createNewDataRecord(
-          createFileQueryObj,
+    // Get coverArtFileUUID for multihash in metadata object, else error
+    let coverArtFileUUID
+    try {
+      coverArtFileUUID = await validateStateForImageDirCIDAndReturnFileUUID(
+        req,
+        metadataJSON.cover_art_sizes
+      )
+    } catch (e) {
+      return errorResponseServerError(e.message)
+    }
+
+    const transaction = await models.sequelize.transaction()
+    try {
+      const existingTrackEntry = await models.Track.findOne({
+        where: {
           cnodeUserUUID,
-          models.File,
-          transaction
-        )
-        fileUUID = file.fileUUID
-
-        await transaction.commit()
-      } catch (e) {
-        await transaction.rollback()
-        return errorResponseServerError(`Could not save to db db: ${e}`)
-      }
-
-      // Await 2/3 write quorum (replicating data to at least 1 secondary)
-      await issueAndWaitForSecondarySyncRequests(req)
-
-      return successResponse({
-        metadataMultihash: multihash,
-        metadataFileUUID: fileUUID
+          blockchainId: blockchainTrackId
+        },
+        order: [['clock', 'DESC']],
+        transaction
       })
-    })
-  )
 
-  /**
-   * Given track blockchainTrackId, blockNumber, and metadataFileUUID, creates/updates Track DB track entry
-   * and associates segment & image file entries with track. Ends track creation/update process.
-   */
-  app.post(
-    '/tracks',
-    authMiddleware,
-    ensurePrimaryMiddleware,
-    ensureStorageMiddleware,
-    handleResponse(async (req, res) => {
-      const {
-        blockchainTrackId,
-        blockNumber,
+      // Insert track entry in DB
+      const createTrackQueryObj = {
         metadataFileUUID,
-        transcodedTrackUUID
-      } = req.body
-
-      // Input validation
-      if (!blockchainTrackId || !blockNumber || !metadataFileUUID) {
-        return errorResponseBadRequest(
-          'Must include blockchainTrackId, blockNumber, and metadataFileUUID.'
-        )
+        metadataJSON,
+        blockchainId: blockchainTrackId,
+        coverArtFileUUID
       }
+      const track = await DBManager.createNewDataRecord(
+        createTrackQueryObj,
+        cnodeUserUUID,
+        models.Track,
+        transaction
+      )
 
-      // Error on outdated blocknumber
-      const cnodeUser = req.session.cnodeUser
-      if (blockNumber < cnodeUser.latestBlockNumber) {
-        return errorResponseBadRequest(
-          `Invalid blockNumber param ${blockNumber}. Must be greater or equal to previously processed blocknumber ${cnodeUser.latestBlockNumber}.`
-        )
-      }
-      const cnodeUserUUID = req.session.cnodeUserUUID
+      /**
+       * Associate matching transcode & segment files on DB with new/updated track
+       * Must be done in same transaction to atomicity
+       *
+       * TODO - consider implications of edge-case -> two attempted /track_content before associate
+       */
 
-      // Fetch metadataJSON for metadataFileUUID, error if not found or malformatted
-      const file = await models.File.findOne({
-        where: { fileUUID: metadataFileUUID, cnodeUserUUID }
-      })
-      if (!file) {
-        return errorResponseBadRequest(
-          `No file db record found for provided metadataFileUUID ${metadataFileUUID}.`
-        )
-      }
-      let metadataJSON
-      try {
-        const fileBuffer = await readFile(file.storagePath)
-        metadataJSON = JSON.parse(fileBuffer)
-        if (
-          !metadataJSON ||
-          !metadataJSON.track_segments ||
-          !Array.isArray(metadataJSON.track_segments) ||
-          !metadataJSON.track_segments.length
-        ) {
-          return errorResponseServerError(
-            `Malformatted metadataJSON stored for metadataFileUUID ${metadataFileUUID}.`
-          )
+      const trackSegmentCIDs = metadataJSON.track_segments.map(
+        (segment) => segment.multihash
+      )
+
+      // if track created, ensure files exist with trackBlockchainId = null and update them
+      if (!existingTrackEntry) {
+        if (!transcodedTrackUUID) {
+          throw new Error('Cannot create track without transcodedTrackUUID.')
         }
-      } catch (e) {
-        return errorResponseServerError(
-          `No file stored on disk for metadataFileUUID ${metadataFileUUID} at storagePath ${file.storagePath}.`
-        )
-      }
 
-      // Get coverArtFileUUID for multihash in metadata object, else error
-      let coverArtFileUUID
-      try {
-        coverArtFileUUID = await validateStateForImageDirCIDAndReturnFileUUID(
-          req,
-          metadataJSON.cover_art_sizes
-        )
-      } catch (e) {
-        return errorResponseServerError(e.message)
-      }
-
-      const transaction = await models.sequelize.transaction()
-      try {
-        const existingTrackEntry = await models.Track.findOne({
+        // Associate the transcode file db record with trackUUID
+        const transcodedFile = await models.File.findOne({
           where: {
+            fileUUID: transcodedTrackUUID,
             cnodeUserUUID,
-            blockchainId: blockchainTrackId
+            trackBlockchainId: null,
+            type: 'copy320'
           },
-          order: [['clock', 'DESC']],
           transaction
         })
-
-        // Insert track entry in DB
-        const createTrackQueryObj = {
-          metadataFileUUID,
-          metadataJSON,
-          blockchainId: blockchainTrackId,
-          coverArtFileUUID
+        if (!transcodedFile || !transcodedFile.sourceFile) {
+          throw new Error(
+            'Did not find a transcoded file for the provided CID.'
+          )
         }
-        const track = await DBManager.createNewDataRecord(
-          createTrackQueryObj,
-          cnodeUserUUID,
-          models.Track,
-          transaction
-        )
-
-        /**
-         * Associate matching transcode & segment files on DB with new/updated track
-         * Must be done in same transaction to atomicity
-         *
-         * TODO - consider implications of edge-case -> two attempted /track_content before associate
-         */
-
-        const trackSegmentCIDs = metadataJSON.track_segments.map(
-          (segment) => segment.multihash
-        )
-
-        // if track created, ensure files exist with trackBlockchainId = null and update them
-        if (!existingTrackEntry) {
-          if (!transcodedTrackUUID) {
-            throw new Error('Cannot create track without transcodedTrackUUID.')
-          }
-
-          // Associate the transcode file db record with trackUUID
-          const transcodedFile = await models.File.findOne({
+        const transcodeAssociateNumAffectedRows = await models.File.update(
+          { trackBlockchainId: track.blockchainId },
+          {
             where: {
               fileUUID: transcodedTrackUUID,
               cnodeUserUUID,
               trackBlockchainId: null,
-              type: 'copy320'
+              type: 'copy320' // TODO - replace with model enum
             },
             transaction
-          })
-          if (!transcodedFile || !transcodedFile.sourceFile) {
-            throw new Error(
-              'Did not find a transcoded file for the provided CID.'
-            )
           }
-          const transcodeAssociateNumAffectedRows = await models.File.update(
-            { trackBlockchainId: track.blockchainId },
-            {
-              where: {
-                fileUUID: transcodedTrackUUID,
-                cnodeUserUUID,
-                trackBlockchainId: null,
-                type: 'copy320' // TODO - replace with model enum
-              },
-              transaction
-            }
+        )
+        if (transcodeAssociateNumAffectedRows === 0) {
+          throw new Error(
+            'Failed to associate the transcoded file for the provided track UUID.'
           )
-          if (transcodeAssociateNumAffectedRows === 0) {
-            throw new Error(
-              'Failed to associate the transcoded file for the provided track UUID.'
-            )
-          }
+        }
 
-          // Associate all segment file db records with trackUUID
-          const trackFiles = await models.File.findAll({
+        // Associate all segment file db records with trackUUID
+        const trackFiles = await models.File.findAll({
+          where: {
+            multihash: trackSegmentCIDs,
+            cnodeUserUUID,
+            trackBlockchainId: null,
+            type: 'track',
+            sourceFile: transcodedFile.sourceFile
+          },
+          transaction
+        })
+
+        if (trackFiles.length !== trackSegmentCIDs.length) {
+          req.logger.error(
+            `Did not find files for every track segment CID for user ${cnodeUserUUID} ${trackFiles} ${trackSegmentCIDs}`
+          )
+          throw new Error('Did not find files for every track segment CID.')
+        }
+        const segmentsAssociateNumAffectedRows = await models.File.update(
+          { trackBlockchainId: track.blockchainId },
+          {
             where: {
               multihash: trackSegmentCIDs,
               cnodeUserUUID,
@@ -462,368 +483,350 @@ module.exports = function (app) {
               sourceFile: transcodedFile.sourceFile
             },
             transaction
-          })
-
-          if (trackFiles.length !== trackSegmentCIDs.length) {
-            req.logger.error(
-              `Did not find files for every track segment CID for user ${cnodeUserUUID} ${trackFiles} ${trackSegmentCIDs}`
-            )
-            throw new Error('Did not find files for every track segment CID.')
           }
-          const segmentsAssociateNumAffectedRows = await models.File.update(
-            { trackBlockchainId: track.blockchainId },
-            {
-              where: {
-                multihash: trackSegmentCIDs,
-                cnodeUserUUID,
-                trackBlockchainId: null,
-                type: 'track',
-                sourceFile: transcodedFile.sourceFile
-              },
-              transaction
-            }
+        )
+        if (
+          parseInt(segmentsAssociateNumAffectedRows, 10) !==
+          trackSegmentCIDs.length
+        ) {
+          req.logger.error(
+            `Failed to associate files for every track segment CID ${cnodeUserUUID} ${track.blockchainId} ${segmentsAssociateNumAffectedRows} ${trackSegmentCIDs.length}`
           )
-          if (
-            parseInt(segmentsAssociateNumAffectedRows, 10) !==
-            trackSegmentCIDs.length
-          ) {
-            req.logger.error(
-              `Failed to associate files for every track segment CID ${cnodeUserUUID} ${track.blockchainId} ${segmentsAssociateNumAffectedRows} ${trackSegmentCIDs.length}`
-            )
-            throw new Error(
-              'Failed to associate files for every track segment CID.'
-            )
-          }
-        } /** updateTrack scenario */ else {
-          /**
-           * If track updated, ensure files exist with trackBlockchainId
-           */
+          throw new Error(
+            'Failed to associate files for every track segment CID.'
+          )
+        }
+      } /** updateTrack scenario */ else {
+        /**
+         * If track updated, ensure files exist with trackBlockchainId
+         */
 
-          // Ensure transcode file db record exists, if uuid provided
-          if (transcodedTrackUUID) {
-            const transcodedFile = await models.File.findOne({
-              where: {
-                fileUUID: transcodedTrackUUID,
-                cnodeUserUUID,
-                trackBlockchainId: track.blockchainId,
-                type: 'copy320'
-              },
-              transaction
-            })
-            if (!transcodedFile) {
-              throw new Error(
-                'Did not find the corresponding transcoded file for the provided track UUID.'
-              )
-            }
-          }
-
-          // Ensure segment file db records exist for all CIDs
-          const trackFiles = await models.File.findAll({
+        // Ensure transcode file db record exists, if uuid provided
+        if (transcodedTrackUUID) {
+          const transcodedFile = await models.File.findOne({
             where: {
-              multihash: trackSegmentCIDs,
+              fileUUID: transcodedTrackUUID,
               cnodeUserUUID,
               trackBlockchainId: track.blockchainId,
-              type: 'track'
+              type: 'copy320'
             },
             transaction
           })
-          if (trackFiles.length < trackSegmentCIDs.length) {
+          if (!transcodedFile) {
             throw new Error(
-              'Did not find files for every track segment CID with trackBlockchainId.'
+              'Did not find the corresponding transcoded file for the provided track UUID.'
             )
           }
         }
 
-        // Update cnodeUser's latestBlockNumber if higher than previous latestBlockNumber.
-        // TODO - move to subquery to guarantee atomicity.
-        const updatedCNodeUser = await models.CNodeUser.findOne({
-          where: { cnodeUserUUID },
+        // Ensure segment file db records exist for all CIDs
+        const trackFiles = await models.File.findAll({
+          where: {
+            multihash: trackSegmentCIDs,
+            cnodeUserUUID,
+            trackBlockchainId: track.blockchainId,
+            type: 'track'
+          },
           transaction
         })
-        if (!updatedCNodeUser || !updatedCNodeUser.latestBlockNumber) {
-          throw new Error('Issue in retrieving udpatedCnodeUser')
+        if (trackFiles.length < trackSegmentCIDs.length) {
+          throw new Error(
+            'Did not find files for every track segment CID with trackBlockchainId.'
+          )
         }
-        req.logger.info(
-          `cnodeuser ${cnodeUserUUID} first latestBlockNumber ${cnodeUser.latestBlockNumber} || \
+      }
+
+      // Update cnodeUser's latestBlockNumber if higher than previous latestBlockNumber.
+      // TODO - move to subquery to guarantee atomicity.
+      const updatedCNodeUser = await models.CNodeUser.findOne({
+        where: { cnodeUserUUID },
+        transaction
+      })
+      if (!updatedCNodeUser || !updatedCNodeUser.latestBlockNumber) {
+        throw new Error('Issue in retrieving udpatedCnodeUser')
+      }
+      req.logger.info(
+        `cnodeuser ${cnodeUserUUID} first latestBlockNumber ${cnodeUser.latestBlockNumber} || \
         current latestBlockNumber ${updatedCNodeUser.latestBlockNumber} || \
         given blockNumber ${blockNumber}`
-        )
-        if (blockNumber > updatedCNodeUser.latestBlockNumber) {
-          // Update cnodeUser's latestBlockNumber
-          await cnodeUser.update(
-            { latestBlockNumber: blockNumber },
-            { transaction }
-          )
-        }
-
-        await transaction.commit()
-
-        // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
-        issueAndWaitForSecondarySyncRequests(req, true)
-
-        return successResponse()
-      } catch (e) {
-        req.logger.error(e.message)
-        await transaction.rollback()
-        return errorResponseServerError(e.message)
-      }
-    })
-  )
-
-  /** Returns download status of track and 320kbps CID if ready + downloadable. */
-  app.get(
-    '/tracks/download_status/:blockchainId',
-    handleResponse(async (req, res) => {
-      const blockchainId = req.params.blockchainId
-      if (!blockchainId) {
-        return errorResponseBadRequest('Please provide blockchainId.')
-      }
-
-      const track = await models.Track.findOne({
-        where: { blockchainId },
-        order: [['clock', 'DESC']]
-      })
-      if (!track) {
-        return errorResponseBadRequest(
-          `No track found for blockchainId ${blockchainId}`
-        )
-      }
-
-      // Case: track is not marked as downloadable
-      if (
-        !track.metadataJSON ||
-        !track.metadataJSON.download ||
-        !track.metadataJSON.download.is_downloadable
-      ) {
-        return successResponse({ isDownloadable: false, cid: null })
-      }
-
-      // Case: track is marked as downloadable
-      // - Check if downloadable file exists. Since copyFile may or may not have trackBlockchainId association,
-      //    fetch a segmentFile for trackBlockchainId, and find copyFile for segmentFile's sourceFile.
-      const segmentFile = await models.File.findOne({
-        where: {
-          type: 'track',
-          trackBlockchainId: track.blockchainId
-        }
-      })
-      const copyFile = await models.File.findOne({
-        where: {
-          type: 'copy320',
-          sourceFile: segmentFile.sourceFile
-        }
-      })
-
-      // Serve from file system
-      return successResponse({
-        isDownloadable: true,
-        cid: copyFile ? copyFile.multihash : null
-      })
-    })
-  )
-
-  /**
-   * Gets a streamable mp3 link for a track by encodedId. Supports range request headers.
-   * @dev - Wrapper around getCID, which retrieves track given its CID.
-   **/
-  app.get(
-    '/tracks/stream/:encodedId',
-    async (req, res, next) => {
-      const libs = req.app.get('audiusLibs')
-      const redisClient = req.app.get('redisClient')
-      const delegateOwnerWallet = config.get('delegateOwnerWallet')
-
-      const encodedId = req.params.encodedId
-      if (!encodedId) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseBadRequest('Please provide a track ID')
-        )
-      }
-
-      const blockchainId = decode(encodedId)
-      if (!blockchainId) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseBadRequest(`Invalid ID: ${encodedId}`)
-        )
-      }
-
-      const isNotServable = await BlacklistManager.trackIdIsInBlacklist(
-        blockchainId
       )
-      if (isNotServable) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseForbidden(
-            `trackId=${blockchainId} cannot be served by this node`
-          )
+      if (blockNumber > updatedCNodeUser.latestBlockNumber) {
+        // Update cnodeUser's latestBlockNumber
+        await cnodeUser.update(
+          { latestBlockNumber: blockNumber },
+          { transaction }
         )
       }
 
-      let fileRecord = await models.File.findOne({
-        attributes: ['multihash'],
-        where: {
-          type: 'copy320',
-          trackBlockchainId: blockchainId
-        },
-        order: [['clock', 'DESC']]
-      })
+      await transaction.commit()
 
-      if (!fileRecord) {
-        try {
-          // see if there's a fileRecord in redis so we can short circuit all this logic
-          let redisFileRecord = await redisClient.get(
-            `streamFallback:::${blockchainId}`
-          )
-          if (redisFileRecord) {
-            redisFileRecord = JSON.parse(redisFileRecord)
-            if (redisFileRecord && redisFileRecord.multihash) {
-              fileRecord = redisFileRecord
-            }
+      // Discovery only indexes metadata and not files, so we eagerly replicate data but don't await it
+      issueAndWaitForSecondarySyncRequests(req, true)
+
+      return successResponse()
+    } catch (e) {
+      req.logger.error(e.message)
+      await transaction.rollback()
+      return errorResponseServerError(e.message)
+    }
+  })
+)
+
+/** Returns download status of track and 320kbps CID if ready + downloadable. */
+router.get(
+  '/tracks/download_status/:blockchainId',
+  handleResponse(async (req, res) => {
+    const blockchainId = req.params.blockchainId
+    if (!blockchainId) {
+      return errorResponseBadRequest('Please provide blockchainId.')
+    }
+
+    const track = await models.Track.findOne({
+      where: { blockchainId },
+      order: [['clock', 'DESC']]
+    })
+    if (!track) {
+      return errorResponseBadRequest(
+        `No track found for blockchainId ${blockchainId}`
+      )
+    }
+
+    // Case: track is not marked as downloadable
+    if (
+      !track.metadataJSON ||
+      !track.metadataJSON.download ||
+      !track.metadataJSON.download.is_downloadable
+    ) {
+      return successResponse({ isDownloadable: false, cid: null })
+    }
+
+    // Case: track is marked as downloadable
+    // - Check if downloadable file exists. Since copyFile may or may not have trackBlockchainId association,
+    //    fetch a segmentFile for trackBlockchainId, and find copyFile for segmentFile's sourceFile.
+    const segmentFile = await models.File.findOne({
+      where: {
+        type: 'track',
+        trackBlockchainId: track.blockchainId
+      }
+    })
+    const copyFile = await models.File.findOne({
+      where: {
+        type: 'copy320',
+        sourceFile: segmentFile.sourceFile
+      }
+    })
+
+    // Serve from file system
+    return successResponse({
+      isDownloadable: true,
+      cid: copyFile ? copyFile.multihash : null
+    })
+  })
+)
+
+/**
+ * Gets a streamable mp3 link for a track by encodedId. Supports range request headers.
+ * @dev - Wrapper around getCID, which retrieves track given its CID.
+ **/
+router.get(
+  '/tracks/stream/:encodedId',
+  async (req, res, next) => {
+    const libs = req.app.get('audiusLibs')
+    const redisClient = req.app.get('redisClient')
+    const delegateOwnerWallet = config.get('delegateOwnerWallet')
+
+    const encodedId = req.params.encodedId
+    if (!encodedId) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseBadRequest('Please provide a track ID')
+      )
+    }
+
+    const blockchainId = decode(encodedId)
+    if (!blockchainId) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseBadRequest(`Invalid ID: ${encodedId}`)
+      )
+    }
+
+    const isNotServable = await BlacklistManager.trackIdIsInBlacklist(
+      blockchainId
+    )
+    if (isNotServable) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseForbidden(
+          `trackId=${blockchainId} cannot be served by this node`
+        )
+      )
+    }
+
+    let fileRecord = await models.File.findOne({
+      attributes: ['multihash'],
+      where: {
+        type: 'copy320',
+        trackBlockchainId: blockchainId
+      },
+      order: [['clock', 'DESC']]
+    })
+
+    if (!fileRecord) {
+      try {
+        // see if there's a fileRecord in redis so we can short circuit all this logic
+        let redisFileRecord = await redisClient.get(
+          `streamFallback:::${blockchainId}`
+        )
+        if (redisFileRecord) {
+          redisFileRecord = JSON.parse(redisFileRecord)
+          if (redisFileRecord && redisFileRecord.multihash) {
+            fileRecord = redisFileRecord
           }
-        } catch (e) {
-          req.logger.error(
-            { error: e },
-            'Error looking for stream fallback in redis'
+        }
+      } catch (e) {
+        req.logger.error(
+          { error: e },
+          'Error looking for stream fallback in redis'
+        )
+      }
+    }
+
+    // if track didn't finish the upload process and was never associated, there may not be a trackBlockchainId for the File records,
+    // try to fall back to discovery to fetch the metadata multihash and see if you can deduce the copy320 file
+    if (!fileRecord) {
+      try {
+        let trackRecord = await libs.Track.getTracks(1, 0, [blockchainId])
+        if (
+          !trackRecord ||
+          trackRecord.length === 0 ||
+          !trackRecord[0].hasOwnProperty('blocknumber')
+        ) {
+          return sendResponse(
+            req,
+            res,
+            errorResponseServerError(
+              'Missing or malformatted track fetched from discovery node.'
+            )
           )
         }
-      }
 
-      // if track didn't finish the upload process and was never associated, there may not be a trackBlockchainId for the File records,
-      // try to fall back to discovery to fetch the metadata multihash and see if you can deduce the copy320 file
-      if (!fileRecord) {
-        try {
-          let trackRecord = await libs.Track.getTracks(1, 0, [blockchainId])
-          if (
-            !trackRecord ||
-            trackRecord.length === 0 ||
-            !trackRecord[0].hasOwnProperty('blocknumber')
-          ) {
-            return sendResponse(
-              req,
-              res,
-              errorResponseServerError(
-                'Missing or malformatted track fetched from discovery node.'
-              )
-            )
+        trackRecord = trackRecord[0]
+
+        // query the files table for a metadata multihash from discovery for a given track
+        // no need to add CNodeUserUUID to the filter because the track is associated with a user and that contains the
+        // user_id inside it which is unique to the user
+        const file = await models.File.findOne({
+          where: {
+            multihash: trackRecord.metadata_multihash,
+            type: 'metadata'
           }
-
-          trackRecord = trackRecord[0]
-
-          // query the files table for a metadata multihash from discovery for a given track
-          // no need to add CNodeUserUUID to the filter because the track is associated with a user and that contains the
-          // user_id inside it which is unique to the user
-          const file = await models.File.findOne({
-            where: {
-              multihash: trackRecord.metadata_multihash,
-              type: 'metadata'
-            }
-          })
-          if (!file) {
-            return sendResponse(
-              req,
-              res,
-              errorResponseServerError(
-                'Missing or malformatted track fetched from discovery node.'
-              )
+        })
+        if (!file) {
+          return sendResponse(
+            req,
+            res,
+            errorResponseServerError(
+              'Missing or malformatted track fetched from discovery node.'
             )
-          }
-
-          // make sure all track segments have the same sourceFile
-          const segments = trackRecord.track_segments.map(
-            (segment) => segment.multihash
-          )
-
-          const fileSegmentRecords = await models.File.findAll({
-            attributes: ['sourceFile'],
-            where: {
-              multihash: segments,
-              cnodeUserUUID: file.cnodeUserUUID
-            },
-            raw: true
-          })
-
-          // check that the number of files in the Files table for these segments for this user matches the number of segments from the metadata object
-          if (fileSegmentRecords.length !== trackRecord.track_segments.length) {
-            req.logger.warn(
-              `Track stream content mismatch for blockchainId ${blockchainId} - number of segments don't match between local and discovery`
-            )
-          }
-
-          // check that there's a single sourceFile that all File records share by getting an array of uniques
-          const uniqSourceFiles = fileSegmentRecords
-            .map((record) => record.sourceFile)
-            .filter((v, i, a) => a.indexOf(v) === i)
-
-          if (uniqSourceFiles.length !== 1) {
-            req.logger.warn(
-              `Track stream content mismatch for blockchainId ${blockchainId} - there's not one sourceFile that matches all segments`
-            )
-          }
-
-          // search for the copy320 record based on the sourceFile
-          fileRecord = await models.File.findOne({
-            attributes: ['multihash'],
-            where: {
-              type: 'copy320',
-              sourceFile: uniqSourceFiles[0]
-            },
-            raw: true
-          })
-
-          // cache the fileRecord in redis for an hour so we don't have to keep making requests to discovery
-          if (fileRecord) {
-            redisClient.set(
-              `streamFallback:::${blockchainId}`,
-              JSON.stringify(fileRecord),
-              'EX',
-              60 * 60
-            )
-          }
-        } catch (e) {
-          req.logger.error(
-            { error: e },
-            `Error falling back to reconstructing data from discovery to stream`
           )
         }
-      }
 
-      if (!fileRecord || !fileRecord.multihash) {
-        return sendResponse(
-          req,
-          res,
-          errorResponseBadRequest(
-            `No file found for blockchainId ${blockchainId}`
+        // make sure all track segments have the same sourceFile
+        const segments = trackRecord.track_segments.map(
+          (segment) => segment.multihash
+        )
+
+        const fileSegmentRecords = await models.File.findAll({
+          attributes: ['sourceFile'],
+          where: {
+            multihash: segments,
+            cnodeUserUUID: file.cnodeUserUUID
+          },
+          raw: true
+        })
+
+        // check that the number of files in the Files table for these segments for this user matches the number of segments from the metadata object
+        if (fileSegmentRecords.length !== trackRecord.track_segments.length) {
+          req.logger.warn(
+            `Track stream content mismatch for blockchainId ${blockchainId} - number of segments don't match between local and discovery`
           )
+        }
+
+        // check that there's a single sourceFile that all File records share by getting an array of uniques
+        const uniqSourceFiles = fileSegmentRecords
+          .map((record) => record.sourceFile)
+          .filter((v, i, a) => a.indexOf(v) === i)
+
+        if (uniqSourceFiles.length !== 1) {
+          req.logger.warn(
+            `Track stream content mismatch for blockchainId ${blockchainId} - there's not one sourceFile that matches all segments`
+          )
+        }
+
+        // search for the copy320 record based on the sourceFile
+        fileRecord = await models.File.findOne({
+          attributes: ['multihash'],
+          where: {
+            type: 'copy320',
+            sourceFile: uniqSourceFiles[0]
+          },
+          raw: true
+        })
+
+        // cache the fileRecord in redis for an hour so we don't have to keep making requests to discovery
+        if (fileRecord) {
+          redisClient.set(
+            `streamFallback:::${blockchainId}`,
+            JSON.stringify(fileRecord),
+            'EX',
+            60 * 60
+          )
+        }
+      } catch (e) {
+        req.logger.error(
+          { error: e },
+          `Error falling back to reconstructing data from discovery to stream`
         )
       }
+    }
 
-      if (libs.identityService) {
-        req.logger.info(
-          `Logging listen for track ${blockchainId} by ${delegateOwnerWallet}`
+    if (!fileRecord || !fileRecord.multihash) {
+      return sendResponse(
+        req,
+        res,
+        errorResponseBadRequest(
+          `No file found for blockchainId ${blockchainId}`
         )
-        const signatureData = generateListenTimestampAndSignature(
-          config.get('delegatePrivateKey')
-        )
-        // Fire and forget listen recording
-        // TODO: Consider queueing these requests
-        libs.identityService.logTrackListen(
-          blockchainId,
-          delegateOwnerWallet,
-          req.ip,
-          signatureData
-        )
-      }
+      )
+    }
 
-      req.params.CID = fileRecord.multihash
-      req.params.streamable = true
-      res.set('Content-Type', 'audio/mpeg')
-      next()
-    },
-    getCID
-  )
-}
+    if (libs.identityService) {
+      req.logger.info(
+        `Logging listen for track ${blockchainId} by ${delegateOwnerWallet}`
+      )
+      const signatureData = generateListenTimestampAndSignature(
+        config.get('delegatePrivateKey')
+      )
+      // Fire and forget listen recording
+      // TODO: Consider queueing these requests
+      libs.identityService.logTrackListen(
+        blockchainId,
+        delegateOwnerWallet,
+        req.ip,
+        signatureData
+      )
+    }
+
+    req.params.CID = fileRecord.multihash
+    req.params.streamable = true
+    res.set('Content-Type', 'audio/mpeg')
+    next()
+  },
+  getCID
+)
+
+module.exports = router

--- a/creator-node/src/routes/users.js
+++ b/creator-node/src/routes/users.js
@@ -1,3 +1,4 @@
+const express = require('express')
 const ethereumUtils = require('ethereumjs-util')
 const crypto = require('crypto')
 const base64url = require('base64-url')
@@ -22,329 +23,329 @@ const CHALLENGE_VALUE_LENGTH = 20
 const CHALLENGE_TTL_SECONDS = 120
 const CHALLENGE_PREFIX = 'userLoginChallenge:'
 
-module.exports = function (app) {
-  /**
-   * Creates CNodeUser table entry if one doesn't already exist
-   */
-  app.post(
-    '/users',
-    ensureStorageMiddleware,
-    handleResponse(async (req, res, next) => {
-      let walletAddress = req.body.walletAddress
-      if (!ethereumUtils.isValidAddress(walletAddress)) {
-        return errorResponseBadRequest('Ethereum address is invalid')
+const router = express.Router()
+
+/**
+ * Creates CNodeUser table entry if one doesn't already exist
+ */
+router.post(
+  '/users',
+  ensureStorageMiddleware,
+  handleResponse(async (req, res, next) => {
+    let walletAddress = req.body.walletAddress
+    if (!ethereumUtils.isValidAddress(walletAddress)) {
+      return errorResponseBadRequest('Ethereum address is invalid')
+    }
+
+    walletAddress = walletAddress.toLowerCase()
+
+    const existingUser = await models.CNodeUser.findOne({
+      where: {
+        walletPublicKey: walletAddress
       }
-
-      walletAddress = walletAddress.toLowerCase()
-
-      const existingUser = await models.CNodeUser.findOne({
-        where: {
-          walletPublicKey: walletAddress
-        }
-      })
-      if (existingUser) {
-        return successResponse() // do nothing if user already exists
-      }
-
-      // Create CNodeUser entry for wallet with clock = 0
-      await models.CNodeUser.create({
-        walletPublicKey: walletAddress,
-        clock: 0
-      })
-
-      return successResponse()
     })
-  )
+    if (existingUser) {
+      return successResponse() // do nothing if user already exists
+    }
 
-  /**
-   * Return a challenge used for validating user login. Challenge value
-   * is also set in redis cache with the key 'userLoginChallenge:<wallet>'.
-   */
-  app.get(
-    '/users/login/challenge',
-    ensureStorageMiddleware,
-    handleResponse(async (req, res, next) => {
-      let walletPublicKey = req.query.walletPublicKey
-
-      if (!walletPublicKey) {
-        return errorResponseBadRequest('Missing wallet address.')
-      }
-
-      walletPublicKey = walletPublicKey.toLowerCase()
-      const userLoginChallengeKey = `${CHALLENGE_PREFIX}${walletPublicKey}`
-      const redisClient = req.app.get('redisClient')
-      const challengeBuffer = await randomBytes(CHALLENGE_VALUE_LENGTH)
-      const challengeBytes = base64url.encode(challengeBuffer)
-      const challenge = `Click sign to authenticate with creator node: ${challengeBytes}`
-
-      // Set challenge ttl to 2 minutes ('EX' option = sets expire time in seconds)
-      // https://redis.io/commands/set
-      // https://github.com/luin/ioredis/blob/master/examples/basic_operations.js#L44
-      await redisClient.set(
-        userLoginChallengeKey,
-        challenge,
-        'EX',
-        CHALLENGE_TTL_SECONDS
-      )
-
-      return successResponse({ walletPublicKey, challenge })
+    // Create CNodeUser entry for wallet with clock = 0
+    await models.CNodeUser.create({
+      walletPublicKey: walletAddress,
+      clock: 0
     })
-  )
 
-  /**
-   * Checks if challenge in request body matches up with what we have stored.
-   * If request challenge matches what we have, remove instance from redis to
-   * prevent replay attacks. Return sessionToken upon success.
-   */
-  app.post(
-    '/users/login/challenge',
-    ensureStorageMiddleware,
-    handleResponse(async (req, res, next) => {
-      const { signature, data: theirChallenge } = req.body
+    return successResponse()
+  })
+)
 
-      if (!signature || !theirChallenge) {
-        return errorResponseBadRequest('Missing request body values.')
+/**
+ * Return a challenge used for validating user login. Challenge value
+ * is also set in redis cache with the key 'userLoginChallenge:<wallet>'.
+ */
+router.get(
+  '/users/login/challenge',
+  ensureStorageMiddleware,
+  handleResponse(async (req, res, next) => {
+    let walletPublicKey = req.query.walletPublicKey
+
+    if (!walletPublicKey) {
+      return errorResponseBadRequest('Missing wallet address.')
+    }
+
+    walletPublicKey = walletPublicKey.toLowerCase()
+    const userLoginChallengeKey = `${CHALLENGE_PREFIX}${walletPublicKey}`
+    const redisClient = req.app.get('redisClient')
+    const challengeBuffer = await randomBytes(CHALLENGE_VALUE_LENGTH)
+    const challengeBytes = base64url.encode(challengeBuffer)
+    const challenge = `Click sign to authenticate with creator node: ${challengeBytes}`
+
+    // Set challenge ttl to 2 minutes ('EX' option = sets expire time in seconds)
+    // https://redis.io/commands/set
+    // https://github.com/luin/ioredis/blob/master/examples/basic_operations.js#L44
+    await redisClient.set(
+      userLoginChallengeKey,
+      challenge,
+      'EX',
+      CHALLENGE_TTL_SECONDS
+    )
+
+    return successResponse({ walletPublicKey, challenge })
+  })
+)
+
+/**
+ * Checks if challenge in request body matches up with what we have stored.
+ * If request challenge matches what we have, remove instance from redis to
+ * prevent replay attacks. Return sessionToken upon success.
+ */
+router.post(
+  '/users/login/challenge',
+  ensureStorageMiddleware,
+  handleResponse(async (req, res, next) => {
+    const { signature, data: theirChallenge } = req.body
+
+    if (!signature || !theirChallenge) {
+      return errorResponseBadRequest('Missing request body values.')
+    }
+
+    let address
+    try {
+      address = utils.verifySignature(theirChallenge, signature)
+      address = address.toLowerCase()
+    } catch (e) {
+      return errorResponseBadRequest(`Unable to verify signature: ${e}`)
+    }
+
+    const user = await models.CNodeUser.findOne({
+      where: {
+        walletPublicKey: address
       }
-
-      let address
-      try {
-        address = utils.verifySignature(theirChallenge, signature)
-        address = address.toLowerCase()
-      } catch (e) {
-        return errorResponseBadRequest(`Unable to verify signature: ${e}`)
-      }
-
-      const user = await models.CNodeUser.findOne({
-        where: {
-          walletPublicKey: address
-        }
-      })
-      if (!user) {
-        return errorResponseBadRequest('Invalid data or signature')
-      }
-
-      const redisClient = req.app.get('redisClient')
-      const userLoginChallengeKey = `${CHALLENGE_PREFIX}${address}`
-      const ourChallenge = await redisClient.get(userLoginChallengeKey)
-
-      if (!ourChallenge) {
-        return errorResponseBadRequest('Missing challenge key')
-      }
-
-      if (theirChallenge !== ourChallenge) {
-        return errorResponseBadRequest(`Invalid response.`)
-      }
-
-      await redisClient.del(userLoginChallengeKey)
-
-      // All checks have passed! generate a new session token for the user
-      const sessionToken = await sessionManager.createSession(
-        user.cnodeUserUUID
-      )
-      return successResponse({ sessionToken })
     })
-  )
+    if (!user) {
+      return errorResponseBadRequest('Invalid data or signature')
+    }
 
-  app.post(
-    '/users/logout',
-    authMiddleware,
-    handleResponse(async (req, res, next) => {
-      await sessionManager.deleteSession(
-        req.get(sessionManager.sessionTokenHeader)
-      )
-      return successResponse()
+    const redisClient = req.app.get('redisClient')
+    const userLoginChallengeKey = `${CHALLENGE_PREFIX}${address}`
+    const ourChallenge = await redisClient.get(userLoginChallengeKey)
+
+    if (!ourChallenge) {
+      return errorResponseBadRequest('Missing challenge key')
+    }
+
+    if (theirChallenge !== ourChallenge) {
+      return errorResponseBadRequest(`Invalid response.`)
+    }
+
+    await redisClient.del(userLoginChallengeKey)
+
+    // All checks have passed! generate a new session token for the user
+    const sessionToken = await sessionManager.createSession(user.cnodeUserUUID)
+    return successResponse({ sessionToken })
+  })
+)
+
+router.post(
+  '/users/logout',
+  authMiddleware,
+  handleResponse(async (req, res, next) => {
+    await sessionManager.deleteSession(
+      req.get(sessionManager.sessionTokenHeader)
+    )
+    return successResponse()
+  })
+)
+
+/**
+ * Returns latest clock value stored in CNodeUsers entry given wallet, or -1 if no entry found
+ * Returns boolean indicating whether a sync is in progress
+ * Optionally returns info on total and skipped CIDs for user
+ * Optionally returns user filesHash
+ */
+router.get(
+  '/users/clock_status/:walletPublicKey',
+  handleResponse(async (req, res) => {
+    const redisClient = req.app.get('redisClient')
+
+    const walletPublicKey = req.params.walletPublicKey.toLowerCase()
+    const returnSkipInfo = req.query.returnSkipInfo === 'true' // default false
+    const returnFilesHash = req.query.returnFilesHash === 'true' // default false
+    const filesHashClockRangeMin =
+      parseInt(req.query.filesHashClockRangeMin) || null
+    const filesHashClockRangeMax =
+      parseInt(req.query.filesHashClockRangeMax) || null
+
+    const response = {}
+
+    const cnodeUser = await models.CNodeUser.findOne({
+      where: { walletPublicKey }
     })
-  )
+    const cnodeUserUUID = cnodeUser ? cnodeUser.dataValues.cnodeUserUUID : null
+    const clockValue = cnodeUser ? cnodeUser.dataValues.clock : -1
+    response.clockValue = clockValue
 
-  /**
-   * Returns latest clock value stored in CNodeUsers entry given wallet, or -1 if no entry found
-   * Returns boolean indicating whether a sync is in progress
-   * Optionally returns info on total and skipped CIDs for user
-   * Optionally returns user filesHash
-   */
-  app.get(
-    '/users/clock_status/:walletPublicKey',
-    handleResponse(async (req, res) => {
-      const redisClient = req.app.get('redisClient')
+    async function fetchCIDSkipInfoIfRequested() {
+      if (returnSkipInfo) {
+        // Set response to default values
+        response.CIDSkipInfo = { numCIDs: 0, numSkippedCIDs: 0 }
 
-      const walletPublicKey = req.params.walletPublicKey.toLowerCase()
-      const returnSkipInfo = req.query.returnSkipInfo === 'true' // default false
-      const returnFilesHash = req.query.returnFilesHash === 'true' // default false
-      const filesHashClockRangeMin =
-        parseInt(req.query.filesHashClockRangeMin) || null
-      const filesHashClockRangeMax =
-        parseInt(req.query.filesHashClockRangeMax) || null
-
-      const response = {}
-
-      const cnodeUser = await models.CNodeUser.findOne({
-        where: { walletPublicKey }
-      })
-      const cnodeUserUUID = cnodeUser
-        ? cnodeUser.dataValues.cnodeUserUUID
-        : null
-      const clockValue = cnodeUser ? cnodeUser.dataValues.clock : -1
-      response.clockValue = clockValue
-
-      async function fetchCIDSkipInfoIfRequested() {
-        if (returnSkipInfo) {
-          // Set response to default values
-          response.CIDSkipInfo = { numCIDs: 0, numSkippedCIDs: 0 }
-
-          if (cnodeUserUUID) {
-            const countsQuery = (
-              await sequelize.query(
-                `
+        if (cnodeUserUUID) {
+          const countsQuery = (
+            await sequelize.query(
+              `
             select
               count(*) as "numCIDs",
               count(case when "skipped" = true then 1 else null end) as "numSkippedCIDs"
             from "Files"
             where "cnodeUserUUID" = :cnodeUserUUID
           `,
-                { replacements: { cnodeUserUUID } }
-              )
-            )[0][0]
+              { replacements: { cnodeUserUUID } }
+            )
+          )[0][0]
 
-            const numCIDs = parseInt(countsQuery.numCIDs)
-            const numSkippedCIDs = parseInt(countsQuery.numSkippedCIDs)
+          const numCIDs = parseInt(countsQuery.numCIDs)
+          const numSkippedCIDs = parseInt(countsQuery.numSkippedCIDs)
 
-            response.CIDSkipInfo = { numCIDs, numSkippedCIDs }
-          }
+          response.CIDSkipInfo = { numCIDs, numSkippedCIDs }
         }
       }
+    }
 
-      async function isSyncInProgress() {
-        let syncInProgress = false
-        try {
-          syncInProgress = await redisClient.WalletWriteLock.syncIsInProgress(
-            walletPublicKey
-          )
-        } catch (e) {
-          // Swallow error, leave syncInProgress unset
-        }
-
-        response.syncInProgress = syncInProgress
+    async function isSyncInProgress() {
+      let syncInProgress = false
+      try {
+        syncInProgress = await redisClient.WalletWriteLock.syncIsInProgress(
+          walletPublicKey
+        )
+      } catch (e) {
+        // Swallow error, leave syncInProgress unset
       }
 
-      async function fetchFilesHashIfRequested() {
-        if (returnFilesHash) {
-          // Set response to default values
-          response.filesHash = null
+      response.syncInProgress = syncInProgress
+    }
+
+    async function fetchFilesHashIfRequested() {
+      if (returnFilesHash) {
+        // Set response to default values
+        response.filesHash = null
+        if (filesHashClockRangeMin || filesHashClockRangeMax) {
+          response.filesHashForClockRange = null
+        }
+
+        if (cnodeUserUUID) {
+          const filesHash = await DBManager.fetchFilesHashFromDB({
+            lookupKey: { lookupCNodeUserUUID: cnodeUserUUID }
+          })
+          response.filesHash = filesHash
+
           if (filesHashClockRangeMin || filesHashClockRangeMax) {
-            response.filesHashForClockRange = null
-          }
-
-          if (cnodeUserUUID) {
-            const filesHash = await DBManager.fetchFilesHashFromDB({
-              lookupKey: { lookupCNodeUserUUID: cnodeUserUUID }
-            })
-            response.filesHash = filesHash
-
-            if (filesHashClockRangeMin || filesHashClockRangeMax) {
-              const filesHashForClockRange =
-                await DBManager.fetchFilesHashFromDB({
-                  lookupKey: { lookupCNodeUserUUID: cnodeUserUUID },
-                  clockMin: filesHashClockRangeMin,
-                  clockMax: filesHashClockRangeMax
-                })
-              response.filesHashForClockRange = filesHashForClockRange
-            }
+            const filesHashForClockRange = await DBManager.fetchFilesHashFromDB(
+              {
+                lookupKey: { lookupCNodeUserUUID: cnodeUserUUID },
+                clockMin: filesHashClockRangeMin,
+                clockMax: filesHashClockRangeMax
+              }
+            )
+            response.filesHashForClockRange = filesHashForClockRange
           }
         }
       }
+    }
 
-      await Promise.all([
-        fetchCIDSkipInfoIfRequested(),
-        isSyncInProgress(),
-        fetchFilesHashIfRequested()
-      ])
+    await Promise.all([
+      fetchCIDSkipInfoIfRequested(),
+      isSyncInProgress(),
+      fetchFilesHashIfRequested()
+    ])
 
-      return successResponse(response)
+    return successResponse(response)
+  })
+)
+
+/**
+ * Returns latest clock value for CNodeUser, or -1 if no entry found
+ * Optionally returns user filesHash, or null if no files found
+ */
+router.post(
+  '/users/batch_clock_status',
+  handleResponse(async (req, res) => {
+    const { walletPublicKeys /* [walletPublicKey] */ } = req.body
+
+    if (walletPublicKeys == null) {
+      return errorResponseBadRequest(
+        'Must provide valid walletPublicKeys field in request body'
+      )
+    }
+
+    const walletPublicKeysSet = new Set(walletPublicKeys)
+
+    // Enforce max # of wallets to prevent high db query time
+    const maxNumWallets = config.get('maxBatchClockStatusBatchSize')
+    if (walletPublicKeysSet.size > maxNumWallets) {
+      return errorResponseBadRequest(
+        `Number of wallets must not exceed ${maxNumWallets} (reduce 'walletPublicKeys' field in request body).`
+      )
+    }
+
+    const returnFilesHash = req.query.returnFilesHash === 'true' // default false
+
+    // Initialize users response object with default values
+    const users = {}
+    walletPublicKeys.forEach((wallet) => {
+      const user = {
+        walletPublicKey: wallet,
+        clock: -1
+      }
+      if (returnFilesHash) {
+        user.filesHash = null
+      }
+      users[wallet] = user
     })
-  )
 
-  /**
-   * Returns latest clock value for CNodeUser, or -1 if no entry found
-   * Optionally returns user filesHash, or null if no files found
-   */
-  app.post(
-    '/users/batch_clock_status',
-    handleResponse(async (req, res) => {
-      const { walletPublicKeys /* [walletPublicKey] */ } = req.body
-
-      if (walletPublicKeys == null) {
-        return errorResponseBadRequest(
-          'Must provide valid walletPublicKeys field in request body'
-        )
-      }
-
-      const walletPublicKeysSet = new Set(walletPublicKeys)
-
-      // Enforce max # of wallets to prevent high db query time
-      const maxNumWallets = config.get('maxBatchClockStatusBatchSize')
-      if (walletPublicKeysSet.size > maxNumWallets) {
-        return errorResponseBadRequest(
-          `Number of wallets must not exceed ${maxNumWallets} (reduce 'walletPublicKeys' field in request body).`
-        )
-      }
-
-      const returnFilesHash = req.query.returnFilesHash === 'true' // default false
-
-      // Initialize users response object with default values
-      const users = {}
-      walletPublicKeys.forEach((wallet) => {
-        const user = {
-          walletPublicKey: wallet,
-          clock: -1
+    // Fetch all cnodeUsers for wallets
+    const cnodeUsers = await models.CNodeUser.findAll({
+      where: {
+        walletPublicKey: {
+          [models.Sequelize.Op.in]: walletPublicKeys
         }
-        if (returnFilesHash) {
-          user.filesHash = null
-        }
-        users[wallet] = user
-      })
-
-      // Fetch all cnodeUsers for wallets
-      const cnodeUsers = await models.CNodeUser.findAll({
-        where: {
-          walletPublicKey: {
-            [models.Sequelize.Op.in]: walletPublicKeys
-          }
-        }
-      })
-
-      // Populate users response object with cnodeUsers data
-      cnodeUsers.forEach(({ walletPublicKey, clock }) => {
-        users[walletPublicKey].walletPublicKey = walletPublicKey
-        users[walletPublicKey].clock = clock
-      })
-
-      // Fetch filesHashes if requested
-      if (returnFilesHash && cnodeUsers.length > 0) {
-        // Fetch filesHashes
-        const cnodeUserUUIDs = cnodeUsers.map(
-          (cnodeUser) => cnodeUser.cnodeUserUUID
-        )
-        const filesHashesByCNodeUserUUID =
-          await DBManager.fetchFilesHashesFromDB({ cnodeUserUUIDs })
-
-        // Populate users response object with filesHash data
-        const cnodeUserUUIDToWalletMap = {}
-        cnodeUsers.forEach((cnodeUser) => {
-          cnodeUserUUIDToWalletMap[cnodeUser.cnodeUserUUID] =
-            cnodeUser.walletPublicKey
-        })
-        Object.entries(filesHashesByCNodeUserUUID).forEach(
-          ([cnodeUserUUID, filesHash]) => {
-            const wallet = cnodeUserUUIDToWalletMap[cnodeUserUUID]
-            users[wallet].filesHash = filesHash
-          }
-        )
       }
-
-      // Convert response object from map(wallet => { info }) to [{ info }]
-      const usersResp = Object.values(users)
-
-      return successResponse({ users: usersResp })
     })
-  )
-}
+
+    // Populate users response object with cnodeUsers data
+    cnodeUsers.forEach(({ walletPublicKey, clock }) => {
+      users[walletPublicKey].walletPublicKey = walletPublicKey
+      users[walletPublicKey].clock = clock
+    })
+
+    // Fetch filesHashes if requested
+    if (returnFilesHash && cnodeUsers.length > 0) {
+      // Fetch filesHashes
+      const cnodeUserUUIDs = cnodeUsers.map(
+        (cnodeUser) => cnodeUser.cnodeUserUUID
+      )
+      const filesHashesByCNodeUserUUID = await DBManager.fetchFilesHashesFromDB(
+        { cnodeUserUUIDs }
+      )
+
+      // Populate users response object with filesHash data
+      const cnodeUserUUIDToWalletMap = {}
+      cnodeUsers.forEach((cnodeUser) => {
+        cnodeUserUUIDToWalletMap[cnodeUser.cnodeUserUUID] =
+          cnodeUser.walletPublicKey
+      })
+      Object.entries(filesHashesByCNodeUserUUID).forEach(
+        ([cnodeUserUUID, filesHash]) => {
+          const wallet = cnodeUserUUIDToWalletMap[cnodeUserUUID]
+          users[wallet].filesHash = filesHash
+        }
+      )
+    }
+
+    // Convert response object from map(wallet => { info }) to [{ info }]
+    const usersResp = Object.values(users)
+
+    return successResponse({ users: usersResp })
+  })
+)
+
+module.exports = router

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -317,14 +317,6 @@ class ServiceRegistry {
       )
     }
 
-    try {
-      await this._setupRouteDurationTracking(app)
-    } catch (e) {
-      this.logError(
-        `DurationTracking || Failed to setup general duration tracking for all routes: ${e.message}. Skipping..`
-      )
-    }
-
     this.servicesThatRequireServerInitialized = true
 
     logInfoWithDuration(
@@ -374,95 +366,6 @@ class ServiceRegistry {
         'spID'
       )}`
     )
-  }
-
-  /**
-   * Gets the regexes for routes with route params. Used for mapping paths in metrics to track route durations
-   *
-   * Structure:
-   *  {regex: <some regex>, path: <path that a matched path will route to in the normalize fn in prometheus middleware>}
-   *
-   * Example of the regex added to PrometheusRegistry:
-   *
-   *  /ipfs/:CID and /content/:CID -> map to /ipfs/#CID
-   *
-   * {
-   *    regex: /(?:^\/ipfs\/(?:([^/]+?))\/?$|^\/content\/(?:([^/]+?))\/?$)/i,
-   *    path: '/ipfs/#CID'
-   * }
-   * @param {Object} app
-   */
-  async _setupRouteDurationTracking(app) {
-    // Get all the routes initialized in the app
-    const routes = app._router.stack.filter(
-      (element) =>
-        (element.route && element.route.path) ||
-        (element.handle && element.handle.stack)
-    )
-
-    // Iterate through the paths and add the regexes if the route
-    // has route params
-
-    // Express routing is... unpredictable. Use a set to manage seen paths
-    const seenPaths = new Set()
-    const parsedRoutes = []
-    routes.forEach((element) => {
-      if (element.name === 'router') {
-        // Iterate through routes initialized with the express router
-        element.handle.stack.forEach((e) => {
-          const path = e.route.path
-          const method = Object.keys(e.route.methods)[0]
-          const regex = e.regexp
-          addToParsedRoutes(path, method, regex)
-        })
-      } else {
-        // Iterate through all the other routes initalized with the app
-        const path = element.route.path
-        const method = Object.keys(element.route.methods)[0]
-        const regex = element.regexp
-        addToParsedRoutes(path, method, regex)
-      }
-    })
-
-    // Only keep track of the routes with route params, e.g. the route with ':'
-    // in the route to indicate a route param
-    function addToParsedRoutes(path, method, regex) {
-      // Routes may come in the form of an array (e.g. ['/ipfs/:CID', '/content/:CID'])
-      if (Array.isArray(path)) {
-        path.forEach((p) => {
-          if (!seenPaths.has(p + method)) {
-            if (p.includes(':')) {
-              seenPaths.add(p + method)
-              parsedRoutes.push({
-                path: p,
-                method,
-                regex
-              })
-            }
-          }
-        })
-      } else {
-        if (!seenPaths.has(path + method)) {
-          if (path.includes(':')) {
-            seenPaths.add(path + method)
-            parsedRoutes.push({
-              path,
-              method,
-              regex
-            })
-          }
-        }
-      }
-    }
-
-    const regexes = parsedRoutes
-      .filter(({ path }) => path.includes(':'))
-      .map(({ path, regex }) => ({
-        regex,
-        path: path.replace(/:/g, '#')
-      }))
-
-    this.prometheusRegistry.initRouteParamRegexes(regexes)
   }
 
   /**

--- a/creator-node/src/services/prometheusMonitoring/prometheusRegistry.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheusRegistry.js
@@ -29,8 +29,6 @@ class PrometheusRegistry {
     this.metricNames = { ...METRIC_NAMES }
 
     this.namespacePrefix = NAMESPACE_PREFIX
-
-    this.regexes = []
   }
 
   /**
@@ -44,14 +42,6 @@ class PrometheusRegistry {
       const metric = new MetricType(metricConfig)
       registry.registerMetric(metric)
     }
-  }
-
-  /**
-   * Initializes the regexes to match on routes with route params
-   * @param {RegExp[]} regexes the regexes used to match on routes with route params
-   */
-  initRouteParamRegexes(regexes) {
-    this.regexes = regexes
   }
 
   /** Getters */

--- a/creator-node/test/prometheus.test.js
+++ b/creator-node/test/prometheus.test.js
@@ -39,6 +39,13 @@ describe('test Prometheus metrics', async function () {
     )
   })
 
+  it('Checks that hitting unregistered routes does not track prometheus metrics', async function () {
+    await request(app).get('/blahblahblah')
+    const resp = await request(app).get('/prometheus_metrics').expect(200)
+
+    assert.ok(!resp.text.includes('blahblahblah'))
+  })
+
   it('Checks the middleware tracks routes with route params', async function () {
     await request(app).get('/ipfs/QmVickyWasHere')
     await request(app).get('/content/QmVickyWasHere')

--- a/creator-node/test/prometheus.test.js
+++ b/creator-node/test/prometheus.test.js
@@ -40,24 +40,63 @@ describe('test Prometheus metrics', async function () {
   })
 
   it('Checks the middleware tracks routes with route params', async function () {
-    app.get('serviceRegistry').prometheusRegistry.regexes = [
-      {
-        regex: /(?:^\/ipfs\/(?:([^/]+?))\/?$|^\/content\/(?:([^/]+?))\/?$)/i,
-        path: '/ipfs/#CID'
-      }
-    ]
-
     await request(app).get('/ipfs/QmVickyWasHere')
     await request(app).get('/content/QmVickyWasHere')
 
     const resp = await request(app).get('/prometheus_metrics').expect(200)
 
     assert.ok(
-      resp.text.includes(NAMESPACE_PREFIX + '_http_request_duration_seconds')
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="0.2",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
     )
 
-    assert.ok(resp.text.includes('/ipfs/#CID'))
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="0.5",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
 
-    assert.ok(!resp.text.includes('/content/#CID'))
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="1",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="4",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="15",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="60",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_bucket{le="+Inf",status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_sum{status_code="400",method="GET",path="/ipfs/:CID"}`
+      )
+    )
+
+    assert.ok(
+      resp.text.includes(
+        `audius_cn_http_request_duration_seconds_count{status_code="400",method="GET",path="/ipfs/:CID"} 2`
+      )
+    )
+
+    assert.ok(!resp.text.includes('/content/:CID'))
   })
 })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
All routes that hit CN get registered, which is not we want. This is to only track registered routes in prometheus. 

To know which routes to track before hand, we needed to convert routes instantiated in `app` as a `router` object instead (to which is the largest chunk of the delta in this PR)


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- hit regular routes -> was tracked
- hit routes with route params -> was tracked
- hit random routes -> not tracked

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Check to see if `/prometheus_metrics` tracks any routes that are not explicitly tracked when hit

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->