### PR TITLE
INF-210 Use set -e within merge-bump to catch all errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,7 @@ commands:
                     {
                       "type": "mrkdwn",
                       "text": "*Author*: $CIRCLE_USERNAME"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                    },
                     {
                       "type": "mrkdwn",
                       "text": "*Mentions*: << parameters.slack_mentions_user >>"

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -84,23 +84,29 @@ function bump-npm () {
 
 # Merge the created branch into master, then delete the branch
 function merge-bump () {
-    git checkout master -f
+    (
+        # exit the function/subshell early on error
+        # https://stackoverflow.com/a/58964551
+        # http://mywiki.wooledge.org/BashFAQ/105
+        set -e
 
-    # pull in any additional commits that may have trickled in
-    git pull
+        git checkout master -f
 
-    # squash branch commit
-    git merge --squash ${STUB}-${VERSION}
-    git commit -m "$(commit-message)"
+        # pull in any additional commits that may have trickled in
+        git pull
 
-    # tag release
-    git tag -a @audius/${STUB}@${VERSION} -m "$(commit-message)"
-    git push origin --tags
+        # squash branch commit
+        git merge --squash ${STUB}-${VERSION}
+        git commit -m "$(commit-message)"
 
-    # if pushing fails, ensure we cleanup()
-    git push -u origin master \
-    && git push origin :${STUB}-${VERSION} \
-    || $(exit 1)
+        # tag release
+        git tag -a @audius/${STUB}@${VERSION} -m "$(commit-message)"
+        git push origin --tags
+
+        # if pushing fails, ensure we cleanup()
+        git push -u origin master
+        git push origin :${STUB}-${VERSION}
+    )
 }
 
 # publish to npm


### PR DESCRIPTION
### Description

A bash script's global `set -e` does not apply to bash functions() when the output is used as part of an `if` or `&&` conditionals.

In order to "reactivate" `set -e`, it's cleaner to launch a subshell within `merge-bump()` and use `set -e` there. Any errors seen within the subshell will be returned correctly to the `&&` conditional.

Additionally, consolidate CircleCi Slack alerts to use less vertical height for Slack mentions.

### Tests

Manually deploying the SDK off `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->