### PR TITLE
[PAY-494] Fixes bug in A up --with-aao

### DIFF
--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -775,7 +775,7 @@ const allUp = async ({
 
   // Add AAO commands
   if (withAAO) {
-    nodeUpCommands.push([Service.AAO, SetupCommand.UP])
+    nodeUpCommands.push([[Service.AAO, SetupCommand.UP]])
     if (buildDataEthContracts) {
       nodeRegisterCommands.push([Service.AAO, SetupCommand.REGISTER])
     }


### PR DESCRIPTION
### Description
Fixes a bug that prevented A up --with-aao from bringing up aao correctly. Missing pair of square brackets caused the running command to spread 'aao' instead of an array containing ['aao', 'up'].

### Tests
Tested on remote dev machine.