### PR TITLE
Add slack-secrets to jobs that use Slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1083,6 +1083,7 @@ workflows:
       - bake-gcp-dev-image:
           context:
             - GCP2
+            - slack-secrets
           name: bake-gcp-dev-image-nightly
       - docker-build-and-push:
           name: build-eth-contracts


### PR DESCRIPTION
### Description

Expose the `slack-secrets` secrets for the GCP bake job.


### Tests

Monitor the nightly run.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->