### PR TITLE
INF-210 fix || exit 1 logic

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -51,11 +51,11 @@ function bump-npm () {
         fi
 
         # only allow tags/commits found on master, release branches, or tags to be deployed
+        echo "tag has to be on master or a release branch"
         git branch -a --contains ${GIT_TAG} \
             | tee /dev/tty \
             | grep -Eq 'remotes/origin/master|remotes/origin/release' \
-            || echo "tag not found on master nor release branches" \
-                && exit 1
+            || exit 1
 
         # Ensure working directory clean
         git reset --hard ${GIT_TAG}


### PR DESCRIPTION
### Description

Fix tricky logic around using `||`, `set -e`, and `function ||` together.

Now echo what is being checked and simply `exit 1` if the check fails.


### Tests

Manually deploying on `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->