### PR TITLE
INF-210 include change log in commit and tag

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -33,9 +33,8 @@ function commit-message () {
 ${CHANGE_LOG}"
 }
 
-# Make a new branch off GIT_COMMIT, bumps npm,
-# commits with the relevant changelog, and pushes
-function bump-npm () {
+# Pull in master, ensure commit is on master, ensure clean build environment
+function git-reset () {
     (
         # Configure git client
         git config --global user.email "audius-infra@audius.co"
@@ -59,11 +58,13 @@ function bump-npm () {
 
         # Ensure working directory clean
         git reset --hard ${GIT_COMMIT}
+    )
+}
 
-        # grab change log early, before the version bump
-        LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
-        CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
-
+# Make a new branch off GIT_COMMIT, bumps npm,
+# commits with the relevant changelog, and pushes
+function bump-npm () {
+    (
         # Patch the version
         VERSION=$(npm version patch)
         tmp=$(mktemp)
@@ -133,7 +134,14 @@ function cleanup () {
 STUB=sdk
 cd ${PROTOCOL_DIR}/libs
 
-# perform release
+# pull in master
+git-reset
+
+# grab change log early, before the version bump
+LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
+CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
+
+# perform version bump and perform publishing dry-run
 bump-npm
 
 # grab VERSION again since we escaped the bump-npm subshell

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -63,7 +63,7 @@ function git-reset () {
 
 # Make a new branch off GIT_COMMIT, bumps npm,
 # commits with the relevant changelog, and pushes
-function bump-npm () {
+function bump-version () {
     (
         # Patch the version
         VERSION=$(npm version patch)
@@ -142,9 +142,9 @@ LAST_RELEASED_SHA=$(jq -r '.audius.releaseSHA' package.json)
 CHANGE_LOG=$(git-changelog ${LAST_RELEASED_SHA})
 
 # perform version bump and perform publishing dry-run
-bump-npm
+bump-version
 
-# grab VERSION again since we escaped the bump-npm subshell
+# grab VERSION again since we escaped the bump-version subshell
 VERSION=v$(jq -r '.version' package.json)
 
 merge-bump && publish && info || cleanup


### PR DESCRIPTION
### Description

Because we're making use of a subshell for better error handling, we need to define $CHANGE_LOG outside of a subshell so it propagates to multiple subshells.


### Tests

Manually releasing off `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->