### PR TITLE
Add new feature flag for Dethroned push notifs

### DIFF
--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -10,7 +10,7 @@ const FEATURE_FLAGS = Object.freeze({
   DETECT_ABUSE_ON_RELAY: 'detect_abuse_on_relay',
   BLOCK_ABUSE_ON_RELAY: 'block_abuse_on_relay',
   TIPPING_ENABLED: 'tipping_enabled',
-  SUPPORTER_DETHRONED_ENABLED: 'supporter_dethroned_enabled'
+  SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED: 'supporter_dethroned_push_notifs_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded
@@ -25,7 +25,7 @@ const DEFAULTS = Object.freeze({
   [FEATURE_FLAGS.DETECT_ABUSE_ON_RELAY]: false,
   [FEATURE_FLAGS.BLOCK_ABUSE_ON_RELAY]: false,
   [FEATURE_FLAGS.TIPPING_ENABLED]: false,
-  [FEATURE_FLAGS.SUPPORTER_DETHRONED_ENABLED]: false
+  [FEATURE_FLAGS.SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED]: false
 })
 
 /**

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -145,7 +145,7 @@ const shouldFilterOutNotification = (notificationType, optimizelyClient) => {
     return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.TIPPING_ENABLED)
   }
   if (notificationType === notificationTypes.SupporterDethroned) {
-    return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.SUPPORTER_DETHRONED_ENABLED)
+    return !getFeatureFlag(optimizelyClient, FEATURE_FLAGS.SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED)
   }
   return false
 }


### PR DESCRIPTION
### Description
- Adds a new feature flag specifically for dethroned push notifs, so we can turn dethroned push notifs on in-app on prod without turning on push notifs system wide


### Tests

None
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->