### PR TITLE
Short circuit when sync queue hasn't initialized

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -60,17 +60,9 @@ const respondToURSMRequestForProposalController = async (req) => {
  */
 const syncRouteController = async (req, res) => {
   const serviceRegistry = req.app.get('serviceRegistry')
-  req.logger.debug(`/sync serviceRegistry empty: ${_.isEmpty(serviceRegistry)}`)
-  req.logger.debug(
-    `/sync serviceRegistry?.nodeConfig empty: ${_.isEmpty(
-      serviceRegistry?.nodeConfig
-    )}`
-  )
-  req.logger.debug(
-    `/sync serviceRegistry?.syncQueue empty: ${_.isEmpty(
-      serviceRegistry?.syncQueue
-    )}`
-  )
+  if (_.isEmpty(serviceRegistry?.syncQueue)) {
+    return errorResponseServerError('Sync Queue is not up and running yet')
+  }
   const nodeConfig = serviceRegistry.nodeConfig
 
   const walletPublicKeys = req.body.wallet // array


### PR DESCRIPTION
### Description
Short-circuit `/sync` requests before they fail with an UncaughtPromiseException, and remove related debugging logs.

### Tests
Made sure syncs succeed locally (update profile with manual syncs disabled).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Keep an eye on `Sync Queue is not up and running yet` errors. There should be a few around the time nodes restart.