### PR TITLE
Clear all reconciliation jobs on restart

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -49,9 +49,9 @@ class StateReconciliationManager {
     })
 
     // Clear any old state if redis was running but the rest of the server restarted
-    await manualSyncQueue.clean({ force: true })
-    await recurringSyncQueue.clean({ force: true })
-    await updateReplicaSetQueue.clean({ force: true })
+    await manualSyncQueue.obliterate({ force: true })
+    await recurringSyncQueue.obliterate({ force: true })
+    await updateReplicaSetQueue.obliterate({ force: true })
 
     this.registerQueueEventHandlersAndJobProcessors({
       manualSyncQueue,


### PR DESCRIPTION
### Description
State machine should be stateless between restarts, and sometimes it can get into a broken state with many jobs in the backlog. This PR makes it clear all jobs for the recurring/manual sync queues and the update-replica-set queue.


### Tests
Restart and make sure job data from before the restart is cleared.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Make sure nothing looks off on the Bull dashboard.