### PR TITLE
[C-749] Support req pagination and ordering in hist/fav/tracks

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_tracks.py
+++ b/discovery-provider/integration_tests/queries/test_get_tracks.py
@@ -11,49 +11,62 @@ def populate_tracks(db):
         "tracks": [
             {
                 "track_id": 1,
+                "title": "track 1",
                 "owner_id": 1287289,
                 "release_date": "Fri Dec 20 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2018, 5, 17),
             },
-            {"track_id": 2, "owner_id": 1287289, "created_at": datetime(2018, 5, 18)},
+            {
+                "track_id": 2,
+                "title": "track 2",
+                "owner_id": 1287289,
+                "created_at": datetime(2018, 5, 18),
+            },
             {
                 "track_id": 3,
+                "title": "track 3",
                 "owner_id": 1287289,
                 "release_date": "Wed Dec 18 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2020, 5, 17),
             },
             {
                 "track_id": 4,
+                "title": "track 4",
                 "owner_id": 1287289,
                 "release_date": "",
                 "created_at": datetime(2018, 5, 19),
             },
             {
                 "track_id": 5,
+                "title": "track 5",
                 "owner_id": 1287289,
                 "release_date": "garbage-should-not-parse",
                 "created_at": datetime(2018, 5, 20),
             },
             {
                 "track_id": 6,
+                "title": "track 6",
                 "owner_id": 4,
                 "release_date": "Wed Dec 18 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2020, 5, 17),
             },
             {
                 "track_id": 7,
+                "title": "track 7",
                 "owner_id": 4,
                 "release_date": "",
                 "created_at": datetime(2018, 5, 19),
             },
             {
                 "track_id": 8,
+                "title": "track 8",
                 "owner_id": 4,
                 "release_date": "garbage-should-not-parse",
                 "created_at": datetime(2018, 5, 20),
             },
             {
                 "track_id": 9,
+                "title": "track 9",
                 "owner_id": 4,
                 "release_date": "Wed Dec 25 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2018, 5, 20),
@@ -61,6 +74,7 @@ def populate_tracks(db):
             },
             {
                 "track_id": 10,
+                "title": "track 10",
                 "owner_id": 4,
                 "release_date": "Wed Dec 25 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2018, 5, 21),
@@ -68,6 +82,7 @@ def populate_tracks(db):
             },
             {
                 "track_id": 11,
+                "title": "track 11",
                 "owner_id": 1287289,
                 "release_date": "Fri Dec 19 2019 12:00:00 GMT-0800",
                 "created_at": datetime(2018, 5, 17),
@@ -129,6 +144,23 @@ def test_get_tracks_by_date(app):
 
         assert tracks[0]["permalink"] == "/some-test-user/track-1"
         assert tracks[4]["permalink"] == "/some-test-user/track-2"
+
+
+def test_get_tracks_with_query(app):
+    """Test getting tracks with a query"""
+
+    with app.app_context():
+        db = get_db()
+
+    populate_tracks(db)
+
+    with db.scoped_session() as session:
+        tracks = _get_tracks(
+            session, {"user_id": 1287289, "offset": 0, "limit": 10, "query": "track 5"}
+        )
+
+        assert len(tracks) == 1
+        assert tracks[0]["track_id"] == 5
 
 
 def test_get_tracks_by_date_authed(app):

--- a/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
+++ b/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
@@ -51,10 +51,7 @@ def test_get_user_listening_history_multiple_plays(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1,
-                current_user_id=1,
-                limit=10,
-                offset=0,
+                user_id=1, current_user_id=1, limit=10, offset=0, query=None
             ),
         )
 
@@ -98,10 +95,7 @@ def test_get_user_listening_history_no_plays(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=3,
-                current_user_id=3,
-                limit=10,
-                offset=0,
+                user_id=3, current_user_id=3, limit=10, offset=0, query=None
             ),
         )
 
@@ -121,10 +115,7 @@ def test_get_user_listening_history_single_play(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=2,
-                current_user_id=2,
-                limit=10,
-                offset=0,
+                user_id=2, current_user_id=2, limit=10, offset=0, query=None
             ),
         )
 
@@ -152,10 +143,7 @@ def test_get_user_listening_history_pagination(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1,
-                current_user_id=1,
-                limit=1,
-                offset=1,
+                user_id=1, current_user_id=1, limit=1, offset=1, query=None
             ),
         )
 
@@ -183,11 +171,34 @@ def test_get_user_listening_history_mismatch_user_id(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1,
-                current_user_id=2,
-                limit=10,
-                offset=0,
+                user_id=1, current_user_id=2, limit=10, offset=0, query=None
             ),
         )
 
     assert len(track_history) == 0
+
+
+def test_get_user_listening_history_with_query(app):
+    """Tests listening history from user with a query"""
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, test_entities)
+
+    with db.scoped_session() as session:
+        _index_user_listening_history(session)
+
+        track_history = _get_user_listening_history(
+            session,
+            GetUserListeningHistoryArgs(
+                user_id=1, current_user_id=1, limit=10, offset=0, query="track 2"
+            ),
+        )
+
+    # We should only get one history item back
+    assert len(track_history) == 1
+
+    assert track_history[0][response_name_constants.track_id] == 2
+    assert track_history[0][response_name_constants.activity_timestamp] == str(
+        TIMESTAMP + timedelta(minutes=3)
+    )

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -4,6 +4,7 @@ from typing import Dict, cast
 
 from flask_restx import reqparse
 from src import api_helpers
+from src.api.v1.models.common import full_response
 from src.models.rewards.challenge import ChallengeType
 from src.queries.get_challenges import ChallengeResponse
 from src.queries.get_support_for_user import SupportResponse
@@ -12,8 +13,6 @@ from src.queries.reactions import ReactionResponse
 from src.utils.config import shared_config
 from src.utils.helpers import decode_string_id, encode_int_id
 from src.utils.spl_audio import to_wei_string
-
-from .models.common import full_response
 
 logger = logging.getLogger(__name__)
 
@@ -487,6 +486,29 @@ pagination_with_current_user_parser.add_argument(
 search_parser = reqparse.RequestParser(argument_class=DescriptiveArgument)
 search_parser.add_argument("query", required=True, description="The search query")
 
+track_history_parser = pagination_with_current_user_parser.copy()
+track_history_parser.add_argument(
+    "query", required=False, description="The filter query"
+)
+
+user_favorited_tracks_parser = pagination_with_current_user_parser.copy()
+user_favorited_tracks_parser.add_argument(
+    "query", required=False, description="The filter query"
+)
+
+user_tracks_route_parser = pagination_with_current_user_parser.copy()
+user_tracks_route_parser.add_argument(
+    "sort",
+    required=False,
+    type=str,
+    default="date",
+    choices=("date", "plays"),
+    description="Field to sort by",
+)
+user_tracks_route_parser.add_argument(
+    "query", required=False, description="The filter query"
+)
+
 full_search_parser = pagination_with_current_user_parser.copy()
 full_search_parser.add_argument("query", required=True, description="The search query")
 full_search_parser.add_argument(
@@ -550,6 +572,10 @@ def format_offset(args, max_offset=MAX_LIMIT):
     if offset is None:
         return DEFAULT_OFFSET
     return max(min(int(offset), max_offset), MIN_OFFSET)
+
+
+def format_query(args):
+    return args.get("query", None)
 
 
 def get_default_max(value, default, max=None):

--- a/discovery-provider/src/queries/get_save_tracks.py
+++ b/discovery-provider/src/queries/get_save_tracks.py
@@ -1,5 +1,7 @@
+from sqlalchemy import or_
 from src.models.social.save import Save, SaveType
 from src.models.tracks.track import Track
+from src.models.users.user import User
 from src.queries import response_name_constants
 from src.queries.query_helpers import (
     add_query_pagination,
@@ -37,7 +39,12 @@ def get_save_tracks(args):
             base_query = base_query.filter(Track.is_delete == False)
 
         if query:
-            base_query = base_query.filter(Track.title.ilike(f"%{query.lower()}%"))
+            base_query = base_query.join(Track.user, aliased=True).filter(
+                or_(
+                    Track.title.ilike(f"%{query.lower()}%"),
+                    User.name.ilike(f"%{query.lower()}%"),
+                )
+            )
 
         base_query = base_query.order_by(Save.created_at.desc(), Track.track_id.desc())
 

--- a/discovery-provider/src/queries/get_save_tracks.py
+++ b/discovery-provider/src/queries/get_save_tracks.py
@@ -3,8 +3,7 @@ from src.models.tracks.track import Track
 from src.queries import response_name_constants
 from src.queries.query_helpers import (
     add_query_pagination,
-    get_users_by_id,
-    get_users_ids,
+    add_users_to_tracks,
     populate_track_metadata,
 )
 from src.utils import helpers
@@ -17,6 +16,7 @@ def get_save_tracks(args):
     limit = args.get("limit")
     offset = args.get("offset")
     filter_deleted = args.get("filter_deleted")
+    query = args.get("query")
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
@@ -36,6 +36,9 @@ def get_save_tracks(args):
         if filter_deleted:
             base_query = base_query.filter(Track.is_delete == False)
 
+        if query:
+            base_query = base_query.filter(Track.title.ilike(f"%{query.lower()}%"))
+
         base_query = base_query.order_by(Save.created_at.desc(), Track.track_id.desc())
 
         query_results = add_query_pagination(base_query, limit, offset).all()
@@ -49,14 +52,7 @@ def get_save_tracks(args):
 
         # bundle peripheral info into track results
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
-
-        if args.get("with_users", False):
-            user_id_list = get_users_ids(tracks)
-            users = get_users_by_id(session, user_id_list, current_user_id)
-            for track in tracks:
-                user = users[track["owner_id"]]
-                if user:
-                    track["user"] = user
+        add_users_to_tracks(session, tracks, current_user_id)
 
         for idx, track in enumerate(tracks):
             track[response_name_constants.activity_timestamp] = save_dates[idx]

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -37,6 +37,7 @@ class GetTrackArgs(TypedDict):
     authed_user_id: Optional[int]
     min_block_number: int
     sort: str
+    query: Optional[str]
     filter_deleted: bool
     routes: List[RouteArgs]
     with_users: bool
@@ -98,6 +99,10 @@ def _get_tracks(session, args):
     if "min_block_number" in args:
         min_block_number = args.get("min_block_number")
         base_query = base_query.filter(Track.blocknumber >= min_block_number)
+
+    if "query" in args:
+        query = args.get("query")
+        base_query = base_query.filter(Track.title.ilike(f"%{query.lower()}%"))
 
     if "sort" in args:
         if args["sort"] == "date":

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -102,7 +102,12 @@ def _get_tracks(session, args):
 
     if "query" in args:
         query = args.get("query")
-        base_query = base_query.filter(Track.title.ilike(f"%{query.lower()}%"))
+        base_query = base_query.join(Track.user, aliased=True).filter(
+            or_(
+                Track.title.ilike(f"%{query.lower()}%"),
+                User.name.ilike(f"%{query.lower()}%"),
+            )
+        )
 
     if "sort" in args:
         if args["sort"] == "date":

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -4,11 +4,7 @@ from sqlalchemy import desc
 from sqlalchemy.orm.session import Session
 from src.models.tracks.track_trending_score import TrackTrendingScore
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
-from src.queries.query_helpers import (
-    get_users_by_id,
-    get_users_ids,
-    populate_track_metadata,
-)
+from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
 from src.tasks.generate_trending import generate_trending
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
@@ -143,11 +139,5 @@ def _get_trending_tracks_with_session(
     # Re-sort the populated tracks b/c it loses sort order in sql query
     sorted_tracks = [tracks_map[track_id] for track_id in track_ids]
 
-    if args.get("with_users", False):
-        user_id_list = get_users_ids(sorted_tracks)
-        users = get_users_by_id(session, user_id_list, current_user_id)
-        for track in sorted_tracks:
-            user = users[track["owner_id"]]
-            if user:
-                track["user"] = user
+    add_users_to_tracks(session, tracks, current_user_id)
     return sorted_tracks

--- a/discovery-provider/src/queries/get_user_listening_history.py
+++ b/discovery-provider/src/queries/get_user_listening_history.py
@@ -109,10 +109,6 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     # Add pagination
     base_query = add_query_pagination(base_query, limit, offset)
     base_query = base_query.all()
-    import logging
-
-    logger = logging.getLogger(__name__)
-    logger.info(f"raymont {base_query}")
     track_ids = track_ids[offset : offset + limit]
 
     tracks = helpers.query_result_to_list(base_query)

--- a/discovery-provider/src/queries/get_user_listening_history.py
+++ b/discovery-provider/src/queries/get_user_listening_history.py
@@ -1,10 +1,15 @@
-from typing import TypedDict
+from typing import Optional, TypedDict
 
+from sqlalchemy import Integer, String, text
 from sqlalchemy.orm.session import Session
 from src.models.tracks.track import Track
 from src.models.users.user_listening_history import UserListeningHistory
 from src.queries import response_name_constants
-from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
+from src.queries.query_helpers import (
+    add_query_pagination,
+    add_users_to_tracks,
+    populate_track_metadata,
+)
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 
@@ -21,6 +26,9 @@ class GetUserListeningHistoryArgs(TypedDict):
 
     # The offset for the listen history
     offset: int
+
+    # Optional filter for the returned results
+    query: Optional[str]
 
 
 def get_user_listening_history(args: GetUserListeningHistoryArgs):
@@ -44,6 +52,7 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     current_user_id = args["current_user_id"]
     limit = args["limit"]
     offset = args["offset"]
+    query = args["query"]
 
     if user_id != current_user_id:
         return []
@@ -57,34 +66,54 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     if not listening_history_results:
         return []
 
-    # add query pagination
-    listening_history_results = listening_history_results[offset : offset + limit]
-
+    # Map out all track ids and listen dates
     track_ids = []
-    listen_dates = []
+    listen_dates = {}
     for listen in listening_history_results:
         track_ids.append(listen["track_id"])
-        listen_dates.append(listen["timestamp"])
+        listen_dates[listen["track_id"]] = listen["timestamp"]
 
-    track_results = (session.query(Track).filter(Track.track_id.in_(track_ids))).all()
+    # Order by the listening history order
+    # This helper just makes sure that we can order by the same ordering
+    # of track ids in the history results
+    # https://stackoverflow.com/questions/866465/order-by-the-in-value-list
+    order = (
+        text(
+            """
+        SELECT * 
+        FROM unnest(:track_ids) WITH ORDINALITY t(id, ord)
+        """
+        )
+        .bindparams(track_ids=track_ids)
+        .columns(id=String, ord=Integer)
+        .alias()
+    )
 
-    track_results_dict = {
-        track_result.track_id: track_result for track_result in track_results
-    }
+    track_results = (
+        session.query(Track)
+        .join(order, order.c.id == Track.track_id)
+        .filter(Track.track_id.in_(track_ids))
+    )
 
-    # sort tracks in listening history order
-    sorted_track_results = []
-    for track_id in track_ids:
-        if track_id in track_results_dict:
-            sorted_track_results.append(track_results_dict[track_id])
+    if query is not None:
+        track_results = track_results.filter(Track.title.ilike(f"%{query.lower()}%"))
 
-    tracks = helpers.query_result_to_list(sorted_track_results)
+    track_results = track_results.order_by(order.c.ord)
+
+    # Add pagination
+    track_results = add_query_pagination(track_results, limit, offset)
+    track_results = track_results.all()
+    track_ids = track_ids[offset : offset + limit]
+
+    tracks = helpers.query_result_to_list(track_results)
 
     # bundle peripheral info into track results
     tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
     add_users_to_tracks(session, tracks, current_user_id)
 
-    for idx, track in enumerate(tracks):
-        track[response_name_constants.activity_timestamp] = listen_dates[idx]
+    for track in tracks:
+        track[response_name_constants.activity_timestamp] = listen_dates[
+            track[response_name_constants.track_id]
+        ]
 
     return tracks

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -21,7 +21,7 @@ from src.models.users.user import User
 from src.models.users.user_bank import UserBankAccount
 from src.queries import response_name_constants
 from src.queries.get_balances import get_balances
-from src.queries.get_unpopulated_users import get_unpopulated_users, set_users_in_cache
+from src.queries.get_unpopulated_users import get_unpopulated_users
 from src.trending_strategies.trending_type_and_version import TrendingVersion
 from src.utils import helpers, redis_connection
 
@@ -1214,15 +1214,9 @@ def add_users_to_tracks(session, tracks, current_user_id=None):
 
     Returns: None
     """
-    user_ids = get_users_ids(tracks)
-    users = []
-    if tracks and len(tracks) > 0 and tracks[0].get("user"):
-        users = list(map(lambda t: t["user"][0], tracks))
-    else:
-        # This shouldn't happen - all tracks should come preloaded with their owners per the relationship
-        users = get_unpopulated_users(session, user_ids)
-        logger.warning("add_users_to_tracks() called but tracks have no users")
-    set_users_in_cache(users)
+    users = [t.get("user")[0] for t in tracks]
+    user_ids = [u.get("user_id") for u in users]
+
     # bundle peripheral info into user results
     populated_users = populate_user_metadata(session, user_ids, users, current_user_id)
     user_map = {}

--- a/libs/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -303,6 +303,10 @@ export interface GetTracksByUserRequest {
      * Field to sort by
      */
     sort?: GetTracksByUserSortEnum;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -326,6 +330,10 @@ export interface GetTracksByUserHandleRequest {
      * Field to sort by
      */
     sort?: GetTracksByUserHandleSortEnum;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface GetUserRequest {
@@ -370,6 +378,10 @@ export interface GetUsersTrackHistoryRequest {
      * The user ID of the user making the request
      */
     userId?: string;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface SearchUsersRequest {
@@ -810,6 +822,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort'] = requestParameters.sort;
         }
 
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -844,6 +860,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.sort !== undefined) {
             queryParameters['sort'] = requestParameters.sort;
+        }
+
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -944,6 +964,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.userId !== undefined) {
             queryParameters['user_id'] = requestParameters.userId;
+        }
+
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -74,6 +74,10 @@ export interface GetFavoritesRequest {
      * The user ID of the user making the request
      */
     userId?: string;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface GetFollowersRequest {
@@ -286,6 +290,10 @@ export interface GetTracksByUserRequest {
      * Field to sort by
      */
     sort?: GetTracksByUserSortEnum;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -309,6 +317,10 @@ export interface GetTracksByUserHandleRequest {
      * Field to sort by
      */
     sort?: GetTracksByUserHandleSortEnum;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 export interface GetUserRequest {
@@ -350,6 +362,10 @@ export interface GetUsersTrackHistoryRequest {
      * The user ID of the user making the request
      */
     userId?: string;
+    /**
+     * The filter query
+     */
+    query?: string;
 }
 
 /**
@@ -377,6 +393,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.userId !== undefined) {
             queryParameters['user_id'] = requestParameters.userId;
+        }
+
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -747,6 +767,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort'] = requestParameters.sort;
         }
 
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -781,6 +805,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.sort !== undefined) {
             queryParameters['sort'] = requestParameters.sort;
+        }
+
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -861,6 +889,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.userId !== undefined) {
             queryParameters['user_id'] = requestParameters.userId;
+        }
+
+        if (requestParameters.query !== undefined) {
+            queryParameters['query'] = requestParameters.query;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Support simple filter on history/faves/tracks for respective table views in client.

The next step is sorters, which is a bit more complex because we don't join with users up front. We should actually change this though -- it should be all in one join RT to the db. This should be possible, but needs a tiny bit of reworking. After this step, we can make the ilike queries here to include artist name, which would be nice. Eventually gql/ES is the way to go here though.
--> EDIT: Part of this was added to this PR b/c we already have the relationship @rickyrombo  added :)

And the third step will be to add total count via the `X-Total-Count` which will be a perf hit b/c that would be a count(*) in addition to the queries. Possibly we don't want that for everything, but it's necessary at least on the artist dashboard side.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Units + local stack pointed at db snapshot

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->