### PR TITLE
New queue for immediate sync

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -12,7 +12,7 @@ const {
   respondToURSMRequestForSignature
 } = require('./URSMRegistrationComponentService')
 const { ensureStorageMiddleware } = require('../../middlewares')
-const { enqueueSync } = require('./syncQueueComponentService')
+const { enqueueSync, processImmediateSync } = require('./syncQueueComponentService')
 const secondarySyncFromPrimary = require('../../services/sync/secondarySyncFromPrimary')
 
 const router = express.Router()
@@ -95,7 +95,7 @@ const syncRouteController = async (req, res) => {
    */
   if (immediate) {
     try {
-      await secondarySyncFromPrimary(
+      await processImmediateSync(
         serviceRegistry,
         walletPublicKeys,
         creatorNodeEndpoint,

--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -62,7 +62,10 @@ const respondToURSMRequestForProposalController = async (req) => {
  */
 const syncRouteController = async (req, res) => {
   const serviceRegistry = req.app.get('serviceRegistry')
-  if (_.isEmpty(serviceRegistry?.syncQueue) || _.isEmpty(serviceRegistry?.syncImmediateQueue)) {
+  if (
+    _.isEmpty(serviceRegistry?.syncQueue) ||
+    _.isEmpty(serviceRegistry?.syncImmediateQueue)
+  ) {
     return errorResponseServerError('Sync Queue is not up and running yet')
   }
   const nodeConfig = serviceRegistry.nodeConfig
@@ -102,7 +105,7 @@ const syncRouteController = async (req, res) => {
         walletPublicKeys,
         creatorNodeEndpoint,
         forceResync
-    })
+      })
     } catch (e) {
       return errorResponseServerError(e)
     }

--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -12,7 +12,10 @@ const {
   respondToURSMRequestForSignature
 } = require('./URSMRegistrationComponentService')
 const { ensureStorageMiddleware } = require('../../middlewares')
-const { enqueueSync, processImmediateSync } = require('./syncQueueComponentService')
+const {
+  enqueueSync,
+  processImmediateSync
+} = require('./syncQueueComponentService')
 const secondarySyncFromPrimary = require('../../services/sync/secondarySyncFromPrimary')
 
 const router = express.Router()

--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -16,7 +16,6 @@ const {
   enqueueSync,
   processImmediateSync
 } = require('./syncQueueComponentService')
-const secondarySyncFromPrimary = require('../../services/sync/secondarySyncFromPrimary')
 
 const router = express.Router()
 
@@ -98,13 +97,12 @@ const syncRouteController = async (req, res) => {
    */
   if (immediate) {
     try {
-      await processImmediateSync(
+      await processImmediateSync({
         serviceRegistry,
         walletPublicKeys,
         creatorNodeEndpoint,
-        blockNumber,
         forceResync
-      )
+    })
     } catch (e) {
       return errorResponseServerError(e)
     }
@@ -123,7 +121,6 @@ const syncRouteController = async (req, res) => {
           serviceRegistry,
           walletPublicKeys: [wallet],
           creatorNodeEndpoint,
-          blockNumber,
           forceResync
         })
         delete syncDebounceQueue[wallet]

--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -63,7 +63,7 @@ const respondToURSMRequestForProposalController = async (req) => {
  */
 const syncRouteController = async (req, res) => {
   const serviceRegistry = req.app.get('serviceRegistry')
-  if (_.isEmpty(serviceRegistry?.syncQueue)) {
+  if (_.isEmpty(serviceRegistry?.syncQueue) || _.isEmpty(serviceRegistry?.syncImmediateQueue)) {
     return errorResponseServerError('Sync Queue is not up and running yet')
   }
   const nodeConfig = serviceRegistry.nodeConfig

--- a/creator-node/src/components/replicaSet/syncQueueComponentService.js
+++ b/creator-node/src/components/replicaSet/syncQueueComponentService.js
@@ -14,6 +14,20 @@ const enqueueSync = async ({
   })
 }
 
+const processImmediateSync = async ({
+  serviceRegistry,
+  walletPublicKeys,
+  creatorNodeEndpoint,
+  forceResync
+}) => {
+  await serviceRegistry.syncImmediateQueue.processImmediateSync({
+    walletPublicKeys,
+    creatorNodeEndpoint,
+    forceResync
+  })
+}
+
 module.exports = {
-  enqueueSync
+  enqueueSync,
+  processImmediateSync
 }

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -488,7 +488,7 @@ const config = convict({
     doc: 'Max concurrency of SyncQueue',
     format: 'nat',
     env: 'syncQueueMaxConcurrency',
-    default: 50
+    default: 30
   },
   issueAndWaitForSecondarySyncRequestsPollingDurationMs: {
     doc: 'Duration for which to poll secondaries for content replication in `issueAndWaitForSecondarySyncRequests` function',

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -62,7 +62,11 @@ class SyncImmediateQueue {
     })
   }
 
-  async processImmediateSync({ walletPublicKeys, creatorNodeEndpoint, forceResync }) {
+  async processImmediateSync({
+    walletPublicKeys,
+    creatorNodeEndpoint,
+    forceResync
+  }) {
     const jobProps = { walletPublicKeys, creatorNodeEndpoint, forceResync }
     const job = await this.queue.add(jobProps)
     const result = await job.finished()

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -4,13 +4,15 @@ const { logger } = require('../../logging')
 const secondarySyncFromPrimary = require('./secondarySyncFromPrimary')
 
 const SYNC_QUEUE_HISTORY = 500
-const LOCK_DURATION = 1000 * 60 * 30 // 30 minutes
+const LOCK_DURATION = 1000 * 60 * 5 // 5 minutes
 
 /**
- * SyncQueue - handles enqueuing and processing of Sync jobs on secondary
+ * SyncImmediateQueue - handles enqueuing and processing of immediate manual Sync jobs on secondary
  * sync job = this node (secondary) will sync data for a user from their primary
+ * this queue is only for manual immediate syncs which are awaited until they're finished, for regular
+ * syncs look at SyncQueue
  */
-class SyncQueue {
+class SyncImmediateQueue {
   /**
    * Construct bull queue and define job processor
    * @notice - accepts `serviceRegistry` instance, even though this class is initialized
@@ -21,7 +23,7 @@ class SyncQueue {
     this.redis = redis
     this.serviceRegistry = serviceRegistry
 
-    this.queue = new Bull('sync-processing-queue', {
+    this.queue = new Bull('sync-immediate-processing-queue', {
       redis: {
         host: this.nodeConfig.get('redisHost'),
         port: this.nodeConfig.get('redisPort')
@@ -35,14 +37,6 @@ class SyncQueue {
       }
     })
 
-    /**
-     * Queue will process tasks concurrently if provided a concurrency number, and will process all on
-     *    main thread if provided an in-line job processor function; it will distribute across child processes
-     *    if provided an absolute path to separate file containing job processor function.
-     *    https://github.com/OptimalBits/bull/tree/013c51942e559517c57a117c27a550a0fb583aa8#separate-processes
-     *
-     * @dev TODO - consider recording failures in redis
-     */
     const jobProcessorConcurrency = this.nodeConfig.get(
       'syncQueueMaxConcurrency'
     )
@@ -68,11 +62,12 @@ class SyncQueue {
     })
   }
 
-  async enqueueSync({ walletPublicKeys, creatorNodeEndpoint, forceResync }) {
+  async processImmediateSync({ walletPublicKeys, creatorNodeEndpoint, forceResync }) {
     const jobProps = { walletPublicKeys, creatorNodeEndpoint, forceResync }
     const job = await this.queue.add(jobProps)
-    return job
+    const result = await job.finished()
+    return result
   }
 }
 
-module.exports = SyncQueue
+module.exports = SyncImmediateQueue

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -40,7 +40,7 @@ class SyncImmediateQueue {
     const jobProcessorConcurrency = this.nodeConfig.get(
       'syncQueueMaxConcurrency'
     )
-    this.queue.process(jobProcessorConcurrency, async (job, done) => {
+    this.queue.process(jobProcessorConcurrency, async (job) => {
       const { walletPublicKeys, creatorNodeEndpoint, forceResync } = job.data
 
       try {
@@ -57,8 +57,6 @@ class SyncImmediateQueue {
           e.message
         )
       }
-
-      done()
     })
   }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
New SyncImmediateQueue to run all immediate syncs through a bull queue synchronously. Benefits are that we can cap manual sync concurrency and run it through bull instead of calling the secondarySyncFromPrimary directly like [this](https://github.com/AudiusProject/audius-protocol/blob/master/creator-node/src/components/replicaSet/replicaSetController.js#L98).

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally with user signups and mad dog on CI

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Bull dashboard under sync-immediate-processing-queue

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->