### PR TITLE
Handle invalid health check values + seed important monitors on init

### DIFF
--- a/creator-node/src/monitors/MonitoringQueue.js
+++ b/creator-node/src/monitors/MonitoringQueue.js
@@ -37,6 +37,8 @@ class MonitoringQueue {
     // Clean up anything that might be still stuck in the queue on restart
     this.queue.empty()
 
+    this.seedInitialValues()
+
     this.queue.process(
       PROCESS_NAMES.monitor,
       /* concurrency */ 1,
@@ -61,6 +63,16 @@ class MonitoringQueue {
         }
       }
     )
+  }
+
+  /**
+   * These values are used in the ensureStorageMiddleware. There could be a small chance of a timing race
+   * where the values are undefined after init and we need to wait for them to be populated, so populate
+   * them on init
+   */
+  async seedInitialValues() {
+    await this.refresh(MONITORS.STORAGE_PATH_SIZE)
+    await this.refresh(MONITORS.STORAGE_PATH_USED)
   }
 
   async refresh(monitor) {

--- a/creator-node/src/routes/healthCheck.js
+++ b/creator-node/src/routes/healthCheck.js
@@ -99,6 +99,14 @@ router.get(
       MONITORS.STORAGE_PATH_SIZE,
       MONITORS.STORAGE_PATH_USED
     ])
+
+    if (!Number.isInteger(parseInt(total)) || !Number.isInteger(parseInt(used)))
+      return errorResponseServerError({
+        total,
+        used,
+        msg: 'Invalid values for disk space'
+      })
+
     const available = total - used
 
     const usagePercent = Math.round((used * 100) / total)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
We occasionally see errors when upgrading content nodes where disk_check shows NaN%. This is because the underlying monitors values are null. This causes two problems
1. We don't properly handle invalid values in disk_check (should not return 200)
2. User actions fail because ensureStorageMiddleware can't access the same values from disk_check so writes get rejected

I've fixed disk_check to handle NaN values and forced the MonitoringQueue to populate storage metrics on init to prevent the user actions from failing

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested disk_check route by deleting the monitors value in redis and it returns 500
Tested immediate population of monitors upon init by commenting out the recurring process function and only allowing the initialize to run and looked for the logs that it successfully populated storage metrics. I only ever saw these two Monitoring Queue logs, which is expected
```
{"name":"audius_creator_node","hostname":"2ae9b725eb9f","pid":2303,"level":30,"msg":"Monitoring Queue: Computed value for storagePathSize 266219864064 || active: 0, waiting: 0, failed 0, delayed: 0, completed: 1 ","time":"2022-07-30T05:19:16.203Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","hostname":"2ae9b725eb9f","pid":2303,"level":30,"msg":"Monitoring Queue: Computed value for storagePathUsed 126762180608 || active: 0, waiting: 0, failed 0, delayed: 0, completed: 1 ","time":"2022-07-30T05:19:16.203Z","v":0,"logLevel":"info"}
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
/disk_check exposes the values

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->