### PR TITLE
INF-210 explicitly catch errors and exit out of subshell

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -96,15 +96,15 @@ function merge-bump () {
         git pull
 
         # squash branch commit
-        git merge --squash ${STUB}-${VERSION}
-        git commit -m "$(commit-message)"
+        git merge --squash ${STUB}-${VERSION} || exit 1
+        git commit -m "$(commit-message)" || exit 1
 
         # tag release
-        git tag -a @audius/${STUB}@${VERSION} -m "$(commit-message)"
-        git push origin --tags
+        git tag -a @audius/${STUB}@${VERSION} -m "$(commit-message)" || exit 1
+        git push origin --tags || exit 1
 
         # if pushing fails, ensure we cleanup()
-        git push -u origin master
+        git push -u origin master || exit 1
         git push origin :${STUB}-${VERSION}
     )
 }


### PR DESCRIPTION
### Description

`exit 1` is required to have the subshell return the proper exit code to start the cleanup process.

`set -e` within the subshell should have caught this, but the `&&` conditional will continue to hide the exitcode.

With the combination of `exit 1` within the subshell, we ensure we get the an error code without having the `exit 1` escape into the main script and end the script early.

### Tests

Manually testing releases off master.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->