### PR TITLE
Clear running migrations on server start

### DIFF
--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -28,8 +28,6 @@ const verifyDBConnection = async () => {
 
 const runDBMigrations = async () => {
   try {
-    logger.info('Clearing running db queries...')
-    clearRunningQueries()
     logger.info('Executing database migrations...')
     await runMigrations()
     logger.info('Migrations completed successfully')
@@ -40,6 +38,7 @@ const runDBMigrations = async () => {
 
 const connectToDBAndRunMigrations = async () => {
   await verifyDBConnection()
+  await clearRunningQueries()
   await runDBMigrations()
 }
 

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -7,7 +7,7 @@ const { Keypair } = require('@solana/web3.js')
 const initializeApp = require('./app')
 const config = require('./config')
 const { sequelize } = require('./models')
-const { runMigrations } = require('./migrationManager')
+const { runMigrations, clearRunningQueries } = require('./migrationManager')
 const { logger } = require('./logging')
 const { serviceRegistry } = require('./serviceRegistry')
 
@@ -28,6 +28,8 @@ const verifyDBConnection = async () => {
 
 const runDBMigrations = async () => {
   try {
+    logger.info('Clearing running db queries...')
+    clearRunningQueries()
     logger.info('Executing database migrations...')
     await runMigrations()
     logger.info('Migrations completed successfully')

--- a/creator-node/src/migrationManager.js
+++ b/creator-node/src/migrationManager.js
@@ -28,6 +28,7 @@ async function clearDatabase() {
 }
 
 async function clearRunningQueries() {
+  logger.info(`Clearing running db queries...`)
   try {
     await sequelize.query(`
     BEGIN;
@@ -43,7 +44,7 @@ async function clearRunningQueries() {
     COMMIT;
   `)
   } catch (e) {
-    logger.info(
+    logger.error(
       `Error running clearRunningQueries: ${e.message}. Continuing with content node setup`
     )
   }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Clear running db migrations on content node server init.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Used psql to print running queries, restarted the server to run the clearRunningQueries() function and confirmed that the previously running queries are no longer running.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Use psql or navicat to check the running queries on a db after init, should be empty

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->