### PR TITLE
Pass in self endpoint

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -24,7 +24,7 @@ const { retrieveUserInfoFromReplicaSet } = require('../stateMachineUtils')
 
 // Number of users to process each time monitor-state job processor is called
 const USERS_PER_JOB = config.get('snapbackUsersPerJob')
-const THIS_CNODE_ENDPOINT = config.get('creatorNodeEndpoint')
+const CREATOR_NODE_ENDPOINT = config.get('creatorNodeEndpoint')
 
 type Decision = {
   stage: string
@@ -60,7 +60,7 @@ module.exports = async function ({
     {
       lastProcessedUserId,
       discoveryNodeEndpoint,
-      THIS_CNODE_ENDPOINT,
+      CREATOR_NODE_ENDPOINT,
       USERS_PER_JOB
     }
   )
@@ -73,7 +73,7 @@ module.exports = async function ({
     try {
       users = await getNodeUsers(
         discoveryNodeEndpoint,
-        THIS_CNODE_ENDPOINT,
+        CREATOR_NODE_ENDPOINT,
         lastProcessedUserId,
         USERS_PER_JOB
       )
@@ -106,7 +106,10 @@ module.exports = async function ({
     }
 
     try {
-      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(users)
+      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(
+        users,
+        CREATOR_NODE_ENDPOINT
+      )
       _addToDecisionTree(decisionTree, 'getUnhealthyPeers Success', logger, {
         unhealthyPeerSetLength: unhealthyPeers?.size,
         unhealthyPeers: Array.from(unhealthyPeers)

--- a/creator-node/test/monitorState.jobProcessor.test.js
+++ b/creator-node/test/monitorState.jobProcessor.test.js
@@ -256,7 +256,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      CONTENT_NODE_ENDPOINT
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -286,7 +289,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      CONTENT_NODE_ENDPOINT
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -317,7 +323,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      CONTENT_NODE_ENDPOINT
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -347,7 +356,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      CONTENT_NODE_ENDPOINT
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -373,7 +385,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      CONTENT_NODE_ENDPOINT
+    )
     expect(buildReplicaSetNodesToUserWalletsMapStub).to.not.have.been.called
     expect(retrieveUserInfoFromReplicaSetStub).to.not.have.been.called
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is so that the current node cannot roll itself off of a user's replica set if it is present. The reason for this is design.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->