### PR TITLE
INF add alerts for failed gcp bake jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,9 @@ jobs:
               --source-disk="$GCLOUD_VM_NAME" \
               --source-disk-zone="$GOOGLE_COMPUTE_ZONE" \
               --storage-location=us
+      - slack-fail:
+          branch_pattern: master
+          slack_mentions_user: "@Dheeraj"
 
   publish-sdk:
     docker:


### PR DESCRIPTION
### Description

Add alerts to #eng-deploys-announcements when a GCP job fails.

### Tests

Monitor #eng-deploys-announcement.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->