### PR TITLE
Log cnode to sp id map when determining replica set updates

### DIFF
--- a/creator-node/src/services/stateMachineManager/CNodeToSpIdMapManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeToSpIdMapManager.js
@@ -1,4 +1,4 @@
-const { logger } = require('../../logging')
+const { logger: genericLogger } = require('../../logging')
 
 /**
  * Queries to periodically keep the mapping of (Content Node endpoint -> SP ID)
@@ -29,7 +29,9 @@ class CNodeToSpIdMapManager {
         cNodeEndpointToSpIdMap[cn.endpoint] = cn.spID
       })
     } catch (e) {
-      logger.error(`updateCnodeEndpointToSpIdMap Error: ${e.message}`)
+      genericLogger.error(
+        `CNodeToSpIdMapManager - Could not fetch content nodes: ${e.message}`
+      )
     }
 
     if (Object.keys(cNodeEndpointToSpIdMap).length > 0) {
@@ -39,12 +41,14 @@ class CNodeToSpIdMapManager {
     const mapLength = Object.keys(this.cNodeEndpointToSpIdMap).length
     if (mapLength === 0) {
       const errorMessage =
-        'updateCnodeEndpointToSpIdMap() Unable to initialize cNodeEndpointToSpIdMap'
-      logger.error(errorMessage)
+        'CNodeToSpIdMapManager - Unable to initialize cNodeEndpointToSpIdMap'
+      genericLogger.error(errorMessage)
       throw new Error(errorMessage)
     }
 
-    logger.info(`updateEndpointToSpIdMap Success. Size: ${mapLength}`)
+    genericLogger.info(
+      `CNodeToSpIdMapManager - updateCnodeEndpointToSpIdMap Success. Size: ${mapLength}`
+    )
   }
 }
 

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.js
@@ -11,7 +11,7 @@ const NodeToSpIdManager = require('../CNodeToSpIdMapManager')
 module.exports = async function ({ logger }) {
   let errorMsg = ''
   try {
-    NodeToSpIdManager.updateCnodeEndpointToSpIdMap(
+    await NodeToSpIdManager.updateCnodeEndpointToSpIdMap(
       QueueInterfacer.getAudiusLibs().ethContracts
     )
   } catch (e) {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.js
@@ -228,14 +228,18 @@ const _findReplicaSetUpdatesForUser = async (
             secondaryInfo.spId
           }, found ${
             CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()[secondary]
-          }. Marking replica as unhealthy.`
+          }. Marking replica as unhealthy. Endpoint to spID mapping: ${JSON.stringify(
+            CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()
+          )}`
         )
         unhealthyReplicas.add(secondary)
 
         // Error case 2 - already marked unhealthy
       } else if (unhealthyPeersSet.has(secondary)) {
         logger.error(
-          `_findReplicaSetUpdatesForUser(): Secondary ${secondary} for user ${wallet} in unhealthy peer set. Marking replica as unhealthy.`
+          `_findReplicaSetUpdatesForUser(): Secondary ${secondary} for user ${wallet} in unhealthy peer set. Marking replica as unhealthy. Endpoint to spID mapping: ${JSON.stringify(
+            CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()
+          )}`
         )
         unhealthyReplicas.add(secondary)
 
@@ -245,7 +249,9 @@ const _findReplicaSetUpdatesForUser = async (
         successRate < minSecondaryUserSyncSuccessPercent
       ) {
         logger.error(
-          `_findReplicaSetUpdatesForUser(): Secondary ${secondary} for user ${wallet} has userSyncSuccessRate of ${successRate}, which is below threshold of ${minSecondaryUserSyncSuccessPercent}. ${successCount} Successful syncs vs ${failureCount} Failed syncs. Marking replica as unhealthy.`
+          `_findReplicaSetUpdatesForUser(): Secondary ${secondary} for user ${wallet} has userSyncSuccessRate of ${successRate}, which is below threshold of ${minSecondaryUserSyncSuccessPercent}. ${successCount} Successful syncs vs ${failureCount} Failed syncs. Marking replica as unhealthy. Endpoint to spID mapping: ${JSON.stringify(
+            CNodeToSpIdMapManager.getCNodeEndpointToSpIdMap()
+          )}`
         )
         unhealthyReplicas.add(secondary)
       }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
There's some interesting mismatched spID errors on staging, so this PR is to log state around. This is also to await the job (though this shouldnt impact anything really)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Just logs, no big changes.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
See `_findReplicaSetUpdatesForUser` logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->