### PR TITLE
Fix upload track w prom metrics

### DIFF
--- a/creator-node/src/AsyncProcessingQueue.js
+++ b/creator-node/src/AsyncProcessingQueue.js
@@ -156,8 +156,8 @@ class AsyncProcessingQueue {
       `Adding ${task} task! uuid=${logContext.requestID}}`,
       logContext
     )
-    const jobName = task || '__default__'
-    const job = await this.queue.add(jobName, params)
+
+    const job = await this.queue.add(params)
 
     return job
   }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Uploads were failing after this PR was merged https://github.com/AudiusProject/audius-protocol/pull/3546
This was the error
```
Error: Missing process handler for job type trackContentUpload
    at Queue.processJob (/usr/src/app/node_modules/bull/lib/queue.js:1155:7)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

It's because we added a task name when we do not process tasks by job name. This is to revert named job processes but still maintain prom metrics for queues.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

- Created user + uploaded track locally successfully
- Checked /prometheus_metrics route for metrics and appears
```
# HELP audius_cn_jobs_duration_milliseconds Time to complete jobs
# TYPE audius_cn_jobs_duration_milliseconds histogram
audius_cn_jobs_duration_milliseconds_bucket{le="1",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_duration_milliseconds_bucket{le="4",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_duration_milliseconds_bucket{le="19",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_duration_milliseconds_bucket{le="84",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_duration_milliseconds_bucket{le="370",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_duration_milliseconds_bucket{le="1622",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_bucket{le="7114",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_bucket{le="31197",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_bucket{le="136815",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_bucket{le="600000",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_bucket{le="+Inf",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_duration_milliseconds_sum{status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2764
audius_cn_jobs_duration_milliseconds_count{status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2

# HELP audius_cn_jobs_waiting_duration_milliseconds Time spent waiting for jobs to run
# TYPE audius_cn_jobs_waiting_duration_milliseconds histogram
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="1",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="4",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 0
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="19",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="84",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="370",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="1622",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="7114",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="31197",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="136815",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="600000",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_bucket{le="+Inf",status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
audius_cn_jobs_waiting_duration_milliseconds_sum{status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 11
audius_cn_jobs_waiting_duration_milliseconds_count{status="completed",job_name="trackContentUpload",queue_name="asyncProcessing",queue_prefix="bull"} 2
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

We should be able to generate charts from these prometheus metrics \ grafana charts

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->