### PR TITLE
CN - Fix export bug

### DIFF
--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -112,11 +112,7 @@ const exportComponentService = async ({
       )
       if (!_.isEmpty(clockRecords) && cnodeUser.clock !== maxClockRecord) {
         const errorMsg = `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecord}`
-        if (forceExport) {
-          logger.error(errorMsg)
-        } else {
-          throw new Error(errorMsg)
-        }
+        throw new Error(errorMsg)
       }
 
       cnodeUser.clockInfo = {

--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const models = require('../../models')
 const { Transaction } = require('sequelize')
 
@@ -105,13 +107,16 @@ const exportComponentService = async ({
       }
 
       // Validate clock values or throw an error
-      const maxClockRecordId = Math.max(
+      const maxClockRecord = Math.max(
         ...clockRecords.map((record) => record.clock)
       )
-      if (cnodeUser.clock !== maxClockRecordId) {
-        throw new Error(
-          `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecordId}`
-        )
+      if (!_.isEmpty(clockRecords) && cnodeUser.clock !== maxClockRecord) {
+        const errorMsg = `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecord}`
+        if (forceExport) {
+          logger.error(errorMsg)
+        } else {
+          throw new Error(errorMsg)
+        }
       }
 
       cnodeUser.clockInfo = {

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -21,6 +21,7 @@ const {
 const { uploadTrack } = require('./lib/helpers')
 const BlacklistManager = require('../src/blacklistManager')
 const sessionManager = require('../src/sessionManager')
+const exportComponentService = require('../src/components/replicaSet/exportComponentService')
 
 const redisClient = require('../src/redis')
 const { stringifiedDateFields } = require('./lib/utils')
@@ -702,7 +703,7 @@ describe('test nodesync', async function () {
       })
     })
 
-    describe('Confirm export throws an error with inconsitent data', async function () {
+    describe('Confirm export throws an error with inconsistent data', async function () {
       beforeEach(setupDepsAndApp)
 
       beforeEach(createUserAndTrack)
@@ -710,22 +711,24 @@ describe('test nodesync', async function () {
       it('Inconsistent clock values', async function () {
         // Mock findOne DB function for cnodeUsers and ClockRecords
         // Have them return inconsistent values
+        const clockRecordTableClock = 8
         const clockRecordsFindAllStub = sandbox.stub().resolves([
           {
-            clock: 8
+            clock: clockRecordTableClock
           }
         ])
+        const cnodeUserTableClock = 7
         const cNodeUserFindAll = sandbox.stub().resolves([
           {
             // Random UUID
             cnodeUserUUID: '48523a08-2a11-4200-8aac-ae74b8a39dd0',
-            clock: 7
+            clock: cnodeUserTableClock
           }
         ])
 
         const modelsMock = {
           ...require('../src/models'),
-          ClockRecords: {
+          ClockRecord: {
             findAll: clockRecordsFindAllStub
           },
           CNodeUser: {
@@ -747,13 +750,11 @@ describe('test nodesync', async function () {
             logger: console
           })
         ).to.eventually.be.rejectedWith(
-          'Cannot export - exported data is not consistent. Exported max clock val = 7 and exported max ClockRecord val -Infinity'
+          `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUserTableClock} and exported max ClockRecord val ${clockRecordTableClock}`
         )
 
-        /**
-         *
-         * Verify
-         */
+        expect(clockRecordsFindAllStub).to.have.been.calledOnce
+        expect(cNodeUserFindAll).to.have.been.calledOnce
       })
     })
   })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

**Problem**
[Recent commit](https://github.com/AudiusProject/audius-protocol/commit/c6ad867e5fb433f49bae4d66466cc8eba170e5b7#diff-603c68a5c307de706249f27b45a7499857db7ed1402ac39b6aefa0ca0fae3e1cR137) introduced bug in export

Example:
https://creatornode9.staging.audius.co/export?wallet_public_key[]=0x33b11f3273523704fecbc7eed7c11bd4a8e4dc4f&clock_range_min=37&source_endpoint=https:%2F%2Fcreatornode5.staging.audius.co

```
Error: Cannot export - exported data is not consistent. Exported max clock val = 36 and exported max ClockRecord val -Infinity
```

[All instances on loggly](https://audius.loggly.com/search#terms=%22Cannot%20export%20-%20exported%20data%20is%20not%20consistent%22%20tag:audius-stage-creator-*&from=2022-07-20T18:41:39.803Z&until=2022-07-22T18:41:39.803Z&source_group=)

This happens when requesting data with a clock range that returns no clock records

**Solution**
Only do clock value comparison if `clockRecords` is not empty


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally where previously returns 500, now returns correct data

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Logs containing `exported max ClockRecord val -Infinity`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->