### PR TITLE
INF-201 Enable local ELK and Grafana-related Sidecars by default for remote-dev

### DIFF
--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -778,6 +778,12 @@ const allUp = async ({
     }
   }
 
+  // Add Centralized Logging
+  nodeUpCommands.push([[Service.LOGGING, SetupCommand.UP]])
+
+  // Spin up local exporters, as well as standalone Prometheus/Grafana
+  nodeUpCommands.push([[Service.MONITORING, SetupCommand.UP]])
+
   const start = Date.now()
 
   // Start up the docker network `audius_dev` and the Solana test validator


### PR DESCRIPTION
### Description

Enable ELK sidecars to provide ELK-backed logging for all remote-dev boxes.

Additionally, enable Prometheus/Grafana-related sidecars to collect metrics during local development.


### Tests

Spin up new machine on this branch and run `A up` successfully.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Looking at ELK for new hostnames.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->