### PR TITLE
Skip entity manager txs that fail to process

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -71,52 +71,56 @@ def entity_manager_update(
                 update_task, tx_receipt
             )
             for event in entity_manager_event_tx:
-                params = ManageEntityParameters(
-                    session,
-                    challenge_bus,
-                    event,
-                    new_records,  # actions below populate these records
-                    existing_records,
-                    pending_track_routes,
-                    ipfs_metadata,
-                    block_timestamp,
-                    block_number,
-                    event_blockhash,
-                    txhash,
-                )
-                if (
-                    params.action == Action.CREATE
-                    and params.entity_type == EntityType.PLAYLIST
-                ):
-                    create_playlist(params)
-                elif (
-                    params.action == Action.UPDATE
-                    and params.entity_type == EntityType.PLAYLIST
-                ):
-                    update_playlist(params)
-                elif (
-                    params.action == Action.DELETE
-                    and params.entity_type == EntityType.PLAYLIST
-                ):
-                    delete_playlist(params)
-                elif (
-                    params.action == Action.CREATE
-                    and params.entity_type == EntityType.TRACK
-                ):
-                    create_track(params)
-                elif (
-                    params.action == Action.UPDATE
-                    and params.entity_type == EntityType.TRACK
-                ):
-                    update_track(params)
+                try:
+                    params = ManageEntityParameters(
+                        session,
+                        challenge_bus,
+                        event,
+                        new_records,  # actions below populate these records
+                        existing_records,
+                        pending_track_routes,
+                        ipfs_metadata,
+                        block_timestamp,
+                        block_number,
+                        event_blockhash,
+                        txhash,
+                    )
+                    if (
+                        params.action == Action.CREATE
+                        and params.entity_type == EntityType.PLAYLIST
+                    ):
+                        create_playlist(params)
+                    elif (
+                        params.action == Action.UPDATE
+                        and params.entity_type == EntityType.PLAYLIST
+                    ):
+                        update_playlist(params)
+                    elif (
+                        params.action == Action.DELETE
+                        and params.entity_type == EntityType.PLAYLIST
+                    ):
+                        delete_playlist(params)
+                    elif (
+                        params.action == Action.CREATE
+                        and params.entity_type == EntityType.TRACK
+                    ):
+                        create_track(params)
+                    elif (
+                        params.action == Action.UPDATE
+                        and params.entity_type == EntityType.TRACK
+                    ):
+                        update_track(params)
 
-                elif (
-                    params.action == Action.DELETE
-                    and params.entity_type == EntityType.TRACK
-                ):
-                    delete_track(params)
-
-        logger.info(new_records)
+                    elif (
+                        params.action == Action.DELETE
+                        and params.entity_type == EntityType.TRACK
+                    ):
+                        delete_track(params)
+                except Exception as e:
+                    # swallow exception to keep indexing
+                    logger.info(
+                        f"entity_manager.py | failed to process tx error {e} | with params {params}"
+                    )
 
         # compile records_to_save
         records_to_save = []
@@ -135,7 +139,7 @@ def entity_manager_update(
         num_total_changes += len(records_to_save)
 
     except Exception as e:
-        logger.error(f"Exception occurred {e}", exc_info=True)
+        logger.error(f"entity_manager.py | Exception occurred {e}", exc_info=True)
         raise e
     return num_total_changes, changed_entity_ids
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

* Swallow errors when processing entity manager tx. Adjust validation to throw exception with message.
* Add last_added_to field which was missing before.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Adjusted integration tests.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check new logs and confirm valid txs are indexed.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->