### PR TITLE
[C-785] Add request sorters to hist/fav/tracks

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
+++ b/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
@@ -6,6 +6,7 @@ from src.queries.get_user_listening_history import (
     GetUserListeningHistoryArgs,
     _get_user_listening_history,
 )
+from src.queries.query_helpers import SortDirection, SortMethod
 from src.tasks.user_listening_history.index_user_listening_history import (
     _index_user_listening_history,
 )
@@ -51,7 +52,13 @@ def test_get_user_listening_history_multiple_plays(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1, current_user_id=1, limit=10, offset=0, query=None
+                user_id=1,
+                current_user_id=1,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -95,7 +102,13 @@ def test_get_user_listening_history_no_plays(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=3, current_user_id=3, limit=10, offset=0, query=None
+                user_id=3,
+                current_user_id=3,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -115,7 +128,13 @@ def test_get_user_listening_history_single_play(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=2, current_user_id=2, limit=10, offset=0, query=None
+                user_id=2,
+                current_user_id=2,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -143,7 +162,13 @@ def test_get_user_listening_history_pagination(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1, current_user_id=1, limit=1, offset=1, query=None
+                user_id=1,
+                current_user_id=1,
+                limit=1,
+                offset=1,
+                query=None,
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -171,7 +196,13 @@ def test_get_user_listening_history_mismatch_user_id(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1, current_user_id=2, limit=10, offset=0, query=None
+                user_id=1,
+                current_user_id=2,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -191,7 +222,13 @@ def test_get_user_listening_history_with_query(app):
         track_history = _get_user_listening_history(
             session,
             GetUserListeningHistoryArgs(
-                user_id=1, current_user_id=1, limit=10, offset=0, query="track 2"
+                user_id=1,
+                current_user_id=1,
+                limit=10,
+                offset=0,
+                query="track 2",
+                sort_method=None,
+                sort_direction=None,
             ),
         )
 
@@ -201,4 +238,54 @@ def test_get_user_listening_history_with_query(app):
     assert track_history[0][response_name_constants.track_id] == 2
     assert track_history[0][response_name_constants.activity_timestamp] == str(
         TIMESTAMP + timedelta(minutes=3)
+    )
+
+
+def test_get_user_listening_history_custom_sort(app):
+    """Tests listening history from user with multiple plays"""
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, test_entities)
+
+    with db.scoped_session() as session:
+        _index_user_listening_history(session)
+
+        track_history = _get_user_listening_history(
+            session,
+            GetUserListeningHistoryArgs(
+                user_id=1,
+                current_user_id=1,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=SortMethod.title,
+                sort_direction=SortDirection.asc,
+            ),
+        )
+
+    assert len(track_history) == 3
+    assert (
+        track_history[2][response_name_constants.user][response_name_constants.balance]
+        is not None
+    )
+    assert track_history[2][response_name_constants.track_id] == 3
+    assert track_history[2][response_name_constants.activity_timestamp] == str(
+        TIMESTAMP + timedelta(minutes=4)
+    )
+    assert (
+        track_history[1][response_name_constants.user][response_name_constants.balance]
+        is not None
+    )
+    assert track_history[1][response_name_constants.track_id] == 2
+    assert track_history[1][response_name_constants.activity_timestamp] == str(
+        TIMESTAMP + timedelta(minutes=3)
+    )
+    assert (
+        track_history[0][response_name_constants.user][response_name_constants.balance]
+        is not None
+    )
+    assert track_history[0][response_name_constants.track_id] == 1
+    assert track_history[0][response_name_constants.activity_timestamp] == str(
+        TIMESTAMP + timedelta(minutes=2)
     )

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -510,6 +510,20 @@ user_favorited_tracks_parser = pagination_with_current_user_parser.copy()
 user_favorited_tracks_parser.add_argument(
     "query", required=False, description="The filter query"
 )
+user_favorited_tracks_parser.add_argument(
+    "sort_method",
+    required=False,
+    description="The sort method",
+    type=str,
+    choices=SortMethod._member_names_,
+)
+user_favorited_tracks_parser.add_argument(
+    "sort_direction",
+    required=False,
+    description="The sort direction",
+    type=str,
+    choices=SortDirection._member_names_,
+)
 
 user_tracks_route_parser = pagination_with_current_user_parser.copy()
 user_tracks_route_parser.add_argument(
@@ -518,10 +532,24 @@ user_tracks_route_parser.add_argument(
     type=str,
     default="date",
     choices=("date", "plays"),
-    description="Field to sort by",
+    description="[Deprecated] Field to sort by",
 )
 user_tracks_route_parser.add_argument(
     "query", required=False, description="The filter query"
+)
+user_tracks_route_parser.add_argument(
+    "sort_method",
+    required=False,
+    description="The sort method",
+    type=str,
+    choices=SortMethod._member_names_,
+)
+user_tracks_route_parser.add_argument(
+    "sort_direction",
+    required=False,
+    description="The sort direction",
+    type=str,
+    choices=SortDirection._member_names_,
 )
 
 full_search_parser = pagination_with_current_user_parser.copy()

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -9,6 +9,7 @@ from src.models.rewards.challenge import ChallengeType
 from src.queries.get_challenges import ChallengeResponse
 from src.queries.get_support_for_user import SupportResponse
 from src.queries.get_undisbursed_challenges import UndisbursedChallengeResponse
+from src.queries.query_helpers import SortDirection, SortMethod
 from src.queries.reactions import ReactionResponse
 from src.utils.config import shared_config
 from src.utils.helpers import decode_string_id, encode_int_id
@@ -490,6 +491,20 @@ track_history_parser = pagination_with_current_user_parser.copy()
 track_history_parser.add_argument(
     "query", required=False, description="The filter query"
 )
+track_history_parser.add_argument(
+    "sort_method",
+    required=False,
+    description="The sort method",
+    type=str,
+    choices=SortMethod._member_names_,
+)
+track_history_parser.add_argument(
+    "sort_direction",
+    required=False,
+    description="The sort direction",
+    type=str,
+    choices=SortDirection._member_names_,
+)
 
 user_favorited_tracks_parser = pagination_with_current_user_parser.copy()
 user_favorited_tracks_parser.add_argument(
@@ -576,6 +591,14 @@ def format_offset(args, max_offset=MAX_LIMIT):
 
 def format_query(args):
     return args.get("query", None)
+
+
+def format_sort_method(args):
+    return args.get("sort_method", None)
+
+
+def format_sort_direction(args):
+    return args.get("sort_direction", None)
 
 
 def get_default_max(value, default, max=None):

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -63,7 +63,7 @@ from src.queries.get_followees_for_user import get_followees_for_user
 from src.queries.get_followers_for_user import get_followers_for_user
 from src.queries.get_related_artists import get_related_artists
 from src.queries.get_repost_feed_for_user import get_repost_feed_for_user
-from src.queries.get_save_tracks import get_save_tracks
+from src.queries.get_save_tracks import GetSaveTracksArgs, get_save_tracks
 from src.queries.get_saves import get_saves
 from src.queries.get_support_for_user import (
     get_support_received_by_user,
@@ -72,7 +72,7 @@ from src.queries.get_support_for_user import (
 from src.queries.get_top_genre_users import get_top_genre_users
 from src.queries.get_top_user_track_tags import get_top_user_track_tags
 from src.queries.get_top_users import get_top_users
-from src.queries.get_tracks import get_tracks
+from src.queries.get_tracks import GetTrackArgs, get_tracks
 from src.queries.get_user_listening_history import (
     GetUserListeningHistoryArgs,
     get_user_listening_history,
@@ -223,22 +223,30 @@ class TrackList(Resource):
 
         current_user_id = get_current_user_id(args)
 
-        sort = args.get("sort", None)
+        sort = args.get("sort", None)  # Deprecated
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
 
-        args = {
-            "user_id": decoded_id,
-            "authed_user_id": authed_user_id,
-            "current_user_id": current_user_id,
-            "with_users": True,
-            "filter_deleted": True,
-            "sort": sort,
-            "limit": limit,
-            "offset": offset,
-            "query": query,
-        }
+        args = GetTrackArgs(
+            user_id=decoded_id,
+            authed_user_id=authed_user_id,
+            current_user_id=current_user_id,
+            filter_deleted=True,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            query=query,
+            sort_method=sort_method,
+            sort_direction=sort_direction,
+            # Unused
+            handle=None,
+            id=None,
+            min_block_number=None,
+            routes=None,
+        )
         tracks = get_tracks(args)
         tracks = list(map(extend_track, tracks))
         return success_response(tracks)
@@ -274,18 +282,26 @@ class FullTrackList(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
 
-        args = {
-            "user_id": decoded_id,
-            "current_user_id": current_user_id,
-            "authed_user_id": authed_user_id,
-            "with_users": True,
-            "filter_deleted": True,
-            "sort": sort,
-            "limit": limit,
-            "offset": offset,
-            "query": query,
-        }
+        args = GetTrackArgs(
+            user_id=decoded_id,
+            authed_user_id=authed_user_id,
+            current_user_id=current_user_id,
+            filter_deleted=True,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            query=query,
+            sort_method=sort_method,
+            sort_direction=sort_direction,
+            # Unused
+            handle=None,
+            id=None,
+            min_block_number=None,
+            routes=None,
+        )
         tracks = get_tracks(args)
         tracks = list(map(extend_track, tracks))
         return success_response(tracks)
@@ -572,14 +588,18 @@ class UserFavoritedTracksFull(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
-        get_tracks_args = {
-            "filter_deleted": False,
-            "user_id": decoded_id,
-            "current_user_id": current_user_id,
-            "limit": limit,
-            "offset": offset,
-            "query": query,
-        }
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
+        get_tracks_args = GetSaveTracksArgs(
+            filter_deleted=False,
+            user_id=decoded_id,
+            current_user_id=current_user_id,
+            limit=limit,
+            offset=offset,
+            query=query,
+            sort_method=sort_method,
+            sort_direction=sort_direction,
+        )
         track_saves = get_save_tracks(get_tracks_args)
         tracks = list(map(extend_activity, track_saves))
         return success_response(tracks)

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -20,6 +20,8 @@ from src.api.v1.helpers import (
     format_limit,
     format_offset,
     format_query,
+    format_sort_direction,
+    format_sort_method,
     get_current_user_id,
     get_default_max,
     make_full_response,
@@ -615,12 +617,16 @@ class TrackHistoryFull(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
         get_tracks_args = GetUserListeningHistoryArgs(
             user_id=decoded_id,
             current_user_id=current_user_id,
             limit=limit,
             offset=offset,
             query=query,
+            sort_method=sort_method,
+            sort_direction=sort_direction,
         )
         track_history = get_user_listening_history(get_tracks_args)
         tracks = list(map(extend_activity, track_history))

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -278,12 +278,15 @@ class FullTrackList(Resource):
 
         current_user_id = get_current_user_id(args)
 
-        sort = args.get("sort", None)
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+
+        sort = args.get("sort", None)  # Deprecated
         sort_method = format_sort_method(args)
         sort_direction = format_sort_direction(args)
+        if sort_method:
+            sort = None
 
         args = GetTrackArgs(
             user_id=decoded_id,

--- a/discovery-provider/src/models/tracks/track_with_aggregates.py
+++ b/discovery-provider/src/models/tracks/track_with_aggregates.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import relationship
+from src.models.social.aggregate_plays import AggregatePlay
+from src.models.tracks.aggregate_track import AggregateTrack
+from src.models.tracks.track import Track
+
+
+class TrackWithAggregates(Track):
+    aggregate_track = relationship(  # type: ignore
+        AggregateTrack,
+        primaryjoin="Track.track_id == foreign(AggregateTrack.track_id)",
+        lazy="joined",
+        viewonly=True,
+    )
+
+    aggregate_play = relationship(  # type: ignore
+        AggregatePlay,
+        primaryjoin="Track.track_id == foreign(AggregatePlay.play_item_id)",
+        lazy="joined",
+        viewonly=True,
+    )

--- a/discovery-provider/src/queries/get_save_tracks.py
+++ b/discovery-provider/src/queries/get_save_tracks.py
@@ -1,9 +1,15 @@
-from sqlalchemy import or_
+from typing import Optional, TypedDict
+
+from sqlalchemy import asc, desc, or_
+from src.models.social.aggregate_plays import AggregatePlay
 from src.models.social.save import Save, SaveType
-from src.models.tracks.track import Track
+from src.models.tracks.aggregate_track import AggregateTrack
+from src.models.tracks.track_with_aggregates import TrackWithAggregates
 from src.models.users.user import User
 from src.queries import response_name_constants
 from src.queries.query_helpers import (
+    SortDirection,
+    SortMethod,
     add_query_pagination,
     add_users_to_tracks,
     populate_track_metadata,
@@ -12,21 +18,48 @@ from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 
 
-def get_save_tracks(args):
+class GetSaveTracksArgs(TypedDict):
+    # The current user logged in (from route param)
+    user_id: int
+
+    # The current user logged in (from query arg)
+    current_user_id: int
+
+    # Wehther or not deleted tracks should be filtered out
+    filter_deleted: bool
+
+    # The maximum number of listens to return
+    limit: int
+
+    # The offset for the listen history
+    offset: int
+
+    # Optional filter for the returned results
+    query: Optional[str]
+
+    # Optional sort method for the returned results
+    sort_method: Optional[SortMethod]
+    sort_direction: Optional[SortDirection]
+
+
+def get_save_tracks(args: GetSaveTracksArgs):
     user_id = args.get("user_id")
     current_user_id = args.get("current_user_id")
     limit = args.get("limit")
     offset = args.get("offset")
     filter_deleted = args.get("filter_deleted")
     query = args.get("query")
+    sort_method = args["sort_method"]
+    sort_direction = args["sort_direction"]
+    sort_fn = desc if sort_direction == SortDirection.desc else asc
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
         base_query = (
-            session.query(Track, Save.created_at)
-            .join(Save, Save.save_item_id == Track.track_id)
+            session.query(TrackWithAggregates, Save.created_at)
+            .join(Save, Save.save_item_id == TrackWithAggregates.track_id)
             .filter(
-                Track.is_current == True,
+                TrackWithAggregates.is_current == True,
                 Save.user_id == user_id,
                 Save.is_current == True,
                 Save.is_delete == False,
@@ -36,17 +69,42 @@ def get_save_tracks(args):
 
         # Allow filtering of deletes
         if filter_deleted:
-            base_query = base_query.filter(Track.is_delete == False)
+            base_query = base_query.filter(TrackWithAggregates.is_delete == False)
 
         if query:
-            base_query = base_query.join(Track.user, aliased=True).filter(
+            base_query = base_query.join(TrackWithAggregates.user, aliased=True).filter(
                 or_(
-                    Track.title.ilike(f"%{query.lower()}%"),
+                    TrackWithAggregates.title.ilike(f"%{query.lower()}%"),
                     User.name.ilike(f"%{query.lower()}%"),
                 )
             )
 
-        base_query = base_query.order_by(Save.created_at.desc(), Track.track_id.desc())
+        if sort_method == SortMethod.title:
+            base_query = base_query.order_by(sort_fn(TrackWithAggregates.title))
+        elif sort_method == SortMethod.artist_name:
+            base_query = base_query.order_by(sort_fn(TrackWithAggregates.user.name))
+        elif sort_method == SortMethod.release_date:
+            base_query = base_query.order_by(sort_fn(TrackWithAggregates.release_date))
+        elif sort_method == SortMethod.added_date:
+            base_query = base_query.order_by(
+                sort_fn(Save.created_at), desc(TrackWithAggregates.track_id)
+            )
+        elif sort_method == SortMethod.plays:
+            base_query = base_query.join(TrackWithAggregates.aggregate_play).order_by(
+                sort_fn(AggregatePlay.count)
+            )
+        elif sort_method == SortMethod.reposts:
+            base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
+                sort_fn(AggregateTrack.repost_count)
+            )
+        elif sort_method == SortMethod.saves:
+            base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
+                sort_fn(AggregateTrack.save_count)
+            )
+        else:
+            base_query = base_query.order_by(
+                desc(Save.created_at), desc(TrackWithAggregates.track_id)
+            )
 
         query_results = add_query_pagination(base_query, limit, offset).all()
 
@@ -58,8 +116,10 @@ def get_save_tracks(args):
         track_ids = list(map(lambda track: track["track_id"], tracks))
 
         # bundle peripheral info into track results
-        tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
-        add_users_to_tracks(session, tracks, current_user_id)
+        tracks = populate_track_metadata(
+            session, track_ids, tracks, current_user_id, track_has_aggregates=True
+        )
+        tracks = add_users_to_tracks(session, tracks, current_user_id)
 
         for idx, track in enumerate(tracks):
             track[response_name_constants.activity_timestamp] = save_dates[idx]

--- a/discovery-provider/src/queries/get_user_listening_history.py
+++ b/discovery-provider/src/queries/get_user_listening_history.py
@@ -1,12 +1,16 @@
 from typing import Optional, TypedDict
 
-from sqlalchemy import Integer, String, or_, text
+from sqlalchemy import Integer, String, asc, desc, or_, text
 from sqlalchemy.orm.session import Session
-from src.models.tracks.track import Track
+from src.models.social.aggregate_plays import AggregatePlay
+from src.models.tracks.aggregate_track import AggregateTrack
+from src.models.tracks.track_with_aggregates import TrackWithAggregates
 from src.models.users.user import User
 from src.models.users.user_listening_history import UserListeningHistory
 from src.queries import response_name_constants
 from src.queries.query_helpers import (
+    SortDirection,
+    SortMethod,
     add_query_pagination,
     add_users_to_tracks,
     populate_track_metadata,
@@ -31,6 +35,10 @@ class GetUserListeningHistoryArgs(TypedDict):
     # Optional filter for the returned results
     query: Optional[str]
 
+    # Optional sort method for the returned results
+    sort_method: Optional[SortMethod]
+    sort_direction: Optional[SortDirection]
+
 
 def get_user_listening_history(args: GetUserListeningHistoryArgs):
     """
@@ -54,6 +62,9 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     limit = args["limit"]
     offset = args["offset"]
     query = args["query"]
+    sort_method = args["sort_method"]
+    sort_direction = args["sort_direction"]
+    sort_fn = desc if sort_direction == SortDirection.desc else asc
 
     if user_id != current_user_id:
         return []
@@ -91,20 +102,41 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     )
 
     base_query = (
-        session.query(Track)
-        .join(order, order.c.id == Track.track_id)
-        .filter(Track.is_current == True)
+        session.query(TrackWithAggregates)
+        .join(order, order.c.id == TrackWithAggregates.track_id)
+        .filter(TrackWithAggregates.is_current == True)
     )
 
     if query is not None:
-        base_query = base_query.join(Track.user, aliased=True).filter(
+        base_query = base_query.join(TrackWithAggregates.user).filter(
             or_(
-                Track.title.ilike(f"%{query.lower()}%"),
+                TrackWithAggregates.title.ilike(f"%{query.lower()}%"),
                 User.name.ilike(f"%{query.lower()}%"),
             )
         )
 
-    base_query = base_query.order_by(order.c.ord)
+    if sort_method == SortMethod.title:
+        base_query = base_query.order_by(sort_fn(TrackWithAggregates.title))
+    elif sort_method == SortMethod.artist_name:
+        base_query = base_query.order_by(sort_fn(TrackWithAggregates.user.name))
+    elif sort_method == SortMethod.release_date:
+        base_query = base_query.order_by(sort_fn(TrackWithAggregates.release_date))
+    elif sort_method == SortMethod.last_listen_date:
+        base_query = base_query.order_by(sort_fn(order.c.ord))
+    elif sort_method == SortMethod.plays:
+        base_query = base_query.join(TrackWithAggregates.aggregate_play).order_by(
+            sort_fn(AggregatePlay.count)
+        )
+    elif sort_method == SortMethod.reposts:
+        base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
+            sort_fn(AggregateTrack.repost_count)
+        )
+    elif sort_method == SortMethod.saves:
+        base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
+            sort_fn(AggregateTrack.save_count)
+        )
+    else:
+        base_query = base_query.order_by(sort_fn(order.c.ord))
 
     # Add pagination
     base_query = add_query_pagination(base_query, limit, offset)
@@ -114,8 +146,10 @@ def _get_user_listening_history(session: Session, args: GetUserListeningHistoryA
     tracks = helpers.query_result_to_list(base_query)
 
     # bundle peripheral info into track results
-    tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
-    add_users_to_tracks(session, tracks, current_user_id)
+    tracks = populate_track_metadata(
+        session, track_ids, tracks, current_user_id, track_has_aggregates=True
+    )
+    tracks = add_users_to_tracks(session, tracks, current_user_id)
 
     for track in tracks:
         track[response_name_constants.activity_timestamp] = listen_dates[

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -111,6 +111,7 @@ class SortMethod(str, enum.Enum):
     artist_name = "artist_name"
     release_date = "release_date"
     last_listen_date = "last_listen_date"
+    added_date = "added_date"
     length = "length"
     plays = "plays"
     reposts = "reposts"

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -439,15 +439,17 @@ def populate_track_metadata(
         track_id = track["track_id"]
 
         if track_has_aggregates:
-            track[response_name_constants.repost_count] = track.get("aggregate_track")[
-                0
-            ].get("repost_count", 0)
-            track[response_name_constants.save_count] = track.get("aggregate_track")[
-                0
-            ].get("save_count", 0)
-            track[response_name_constants.play_count] = track.get("aggregate_play")[
-                0
-            ].get("count", 0)
+            aggregate_track = track.get("aggregate_track")
+            track[response_name_constants.repost_count] = (
+                aggregate_track[0].get("repost_count", 0) if aggregate_track else 0
+            )
+            track[response_name_constants.save_count] = (
+                aggregate_track[0].get("save_count", 0) if aggregate_track else 0
+            )
+            aggregate_play = track.get("aggregate_play")
+            track[response_name_constants.play_count] = (
+                aggregate_play[0].get("count", 0) if aggregate_play else 0
+            )
         else:
             track[response_name_constants.repost_count] = count_dict.get(
                 track_id, {}

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -1,4 +1,5 @@
 # pylint: disable=too-many-lines
+import enum
 import logging
 from typing import Tuple
 
@@ -103,6 +104,22 @@ def parse_sort_param(base_query, model, whitelist_sort_params):
         order_bys.append(attr)
 
     return base_query.order_by(*order_bys)
+
+
+class SortMethod(str, enum.Enum):
+    title = "title"  # type: ignore
+    artist_name = "artist_name"
+    release_date = "release_date"
+    last_listen_date = "last_listen_date"
+    length = "length"
+    plays = "plays"
+    reposts = "reposts"
+    saves = "saves"
+
+
+class SortDirection(str, enum.Enum):
+    asc = "asc"
+    desc = "desc"
 
 
 # given list of user ids and corresponding users, populates each user object with:
@@ -318,29 +335,32 @@ def get_track_play_count_dict(session, track_ids):
 #   repost_count, save_count
 #   if remix: remix users, has_remix_author_reposted, has_remix_author_saved
 #   if current_user_id available, populates followee_reposts, has_current_user_reposted, has_current_user_saved
-def populate_track_metadata(session, track_ids, tracks, current_user_id):
-    # build dict of track id --> repost count
-    counts = (
-        session.query(
-            AggregateTrack.track_id,
-            AggregateTrack.repost_count,
-            AggregateTrack.save_count,
+def populate_track_metadata(
+    session, track_ids, tracks, current_user_id, track_has_aggregates=False
+):
+    if not track_has_aggregates:
+        # build dict of track id --> repost count
+        counts = (
+            session.query(
+                AggregateTrack.track_id,
+                AggregateTrack.repost_count,
+                AggregateTrack.save_count,
+            )
+            .filter(
+                AggregateTrack.track_id.in_(track_ids),
+            )
+            .all()
         )
-        .filter(
-            AggregateTrack.track_id.in_(track_ids),
-        )
-        .all()
-    )
 
-    count_dict = {
-        track_id: {
-            response_name_constants.repost_count: repost_count,
-            response_name_constants.save_count: save_count,
+        count_dict = {
+            track_id: {
+                response_name_constants.repost_count: repost_count,
+                response_name_constants.save_count: save_count,
+            }
+            for (track_id, repost_count, save_count) in counts
         }
-        for (track_id, repost_count, save_count) in counts
-    }
 
-    play_count_dict = get_track_play_count_dict(session, track_ids)
+        play_count_dict = get_track_play_count_dict(session, track_ids)
 
     remixes = get_track_remix_metadata(session, tracks, current_user_id)
 
@@ -416,13 +436,25 @@ def populate_track_metadata(session, track_ids, tracks, current_user_id):
 
     for track in tracks:
         track_id = track["track_id"]
-        track[response_name_constants.repost_count] = count_dict.get(track_id, {}).get(
-            response_name_constants.repost_count, 0
-        )
-        track[response_name_constants.save_count] = count_dict.get(track_id, {}).get(
-            response_name_constants.save_count, 0
-        )
-        track[response_name_constants.play_count] = play_count_dict.get(track_id, 0)
+
+        if track_has_aggregates:
+            track[response_name_constants.repost_count] = track.get("aggregate_track")[
+                0
+            ].get("repost_count", 0)
+            track[response_name_constants.save_count] = track.get("aggregate_track")[
+                0
+            ].get("save_count", 0)
+            track[response_name_constants.play_count] = track.get("aggregate_play")[
+                0
+            ].get("count", 0)
+        else:
+            track[response_name_constants.repost_count] = count_dict.get(
+                track_id, {}
+            ).get(response_name_constants.repost_count, 0)
+            track[response_name_constants.save_count] = count_dict.get(
+                track_id, {}
+            ).get(response_name_constants.save_count, 0)
+            track[response_name_constants.play_count] = play_count_dict.get(track_id, 0)
         # current user specific
         track[
             response_name_constants.followee_reposts
@@ -1212,7 +1244,7 @@ def add_users_to_tracks(session, tracks, current_user_id=None):
     Side Effects:
         Modifies the track dictionaries to add a nested owner user
 
-    Returns: None
+    Returns: Tracks with users attached
     """
     users = [t.get("user")[0] for t in tracks]
     user_ids = [u.get("user_id") for u in users]
@@ -1227,3 +1259,5 @@ def add_users_to_tracks(session, tracks, current_user_id=None):
         user = user_map[track["owner_id"]]
         if user:
             track["user"] = user
+
+    return tracks

--- a/libs/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -300,13 +300,21 @@ export interface GetTracksByUserRequest {
      */
     userId?: string;
     /**
-     * Field to sort by
+     * [Deprecated] Field to sort by
      */
     sort?: GetTracksByUserSortEnum;
     /**
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetTracksByUserSortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetTracksByUserSortDirectionEnum;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -327,13 +335,21 @@ export interface GetTracksByUserHandleRequest {
      */
     userId?: string;
     /**
-     * Field to sort by
+     * [Deprecated] Field to sort by
      */
     sort?: GetTracksByUserHandleSortEnum;
     /**
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetTracksByUserHandleSortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetTracksByUserHandleSortDirectionEnum;
 }
 
 export interface GetUserRequest {
@@ -382,6 +398,14 @@ export interface GetUsersTrackHistoryRequest {
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetUsersTrackHistorySortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetUsersTrackHistorySortDirectionEnum;
 }
 
 export interface SearchUsersRequest {
@@ -826,6 +850,14 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['query'] = requestParameters.query;
         }
 
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -864,6 +896,14 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.query !== undefined) {
             queryParameters['query'] = requestParameters.query;
+        }
+
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -970,6 +1010,14 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['query'] = requestParameters.query;
         }
 
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -1042,7 +1090,76 @@ export enum GetTracksByUserSortEnum {
     * @export
     * @enum {string}
     */
+export enum GetTracksByUserSortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserSortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
 export enum GetTracksByUserHandleSortEnum {
     Date = 'date',
     Plays = 'plays'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleSortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleSortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetUsersTrackHistorySortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetUsersTrackHistorySortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
 }

--- a/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -78,6 +78,14 @@ export interface GetFavoritesRequest {
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetFavoritesSortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetFavoritesSortDirectionEnum;
 }
 
 export interface GetFollowersRequest {
@@ -287,13 +295,21 @@ export interface GetTracksByUserRequest {
      */
     userId?: string;
     /**
-     * Field to sort by
+     * [Deprecated] Field to sort by
      */
     sort?: GetTracksByUserSortEnum;
     /**
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetTracksByUserSortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetTracksByUserSortDirectionEnum;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -314,13 +330,21 @@ export interface GetTracksByUserHandleRequest {
      */
     userId?: string;
     /**
-     * Field to sort by
+     * [Deprecated] Field to sort by
      */
     sort?: GetTracksByUserHandleSortEnum;
     /**
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetTracksByUserHandleSortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetTracksByUserHandleSortDirectionEnum;
 }
 
 export interface GetUserRequest {
@@ -366,6 +390,14 @@ export interface GetUsersTrackHistoryRequest {
      * The filter query
      */
     query?: string;
+    /**
+     * The sort method
+     */
+    sortMethod?: GetUsersTrackHistorySortMethodEnum;
+    /**
+     * The sort direction
+     */
+    sortDirection?: GetUsersTrackHistorySortDirectionEnum;
 }
 
 /**
@@ -397,6 +429,14 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.query !== undefined) {
             queryParameters['query'] = requestParameters.query;
+        }
+
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -771,6 +811,14 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['query'] = requestParameters.query;
         }
 
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -809,6 +857,14 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.query !== undefined) {
             queryParameters['query'] = requestParameters.query;
+        }
+
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -895,6 +951,14 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['query'] = requestParameters.query;
         }
 
+        if (requestParameters.sortMethod !== undefined) {
+            queryParameters['sort_method'] = requestParameters.sortMethod;
+        }
+
+        if (requestParameters.sortDirection !== undefined) {
+            queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -911,6 +975,29 @@ export class UsersApi extends runtime.BaseAPI {
     * @export
     * @enum {string}
     */
+export enum GetFavoritesSortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetFavoritesSortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
 export enum GetTracksByUserSortEnum {
     Date = 'date',
     Plays = 'plays'
@@ -919,7 +1006,76 @@ export enum GetTracksByUserSortEnum {
     * @export
     * @enum {string}
     */
+export enum GetTracksByUserSortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserSortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
 export enum GetTracksByUserHandleSortEnum {
     Date = 'date',
     Plays = 'plays'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleSortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleSortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetUsersTrackHistorySortMethodEnum {
+    Title = 'title',
+    ArtistName = 'artist_name',
+    ReleaseDate = 'release_date',
+    LastListenDate = 'last_listen_date',
+    AddedDate = 'added_date',
+    Length = 'length',
+    Plays = 'plays',
+    Reposts = 'reposts',
+    Saves = 'saves'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetUsersTrackHistorySortDirectionEnum {
+    Asc = 'asc',
+    Desc = 'desc'
 }

--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -256,9 +256,8 @@ const runSetupCommand = async (
       }
       const durationSeconds = Math.abs((Date.now() - start) / 1000)
       console.log(
-        `${service} ${
-          serviceNumber || ''
-        } - ${setupCommand} | executed in ${durationSeconds}s`.info
+        `${service} ${serviceNumber || ''
+          } - ${setupCommand} | executed in ${durationSeconds}s`.info
       )
       return outputs
     } catch (err) {
@@ -291,9 +290,8 @@ const getServiceURL = (service, serviceNumber) => {
     if (!serviceNumber) {
       throw new Error('Missing serviceNumber')
     }
-    return `http://${getContentNodeContainerName(serviceNumber)}:${
-      4000 + parseInt(serviceNumber) - 1
-    }/${healthCheckEndpoint}`
+    return `http://${getContentNodeContainerName(serviceNumber)}:${4000 + parseInt(serviceNumber) - 1
+      }/${healthCheckEndpoint}`
   }
   return `${protocol}://${host}:${port}/${healthCheckEndpoint}`
 }
@@ -393,14 +391,13 @@ const discoveryNodeUp = async (options = { verbose: false }) => {
 
   const setup = [
     [Service.NETWORK, SetupCommand.UP],
-    [Service.SOLANA_VALIDATOR, SetupCommand.UP],
-    [Service.SOLANA_VALIDATOR, SetupCommand.HEALTH_CHECK_RETRY]
+    [Service.SOLANA_VALIDATOR_PREDEPLOYED, SetupCommand.UP, { waitSec: 3 }],
+    [Service.SOLANA_VALIDATOR_PREDEPLOYED, SetupCommand.HEALTH_CHECK_RETRY]
   ]
 
   const inParallel = [
-    [Service.CONTRACTS, SetupCommand.UP],
-    [Service.ETH_CONTRACTS, SetupCommand.UP],
-    [Service.SOLANA_PROGRAMS, SetupCommand.UP]
+    [Service.CONTRACTS_PREDEPLOYED, SetupCommand.UP],
+    [Service.ETH_CONTRACTS_PREDEPLOYED, SetupCommand.UP]
   ]
 
   const sequential = [


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add sorters to endpoints via a string enum w/ "choices."
This hits all of the sorting desires except track length, which is an unindexed field (but we should make it one in future).

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

New unit test for history, tested also manually requesting each endpoint and setting the sorters

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Existing history, favorites, profile, artist dashboard pages

Will confirm new tables work with req. pagination as expected

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->