### PR TITLE
Remove unused labels

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -71,10 +71,6 @@ export const METRIC_NAMES = Object.freeze(
 
 export const METRIC_LABELS = Object.freeze({
   [METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM]: {
-    sync_type: Object.values(SyncType as Record<string, string>).map(snakeCase),
-    sync_mode: Object.values(SYNC_MODES as Record<string, string>).map(
-      snakeCase
-    ),
     result: [
       'success',
       'failure_sync_secondary_from_primary',

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -618,7 +618,7 @@ const handleSyncFromPrimary = async (
  *    any data corruption from primary needs to be handled separately and should not be replicated.
  *
  * @notice - There is a maxExportClockValueRange enforced in export, meaning that some syncs will
- *    only replicate partial data state. This is by design, and Snapback will trigger repeated syncs
+ *    only replicate partial data state. This is by design, and state machine will trigger repeated syncs
  *    with progressively increasing clock values until secondaries have completely synced up.
  *    Secondaries have no knowledge of the current data state on primary, they simply replicate
  *    what they receive in each export.
@@ -637,18 +637,18 @@ module.exports = async function (
   )
   const metricEndTimerFn = secondarySyncFromPrimaryMetric.startTimer()
 
-  const { error, ...labels } = await handleSyncFromPrimary(
+  const { error, result } = await handleSyncFromPrimary(
     serviceRegistry,
     walletPublicKeys,
     creatorNodeEndpoint,
     blockNumber,
     forceResync
   )
-  metricEndTimerFn(labels)
+  metricEndTimerFn(result)
 
   if (error) {
     throw new Error(error)
   }
 
-  return labels
+  return result
 }

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -644,11 +644,11 @@ module.exports = async function (
     blockNumber,
     forceResync
   )
-  metricEndTimerFn(result)
+  metricEndTimerFn({ result })
 
   if (error) {
     throw new Error(error)
   }
 
-  return result
+  return { result }
 }

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -21,7 +21,6 @@ const {
 const { uploadTrack } = require('./lib/helpers')
 const BlacklistManager = require('../src/blacklistManager')
 const sessionManager = require('../src/sessionManager')
-const exportComponentService = require('../src/components/replicaSet/exportComponentService')
 
 const redisClient = require('../src/redis')
 const { stringifiedDateFields } = require('./lib/utils')


### PR DESCRIPTION
### Description
Remove labels that aren't used in the `audius_cn_secondary_sync_from_primary_duration_seconds_bucket` Prometheus metric. These extraneous labels are confusing when using `prometheus.constants` as a reference for creating Grafana panels.


### Tests
Make sure mad dog and tests pass -- this was just a cosmetic change.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Look for errors that start with `secondarySyncFromPrimary` or containing `is not included in initial labelset`.