### PR TITLE
INF-210 Rename publish-libs job to publish-sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
               --source-disk-zone="$GOOGLE_COMPUTE_ZONE" \
               --storage-location=us
 
-  publish-libs:
+  publish-sdk:
     docker:
       - image: circleci/node:14.17.5
     resource_class: xlarge
@@ -1011,11 +1011,11 @@ workflows:
   sdk-release:
     when: << pipeline.parameters.sdk_release_tag >>
     jobs:
-      - publish-libs:
+      - publish-sdk:
           context:
             - Audius Client
             - slack-secrets
-          name: publish-libs (<< pipeline.parameters.sdk_release_tag >>)
+          name: publish-sdk (<< pipeline.parameters.sdk_release_tag >>)
           sdk_release_tag: << pipeline.parameters.sdk_release_tag >>
           slack_mentions_user: << pipeline.parameters.slack_mentions_user >>
           filters:

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -117,9 +117,9 @@ function publish () {
 # informative links
 function info () {
     echo "Released to:
-    * https://github.com/AudiusProject/audius-protocol/commits/master
-    * https://github.com/AudiusProject/audius-protocol/tags
-    * https://www.npmjs.com/package/@audius/sdk?activeTab=versions"
+      https://github.com/AudiusProject/audius-protocol/commits/master
+      https://github.com/AudiusProject/audius-protocol/tags
+      https://www.npmjs.com/package/@audius/sdk?activeTab=versions"
 }
 
 # cleanup when merging step fails

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -85,11 +85,6 @@ function bump-npm () {
 # Merge the created branch into master, then delete the branch
 function merge-bump () {
     (
-        # exit the function/subshell early on error
-        # https://stackoverflow.com/a/58964551
-        # http://mywiki.wooledge.org/BashFAQ/105
-        set -e
-
         git checkout master -f
 
         # pull in any additional commits that may have trickled in


### PR DESCRIPTION
### Description

Rename publish-libs job to publish-sdk.

Additionally, cleanup info echo and remove unneeded `set -e` code which is unused due to the calling function being used as part of a conditional.


### Tests

Manually run a release on `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->