### PR TITLE
Fix attemptNumber not getting updated

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -42,19 +42,19 @@ export const MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS = 2
 
 export const QUEUE_HISTORY = Object.freeze({
   // Max number of completed/failed jobs to keep in redis for the monitor-state queue
-  MONITOR_STATE: 20,
+  MONITOR_STATE: 100,
   // Max number of completed/failed jobs to keep in redis for the find-sync-requests queue
-  FIND_SYNC_REQUESTS: 20,
+  FIND_SYNC_REQUESTS: 100,
   // Max number of completed/failed jobs to keep in redis for the find-replica-set-updates queue
-  FIND_REPLICA_SET_UPDATES: 20,
+  FIND_REPLICA_SET_UPDATES: 100,
   // Max number of completed/failed jobs to keep in redis for the cNodeEndpoint->spId map queue
   FETCH_C_NODE_ENDPOINT_TO_SP_ID_MAP: 100,
   // Max number of completed/failed jobs to keep in redis for the manual sync queue
-  MANUAL_SYNC: 300,
+  MANUAL_SYNC: 100_000,
   // Max number of completed/failed jobs to keep in redis for the recurring sync queue
-  RECURRING_SYNC: 300,
+  RECURRING_SYNC: 100_000,
   // Max number of completed/failed jobs to keep in redis for the update-replica-set queue
-  UPDATE_REPLICA_SET: 300
+  UPDATE_REPLICA_SET: 100_000
 })
 
 export const QUEUE_NAMES = {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -111,19 +111,21 @@ module.exports = async function ({
     syncReqToEnqueue?.syncType === SyncType.Manual
       ? MAX_ISSUE_MANUAL_SYNC_JOB_ATTEMPTS
       : MAX_ISSUE_RECURRING_SYNC_JOB_ATTEMPTS
-  if (!_.isEmpty(syncReqToEnqueue) && attemptNumber < maxRetries) {
-    logger.info(`Retrying issue-sync-request after attempt #${attemptNumber}`)
-    const queueName =
-      syncReqToEnqueue?.syncType === SyncType.Manual
-        ? QUEUE_NAMES.MANUAL_SYNC
-        : QUEUE_NAMES.RECURRING_SYNC
-    jobsToEnqueue = {
-      [queueName]: [{ ...syncReqToEnqueue, attemptNumber: attemptNumber + 1 }]
+  if (!_.isEmpty(syncReqToEnqueue)) {
+    if (attemptNumber < maxRetries) {
+      logger.info(`Retrying issue-sync-request after attempt #${attemptNumber}`)
+      const queueName =
+        syncReqToEnqueue?.syncType === SyncType.Manual
+          ? QUEUE_NAMES.MANUAL_SYNC
+          : QUEUE_NAMES.RECURRING_SYNC
+      jobsToEnqueue = {
+        [queueName]: [{ ...syncReqToEnqueue, attemptNumber: attemptNumber + 1 }]
+      }
+    } else {
+      logger.info(
+        `Gave up retrying issue-sync-request (type: ${syncReqToEnqueue?.syncType}) after ${attemptNumber} failed attempts`
+      )
     }
-  } else {
-    logger.info(
-      `Gave up retrying issue-sync-request (type: ${syncReqToEnqueue?.syncType}) after ${attemptNumber} failed attempts`
-    )
   }
 
   // Make metrics to record

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -54,7 +54,6 @@ type HandleIssueSyncReqParams = {
   syncMode: string
   syncRequestParameters: SyncRequestAxiosParams
   logger: Logger
-  attemptNumber: number
 }
 type HandleIssueSyncReqResult = {
   result: string
@@ -100,8 +99,7 @@ module.exports = async function ({
     syncType,
     syncMode,
     syncRequestParameters,
-    logger,
-    attemptNumber
+    logger
   })
   if (errorResp) {
     error = errorResp
@@ -120,7 +118,7 @@ module.exports = async function ({
         ? QUEUE_NAMES.MANUAL_SYNC
         : QUEUE_NAMES.RECURRING_SYNC
     jobsToEnqueue = {
-      [queueName]: [{ attemptNumber: attemptNumber + 1, ...syncReqToEnqueue }]
+      [queueName]: [{ ...syncReqToEnqueue, attemptNumber: attemptNumber + 1 }]
     }
   } else {
     logger.info(
@@ -152,8 +150,7 @@ async function _handleIssueSyncRequest({
   syncType,
   syncMode,
   syncRequestParameters,
-  logger,
-  attemptNumber
+  logger
 }: HandleIssueSyncReqParams): Promise<HandleIssueSyncReqResult> {
   if (!syncRequestParameters?.data?.wallet?.length) {
     return { result: 'failure_missing_wallet' }
@@ -248,8 +245,7 @@ async function _handleIssueSyncRequest({
       syncReqToEnqueue: {
         syncType,
         syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
-        syncRequestParameters,
-        attemptNumber
+        syncRequestParameters
       }
     }
   }
@@ -265,8 +261,7 @@ async function _handleIssueSyncRequest({
     syncType,
     syncMode,
     syncRequestParameters,
-    logger,
-    attemptNumber
+    logger
   )
 
   return {
@@ -315,8 +310,7 @@ const _additionalSyncIsRequired = async (
   syncType: string,
   syncMode: string,
   syncRequestParameters: SyncRequestAxiosParams,
-  logger: any,
-  attemptNumber: number
+  logger: any
 ): Promise<AdditionalSyncIsRequiredResponse> => {
   const userWallet = syncRequestParameters.data.wallet[0]
   const secondaryUrl = syncRequestParameters.baseURL
@@ -421,8 +415,7 @@ const _additionalSyncIsRequired = async (
     response.syncReqToEnqueue = {
       syncType,
       syncMode: SYNC_MODES.SyncSecondaryFromPrimary,
-      syncRequestParameters,
-      attemptNumber: attemptNumber + 1
+      syncRequestParameters
     }
   }
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/types.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/types.ts
@@ -14,7 +14,7 @@ export type IssueSyncRequestJobParams = {
   syncType: string
   syncMode: string
   syncRequestParameters: SyncRequestAxiosParams
-  attemptNumber: number
+  attemptNumber?: number
 }
 export type IssueSyncRequestJobReturnValue = {
   error: any


### PR DESCRIPTION
### Description
- The order that we spread by was overriding `attemptNumber` to never increment when retrying syncs, so this PR fixes that
- Histories of some queues have been higher without any negative impact (and Redis memory having lots of wiggle room still), so this PR also bumps those histories to allow us to view more completed/failed jobs.


### Tests
Make sure mad dog passes and verify fewer retries on staging.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor manual sync queue volume on staging.