### PR TITLE
[CON-222] Fix SequelizeUniqueConstraintError for blockchain track ID

### DIFF
--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -118,8 +118,10 @@ router.post(
     const userResp = await libs.contracts.UserFactoryClient.getUser(
       blockchainUserId
     )
-    // eslint-disable-next-line eqeqeq
-    if (userResp.wallet != req.session.wallet) {
+    if (
+      !userResp?.wallet ||
+      userResp.wallet.toLowerCase() !== req.session.wallet.toLowerCase()
+    ) {
       throw new Error(
         `Owner wallet ${userResp.wallet} of blockchainUserId ${blockchainUserId} does not match the wallet of the user attempting to write this data: ${req.session.wallet}`
       )

--- a/creator-node/src/routes/audiusUsers.js
+++ b/creator-node/src/routes/audiusUsers.js
@@ -112,6 +112,19 @@ router.post(
       )
     }
 
+    // Verify that wallet of the user on the blockchain for the given ID matches the user attempting to update
+    const serviceRegistry = req.app.get('serviceRegistry')
+    const { libs } = serviceRegistry
+    const userResp = await libs.contracts.UserFactoryClient.getUser(
+      blockchainUserId
+    )
+    // eslint-disable-next-line eqeqeq
+    if (userResp.wallet != req.session.wallet) {
+      throw new Error(
+        `Owner wallet ${userResp.wallet} of blockchainUserId ${blockchainUserId} does not match the wallet of the user attempting to write this data: ${req.session.wallet}`
+      )
+    }
+
     const cnodeUserUUID = req.session.cnodeUserUUID
 
     // Fetch metadataJSON for metadataFileUUID.

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -424,7 +424,7 @@ router.post(
         // Verify that blockchain track id is owned by user attempting to upload it
         const serviceRegistry = req.app.get('serviceRegistry')
         const { libs } = serviceRegistry
-        const trackResp = await libs.contracts.TrackFactory.getTrack(
+        const trackResp = await libs.contracts.TrackFactoryClient.getTrack(
           blockchainTrackId
         )
         // eslint-disable-next-line eqeqeq

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -421,6 +421,19 @@ router.post(
           throw new Error('Cannot create track without transcodedTrackUUID.')
         }
 
+        // Verify that blockchain track id is owned by user attempting to upload it
+        const serviceRegistry = req.app.get('serviceRegistry')
+        const { libs } = serviceRegistry
+        const trackResp = await libs.contracts.TrackFactory.getTrack(
+          blockchainTrackId
+        )
+        // eslint-disable-next-line eqeqeq
+        if (trackResp.trackOwnerId != req.session.userId) {
+          throw new Error(
+            `Owner ID ${trackResp.trackOwnerId} of blockchainTrackId ${blockchainTrackId} does not match the ID of the user attempting to write this track: ${req.session.userId}`
+          )
+        }
+
         // Associate the transcode file db record with trackUUID
         const transcodedFile = await models.File.findOne({
           where: {

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -429,8 +429,8 @@ router.post(
         )
         if (
           !trackResp?.trackOwnerId ||
-          // eslint-disable-next-line eqeqeq
-          trackResp.trackOwnerId != req.session.userId
+          parseInt(trackResp.trackOwnerId, 10) !==
+            parseInt(req.session.userId, 10)
         ) {
           throw new Error(
             `Owner ID ${trackResp.trackOwnerId} of blockchainTrackId ${blockchainTrackId} does not match the ID of the user attempting to write this track: ${req.session.userId}`

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -427,8 +427,11 @@ router.post(
         const trackResp = await libs.contracts.TrackFactoryClient.getTrack(
           blockchainTrackId
         )
-        // eslint-disable-next-line eqeqeq
-        if (trackResp.trackOwnerId != req.session.userId) {
+        if (
+          !trackResp?.trackOwnerId ||
+          // eslint-disable-next-line eqeqeq
+          trackResp.trackOwnerId != req.session.userId
+        ) {
           throw new Error(
             `Owner ID ${trackResp.trackOwnerId} of blockchainTrackId ${blockchainTrackId} does not match the ID of the user attempting to write this track: ${req.session.userId}`
           )

--- a/creator-node/test/audiusUsers.test.js
+++ b/creator-node/test/audiusUsers.test.js
@@ -118,11 +118,24 @@ describe('Test AudiusUsers', function () {
     } })
     assert.ok(file)
 
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = session.walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .send({ blockchainUserId, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(200)
   })
 
@@ -143,18 +156,31 @@ describe('Test AudiusUsers', function () {
       throw new Error('invalid return data')
     }
 
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = session.walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .send({ blockchainUserId, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(200)
 
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .send({ blockchainUserId, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(200)
   })
 
@@ -191,11 +217,24 @@ describe('Test AudiusUsers', function () {
       throw new Error('invalid return data')
     }
 
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = session.walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp2.body.data.metadataFileUUID })
+      .send({ blockchainUserId, blockNumber: 10, metadataFileUUID: resp2.body.data.metadataFileUUID })
       .expect(200)
   })
 
@@ -220,11 +259,24 @@ describe('Test AudiusUsers', function () {
     const cnodeUser = await models.CNodeUser.findOne({ where: { cnodeUserUUID: session.cnodeUserUUID } })
     await cnodeUser.update({ latestBlockNumber: 100 })
 
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = session.walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
     await request(app)
       .post('/audius_users')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
-      .send({ blockchainUserId: 1, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
+      .send({ blockchainUserId, blockNumber: 10, metadataFileUUID: resp.body.data.metadataFileUUID })
       .expect(400, {
         error: 'Invalid blockNumber param 10. Must be greater or equal to previously processed blocknumber 100.'
       })

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -1102,7 +1102,7 @@ describe('test ContentBlacklist', function () {
         trackOwnerId
       }
     })
-    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
     // associate track metadata with track
     await request(app)

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -1091,6 +1091,19 @@ describe('test ContentBlacklist', function () {
       .set('User-Id', inputUserId)
       .set('Enforce-Write-Quorum', false)
       .send({ metadata: trackMetadata, source_file: sourceFile })
+
+    // Make chain recognize wallet as owner of track
+    const getTrackStub = sinon.stub().callsFake((blockchainTrackId) => {
+      let trackOwnerId = -1
+      if (blockchainTrackId === trackId) {
+        trackOwnerId = inputUserId
+      }
+      return {
+        trackOwnerId
+      }
+    })
+    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
     // associate track metadata with track
     await request(app)
       .post('/tracks')

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -27,34 +27,6 @@ const { fetchDBStateForWallet, assertTableEquality } = require('./lib/utils')
 
 const TestAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
-/** Add state to AudiusUsers table for given userId */
-const uploadAudiusUserState = async function ({
-  app,
-  userId,
-  sessionToken,
-  metadataObj,
-  audiusUserBlockNumber
-}) {
-  const audiusUserMetadataResp = await request(app)
-    .post('/audius_users/metadata')
-    .set('X-Session-ID', sessionToken)
-    .set('User-Id', userId)
-    .set('Enforce-Write-Quorum', false)
-    .send({ metadata: metadataObj })
-    .expect(200)
-
-  await request(app)
-    .post('/audius_users')
-    .set('X-Session-ID', sessionToken)
-    .set('User-Id', userId)
-    .send({
-      blockchainUserId: userId,
-      blockNumber: audiusUserBlockNumber,
-      metadataFileUUID: audiusUserMetadataResp.body.data.metadataFileUUID
-    })
-    .expect(200)
-}
-
 describe('Test createNewDataRecord()', async function () {
   const req = {
     logger: {
@@ -714,6 +686,18 @@ describe('Test deleteAllCNodeUserDataFromDB()', async function () {
         .set('Enforce-Write-Quorum', false)
         .send({ metadata: audiusUserMetadata })
         .expect(200)
+      // Make chain recognize current session wallet as the wallet for the session user ID
+      const blockchainUserId = 1
+      const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+        let wallet = 'no wallet'
+        if (blockchainUserIdArg === blockchainUserId) {
+          wallet = session.walletPublicKey
+        }
+        return {
+          wallet
+        }
+      })
+      libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
       await request(app)
         .post('/audius_users')
         .set('X-Session-ID', session.sessionToken)
@@ -1112,11 +1096,12 @@ describe('Test fetchFilesHashFromDB()', async function () {
 describe('Test fixInconsistentUser()', async function () {
   const userId = 1
 
-  let server, app
+  let server, app, libsMock
 
   /** Init server to run DB migrations */
   before(async function () {
-    const appInfo = await getApp(getLibsMock())
+    libsMock = getLibsMock()
+    const appInfo = await getApp(libsMock)
     server = appInfo.server
     app = appInfo.app
   })
@@ -1132,6 +1117,46 @@ describe('Test fixInconsistentUser()', async function () {
     await server.close()
   })
 
+  /** Add state to AudiusUsers table for given userId */
+  const uploadAudiusUserState = async function ({
+    sessionToken,
+    walletPublicKey,
+    metadataObj,
+    audiusUserBlockNumber
+  }) {
+    const audiusUserMetadataResp = await request(app)
+      .post('/audius_users/metadata')
+      .set('X-Session-ID', sessionToken)
+      .set('User-Id', userId)
+      .set('Enforce-Write-Quorum', false)
+      .send({ metadata: metadataObj })
+      .expect(200)
+
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
+    await request(app)
+      .post('/audius_users')
+      .set('X-Session-ID', sessionToken)
+      .set('User-Id', userId)
+      .send({
+        blockchainUserId: userId,
+        blockNumber: audiusUserBlockNumber,
+        metadataFileUUID: audiusUserMetadataResp.body.data.metadataFileUUID
+      })
+      .expect(200)
+  }
+
   it('Confirm no change to healthy users DB state', async function () {
     const { cnodeUserUUID, walletPublicKey, sessionToken } = await createStarterCNodeUser(userId)
 
@@ -1140,9 +1165,8 @@ describe('Test fixInconsistentUser()', async function () {
     const audiusUserMetadata = { test: 'field1' }
     const metadataCID = 'QmQMHXPMuey2AT6fPTKnzKQCrRjPS7AbaQdDTM8VXbHC8W'
     await uploadAudiusUserState({
-      app,
-      userId,
       sessionToken,
+      walletPublicKey,
       metadataObj: audiusUserMetadata,
       audiusUserBlockNumber
     })
@@ -1227,9 +1251,8 @@ describe('Test fixInconsistentUser()', async function () {
     const audiusUserMetadata = { test: 'field1' }
     const metadataCID = 'QmQMHXPMuey2AT6fPTKnzKQCrRjPS7AbaQdDTM8VXbHC8W'
     await uploadAudiusUserState({
-      app,
-      userId,
       sessionToken,
+      walletPublicKey,
       metadataObj: audiusUserMetadata,
       audiusUserBlockNumber
     })

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -792,13 +792,26 @@ describe('Test deleteAllCNodeUserDataFromDB()', async function () {
         expectedTrackMetadataMultihash
       )
 
+      // Make chain recognize wallet as owner of track
+      const blockchainTrackId = 1
+      const getTrackStub = sinon.stub().callsFake((blockchainTrackIdArg) => {
+        let trackOwnerId = -1
+        if (blockchainTrackIdArg === blockchainTrackId) {
+          trackOwnerId = userId
+        }
+        return {
+          trackOwnerId
+        }
+      })
+      libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
       // Complete track upload
       await request(app)
         .post('/tracks')
         .set('X-Session-ID', session.sessionToken)
         .set('User-Id', session.userId)
         .send({
-          blockchainTrackId: 1,
+          blockchainTrackId,
           blockNumber: 10,
           metadataFileUUID: trackMetadataResp.body.data.metadataFileUUID,
           transcodedTrackUUID

--- a/creator-node/test/dbManager.test.js
+++ b/creator-node/test/dbManager.test.js
@@ -787,7 +787,7 @@ describe('Test deleteAllCNodeUserDataFromDB()', async function () {
           trackOwnerId
         }
       })
-      libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+      libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
       // Complete track upload
       await request(app)

--- a/creator-node/test/pollingTracks.test.js
+++ b/creator-node/test/pollingTracks.test.js
@@ -696,7 +696,7 @@ describe('test Polling Tracks with mocked IPFS', function () {
         trackOwnerId
       }
     })
-    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
     await request(app)
       .post('/tracks')
@@ -747,7 +747,7 @@ describe('test Polling Tracks with mocked IPFS', function () {
     // Make chain NOT recognize wallet as owner of track
     const blockchainTrackId = 1
     const getTrackStub = sinon.stub().resolves(-1)
-    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
     await request(app)
       .post('/tracks')
@@ -861,7 +861,7 @@ describe('test Polling Tracks with mocked IPFS', function () {
         trackOwnerId
       }
     })
-    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
     await request(app)
       .post('/tracks')
@@ -1195,7 +1195,7 @@ describe('test Polling Tracks with real files', function () {
         trackOwnerId
       }
     })
-    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
     // Complete track1 creation
     await request(app2)

--- a/creator-node/test/pollingTracks.test.js
+++ b/creator-node/test/pollingTracks.test.js
@@ -1109,13 +1109,26 @@ describe('test Polling Tracks with real files', function () {
       .expect(200)
     const trackMetadataFileUUID = trackMetadataResp.body.data.metadataFileUUID
 
+    // Make chain recognize wallet as owner of track
+    const blockchainTrackId = 1
+    const getTrackStub = sinon.stub().callsFake((blockchainTrackIdArg) => {
+      let trackOwnerId = -1
+      if (blockchainTrackIdArg === blockchainTrackId) {
+        trackOwnerId = userId
+      }
+      return {
+        trackOwnerId
+      }
+    })
+    libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
+
     // Complete track creation
     await request(app2)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', userId)
       .send({
-        blockchainTrackId: 1,
+        blockchainTrackId,
         blockNumber: 10,
         metadataFileUUID: trackMetadataFileUUID,
         transcodedTrackUUID

--- a/creator-node/test/pollingTracks.test.js
+++ b/creator-node/test/pollingTracks.test.js
@@ -9,8 +9,6 @@ const _ = require('lodash')
 
 const config = require('../src/config')
 const defaultConfig = require('../default-config.json')
-const { libs } = require('@audius/sdk')
-const Utils = libs
 const BlacklistManager = require('../src/blacklistManager')
 const TranscodingQueue = require('../src/TranscodingQueue')
 const models = require('../src/models')
@@ -687,12 +685,25 @@ describe('test Polling Tracks with mocked IPFS', function () {
       'QmTWhw49RfSMSJJmfm8cMHFBptgWoBGpNwjAc5jy2qeJfs'
     )
 
+    // Make chain recognize wallet as owner of track
+    const blockchainTrackId = 1
+    const getTrackStub = sinon.stub().callsFake((blockchainTrackIdArg) => {
+      let trackOwnerId = -1
+      if (blockchainTrackIdArg === blockchainTrackId) {
+        trackOwnerId = userId
+      }
+      return {
+        trackOwnerId
+      }
+    })
+    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
       .send({
-        blockchainTrackId: 1,
+        blockchainTrackId,
         blockNumber: 10,
         metadataFileUUID: trackMetadataResp.body.data.metadataFileUUID,
         transcodedTrackUUID
@@ -788,12 +799,25 @@ describe('test Polling Tracks with mocked IPFS', function () {
       'QmPjrvx9MBcvf495t43ZhiMpKWwu1JnqkcNUN3Z9EBWm49'
     )
 
+    // Make chain recognize wallet as owner of track
+    const blockchainTrackId = 1
+    const getTrackStub = sinon.stub().callsFake((blockchainTrackIdArg) => {
+      let trackOwnerId = -1
+      if (blockchainTrackIdArg === blockchainTrackId) {
+        trackOwnerId = userId
+      }
+      return {
+        trackOwnerId
+      }
+    })
+    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
     await request(app)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', session.userId)
       .send({
-        blockchainTrackId: 1,
+        blockchainTrackId,
         blockNumber: 10,
         metadataFileUUID: trackMetadataResp.body.data.metadataFileUUID,
         transcodedTrackUUID
@@ -1105,13 +1129,30 @@ describe('test Polling Tracks with real files', function () {
       .expect(200)
     const track2MetadataFileUUID = track2MetadataResp.body.data.metadataFileUUID
 
+    // Make chain recognize wallet as owner of track
+    const track1BlockchainId = 1
+    const track2BlockchainId = 2
+    const getTrackStub = sinon.stub().callsFake((blockchainTrackId) => {
+      let trackOwnerId = -1
+      if (
+        blockchainTrackId === track1BlockchainId ||
+        blockchainTrackId === track2BlockchainId
+      ) {
+        trackOwnerId = userId
+      }
+      return {
+        trackOwnerId
+      }
+    })
+    libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
     // Complete track1 creation
     await request(app2)
       .post('/tracks')
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', userId)
       .send({
-        blockchainTrackId: 1,
+        blockchainTrackId: track1BlockchainId,
         blockNumber: 10,
         metadataFileUUID: trackMetadataFileUUID,
         transcodedTrackUUID
@@ -1124,7 +1165,7 @@ describe('test Polling Tracks with real files', function () {
       .set('X-Session-ID', session.sessionToken)
       .set('User-Id', userId)
       .send({
-        blockchainTrackId: 2,
+        blockchainTrackId: track2BlockchainId,
         blockNumber: 20,
         metadataFileUUID: track2MetadataFileUUID,
         transcodedTrackUUID: transcodedTrack2UUID

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -85,6 +85,7 @@ describe('test nodesync', async function () {
   describe('test /export route', async function () {
     let cnodeUserUUID,
       sessionToken,
+      sessionWalletPublicKey,
       metadataMultihash,
       metadataFileUUID,
       transcodedTrackCID,
@@ -97,9 +98,12 @@ describe('test nodesync', async function () {
 
     const createUserAndTrack = async function () {
       // Create user
-      ;({ cnodeUserUUID, sessionToken, userId } = await createStarterCNodeUser(
-        userId
-      ))
+      ;({
+        cnodeUserUUID,
+        sessionToken,
+        userId,
+        walletPublicKey: sessionWalletPublicKey
+      } = await createStarterCNodeUser(userId))
 
       // Upload user metadata
       const metadata = {
@@ -116,6 +120,19 @@ describe('test nodesync', async function () {
         .expect(200)
       metadataMultihash = userMetadataResp.body.data.metadataMultihash
       metadataFileUUID = userMetadataResp.body.data.metadataFileUUID
+
+      // Make chain recognize current session wallet as the wallet for the session user ID
+      const blockchainUserId = 1
+      const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+        let wallet = 'no wallet'
+        if (blockchainUserIdArg === blockchainUserId) {
+          wallet = sessionWalletPublicKey
+        }
+        return {
+          wallet
+        }
+      })
+      libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
 
       // Associate user with with blockchain ID
       const associateRequest = {
@@ -800,6 +817,19 @@ describe('test nodesync', async function () {
 
       const metadataFileUUID = userMetadataResp.body.data.metadataFileUUID
 
+      // Make chain recognize current session wallet as the wallet for the session user ID
+      const blockchainUserId = 1
+      const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+        let wallet = 'no wallet'
+        if (blockchainUserIdArg === blockchainUserId) {
+          wallet = session.walletPublicKey
+        }
+        return {
+          wallet
+        }
+      })
+      libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
+
       // Associate user with with blockchain ID
       const associateRequest = {
         blockchainUserId: 1,
@@ -1364,6 +1394,19 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
       .expect(200)
 
     const metadataFileUUID = userMetadataResp.body.data.metadataFileUUID
+
+    // Make chain recognize current session wallet as the wallet for the session user ID
+    const blockchainUserId = 1
+    const getUserStub = sinon.stub().callsFake((blockchainUserIdArg) => {
+      let wallet = 'no wallet'
+      if (blockchainUserIdArg === blockchainUserId) {
+        wallet = session.walletPublicKey
+      }
+      return {
+        wallet
+      }
+    })
+    libsMock.contracts.UserFactoryClient = { getUser: getUserStub }
 
     // Associate user with with blockchain ID
     const associateRequest = {

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -210,7 +210,7 @@ describe('test nodesync', async function () {
 
       beforeEach(createUserAndTrack)
 
-      it.only('Test default export', async function () {
+      it('Test default export', async function () {
         // confirm maxExportClockValueRange > cnodeUser.clock
         const cnodeUserClock = (
           await models.CNodeUser.findOne({

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -190,7 +190,7 @@ describe('test nodesync', async function () {
           trackOwnerId
         }
       })
-      libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+      libsMock.contracts.TrackFactoryClient = { getTrack: getTrackStub }
 
       // associate track + track metadata with blockchain ID
       await request(app)
@@ -210,7 +210,7 @@ describe('test nodesync', async function () {
 
       beforeEach(createUserAndTrack)
 
-      it('Test default export', async function () {
+      it.only('Test default export', async function () {
         // confirm maxExportClockValueRange > cnodeUser.clock
         const cnodeUserClock = (
           await models.CNodeUser.findOne({

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -162,13 +162,26 @@ describe('test nodesync', async function () {
       trackMetadataMultihash = trackMetadataResp.body.data.metadataMultihash
       trackMetadataFileUUID = trackMetadataResp.body.data.metadataFileUUID
 
+      // Make chain recognize wallet as owner of track
+      const blockchainTrackId = 1
+      const getTrackStub = sinon.stub().callsFake((blockchainTrackIdArg) => {
+        let trackOwnerId = -1
+        if (blockchainTrackIdArg === blockchainTrackId) {
+          trackOwnerId = userId
+        }
+        return {
+          trackOwnerId
+        }
+      })
+      libsMock.contracts.TrackFactory = { getTrack: getTrackStub }
+
       // associate track + track metadata with blockchain ID
       await request(app)
         .post('/tracks')
         .set('X-Session-ID', sessionToken)
         .set('User-Id', userId)
         .send({
-          blockchainTrackId: 1,
+          blockchainTrackId,
           blockNumber: 10,
           metadataFileUUID: trackMetadataFileUUID,
           transcodedTrackUUID


### PR DESCRIPTION
### Description
- The following error is caused by load test on staging, so it doesn't impact prod (verify lack of prod impact by searching the following in loggly with and without the audius-stage/prod tag: `"SequelizeUniqueConstraintError" tag:"audius-prod" -"Queue.onFailed" -"secondarySyncFromPrimary failure for wallets" "Tracks_unique"`): `[SequelizeUniqueConstraintError] blockchainId must be unique`
- `blockchainId` is a smart-contract generated global track ID that is supposed to be unique
- Likely something with the load test uploading multiple tracks at the same time caused it to make Content Node's `/tracks` endpoint associate the same track ID with multiple uploads
- The solution to prevent this broken state from being created in the future is to make Content Node's `/tracks` endpoint verify that the owner of the track ID on chain is the same owner of the wallet attempting to associate the ID with their track
- This PR also applies the same solution for the `/audius_users` endpoint to prevent a similar issue in the AudiusUsers table

### Tests
- Updated integration tests
- Added new test to make sure `/tracks` errors when it's given a wallet+trackId that doesn't match what's on-chain


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- We'll need to fix the currently broken state before verifying that no more `SequelizeUniqueConstraintError` logs happen in prod due to the blockchainId+clock unique constraint
- Watch track uploads carefully on staging to make sure there are no new failures -- particularly with the error message `does not match the ID of the user attempting to write this track`