### PR TITLE
Don't set the nginx cache in the application layer

### DIFF
--- a/creator-node/Dockerfile
+++ b/creator-node/Dockerfile
@@ -79,6 +79,7 @@ ENV logglyDisable=$audius_loggly_disable
 ENV logglyToken=$audius_loggly_token
 ENV logglyTags=$audius_loggly_tags
 ENV port=4000
+ENV contentCacheLayerEnabled=true
 
 EXPOSE 4000
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -631,10 +631,10 @@ const config = convict({
     default: 8760 // 1 year in hrs
   },
   contentCacheLayerEnabled: {
-    doc: 'Flag to enable or disable the nginx cache layer that caches content',
+    doc: 'Flag to enable or disable the nginx cache layer that caches content. DO NOT SET THIS HERE, set in the Dockerfile because it needs to be set above the application layer',
     format: 'BooleanCustom',
     env: 'contentCacheLayerEnabled',
-    default: true
+    default: false
   },
   reconfigNodeWhitelist: {
     doc: 'Comma separated string - list of Content Nodes to select from for reconfig. Empty string = whitelist all.',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Setting the `contentCacheLayerEnabled` flag inside the application means it doesn't get propogated up to the start script where OpenResty gets called to start the process. This means there's no process running on 4000, but the content node runs at 3000 so the Docker container can't run the health check and it thinks the application is unhealthy. Fix is to set contentCacheLayerEnabled in the Dockerfile.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Test on staging on nodes with contentCacheLayerEnabled flag set to true, false and not set


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Content node will not come up if this causes an error

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->