### PR TITLE
INF-210 use slack-secrets and better handling of commits coming into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -903,7 +903,9 @@ workflows:
     when: << pipeline.parameters.sdk_release_tag >>
     jobs:
       - publish-libs:
-          context: Audius Client
+          context:
+            - Audius Client
+            - slack-secrets
           name: publish-libs (<< pipeline.parameters.sdk_release_tag >>)
           sdk_release_tag: << pipeline.parameters.sdk_release_tag >>
           filters:

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -86,12 +86,16 @@ function bump-npm () {
 # Merge the created branch into master, then delete the branch
 function merge-bump () {
     git checkout master -f
+
+    # pull in any additional commits that may have trickled in
+    git pull
+
     git merge ${STUB}-${VERSION} -m "$(commit-message)"
 
-    git push -u origin master
-
-    # clean up release branches
-    git push origin :${STUB}-${VERSION}
+    # if pushing fails, ensure we cleanup()
+    git push -u origin master \
+    && git push origin :${STUB}-${VERSION} \
+    || $(exit 1)
 }
 
 # publish to npm


### PR DESCRIPTION
### Description

Pull master before merging our version bump change (to minimize race conditions when someone merges in parallel with the build).

Use the new slack-secrets context that was lost as PRs for INF-209 and INF-210 were separated.


### Tests

Manually testing releases at the moment.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->