### PR TITLE
Prevent extra unnecessary reconfig events

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -150,5 +150,5 @@ export const SYNC_MODES = Object.freeze({
 
 export const FETCH_FILES_HASH_NUM_RETRIES = 3
 
-// Seconds to hold the cache of healthy content nodes for update-replica-set jobs (10 mins)
-export const HEALTHY_SERVICES_TTL_SEC = 10 * 60
+// Seconds to hold the cache of healthy content nodes for update-replica-set jobs
+export const HEALTHY_SERVICES_TTL_SEC = 60 /* 1 min */

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -529,7 +529,7 @@ const _issueUpdateReplicaSetOp = async (
       // NOTE: This error might be misleading because the reconfig event already took place in another node in the replica set.
       // Check the transaction for details, or user history to make sure only 1 reconfig event occurred.
       throw new Error(
-        `[_issueUpdateReplicaSetOp] Update replica set failed in ${timeElapsedMs}ms. Look into txn for details as this may be a false alarm. - Error ${e.message}`
+        `UserReplicaSetManagerClient.updateReplicaSet() Failed in ${timeElapsedMs}ms. Look into the txn for more details as this may be a false alarm. - Error ${e.message}`
       )
     }
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -617,7 +617,7 @@ type CanReconfigParams = {
   oldSecondary1SpId: number
   oldSecondary2SpId: number
   userId: number
-  logger: any
+  logger: Logger
 }
 const _canReconfig = async ({
   libs,

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -494,13 +494,6 @@ const _issueUpdateReplicaSetOp = async (
       )
     }
 
-    const oldPrimarySpId =
-      ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[primary]
-    const oldSecondary1SpId =
-      ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[secondary1]
-    const oldSecondary2SpId =
-      ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[secondary2]
-
     // Submit chain tx to update replica set
     const startTimeMs = Date.now()
     try {
@@ -513,6 +506,12 @@ const _issueUpdateReplicaSetOp = async (
           logger
         })
       }
+
+      const {
+        [primary]: oldPrimarySpId,
+        [secondary1]: oldSecondary1SpId,
+        [secondary2]: oldSecondary2SpId
+      } = ContentNodeInfoManager.getCNodeEndpointToSpIdMap()
 
       const canReconfig = await _canReconfig({
         libs: audiusLibs,

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -407,7 +407,9 @@ const _selectRandomReplicaSetNodes = async (
       }
     } catch (e: any) {
       // Something went wrong in checking clock value. Reselect another secondary.
-      logger.error(`${logStr} ${e.message}`)
+      logger.error(
+        `${logStr} randomHealthyNode=${randomHealthyNode} ${e.message}`
+      )
     }
   }
 
@@ -529,7 +531,7 @@ const _issueUpdateReplicaSetOp = async (
       // NOTE: This error might be misleading because the reconfig event already took place in another node in the replica set.
       // Check the transaction for details, or user history to make sure only 1 reconfig event occurred.
       throw new Error(
-        `UserReplicaSetManagerClient.updateReplicaSet() Failed in ${timeElapsedMs}ms. Look into the txn for more details as this may be a false alarm. - Error ${e.message}`
+        `UserReplicaSetManagerClient._updateReplicaSet() Failed in ${timeElapsedMs}ms. Look into the txn for more details as this may be a false alarm. - Error ${e.message}`
       )
     }
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -514,7 +514,7 @@ const _issueUpdateReplicaSetOp = async (
         })
       }
 
-      const shouldReconfig = await _shouldReconfig({
+      const canReconfig = await _canReconfig({
         libs: audiusLibs,
         oldPrimarySpId,
         oldSecondary1SpId,
@@ -523,7 +523,7 @@ const _issueUpdateReplicaSetOp = async (
         logger
       })
 
-      if (!shouldReconfig) {
+      if (!canReconfig) {
         logger.info(
           `[_issueUpdateReplicaSetOp] skipping _updateReplicaSet as reconfig already occurred for userId=${userId} wallet=${wallet}`
         )
@@ -611,7 +611,7 @@ const _isReconfigEnabled = (enabledReconfigModes: string[], mode: string) => {
   return enabledReconfigModes.includes(mode)
 }
 
-type ShouldReconfigParams = {
+type CanReconfigParams = {
   libs: any
   oldPrimarySpId: number
   oldSecondary1SpId: number
@@ -619,17 +619,17 @@ type ShouldReconfigParams = {
   userId: number
   logger: any
 }
-const _shouldReconfig = async ({
+const _canReconfig = async ({
   libs,
   oldPrimarySpId,
   oldSecondary1SpId,
   oldSecondary2SpId,
   userId,
   logger
-}: ShouldReconfigParams): Promise<boolean> => {
-  // If any error occurs in determing if a reconfig event should happen, default to issuing
+}: CanReconfigParams): Promise<boolean> => {
+  // If any error occurs in determining if a reconfig event can happen, default to issuing
   // a reconfig event anyway just to prevent users from keeping an unhealthy replica set
-  let shouldReconfig = true
+  let canReconfig = true
   try {
     const {
       primaryId: currentPrimarySpId,
@@ -648,17 +648,17 @@ const _shouldReconfig = async ({
       )
     }
 
-    shouldReconfig =
+    canReconfig =
       currentPrimarySpId === oldPrimarySpId &&
       currentSecondarySpIds[0] === oldSecondary1SpId &&
       currentSecondarySpIds[1] === oldSecondary2SpId
   } catch (e: any) {
     logger.error(
-      `[_issueUpdateReplicaSetOp] error in _shouldReconfig. : ${e.message}`
+      `[_issueUpdateReplicaSetOp] error in _canReconfig. : ${e.message}`
     )
   }
 
-  return shouldReconfig
+  return canReconfig
 }
 
 module.exports = updateReplicaSetJobProcessor

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -85,7 +85,8 @@ describe('test updateReplicaSet job processor', function () {
       },
       contracts: {
         UserReplicaSetManagerClient: {
-          updateReplicaSet: updateReplicaSetStub
+          updateReplicaSet: updateReplicaSetStub,
+          _updateReplicaSet: updateReplicaSetStub
         }
       }
     }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
There were unnecessary reconfig events being made. To prevent this from happening, we have to pass in the old replica set and call the fn that requires passing in the old replica set.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
1. Created user
2. Uploaded 2 tracks
3. Checked existing replica set
4. Stopped a secondary
5. Waited to see if user got rolled onto another secondary
6. Confirmed that one of user's replica set nodes successfully rolled onto another secondary
```
{"name":"audius_creator_node","hostname":"baf7882f9f52","pid":26576,"queue":"update-replica-set-queue","jobId":"2","level":30,"msg":"[_issueUpdateReplicaSetOp] Reconfig SUCCESS: userId=2 wallet=0x3ce45ff75ed2e9e8439dbc57e835bc37bcedd0a2 old replica set=[http://cn2_creator-node_1:4001,http://cn3_creator-node_1:4002,http://cn4_creator-node_1:4003] | new replica set=[http://cn2_creator-node_1:4001,http://cn3_creator-node_1:4002,http://cn1_creator-node_1:4000] | reconfig type=[ONE_SECONDARY]","time":"2022-08-10T21:51:49.014Z","v":0,"logLevel":"info"}
```
7. Confirmed that the other user's replica set node did not roll onto another secondary
```
{"name":"audius_creator_node","hostname":"7af26083da6e","pid":10184,"queue":"update-replica-set-queue","jobId":"1","level":30,"msg":"[_issueUpdateReplicaSetOp] skipping updateReplicaSet as reconfig already occurred for userId=2 wallet=0x3ce45ff75ed2e9e8439dbc57e835bc37bcedd0a2","time":"2022-08-10T21:52:27.790Z","v":0,"logLevel":"info"}
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
See logs surrounding `_issueUpdateReplicaSetOp`. 

**Followups**
- can we make this smarter than letting the txn fail? we will see 5 retries that are useless. maybe we can also instead check the replica set on chain instead of making an extra reconfig call

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->