### PR TITLE
Stop infinite sync retries for jobs that error

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -249,7 +249,7 @@ async function _handleIssueSyncRequest({
         syncType,
         syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
         syncRequestParameters,
-        attemptNumber
+        attemptNumber: attemptNumber + 1
       }
     }
   }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
When a sync errors, it's supposed to increment the attempt number by 1 and enqueue another job. But we return the same attemptNumber over and over without ever increment. For example, if manual-sync-queue enqueues a job to retry, the attemptNumber should not be 1.


<img width="533" alt="Bull_Dashboard" src="https://user-images.githubusercontent.com/295938/182482496-2730299d-b957-4413-a349-93277fa74a76.png">

In cases that don't error, the _additionalSyncIsRequired function increments the count [here](https://github.com/AudiusProject/audius-protocol/blob/4ce327498a466c3051bca6156a79463fd0fcfcbf/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts#L425)
### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested by running mad-dog

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
In bull dashboard verify any job added from a queue has attemptNumber > 1

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->