### PR TITLE
Dont reissue manual syncs + separate manual sync timeout

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -607,10 +607,16 @@ const config = convict({
     default: 20
   },
   maxSyncMonitoringDurationInMs: {
-    doc: 'Max duration that primary will monitor secondary for syncRequest completion',
+    doc: 'Max duration that primary will monitor secondary for syncRequest completion for non-manual syncs',
     format: 'nat',
     env: 'maxSyncMonitoringDurationInMs',
     default: 300000 // 5min (prod default)
+  },
+  maxManualSyncMonitoringDurationInMs: {
+    doc: 'Max duration that primary will monitor secondary for syncRequest completion for manual syncs',
+    format: 'nat',
+    env: 'maxManualSyncMonitoringDurationInMs',
+    default: 45000 // 45 sec (prod default)
   },
   syncRequestMaxUserFailureCountBeforeSkip: {
     doc: '[on Secondary] Max number of failed syncs per user before skipping un-retrieved content, saving to db, and succeeding sync',

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -37,6 +37,9 @@ const secondaryUserSyncDailyFailureCountThreshold = config.get(
 const maxSyncMonitoringDurationInMs = config.get(
   'maxSyncMonitoringDurationInMs'
 )
+const maxManualSyncMonitoringDurationInMs = config.get(
+  'maxManualSyncMonitoringDurationInMs'
+)
 const mergePrimaryAndSecondaryEnabled = config.get(
   'mergePrimaryAndSecondaryEnabled'
 )
@@ -313,7 +316,11 @@ const _additionalSyncIsRequired = async (
   const logMsgString = `additionalSyncIsRequired() (${syncType}): wallet ${userWallet} secondary ${secondaryUrl} primaryClock ${primaryClockValue}`
 
   const startTimeMs = Date.now()
-  const maxMonitoringTimeMs = startTimeMs + maxSyncMonitoringDurationInMs
+  const maxMonitoringTimeMs =
+    startTimeMs +
+    (syncType === SyncType.MANUAL
+      ? maxManualSyncMonitoringDurationInMs
+      : maxSyncMonitoringDurationInMs)
 
   /**
    * Poll secondary for sync completion, up to `maxMonitoringTimeMs`

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -140,35 +140,9 @@ const issueSyncRequestsUntilSynced = async (
       // If secondary is synced, return successfully
       if (secondaryClockVal >= primaryClockVal) {
         return
-
-        // Else, if a sync is not already in progress on the secondary, issue a new SyncRequest
-      } else if (!syncInProgress) {
-        const { duplicateSyncReq, syncReqToEnqueue } = getNewOrExistingSyncReq({
-          userWallet: wallet,
-          secondaryEndpoint: secondaryUrl,
-          primaryEndpoint: primaryUrl,
-          syncType: SyncType.Manual,
-          syncMode: SYNC_MODES.SyncSecondaryFromPrimary
-        })
-        if (!_.isEmpty(duplicateSyncReq)) {
-          // Log duplicate and return
-          logger.warn(`Duplicate sync request: ${duplicateSyncReq}`)
-          return
-        } else if (!_.isEmpty(syncReqToEnqueue)) {
-          await queue.add({
-            enqueuedBy: 'issueSyncRequestsUntilSynced retry',
-            ...syncReqToEnqueue
-          })
-        } else {
-          // Log error that the sync request couldn't be created and return
-          logger.error(
-            `Failed to create manual sync request: ${duplicateSyncReq}`
-          )
-          return
-        }
       }
 
-      // Give secondary some time to process ongoing or newly enqueued sync
+      // Give secondary some time to process ongoing sync
       // NOTE - we might want to make this timeout longer
       await Utils.timeout(500)
     } catch (e) {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Seeing excessive number of waiting jobs in manual sync queue on bull. Theory is that since write quorum continues to add jobs every few seconds for up to 5 minutes, if there's ever a backlog on manual sync it accelerates a problem and makes it much, much worse. The two fixes here are:

1. Only issue one manual sync request as part of write quorum (this will be retried up to 2 times)
2. Have a separate write quorum timeout. Since write quorum has a max timeout of 1 min, i set the monitoring time to 45 seconds

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- Create a user and upload track to make sure those operations are successful
- Run mad dog on local and CI successfully
- Clear state on stage CN7 and let this soak and make sure manual sync queue waiting numbers are reasonable


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Number of jobs in manual sync queue 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->