### PR TITLE
INF-210 grab VERSION after exiting subshell that bumped version

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -135,4 +135,8 @@ cd ${PROTOCOL_DIR}/libs
 
 # perform release
 bump-npm
+
+# grab VERSION again since we escaped the bump-npm subshell
+VERSION=$(jq -r '.version' package.json)
+
 merge-bump && publish && info || cleanup


### PR DESCRIPTION
### Description

VERSION needs to be grabbed again since we now wrap bump-npm() within a subshell for better error detection.

### Tests

Manually deploy from `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->