### PR TITLE
Fixes for Discovery Dockerfile following alpine update

### DIFF
--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -14,40 +14,31 @@ RUN mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
 # Script originally from https://github.com/ufoscout/docker-compose-wait/releases/download/2.4.0/wait
 COPY scripts/wait /wait
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories && \
-    apk update && \
+RUN apk update && \
     apk add \
-        alpine-sdk=1.0-r1 \
-        bash=5.1.16-r0 \
+        alpine-sdk \
+        bash \
         curl \
         docker \
         libffi-dev \
-        libpq=11.12-r0 \
         libseccomp-dev \
-        linux-headers=5.10.41-r0 \
+        linux-headers \
         nodejs \
         npm \
-        postgresql-client=11.12-r0 \
-        postgresql-contrib=11.12-r0 \
-        postgresql-dev=11.12-r0 \
-        postgresql-libs=11.12-r0 \
-        postgresql=11.12-r0 \
         py3-numpy \
         py3-pip \
         py3-scipy \
         py3-wheel \
         python3 \
         python3-dev \
-        redis=6.2.7-r0 \
+        redis \
         rsyslog \
-        sudo && \
-    apk add --virtual .build-deps \
+        wget \
+        sudo \
         gcc \
-        musl-dev \
-        postgresql-dev=11.12-r0
+        musl-dev
 
 RUN echo 'http://mirror.leaseweb.com/alpine/v3.13/community' >> /etc/apk/repositories && \
-    apk add wget && \
     wget 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' && \
     mv 'admin@openresty.com-5ea678a6.rsa.pub' /etc/apk/keys/ && \
     source /etc/os-release && \
@@ -60,16 +51,24 @@ RUN echo 'http://mirror.leaseweb.com/alpine/v3.13/community' >> /etc/apk/reposit
     mkdir /usr/local/openresty/conf && \
     mkdir /usr/local/openresty/logs
 
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories && \
+    apk update && \
+    apk add \
+        libpq=11.12-r0 \
+        postgresql-client=11.12-r0 \
+        postgresql-contrib=11.12-r0 \
+        postgresql-dev=11.12-r0 \
+        postgresql-libs=11.12-r0 \
+        postgresql=11.12-r0
+
 COPY nginx_conf /usr/local/openresty/conf/
 
 COPY scripts/init-db.sh scripts/init-db.sh
 RUN bash scripts/init-db.sh
 
 # Upgrade pip first to accomodate anchor.py installation
-RUN python3 -m pip install --upgrade pip && \
-    apk --purge del .build-deps
 COPY requirements.txt requirements.txt
-RUN python3 -m pip install -r requirements.txt --no-cache-dir
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt --no-cache-dir
 
 COPY . .
 RUN cd es-indexer && npm install && npm run build

--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -1,7 +1,7 @@
 # requires authentication to Dockerhub
 FROM audius/contracts:1.0.0 AS contracts
 
-FROM alpine:3.15
+FROM alpine:3.14
 LABEL maintainer="Hareesh Nagaraj <hareesh@audius.co>"
 
 ENV INSTALL_PATH /audius-discovery-provider
@@ -15,14 +15,13 @@ RUN mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
 COPY scripts/wait /wait
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories && \
     apk update && \
     apk add \
         alpine-sdk=1.0-r1 \
         bash=5.1.16-r0 \
         curl \
         docker \
-        libffi-dev=3.4.2-r1 \
+        libffi-dev \
         libpq=11.12-r0 \
         libseccomp-dev \
         linux-headers=5.10.41-r0 \

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -40,7 +40,7 @@ psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1
 click==8.0.4
-numpy==1.21.4
+numpy==1.20.3
 datasketch==1.5.7
 
 # Solana support

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -54,7 +54,6 @@ pycparser==2.20
 PyNaCl==1.4.0
 requests==2.25.1
 aiohttp==3.8.1
-six==1.16.0
 solana==0.23.1
 typing-extensions==3.10.0.0
 urllib3==1.26.3


### PR DESCRIPTION
### Description
Due to a recent change in alpine repos, the Python version we pull is either not compatible with our requirements.txt or not present.

This PR downgrades Python to 3.9.5 so that we can still use the same version of other python requirements.

This PR also cleans up our Dockerfile and pins the repos so that we only have to pin packages that require to be pinned.

### Tests
https://discoveryprovider3.staging.audius.co/health_check


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA