### PR TITLE
CON-303 Cache CN 200-status /health_check responses for 1sec in nginx

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -1,3 +1,8 @@
+# nginx Configuration file
+#
+# Notes:
+#   - any value below prefixed with $arg indicates a request query param, e.g. $arg_bypasscache will match query param `bypasscache=<value>`
+
 worker_processes 1;
 
 events {
@@ -75,6 +80,9 @@ http {
 
             # Cache responses with 200 status, for 1 second
             proxy_cache_valid 200 1s;
+
+            # Bypass cache with bypasscache=true query string and save new response to proxy cache
+            proxy_cache_bypass $arg_bypasscache;
 
             # Add response header to indicate the status of the cache with this request
             add_header X-Cache-Status $upstream_cache_status always;

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -19,7 +19,7 @@ http {
     # If inactive period passes, content WILL BE DELETED from the cache by the cache
     # manager, regardless whether or not it has expired.
     # https://www.nginx.com/blog/nginx-caching-guide#How-to-Set-Up-and-Configure-Basic-Caching
-    proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cidcache:1000m
+    proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cache:1000m
 					max_size=4g inactive=12h use_temp_path=off;
     proxy_read_timeout 3600; # 1 hour in seconds
 
@@ -30,10 +30,10 @@ http {
         # If present in cache, serve. Else, hit upstream server + update cache + serve.
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
         location ~ (/ipfs/|/content/) {
-            proxy_cache cidcache;
+            proxy_cache cache;
             proxy_pass http://127.0.0.1:3000;
 
-            # Set client IP
+            # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
 
             # proxy_cache_use_stale + proxy_cache_background_update -> deliver stale content when client requests
@@ -60,6 +60,23 @@ http {
             proxy_cache_bypass $arg_bypasscache;
 
             # Add header to indicate the status of the cache with this request
+            add_header X-Cache-Status $upstream_cache_status always;
+        }
+
+        location = /health_check {
+            proxy_cache cache;
+
+            proxy_pass http://127.0.0.1:3000;
+
+            # Set client IP as `X-Forwarded-For` response header
+            proxy_set_header X-Forwarded-For $remote_addr;
+
+            # Never serve a stale response
+
+            # Cache responses with 200 status, for 1 second
+            proxy_cache_valid 200 1s;
+
+            # Add response header to indicate the status of the cache with this request
             add_header X-Cache-Status $upstream_cache_status always;
         }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Cache 200-status /health_check responses from CN in nginx for 1second
1sec is minimum allowable time in nginx (see open ticket - https://trac.nginx.org/nginx/ticket/1505)

< 1sec would be better probably, but I think 1sec is acceptable - worth consideration tho

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested manually (see below for HIT and EXPIRED responses)
<img width="447" alt="Screen Shot 2022-08-03 at 3 39 14 PM" src="https://user-images.githubusercontent.com/3323835/182694782-e23e3a84-afa7-4ebd-aa6d-7fce355cdadc.png">
<img width="447" alt="Screen Shot 2022-08-03 at 3 39 14 PM" src="https://user-images.githubusercontent.com/3323835/182694836-5888e4f7-772c-4e45-b091-0aa2f01a9639.png">

Existing CN + maddog tests sufficient for regression coverage

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Grafana dashboard for CN health check metrics - http://grafana.audius.co/d/q7ZzPaR4k/vickys-dashboard?orgId=1&var-environment=prod&var-host=All&var-path=%2Fhealth_check&var-status_code=All&var-method=GET

Also observe `nginx` logs per this doc - https://www.notion.so/audiusproject/How-to-debug-nginx-cache-layer-e2097937dc0e4a0fae5583054ed417d0

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->