### PR TITLE
[CON-294] Make manual sync queue less backed up

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.js
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.js
@@ -39,7 +39,7 @@ module.exports = {
   MAX_ISSUE_MANUAL_SYNC_JOB_ATTEMPTS: 2,
 
   // Max number of attempts to run a job that attempts to issue a recurring sync
-  MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS: 1,
+  MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS: 2,
 
   QUEUE_HISTORY: Object.freeze({
     // Max number of completed/failed jobs to keep in redis for the monitor-state queue

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.js
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.js
@@ -35,8 +35,11 @@ module.exports = {
   // Max number of attempts to select new replica set in reconfig
   MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS: 5,
 
-  // Max number of attempts to run a job that attempts to issue a sync (manual or recurring)
-  MAX_ISSUE_SYNC_JOB_ATTEMPTS: 3,
+  // Max number of attempts to run a job that attempts to issue a manual sync
+  MAX_ISSUE_MANUAL_SYNC_JOB_ATTEMPTS: 2,
+
+  // Max number of attempts to run a job that attempts to issue a recurring sync
+  MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS: 1,
 
   QUEUE_HISTORY: Object.freeze({
     // Max number of completed/failed jobs to keep in redis for the monitor-state queue

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
@@ -210,7 +210,7 @@ const _findReplicaSetUpdatesForUser = async (
     )
 
     /**
-     * For each secondary, enqueue `potentialSyncRequest` if healthy else add to `unhealthyReplicas`
+     * For each secondary, add to `unhealthyReplicas` if unhealthy
      */
     for (const secondaryInfo of secondariesInfo) {
       const secondary = secondaryInfo.endpoint

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -117,7 +117,7 @@ class StateReconciliationManager {
 
     // Register the logic that gets executed to process each new job from the queue
     manualSyncQueue.process(
-      1, // config.get('maxManualRequestSyncJobConcurrency'),
+      config.get('maxManualRequestSyncJobConcurrency'),
       processManualSync
     )
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -73,13 +73,15 @@ const getNewOrExistingSyncReq = ({
     syncRequestParameters
   }
 
-  // Record sync in syncDeDuplicator
-  SyncRequestDeDuplicator.recordSync(
-    syncType,
-    userWallet,
-    secondaryEndpoint,
-    syncReqToEnqueue
-  )
+  // Record sync in syncDeDuplicator for recurring syncs only
+  if (syncType === SyncType.Recurring) {
+    SyncRequestDeDuplicator.recordSync(
+      syncType,
+      userWallet,
+      secondaryEndpoint,
+      syncReqToEnqueue
+    )
+  }
 
   return { syncReqToEnqueue }
 }


### PR DESCRIPTION
### Description

- Add option to use different # of max retries for manual and recurring syncs and set them both to 2 (previously was 3, but sync queues are getting backed up)
- Make lack of sync request deduplication explicit for manual syncs so we can parallelize those jobs (actually don't think this is necessary for higher concurrency – only for sandboxed workers – but it doesn't hurt in case we want to try sandboxed workers in the future)
- Change manual sync concurrency from 1 back to its config value (default 15)



### Tests
Create a user and make sure their manual syncs go through. The real testing will need to be on staging to see if the manual and recurring sync queues get less backed up.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Deploy to staging and monitor the number of waiting jobs at the `/health/bull/queue/manual-sync-queue` endpoint.