### PR TITLE
[CON-281] - Add CNodeToSpIdMapManager init in stateMachineManager init

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -7,6 +7,7 @@ const StateReconciliationManager = require('./stateReconciliation')
 const { RECONFIG_MODES, QUEUE_NAMES } = require('./stateMachineConstants')
 const QueueInterfacer = require('./QueueInterfacer')
 const makeOnCompleteCallback = require('./makeOnCompleteCallback')
+const CNodeToSpIdMapManager = require('./CNodeToSpIdMapManager')
 
 /**
  * Manages the queue for monitoring the state of Content Nodes and
@@ -19,6 +20,11 @@ class StateMachineManager {
 
     // TODO: Remove this and libs another way -- maybe init a new instance for each updateReplicaSet job
     QueueInterfacer.init(audiusLibs)
+
+    // Initialize class immediately since bull jobs are run on cadence even on deploy
+    await CNodeToSpIdMapManager.updateCnodeEndpointToSpIdMap(
+      audiusLibs.ethContracts
+    )
 
     // Initialize queues
     const stateMonitoringManager = new StateMonitoringManager()

--- a/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.js
+++ b/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.js
@@ -55,7 +55,7 @@ module.exports = function (queueNameToQueueMap, prometheusRegistry) {
       logger.info(`Job successfully completed. Parsing result: ${resultString}`)
       jobResult = JSON.parse(resultString) || {}
     } catch (e) {
-      logger.error(`Failed to parse job result string`)
+      logger.error(`Failed to parse job result string: ${e.message}`)
       return
     }
 

--- a/creator-node/test/CNodeToSpIdMapManager.test.js
+++ b/creator-node/test/CNodeToSpIdMapManager.test.js
@@ -108,7 +108,7 @@ describe('test CNodeToSpIdMapManager', function () {
       CNodeToSpIdMapManager.updateCnodeEndpointToSpIdMap(ethContracts)
     )
       .to.eventually.be.rejectedWith(
-        'updateCnodeEndpointToSpIdMap() Unable to initialize cNodeEndpointToSpIdMap'
+        'CNodeToSpIdMapManager - Unable to initialize cNodeEndpointToSpIdMap'
       )
       .and.be.an.instanceOf(Error)
   })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
On deploy, the cadence of which bull adds jobs does not change. Therefore, even though the logic is correct, the job wouldnt run immediately on deploy. This was thus causing the class to not have the proper data to perform reconfig and propagating false negatives that there are mismatched spIDs on staging.

This PR is to always init the class on `stateMachineManager` init

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Deployed to stage content node 8 with no change in fetch cnode to spID mapping and no more mismatch spIDs occurred following the deploy. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
look for the prefix `_findReplicaSetUpdatesForUser():` and `mismatched spID`log

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->