### PR TITLE
Log stack traces of update-replica-set errors

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -100,9 +100,8 @@ const updateReplicaSetJobProcessor = async function ({
         )
       await cacheHealthyNodes(healthyNodes)
     } catch (e: any) {
-      const errorMsg = `Error initting libs and auto-selecting creator nodes: ${e.message}. Logging stack...`
+      const errorMsg = `Error initting libs and auto-selecting creator nodes: ${e.message}: ${e.stack}`
       logger.error(errorMsg)
-      logger.error(e.stack)
       return {
         errorMsg,
         issuedReconfig,
@@ -137,9 +136,10 @@ const updateReplicaSetJobProcessor = async function ({
       ))
   } catch (e: any) {
     logger.error(
-      `ERROR issuing update replica set op: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | Error: ${e.toString()}`
+      `ERROR issuing update replica set op: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | Error: ${e.toString()}: ${
+        e.stack
+      }`
     )
-    logger.error(e.stack)
     errorMsg = e.toString()
   }
 


### PR DESCRIPTION
### Description
Log stack traces for update-replica-set job errors to narrow down which network call is resulting in a 502. Currently we just print the error message and are unaware of which inner step actually causes the error.


### Tests
N/A - just logs. Make sure integration tests pass.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Search for the error `Error initting libs and auto-selecting creator nodes` and look for the new stack trace in `ERROR issuing update replica set op` logs