### PR TITLE
Factor _score in to script_score script

### DIFF
--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -368,7 +368,7 @@ def default_function_score(dsl, ranking_field):
             "script_score": {
                 "query": {"bool": dsl},
                 "script": {
-                    "source": f" Math.log(Math.max(doc['{ranking_field}'].value, 0) + 2)"
+                    "source": f"_score * Math.log(Math.max(doc['{ranking_field}'].value, 0) + 2)"
                 },
             }
         },


### PR DESCRIPTION
### Description

In a `script_score` you have to actually factor in `_score` if you want it to behave like `field_value_factor`


### Tests

Ran search_quality script thusly:

```
    A up
    docker exec -it dn1_web-server_1 bash
    PYTHONPATH=. python3 scripts/search_quality.py
```

Confirmed results look correct.

