### PR TITLE
Fix Prometheus Metric Names for Bull Queue Durations

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheusRegistry.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheusRegistry.ts
@@ -84,14 +84,15 @@ export class PrometheusRegistry {
 
     // job duration in seconds
     const jobDuration = (job.finishedOn - job.processedOn!) * 1000
-    this.getMetric(
-      this.metricNames.JOBS_DURATION_MILLISECONDS_HISTOGRAM
-    ).observe(jobLabels, jobDuration)
+    this.getMetric(this.metricNames.JOBS_DURATION_SECONDS_HISTOGRAM).observe(
+      jobLabels,
+      jobDuration
+    )
 
     // job duration in seconds
     const waitingDuration = (job.processedOn! - job.timestamp) * 1000
     this.getMetric(
-      this.metricNames.JOBS_WAITING_DURATION_MILLISECONDS_HISTOGRAM
+      this.metricNames.JOBS_WAITING_DURATION_SECONDS_HISTOGRAM
     ).observe(jobLabels, waitingDuration)
 
     this.getMetric(this.metricNames.JOBS_ATTEMPTS_HISTOGRAM).observe(

--- a/creator-node/test/lib/genericBullQueueMock.js
+++ b/creator-node/test/lib/genericBullQueueMock.js
@@ -19,7 +19,7 @@ class GenericBullQueue {
     const prometheusRegistry = new PrometheusRegistry()
     prometheusRegistry.startQueueMetrics(this.queue)
 
-    this.queue.process(1, async (job, done) => {
+    this.queue.process(1, async (job) => {
       console.log(this.params)
 
       const { timeout } = job.data
@@ -27,8 +27,6 @@ class GenericBullQueue {
         console.log(`waiting ${timeout}`)
         setTimeout(() => console.log(`done ${timeout}`), timeout)
       }
-
-      done()
     })
   }
 

--- a/creator-node/test/lib/genericBullQueueMock.js
+++ b/creator-node/test/lib/genericBullQueueMock.js
@@ -1,0 +1,42 @@
+const PrometheusRegistry = require('../../src/services/prometheusMonitoring/prometheusRegistry')
+const Bull = require('bull')
+
+const config = require('../../src/config')
+
+// Mock monitoring queue that sets monitor values on construction
+class GenericBullQueue {
+  constructor() {
+    this.queue = Bull('genericBullQueue', {
+      redis: {
+        host: config.get('redisHost'),
+        port: config.get('redisPort')
+      },
+      defaultJobOptions: {
+        removeOnComplete: 0,
+        removeOnFail: 0
+      }
+    })
+    const prometheusRegistry = new PrometheusRegistry()
+    prometheusRegistry.startQueueMetrics(this.queue)
+
+    this.queue.process(1, async (job, done) => {
+      console.log(this.params)
+
+      const { timeout } = job.data
+      if (timeout) {
+        console.log(`waiting ${timeout}`)
+        setTimeout(() => console.log(`done ${timeout}`), timeout)
+      }
+
+      done()
+    })
+  }
+
+  async addTask(params) {
+    const job = await this.queue.add(params)
+
+    return job
+  }
+}
+
+module.exports = GenericBullQueue

--- a/creator-node/test/lib/genericBullQueueMock.js
+++ b/creator-node/test/lib/genericBullQueueMock.js
@@ -20,8 +20,6 @@ class GenericBullQueue {
     prometheusRegistry.startQueueMetrics(this.queue)
 
     this.queue.process(1, async (job) => {
-      console.log(this.params)
-
       const { timeout } = job.data
       if (timeout) {
         console.log(`waiting ${timeout}`)

--- a/creator-node/test/prometheus.test.js
+++ b/creator-node/test/prometheus.test.js
@@ -119,16 +119,13 @@ describe('test Prometheus metrics', async function () {
     assert.ok(resp.text.includes(NAMESPACE_PREFIX + '_jobs_delayed'))
   })
 
-  it.only('Checks the duration of a bull queue job', async function () {
-    await request(app).get('/health_check')
-
+  it('Checks the duration of a bull queue job', async function () {
     const genericBullQueue = new GenericBullQueue()
     const job = await genericBullQueue.addTask({ timeout: 500 })
 
     await job.finished()
 
     const resp = await request(app).get('/prometheus_metrics').expect(200)
-    console.log(resp)
     assert.ok(
       resp.text.includes(NAMESPACE_PREFIX + '_jobs_duration_seconds_bucket')
     )

--- a/creator-node/test/prometheus.test.js
+++ b/creator-node/test/prometheus.test.js
@@ -129,5 +129,6 @@ describe('test Prometheus metrics', async function () {
     assert.ok(
       resp.text.includes(NAMESPACE_PREFIX + '_jobs_duration_seconds_bucket')
     )
+    assert.ok(resp.text.includes(`queue_name="genericBullQueue"`))
   })
 })

--- a/creator-node/test/prometheus.test.js
+++ b/creator-node/test/prometheus.test.js
@@ -6,6 +6,7 @@ const { getLibsMock } = require('./lib/libsMock')
 const {
   NAMESPACE_PREFIX
 } = require('../src/services/prometheusMonitoring/prometheus.constants')
+const GenericBullQueue = require('./lib/genericBullQueueMock')
 
 describe('test Prometheus metrics', async function () {
   let app, server, libsMock
@@ -116,5 +117,20 @@ describe('test Prometheus metrics', async function () {
     assert.ok(resp.text.includes(NAMESPACE_PREFIX + '_jobs_failed'))
     assert.ok(resp.text.includes(NAMESPACE_PREFIX + '_jobs_active'))
     assert.ok(resp.text.includes(NAMESPACE_PREFIX + '_jobs_delayed'))
+  })
+
+  it.only('Checks the duration of a bull queue job', async function () {
+    await request(app).get('/health_check')
+
+    const genericBullQueue = new GenericBullQueue()
+    const job = await genericBullQueue.addTask({ timeout: 500 })
+
+    await job.finished()
+
+    const resp = await request(app).get('/prometheus_metrics').expect(200)
+    console.log(resp)
+    assert.ok(
+      resp.text.includes(NAMESPACE_PREFIX + '_jobs_duration_seconds_bucket')
+    )
   })
 })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR fixes a metric name mismatch and changes the name of the metric names from
`JOBS_DURATION_MILLISECONDS_HISTOGRAM` => `JOBS_DURATION_SECONDS_HISTOGRAM`
`JOBS_WAITING_DURATION_MILLISECONDS_HISTOGRAM` => `JOBS_WAITING_DURATION_SECONDS_HISTOGRAM`

the new prometheus metrics should look like this when deployed

```
# HELP audius_cn_jobs_duration_seconds Time to complete jobs
# TYPE audius_cn_jobs_duration_seconds histogram
audius_cn_jobs_duration_seconds_bucket{le="1",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="2",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="4",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="8",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="17",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="35",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="71",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="145",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="295",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="600",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 0
audius_cn_jobs_duration_seconds_bucket{le="+Inf",status="completed",job_name="__default__",queue_name="monitor-state-queue"} 4
audius_cn_jobs_duration_seconds_sum{status="completed",job_name="__default__",queue_name="monitor-state-queue"} 152000
audius_cn_jobs_duration_seconds_count{status="completed",job_name="__default__",queue_name="monitor-state-queue"} 4
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

A new test was added that `Checks the duration of a bull queue job` and added a new `GenericBullQueue` for testing purposes


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

These changes will be monitored with the prometheus metrics mentioned above

`JOBS_DURATION_SECONDS_HISTOGRAM`
`JOBS_WAITING_DURATION_SECONDS_HISTOGRAM`


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->