### PR TITLE
Add prometheus metrics for `secondarySyncFromPrimary`

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -90,15 +90,16 @@ const syncRouteController = async (req, res) => {
    * Else, debounce + add sync to queue
    */
   if (immediate) {
-    const errorObj = await secondarySyncFromPrimary(
-      serviceRegistry,
-      walletPublicKeys,
-      creatorNodeEndpoint,
-      blockNumber,
-      forceResync
-    )
-    if (errorObj) {
-      return errorResponseServerError(errorObj)
+    try {
+      await secondarySyncFromPrimary(
+        serviceRegistry,
+        walletPublicKeys,
+        creatorNodeEndpoint,
+        blockNumber,
+        forceResync
+      )
+    } catch (e) {
+      return errorResponseServerError(e)
     }
   } else {
     const debounceTime = nodeConfig.get('debounceTime')

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -68,7 +68,9 @@ const METRIC_LABELS = Object.freeze({
       'failure_import_not_consistent',
       'failure_import_not_contiguous',
       'failure_inconsistent_clock'
-    ]
+    ],
+    // 5 buckets in the range of 1 second to max seconds before timing out write quorum
+    buckets: exponentialBucketsRange(0.1, 60, 10)
   },
   [METRIC_NAMES.ISSUE_SYNC_REQUEST_DURATION_SECONDS_HISTOGRAM]: {
     sync_type: Object.values(SyncType).map(_.snakeCase),

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -62,8 +62,10 @@ const METRIC_LABELS = Object.freeze({
       'failure_sync_secondary_from_primary',
       'failure_db_transaction',
       'failure_sync_in_progress',
-      'failure_failed_export',
-      'failure_threshold_not_reached'
+      'failure_export_wallet',
+      'failure_threshold_not_reached',
+      'failure_import_not_consistent',
+      'failure_import_not_contiguous'
     ]
   },
   [METRIC_NAMES.ISSUE_SYNC_REQUEST_DURATION_SECONDS_HISTOGRAM]: {

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -38,7 +38,9 @@ const metricNames = {
   ISSUE_SYNC_REQUEST_DURATION_SECONDS_HISTOGRAM:
     'issue_sync_request_duration_seconds',
   FIND_SYNC_REQUEST_COUNTS_GAUGE: 'find_sync_request_counts',
-  WRITE_QUORUM_DURATION_SECONDS_HISTOGRAM: 'write_quorum_duration_seconds'
+  WRITE_QUORUM_DURATION_SECONDS_HISTOGRAM: 'write_quorum_duration_seconds',
+  SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM:
+    'secondary_sync_from_primary_duration_seconds'
 }
 // Add a histogram for each job in the state machine queues.
 // Some have custom labels below, and all of them use the label: uncaughtError=true/false
@@ -52,6 +54,18 @@ const METRIC_NAMES = Object.freeze(
 )
 
 const METRIC_LABELS = Object.freeze({
+  [METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM]: {
+    sync_type: Object.values(SyncType).map(_.snakeCase),
+    sync_mode: Object.values(SYNC_MODES).map(_.snakeCase),
+    result: [
+      'success',
+      'failure_sync_secondary_from_primary',
+      'failure_db_transaction',
+      'failure_sync_in_progress',
+      'failure_failed_export',
+      'failure_threshold_not_reached'
+    ]
+  },
   [METRIC_NAMES.ISSUE_SYNC_REQUEST_DURATION_SECONDS_HISTOGRAM]: {
     sync_type: Object.values(SyncType).map(_.snakeCase),
     sync_mode: Object.values(SYNC_MODES).map(_.snakeCase),

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -149,6 +149,17 @@ const MetricLabelNames = Object.freeze(
 )
 
 const METRICS = Object.freeze({
+  [METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM]: {
+    metricType: METRIC_TYPES.HISTOGRAM,
+    metricConfig: {
+      name: METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM,
+      help: 'Time spent to sync a secondary from a primary (seconds)',
+      labelNames:
+        MetricLabelNames[
+          METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM
+        ]
+    }
+  },
   [METRIC_NAMES.SYNC_QUEUE_JOBS_TOTAL_GAUGE]: {
     metricType: METRIC_TYPES.GAUGE,
     metricConfig: {

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.js
@@ -60,12 +60,14 @@ const METRIC_LABELS = Object.freeze({
     result: [
       'success',
       'failure_sync_secondary_from_primary',
+      'failure_malformed_export',
       'failure_db_transaction',
       'failure_sync_in_progress',
       'failure_export_wallet',
-      'failure_threshold_not_reached',
+      'failure_skip_threshold_not_reached',
       'failure_import_not_consistent',
-      'failure_import_not_contiguous'
+      'failure_import_not_contiguous',
+      'failure_inconsistent_clock'
     ]
   },
   [METRIC_NAMES.ISSUE_SYNC_REQUEST_DURATION_SECONDS_HISTOGRAM]: {

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -643,4 +643,6 @@ module.exports = async function (
   if (error) {
     throw new Error(error)
   }
+
+  return labels
 }

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -631,7 +631,7 @@ module.exports = async function (
   )
   const metricEndTimerFn = secondarySyncFromPrimaryMetric.startTimer()
 
-  const { error, ...labels } = handleSyncFromPrimary(
+  const { error, ...labels } = await handleSyncFromPrimary(
     serviceRegistry,
     walletPublicKeys,
     creatorNodeEndpoint,

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -114,7 +114,7 @@ const handleSyncFromPrimary = async (
       } else {
         return {
           error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
-          result: 'failure_export_wallet'
+          result: 'failure_malformed_export'
         }
       }
     }
@@ -123,7 +123,7 @@ const handleSyncFromPrimary = async (
     if (!body.data.hasOwnProperty('cnodeUsers')) {
       return {
         error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
-        result: 'failure_export_wallet'
+        result: 'failure_malformed_export'
       }
     }
 
@@ -146,7 +146,7 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Malformed response received from ${creatorNodeEndpoint}. "walletPublicKey" property not found on CNodeUser in response object`
           ),
-          result: 'failure_export_wallet'
+          result: 'failure_malformed_export'
         }
       }
       const fetchedWalletPublicKey = fetchedCNodeUser.walletPublicKey
@@ -185,7 +185,7 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Malformed response from ${creatorNodeEndpoint}. Returned data for walletPublicKey that was not requested.`
           ),
-          result: 'failure_export_wallet'
+          result: 'failure_malformed_export'
         }
       }
 
@@ -210,7 +210,7 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Cannot sync for localMaxClockVal ${localMaxClockVal} - imported data has max clock val ${fetchedLatestClockVal}`
           ),
-          result: 'failure_sync_secondary_from_primary'
+          result: 'failure_inconsistent_clock'
         }
       } else if (fetchedLatestClockVal === localMaxClockVal) {
         // Already up to date, no sync necessary
@@ -458,7 +458,7 @@ const handleSyncFromPrimary = async (
             logger.error(logPrefix, errorMsg)
             return {
               error: new Error(errorMsg),
-              result: 'failure_threshold_not_reached'
+              result: 'failure_skip_threshold_not_reached'
             }
 
             // If max failure threshold reached, continue with sync and reset failure count

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const axios = require('axios')
 
 const { logger } = require('../../logging')
@@ -230,7 +231,10 @@ const handleSyncFromPrimary = async (
           ),
           result: 'failure_import_not_contiguous'
         }
-      } else if (maxClockRecordId !== fetchedLatestClockVal) {
+      } else if (
+        !_.isEmpty(fetchedCNodeUser.clockRecords) &&
+        maxClockRecordId !== fetchedLatestClockVal
+      ) {
         return {
           error: new Error(
             `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -8,27 +8,14 @@ const SyncHistoryAggregator = require('../../snapbackSM/syncHistoryAggregator')
 const DBManager = require('../../dbManager')
 const UserSyncFailureCountManager = require('./UserSyncFailureCountManager')
 
-/**
- * This function is only run on secondaries, to export and sync data from a user's primary.
- *
- * @notice - By design, will reject any syncs with non-contiguous clock values. For now,
- *    any data corruption from primary needs to be handled separately and should not be replicated.
- *
- * @notice - There is a maxExportClockValueRange enforced in export, meaning that some syncs will
- *    only replicate partial data state. This is by design, and Snapback will trigger repeated syncs
- *    with progressively increasing clock values until secondaries have completely synced up.
- *    Secondaries have no knowledge of the current data state on primary, they simply replicate
- *    what they receive in each export.
- */
-module.exports = async function (
+const handleSyncFromPrimary = async (
   serviceRegistry,
   walletPublicKeys,
   creatorNodeEndpoint,
   blockNumber = null,
   forceResync = false
-) {
+) => {
   const { nodeConfig, redis, libs } = serviceRegistry
-
   const FileSaveMaxConcurrency = nodeConfig.get(
     'nodeSyncFileSaveMaxConcurrency'
   )
@@ -39,9 +26,6 @@ module.exports = async function (
   const start = Date.now()
 
   logger.info('begin nodesync for ', walletPublicKeys, 'time', start)
-
-  // object to track if the function errored, returned at the end of the function
-  let errorObj = null
 
   /**
    * Ensure access to each wallet, then acquire redis lock for duration of sync
@@ -56,10 +40,12 @@ module.exports = async function (
         redis.WalletWriteLock.VALID_ACQUIRERS.SecondarySyncFromPrimary
       )
     } catch (e) {
-      errorObj = new Error(
-        `Cannot change state of wallet ${wallet}. Node sync currently in progress.`
-      )
-      return errorObj
+      return {
+        error: new Error(
+          `Cannot change state of wallet ${wallet}. Node sync currently in progress.`
+        ),
+        result: 'failure_sync_in_progress'
+      }
     }
   }
 
@@ -115,19 +101,30 @@ module.exports = async function (
         `Failed to retrieve export from ${creatorNodeEndpoint} for wallets`,
         walletPublicKeys
       )
-      throw new Error(resp.data.error)
+      return {
+        error: new Error(resp.data.error),
+        result: 'failure_failed_export'
+      }
     }
 
     // TODO - explain patch
     if (!resp.data) {
       if (resp.request && resp.request.responseText) {
         resp.data = JSON.parse(resp.request.responseText)
-      } else throw new Error(`Malformed response from ${creatorNodeEndpoint}.`)
+      } else {
+        return {
+          error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
+          result: 'failure_failed_export'
+        }
+      }
     }
 
     const { data: body } = resp
     if (!body.data.hasOwnProperty('cnodeUsers')) {
-      throw new Error(`Malformed response from ${creatorNodeEndpoint}.`)
+      return {
+        error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
+        result: 'failure_failed_export'
+      }
     }
 
     logger.info(
@@ -145,9 +142,12 @@ module.exports = async function (
       // Since different nodes may assign different cnodeUserUUIDs to a given walletPublicKey,
       // retrieve local cnodeUserUUID from fetched walletPublicKey and delete all associated data.
       if (!fetchedCNodeUser.hasOwnProperty('walletPublicKey')) {
-        throw new Error(
-          `Malformed response received from ${creatorNodeEndpoint}. "walletPublicKey" property not found on CNodeUser in response object`
-        )
+        return {
+          error: new Error(
+            `Malformed response received from ${creatorNodeEndpoint}. "walletPublicKey" property not found on CNodeUser in response object`
+          ),
+          result: 'failure_failed_export'
+        }
       }
       const fetchedWalletPublicKey = fetchedCNodeUser.walletPublicKey
 
@@ -181,9 +181,12 @@ module.exports = async function (
       }
 
       if (!walletPublicKeys.includes(fetchedWalletPublicKey)) {
-        throw new Error(
-          `Malformed response from ${creatorNodeEndpoint}. Returned data for walletPublicKey that was not requested.`
-        )
+        return {
+          error: new Error(
+            `Malformed response from ${creatorNodeEndpoint}. Returned data for walletPublicKey that was not requested.`
+          ),
+          result: 'failure_failed_export'
+        }
       }
 
       /**
@@ -203,9 +206,12 @@ module.exports = async function (
 
       // Error if returned data is not within requested range
       if (fetchedLatestClockVal < localMaxClockVal) {
-        throw new Error(
-          `Cannot sync for localMaxClockVal ${localMaxClockVal} - imported data has max clock val ${fetchedLatestClockVal}`
-        )
+        return {
+          error: new Error(
+            `Cannot sync for localMaxClockVal ${localMaxClockVal} - imported data has max clock val ${fetchedLatestClockVal}`
+          ),
+          result: 'failure_sync_secondary_from_primary'
+        }
       } else if (fetchedLatestClockVal === localMaxClockVal) {
         // Already up to date, no sync necessary
         logger.info(
@@ -218,13 +224,19 @@ module.exports = async function (
         fetchedClockRecords[0] &&
         fetchedClockRecords[0].clock !== localMaxClockVal + 1
       ) {
-        throw new Error(
-          `Cannot sync - imported data is not contiguous. Local max clock val = ${localMaxClockVal} and imported min clock val ${fetchedClockRecords[0].clock}`
-        )
+        return {
+          error: new Error(
+            `Cannot sync - imported data is not contiguous. Local max clock val = ${localMaxClockVal} and imported min clock val ${fetchedClockRecords[0].clock}`
+          ),
+          result: 'failure_sync_secondary_from_primary'
+        }
       } else if (maxClockRecordId !== fetchedLatestClockVal) {
-        throw new Error(
-          `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`
-        )
+        return {
+          error: new Error(
+            `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`
+          ),
+          result: 'failure_sync_secondary_from_primary'
+        }
       }
 
       // All DB updates must happen in single atomic tx - partial state updates will lead to data loss
@@ -282,9 +294,12 @@ module.exports = async function (
 
           // Error if update failed
           if (numRowsUpdated !== 1 || respObj.length !== 1) {
-            throw new Error(
-              `Failed to update cnodeUser row for cnodeUser wallet ${fetchedWalletPublicKey}`
-            )
+            return {
+              error: new Error(
+                `Failed to update cnodeUser row for cnodeUser wallet ${fetchedWalletPublicKey}`
+              ),
+              result: 'failure_db_transaction'
+            }
           }
           cnodeUser = respObj[0]
         } else {
@@ -441,7 +456,10 @@ module.exports = async function (
           if (userSyncFailureCount < SyncRequestMaxUserFailureCountBeforeSkip) {
             const errorMsg = `User Sync failed due to ${numCIDsThatFailedSaveFileOp} failing saveFileForMultihashToFS op. userSyncFailureCount = ${userSyncFailureCount} // SyncRequestMaxUserFailureCountBeforeSkip = ${SyncRequestMaxUserFailureCountBeforeSkip}`
             logger.error(logPrefix, errorMsg)
-            throw new Error(errorMsg)
+            return {
+              error: new Error(errorMsg),
+              result: 'failure_threshold_not_reached'
+            }
 
             // If max failure threshold reached, continue with sync and reset failure count
           } else {
@@ -538,14 +556,28 @@ module.exports = async function (
 
         await transaction.rollback()
 
-        throw new Error(e)
+        return {
+          error: new Error(e),
+          result: 'failure_db_transaction'
+        }
       }
     }
   } catch (e) {
-    errorObj = e
-
     for (const wallet of walletPublicKeys) {
       await SyncHistoryAggregator.recordSyncFail(wallet)
+    }
+    logger.error(
+      logPrefix,
+      `Sync complete for wallets: ${walletPublicKeys.join(
+        ','
+      )}. Status: Error, message: ${e.message}. Duration sync: ${
+        Date.now() - start
+      }. From endpoint ${creatorNodeEndpoint}.`
+    )
+
+    return {
+      error: new Error(e),
+      result: 'failure_sync_secondary_from_primary'
     }
   } finally {
     // Release all redis locks
@@ -559,27 +591,56 @@ module.exports = async function (
         )
       }
     }
-
-    if (errorObj) {
-      logger.error(
-        logPrefix,
-        `Sync complete for wallets: ${walletPublicKeys.join(
-          ','
-        )}. Status: Error, message: ${errorObj.message}. Duration sync: ${
-          Date.now() - start
-        }. From endpoint ${creatorNodeEndpoint}.`
-      )
-    } else {
-      logger.info(
-        logPrefix,
-        `Sync complete for wallets: ${walletPublicKeys.join(
-          ','
-        )}. Status: Success. Duration sync: ${
-          Date.now() - start
-        }. From endpoint ${creatorNodeEndpoint}.`
-      )
-    }
   }
 
-  return errorObj
+  logger.info(
+    logPrefix,
+    `Sync complete for wallets: ${walletPublicKeys.join(
+      ','
+    )}. Status: Success. Duration sync: ${
+      Date.now() - start
+    }. From endpoint ${creatorNodeEndpoint}.`
+  )
+
+  return { result: 'success' }
+}
+
+/**
+ * This function is only run on secondaries, to export and sync data from a user's primary.
+ *
+ * @notice - By design, will reject any syncs with non-contiguous clock values. For now,
+ *    any data corruption from primary needs to be handled separately and should not be replicated.
+ *
+ * @notice - There is a maxExportClockValueRange enforced in export, meaning that some syncs will
+ *    only replicate partial data state. This is by design, and Snapback will trigger repeated syncs
+ *    with progressively increasing clock values until secondaries have completely synced up.
+ *    Secondaries have no knowledge of the current data state on primary, they simply replicate
+ *    what they receive in each export.
+ */
+module.exports = async function (
+  serviceRegistry,
+  walletPublicKeys,
+  creatorNodeEndpoint,
+  blockNumber = null,
+  forceResync = false
+) {
+  const { prometheusRegistry } = serviceRegistry
+  const secondarySyncFromPrimaryMetric = prometheusRegistry.getMetric(
+    prometheusRegistry.metricNames
+      .SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM
+  )
+  const metricEndTimerFn = secondarySyncFromPrimaryMetric.startTimer()
+
+  const { error, ...labels } = handleSyncFromPrimary(
+    serviceRegistry,
+    walletPublicKeys,
+    creatorNodeEndpoint,
+    blockNumber,
+    forceResync
+  )
+  metricEndTimerFn(labels)
+
+  if (error) {
+    throw new Error(error)
+  }
 }

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -103,7 +103,7 @@ const handleSyncFromPrimary = async (
       )
       return {
         error: new Error(resp.data.error),
-        result: 'failure_failed_export'
+        result: 'failure_export_wallet'
       }
     }
 
@@ -114,7 +114,7 @@ const handleSyncFromPrimary = async (
       } else {
         return {
           error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
-          result: 'failure_failed_export'
+          result: 'failure_export_wallet'
         }
       }
     }
@@ -123,7 +123,7 @@ const handleSyncFromPrimary = async (
     if (!body.data.hasOwnProperty('cnodeUsers')) {
       return {
         error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
-        result: 'failure_failed_export'
+        result: 'failure_export_wallet'
       }
     }
 
@@ -146,7 +146,7 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Malformed response received from ${creatorNodeEndpoint}. "walletPublicKey" property not found on CNodeUser in response object`
           ),
-          result: 'failure_failed_export'
+          result: 'failure_export_wallet'
         }
       }
       const fetchedWalletPublicKey = fetchedCNodeUser.walletPublicKey
@@ -185,7 +185,7 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Malformed response from ${creatorNodeEndpoint}. Returned data for walletPublicKey that was not requested.`
           ),
-          result: 'failure_failed_export'
+          result: 'failure_export_wallet'
         }
       }
 
@@ -228,14 +228,14 @@ const handleSyncFromPrimary = async (
           error: new Error(
             `Cannot sync - imported data is not contiguous. Local max clock val = ${localMaxClockVal} and imported min clock val ${fetchedClockRecords[0].clock}`
           ),
-          result: 'failure_sync_secondary_from_primary'
+          result: 'failure_import_not_contiguous'
         }
       } else if (maxClockRecordId !== fetchedLatestClockVal) {
         return {
           error: new Error(
             `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`
           ),
-          result: 'failure_sync_secondary_from_primary'
+          result: 'failure_import_not_consistent'
         }
       }
 

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -58,7 +58,8 @@ function getServiceRegistryMock(libsClient, blacklistManager) {
     monitoringQueue: new MonitoringQueueMock(),
     syncQueue: new SyncQueue(nodeConfig, redisClient),
     nodeConfig,
-    initLibs: async function () {}
+    initLibs: async function () {},
+    prometheusRegistry: new PrometheusRegistry()
   }
 }
 

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1009,11 +1009,15 @@ describe('test nodesync', async function () {
       assert.strictEqual(initialCNodeUserCount, 0)
 
       // Call secondarySyncFromPrimary
-      await secondarySyncFromPrimary(
+      const result = await secondarySyncFromPrimary(
         serviceRegistryMock,
         userWallets,
         TEST_ENDPOINT
       )
+
+      assert.deepStrictEqual(result, {
+        result: 'success'
+      })
 
       const newCNodeUserUUID = await verifyLocalCNodeUserStateForUser(
         exportedCnodeUser
@@ -1054,11 +1058,15 @@ describe('test nodesync', async function () {
       assert.strictEqual(localCNodeUserCount, 1)
 
       // Call secondarySyncFromPrimary
-      await secondarySyncFromPrimary(
+      const result = await secondarySyncFromPrimary(
         serviceRegistryMock,
         userWallets,
         TEST_ENDPOINT
       )
+
+      assert.deepStrictEqual(result, {
+        result: 'success'
+      })
 
       await verifyLocalCNodeUserStateForUser(exportedCnodeUser)
 
@@ -1097,13 +1105,17 @@ describe('test nodesync', async function () {
       assert.strictEqual(localCNodeUserCount, 1)
 
       // Call secondarySyncFromPrimary with `forceResync` = true
-      await secondarySyncFromPrimary(
+      const result = await secondarySyncFromPrimary(
         serviceRegistryMock,
         userWallets,
         TEST_ENDPOINT,
         /* blockNumber */ null,
         /* forceResync */ true
       )
+
+      assert.deepStrictEqual(result, {
+        result: 'success'
+      })
 
       const newCNodeUserUUID = await verifyLocalCNodeUserStateForUser(
         exportedCnodeUser


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds a prometheus metric for `secondarySyncFromPrimary`. 

Example metric below

```
# HELP audius_cn_secondary_sync_from_primary_duration_seconds Time spent to sync a secondary from a primary (seconds)
# TYPE audius_cn_secondary_sync_from_primary_duration_seconds histogram
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.005",result="success"} 0
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.01",result="success"} 0
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.025",result="success"} 0
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.05",result="success"} 0
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.1",result="success"} 0
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.25",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="0.5",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="1",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="2.5",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="5",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="10",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_bucket{le="+Inf",result="success"} 2
audius_cn_secondary_sync_from_primary_duration_seconds_sum{result="success"} 0.29532314000000004
audius_cn_secondary_sync_from_primary_duration_seconds_count{result="success"} 2
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

This PR doesn't change any core functions or business logic so no new tests are needed. 

Although, the serviceRegistryMock was modified and had the prometheusRegistry added to it so the tests would pass.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

These changes will be monitored with prometheus and soon grafana.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->