### PR TITLE
Fix legacy and sdk types, monitoringCallbacks, native exports

### DIFF
--- a/libs/rollup.config.js
+++ b/libs/rollup.config.js
@@ -157,7 +157,7 @@ export default [
    * Includes libs but does not include polyfills
    */
   {
-    input: 'src/index.ts',
+    input: 'src/legacy.ts',
     output: [{ file: 'dist/legacy.js', format: 'cjs', sourcemap: true }],
     ...browserLegacyConfig
   },

--- a/libs/src/AudiusLibs.ts
+++ b/libs/src/AudiusLibs.ts
@@ -20,11 +20,7 @@ import { IdentityService } from './services/identity'
 import { Comstock } from './services/comstock'
 import { Hedgehog, HedgehogConfig } from './services/hedgehog'
 import type { Hedgehog as HedgehogBase } from '@audius/hedgehog'
-import {
-  CreatorNode,
-  CreatorNodeConfig,
-  MonitoringCallbacks
-} from './services/creatorNode'
+import { CreatorNode, CreatorNodeConfig } from './services/creatorNode'
 import {
   DiscoveryProvider,
   DiscoveryProviderConfig
@@ -48,6 +44,7 @@ import Web3 from './LibsWeb3'
 import { Keypair, PublicKey } from '@solana/web3.js'
 import { getPlatformLocalStorage, LocalStorage } from './utils/localStorage'
 import type { BaseConstructorArgs } from './api/base'
+import type { MonitoringCallbacks } from './services/types'
 
 type LibsIdentityServiceConfig = {
   url: string

--- a/libs/src/NativeAudiusLibs.ts
+++ b/libs/src/NativeAudiusLibs.ts
@@ -4,11 +4,7 @@ import { version } from './version'
 import type { SolanaWeb3Config } from './services/solana'
 import { Hedgehog, HedgehogConfig } from './services/hedgehog'
 import type { Hedgehog as HedgehogBase } from '@audius/hedgehog'
-import {
-  CreatorNode,
-  CreatorNodeConfig,
-  MonitoringCallbacks
-} from './services/creatorNode'
+import { CreatorNode, CreatorNodeConfig } from './services/creatorNode'
 import {
   DiscoveryProvider,
   DiscoveryProviderConfig
@@ -34,6 +30,7 @@ import { Reactions } from './api/Reactions'
 import { File } from './api/File'
 import { ServiceProvider } from './api/ServiceProvider'
 import type { BaseConstructorArgs } from './api/base'
+import type { MonitoringCallbacks } from './services/types'
 
 type LibsIdentityServiceConfig = {
   url: string
@@ -124,6 +121,7 @@ export class AudiusLibs {
     web3Provider: string,
     // network chain id
     networkId: string,
+
     // wallet address to force use instead of the first wallet on the provided web3
     walletOverride: Nullable<string> = null
   ) {
@@ -207,6 +205,30 @@ export class AudiusLibs {
       claimDistributionContractAddress,
       wormholeContractAddress
     }
+  }
+
+  /**
+   * Configures wormhole
+   * This is a stubbed version for native
+   */
+  static configWormhole() {
+    return {}
+  }
+
+  /**
+   * Configures a solana web3
+   * This is a stubbed version for native
+   */
+  static configSolanaWeb3() {
+    return {}
+  }
+
+  /**
+   * Configures a solana audius-data
+   * This is a stubbed version for native
+   */
+  static configSolanaAudiusData() {
+    return {}
   }
 
   version: string
@@ -492,3 +514,6 @@ export class AudiusLibs {
     this.Reactions = new Reactions(...services)
   }
 }
+
+export { Utils } from './utils'
+export { SanityChecks } from './sanityChecks'

--- a/libs/src/index.ts
+++ b/libs/src/index.ts
@@ -1,7 +1,1 @@
-export { sdk } from './sdk'
-
-/**
- * @deprecated Please migrate to using `sdk` when possible
- */
-export * from './AudiusLibs'
-export * from './AudiusLibsLegacyShim'
+export * from './sdk'

--- a/libs/src/index.ts
+++ b/libs/src/index.ts
@@ -1,1 +1,1 @@
-export * from './sdk'
+export * from './legacy'

--- a/libs/src/legacy.ts
+++ b/libs/src/legacy.ts
@@ -1,0 +1,4 @@
+export { sdk } from './sdk'
+
+export * from './AudiusLibs'
+export * from './AudiusLibsLegacyShim'

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -9,6 +9,7 @@ import {
 } from '../schemaValidator/SchemaValidator'
 import type { Web3Manager } from '../web3Manager'
 import type { CurrentUser, UserStateManager } from '../../userStateManager'
+import type { MonitoringCallbacks } from '../types'
 
 const { wait } = Utils
 
@@ -17,11 +18,6 @@ const POLL_STATUS_INTERVAL = 3000 // 3s
 const BROWSER_SESSION_REFRESH_TIMEOUT = 604800000 // 1 week
 
 type ProgressCB = (loaded: number, total: number) => void
-
-export type MonitoringCallbacks = {
-  request?: Function
-  healthCheck?: Function
-}
 
 type ClockValueRequestConfig = {
   user: CurrentUser

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -14,7 +14,7 @@ import {
   Logger
 } from '../../utils'
 import { CREATOR_NODE_SERVICE_NAME, DECISION_TREE_STATE } from './constants'
-import type { MonitoringCallbacks } from './CreatorNode'
+import type { MonitoringCallbacks } from '../types'
 
 type Timeout = number | null
 
@@ -428,8 +428,7 @@ export class CreatorNodeSelection extends ServiceSelection {
           const url = new URL(check.request.url)
           const data = check.response.data.data
           try {
-            // @ts-expect-error we make a check that it exists above, not sure why this isn't caught
-            this.creatorNode.monitoringCallbacks.healthCheck({
+            this.creatorNode.monitoringCallbacks.healthCheck?.({
               endpoint: url.origin,
               pathname: url.pathname,
               searchParams: url.searchParams,

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -900,7 +900,7 @@ export class DiscoveryProvider {
       // Fire monitoring callbacks for request success case
       if (this.monitoringCallbacks && 'request' in this.monitoringCallbacks) {
         try {
-          this.monitoringCallbacks.request({
+          this.monitoringCallbacks.request?.({
             endpoint: url.origin,
             pathname: url.pathname,
             queryString: url.search,
@@ -924,7 +924,7 @@ export class DiscoveryProvider {
       // Fire monitoring callbacks for request failure case
       if (this.monitoringCallbacks && 'request' in this.monitoringCallbacks) {
         try {
-          this.monitoringCallbacks.request({
+          this.monitoringCallbacks.request?.({
             endpoint: url.origin,
             pathname: url.pathname,
             queryString: url.search,

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -16,6 +16,7 @@ import type { EthContracts } from '../ethContracts'
 import type { AxiosResponse } from 'axios'
 import type { Maybe, Nullable } from '../../utils'
 import type { LocalStorage } from '../../utils/localStorage'
+import type { MonitoringCallbacks } from '../types'
 
 const PREVIOUS_VERSIONS_TO_CHECK = 5
 
@@ -25,10 +26,7 @@ export type DiscoveryProviderSelectionConfig = Omit<
 > & {
   reselectTimeout?: number
   selectionCallback?: (endpoint: string, decisionTree: Decision[]) => void
-  monitoringCallbacks?: {
-    healthCheck: (config: Record<string, unknown>) => void
-    request: (config: Record<string, unknown>) => void
-  }
+  monitoringCallbacks?: MonitoringCallbacks
   unhealthySlotDiffPlays?: number
   unhealthyBlockDiff?: number
   localStorage?: LocalStorage
@@ -183,7 +181,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
     if ('healthCheck' in this.monitoringCallbacks) {
       const url = new URL(response.config.url as string)
       try {
-        this.monitoringCallbacks.healthCheck({
+        this.monitoringCallbacks.healthCheck?.({
           endpoint: url.origin,
           pathname: url.pathname,
           queryString: url.search,

--- a/libs/src/services/types.ts
+++ b/libs/src/services/types.ts
@@ -1,0 +1,4 @@
+export type MonitoringCallbacks = {
+  request?: (config: Record<string, unknown>) => void
+  healthCheck?: (config: Record<string, unknown>) => void
+}


### PR DESCRIPTION
### Description
- Fixes legacy and sdk types (legacy was untyped since it was being reffed by src/index.ts)
- Consolidates monitoringCallback types across libs
- Exports Utils and SanityChecks in native build, and also adds configure stubs