### PR TITLE
Fix add track to playlist notification timestamp

### DIFF
--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -849,7 +849,7 @@ def notifications():
         )
         playlist_track_added_results = playlist_track_added_query.all()
         # Loop over all playlist updates and determine if there were tracks added
-        # at the block that the playlist update is at
+        # within the notification block range
         track_added_to_playlist_notifications = []
         track_ids = []
         for entry in playlist_track_added_results:
@@ -873,7 +873,9 @@ def notifications():
                     track_added_to_playlist_notification = {
                         const.notification_type: const.notification_type_add_track_to_playlist,
                         const.notification_blocknumber: entry.blocknumber,
-                        const.notification_timestamp: entry.created_at,
+                        const.notification_timestamp: datetime.fromtimestamp(
+                            track_timestamp
+                        ),
                         const.notification_initiator: entry.playlist_owner_id,
                     }
                     metadata = {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fix add track to playlist notification. Currently, the notification timestamp uses the playlist creation date so notification ordering is inaccurate. The new behavior uses the timestamp that the track was added to the playlist. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on staging.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Check for notification. 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->