### PR TITLE
INF-210 Collection of fixes to streamline SDK Publishing job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ commands:
       text:
         description: Markdown formatted Slack message
         type: string
+        default: "Job started. :crossed_fingers:"
+      slack_mentions_user:
+        description: Used for CircleCI @mentions
+        type: string
         default: ""
     steps:
       - slack/notify:
@@ -34,12 +38,58 @@ commands:
             {
               "blocks": [
                 {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "<< parameters.text >>",
+                    "emoji": true
+                  }
+                },
+                {
                   "type": "section",
                   "fields": [
                     {
-                      "type": "plain_text",
-                      "text": "<< parameters.text >>",
-                      "emoji": true
+                      "type": "mrkdwn",
+                      "text": "*Job*: ${CIRCLE_JOB}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch*: $CIRCLE_BRANCH"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author*: $CIRCLE_USERNAME"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Mentions*: @<< parameters.slack_mentions_user >>"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${CIRCLE_BUILD_URL}"
                     }
                   ]
                 }
@@ -147,6 +197,9 @@ parameters:
   sdk_release_tag:
     type: string
     default: ""
+  slack_mentions_user:
+    type: string
+    default: ""
   full_ci:
     type: boolean
     default: false
@@ -203,6 +256,10 @@ jobs:
         description: The git tag/commit to build and release
         type: string
         default: ""
+      slack_mentions_user:
+        description: Used for CircleCI @mentions
+        type: string
+        default: ""
     steps:
       - checkout
       - setup_remote_docker
@@ -215,12 +272,12 @@ jobs:
       - slack-basic:
           event: always
           branch_pattern: master
-          text: "$CIRCLE_USERNAME is publishing SDK@<< pipeline.parameters.sdk_release_tag >>."
+          slack_mentions_user: << parameters.slack_mentions_user >>
       - run:
           name: Bump and Publish Libs
           command: |
             export PROTOCOL_DIR=/home/circleci/project
-            libs/scripts/release.sh << pipeline.parameters.sdk_release_tag >>
+            libs/scripts/release.sh << parameters.sdk_release_tag >>
       - slack/notify:
           event: fail
           branch_pattern: master
@@ -906,6 +963,7 @@ workflows:
             - slack-secrets
           name: publish-libs (<< pipeline.parameters.sdk_release_tag >>)
           sdk_release_tag: << pipeline.parameters.sdk_release_tag >>
+          slack_mentions_user: << pipeline.parameters.slack_mentions_user >>
           filters:
             branches:
               only: /(^master$)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,35 @@ commands:
           channel: << parameters.channel >>
           text: << parameters.text >>
           slack_mentions_user: << parameters.slack_mentions_user >>
+  slack-success:
+    parameters:
+      event:
+        description: when this notification will fire. options are fail, pass, always.
+        type: string
+        default: pass
+      branch_pattern:
+        description: branch_pattern arg for slack/notify
+        type: string
+        default: .+
+      channel:
+        description: Slack channel to send message to
+        type: string
+        default: $SLACK_DEFAULT_CHANNEL
+      text:
+        description: Markdown formatted Slack message
+        type: string
+        default: "Deployment Successful! :tada:"
+      slack_mentions_user:
+        description: Used for CircleCI @mentions
+        type: string
+        default: ""
+    steps:
+      - slack-basic:
+          event: << parameters.event >>
+          branch_pattern: << parameters.branch_pattern >>
+          channel: << parameters.channel >>
+          text: << parameters.text >>
+          slack_mentions_user: << parameters.slack_mentions_user >>
 
   diff-if-necessary:
     parameters:
@@ -309,10 +338,8 @@ jobs:
             libs/scripts/release.sh << parameters.sdk_release_tag >>
       - slack-fail:
           branch_pattern: master
-      # - slack/notify:
-      #     event: pass
-      #     branch_pattern: master
-      #     template: success_tagged_deploy_1
+      - slack-success:
+          branch_pattern: master
 
   test-mad-dog-e2e:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,8 +338,10 @@ jobs:
             libs/scripts/release.sh << parameters.sdk_release_tag >>
       - slack-fail:
           branch_pattern: master
+          slack_mentions_user: << parameters.slack_mentions_user >>
       - slack-success:
           branch_pattern: master
+          slack_mentions_user: << parameters.slack_mentions_user >>
 
   test-mad-dog-e2e:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Mentions*: @<< parameters.slack_mentions_user >>"
+                      "text": "*Mentions*: << parameters.slack_mentions_user >>"
                     }
                   ]
                 },

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,35 @@ commands:
               ]
             }
           event: << parameters.event >>
+  slack-fail:
+    parameters:
+      event:
+        description: when this notification will fire. options are fail, pass, always.
+        type: string
+        default: fail
+      branch_pattern:
+        description: branch_pattern arg for slack/notify
+        type: string
+        default: .+
+      channel:
+        description: Slack channel to send message to
+        type: string
+        default: $SLACK_DEFAULT_CHANNEL
+      text:
+        description: Markdown formatted Slack message
+        type: string
+        default: "Job Failed. :red_circle:"
+      slack_mentions_user:
+        description: Used for CircleCI @mentions
+        type: string
+        default: ""
+    steps:
+      - slack-basic:
+          event: << parameters.event >>
+          branch_pattern: << parameters.branch_pattern >>
+          channel: << parameters.channel >>
+          text: << parameters.text >>
+          slack_mentions_user: << parameters.slack_mentions_user >>
 
   diff-if-necessary:
     parameters:
@@ -278,10 +307,8 @@ jobs:
           command: |
             export PROTOCOL_DIR=/home/circleci/project
             libs/scripts/release.sh << parameters.sdk_release_tag >>
-      - slack/notify:
-          event: fail
+      - slack-fail:
           branch_pattern: master
-          template: basic_fail_1
       # - slack/notify:
       #     event: pass
       #     branch_pattern: master

--- a/.circleci/triggers/deploy-sdk.py
+++ b/.circleci/triggers/deploy-sdk.py
@@ -21,13 +21,26 @@ from triggers import ensure_tag_on_master
     envvar="CIRCLE_API_KEY",
     required=True,
 )
-def cli(git_tag, circle_api_key):
+@click.option(
+    "-u",
+    "--slack-mentions-user",
+    help="Used for CircleCI @mentions",
+    envvar="SLACK_MENTIONS_USER",
+    required=True,
+)
+def cli(git_tag, circle_api_key, slack_mentions_user):
     # only allow merged git_tags to be deployed
     ensure_tag_on_master(git_tag)
 
     # trigger a circleci job
     project = "audius-protocol"
-    data = {"branch": "master", "parameters": {"sdk_release_tag": git_tag}}
+    data = {
+        "branch": "master",
+        "parameters": {
+            "sdk_release_tag": git_tag,
+            "slack_mentions_user": slack_mentions_user,
+        },
+    }
     r = requests.post(
         f"https://circleci.com/api/v2/project/github/AudiusProject/{project}/pipeline",
         allow_redirects=True,

--- a/.circleci/triggers/deploy-sdk.py
+++ b/.circleci/triggers/deploy-sdk.py
@@ -25,7 +25,7 @@ from triggers import ensure_tag_on_master
     "-u",
     "--slack-mentions-user",
     help="Used for CircleCI @mentions",
-    envvar="SLACK_MENTIONS_USER",
+    envvar="CIRCLE_SLACK_MENTIONS_USER",
     required=True,
 )
 def cli(git_tag, circle_api_key, slack_mentions_user):

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -57,12 +57,12 @@ function bump-npm () {
     git reset --hard ${GIT_TAG}
 
     # grab change log early, before the version bump
-    LAST_RELEASED_SHA=$(jq -r '.audius.releaseSha' package.json)
+    LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
     CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
 
     # Patch the version
     VERSION=$(npm version patch)
-    jq ". += {audius: {releaseSha: \"${GIT_TAG}\"}}" package.json \
+    jq ". += {audius: {releaseSHA: \"${GIT_TAG}\"}}" package.json \
         | sponge package.json
 
     # Build project

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -57,12 +57,12 @@ function bump-npm () {
     git reset --hard ${GIT_TAG}
 
     # grab change log early, before the version bump
-    LAST_RELEASED_SHA=$(jq -r '.audius."last-released-sha"' package.json)
+    LAST_RELEASED_SHA=$(jq -r '.audius.releaseSha' package.json)
     CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
 
     # Patch the version
     VERSION=$(npm version patch)
-    jq ". += {audius: {\"last-released-sha\": \"${GIT_TAG}\"}}" package.json \
+    jq ". += {audius: {releaseSha: \"${GIT_TAG}\"}}" package.json \
         | sponge package.json
 
     # Build project

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -16,12 +16,9 @@ fi
 
 set -ex
 
-# Finds the lastest commit that looks like a version commit,
-# and gets the list of commits after that
+# Generate change log between last released sha and HEAD
 function git-changelog () {
-    # Find the latest release commit by using the last time the first `version` key changed
-    version_line_number=$(grep -m 1 -n version package.json | cut -d: -f 1)
-    release_commit=$(git blame -L ${version_line_number},+1 --porcelain -- package.json | awk 'NR==1{ print $1 }')
+    release_commit=${1}
 
     # Print the log as "- <commmiter short date> [<commit short hash>] <commit message> <author name>"
     git log --pretty=format:"- %cd [%h] %s [%an]" --date=short $release_commit..HEAD
@@ -60,10 +57,13 @@ function bump-npm () {
     git reset --hard ${GIT_TAG}
 
     # grab change log early, before the version bump
-    CHANGE_LOG=$(git-changelog)
+    LAST_RELEASED_SHA=$(jq -r '.audius."last-released-sha"' package.json)
+    CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
 
     # Patch the version
     VERSION=$(npm version patch)
+    jq ". += {audius: {\"last-released-sha\": \"${GIT_TAG}\"}}" package.json \
+        | sponge package.json
 
     # Build project
     npm i


### PR DESCRIPTION
### Description

Followup to a few issues seen when testing SDK releases last Friday.

Changes include:

* customized slack notifications
  * cuts down on vertical slack noise
  * adds ability to include Slack @mentions in Slack alerts
* track `package.json:audius.releaseSHA` to simplify race conditions on change-log when releasing non-HEAD commits
  * uses this tracked git hash to generate change-log
  * ensures each commit will appear in at least one change log

### Tests

Manually release a few versions of the SDK.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->