### PR TITLE
Concurrency of 15 for updateReplicaSet might be too high for the network

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -536,7 +536,7 @@ const config = convict({
     doc: 'Max bull queue concurrency for update replica set jobs',
     format: 'nat',
     env: 'maxUpdateReplicaSetJobConcurrency',
-    default: 15
+    default: 3
   },
   peerHealthCheckRequestTimeout: {
     doc: 'Timeout [ms] for checking health check route',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
UpdateReplicaSet initialized libs with content node selection with a concurrency of 15, I think that might be too high, lowering to 3 until we optimize that flow.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on prod

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Bull queue health dashboard

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->