### PR TITLE
Add is_streamable to api surface

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -210,6 +210,10 @@ def extend_track(track):
     if "save_count" in track:
         track["favorite_count"] = track["save_count"]
 
+    track["is_streamable"] = (
+        not track["is_delete"] and not track["user"]["is_deactivated"]
+    )
+
     duration = 0.0
     for segment in track["track_segments"]:
         # NOTE: Legacy track segments store the duration as a string

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -92,6 +92,7 @@ track = ns.model(
         "downloadable": fields.Boolean,
         "play_count": fields.Integer(required=True),
         "permalink": fields.String,
+        "is_streamable": fields.Boolean,
     },
 )
 

--- a/libs/src/sdk/api/generated/default/models/Track.ts
+++ b/libs/src/sdk/api/generated/default/models/Track.ts
@@ -134,5 +134,11 @@ export interface Track {
      * @memberof Track
      */
     permalink?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof Track
+     */
+    is_streamable?: boolean;
 }
 

--- a/libs/src/sdk/api/generated/full/models/TrackFull.ts
+++ b/libs/src/sdk/api/generated/full/models/TrackFull.ts
@@ -172,6 +172,12 @@ export interface TrackFull {
     permalink?: string;
     /**
      * 
+     * @type {boolean}
+     * @memberof TrackFull
+     */
+    is_streamable?: boolean;
+    /**
+     * 
      * @type {number}
      * @memberof TrackFull
      */


### PR DESCRIPTION
### Description
Add `is_streamable` to api surface
Checks against is_delete and user's is_deactivated - ref: https://github.com/AudiusProject/audius-protocol/blob/5d719204e9c7c751789730cfe34fe61e6f2a3a2c/discovery-provider/src/api/v1/tracks.py#L384

Fixes PLAT-290

### Tests
ran locally against staging db

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->