### PR TITLE
Fix get node health call

### DIFF
--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.js
@@ -89,8 +89,8 @@ class CNodeHealthManager {
    * determine if a node is healthy
    * @param {string} peer content node endpoint
    * @param {boolean?} [checkHealthCheckResults=true] flag to dictate whether or not to check health check response to
-   *  determine node health 
-   * @returns true or false 
+   *  determine node health
+   * @returns true or false
    */
   async isNodeHealthy(peer, checkHealthCheckResults = true) {
     try {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -106,7 +106,10 @@ module.exports = async function ({
     }
 
     try {
-      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(users, CREATOR_NODE_ENDPOINT)
+      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(
+        users,
+        CREATOR_NODE_ENDPOINT
+      )
       _addToDecisionTree(decisionTree, 'getUnhealthyPeers Success', logger, {
         unhealthyPeerSetLength: unhealthyPeers?.size,
         unhealthyPeers: Array.from(unhealthyPeers)

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -24,7 +24,7 @@ const { retrieveUserInfoFromReplicaSet } = require('../stateMachineUtils')
 
 // Number of users to process each time monitor-state job processor is called
 const USERS_PER_JOB = config.get('snapbackUsersPerJob')
-const THIS_CNODE_ENDPOINT = config.get('creatorNodeEndpoint')
+const CREATOR_NODE_ENDPOINT = config.get('creatorNodeEndpoint')
 
 type Decision = {
   stage: string
@@ -60,7 +60,7 @@ module.exports = async function ({
     {
       lastProcessedUserId,
       discoveryNodeEndpoint,
-      THIS_CNODE_ENDPOINT,
+      CREATOR_NODE_ENDPOINT,
       USERS_PER_JOB
     }
   )
@@ -73,7 +73,7 @@ module.exports = async function ({
     try {
       users = await getNodeUsers(
         discoveryNodeEndpoint,
-        THIS_CNODE_ENDPOINT,
+        CREATOR_NODE_ENDPOINT,
         lastProcessedUserId,
         USERS_PER_JOB
       )
@@ -106,7 +106,7 @@ module.exports = async function ({
     }
 
     try {
-      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(users)
+      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(users, CREATOR_NODE_ENDPOINT)
       _addToDecisionTree(decisionTree, 'getUnhealthyPeers Success', logger, {
         unhealthyPeerSetLength: unhealthyPeers?.size,
         unhealthyPeers: Array.from(unhealthyPeers)

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -98,7 +98,8 @@ const alwaysSendNotifications = [
   notificationTypes.Reaction,
   notificationTypes.TipReceive,
   notificationTypes.SupporterRankUp,
-  notificationTypes.SupportingRankUp
+  notificationTypes.SupportingRankUp,
+  notificationTypes.SupporterDethroned
 ]
 
 const mapNotificationBaseTypeToSettings = {

--- a/identity-service/src/routes/relay.js
+++ b/identity-service/src/routes/relay.js
@@ -39,6 +39,12 @@ module.exports = function (app) {
       user.isAbusiveErrorCode &&
       blockRelayAbuseErrorCodes.has(user.isAbusiveErrorCode)
     ) {
+      // allow previously abusive users to redeem themselves for next relays
+      if (detectAbuseOnRelay) {
+        const reqIP = req.get('X-Forwarded-For') || req.ip
+        detectAbuse(user, 'relay', reqIP) // fired & forgotten
+      }
+
       return errorResponseForbidden(
         `Forbidden ${user.isAbusiveErrorCode}`
       )


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This PR is to:
- pass in the self content node endpoint to prevent a node from rolling itself off of a replica set
- refactor code slightly
- query the regular health check, not the verbose health check

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- adjusted the unit tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Since there aren't any functionality changes (except for the code where the tests were modified), the existing logs should suffice. See logs surrounding `isNodeHealthy()`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->