### PR TITLE
[CON-293] Allow selecting nodes with pre-existing state

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -329,13 +329,11 @@ const _determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
 }
 
 /**
- * Select a random node that is not from the current replica set. Make sure the random node does not have any
- * existing user data for the current user. If there is pre-existing data in the randomly selected node, keep
- * searching for a node that has no state.
+ * Select a random healthy node that is not from the current replica set and not in the unhealthy replica set.
  *
  * If an insufficient amount of new replica set nodes are chosen, this method will throw an error.
  * @param {Set<string>} healthyReplicaSet a set of the healthy replica set endpoints
- * @param {number} numberOfUnhealthyReplicas the number of unhealthy replica set endpoints
+ * @param {Set<string>} unhealthyReplicasSet a set of the unhealthy replica set endpoints
  * @param {string[]} healthyNodes an array of all the healthy nodes available on the network
  * @param {string} wallet the wallet of the current user
  * @param {Object} logger a logger that can be filtered on jobName and jobId
@@ -385,9 +383,9 @@ const _selectRandomReplicaSetNodes = async (
         wallet
       )
       newReplicaNodesSet.add(randomHealthyNode)
-      if (clockValue === -1) {
+      if (clockValue !== -1) {
         logger.warn(
-          `${logStr} Found a node with clock value of ${clockValue}, selecting anyway`
+          `${logStr} Found a node with previous state (clock value of ${clockValue}), selecting anyway`
         )
       }
     } catch (e: any) {

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -288,7 +288,7 @@ describe('test updateReplicaSet job processor', function () {
         enabledReconfigModes: [RECONFIG_MODES.ENTIRE_REPLICA_SET.key]
       })
     ).to.eventually.be.fulfilled.and.deep.equal({
-      errorMsg: '',
+      errorMsg: `Error: [_selectRandomReplicaSetNodes] wallet=${wallet} healthyReplicaSet=[] numberOfUnhealthyReplicas=3 healthyNodes=${primary},${secondary2},${fourthHealthyNode} || Not enough healthy nodes found to issue new replica set after 100 attempts`,
       issuedReconfig: false,
       newReplicaSet: {
         newPrimary: null,


### PR DESCRIPTION
### Description
- Allow nodes that already have state to be selected during reconfigs. Previously, we didn't want to choose nodes that the user previously had state on in, but we can now rely on recurring syncs to reconcile any state differences between nodes that get removed and subsequently added back to a user's replica set.
- On step 5 of the below tests, I noticed that a user's unhealthy primary got set as their secondary during a replica set update. This is because we get healthy nodes from `ServiceProvider.autoSelectCreatorNodes` during the replica set update, so this ignores our previous health checks from the monitoring job. I changed it to bias toward treating a node as unhealthy (i.e., make our previous health checks take precedence over `ServiceProvider.autoSelectCreatorNodes`).

### Tests

1. Create 2 users and upload a track for one of them
2. Make a node in the user's replica set unhealthy (I did this by manually changing NodeHealthManager#getUnhealthyPeers() to return an array containing that node's endpoint)
3. Wait for reconfig to succeed and verify that the clock value is the same across all nodes
4. Upload another track and verify that the clock value is still the same across 3 of the 4 nodes
5. Make the node healthy again and make another node unhealthy
6. Make sure the user's replica set gets updated back to the now-healthy node that was previously in its replica set
7. Make sure the clock value is the same across all 4 nodes

**Original replica sets (after step 1):**
<img width="566" alt="Screen Shot 2022-07-28 at 7 56 08 PM" src="https://user-images.githubusercontent.com/4657956/181673337-1d3f959e-0eab-4a07-a707-a43b71187679.png">

**Updated replica sets after marking CN3 unhealthy (after step 3):**
<img width="559" alt="Screen Shot 2022-07-28 at 7 57 26 PM" src="https://user-images.githubusercontent.com/4657956/181673487-e384376e-81b7-4eba-a842-a399461419f8.png">

**Updated replica sets after marking CN3 healthy and CN4 unhealthy (after step 6):**
<img width="568" alt="Screen Shot 2022-07-28 at 7 57 39 PM" src="https://user-images.githubusercontent.com/4657956/181673526-9e8a8d0d-cb72-4d5d-b5da-eee58070c419.png">


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
We shouldn't see the following error log as often anymore: `Not enough healthy nodes found to issue new replica set`