### PR TITLE
Change openresty location directive from exact match to regex

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -68,7 +68,7 @@ http {
             add_header X-Cache-Status $upstream_cache_status always;
         }
 
-        location = /health_check {
+        location ~ (/health_check) {
             proxy_cache cache;
 
             proxy_pass http://127.0.0.1:3000;

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -713,6 +713,12 @@ const config = convict({
     format: Boolean,
     env: 'mergePrimaryAndSecondaryEnabled',
     default: false
+  },
+  findCIDInNetworkEnabled: {
+    doc: 'enable findCIDInNetwork lookups',
+    format: Boolean,
+    env: 'findCIDInNetworkEnabled',
+    default: true
   }
   /**
    * unsupported options at the moment

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -120,6 +120,7 @@ async function findCIDInNetwork(
   trackId = null,
   excludeList = []
 ) {
+  if (!config.get('findCIDInNetworkEnabled')) return
   let found = false
 
   const attemptedStateFix = await getIfAttemptedStateFix(filePath)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Two optimizations
1. Ability to turn `findCIDInNetwork` off via env var
2. Add regex support for verbose health check in openresty

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Both of these have been tested on production.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
For openresty tail access logs by running `tail -f /usr/local/openresty/logs/access.log`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->