### PR TITLE
Add disable flag to logspout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,7 +900,7 @@ jobs:
             # 2. CIRCLE_TAG if defined,
             # 3. Branch name if 'hotfix' in branch name (branch name passed in via $CIRCLE_BRANCH)
             # 4. 'latest', which is the default
-            echo "export IMAGE_TAG=`[ << parameters.logspout-tag >> ] && echo $(head -n1 logspout/Dockerfile | cut -f 2 -d ':') || [ $CIRCLE_TAG ] && echo $(echo $CIRCLE_TAG | cut -d@ -f3) || [[ "$CIRCLE_BRANCH" =~ (hotfix) ]] && echo $CIRCLE_BRANCH || echo "latest" `" | tee -a $BASH_ENV
+            echo "export IMAGE_TAG=`[ << parameters.logspout-tag >> ] && echo $(head -n1 logspout/Dockerfile | cut -f 2 -d '=') || [ $CIRCLE_TAG ] && echo $(echo $CIRCLE_TAG | cut -d@ -f3) || [[ "$CIRCLE_BRANCH" =~ (hotfix) ]] && echo $CIRCLE_BRANCH || echo "latest" `" | tee -a $BASH_ENV
       - run:
           name: Docker login
           command: |

--- a/creator-node/Dockerfile
+++ b/creator-node/Dockerfile
@@ -69,6 +69,7 @@ COPY . .
 # Compile js code to typescript based on tsconfig.json
 RUN node_modules/.bin/tsc --project ./
 
+# ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars
 ARG git_sha
 ARG audius_loggly_disable
 ARG audius_loggly_token

--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -72,6 +72,7 @@ RUN cd es-indexer && npm install && npm run build
 
 COPY --from=contracts /usr/src/app/build/contracts/ build/contracts/
 
+# ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars
 ARG git_sha
 ARG audius_loggly_disable
 ARG audius_loggly_token

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=v3.2.14-update-1
+ARG TAG=v3.2.14-1
 FROM gliderlabs/logspout:v3.2.14
 
 # ignores previously log on startup

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -1,3 +1,4 @@
+ARG TAG=v3.2.14-dm-test-1
 FROM gliderlabs/logspout:v3.2.14
 
 # ignores previously log on startup

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=v3.2.14-disable-logging
+ARG TAG=v3.2.14-update-1
 FROM gliderlabs/logspout:v3.2.14
 
 # ignores previously log on startup

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=v3.2.14-dm-test-1
+ARG TAG=v3.2.14-disable-logging
 FROM gliderlabs/logspout:v3.2.14
 
 # ignores previously log on startup

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -7,7 +7,7 @@ In the event we want to build the Logspout container by hand
 # .env contains: audius_loggly_token=xxx
 . .env
 
-LOGSPOUT_VERSION=$(head -n1 Dockerfile | cut -f 2 -d ':')
+LOGSPOUT_VERSION=$(head -n1 Dockerfile | cut -f 2 -d '=')
 [ ${audius_loggly_token} ] \
     && audius_loggly_token_64=$(echo ${audius_loggly_token} | base64) \
     && docker build \

--- a/logspout/start.sh
+++ b/logspout/start.sh
@@ -33,5 +33,7 @@ done
 export SYSLOG_STRUCTURED_DATA="$(echo ${audius_loggly_token} | base64 -d)@41058 ${tags}"
 echo SYSLOG_STRUCTURED_DATA=${SYSLOG_STRUCTURED_DATA}
 
-# start logspout and point it to Loggly
-/bin/logspout multiline+syslog+tcp://logs-01.loggly.com:514
+# start logspout if audius_loggly_disable is not set
+if [[ -z "$audius_loggly_disable" ]]; then
+   /bin/logspout multiline+syslog+tcp://logs-01.loggly.com:514
+fi

--- a/logspout/start.sh
+++ b/logspout/start.sh
@@ -13,6 +13,9 @@ if [[ "${audius_discprov_url}" ]]; then
    hostname=${audius_discprov_url}
 elif [[ "${creatorNodeEndpoint}" ]]; then
    hostname=${creatorNodeEndpoint}
+# if neither hostname is not defined, set audius_delegate_owner_wallet as a proxy for hostname
+elif [[ "${audius_delegate_owner_wallet}" ]]; then
+   hostname=DelegateOwnerWallet-${audius_delegate_owner_wallet}
 fi
 
 # use regex to extract domain in url (source: https://stackoverflow.com/a/2506635/8674706)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Add a flag to disable sending logs through logspout.

There's 4 cases that should all work, but we should probably disable the single docker container transport and only do it through logspout sidecar

Logs enabled
- via docker-compose by default
- via single docker container by default (enableRsyslog defaulted to true)

Logs disabled
- via docker-compose with (audius_logging_disabled set to true)
- via single docker container with (audius_logging_disabled set to true)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested this on a new docker compose discovery node with audius_logging_disabled both set and unset.

This PR needs to be merged before https://github.com/AudiusProject/audius-docker-compose/pull/50 is merged because of the tag dependency

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Logs should be appearing in Loggly for nodes with logging enabled.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->