### PR TITLE
Fix not returning result when secondarySyncFromPrimary sync is not required

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -73,6 +73,7 @@ export const METRIC_LABELS = Object.freeze({
     mode: ['force_resync', 'default'],
     result: [
       'success',
+      'success_clocks_already_match',
       'failure_force_resync_check',
       'failure_delete_db_data',
       'failure_sync_secondary_from_primary',

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -213,434 +213,431 @@ const handleSyncFromPrimary = async ({
      * Replace CNodeUser's local DB state with retrieved data + fetch + save missing files.
      */
 
-      // Retrieve user's replica set to use as gateways for content fetching in saveFileForMultihashToFS.
-      // Note that sync is only called on secondaries so `myCnodeEndpoint` below always represents a secondary.
-      let userReplicaSet = []
-      try {
-        const myCnodeEndpoint = await getOwnEndpoint(serviceRegistry)
-        userReplicaSet = await getUserReplicaSetEndpointsFromDiscovery({
-          libs,
-          logger: genericLogger,
-          wallet: fetchedWalletPublicKey,
-          blockNumber,
-          ensurePrimary: false,
-          myCnodeEndpoint
-        })
+    // Retrieve user's replica set to use as gateways for content fetching in saveFileForMultihashToFS.
+    // Note that sync is only called on secondaries so `myCnodeEndpoint` below always represents a secondary.
+    let userReplicaSet = []
+    try {
+      const myCnodeEndpoint = await getOwnEndpoint(serviceRegistry)
+      userReplicaSet = await getUserReplicaSetEndpointsFromDiscovery({
+        libs,
+        logger: genericLogger,
+        wallet: fetchedWalletPublicKey,
+        blockNumber,
+        ensurePrimary: false,
+        myCnodeEndpoint
+      })
 
-        // Filter out current node from user's replica set
-        userReplicaSet = userReplicaSet.filter((url) => url !== myCnodeEndpoint)
+      // Filter out current node from user's replica set
+      userReplicaSet = userReplicaSet.filter((url) => url !== myCnodeEndpoint)
 
-        // Spread + set uniq's the array
-        userReplicaSet = [...new Set(userReplicaSet)]
-      } catch (e) {
-        genericLogger.error(
-          logPrefix,
-          `Couldn't get user's replica set, can't use cnode gateways in saveFileForMultihashToFS - ${e.message}`
-        )
+      // Spread + set uniq's the array
+      userReplicaSet = [...new Set(userReplicaSet)]
+    } catch (e) {
+      genericLogger.error(
+        logPrefix,
+        `Couldn't get user's replica set, can't use cnode gateways in saveFileForMultihashToFS - ${e.message}`
+      )
+    }
+
+    /**
+     * This node (secondary) must compare its local clock state against clock state received in export from primary.
+     * Only allow sync if received clock state contains new data and is contiguous with existing data.
+     */
+
+    const maxClockRecordId = Math.max(
+      ...fetchedClockRecords.map((record) => record.clock)
+    )
+
+    // Error if returned data is not within requested range
+    if (fetchedLatestClockVal < localMaxClockVal) {
+      returnValue = {
+        error: new Error(
+          `Cannot sync for localMaxClockVal ${localMaxClockVal} - imported data has max clock val ${fetchedLatestClockVal}`
+        ),
+        result: 'failure_inconsistent_clock'
       }
+      throw returnValue.error
+    } else if (
+      localMaxClockVal !== -1 &&
+      fetchedClockRecords[0] &&
+      fetchedClockRecords[0].clock !== localMaxClockVal + 1
+    ) {
+      returnValue = {
+        error: new Error(
+          `Cannot sync - imported data is not contiguous. Local max clock val = ${localMaxClockVal} and imported min clock val ${fetchedClockRecords[0].clock}`
+        ),
+        result: 'failure_import_not_contiguous'
+      }
+      throw returnValue.error
+    } else if (
+      !_.isEmpty(fetchedClockRecords) &&
+      maxClockRecordId !== fetchedLatestClockVal
+    ) {
+      returnValue = {
+        error: new Error(
+          `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`
+        ),
+        result: 'failure_import_not_consistent'
+      }
+      throw returnValue.error
+    }
 
-      /**
-       * This node (secondary) must compare its local clock state against clock state received in export from primary.
-       * Only allow sync if received clock state contains new data and is contiguous with existing data.
-       */
+    // All DB updates must happen in single atomic tx - partial state updates will lead to data loss
+    const transaction = await models.sequelize.transaction()
 
-      const maxClockRecordId = Math.max(
-        ...fetchedClockRecords.map((record) => record.clock)
+    /**
+     * Process all DB updates for cnodeUser
+     */
+    try {
+      genericLogger.info(
+        logPrefix,
+        `beginning add ops for cnodeUser wallet ${fetchedWalletPublicKey}`
       )
 
-      // Error if returned data is not within requested range
-      if (fetchedLatestClockVal < localMaxClockVal) {
-        returnValue = {
-          error: new Error(
-            `Cannot sync for localMaxClockVal ${localMaxClockVal} - imported data has max clock val ${fetchedLatestClockVal}`
-          ),
-          result: 'failure_inconsistent_clock'
-        }
-        throw returnValue.error
-      } else if (
-        localMaxClockVal !== -1 &&
-        fetchedClockRecords[0] &&
-        fetchedClockRecords[0].clock !== localMaxClockVal + 1
-      ) {
-        returnValue = {
-          error: new Error(
-            `Cannot sync - imported data is not contiguous. Local max clock val = ${localMaxClockVal} and imported min clock val ${fetchedClockRecords[0].clock}`
-          ),
-          result: 'failure_import_not_contiguous'
-        }
-        throw returnValue.error
-      } else if (
-        !_.isEmpty(fetchedClockRecords) &&
-        maxClockRecordId !== fetchedLatestClockVal
-      ) {
-        returnValue = {
-          error: new Error(
-            `Cannot sync - imported data is not consistent. Imported max clock val = ${fetchedLatestClockVal} and imported max ClockRecord val ${maxClockRecordId}`
-          ),
-          result: 'failure_import_not_consistent'
-        }
-        throw returnValue.error
-      }
+      /**
+       * Update CNodeUser entry if exists else create new
+       *
+       * Cannot use upsert since it fails to use default value for cnodeUserUUID per this issue https://github.com/sequelize/sequelize/issues/3247
+       */
 
-      // All DB updates must happen in single atomic tx - partial state updates will lead to data loss
-      const transaction = await models.sequelize.transaction()
+      let cnodeUser
+
+      // Fetch current cnodeUser from DB
+      const cnodeUserRecord = await models.CNodeUser.findOne({
+        where: { walletPublicKey: fetchedWalletPublicKey },
+        transaction
+      })
 
       /**
-       * Process all DB updates for cnodeUser
+       * The first sync for a user will enter else case where no local cnodeUserRecord is found
+       *    creating a new entry with a new auto-generated cnodeUserUUID.
+       * Every subsequent sync will enter the if case and update the existing local cnodeUserRecord.
        */
-      try {
+      if (cnodeUserRecord) {
         genericLogger.info(
           logPrefix,
-          `beginning add ops for cnodeUser wallet ${fetchedWalletPublicKey}`
+          `cNodeUserRecord was non-empty -- updating CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
         )
-
-        /**
-         * Update CNodeUser entry if exists else create new
-         *
-         * Cannot use upsert since it fails to use default value for cnodeUserUUID per this issue https://github.com/sequelize/sequelize/issues/3247
-         */
-
-        let cnodeUser
-
-        // Fetch current cnodeUser from DB
-        const cnodeUserRecord = await models.CNodeUser.findOne({
-          where: { walletPublicKey: fetchedWalletPublicKey },
-          transaction
-        })
-
-        /**
-         * The first sync for a user will enter else case where no local cnodeUserRecord is found
-         *    creating a new entry with a new auto-generated cnodeUserUUID.
-         * Every subsequent sync will enter the if case and update the existing local cnodeUserRecord.
-         */
-        if (cnodeUserRecord) {
-          genericLogger.info(
-            logPrefix,
-            `cNodeUserRecord was non-empty -- updating CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
-          )
-          const [numRowsUpdated, respObj] = await models.CNodeUser.update(
-            {
-              lastLogin: fetchedCNodeUser.lastLogin,
-              latestBlockNumber: fetchedLatestBlockNumber,
-              clock: fetchedLatestClockVal,
-              createdAt: fetchedCNodeUser.createdAt
-            },
-            {
-              where: { walletPublicKey: fetchedWalletPublicKey },
-              fields: [
-                'lastLogin',
-                'latestBlockNumber',
-                'clock',
-                'createdAt',
-                'updatedAt'
-              ],
-              returning: true,
-              transaction
-            }
-          )
-
-          // Error if update failed
-          if (numRowsUpdated !== 1 || respObj.length !== 1) {
-            returnValue = {
-              error: new Error(
-                `Failed to update cnodeUser row for cnodeUser wallet ${fetchedWalletPublicKey}`
-              ),
-              result: 'failure_db_transaction'
-            }
-            throw returnValue.error
+        const [numRowsUpdated, respObj] = await models.CNodeUser.update(
+          {
+            lastLogin: fetchedCNodeUser.lastLogin,
+            latestBlockNumber: fetchedLatestBlockNumber,
+            clock: fetchedLatestClockVal,
+            createdAt: fetchedCNodeUser.createdAt
+          },
+          {
+            where: { walletPublicKey: fetchedWalletPublicKey },
+            fields: [
+              'lastLogin',
+              'latestBlockNumber',
+              'clock',
+              'createdAt',
+              'updatedAt'
+            ],
+            returning: true,
+            transaction
           }
-          cnodeUser = respObj[0]
-        } else {
-          genericLogger.info(
-            logPrefix,
-            `cNodeUserRecord was empty -- inserting CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
-          )
-          // Will throw error if creation fails
-          cnodeUser = await models.CNodeUser.create(
-            {
-              walletPublicKey: fetchedWalletPublicKey,
-              lastLogin: fetchedCNodeUser.lastLogin,
-              latestBlockNumber: fetchedLatestBlockNumber,
-              clock: fetchedLatestClockVal,
-              createdAt: fetchedCNodeUser.createdAt
-            },
-            {
-              returning: true,
-              transaction
-            }
-          )
-        }
+        )
 
-        const cnodeUserUUID = cnodeUser.cnodeUserUUID
+        // Error if update failed
+        if (numRowsUpdated !== 1 || respObj.length !== 1) {
+          returnValue = {
+            error: new Error(
+              `Failed to update cnodeUser row for cnodeUser wallet ${fetchedWalletPublicKey}`
+            ),
+            result: 'failure_db_transaction'
+          }
+          throw returnValue.error
+        }
+        cnodeUser = respObj[0]
+      } else {
         genericLogger.info(
           logPrefix,
-          `Upserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedLatestClockVal}`
+          `cNodeUserRecord was empty -- inserting CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}. Clock value: ${fetchedLatestClockVal}`
+        )
+        // Will throw error if creation fails
+        cnodeUser = await models.CNodeUser.create(
+          {
+            walletPublicKey: fetchedWalletPublicKey,
+            lastLogin: fetchedCNodeUser.lastLogin,
+            latestBlockNumber: fetchedLatestBlockNumber,
+            clock: fetchedLatestClockVal,
+            createdAt: fetchedCNodeUser.createdAt
+          },
+          {
+            returning: true,
+            transaction
+          }
+        )
+      }
+
+      const cnodeUserUUID = cnodeUser.cnodeUserUUID
+      genericLogger.info(
+        logPrefix,
+        `Upserted CNodeUser for cnodeUser wallet ${fetchedWalletPublicKey}: cnodeUserUUID: ${cnodeUserUUID}. Clock value: ${fetchedLatestClockVal}`
+      )
+
+      /**
+       * Populate all new data for fetched cnodeUser
+       * Always use local cnodeUserUUID in favor of cnodeUserUUID in exported dataset to ensure consistency
+       */
+
+      /*
+       * Make list of all track Files to add after track creation
+       *
+       * Files with trackBlockchainIds cannot be created until tracks have been created,
+       *    but tracks cannot be created until metadata and cover art files have been created.
+       */
+
+      const trackFiles = fetchedCNodeUser.files.filter((file) =>
+        models.File.TrackTypes.includes(file.type)
+      )
+      const nonTrackFiles = fetchedCNodeUser.files.filter((file) =>
+        models.File.NonTrackTypes.includes(file.type)
+      )
+      const numTotalFiles = trackFiles.length + nonTrackFiles.length
+
+      const CIDsThatFailedSaveFileOp = new Set()
+
+      // Save all track files to disk in batches (to limit concurrent load)
+      for (let i = 0; i < trackFiles.length; i += FileSaveMaxConcurrency) {
+        const trackFilesSlice = trackFiles.slice(i, i + FileSaveMaxConcurrency)
+        genericLogger.info(
+          logPrefix,
+          `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${
+            i + FileSaveMaxConcurrency
+          } out of total ${trackFiles.length}...`
         )
 
         /**
-         * Populate all new data for fetched cnodeUser
-         * Always use local cnodeUserUUID in favor of cnodeUserUUID in exported dataset to ensure consistency
+         * Fetch content for each CID + save to FS
+         * Record any CIDs that failed retrieval/saving for later use
+         * @notice `saveFileForMultihashToFS()` should never reject - it will return error indicator for post processing
          */
+        await Promise.all(
+          trackFilesSlice.map(async (trackFile) => {
+            const error = await saveFileForMultihashToFS(
+              libs,
+              genericLogger,
+              trackFile.multihash,
+              trackFile.storagePath,
+              userReplicaSet,
+              null,
+              trackFile.trackBlockchainId
+            )
 
-        /*
-         * Make list of all track Files to add after track creation
-         *
-         * Files with trackBlockchainIds cannot be created until tracks have been created,
-         *    but tracks cannot be created until metadata and cover art files have been created.
-         */
-
-        const trackFiles = fetchedCNodeUser.files.filter((file) =>
-          models.File.TrackTypes.includes(file.type)
+            // If saveFile op failed, record CID for later processing
+            if (error) {
+              CIDsThatFailedSaveFileOp.add(trackFile.multihash)
+            }
+          })
         )
-        const nonTrackFiles = fetchedCNodeUser.files.filter((file) =>
-          models.File.NonTrackTypes.includes(file.type)
+      }
+      genericLogger.info(logPrefix, 'Saved all track files to disk.')
+
+      // Save all non-track files to disk in batches (to limit concurrent load)
+      for (let i = 0; i < nonTrackFiles.length; i += FileSaveMaxConcurrency) {
+        const nonTrackFilesSlice = nonTrackFiles.slice(
+          i,
+          i + FileSaveMaxConcurrency
         )
-        const numTotalFiles = trackFiles.length + nonTrackFiles.length
-
-        const CIDsThatFailedSaveFileOp = new Set()
-
-        // Save all track files to disk in batches (to limit concurrent load)
-        for (let i = 0; i < trackFiles.length; i += FileSaveMaxConcurrency) {
-          const trackFilesSlice = trackFiles.slice(
-            i,
+        genericLogger.info(
+          logPrefix,
+          `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${
             i + FileSaveMaxConcurrency
-          )
-          genericLogger.info(
-            logPrefix,
-            `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${
-              i + FileSaveMaxConcurrency
-            } out of total ${trackFiles.length}...`
-          )
+          } out of total ${nonTrackFiles.length}...`
+        )
+        await Promise.all(
+          nonTrackFilesSlice.map(async (nonTrackFile) => {
+            // Skip over directories since there's no actual content to sync
+            // The files inside the directory are synced separately
+            if (nonTrackFile.type !== 'dir') {
+              const multihash = nonTrackFile.multihash
 
-          /**
-           * Fetch content for each CID + save to FS
-           * Record any CIDs that failed retrieval/saving for later use
-           * @notice `saveFileForMultihashToFS()` should never reject - it will return error indicator for post processing
-           */
-          await Promise.all(
-            trackFilesSlice.map(async (trackFile) => {
-              const error = await saveFileForMultihashToFS(
-                libs,
-                genericLogger,
-                trackFile.multihash,
-                trackFile.storagePath,
-                userReplicaSet,
-                null,
-                trackFile.trackBlockchainId
-              )
+              // if it's an image file, we need to pass in the actual filename because the gateway request is /ipfs/Qm123/<filename>
+              // need to also check fileName is not null to make sure it's a dir-style image. non-dir images won't have a 'fileName' db column
+              let error
+              if (
+                nonTrackFile.type === 'image' &&
+                nonTrackFile.fileName !== null
+              ) {
+                error = await saveFileForMultihashToFS(
+                  libs,
+                  genericLogger,
+                  multihash,
+                  nonTrackFile.storagePath,
+                  userReplicaSet,
+                  nonTrackFile.fileName
+                )
+              } else {
+                error = await saveFileForMultihashToFS(
+                  libs,
+                  genericLogger,
+                  multihash,
+                  nonTrackFile.storagePath,
+                  userReplicaSet
+                )
+              }
 
               // If saveFile op failed, record CID for later processing
               if (error) {
-                CIDsThatFailedSaveFileOp.add(trackFile.multihash)
+                CIDsThatFailedSaveFileOp.add(multihash)
               }
-            })
-          )
-        }
-        genericLogger.info(logPrefix, 'Saved all track files to disk.')
-
-        // Save all non-track files to disk in batches (to limit concurrent load)
-        for (let i = 0; i < nonTrackFiles.length; i += FileSaveMaxConcurrency) {
-          const nonTrackFilesSlice = nonTrackFiles.slice(
-            i,
-            i + FileSaveMaxConcurrency
-          )
-          genericLogger.info(
-            logPrefix,
-            `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${
-              i + FileSaveMaxConcurrency
-            } out of total ${nonTrackFiles.length}...`
-          )
-          await Promise.all(
-            nonTrackFilesSlice.map(async (nonTrackFile) => {
-              // Skip over directories since there's no actual content to sync
-              // The files inside the directory are synced separately
-              if (nonTrackFile.type !== 'dir') {
-                const multihash = nonTrackFile.multihash
-
-                // if it's an image file, we need to pass in the actual filename because the gateway request is /ipfs/Qm123/<filename>
-                // need to also check fileName is not null to make sure it's a dir-style image. non-dir images won't have a 'fileName' db column
-                let error
-                if (
-                  nonTrackFile.type === 'image' &&
-                  nonTrackFile.fileName !== null
-                ) {
-                  error = await saveFileForMultihashToFS(
-                    libs,
-                    genericLogger,
-                    multihash,
-                    nonTrackFile.storagePath,
-                    userReplicaSet,
-                    nonTrackFile.fileName
-                  )
-                } else {
-                  error = await saveFileForMultihashToFS(
-                    libs,
-                    genericLogger,
-                    multihash,
-                    nonTrackFile.storagePath,
-                    userReplicaSet
-                  )
-                }
-
-                // If saveFile op failed, record CID for later processing
-                if (error) {
-                  CIDsThatFailedSaveFileOp.add(multihash)
-                }
-              }
-            })
-          )
-        }
-        genericLogger.info(logPrefix, 'Saved all non-track files to disk.')
-
-        /**
-         * Handle scenario where failed to retrieve/save > 0 CIDs
-         * Reject sync if number of failures for user is below threshold, else proceed and mark unretrieved files as skipped
-         */
-        const numCIDsThatFailedSaveFileOp = CIDsThatFailedSaveFileOp.size
-        if (numCIDsThatFailedSaveFileOp > 0) {
-          const userSyncFailureCount =
-            await UserSyncFailureCountService.incrementFailureCount(
-              fetchedWalletPublicKey
-            )
-
-          // Throw error if failure threshold not yet reached
-          if (userSyncFailureCount < SyncRequestMaxUserFailureCountBeforeSkip) {
-            const errorMsg = `User Sync failed due to ${numCIDsThatFailedSaveFileOp} failing saveFileForMultihashToFS op. userSyncFailureCount = ${userSyncFailureCount} // SyncRequestMaxUserFailureCountBeforeSkip = ${SyncRequestMaxUserFailureCountBeforeSkip}`
-            genericLogger.error(logPrefix, errorMsg)
-            returnValue = {
-              error: new Error(errorMsg),
-              result: 'failure_skip_threshold_not_reached'
             }
-            throw returnValue.error
+          })
+        )
+      }
+      genericLogger.info(logPrefix, 'Saved all non-track files to disk.')
 
-            // If max failure threshold reached, continue with sync and reset failure count
-          } else {
-            // Reset falure count so subsequent user syncs will not always succeed & skip
-            await UserSyncFailureCountService.resetFailureCount(
-              fetchedWalletPublicKey
-            )
+      /**
+       * Handle scenario where failed to retrieve/save > 0 CIDs
+       * Reject sync if number of failures for user is below threshold, else proceed and mark unretrieved files as skipped
+       */
+      const numCIDsThatFailedSaveFileOp = CIDsThatFailedSaveFileOp.size
+      if (numCIDsThatFailedSaveFileOp > 0) {
+        const userSyncFailureCount =
+          await UserSyncFailureCountService.incrementFailureCount(
+            fetchedWalletPublicKey
+          )
 
-            genericLogger.info(
-              logPrefix,
-              `User Sync continuing with ${numCIDsThatFailedSaveFileOp} skipped files, since SyncRequestMaxUserFailureCountBeforeSkip (${SyncRequestMaxUserFailureCountBeforeSkip}) reached.`
-            )
+        // Throw error if failure threshold not yet reached
+        if (userSyncFailureCount < SyncRequestMaxUserFailureCountBeforeSkip) {
+          const errorMsg = `User Sync failed due to ${numCIDsThatFailedSaveFileOp} failing saveFileForMultihashToFS op. userSyncFailureCount = ${userSyncFailureCount} // SyncRequestMaxUserFailureCountBeforeSkip = ${SyncRequestMaxUserFailureCountBeforeSkip}`
+          genericLogger.error(logPrefix, errorMsg)
+          returnValue = {
+            error: new Error(errorMsg),
+            result: 'failure_skip_threshold_not_reached'
           }
+          throw returnValue.error
+
+          // If max failure threshold reached, continue with sync and reset failure count
         } else {
-          // Reset failure count if all files were successfully saved
+          // Reset falure count so subsequent user syncs will not always succeed & skip
           await UserSyncFailureCountService.resetFailureCount(
             fetchedWalletPublicKey
           )
+
+          genericLogger.info(
+            logPrefix,
+            `User Sync continuing with ${numCIDsThatFailedSaveFileOp} skipped files, since SyncRequestMaxUserFailureCountBeforeSkip (${SyncRequestMaxUserFailureCountBeforeSkip}) reached.`
+          )
         }
+      } else {
+        // Reset failure count if all files were successfully saved
+        await UserSyncFailureCountService.resetFailureCount(
+          fetchedWalletPublicKey
+        )
+      }
 
-        /**
-         * Write all records to DB
-         */
+      /**
+       * Write all records to DB
+       */
 
-        await models.ClockRecord.bulkCreate(
-          fetchedClockRecords.map((clockRecord) => ({
-            ...clockRecord,
+      await models.ClockRecord.bulkCreate(
+        fetchedClockRecords.map((clockRecord) => ({
+          ...clockRecord,
+          cnodeUserUUID
+        })),
+        { transaction }
+      )
+      genericLogger.info(logPrefix, 'Saved all ClockRecord entries to DB')
+
+      await models.File.bulkCreate(
+        nonTrackFiles.map((file) => {
+          if (CIDsThatFailedSaveFileOp.has(file.multihash)) {
+            file.skipped = true // defaults to false
+          }
+          return {
+            ...file,
+            trackBlockchainId: null,
             cnodeUserUUID
-          })),
-          { transaction }
-        )
-        genericLogger.info(logPrefix, 'Saved all ClockRecord entries to DB')
+          }
+        }),
+        { transaction }
+      )
+      genericLogger.info(logPrefix, 'Saved all non-track File entries to DB')
 
-        await models.File.bulkCreate(
-          nonTrackFiles.map((file) => {
-            if (CIDsThatFailedSaveFileOp.has(file.multihash)) {
-              file.skipped = true // defaults to false
-            }
-            return {
-              ...file,
-              trackBlockchainId: null,
-              cnodeUserUUID
-            }
-          }),
-          { transaction }
-        )
-        genericLogger.info(logPrefix, 'Saved all non-track File entries to DB')
+      await models.Track.bulkCreate(
+        fetchedCNodeUser.tracks.map((track) => ({
+          ...track,
+          cnodeUserUUID
+        })),
+        { transaction }
+      )
+      genericLogger.info(logPrefix, 'Saved all Track entries to DB')
 
-        await models.Track.bulkCreate(
-          fetchedCNodeUser.tracks.map((track) => ({
-            ...track,
+      await models.File.bulkCreate(
+        trackFiles.map((trackFile) => {
+          if (CIDsThatFailedSaveFileOp.has(trackFile.multihash)) {
+            trackFile.skipped = true // defaults to false
+          }
+          return {
+            ...trackFile,
             cnodeUserUUID
-          })),
-          { transaction }
+          }
+        }),
+        { transaction }
+      )
+      genericLogger.info(logPrefix, 'Saved all track File entries to DB')
+
+      await models.AudiusUser.bulkCreate(
+        fetchedCNodeUser.audiusUsers.map((audiusUser) => ({
+          ...audiusUser,
+          cnodeUserUUID
+        })),
+        { transaction }
+      )
+      genericLogger.info(logPrefix, 'Saved all AudiusUser entries to DB')
+
+      await transaction.commit()
+
+      genericLogger.info(
+        logPrefix,
+        `Transaction successfully committed for cnodeUser wallet ${fetchedWalletPublicKey} with ${numTotalFiles} files processed and ${numCIDsThatFailedSaveFileOp} skipped.`
+      )
+
+      // track that sync for this user was successful
+      await SyncHistoryAggregator.recordSyncSuccess(fetchedWalletPublicKey)
+
+      genericLogger.info(
+        logPrefix,
+        `Sync complete for wallet: ${wallet}. Status: Success. Duration sync: ${
+          Date.now() - start
+        }. From endpoint ${creatorNodeEndpoint}.`
+      )
+
+      return { result: 'success' }
+    } catch (e) {
+      genericLogger.error(
+        logPrefix,
+        `Transaction failed for cnodeUser wallet ${fetchedWalletPublicKey}`,
+        e
+      )
+
+      await transaction.rollback()
+
+      try {
+        const numRowsUpdated = await DBManager.fixInconsistentUser(
+          fetchedCNodeUser.cnodeUserUUID
         )
-        genericLogger.info(logPrefix, 'Saved all Track entries to DB')
-
-        await models.File.bulkCreate(
-          trackFiles.map((trackFile) => {
-            if (CIDsThatFailedSaveFileOp.has(trackFile.multihash)) {
-              trackFile.skipped = true // defaults to false
-            }
-            return {
-              ...trackFile,
-              cnodeUserUUID
-            }
-          }),
-          { transaction }
-        )
-        genericLogger.info(logPrefix, 'Saved all track File entries to DB')
-
-        await models.AudiusUser.bulkCreate(
-          fetchedCNodeUser.audiusUsers.map((audiusUser) => ({
-            ...audiusUser,
-            cnodeUserUUID
-          })),
-          { transaction }
-        )
-        genericLogger.info(logPrefix, 'Saved all AudiusUser entries to DB')
-
-        await transaction.commit()
-
-        genericLogger.info(
+        genericLogger.warn(
           logPrefix,
-          `Transaction successfully committed for cnodeUser wallet ${fetchedWalletPublicKey} with ${numTotalFiles} files processed and ${numCIDsThatFailedSaveFileOp} skipped.`
+          `fixInconsistentUser() executed for ${fetchedCNodeUser.cnodeUserUUID} - numRowsUpdated:${numRowsUpdated}`
         )
-
-        // track that sync for this user was successful
-        await SyncHistoryAggregator.recordSyncSuccess(fetchedWalletPublicKey)
-
-        genericLogger.info(
-          logPrefix,
-          `Sync complete for wallet: ${wallet}. Status: Success. Duration sync: ${
-            Date.now() - start
-          }. From endpoint ${creatorNodeEndpoint}.`
-        )
-
-        return { result: 'success' }
       } catch (e) {
         genericLogger.error(
           logPrefix,
-          `Transaction failed for cnodeUser wallet ${fetchedWalletPublicKey}`,
-          e
+          `fixInconsistentUser() error for ${fetchedCNodeUser.cnodeUserUUID} - ${e.message}`
         )
-
-        await transaction.rollback()
-
-        try {
-          const numRowsUpdated = await DBManager.fixInconsistentUser(
-            fetchedCNodeUser.cnodeUserUUID
-          )
-          genericLogger.warn(
-            logPrefix,
-            `fixInconsistentUser() executed for ${fetchedCNodeUser.cnodeUserUUID} - numRowsUpdated:${numRowsUpdated}`
-          )
-        } catch (e) {
-          genericLogger.error(
-            logPrefix,
-            `fixInconsistentUser() error for ${fetchedCNodeUser.cnodeUserUUID} - ${e.message}`
-          )
-        }
-
-        return _.isEmpty(returnValue)
-          ? {
-              error: new Error(e),
-              result: 'failure_db_transaction'
-            }
-          : returnValue
       }
+
+      return _.isEmpty(returnValue)
+        ? {
+            error: new Error(e),
+            result: 'failure_db_transaction'
+          }
+        : returnValue
+    }
   } catch (e) {
     await SyncHistoryAggregator.recordSyncFail(wallet)
     genericLogger.error(

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -156,7 +156,10 @@ const handleSyncFromPrimary = async ({
     }
 
     const { data: body } = resp
-    if (!body.data.hasOwnProperty('cnodeUsers') || !body.data.length) {
+    if (
+      !body.data.hasOwnProperty('cnodeUsers') ||
+      _.isEmpty(body.data.cnodeUsers)
+    ) {
       returnValue = {
         error: new Error(`Malformed response from ${creatorNodeEndpoint}.`),
         result: 'failure_malformed_export'


### PR DESCRIPTION
### Description
- When a sync request was processed on a secondary and clock values already matched, it `continue`d.
- This prevented it from returning a `result` value, which is expected elsewhere.
- This PR makes the sync return a new `success_clocks_already_match` value for the `result` metric label

NOTE: The diff is hard to review because there was a for loop that only ever had one iteration after removing this `continue`. Reviewing commit-by-commit is much easier to follow so that you can skip reviewing the giant linting of the for loop.


### Tests
Integration tests pass.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Add the new label value (`success_clocks_already_match`) to Grafana panels that expect successes, and make sure it has some values.
- Make sure there are no more errors like `Cannot destructure property 'error' of '(intermediate value)' as it is undefined` for `secondarySyncFromPrimary`