### PR TITLE
[C-738] Expose esm bundles for sdk

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -11967,7 +11967,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw=="
     },
     "snake-case": {
       "version": "3.0.4",
@@ -13953,7 +13953,7 @@
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
         "bs58check": "<3.0.0"
       }
@@ -14015,7 +14015,7 @@
     "write-file-atomic": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/libs/package.json
+++ b/libs/package.json
@@ -2,15 +2,13 @@
   "name": "@audius/sdk",
   "version": "0.0.22",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "types": "dist/types.d.ts",
-  "browser": "dist/browser.js",
-  "sdkBrowserDistFile": "dist/sdk.js",
-  "sdkBrowserDistFileMini": "dist/sdk.min.js",
-  "legacy": "dist/legacy.js",
-  "legacyTypes": "dist/legacy.d.ts",
-  "core": "dist/core.js",
-  "coreTypes": "dist/core.d.ts",
+  "browser": {
+    "./dist/index.cjs.js": "./dist/index.browser.cjs.js",
+    "./dist/index.esm.js": "./dist/index.browser.esm.js"
+  },
   "scripts": {
     "init-local": "ts-node initScripts/local.js",
     "test": "./scripts/test.sh",

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -135,14 +135,15 @@ export default [
   {
     input: 'src/index.js',
     output: [
-      { file: pkg.main, format: 'cjs', exports: 'auto', sourcemap: true }
+      { file: pkg.main, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     ...commonConfig
   },
 
   {
-    input: './src/types.ts',
-    output: [{ file: pkg.types, format: 'cjs' }],
+    input: 'src/types.ts',
+    output: [{ file: pkg.types, format: 'es' }],
     ...commonTypeConfig
   },
 
@@ -153,7 +154,8 @@ export default [
   {
     input: 'src/sdk/index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs', exports: 'auto', sourcemap: true }
+      { file: 'dist/index.browser.cjs.js', format: 'es', sourcemap: true },
+      { file: 'dist/index.browser.esm.js', format: 'es', sourcemap: true }
     ],
     ...browserConfig
   },
@@ -166,7 +168,7 @@ export default [
     input: 'src/sdk/sdkBrowserDist.ts',
     output: [
       {
-        file: pkg.sdkBrowserDistFile,
+        file: 'dist/sdk.js',
         globals: {
           web3: 'window.Web3'
         },
@@ -185,15 +187,13 @@ export default [
    */
   {
     input: 'src/index.js',
-    output: [
-      { file: pkg.legacy, format: 'cjs', exports: 'auto', sourcemap: true }
-    ],
+    output: [{ file: 'dist/legacy.js', format: 'cjs', sourcemap: true }],
     ...browserLegacyConfig
   },
 
   {
     input: './src/types.ts',
-    output: [{ file: pkg.legacyTypes, format: 'cjs' }],
+    output: [{ file: 'dist/legacy.d.ts', format: 'es' }],
     ...commonTypeConfig
   },
 
@@ -203,13 +203,14 @@ export default [
   {
     input: 'src/core.ts',
     output: [
-      { file: pkg.core, format: 'cjs', exports: 'auto', sourcemap: true }
+      { file: 'dist/core.cjs.js', format: 'cjs', sourcemap: true },
+      { file: 'dist/core.esm.js', format: 'es', sourcemap: true }
     ],
     ...commonConfig
   },
   {
     input: './src/core.ts',
-    output: [{ file: pkg.coreTypes, format: 'cjs' }],
+    output: [{ file: pkg.coreTypes, format: 'es' }],
     ...commonTypeConfig
   }
 ]

--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -192,7 +192,7 @@ export default [
   },
 
   {
-    input: './src/types.ts',
+    input: 'src/types.ts',
     output: [{ file: 'dist/legacy.d.ts', format: 'es' }],
     ...commonTypeConfig
   },
@@ -209,7 +209,7 @@ export default [
     ...commonConfig
   },
   {
-    input: './src/core.ts',
+    input: 'src/core.ts',
     output: [{ file: pkg.coreTypes, format: 'es' }],
     ...commonTypeConfig
   }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

* Update rollup config to expose esm & cjs bundles for node & browser
* Update type file format to `es`
* Remove file paths from the package.json, basically following solana's lead here: 
  https://github.com/solana-labs/solana/blob/master/web3.js/package.json
  https://github.com/solana-labs/solana/blob/master/web3.js/rollup.config.js
* Keep legacy export as cjs only, difficulties getting this one to bundle as es but should be ok because it's only for internal use


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested in main bundle in test app
Tested legacy bundle in audius-client


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->