### PR TITLE
Add force_export query param to /export route for MergePrimaryAndSecondary

### DIFF
--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -112,11 +112,7 @@ const exportComponentService = async ({
       )
       if (!_.isEmpty(clockRecords) && cnodeUser.clock !== maxClockRecord) {
         const errorMsg = `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecord}`
-        if (forceExport) {
-          logger.error(errorMsg)
-        } else {
-          throw new Error(errorMsg)
-        }
+        throw new Error(errorMsg)
       }
 
       cnodeUser.clockInfo = {

--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const models = require('../../models')
 const { Transaction } = require('sequelize')
 
@@ -105,13 +107,16 @@ const exportComponentService = async ({
       }
 
       // Validate clock values or throw an error
-      const maxClockRecordId = Math.max(
+      const maxClockRecord = Math.max(
         ...clockRecords.map((record) => record.clock)
       )
-      if (cnodeUser.clock !== maxClockRecordId) {
-        throw new Error(
-          `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecordId}`
-        )
+      if (!_.isEmpty(clockRecords) && cnodeUser.clock !== maxClockRecord) {
+        const errorMsg = `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecord}`
+        if (forceExport) {
+          logger.error(errorMsg)
+        } else {
+          throw new Error(errorMsg)
+        }
       }
 
       cnodeUser.clockInfo = {

--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -14,7 +14,7 @@ const exportComponentService = async ({
   walletPublicKeys,
   requestedClockRangeMin,
   requestedClockRangeMax,
-  forceExport,
+  forceExport = false,
   logger
 }) => {
   const transaction = await models.sequelize.transaction({

--- a/creator-node/src/components/replicaSet/exportComponentService.js
+++ b/creator-node/src/components/replicaSet/exportComponentService.js
@@ -14,6 +14,7 @@ const exportComponentService = async ({
   walletPublicKeys,
   requestedClockRangeMin,
   requestedClockRangeMax,
+  forceExport,
   logger
 }) => {
   const transaction = await models.sequelize.transaction({
@@ -112,7 +113,10 @@ const exportComponentService = async ({
       )
       if (!_.isEmpty(clockRecords) && cnodeUser.clock !== maxClockRecord) {
         const errorMsg = `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUser.clock} and exported max ClockRecord val ${maxClockRecord}`
-        throw new Error(errorMsg)
+        logger.error(errorMsg)
+        if (!forceExport) {
+          throw new Error(errorMsg)
+        }
       }
 
       cnodeUser.clockInfo = {

--- a/creator-node/src/routes/nodeSync.js
+++ b/creator-node/src/routes/nodeSync.js
@@ -29,6 +29,7 @@ router.get(
 
     const walletPublicKeys = req.query.wallet_public_key // array
     const sourceEndpoint = req.query.source_endpoint // string
+    const forceExport = !!req.query.force_export // boolean
 
     const maxExportClockValueRange = config.get('maxExportClockValueRange')
 
@@ -44,6 +45,7 @@ router.get(
             walletPublicKeys,
             requestedClockRangeMin,
             requestedClockRangeMax,
+            forceExport,
             logger: req.logger
           })
         },

--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -128,7 +128,8 @@ async function fetchExportFromSecondary({
   const exportQueryParams = {
     wallet_public_key: [wallet], // export requires a wallet array
     clock_range_min: clockRangeMin,
-    source_endpoint: selfEndpoint
+    source_endpoint: selfEndpoint,
+    force_export: true
   }
 
   try {

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -21,6 +21,7 @@ const {
 const { uploadTrack } = require('./lib/helpers')
 const BlacklistManager = require('../src/blacklistManager')
 const sessionManager = require('../src/sessionManager')
+const exportComponentService = require('../src/components/replicaSet/exportComponentService')
 
 const redisClient = require('../src/redis')
 const { stringifiedDateFields } = require('./lib/utils')
@@ -702,7 +703,7 @@ describe('test nodesync', async function () {
       })
     })
 
-    describe('Confirm export throws an error with inconsitent data', async function () {
+    describe('Confirm export throws an error with inconsistent data', async function () {
       beforeEach(setupDepsAndApp)
 
       beforeEach(createUserAndTrack)
@@ -710,22 +711,24 @@ describe('test nodesync', async function () {
       it('Inconsistent clock values', async function () {
         // Mock findOne DB function for cnodeUsers and ClockRecords
         // Have them return inconsistent values
+        const clockRecordTableClock = 8
         const clockRecordsFindAllStub = sandbox.stub().resolves([
           {
-            clock: 8
+            clock: clockRecordTableClock
           }
         ])
+        const cnodeUserTableClock = 7
         const cNodeUserFindAll = sandbox.stub().resolves([
           {
             // Random UUID
             cnodeUserUUID: '48523a08-2a11-4200-8aac-ae74b8a39dd0',
-            clock: 7
+            clock: cnodeUserTableClock
           }
         ])
 
         const modelsMock = {
           ...require('../src/models'),
-          ClockRecords: {
+          ClockRecord: {
             findAll: clockRecordsFindAllStub
           },
           CNodeUser: {
@@ -747,13 +750,11 @@ describe('test nodesync', async function () {
             logger: console
           })
         ).to.eventually.be.rejectedWith(
-          'Cannot export - exported data is not consistent. Exported max clock val = 7 and exported max ClockRecord val -Infinity'
+          `Cannot export - exported data is not consistent. Exported max clock val = ${cnodeUserTableClock} and exported max ClockRecord val ${clockRecordTableClock}`
         )
 
-        /**
-         *
-         * Verify
-         */
+        expect(clockRecordsFindAllStub).to.have.been.calledOnce
+        expect(cNodeUserFindAll).to.have.been.calledOnce
       })
     })
   })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

**Problem**
If any corrupted state in a node, it currently rejects any export with error, which breaks the MergePrimaryAndSecondary flow. A primary should be able to merge secondary content over regardless of any corrupted state (in fact, this is when it really matters)

**Solution**
Add an optional `force_export` query param to export route to return user info instead of throwing error


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Existing test coverage

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Ensure no `/export` routes with non-200 status code and `force_export` query param

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->