### PR TITLE
De-dupe manual syncs in state machine

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -316,7 +316,7 @@ class ServiceRegistry {
     this.findReplicaSetUpdatesQueue = findReplicaSetUpdatesQueue
     this.cNodeEndpointToSpIdMapQueue = cNodeEndpointToSpIdMapQueue
     this.manualSyncQueue = manualSyncQueue
-    this.recurringSyncQueue = recurringSyncQueue
+    this.recurringSyncQueue = null
     this.updateReplicaSetQueue = updateReplicaSetQueue
 
     // SyncQueue construction (requires L1 identity)

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -316,7 +316,7 @@ class ServiceRegistry {
     this.findReplicaSetUpdatesQueue = findReplicaSetUpdatesQueue
     this.cNodeEndpointToSpIdMapQueue = cNodeEndpointToSpIdMapQueue
     this.manualSyncQueue = manualSyncQueue
-    this.recurringSyncQueue = null
+    this.recurringSyncQueue = recurringSyncQueue
     this.updateReplicaSetQueue = updateReplicaSetQueue
 
     // SyncQueue construction (requires L1 identity)

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/SyncRequestDeDuplicator.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/SyncRequestDeDuplicator.js
@@ -12,28 +12,28 @@ class SyncRequestDeDuplicator {
   }
 
   /** Stringify properties to enable storage with a flat map */
-  _getSyncKey(syncType, userWallet, secondaryEndpoint) {
-    return `${syncType}::${userWallet}::${secondaryEndpoint}`
+  _getSyncKey(syncType, userWallet, secondaryEndpoint, immediate=false) {
+    return `${syncType}::${userWallet}::${secondaryEndpoint}::${immediate}`
   }
 
   /** Return job info of sync with given properties if present else null */
-  getDuplicateSyncJobInfo(syncType, userWallet, secondaryEndpoint) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint)
+  getDuplicateSyncJobInfo(syncType, userWallet, secondaryEndpoint, immediate=false) {
+    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
 
     const duplicateSyncJobInfo = this.waitingSyncsByUserWalletMap[syncKey]
     return duplicateSyncJobInfo || null
   }
 
   /** Record job info for sync with given properties */
-  recordSync(syncType, userWallet, secondaryEndpoint, jobProps) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint)
+  recordSync(syncType, userWallet, secondaryEndpoint, immediate=false, jobProps) {
+    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
 
     this.waitingSyncsByUserWalletMap[syncKey] = jobProps
   }
 
   /** Remove sync with given properties */
-  removeSync(syncType, userWallet, secondaryEndpoint) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint)
+  removeSync(syncType, userWallet, secondaryEndpoint, immediate=false) {
+    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
 
     delete this.waitingSyncsByUserWalletMap[syncKey]
   }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/SyncRequestDeDuplicator.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/SyncRequestDeDuplicator.js
@@ -12,28 +12,54 @@ class SyncRequestDeDuplicator {
   }
 
   /** Stringify properties to enable storage with a flat map */
-  _getSyncKey(syncType, userWallet, secondaryEndpoint, immediate=false) {
+  _getSyncKey(syncType, userWallet, secondaryEndpoint, immediate = false) {
     return `${syncType}::${userWallet}::${secondaryEndpoint}::${immediate}`
   }
 
   /** Return job info of sync with given properties if present else null */
-  getDuplicateSyncJobInfo(syncType, userWallet, secondaryEndpoint, immediate=false) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
+  getDuplicateSyncJobInfo(
+    syncType,
+    userWallet,
+    secondaryEndpoint,
+    immediate = false
+  ) {
+    const syncKey = this._getSyncKey(
+      syncType,
+      userWallet,
+      secondaryEndpoint,
+      immediate
+    )
 
     const duplicateSyncJobInfo = this.waitingSyncsByUserWalletMap[syncKey]
     return duplicateSyncJobInfo || null
   }
 
   /** Record job info for sync with given properties */
-  recordSync(syncType, userWallet, secondaryEndpoint, immediate=false, jobProps) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
+  recordSync(
+    syncType,
+    userWallet,
+    secondaryEndpoint,
+    immediate = false,
+    jobProps
+  ) {
+    const syncKey = this._getSyncKey(
+      syncType,
+      userWallet,
+      secondaryEndpoint,
+      immediate
+    )
 
     this.waitingSyncsByUserWalletMap[syncKey] = jobProps
   }
 
   /** Remove sync with given properties */
-  removeSync(syncType, userWallet, secondaryEndpoint, immediate=false) {
-    const syncKey = this._getSyncKey(syncType, userWallet, secondaryEndpoint, immediate)
+  removeSync(syncType, userWallet, secondaryEndpoint, immediate = false) {
+    const syncKey = this._getSyncKey(
+      syncType,
+      userWallet,
+      secondaryEndpoint,
+      immediate
+    )
 
     delete this.waitingSyncsByUserWalletMap[syncKey]
   }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -34,6 +34,7 @@ const {
   MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS
 } = require('../stateMachineConstants')
 const primarySyncFromSecondary = require('../../sync/primarySyncFromSecondary')
+const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
 
 const secondaryUserSyncDailyFailureCountThreshold = config.get(
   'secondaryUserSyncDailyFailureCountThreshold'
@@ -171,7 +172,6 @@ async function _handleIssueSyncRequest({
    * Remove sync from SyncRequestDeDuplicator once it moves to Active status, before processing.
    * It is ok for two identical syncs to be present in Active and Waiting, just not two in Waiting.
    */
-  const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
   SyncRequestDeDuplicator.removeSync(
     syncType,
     userWallet,

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -172,7 +172,12 @@ async function _handleIssueSyncRequest({
    * It is ok for two identical syncs to be present in Active and Waiting, just not two in Waiting.
    */
   const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
-  SyncRequestDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint, immediate)
+  SyncRequestDeDuplicator.removeSync(
+    syncType,
+    userWallet,
+    secondaryEndpoint,
+    immediate
+  )
 
   /**
    * Do not issue syncRequest if SecondaryUserSyncFailureCountForToday already exceeded threshold

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -163,6 +163,7 @@ async function _handleIssueSyncRequest({
 
   const userWallet = syncRequestParameters.data.wallet[0]
   const secondaryEndpoint = syncRequestParameters.baseURL
+  const immediate = syncRequestParameters.data.immediate
 
   const logMsgString = `_handleIssueSyncRequest() (${syncType})(${syncMode}) User ${userWallet} | Secondary: ${secondaryEndpoint}`
 
@@ -173,7 +174,7 @@ async function _handleIssueSyncRequest({
    */
   if (syncType === SyncType.Recurring) {
     const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
-    SyncRequestDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint)
+    SyncRequestDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint, immediate)
   }
 
   /**

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -170,12 +170,9 @@ async function _handleIssueSyncRequest({
   /**
    * Remove sync from SyncRequestDeDuplicator once it moves to Active status, before processing.
    * It is ok for two identical syncs to be present in Active and Waiting, just not two in Waiting.
-   * We don't dedupe manual syncs.
    */
-  if (syncType === SyncType.Recurring) {
-    const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
-    SyncRequestDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint, immediate)
-  }
+  const SyncRequestDeDuplicator = require('./SyncRequestDeDuplicator')
+  SyncRequestDeDuplicator.removeSync(syncType, userWallet, secondaryEndpoint, immediate)
 
   /**
    * Do not issue syncRequest if SecondaryUserSyncFailureCountForToday already exceeded threshold

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/stateReconciliationUtils.js
@@ -47,9 +47,10 @@ const getNewOrExistingSyncReq = ({
   const duplicateSyncJobInfo = SyncRequestDeDuplicator.getDuplicateSyncJobInfo(
     syncType,
     userWallet,
-    secondaryEndpoint
+    secondaryEndpoint,
+    immediate
   )
-  if (duplicateSyncJobInfo && syncType !== SyncType.Manual) {
+  if (duplicateSyncJobInfo) {
     logger.info(
       `getNewOrExistingSyncReq() Failure - a sync of type ${syncType} is already waiting for user wallet ${userWallet} against secondary ${secondaryEndpoint}`
     )
@@ -81,15 +82,13 @@ const getNewOrExistingSyncReq = ({
     syncRequestParameters
   }
 
-  // Record sync in syncDeDuplicator for recurring syncs only
-  if (syncType === SyncType.Recurring) {
-    SyncRequestDeDuplicator.recordSync(
-      syncType,
-      userWallet,
-      secondaryEndpoint,
-      syncReqToEnqueue
-    )
-  }
+  SyncRequestDeDuplicator.recordSync(
+    syncType,
+    userWallet,
+    secondaryEndpoint,
+    syncReqToEnqueue,
+    immediate
+  )
 
   return { syncReqToEnqueue }
 }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Put manual syncs back in the de-dupe flow. I had taken it out to pass mad dog due to timing / uniqueness issues but it looks like lots of duplicate syncs are being triggered if not de-duped.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally by creating user and uploading track and mad dog on CI

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
manual-sync-queue should stay clear and secondaries should not be getting multiple syncs for the same user at the same time in the logs.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->