### PR TITLE
Cache healthy nodes in RS update

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -76,7 +76,7 @@ class ServiceRegistry {
   async initServices() {
     const start = getStartTime()
 
-    this.libs = await initAudiusLibs()
+    this.libs = await initAudiusLibs({})
 
     // Transcode handoff requires libs. Set libs in AsyncProcessingQueue after libs init is complete
     this.asyncProcessingQueue = new AsyncProcessingQueue(

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -8,7 +8,11 @@ const { logger: genericLogger } = require('../logging')
  *
  * Configures dataWeb3 to be internal to libs, logged in with delegatePrivateKey in order to write chain TX
  */
-module.exports = async (excludeDiscovery = false, logger = genericLogger) => {
+module.exports = async (
+  contractsOnly = false,
+  excludeDiscoveryNode = false,
+  logger = genericLogger
+) => {
   /**
    * Define all config variables
    */
@@ -51,12 +55,14 @@ module.exports = async (excludeDiscovery = false, logger = genericLogger) => {
    * Create AudiusLibs instance
    */
   const audiusLibs = new AudiusLibs({
-    ethWeb3Config: AudiusLibs.configEthWeb3(
-      ethTokenAddress,
-      ethRegistryAddress,
-      ethWeb3,
-      ethOwnerWallet
-    ),
+    ethWeb3Config: contractsOnly
+      ? null
+      : AudiusLibs.configEthWeb3(
+          ethTokenAddress,
+          ethRegistryAddress,
+          ethWeb3,
+          ethOwnerWallet
+        ),
     web3Config: AudiusLibs.configInternalWeb3(
       dataRegistryAddress,
       // pass as array
@@ -64,14 +70,17 @@ module.exports = async (excludeDiscovery = false, logger = genericLogger) => {
       // TODO - formatting this private key here is not ideal
       delegatePrivateKey.replace('0x', '')
     ),
-    discoveryProviderConfig: excludeDiscovery
-      ? null
-      : {
-          whitelist: discoveryProviderWhitelist,
-          unhealthyBlockDiff: discoveryNodeUnhealthyBlockDiff
-        },
+    discoveryProviderConfig:
+      contractsOnly || excludeDiscoveryNode
+        ? null
+        : {
+            whitelist: discoveryProviderWhitelist,
+            unhealthyBlockDiff: discoveryNodeUnhealthyBlockDiff
+          },
     // If an identity service config is present, set up libs with the connection, otherwise do nothing
-    identityServiceConfig: identityService
+    identityServiceConfig: contractsOnly
+      ? null
+      : identityService
       ? AudiusLibs.configIdentityService(identityService)
       : undefined,
     isDebug: creatorNodeIsDebug,

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -8,11 +8,13 @@ const { logger: genericLogger } = require('../logging')
  *
  * Configures dataWeb3 to be internal to libs, logged in with delegatePrivateKey in order to write chain TX
  */
-module.exports = async (
-  contractsOnly = false,
-  excludeDiscoveryNode = false,
+module.exports = async ({
+  enableEthContracts = true,
+  enableContracts = true,
+  enableDiscovery = true,
+  enableIdentity = true,
   logger = genericLogger
-) => {
+}) => {
   /**
    * Define all config variables
    */
@@ -55,34 +57,36 @@ module.exports = async (
    * Create AudiusLibs instance
    */
   const audiusLibs = new AudiusLibs({
-    ethWeb3Config: contractsOnly
-      ? null
-      : AudiusLibs.configEthWeb3(
+    ethWeb3Config: enableEthContracts
+      ? AudiusLibs.configEthWeb3(
           ethTokenAddress,
           ethRegistryAddress,
           ethWeb3,
           ethOwnerWallet
-        ),
-    web3Config: AudiusLibs.configInternalWeb3(
-      dataRegistryAddress,
-      // pass as array
-      [dataProviderUrl],
-      // TODO - formatting this private key here is not ideal
-      delegatePrivateKey.replace('0x', '')
-    ),
-    discoveryProviderConfig:
-      contractsOnly || excludeDiscoveryNode
-        ? null
-        : {
-            whitelist: discoveryProviderWhitelist,
-            unhealthyBlockDiff: discoveryNodeUnhealthyBlockDiff
-          },
+        )
+      : null,
+    // AudiusContracts (enabled by enableContracts) needs web3Config
+    web3Config: enableContracts
+      ? AudiusLibs.configInternalWeb3(
+          dataRegistryAddress,
+          // pass as array
+          [dataProviderUrl],
+          // TODO - formatting this private key here is not ideal
+          delegatePrivateKey.replace('0x', '')
+        )
+      : null,
+    discoveryProviderConfig: enableDiscovery
+      ? {
+          whitelist: discoveryProviderWhitelist,
+          unhealthyBlockDiff: discoveryNodeUnhealthyBlockDiff
+        }
+      : null,
     // If an identity service config is present, set up libs with the connection, otherwise do nothing
-    identityServiceConfig: contractsOnly
-      ? null
-      : identityService
-      ? AudiusLibs.configIdentityService(identityService)
-      : undefined,
+    identityServiceConfig: enableIdentity
+      ? identityService
+        ? AudiusLibs.configIdentityService(identityService)
+        : undefined
+      : null,
     isDebug: creatorNodeIsDebug,
     isServer: true,
     preferHigherPatchForPrimary: true,

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -149,3 +149,6 @@ export const SYNC_MODES = Object.freeze({
 })
 
 export const FETCH_FILES_HASH_NUM_RETRIES = 3
+
+// Seconds to hold the cache of healthy content nodes for update-replica-set jobs (10 mins)
+export const HEALTHY_SERVICES_TTL_SEC = 10 * 60

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.ts
@@ -21,7 +21,7 @@ module.exports = async function ({
 > {
   let errorMsg = ''
   try {
-    const audiusLibs = await initAudiusLibs(true)
+    const audiusLibs = await initAudiusLibs(false, true)
     await NodeToSpIdManager.updateCnodeEndpointToSpIdMap(
       audiusLibs.ethContracts
     )

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/fetchCNodeEndpointToSpIdMap.jobProcessor.ts
@@ -21,7 +21,13 @@ module.exports = async function ({
 > {
   let errorMsg = ''
   try {
-    const audiusLibs = await initAudiusLibs(false, true)
+    const audiusLibs = await initAudiusLibs({
+      enableEthContracts: true,
+      enableContracts: false,
+      enableDiscovery: false,
+      enableIdentity: false,
+      logger
+    })
     await NodeToSpIdManager.updateCnodeEndpointToSpIdMap(
       audiusLibs.ethContracts
     )

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -1,9 +1,17 @@
 const _ = require('lodash')
 const axios = require('axios')
+
+const redisClient = require('../../../redis')
 const { logger } = require('../../../logging')
 const Utils = require('../../../utils')
-const { SyncType, SYNC_MODES } = require('../stateMachineConstants')
+const {
+  SyncType,
+  SYNC_MODES,
+  HEALTHY_SERVICES_TTL_SEC
+} = require('../stateMachineConstants')
 const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
+
+const HEALTHY_NODES_CACHE_KEY = 'stateMachineHealthyContentNodes'
 
 /**
  * Returns a job can be enqueued to add a sync request for the given user to the given secondary,
@@ -156,7 +164,23 @@ const issueSyncRequestsUntilSynced = async (
   )
 }
 
+const getCachedHealthyNodes = async () => {
+  const healthyNodes = await redisClient.lrange(HEALTHY_NODES_CACHE_KEY, 0, -1)
+  return healthyNodes
+}
+
+const cacheHealthyNodes = async (healthyNodes) => {
+  const pipeline = redisClient.pipeline()
+  await pipeline
+    .del(HEALTHY_NODES_CACHE_KEY)
+    .rpush(HEALTHY_NODES_CACHE_KEY, ...(healthyNodes || []))
+    .expire(HEALTHY_NODES_CACHE_KEY, HEALTHY_SERVICES_TTL_SEC)
+    .exec()
+}
+
 module.exports = {
   getNewOrExistingSyncReq,
-  issueSyncRequestsUntilSynced
+  issueSyncRequestsUntilSynced,
+  getCachedHealthyNodes,
+  cacheHealthyNodes
 }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -68,7 +68,13 @@ module.exports = async function ({
   let healthyNodes = []
   healthyNodes = await getCachedHealthyNodes()
   if (healthyNodes.length === 0) {
-    audiusLibs = await initAudiusLibs(false, true)
+    audiusLibs = await initAudiusLibs({
+      enableEthContracts: true,
+      enableContracts: true,
+      enableDiscovery: false,
+      enableIdentity: true,
+      logger
+    })
     const { services: healthyServicesMap } =
       await audiusLibs.ServiceProvider.autoSelectCreatorNodes({
         performSyncCheck: false,
@@ -489,7 +495,13 @@ const _issueUpdateReplicaSetOp = async (
     const startTimeMs = Date.now()
     try {
       if (!audiusLibs) {
-        audiusLibs = await initAudiusLibs(true)
+        audiusLibs = await initAudiusLibs({
+          enableEthContracts: false,
+          enableContracts: true,
+          enableDiscovery: false,
+          enableIdentity: true,
+          logger
+        })
       }
       await audiusLibs.contracts.UserReplicaSetManagerClient.updateReplicaSet(
         userId,

--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -42,7 +42,7 @@ module.exports = async function primarySyncFromSecondary({
   try {
     let libs
     try {
-      libs = await initAudiusLibs()
+      libs = await initAudiusLibs({})
     } catch (e) {
       throw new Error(`InitAudiusLibs Error - ${e.message}`)
     }


### PR DESCRIPTION
### Description
When a replica set update is performed, the job processor has to init libs and check which content nodes are healthy. This puts a lot of strain on other nodes, so this PR caches the healthy nodes in Redis for 10 minutes. It also skips other steps of initializing libs when not necessary in the update replica set job processor.


### Tests
- Brought down and up nodes a few times to make sure it reconfigured properly and set the right values in redis (verified directly via redis-cli)
- Waited 10 minutes to make sure the key expired properly


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Look for errors in replica set update jobs. This can be filtered in Loggly to: `json.queue:"update-replica-set-queue"`