### PR TITLE
Sanity check setIsCreatorToTrue

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -11728,7 +11728,7 @@
     "scryptsy": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-      "integrity": "sha512-aldIRgMozSJ/Gl6K6qmJZysRP82lz83Wb42vl4PWN8SaLFHIaOzLPc9nUUW2jQN88CuGm5q5HefJ9jZ3nWSmTw==",
+      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
       "requires": {
         "pbkdf2": "^3.0.3"
       }

--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -11728,7 +11728,7 @@
     "scryptsy": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+      "integrity": "sha512-aldIRgMozSJ/Gl6K6qmJZysRP82lz83Wb42vl4PWN8SaLFHIaOzLPc9nUUW2jQN88CuGm5q5HefJ9jZ3nWSmTw==",
       "requires": {
         "pbkdf2": "^3.0.3"
       }

--- a/libs/src/api/user.js
+++ b/libs/src/api/user.js
@@ -21,7 +21,8 @@ const USER_PROPS = [
   'associated_sol_wallets',
   'collectibles',
   'playlist_library',
-  'events'
+  'events',
+  'is_creator'
 ]
 // User metadata fields that are required on the metadata object and only can have
 // non-null values
@@ -36,7 +37,8 @@ const USER_PROP_NAME_CONSTANTS = Object.freeze({
   LOCATION: 'location',
   PROFILE_PICTURE_SIZES: 'profile_picture_sizes',
   COVER_PHOTO_SIZES: 'cover_photo_sizes',
-  CREATOR_NODE_ENDPOINT: 'creator_node_endpoint'
+  CREATOR_NODE_ENDPOINT: 'creator_node_endpoint',
+  IS_CREATOR: 'is_creator'
 })
 
 class Users extends Base {
@@ -683,6 +685,9 @@ class Users extends Base {
             userId,
             Utils.decodeMultihash(metadata[USER_PROP_NAME_CONSTANTS.PROFILE_PICTURE_SIZES]).digest
           ))
+        }
+        if (key === USER_PROP_NAME_CONSTANTS.IS_CREATOR) {
+          updateOps.push(this.contracts.UserFactoryClient.updateIsCreator(userId, metadata[USER_PROP_NAME_CONSTANTS.IS_CREATOR]))
         }
         if (key === USER_PROP_NAME_CONSTANTS.COVER_PHOTO_SIZES) {
           updateOps.push(this.contracts.UserFactoryClient.updateCoverPhoto(

--- a/libs/src/sanityChecks/index.js
+++ b/libs/src/sanityChecks/index.js
@@ -1,3 +1,4 @@
+const setIsCreatorToTrue = require('./setIsCreatorToTrue')
 const sanitizeNodes = require('./sanitizeNodes')
 const addSecondaries = require('./addSecondaries')
 const syncNodes = require('./syncNodes')
@@ -17,6 +18,7 @@ class SanityChecks {
    * @param {Set<string>} creatorNodeWhitelist
    */
   async run (creatorNodeWhitelist = null) {
+    await setIsCreatorToTrue(this.libs)
     await sanitizeNodes(this.libs)
     await addSecondaries(this.libs)
     await assignReplicaSetIfNecessary(this.libs)

--- a/libs/src/sanityChecks/setIsCreatorToTrue.js
+++ b/libs/src/sanityChecks/setIsCreatorToTrue.js
@@ -1,0 +1,14 @@
+const setIsCreatorToTrue = async (libs) => {
+  console.error('Sanity Check - setIsCreatorToTrue')
+  const user = libs.userStateManager.getCurrentUser()
+
+  if (!user) return
+
+  if (!user.is_creator) {
+    const newMetadata = { ...user, is_creator: true }
+
+    await libs.User.updateCreator(user.user_id, newMetadata)
+  }
+}
+
+module.exports = setIsCreatorToTrue

--- a/libs/src/sanityChecks/setIsCreatorToTrue.js
+++ b/libs/src/sanityChecks/setIsCreatorToTrue.js
@@ -1,10 +1,10 @@
 const setIsCreatorToTrue = async (libs) => {
-  console.error('Sanity Check - setIsCreatorToTrue')
   const user = libs.userStateManager.getCurrentUser()
 
   if (!user) return
 
   if (!user.is_creator) {
+    console.log('Setting is_creator to true')
     const newMetadata = { ...user, is_creator: true }
 
     await libs.User.updateCreator(user.user_id, newMetadata)

--- a/libs/src/services/dataContracts/UserFactoryClient.ts
+++ b/libs/src/services/dataContracts/UserFactoryClient.ts
@@ -86,6 +86,32 @@ export class UserFactoryClient extends ContractClient {
     }
   }
 
+  async updateIsCreator(userId: number, isCreator: boolean) {
+    const [nonce, sig] = await this.getUpdateNonceAndSig(
+      signatureSchemas.generators.getUpdateUserCreatorRequestData,
+      userId,
+      isCreator
+    )
+    const method = await this.getMethod(
+      'updateIsCreator',
+      userId,
+      isCreator,
+      nonce,
+      sig
+    )
+    const contractAddress = await this.getAddress()
+
+    const tx = await this.web3Manager.sendTransaction(
+      method,
+      this.contractRegistryKey,
+      contractAddress
+    )
+    return {
+      txReceipt: tx,
+      isCreator: tx.events?.['UpdateIsCreator']?.returnValues._isCreator
+    }
+  }
+
   async updateName(userId: number, name: string) {
     Utils.checkStrLen(name, 32)
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add sanity check to set `is_creator` to `true` to help along old clients that have not updated to >=1.1.13. Flare-97

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally with new web and old client and verified that user is able to update metadata on the old client

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->