### PR TITLE
Fix TypeError for userSecondarySyncMetrics

### DIFF
--- a/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.ts
+++ b/creator-node/src/services/stateMachineManager/makeOnCompleteCallback.ts
@@ -53,8 +53,11 @@ module.exports = function (
   prometheusRegistry: any
 ) {
   return async function (jobId: string, resultString: string) {
-    // Create a logger so that we can filter logs by the tag `jobId` = <id of the job that successfully completed>
-    const logger = createChildLogger(baseLogger, { jobId })
+    // Create a logger so that we can filter logs by the tags `queue` and `jobId` = <id of the job that successfully completed>
+    const logger = createChildLogger(baseLogger, {
+      queue: nameOfQueueWithCompletedJob,
+      jobId
+    })
 
     // update-replica-set jobs need enabledReconfigModes as an array.
     // `this` comes from the function being bound via .bind() to ./index.js

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
@@ -79,8 +79,8 @@ module.exports = async function ({
     const { wallet, primary, secondary1, secondary2 } = user
 
     const userSecondarySyncMetrics = {
-      [secondary1]: { successRate: 1, failureCount: 0 },
-      [secondary2]: { successRate: 1, failureCount: 0 },
+      [secondary1]: { successRate: 1, failureCount: 0, successCount: 0 },
+      [secondary2]: { successRate: 1, failureCount: 0, successCount: 0 },
       ...userSecondarySyncMetricsMap[wallet]
     }
     logger.info(

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
@@ -78,24 +78,16 @@ module.exports = async function ({
   for (const user of users) {
     const { wallet, primary, secondary1, secondary2 } = user
 
-    const userSecondarySyncMetrics = userSecondarySyncMetricsMap[wallet] || {}
+    const userSecondarySyncMetrics = {
+      [secondary1]: { successRate: 1, failureCount: 0 },
+      [secondary2]: { successRate: 1, failureCount: 0 },
+      ...userSecondarySyncMetricsMap[wallet]
+    }
     logger.info(
       `Finding sync requests for user ${JSON.stringify(
         user
       )} with secondarySyncMetrics ${JSON.stringify(userSecondarySyncMetrics)}`
     )
-    userSecondarySyncMetrics[secondary1] = userSecondarySyncMetrics[
-      secondary1
-    ] || {
-      successRate: 1,
-      failureCount: 0
-    }
-    userSecondarySyncMetrics[secondary2] = userSecondarySyncMetrics[
-      secondary2
-    ] || {
-      successRate: 1,
-      failureCount: 0
-    }
 
     const {
       syncReqsToEnqueue: userSyncReqsToEnqueue,

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
@@ -78,9 +78,23 @@ module.exports = async function ({
   for (const user of users) {
     const { wallet, primary, secondary1, secondary2 } = user
 
-    const userSecondarySyncMetrics = userSecondarySyncMetricsMap[wallet] || {
-      [secondary1]: { successRate: 1, failureCount: 0 },
-      [secondary2]: { successRate: 1, failureCount: 0 }
+    const userSecondarySyncMetrics = userSecondarySyncMetricsMap[wallet] || {}
+    logger.info(
+      `Finding sync requests for user ${JSON.stringify(
+        user
+      )} with secondarySyncMetrics ${JSON.stringify(userSecondarySyncMetrics)}`
+    )
+    userSecondarySyncMetrics[secondary1] = userSecondarySyncMetrics[
+      secondary1
+    ] || {
+      successRate: 1,
+      failureCount: 0
+    }
+    userSecondarySyncMetrics[secondary2] = userSecondarySyncMetrics[
+      secondary2
+    ] || {
+      successRate: 1,
+      failureCount: 0
     }
 
     const {


### PR DESCRIPTION
### Description
- Add default value for each secondary in the userSecondarySyncMetrics mapping to fix an error thrown for destructuring from undefined. We previously had a default for the entire mapping, but that didn't cover the case where the wallet had metrics for only one secondary
  - The line where this error was thrown was in findSyncRequests.jobProcessor.ts: `const { successRate, failureCount } = userSecondarySyncMetricsMap[secondary];`
- Add filter for queue name to onComplete logs – combing the logs to verify the cause of this error has been a little more time consuming without this filter



### Tests
Unit tests pass and jobs in the find-sync-requests-queue complete successfully locally after seeding users.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Search for the following error: `"TypeError: Cannot destructure property 'successRate' of 'userSecondarySyncMetricsMap[secondary]' as it is undefined"`