### PR TITLE
INF-210 use mktemp instead of sponge

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -62,8 +62,9 @@ function bump-npm () {
 
     # Patch the version
     VERSION=$(npm version patch)
-    jq ". += {audius: {releaseSHA: \"${GIT_TAG}\"}}" package.json \
-        | sponge package.json
+    tmp=$(mktemp)
+    jq ". += {audius: {releaseSHA: \"${GIT_TAG}\"}}" package.json > "$tmp" \
+        && mv "$tmp" package.json
 
     # Build project
     npm i


### PR DESCRIPTION
### Description

Sponge is not included in CircleCI's image by default. Use `mktemp` instead to redirect `jq` output back to the input.json.

### Tests

Manually testing on `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->