### PR TITLE
Remove extra done() callback

### DIFF
--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -275,6 +275,10 @@ const handleSyncFromPrimary = async (
          * Every subsequent sync will enter the if case and update the existing local cnodeUserRecord.
          */
         if (cnodeUserRecord) {
+          logger.info(
+            logPrefix,
+            `cNodeUserRecord was non-empty -- updating CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
+          )
           const [numRowsUpdated, respObj] = await models.CNodeUser.update(
             {
               lastLogin: fetchedCNodeUser.lastLogin,
@@ -307,6 +311,10 @@ const handleSyncFromPrimary = async (
           }
           cnodeUser = respObj[0]
         } else {
+          logger.info(
+            logPrefix,
+            `cNodeUserRecord was empty -- inserting CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
+          )
           // Will throw error if creation fails
           cnodeUser = await models.CNodeUser.create(
             {
@@ -326,7 +334,7 @@ const handleSyncFromPrimary = async (
         const cnodeUserUUID = cnodeUser.cnodeUserUUID
         logger.info(
           logPrefix,
-          `Inserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}`
+          `Upserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
         )
 
         /**

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -277,13 +277,13 @@ const handleSyncFromPrimary = async (
         if (cnodeUserRecord) {
           logger.info(
             logPrefix,
-            `cNodeUserRecord was non-empty -- updating CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
+            `cNodeUserRecord was non-empty -- updating CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
           )
           const [numRowsUpdated, respObj] = await models.CNodeUser.update(
             {
               lastLogin: fetchedCNodeUser.lastLogin,
               latestBlockNumber: fetchedLatestBlockNumber,
-              clock: fetchedCNodeUser.clock,
+              clock: fetchedLatestClockVal,
               createdAt: fetchedCNodeUser.createdAt
             },
             {
@@ -313,7 +313,7 @@ const handleSyncFromPrimary = async (
         } else {
           logger.info(
             logPrefix,
-            `cNodeUserRecord was empty -- inserting CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
+            `cNodeUserRecord was empty -- inserting CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
           )
           // Will throw error if creation fails
           cnodeUser = await models.CNodeUser.create(
@@ -321,7 +321,7 @@ const handleSyncFromPrimary = async (
               walletPublicKey: fetchedWalletPublicKey,
               lastLogin: fetchedCNodeUser.lastLogin,
               latestBlockNumber: fetchedLatestBlockNumber,
-              clock: fetchedCNodeUser.clock,
+              clock: fetchedLatestClockVal,
               createdAt: fetchedCNodeUser.createdAt
             },
             {
@@ -334,7 +334,7 @@ const handleSyncFromPrimary = async (
         const cnodeUserUUID = cnodeUser.cnodeUserUUID
         logger.info(
           logPrefix,
-          `Upserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedCNodeUser?.clock}`
+          `Upserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedLatestClockVal}`
         )
 
         /**

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -33,7 +33,9 @@ class SyncImmediateQueue {
         removeOnFail: SYNC_QUEUE_HISTORY
       },
       settings: {
-        lockDuration: LOCK_DURATION
+        lockDuration: LOCK_DURATION,
+        // We never want to re-process stalled jobs
+        maxStalledCount: 0
       }
     })
 

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -46,7 +46,7 @@ class SyncQueue {
     const jobProcessorConcurrency = this.nodeConfig.get(
       'syncQueueMaxConcurrency'
     )
-    this.queue.process(jobProcessorConcurrency, async (job, done) => {
+    this.queue.process(jobProcessorConcurrency, async (job) => {
       const { walletPublicKeys, creatorNodeEndpoint, forceResync } = job.data
 
       try {
@@ -63,8 +63,6 @@ class SyncQueue {
           e.message
         )
       }
-
-      done()
     })
   }
 

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -31,7 +31,9 @@ class SyncQueue {
         removeOnFail: SYNC_QUEUE_HISTORY
       },
       settings: {
-        lockDuration: LOCK_DURATION
+        lockDuration: LOCK_DURATION,
+        // We never want to re-process stalled jobs
+        maxStalledCount: 0
       }
     })
 
@@ -49,8 +51,9 @@ class SyncQueue {
     this.queue.process(jobProcessorConcurrency, async (job) => {
       const { walletPublicKeys, creatorNodeEndpoint, forceResync } = job.data
 
+      let result = {}
       try {
-        await secondarySyncFromPrimary(
+        result = await secondarySyncFromPrimary(
           this.serviceRegistry,
           walletPublicKeys,
           creatorNodeEndpoint,
@@ -62,7 +65,10 @@ class SyncQueue {
           `secondarySyncFromPrimary failure for wallets ${walletPublicKeys} against ${creatorNodeEndpoint}`,
           e.message
         )
+        result = { error: e.message }
       }
+
+      return result
     })
   }
 


### PR DESCRIPTION
### Description
- Removes the extra `done()` from the sync processing queue to make our pattern consistent with other job processors. We should only use an async function or a `done()` callback in a job processor, but not both since this can potentially cause issues (the Bull dev flagged this previously).
- Adds `result` field to sync processing queue for debugging purposes
- Adds bull option to not reprocess stalled jobs for sync and sync-immediate queues


### Tests
Make sure mad dog passes.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor logs for `secondarySyncFromPrimary failure for wallets` errors.