### PR TITLE
Add custom headers to all axios calls to health check in content node

### DIFF
--- a/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
+++ b/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
@@ -104,9 +104,9 @@ const respondToURSMRequestForSignature = async (
       randomBytesToSign
     },
     headers: {
-      'User-Agent': `Axios - called in URSMRegistrationComponentService#respondToURSMRequestForSignature by ${config.get(
+      'User-Agent': `Axios - audius/content-node - ${config.get(
         'creatorNodeEndpoint'
-      )}`
+      )} - URSMRegistrationComponentService#respondToURSMRequestForSignature`
     }
   })
   const { responseData, signatureData } = parseCNodeResponse(

--- a/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
+++ b/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
@@ -104,7 +104,7 @@ const respondToURSMRequestForSignature = async (
       randomBytesToSign
     },
     headers: {
-      'User-Agent': `Axios - audius/content-node - ${config.get(
+      'User-Agent': `Axios - @audius/content-node - ${config.get(
         'creatorNodeEndpoint'
       )} - URSMRegistrationComponentService#respondToURSMRequestForSignature`
     }

--- a/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
+++ b/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
@@ -101,6 +101,9 @@ const respondToURSMRequestForSignature = async (
     timeout: 1000,
     params: {
       randomBytesToSign
+    },
+    headers: {
+      'User-Agent': `Axios - called in URSMRegistrationComponentService#respondToURSMRequestForSignature by ${config.get('creatorNodeEndpoint')}`
     }
   })
   const { responseData, signatureData } = parseCNodeResponse(

--- a/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
+++ b/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
@@ -2,6 +2,7 @@ const axios = require('axios')
 const { promisify } = require('util')
 const crypto = require('crypto')
 const randomBytes = promisify(crypto.randomBytes)
+const config = require('../../config')
 
 const {
   parseCNodeResponse,
@@ -103,7 +104,9 @@ const respondToURSMRequestForSignature = async (
       randomBytesToSign
     },
     headers: {
-      'User-Agent': `Axios - called in URSMRegistrationComponentService#respondToURSMRequestForSignature by ${config.get('creatorNodeEndpoint')}`
+      'User-Agent': `Axios - called in URSMRegistrationComponentService#respondToURSMRequestForSignature by ${config.get(
+        'creatorNodeEndpoint'
+      )}`
     }
   })
   const { responseData, signatureData } = parseCNodeResponse(

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
@@ -115,7 +115,7 @@ class CNodeHealthManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {
-        'User-Agent': `Axios - audius/content-node - ${config.get(
+        'User-Agent': `Axios - @audius/content-node - ${config.get(
           'creatorNodeEndpoint'
         )} - CNodeHealthManager#queryVerboseHealthCheck`
       }

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
@@ -113,7 +113,10 @@ class CNodeHealthManager {
       baseURL: endpoint,
       url: '/health_check/verbose',
       method: 'get',
-      timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS
+      timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
+      headers: {
+        'User-Agent': `Axios - called in CNodeHealthManager#queryVerboseHealthCheck by ${config.get('creatorNodeEndpoint')}`
+      }
     })
 
     return resp.data.data

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
@@ -115,7 +115,9 @@ class CNodeHealthManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {
-        'User-Agent': `Axios - called in CNodeHealthManager#queryVerboseHealthCheck by ${config.get('creatorNodeEndpoint')}`
+        'User-Agent': `Axios - called in CNodeHealthManager#queryVerboseHealthCheck by ${config.get(
+          'creatorNodeEndpoint'
+        )}`
       }
     })
 

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
@@ -115,9 +115,9 @@ class CNodeHealthManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {
-        'User-Agent': `Axios - called in CNodeHealthManager#queryVerboseHealthCheck by ${config.get(
+        'User-Agent': `Axios - audius/content-node - ${config.get(
           'creatorNodeEndpoint'
-        )}`
+        )} - CNodeHealthManager#queryVerboseHealthCheck`
       }
     })
 

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -236,7 +236,10 @@ class PeerSetManager {
       baseURL: endpoint,
       url: '/health_check/verbose',
       method: 'get',
-      timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS
+      timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
+      headers: {
+        'User-Agent': `Axios - called in peerSetManager#queryVerboseHealthCheck by ${config.get('creatorNodeEndpoint')}`
+      }
     })
 
     return resp.data.data

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -238,7 +238,7 @@ class PeerSetManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {
-        'User-Agent': `Axios - audius/content-node - ${config.get(
+        'User-Agent': `Axios - @audius/content-node - ${config.get(
           'creatorNodeEndpoint'
         )} - peerSetManager#queryVerboseHealthCheck`
       }

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -238,7 +238,9 @@ class PeerSetManager {
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {
-        'User-Agent': `Axios - called in peerSetManager#queryVerboseHealthCheck by ${config.get('creatorNodeEndpoint')}`
+        'User-Agent': `Axios - audius/content-node - ${config.get(
+          'creatorNodeEndpoint'
+        )} - peerSetManager#queryVerboseHealthCheck`
       }
     })
 

--- a/libs/src/api/ServiceProvider.ts
+++ b/libs/src/api/ServiceProvider.ts
@@ -77,7 +77,8 @@ export class ServiceProvider extends Base {
         url: `${node.endpoint}/health_check/verbose`
       })),
       sortByVersion: true,
-      timeout
+      timeout,
+      headers: { 'User-Agent': 'Axios - called by getSelectableCreatorNodes.ts' }
     })
 
     const services: { [id: string]: any } = {}

--- a/libs/src/api/ServiceProvider.ts
+++ b/libs/src/api/ServiceProvider.ts
@@ -78,7 +78,10 @@ export class ServiceProvider extends Base {
       })),
       sortByVersion: true,
       timeout,
-      headers: { 'User-Agent': 'Axios - called by getSelectableCreatorNodes.ts' }
+      headers: {
+        'User-Agent':
+          'Axios - @audius/sdk - ServiceProvider.ts#getSelectableCreatorNodes'
+      }
     })
 
     const services: { [id: string]: any } = {}

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -364,7 +364,8 @@ export class CreatorNodeSelection extends ServiceSelection {
       sortByVersion: false,
       currentVersion: this.currentVersion,
       timeout: this.timeout,
-      equivalencyDelta: this.equivalencyDelta
+      equivalencyDelta: this.equivalencyDelta,
+      headers: { 'User-Agent': 'Axios - called by CreatorNodeSelection.ts' }
     })
 
     const healthyServices = healthCheckedServices.filter((resp) => {

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -365,7 +365,10 @@ export class CreatorNodeSelection extends ServiceSelection {
       currentVersion: this.currentVersion,
       timeout: this.timeout,
       equivalencyDelta: this.equivalencyDelta,
-      headers: { 'User-Agent': 'Axios - called by CreatorNodeSelection.ts' }
+      headers: {
+        'User-Agent':
+          'Axios - @audius/sdk - CreatorNodeSelection.ts#_performHealthChecks'
+      }
     })
 
     const healthyServices = healthCheckedServices.filter((resp) => {

--- a/libs/src/utils/network.ts
+++ b/libs/src/utils/network.ts
@@ -151,7 +151,9 @@ async function timeRequests({
   headers = null
 }: TimeRequestsConfig) {
   let serviceTimings = await Promise.all(
-    requests.map(async (request) => await timeRequest(request, timeout, headers))
+    requests.map(
+      async (request) => await timeRequest(request, timeout, headers)
+    )
   )
 
   if (filterNonResponsive) {

--- a/libs/src/utils/network.ts
+++ b/libs/src/utils/network.ts
@@ -23,8 +23,9 @@ interface Request {
   url: string
 }
 
-interface TimingConfig {
+interface AxiosConfig {
   timeout?: number
+  headers?: object
 }
 
 export interface Timing {
@@ -38,15 +39,17 @@ export interface Timing {
  */
 async function timeRequest(
   request: Request,
-  timeout?: number | null
+  timeout?: number | null,
+  headers?: object | null
 ): Promise<Timing> {
   // This is non-perfect because of the js event loop, but enough
   // of a proximation. Don't use for mission-critical timing.
   const startTime = new Date().getTime()
-  const config: TimingConfig = {}
+  const config: AxiosConfig = {}
   if (timeout !== null && timeout !== undefined) {
     config.timeout = timeout
   }
+  if (headers) config.headers = headers
   let response
   try {
     response = await axios.get(request.url, config)
@@ -131,6 +134,7 @@ interface TimeRequestsConfig {
    *  (even if by 1ms) will be picked always.
    */
   equivalencyDelta?: number | null
+  headers?: object | null
 }
 
 /**
@@ -143,10 +147,11 @@ async function timeRequests({
   currentVersion = null, // only required if `sortByVersion` = false
   filterNonResponsive = false,
   timeout = null,
-  equivalencyDelta = null
+  equivalencyDelta = null,
+  headers = null
 }: TimeRequestsConfig) {
   let serviceTimings = await Promise.all(
-    requests.map(async (request) => await timeRequest(request, timeout))
+    requests.map(async (request) => await timeRequest(request, timeout, headers))
   )
 
   if (filterNonResponsive) {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
In order to better debug bursts of health_check requests between content nodes and from libs, this PR adds identifying 'User-Agent' headers to all axios requests.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally and observed that headers get displayed in the logs
```
/usr/src/app # tail -f /usr/local/openresty/logs/access.log | grep "verbose"
172.22.0.17 - - [12/Aug/2022:19:42:21 +0000] "GET /health_check/verbose HTTP/1.1" 200 x-cache-status=EXPIRED 2959 "-" "Axios - called in CNodeHealthManager#queryVerboseHealthCheck by http://cn2_creator-node_1:4001" "-"
172.22.0.14 - - [12/Aug/2022:19:42:21 +0000] "GET /health_check/verbose HTTP/1.1" 200 x-cache-status=HIT 2955 "-" "Axios - called in CNodeHealthManager#queryVerboseHealthCheck by http://cn1_creator-node_1:4000" "-"
172.22.0.23 - - [12/Aug/2022:19:42:21 +0000] "GET /health_check/verbose HTTP/1.1" 200 x-cache-status=HIT 2955 "-" "Axios - called in CNodeHealthManager#queryVerboseHealthCheck by http://cn4_creator-node_1:4003" "-"
172.22.0.1 - - [12/Aug/2022:19:42:42 +0000] "GET /health_check/verbose HTTP/1.1" 200 x-cache-status=EXPIRED 2959 "-" "Axios - called by CreatorNodeSelection.ts" "-"
172.22.0.17 - - [12/Aug/2022:19:43:43 +0000] "GET /health_check/verbose HTTP/1.1" 200 x-cache-status=EXPIRED 2956 "-" "Axios - called in CNodeHealthManager#queryVerboseHealthCheck by http://cn2_creator-node_1:4001" "-"
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Check OpenResty logs to see 'User-Agent' headers

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->