### PR TITLE
Fix enqueuedBy job data field using wrong queue name

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -45,12 +45,14 @@ class StateMachineManager {
       [QUEUE_NAMES.RECURRING_SYNC]: recurringSyncQueue,
       [QUEUE_NAMES.UPDATE_REPLICA_SET]: updateReplicaSetQueue
     }
-    for (const queue of Object.values(queueNameToQueueMap)) {
+    for (const [queueName, queue] of Object.entries(queueNameToQueueMap)) {
       queue.on(
         'global:completed',
-        makeOnCompleteCallback(queueNameToQueueMap, prometheusRegistry).bind(
-          this
-        )
+        makeOnCompleteCallback(
+          queueName,
+          queueNameToQueueMap,
+          prometheusRegistry
+        ).bind(this)
       )
     }
 


### PR DESCRIPTION
### Description
We inject an `enqueuedBy` field into each job's data to track which queue and job ID caused the new job to be enqueued. The queue named being used was incorrect, so this PR fixes that.


### Tests
I looked at some jobs (e.g., `find-sync-requests-queue`) and verified that their `enqueuedBy` field used the correct queue name (e.g., `monitor-state-queue`).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A -- this is for tracking the flow of jobs between queues.