### PR TITLE
Unpin Python to fix discovery build

### DIFF
--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -33,15 +33,15 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositor
         postgresql-dev=11.12-r0 \
         postgresql-libs=11.12-r0 \
         postgresql=11.12-r0 \
-        py3-pip=20.3.4-r1 \
-        py3-wheel=0.36.2-r2 \
-        python3-dev=3.9.7-r4 \
-        python3=3.9.7-r4 \
         py3-numpy \
+        py3-pip \
         py3-scipy \
+        py3-wheel \
+        python3 \
+        python3-dev \
         redis=6.2.7-r0 \
         rsyslog \
-        sudo=1.9.8_p2-r1 && \
+        sudo && \
     apk add --virtual .build-deps \
         gcc \
         musl-dev \


### PR DESCRIPTION
### Description
Discovery Provider no longer builds on master due to a bug in our build image. Contrary to popular believe alpine images pull from public (read changing) repos and therefore are not reliable even if you pin the repo.

https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/25614/workflows/db5c4e1a-cba5-4803-9039-4972ed1fb737/jobs/305567


### Tests
See successful CI build below

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA