### PR TITLE
Fix hedgehog privateKey access

### DIFF
--- a/libs/src/services/wormhole/index.js
+++ b/libs/src/services/wormhole/index.js
@@ -361,8 +361,8 @@ class Wormhole {
       nonce,
       deadline
     )
-    const myPrivateKey = this.hedgehog.wallet._privKey
-    const signedDigest = sign(digest, myPrivateKey)
+    const { privateKey } = this.hedgehog.getWallet()
+    const signedDigest = sign(digest, privateKey)
     return {
       chainId,
       deadline,

--- a/service-commands/src/commands/seed/SeedSession.js
+++ b/service-commands/src/commands/seed/SeedSession.js
@@ -113,7 +113,7 @@ class SeedSession {
       })
       this.cache.addWalletDetails({
         entropy: hedgehogEntropyKey,
-        privKey: this.libs.hedgehog.wallet._privKey.toString('hex')
+        privKey: this.libs.hedgehog.getWallet().privateKey.toString('hex')
       })
       this.cache.setActiveUser(userAlias)
       console.log(


### PR DESCRIPTION
### Description
The recent hedgehog upgraded included upgraded ethereum dependencies. With that came a new Wallet type that replaced var `_privKey` with `privateKey`. This pr updates usages of _privKey in audius-protocol


### Tests
Tested wormhole access and service commands


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
service-commands users will ensure it works