### PR TITLE
[CON-324] Add orphaned data recovery queue

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -174,6 +174,12 @@ const healthCheck = async (
     stateMonitoringQueueRateLimitJobsPerInterval: config.get(
       'stateMonitoringQueueRateLimitJobsPerInterval'
     ),
+    recoverOrphanedDataQueueRateLimitInterval: config.get(
+      'recoverOrphanedDataQueueRateLimitInterval'
+    ),
+    recoverOrphanedDataQueueRateLimitJobsPerInterval: config.get(
+      'recoverOrphanedDataQueueRateLimitJobsPerInterval'
+    ),
     transcodeActive,
     transcodeWaiting,
     transcodeQueueIsAvailable: isAvailable,

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -149,6 +149,8 @@ describe('Test Health Check', function () {
     config.set('snapbackUsersPerJob', 2)
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
+    config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -214,6 +216,8 @@ describe('Test Health Check', function () {
       snapbackUsersPerJob: 2,
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
+      recoverOrphanedDataQueueRateLimitInterval: 50_000,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -267,6 +271,8 @@ describe('Test Health Check', function () {
     config.set('snapbackUsersPerJob', 2)
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
+    config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -327,6 +333,8 @@ describe('Test Health Check', function () {
       snapbackUsersPerJob: 2,
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
+      recoverOrphanedDataQueueRateLimitInterval: 50_000,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -429,6 +437,8 @@ describe('Test Health Check', function () {
       snapbackUsersPerJob: 2,
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
+      recoverOrphanedDataQueueRateLimitInterval: 50_000,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -513,6 +523,8 @@ describe('Test Health Check Verbose', function () {
     config.set('snapbackUsersPerJob', 2)
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
+    config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 
@@ -572,6 +584,8 @@ describe('Test Health Check Verbose', function () {
       snapbackUsersPerJob: 2,
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
+      recoverOrphanedDataQueueRateLimitInterval: 50_000,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -625,6 +639,8 @@ describe('Test Health Check Verbose', function () {
     config.set('snapbackUsersPerJob', 2)
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
+    config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.test.js
@@ -150,7 +150,7 @@ describe('Test Health Check', function () {
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
     config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
-    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 1)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -217,7 +217,7 @@ describe('Test Health Check', function () {
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
       recoverOrphanedDataQueueRateLimitInterval: 50_000,
-      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 1,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -272,7 +272,7 @@ describe('Test Health Check', function () {
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
     config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
-    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 1)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
     config.set('solDelegatePrivateKeyBase64', SOL_SECRET_KEY_BASE64)
@@ -334,7 +334,7 @@ describe('Test Health Check', function () {
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
       recoverOrphanedDataQueueRateLimitInterval: 50_000,
-      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 1,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -438,7 +438,7 @@ describe('Test Health Check', function () {
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
       recoverOrphanedDataQueueRateLimitInterval: 50_000,
-      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 1,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -524,7 +524,7 @@ describe('Test Health Check Verbose', function () {
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
     config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
-    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 1)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 
@@ -585,7 +585,7 @@ describe('Test Health Check Verbose', function () {
       stateMonitoringQueueRateLimitInterval: 20_000,
       stateMonitoringQueueRateLimitJobsPerInterval: 2,
       recoverOrphanedDataQueueRateLimitInterval: 50_000,
-      recoverOrphanedDataQueueRateLimitJobsPerInterval: 5,
+      recoverOrphanedDataQueueRateLimitJobsPerInterval: 1,
       transcodeActive: 4,
       transcodeWaiting: 0,
       transcodeQueueIsAvailable: true,
@@ -640,7 +640,7 @@ describe('Test Health Check Verbose', function () {
     config.set('stateMonitoringQueueRateLimitInterval', 20_000)
     config.set('stateMonitoringQueueRateLimitJobsPerInterval', 2)
     config.set('recoverOrphanedDataQueueRateLimitInterval', 50_000)
-    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 5)
+    config.set('recoverOrphanedDataQueueRateLimitJobsPerInterval', 1)
     config.set('snapbackModuloBase', 18)
     config.set('manualSyncsDisabled', false)
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -455,7 +455,7 @@ const config = convict({
     default: 3_600_000 // 1hr
   },
   stateMonitoringQueueRateLimitInterval: {
-    doc: 'interval (ms) during which at most stateMonitoringQueueRateLimitJobsPerInterval jobs will run',
+    doc: 'interval (ms) during which at most stateMonitoringQueueRateLimitJobsPerInterval monitor-state jobs will run',
     format: 'nat',
     env: 'stateMonitoringQueueRateLimitInterval',
     default: 60_000 // 1m
@@ -465,6 +465,18 @@ const config = convict({
     format: 'nat',
     env: 'stateMonitoringQueueRateLimitJobsPerInterval',
     default: 3
+  },
+  recoverOrphanedDataQueueRateLimitInterval: {
+    doc: 'interval (ms) during which at most recoverOrphanedDataQueueRateLimitJobsPerInterval recover-orphaned-data jobs will run',
+    format: 'nat',
+    env: 'recoverOrphanedDataQueueRateLimitInterval',
+    default: 60_000 // 1m
+  },
+  recoverOrphanedDataQueueRateLimitJobsPerInterval: {
+    doc: 'number of recover-orphaned-data jobs that can run in each interval (0 to pause queue)',
+    format: 'nat',
+    env: 'recoverOrphanedDataQueueRateLimitJobsPerInterval',
+    default: 1
   },
   debounceTime: {
     doc: 'sync debounce time in ms',

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -64,6 +64,7 @@ class ServiceRegistry {
     this.manualSyncQueue = null // Handles jobs for issuing a manual sync request
     this.recurringSyncQueue = null // Handles jobs for issuing a recurring sync request
     this.updateReplicaSetQueue = null // Handles jobs for updating a replica set
+    this.recoverOrphanedDataQueue = null // Handles jobs for finding+reconciling state on nodes outside of a user's replica set
     this.stateMachineQueue = null // DEPRECATED -- being removed very soon. Handles sync jobs based on user state
 
     // Flags that indicate whether categories of services have been initialized
@@ -194,6 +195,7 @@ class ServiceRegistry {
         new BullAdapter(this.manualSyncQueue, { readOnlyMode: true }),
         new BullAdapter(this.recurringSyncQueue, { readOnlyMode: true }),
         new BullAdapter(this.updateReplicaSetQueue, { readOnlyMode: true }),
+        new BullAdapter(this.recoverOrphanedDataQueue, { readOnlyMode: true }),
         new BullAdapter(this.stateMachineQueue, { readOnlyMode: true }),
         new BullAdapter(imageProcessingQueue, { readOnlyMode: true }),
         new BullAdapter(syncProcessingQueue, { readOnlyMode: true }),
@@ -313,7 +315,8 @@ class ServiceRegistry {
       cNodeEndpointToSpIdMapQueue,
       manualSyncQueue,
       recurringSyncQueue,
-      updateReplicaSetQueue
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
     } = await this.stateMachineManager.init(this.libs, this.prometheusRegistry)
     this.monitorStateQueue = monitorStateQueue
     this.findSyncRequestsQueue = findSyncRequestsQueue
@@ -322,6 +325,7 @@ class ServiceRegistry {
     this.manualSyncQueue = manualSyncQueue
     this.recurringSyncQueue = recurringSyncQueue
     this.updateReplicaSetQueue = updateReplicaSetQueue
+    this.recoverOrphanedDataQueue = recoverOrphanedDataQueue
 
     // SyncQueue construction (requires L1 identity)
     // Note - passes in reference to instance of self (serviceRegistry), a very sub-optimal workaround

--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -33,8 +33,12 @@ class StateMachineManager {
       audiusLibs.discoveryProvider.discoveryProviderEndpoint,
       prometheusRegistry
     )
-    const { manualSyncQueue, recurringSyncQueue, updateReplicaSetQueue } =
-      await stateReconciliationManager.init(prometheusRegistry)
+    const {
+      manualSyncQueue,
+      recurringSyncQueue,
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
+    } = await stateReconciliationManager.init(prometheusRegistry)
 
     // Upon completion, make queue jobs record metrics and enqueue other jobs as necessary
     const queueNameToQueueMap = {
@@ -43,7 +47,8 @@ class StateMachineManager {
       [QUEUE_NAMES.FIND_REPLICA_SET_UPDATES]: findReplicaSetUpdatesQueue,
       [QUEUE_NAMES.MANUAL_SYNC]: manualSyncQueue,
       [QUEUE_NAMES.RECURRING_SYNC]: recurringSyncQueue,
-      [QUEUE_NAMES.UPDATE_REPLICA_SET]: updateReplicaSetQueue
+      [QUEUE_NAMES.UPDATE_REPLICA_SET]: updateReplicaSetQueue,
+      [QUEUE_NAMES.RECOVER_ORPHANED_DATA]: recoverOrphanedDataQueue
     }
     for (const [queueName, queue] of Object.entries(queueNameToQueueMap)) {
       queue.on(
@@ -69,7 +74,8 @@ class StateMachineManager {
       cNodeEndpointToSpIdMapQueue,
       manualSyncQueue,
       recurringSyncQueue,
-      updateReplicaSetQueue
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
     }
   }
 

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -54,7 +54,9 @@ export const QUEUE_HISTORY = Object.freeze({
   // Max number of completed/failed jobs to keep in redis for the recurring sync queue
   RECURRING_SYNC: 100_000,
   // Max number of completed/failed jobs to keep in redis for the update-replica-set queue
-  UPDATE_REPLICA_SET: 100_000
+  UPDATE_REPLICA_SET: 100_000,
+  // Max number of completed/failed jobs to keep in redis for the recover-orphaned-data queue
+  RECOVER_ORPHANED_DATA: 10_000
 })
 
 export const QUEUE_NAMES = {
@@ -71,7 +73,9 @@ export const QUEUE_NAMES = {
   // Name of queue that only processes jobs to issue a recurring sync
   RECURRING_SYNC: 'recurring-sync-queue',
   // Name of queue that only processes jobs to update a replica set
-  UPDATE_REPLICA_SET: 'update-replica-set-queue'
+  UPDATE_REPLICA_SET: 'update-replica-set-queue',
+  // Name of queue that only processes jobs to search for nodes with orphaned data and merge it into a Replica Set
+  RECOVER_ORPHANED_DATA: 'recover-orphaned-data-queue'
 } as const
 export type TQUEUE_NAMES = typeof QUEUE_NAMES[keyof typeof QUEUE_NAMES]
 
@@ -92,7 +96,9 @@ export const MAX_QUEUE_RUNTIMES = Object.freeze({
   // Max millis to run a recurring sync job for before marking it as stalled
   RECURRING_SYNC: 6 /* min */ * 60 * 1000,
   // Max millis to run an update-replica-set job for before marking it as stalled
-  UPDATE_REPLICA_SET: 5 /* min */ * 60 * 1000
+  UPDATE_REPLICA_SET: 5 /* min */ * 60 * 1000,
+  // Max millis to run a recover-orphaned-data job for before marking it as stalled
+  RECOVER_ORPHANED_DATA: 60 /* min */ * 60 * 1000
 })
 
 /**

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -63,7 +63,7 @@ class StateMonitoringManager {
       lockDuration: MAX_QUEUE_RUNTIMES.MONITOR_STATE,
       prometheusRegistry,
       limiter: {
-        // Bull doesn't allow either of these to be set to 0
+        // Bull doesn't allow either of these to be set to 0, so we'll pause the queue later if the jobs per interval is 0
         max: config.get('stateMonitoringQueueRateLimitJobsPerInterval') || 1,
         duration: config.get('stateMonitoringQueueRateLimitInterval') || 1
       }
@@ -224,7 +224,7 @@ class StateMonitoringManager {
   }
 
   /**
-   * Clears the monitoring queue and adds a job that will start processing users
+   * Adds a job that will start processing users
    * starting from a random userId. Future jobs are added to the queue as a
    * result of this initial job succeeding or failing to complete.
    * @param {Object} queue the StateMonitoringQueue to consume jobs from

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -9,6 +9,7 @@ const processJob = require('../processJob')
 const { logger: baseLogger, createChildLogger } = require('../../../logging')
 const handleSyncRequestJobProcessor = require('./issueSyncRequest.jobProcessor')
 const updateReplicaSetJobProcessor = require('./updateReplicaSet.jobProcessor')
+const recoverOrphanedDataJobProcessor = require('./recoverOrphanedData.jobProcessor')
 
 const recurringSyncLogger = createChildLogger(baseLogger, {
   queue: QUEUE_NAMES.RECURRING_SYNC
@@ -18,6 +19,10 @@ const manualSyncLogger = createChildLogger(baseLogger, {
 })
 const updateReplicaSetLogger = createChildLogger(baseLogger, {
   queue: QUEUE_NAMES.UPDATE_REPLICA_SET
+})
+
+const recoverOrphanedDataLogger = createChildLogger(baseLogger, {
+  queue: QUEUE_NAMES.RECOVER_ORPHANED_DATA
 })
 
 /**
@@ -51,27 +56,49 @@ class StateReconciliationManager {
       prometheusRegistry
     })
 
+    const recoverOrphanedDataQueue = makeQueue({
+      name: QUEUE_NAMES.RECOVER_ORPHANED_DATA,
+      removeOnComplete: QUEUE_HISTORY.RECOVER_ORPHANED_DATA,
+      removeOnFail: QUEUE_HISTORY.RECOVER_ORPHANED_DATA,
+      lockDuration: MAX_QUEUE_RUNTIMES.RECOVER_ORPHANED_DATA,
+      prometheusRegistry,
+      limiter: {
+        // Bull doesn't allow either of these to be set to 0, so we'll pause the queue later if the jobs per interval is 0
+        max:
+          config.get('recoverOrphanedDataQueueRateLimitJobsPerInterval') || 1,
+        duration: config.get('recoverOrphanedDataQueueRateLimitInterval') || 1
+      }
+    })
+
     // Clear any old state if redis was running but the rest of the server restarted
     await manualSyncQueue.obliterate({ force: true })
     await recurringSyncQueue.obliterate({ force: true })
     await updateReplicaSetQueue.obliterate({ force: true })
+    await recoverOrphanedDataQueue.obliterate({ force: true })
+
+    // Queue the first recoverOrphanedData job, which will re-enqueue itself
+    await this.startRecoverOrphanedDataQueue(recoverOrphanedDataQueue)
 
     this.registerQueueEventHandlersAndJobProcessors({
       manualSyncQueue,
       recurringSyncQueue,
       updateReplicaSetQueue,
+      recoverOrphanedDataQueue,
       processManualSync:
         this.makeProcessManualSyncJob(prometheusRegistry).bind(this),
       processRecurringSync:
         this.makeProcessRecurringSyncJob(prometheusRegistry).bind(this),
       processUpdateReplicaSet:
-        this.makeProcessUpdateReplicaSetJob(prometheusRegistry).bind(this)
+        this.makeProcessUpdateReplicaSetJob(prometheusRegistry).bind(this),
+      recoverOrphanedData:
+        this.makeRecoverOrphanedDataJob(prometheusRegistry).bind(this)
     })
 
     return {
       manualSyncQueue,
       recurringSyncQueue,
-      updateReplicaSetQueue
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
     }
   }
 
@@ -81,22 +108,27 @@ class StateReconciliationManager {
    * @param {Object} params.manualSyncQueue the manual sync queue
    * @param {Object} params.recurringSyncQueue the recurring sync queue
    * @param {Object} params.updateReplicaSetQueue the updateReplicaSetQueue queue
+   * @param {Object} params.recoverOrphanedDataQueue the recoverOrphanedDataQueue queue
    * @param {Function<job>} params.processManualSync the function to call when processing a manual sync job from the queue
    * @param {Function<job>} params.processRecurringSync the function to call when processing a recurring sync job from the queue
    * @param {Function<job>} params.processUpdateReplicaSet the function to call when processing an update-replica-set job from the queue
+   * @param {Function<job>} params.recoverOrphanedData the function to call when processing a recover-orphaned-data job from the queue
    */
   registerQueueEventHandlersAndJobProcessors({
     manualSyncQueue,
     recurringSyncQueue,
     updateReplicaSetQueue,
+    recoverOrphanedDataQueue,
     processManualSync,
     processRecurringSync,
-    processUpdateReplicaSet
+    processUpdateReplicaSet,
+    recoverOrphanedData
   }) {
     // Add handlers for logging
     registerQueueEvents(manualSyncQueue, manualSyncLogger)
     registerQueueEvents(recurringSyncQueue, recurringSyncLogger)
     registerQueueEvents(updateReplicaSetQueue, updateReplicaSetLogger)
+    registerQueueEvents(recoverOrphanedDataQueue, recoverOrphanedDataLogger)
 
     // Log when a job fails to complete
     manualSyncQueue.on('failed', (job, err) => {
@@ -117,6 +149,14 @@ class StateReconciliationManager {
       })
       logger.error(`Job failed to complete. ID=${job?.id}. Error=${err}`)
     })
+    recoverOrphanedDataQueue.on('failed', (job, err) => {
+      const logger = createChildLogger(recoverOrphanedDataLogger, {
+        jobId: job?.id || 'unknown'
+      })
+      logger.error(`Job failed to complete. ID=${job?.id}. Error=${err}`)
+      // This is a recurring job that re-enqueues itself on success, so we want to also re-enqueue on failure
+      recoverOrphanedDataQueue.add({})
+    })
 
     // Register the logic that gets executed to process each new job from the queues
     manualSyncQueue.process(
@@ -131,6 +171,24 @@ class StateReconciliationManager {
       config.get('maxUpdateReplicaSetJobConcurrency'),
       processUpdateReplicaSet
     )
+    recoverOrphanedDataQueue.process(1 /** concurrency */, recoverOrphanedData)
+  }
+
+  /**
+   * Adds a job that will find+reconcile data on nodes outside of a user's replica set.
+   * Future jobs are added to the queue as a result of this initial job succeeding or failing to complete.
+   * @param queue the queue that processes jobs to recover orphaned data
+   */
+  async startRecoverOrphanedDataQueue(queue) {
+    // Since we can't pass 0 to Bull's limiter.max, enforce a rate limit of 0 by
+    // pausing the queue and not enqueuing the first job
+    if (config.get('recoverOrphanedDataQueueRateLimitJobsPerInterval') === 0) {
+      await queue.pause()
+      return
+    }
+
+    // Enqueue first recoverOrphanedData job after a delay. This job requeues itself upon completion or failure
+    await queue.add({})
   }
 
   /*
@@ -163,6 +221,16 @@ class StateReconciliationManager {
         job,
         updateReplicaSetJobProcessor,
         updateReplicaSetLogger,
+        prometheusRegistry
+      )
+  }
+
+  makeRecoverOrphanedDataJob(prometheusRegistry) {
+    return async (job) =>
+      processJob(
+        job,
+        recoverOrphanedDataJobProcessor,
+        recoverOrphanedDataLogger,
         prometheusRegistry
       )
   }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -1,0 +1,59 @@
+import type {
+  DecoratedJobParams,
+  DecoratedJobReturnValue,
+  JobsToEnqueue
+} from '../types'
+import type {
+  RecoverOrphanedDataJobParams,
+  RecoverOrphanedDataJobReturnValue
+} from './types'
+
+const {
+  QUEUE_NAMES
+} = require('../../prometheusMonitoring/prometheus.constants')
+
+/**
+ * Processes a job to find users who have data on this node but who do not have this node in their replica set.
+ * This means their data is "orphaned,"" so the job also merges this data back into the primary of the user's replica set and then wipes it from this node.
+ *
+ * @param {Object} param job data
+ * @param {Object} param.logger the logger that can be filtered by jobName and jobId
+ */
+module.exports = async function ({
+  logger
+}: DecoratedJobParams<RecoverOrphanedDataJobParams>): Promise<
+  DecoratedJobReturnValue<RecoverOrphanedDataJobReturnValue>
+> {
+  // TODO: Clear redis state
+
+  // TODO: Query this node's db to find all users who have data on it and save them in a redis set
+  const usersOnThisNode = {}
+
+  /**
+   * TODO: Query Discovery to find all users who have this node as their primary or secondary.
+   *       This will do some kind of while loop that requests paginated responses from
+   *       `/v1/full/users/content_node/all?creator_node_endpoint=<THIS_CONTENT_NODE>` and adds
+   *       them to a redis set until reaching the end of the pagination
+   */
+  const usersWithThisNodeInReplica = {}
+
+  // TODO: Perform a set difference between usersOnThisNode and usersWithThisNodeInReplica.
+  //       https://redis.io/commands/sdiff/
+  const usersWithOrphanedData: any[] = []
+
+  /**
+   *  TODO: Run modified "force wipe" (modified forceResync=true flag) on each user with orphaned data:
+   *        1. Merge orphaned data from this node into the user's primary.
+   *        2. Wipe the user's data from this node.
+   *        3. *DON'T* resync from the primary to this node -- this is what non-modified forceResync would do.
+   * */
+
+  // Enqueue another job to search for any new data that gets orphaned after this job finishes
+  const jobsToEnqueue: JobsToEnqueue = {
+    [QUEUE_NAMES.RECOVER_ORPHANED_DATA]: [{}]
+  }
+  return {
+    jobsToEnqueue,
+    usersWithOrphanedData
+  }
+}

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -8,9 +8,7 @@ import type {
   RecoverOrphanedDataJobReturnValue
 } from './types'
 
-const {
-  QUEUE_NAMES
-} = require('../../prometheusMonitoring/prometheus.constants')
+const { QUEUE_NAMES } = require('../stateMachineConstants')
 
 /**
  * Processes a job to find users who have data on this node but who do not have this node in their replica set.

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/types.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/types.ts
@@ -85,3 +85,9 @@ export type UpdateReplicaSetJobReturnValue = {
   newReplicaSet: NewReplicaSet
   healthyNodes: string[]
 }
+
+// Recover orphaned data job
+export type RecoverOrphanedDataJobParams = {}
+export type RecoverOrphanedDataJobReturnValue = {
+  usersWithOrphanedData: any[] // TODO: Choose user type
+}

--- a/creator-node/test/StateReconciliationManager.test.js
+++ b/creator-node/test/StateReconciliationManager.test.js
@@ -79,13 +79,18 @@ describe('test StateReconciliationManager initialization, events, and job proces
       stateReconciliationManager,
       'registerQueueEventHandlersAndJobProcessors'
     )
-    const { manualSyncQueue, recurringSyncQueue, updateReplicaSetQueue } =
-      await stateReconciliationManager.init(getPrometheusRegistry())
+    const {
+      manualSyncQueue,
+      recurringSyncQueue,
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
+    } = await stateReconciliationManager.init(getPrometheusRegistry())
 
     // Verify that the queues were successfully initialized and that their event listeners were registered
     expect(manualSyncQueue).to.exist.and.to.be.instanceOf(BullQueue)
     expect(recurringSyncQueue).to.exist.and.to.be.instanceOf(BullQueue)
     expect(updateReplicaSetQueue).to.exist.and.to.be.instanceOf(BullQueue)
+    expect(recoverOrphanedDataQueue).to.exist.and.to.be.instanceOf(BullQueue)
     expect(
       stateReconciliationManager.registerQueueEventHandlersAndJobProcessors
     ).to.have.been.calledOnce
@@ -110,6 +115,13 @@ describe('test StateReconciliationManager initialization, events, and job proces
     )
       .to.have.property('updateReplicaSetQueue')
       .that.has.deep.property('name', QUEUE_NAMES.UPDATE_REPLICA_SET)
+    expect(
+      stateReconciliationManager.registerQueueEventHandlersAndJobProcessors.getCall(
+        0
+      ).args[0]
+    )
+      .to.have.property('recoverOrphanedDataQueue')
+      .that.has.deep.property('name', QUEUE_NAMES.RECOVER_ORPHANED_DATA)
   })
 
   it('processes manual sync jobs with expected data and returns the expected results', async function () {
@@ -228,6 +240,32 @@ describe('test StateReconciliationManager initialization, events, and job proces
       unhealthyReplicas,
       replicaSetNodesToUserClockStatusesMap,
       enabledReconfigModes
+    })
+  })
+
+  it('processes recoverOrphanedData jobs with expected data and returns the expected results', async function () {
+    // Mock StateReconciliationManager to have recoverOrphanedData job processor return dummy data and mocked processJob util
+    const expectedResult = { test: 'test' }
+    const recoverOrphanedDataStub = sandbox.stub().resolves(expectedResult)
+    const { processJobMock, loggerStub } = getProcessJobMock()
+    const MockStateReconciliationManager = proxyquire(
+      '../src/services/stateMachineManager/stateReconciliation/index.js',
+      {
+        './recoverOrphanedData.jobProcessor': recoverOrphanedDataStub,
+        '../processJob': processJobMock
+      }
+    )
+
+    // Verify that StateReconciliationManager returns our dummy data
+    const job = {}
+    await expect(
+      new MockStateReconciliationManager().makeRecoverOrphanedDataJob(
+        getPrometheusRegistry()
+      )(job)
+    ).to.eventually.be.fulfilled.and.deep.equal(expectedResult)
+    expect(recoverOrphanedDataStub).to.have.been.calledOnceWithExactly({
+      logger: loggerStub,
+      ...job
     })
   })
 })

--- a/creator-node/test/recoverOrphanedData.jobProcessor.test.js
+++ b/creator-node/test/recoverOrphanedData.jobProcessor.test.js
@@ -1,0 +1,15 @@
+const chai = require('chai')
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+const { expect } = chai
+
+describe('test recoverOrphanedData job processor', function () {
+  it('Finds and reconciles data when this node is not in replica set', async function () {
+    expect(true) // TODO: TDD
+  })
+
+  it('Skips when when this node is in replica set', async function () {
+    expect(true) // TODO: TDD
+  })
+})


### PR DESCRIPTION
### Description
- Add queue to process jobs for a node to find+reconcile data that's on it but that belongs to a user who doesn't have the node in their replica set
- Add TODOs for steps of the job (ready to high level review but not implementation details or else this PR would balloon)

### Tests
- Updated tests for StateReconciliationQueue and added skeleton for future tests to be completed once the job processor is implemented
- Verified that the queue runs locally at the correct rate limit (1 job per minute)


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Search for the queue's logs that will be added in a followup PR (filter by `json.queue:"recover-orphaned-data-queue"`)
- Monitor the queue's Bull dashboard (`/health/bull/queue/recover-orphaned-data-queue` endpoint)