### PR TITLE
Update write quorum monitoring timeout to less than connection timeout

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -494,7 +494,7 @@ const config = convict({
     doc: 'Duration for which to poll secondaries for content replication in `issueAndWaitForSecondarySyncRequests` function',
     format: 'nat',
     env: 'issueAndWaitForSecondarySyncRequestsPollingDurationMs',
-    default: 60000 // 60000ms = 1m (prod default)
+    default: 45000 // 45 seconds (prod default)
   },
   enforceWriteQuorum: {
     doc: 'Boolean flag indicating whether or not primary should reject write until 2/3 replication across replica set',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
On production our normal connection timeout is 1 min. Having the write quorum timeout set to 1m can sometimes cause a race and if the metadata polling takes longer than 1 min, there's no connection to send a response back to.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Observed bug on prod content nodes, pushed out a fix and tested directly on prod content node

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Upload success rate should stay high

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->