### PR TITLE
[PAY-459] Add dethroned notifications on Identity

### DIFF
--- a/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
+++ b/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: (queryInterface) => {
@@ -9,7 +9,6 @@ module.exports = {
 
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (transaction) => {
-
       // Drop any DethronedNotifs
       await queryInterface.sequelize.query(`
         DELETE FROM "SolanaNotifications"
@@ -44,4 +43,4 @@ module.exports = {
       `, { transaction })
     })
   }
-};
+}

--- a/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
+++ b/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.query(
+      `ALTER TYPE "enum_SolanaNotifications_type" ADD VALUE 'SupporterDethroned'`
+    )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+
+      // Recreate the old enum:
+
+      // Create a new enum
+      await queryInterface.sequelize.query(`
+        CREATE TYPE "enum_SolanaNotifications_type_new"
+        AS ENUM ('ChallengeReward', 'MilestoneListen', 'TipSend', 'TipReceive', 'Reaction', 'SupporterRankUp', 'SupportingRankUp');
+      `, { transaction })
+
+      // Set the column to the new enum
+      await queryInterface.sequelize.query(`
+        ALTER TABLE "SolanaNotifications"
+        ALTER COLUMN "type"
+          TYPE "enum_SolanaNotifications_type_new"
+          USING ("type"::text::"enum_SolanaNotifications_type_new");
+    `, { transaction })
+
+      // Drop old enum
+      await queryInterface.sequelize.query(`
+        DROP TYPE "enum_SolanaNotifications_type";
+      `, { transaction })
+
+      // Rename new enum
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_SolanaNotifications_type_new"
+        RENAME TO "enum_SolanaNotifications_type";
+      `, { transaction })
+    })
+  }
+};

--- a/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
+++ b/identity-service/sequelize/migrations/20220809211742-add_supporter_dethroned.js
@@ -10,6 +10,12 @@ module.exports = {
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (transaction) => {
 
+      // Drop any DethronedNotifs
+      await queryInterface.sequelize.query(`
+        DELETE FROM "SolanaNotifications"
+        WHERE "type" = 'SupporterDethroned';
+      `, { transaction })
+
       // Recreate the old enum:
 
       // Create a new enum

--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -8,7 +8,8 @@ const FEATURE_FLAGS = Object.freeze({
   REWARDS_NOTIFICATIONS_ENABLED: 'rewards_notifications_enabled',
   SOCIAL_PROOF_TO_SEND_AUDIO_ENABLED: 'social_proof_to_send_audio_enabled',
   DETECT_ABUSE_ON_RELAY: 'detect_abuse_on_relay',
-  TIPPING_ENABLED: 'tipping_enabled'
+  TIPPING_ENABLED: 'tipping_enabled',
+  SUPPORTER_DETHRONED_ENABLED: 'supporter_dethroned_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded
@@ -21,7 +22,8 @@ const DEFAULTS = Object.freeze({
   [FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED]: false,
   [FEATURE_FLAGS.SOCIAL_PROOF_TO_SEND_AUDIO_ENABLED]: true,
   [FEATURE_FLAGS.DETECT_ABUSE_ON_RELAY]: false,
-  [FEATURE_FLAGS.TIPPING_ENABLED]: false
+  [FEATURE_FLAGS.TIPPING_ENABLED]: false,
+  [FEATURE_FLAGS.SUPPORTER_DETHRONED_ENABLED]: false
 })
 
 /**

--- a/identity-service/src/notifications/constants.js
+++ b/identity-service/src/notifications/constants.js
@@ -37,6 +37,7 @@ const notificationTypes = Object.freeze({
   Reaction: 'Reaction',
   SupporterRankUp: 'SupporterRankUp',
   SupportingRankUp: 'SupportingRankUp',
+  SupporterDethroned: 'SupporterDethroned',
   AddTrackToPlaylist: 'AddTrackToPlaylist'
 })
 

--- a/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -290,6 +290,11 @@ async function fetchNotificationMetadata (
         }
         break
       }
+      case NotificationType.SupporterDethroned:
+        // Fetch both the supported user, and the new top supporter
+        userIdsToFetch.push(notification.metadata.supportingUserId)
+        userIdsToFetch.push(notification.metadata.newTopSupporterUserId)
+        break
     }
   }
 

--- a/identity-service/src/notifications/formatNotificationMetadata.js
+++ b/identity-service/src/notifications/formatNotificationMetadata.js
@@ -231,7 +231,7 @@ function formatSupportingRankUp (notification, metadata) {
   }
 }
 
-function formatSupporterDethroned(notification, metadata) {
+function formatSupporterDethroned (notification, metadata) {
   return {
     type: NotificationType.SupporterDethroned,
     receivingUser: notification.initiator,
@@ -408,7 +408,7 @@ const notificationResponseTitleMap = {
   [NotificationType.TipReceive]: () => TipReceiveTitle,
   [NotificationType.SupporterRankUp]: makeSupportingOrSupporterTitle,
   [NotificationType.SupportingRankUp]: makeSupportingOrSupporterTitle,
-  [NotificationType.SupporterDethroned]: () => DethronedTitle,
+  [NotificationType.SupporterDethroned]: () => DethronedTitle
 
 }
 

--- a/identity-service/src/notifications/formatNotificationMetadata.js
+++ b/identity-service/src/notifications/formatNotificationMetadata.js
@@ -230,6 +230,18 @@ function formatSupportingRankUp (notification, metadata) {
     receivingUser: user
   }
 }
+
+function formatSupporterDethroned(notification, metadata) {
+  return {
+    type: NotificationType.SupporterDethroned,
+    receivingUser: notification.initiator,
+    newTopSupporter: metadata.users[notification.metadata.newTopSupporterUserId],
+    supportedUser: metadata.users[notification.metadata.supportedUserId],
+    oldAmount: formatWei(new BN(notification.metadata.oldAmount)),
+    newAmount: formatWei(new BN(notification.metadata.newAmount))
+  }
+}
+
 // This is different from the above corresponding function
 // because it operates on data coming from the database
 // as opposed to that coming from the DN.
@@ -304,6 +316,7 @@ const notificationResponseMap = {
   [NotificationType.TipReceive]: formatTipReceive,
   [NotificationType.SupporterRankUp]: formatSupporterRankUp,
   [NotificationType.SupportingRankUp]: formatSupportingRankUp,
+  [NotificationType.SupporterDethroned]: formatSupporterDethroned,
   [NotificationType.Announcement]: formatAnnouncement,
   [NotificationType.MilestoneRepost]: formatMilestone('repost'),
   [NotificationType.MilestoneFavorite]: formatMilestone('favorite'),
@@ -333,6 +346,7 @@ const RemixCreateTitle = 'New Remix Of Your Track ♻️'
 const RemixCosignTitle = 'New Track Co-Sign! 🔥'
 const AddTrackToPlaylistTitle = 'Your track got on a playlist! 💿'
 const TipReceiveTitle = 'You Received a Tip!'
+const DethronedTitle = "👑 You've Been Dethroned!"
 
 const challengeInfoMap = {
   'profile-completion': {
@@ -393,7 +407,8 @@ const notificationResponseTitleMap = {
   [NotificationType.Reaction]: makeReactionTitle,
   [NotificationType.TipReceive]: () => TipReceiveTitle,
   [NotificationType.SupporterRankUp]: makeSupportingOrSupporterTitle,
-  [NotificationType.SupportingRankUp]: makeSupportingOrSupporterTitle
+  [NotificationType.SupportingRankUp]: makeSupportingOrSupporterTitle,
+  [NotificationType.SupporterDethroned]: () => DethronedTitle,
 
 }
 
@@ -468,6 +483,9 @@ const pushNotificationMessagesMap = {
   },
   [notificationTypes.TipReceive] (notification) {
     return `${capitalize(notification.sendingUser.name)} sent you a tip of ${notification.amount} $AUDIO`
+  },
+  [notificationTypes.SupporterDethroned] (notification) {
+    return `${capitalize(notification.newTopSupporter.handle)} dethroned you to become ${notification.supportedUser.name}'s top supporter. Tip to reclaim the throne?`
   }
 
 }

--- a/identity-service/src/notifications/processNotifications/supporterRankChangeNotification.js
+++ b/identity-service/src/notifications/processNotifications/supporterRankChangeNotification.js
@@ -95,7 +95,7 @@ async function processSupporterRankChangeNotification (notifications, tx) {
 
 const getSupporters = async (receiverUserId) => {
   const encodedReceiverId = encodeHashId(receiverUserId)
-  const { discoveryProvider} = audiusLibsWrapper.getAudiusLibs()
+  const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
   const url = `${discoveryProvider.discoveryProviderEndpoint}/v1/full/users/${encodedReceiverId}/supporters`
 
   try {

--- a/identity-service/src/notifications/processNotifications/supporterRankChangeNotification.js
+++ b/identity-service/src/notifications/processNotifications/supporterRankChangeNotification.js
@@ -1,12 +1,15 @@
 
+const { default: Axios } = require('axios')
+const audiusLibsWrapper = require('../../audiusLibsInstance')
 const models = require('../../models')
 const { notificationTypes } = require('../constants')
+const { decodeHashId, encodeHashId } = require('../utils')
 
 async function processSupporterRankChangeNotification (notifications, tx) {
   for (const notification of notifications) {
     const { slot, initiator: receiverUserId, metadata: { entity_id: senderUserId, rank } } = notification
 
-    await Promise.all([
+    const promises = [
       // SupportingRankUp sent to the user who is supporting
       models.SolanaNotification.findOrCreate({
         where: {
@@ -33,8 +36,77 @@ async function processSupporterRankChangeNotification (notifications, tx) {
         },
         transaction: tx
       })
-    ])
+    ]
+
+    // If this is a new top supporter, see who just became dethroned
+    if (rank === 1) {
+      const supporters = await getSupporters(receiverUserId)
+
+      const isSingleSupporter = supporters.length < 2
+      if (!isSingleSupporter) {
+        const topSupporterId = decodeHashId(supporters[0].sender.id)
+        const dethronedUserId = decodeHashId(supporters[1].sender.id)
+
+        // Ensure that the top supporter on DN is the top supporter that caused this index
+        const isDiscoveryUpToDate = topSupporterId === senderUserId
+        // Ensure that you don't get dethroned for a tie
+        const isTie = topSupporterId === dethronedUserId
+
+        if (isDiscoveryUpToDate && !isTie) {
+          const dethronedNotif = models.SolanaNotification.findOrCreate({
+            where: {
+              slot,
+              type: notificationTypes.SupporterDethroned,
+              userId: dethronedUserId, // Notif goes to the dethroned user
+              entityId: 2, // Rank 2
+              metadata: {
+                supportedUserId: receiverUserId, // The user originally tipped
+                newTopSupporterUserId: topSupporterId, // The usurping user
+                oldAmount: supporters[1].amount,
+                newAmount: supporters[0].amount
+              }
+            },
+            transaction: tx
+          })
+
+          // Create the notif model for the DB
+          promises.push(dethronedNotif)
+
+          // Create a fake notif from discovery for further processing down the pipeline
+          notifications.push({
+            slot,
+            type: notificationTypes.SupporterDethroned,
+            initiator: dethronedUserId, // Notif goes to the dethroned user
+            metadata: {
+              supportedUserId: receiverUserId, // The user originally tipped
+              newTopSupporterUserId: topSupporterId, // The usurping user
+              oldAmount: supporters[1].amount,
+              newAmount: supporters[0].amount
+            }
+          })
+        }
+      }
+    }
+
+    await Promise.all(promises)
     return notifications
+  }
+}
+
+const getSupporters = async (receiverUserId) => {
+  const encodedReceiverId = encodeHashId(receiverUserId)
+  const { discoveryProvider} = audiusLibsWrapper.getAudiusLibs()
+  const url = `${discoveryProvider.discoveryProviderEndpoint}/v1/full/users/${encodedReceiverId}/supporters`
+
+  try {
+    const response = await Axios({
+      method: 'get',
+      url
+    })
+    return response.data.data
+  } catch (e) {
+    console.error(`Error fetching supporters for user: ${receiverUserId}: ${e}`)
+    return []
   }
 }
 

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -263,7 +263,7 @@ async function formatNotifications (notifications, notificationSettings, tx) {
     }
 
     if (notif.type === notificationTypes.SupporterDethroned) {
-      formattedNotifications.push({...notif})
+      formattedNotifications.push({ ...notif })
     }
   }
   const [formattedCreateNotifications, users] = await _processSubscriberPushNotifications()

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -261,6 +261,10 @@ async function formatNotifications (notifications, notificationSettings, tx) {
       }
       formattedNotifications.push(formattedTipNotification)
     }
+
+    if (notif.type === notificationTypes.SupporterDethroned) {
+      formattedNotifications.push({...notif})
+    }
   }
   const [formattedCreateNotifications, users] = await _processSubscriberPushNotifications()
   formattedNotifications.push(...formattedCreateNotifications)

--- a/identity-service/src/notifications/sendNotifications/index.js
+++ b/identity-service/src/notifications/sendNotifications/index.js
@@ -37,6 +37,8 @@ function getUserIdsToNotify (notifications) {
         const supportingId = notification.metadata.entity_id
         const supportedId = notification.initiator
         return userIds.concat([supportingId, supportedId])
+      case notificationTypes.SupporterDethroned:
+        return userIds.concat(notification.initiator)
       default:
         return userIds
     }

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -64,7 +64,7 @@ const solanaNotificationBaseTypes = [
   notificationTypes.Reaction,
   notificationTypes.SupporterRankUp,
   notificationTypes.SupportingRankUp,
-  notificationTypes.SupporterDethroned,
+  notificationTypes.SupporterDethroned
 ]
 
 // Gets the userId that a notification should be sent to based off the notification's base type

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -52,6 +52,8 @@ const getPublishNotifBaseType = (notification) => {
       return notificationTypes.SupporterRankUp
     case notificationTypes.SupportingRankUp:
       return notificationTypes.SupportingRankUp
+    case notificationTypes.SupporterDethroned:
+      return notificationTypes.SupporterDethroned
   }
 }
 
@@ -61,7 +63,8 @@ const solanaNotificationBaseTypes = [
   notificationTypes.TipReceive,
   notificationTypes.Reaction,
   notificationTypes.SupporterRankUp,
-  notificationTypes.SupportingRankUp
+  notificationTypes.SupportingRankUp,
+  notificationTypes.SupporterDethroned,
 ]
 
 // Gets the userId that a notification should be sent to based off the notification's base type
@@ -80,6 +83,7 @@ const getPublishUserId = (notif, baseType) => {
   else if (baseType === notificationTypes.SupporterRankUp) return notif.initiator
   else if (baseType === notificationTypes.SupportingRankUp) return notif.metadata.entity_id
   else if (baseType === notificationTypes.TipReceive) return notif.initiator
+  else if (baseType === notificationTypes.SupporterDethroned) return notif.initiator
 }
 
 // Notification types that always get send a notification, regardless of settings
@@ -138,6 +142,9 @@ const shouldFilterOutNotification = (notificationType, optimizelyClient) => {
   }
   if ([notificationTypes.TipReceive, notificationTypes.Reaction, notificationTypes.SupporterRankUp, notificationTypes.SupportingRankUp].includes(notificationType)) {
     return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.TIPPING_ENABLED)
+  }
+  if (notificationType === notificationTypes.SupporterDethroned) {
+    return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.SUPPORTER_DETHRONED_ENABLED)
   }
   return false
 }

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -208,6 +208,16 @@ const formatSupportingRankUp = (notification) => ({
   entityType: Entity.User
 })
 
+const formatSupporterDethroned = (notification) => ({
+  ...getCommonNotificationsFields(notification),
+  type: notification.type,
+  entityType: Entity.User,
+  entityId: notification.metadata.newTopSupporterUserId,
+  supportedUserId:  notification.metadata.supportedUserId,
+  newAmount: notification.metadata.newAmount,
+  oldAmount: notification.metadata.oldAmount
+})
+
 const formatSupporterRankUp = (notification) => ({
   ...getCommonNotificationsFields(notification),
   type: notification.type,
@@ -267,6 +277,7 @@ const notificationResponseMap = {
   [NotificationType.Reaction]: formatReaction,
   [NotificationType.SupporterRankUp]: formatSupporterRankUp,
   [NotificationType.SupportingRankUp]: formatSupportingRankUp,
+  [NotificationType.SupporterDethroned]: formatSupporterDethroned,
   [NotificationType.AddTrackToPlaylist]: formatAddTrackToPlaylist
 }
 
@@ -373,6 +384,10 @@ module.exports = function (app) {
         NotificationType.SupporterRankUp,
         NotificationType.SupportingRankUp
       ]
+    }
+
+    if (req.query.withSupporterDethroned !== 'true') {
+      filterSolanaNotificationTypes.push(NotificationType.SupporterDethroned)
     }
 
     const queryFilter = filterNotificationTypes.length > 0 ? {

--- a/identity-service/src/routes/notifications.js
+++ b/identity-service/src/routes/notifications.js
@@ -213,7 +213,7 @@ const formatSupporterDethroned = (notification) => ({
   type: notification.type,
   entityType: Entity.User,
   entityId: notification.metadata.newTopSupporterUserId,
-  supportedUserId:  notification.metadata.supportedUserId,
+  supportedUserId: notification.metadata.supportedUserId,
   newAmount: notification.metadata.newAmount,
   oldAmount: notification.metadata.oldAmount
 })


### PR DESCRIPTION
### Description
- Adds dethroned notification if you lose your top supporter spot
- I'm including the old + new tip amounts in the notification object even though we're not currently using this in the UI/push notif copy, just because they're easily accessible and I wouldn't be surprised if we end up wanting to surface them later on


### Tests

- Tested locally; push notifications are created and dethroned notifs appear in notifs route
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->