### PR TITLE
INF-210 rename GIT_TAG to GIT_COMMIT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ commands:
 
 # global parameters
 parameters:
-  sdk_release_tag:
+  sdk_release_commit:
     type: string
     default: ""
   slack_mentions_user:
@@ -308,8 +308,8 @@ jobs:
       - image: circleci/node:14.17.5
     resource_class: xlarge
     parameters:
-      sdk_release_tag:
-        description: The git tag/commit to build and release
+      sdk_release_commit:
+        description: The git commit to build and release
         type: string
         default: ""
       slack_mentions_user:
@@ -333,7 +333,7 @@ jobs:
           name: Bump and Publish Libs
           command: |
             export PROTOCOL_DIR=/home/circleci/project
-            libs/scripts/release.sh << parameters.sdk_release_tag >>
+            libs/scripts/release.sh << parameters.sdk_release_commit >>
       - slack-fail:
           branch_pattern: master
           slack_mentions_user: << parameters.slack_mentions_user >>
@@ -955,7 +955,7 @@ workflows:
     when:
       and:
          - not: << pipeline.parameters.full_ci >>
-         - not: << pipeline.parameters.sdk_release_tag >>
+         - not: << pipeline.parameters.sdk_release_commit >>
     jobs:
       - test-libs:
           name: test-libs
@@ -1006,16 +1006,16 @@ workflows:
   # 1. go to the CircleCI dashboard
   # 2. go to your branch of choice
   # 3. click "Trigger Pipeline"
-  # 4. Add string paramter "sdk_release_tag" and set to a valid git tag/commit
+  # 4. Add string paramter "sdk_release_commit" and set to a valid git commit
   sdk-release:
-    when: << pipeline.parameters.sdk_release_tag >>
+    when: << pipeline.parameters.sdk_release_commit >>
     jobs:
       - publish-sdk:
           context:
             - Audius Client
             - slack-secrets
-          name: publish-sdk (<< pipeline.parameters.sdk_release_tag >>)
-          sdk_release_tag: << pipeline.parameters.sdk_release_tag >>
+          name: publish-sdk (<< pipeline.parameters.sdk_release_commit >>)
+          sdk_release_commit: << pipeline.parameters.sdk_release_commit >>
           slack_mentions_user: << pipeline.parameters.slack_mentions_user >>
           filters:
             branches:

--- a/.circleci/triggers/__init__.py
+++ b/.circleci/triggers/__init__.py
@@ -46,14 +46,14 @@ def standardize_branch(branches):
     return result
 
 
-def ensure_tag_on_master(tag):
-    """Ensure tag has been merged before proceeding"""
-    if tag == "master":
+def ensure_commit_on_master(commit):
+    """Ensure commit has been merged before proceeding"""
+    if commit == "master":
         print("Commit cannot be 'master'.")
         exit(1)
     try:
         branches = run_cmd(
-            f"git branch -a --contains {tag}", exit_on_error=False
+            f"git branch -a --contains {commit}", exit_on_error=False
         ).split("\n")
     except:
         branches = ["missing"]

--- a/.circleci/triggers/deploy-sdk.py
+++ b/.circleci/triggers/deploy-sdk.py
@@ -11,9 +11,7 @@ from triggers import ensure_commit_on_master
 
 @click.command()
 @click.help_option("-h", "--help")
-@click.option(
-    "-t", "--git-commit", help="Git commit to deploy from.", required=True
-)
+@click.option("-t", "--git-commit", help="Git commit to deploy from.", required=True)
 @click.option(
     "-k",
     "--circle-api-key",

--- a/.circleci/triggers/deploy-sdk.py
+++ b/.circleci/triggers/deploy-sdk.py
@@ -6,13 +6,13 @@ from pprint import pprint
 
 import click
 import requests
-from triggers import ensure_tag_on_master
+from triggers import ensure_commit_on_master
 
 
 @click.command()
 @click.help_option("-h", "--help")
 @click.option(
-    "-t", "--git-tag", help="Git tag or commit to deploy from.", required=True
+    "-t", "--git-commit", help="Git commit to deploy from.", required=True
 )
 @click.option(
     "-k",
@@ -28,16 +28,16 @@ from triggers import ensure_tag_on_master
     envvar="CIRCLE_SLACK_MENTIONS_USER",
     required=True,
 )
-def cli(git_tag, circle_api_key, slack_mentions_user):
-    # only allow merged git_tags to be deployed
-    ensure_tag_on_master(git_tag)
+def cli(git_commit, circle_api_key, slack_mentions_user):
+    # only allow merged commits to be deployed
+    ensure_commit_on_master(git_commit)
 
     # trigger a circleci job
     project = "audius-protocol"
     data = {
         "branch": "master",
         "parameters": {
-            "sdk_release_tag": git_tag,
+            "sdk_release_commit": git_commit,
             "slack_mentions_user": slack_mentions_user,
         },
     }

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -4,7 +4,7 @@ if [[ -z ${1} ]]; then
     echo "A git tag must be supplied as the first parameter."
     exit 1
 else
-    GIT_TAG=${1}
+    GIT_HASH=${1}
 fi
 
 if [[ $(whoami) != "circleci" ]]; then
@@ -33,7 +33,7 @@ function commit-message () {
 ${CHANGE_LOG}"
 }
 
-# Make a new branch off GIT_TAG, bumps npm,
+# Make a new branch off GIT_HASH, bumps npm,
 # commits with the relevant changelog, and pushes
 function bump-npm () {
     (
@@ -45,20 +45,20 @@ function bump-npm () {
         git checkout master -f
         git pull
 
-        if [[ "${GIT_TAG}" == "master" ]]; then
+        if [[ "${GIT_HASH}" == "master" ]]; then
             echo "Commit cannot be 'master'."
             exit 1
         fi
 
         # only allow tags/commits found on master, release branches, or tags to be deployed
         echo "tag has to be on master or a release branch"
-        git branch -a --contains ${GIT_TAG} \
+        git branch -a --contains ${GIT_HASH} \
             | tee /dev/tty \
             | grep -Eq 'remotes/origin/master|remotes/origin/release' \
             || exit 1
 
         # Ensure working directory clean
-        git reset --hard ${GIT_TAG}
+        git reset --hard ${GIT_HASH}
 
         # grab change log early, before the version bump
         LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
@@ -67,7 +67,7 @@ function bump-npm () {
         # Patch the version
         VERSION=$(npm version patch)
         tmp=$(mktemp)
-        jq ". += {audius: {releaseSHA: \"${GIT_TAG}\"}}" package.json > "$tmp" \
+        jq ". += {audius: {releaseSHA: \"${GIT_HASH}\"}}" package.json > "$tmp" \
             && mv "$tmp" package.json
 
         # Build project

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 if [[ -z ${1} ]]; then
-    echo "A git tag must be supplied as the first parameter."
+    echo "A git commit must be supplied as the first parameter."
     exit 1
 else
-    GIT_HASH=${1}
+    GIT_COMMIT=${1}
 fi
 
 if [[ $(whoami) != "circleci" ]]; then
@@ -33,7 +33,7 @@ function commit-message () {
 ${CHANGE_LOG}"
 }
 
-# Make a new branch off GIT_HASH, bumps npm,
+# Make a new branch off GIT_COMMIT, bumps npm,
 # commits with the relevant changelog, and pushes
 function bump-npm () {
     (
@@ -45,20 +45,20 @@ function bump-npm () {
         git checkout master -f
         git pull
 
-        if [[ "${GIT_HASH}" == "master" ]]; then
+        if [[ "${GIT_COMMIT}" == "master" ]]; then
             echo "Commit cannot be 'master'."
             exit 1
         fi
 
-        # only allow tags/commits found on master, release branches, or tags to be deployed
-        echo "tag has to be on master or a release branch"
-        git branch -a --contains ${GIT_HASH} \
+        # only allow commits found on master or release branches to be deployed
+        echo "commit has to be on master or a release branch"
+        git branch -a --contains ${GIT_COMMIT} \
             | tee /dev/tty \
             | grep -Eq 'remotes/origin/master|remotes/origin/release' \
             || exit 1
 
         # Ensure working directory clean
-        git reset --hard ${GIT_HASH}
+        git reset --hard ${GIT_COMMIT}
 
         # grab change log early, before the version bump
         LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
@@ -67,7 +67,7 @@ function bump-npm () {
         # Patch the version
         VERSION=$(npm version patch)
         tmp=$(mktemp)
-        jq ". += {audius: {releaseSHA: \"${GIT_HASH}\"}}" package.json > "$tmp" \
+        jq ". += {audius: {releaseSHA: \"${GIT_COMMIT}\"}}" package.json > "$tmp" \
             && mv "$tmp" package.json
 
         # Build project

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -135,4 +135,8 @@ cd ${PROTOCOL_DIR}/libs
 
 # perform release
 bump-npm
+
+# grab VERSION again since we escaped the bump-npm subshell
+VERSION=$(jq -r '.version' package.json)
+
 merge-bump && publish && info || cleanup


### PR DESCRIPTION
### Description

As per @dylanjeffers 's suggestion to not overload the git term "tag".

Updated Notion docs to reflect change as well.

### Tests

Manually deploying sdk on `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->