### PR TITLE
Add first playlist challenge to entity manager

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -81,15 +81,20 @@ def create_playlist(params: ManageEntityParameters):
     )
     params.add_playlist_record(playlist_id, create_playlist_record)
 
-    dispatch_challenge_playlist_upload(
-        params.challenge_bus, params.block_number, create_playlist_record
-    )
+    if tracks:
+        dispatch_challenge_playlist_upload(
+            params.challenge_bus, params.block_number, create_playlist_record
+        )
 
 
 def dispatch_challenge_playlist_upload(
     bus: ChallengeEventBus, block_number: int, playlist_record: Playlist
 ):
-    bus.dispatch(ChallengeEvent.first_playlist, block_number, playlist_record.playlist_owner_id)
+    # Adds challenge for creating your first playlist and adding a track to it.
+    bus.dispatch(
+        ChallengeEvent.first_playlist, block_number, playlist_record.playlist_owner_id
+    )
+
 
 def update_playlist(params: ManageEntityParameters):
     validate_playlist_tx(params)
@@ -115,6 +120,11 @@ def update_playlist(params: ManageEntityParameters):
         params.metadata_cid,
     )
     params.add_playlist_record(playlist_id, updated_playlist)
+
+    if updated_playlist.playlist_contents["track_ids"]:
+        dispatch_challenge_playlist_upload(
+            params.challenge_bus, params.block_number, updated_playlist
+        )
 
 
 def delete_playlist(params: ManageEntityParameters):

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Set
 
+from src.challenges.challenge_event import ChallengeEvent
+from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.models.playlists.playlist import Playlist
 from src.tasks.entity_manager.utils import (
     PLAYLIST_ID_OFFSET,
@@ -79,6 +81,15 @@ def create_playlist(params: ManageEntityParameters):
     )
     params.add_playlist_record(playlist_id, create_playlist_record)
 
+    dispatch_challenge_playlist_upload(
+        params.challenge_bus, params.block_number, create_playlist_record
+    )
+
+
+def dispatch_challenge_playlist_upload(
+    bus: ChallengeEventBus, block_number: int, playlist_record: Playlist
+):
+    bus.dispatch(ChallengeEvent.first_playlist, block_number, playlist_record.playlist_owner_id)
 
 def update_playlist(params: ManageEntityParameters):
     validate_playlist_tx(params)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add first-playlist challenge to entity manager playlists


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Ran locally and confirmed playlist challenge record was created in user_challenges table.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Same as test.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->