### PR TITLE
CircleCI GCP image bake env var was undefined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,18 +855,12 @@ workflows:
             - hold-build-logspout
       - hold-bake-gcp-dev-image:
           type: approval
-          filters:
-            branches:
-              only: /(^master$)/
       - bake-gcp-dev-image:
           context:
             - GCP2
           name: bake-gcp-dev-image
           requires:
             - hold-bake-gcp-dev-image
-          filters:
-            branches:
-              only: /(^master$)/
       - hold-publish-libs:
           type: approval
           filters:
@@ -880,10 +874,6 @@ workflows:
           filters:
             branches:
               only: /(^master$)/
-      - bake-gcp-dev-image:
-          context:
-            - GCP2
-          name: bake-gcp-dev-image
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,6 +880,10 @@ workflows:
           filters:
             branches:
               only: /(^master$)/
+      - bake-gcp-dev-image:
+          context:
+            - GCP2
+          name: bake-gcp-dev-image
 
   # test master at midnight daily
   test-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
             cd audius-protocol/;
             git checkout -f;
           post-gcp-command: |
+            BAKE_IMAGE_NAME=ci-image-bake-latest
+
             # Stop GCP box, can't take an image from a running VM
             gcloud compute instances stop $GCLOUD_VM_NAME
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
GCP Image bake was broken with this error `ERROR: (gcloud.compute.images.delete) argument IMAGE_NAME [IMAGE_NAME ...]: Must be specified.` https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/25604/workflows/7e7259e2-c830-4107-91b5-96756c1c2ded/jobs/305432

I think this var was just deleted by accident.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Do a full CI run for image bake successfully https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/25663/workflows/22e17fb5-6f39-45dc-8cfe-681482c8a5e6/jobs/306068.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
CircleCI nightly image bake will fail

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->