### PR TITLE
Fix core libs bundle so it can be consumed in client

### DIFF
--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -125,7 +125,7 @@ export default [
   {
     input: 'src/sdk/index.ts',
     output: [
-      { file: 'dist/index.browser.cjs.js', format: 'es', sourcemap: true },
+      { file: 'dist/index.browser.cjs.js', format: 'cjs', sourcemap: true },
       { file: 'dist/index.browser.esm.js', format: 'es', sourcemap: true }
     ],
     ...browserConfig
@@ -168,7 +168,7 @@ export default [
    */
   {
     input: 'src/native-libs.ts',
-    output: [{ file: 'dist/native-libs.js', format: 'esm', sourcemap: true }],
+    output: [{ file: 'dist/native-libs.js', format: 'es', sourcemap: true }],
     ...browserLegacyConfig
   },
 
@@ -177,10 +177,7 @@ export default [
    */
   {
     input: 'src/core.ts',
-    output: [
-      { file: 'dist/core.cjs.js', format: 'cjs', sourcemap: true },
-      { file: 'dist/core.esm.js', format: 'es', sourcemap: true }
-    ],
+    output: [{ file: 'dist/core.js', format: 'es', sourcemap: true }],
     ...commonConfig
   }
 ]


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

* Removes the cjs core bundle and only exposes the es one
* Fixes a typo where the cjs browser bundle was actually esm


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->