### PR TITLE
[PAY-579] Checks associated account or SOL before transfer

### DIFF
--- a/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -1,4 +1,9 @@
-import solanaWeb3, { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import solanaWeb3, {
+  Connection,
+  Keypair,
+  PublicKey,
+  LAMPORTS_PER_SOL
+} from '@solana/web3.js'
 import type BN from 'bn.js'
 import splToken from '@solana/spl-token'
 import anchor, { Address, Idl, Program } from '@project-serum/anchor'
@@ -546,7 +551,7 @@ export class SolanaWeb3Manager {
 
   async getSolBalance(address: string) {
     const publicKey = new PublicKey(address)
-    const balance = await this.getBalance({ publicKey})
+    const balance = await this.getBalance({ publicKey })
     const balanceBN = Utils.toBN(balance * LAMPORTS_PER_SOL)
     return balanceBN
   }

--- a/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -1,4 +1,4 @@
-import solanaWeb3, { Connection, Keypair, PublicKey } from '@solana/web3.js'
+import solanaWeb3, { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import type BN from 'bn.js'
 import splToken from '@solana/spl-token'
 import anchor, { Address, Idl, Program } from '@project-serum/anchor'
@@ -542,6 +542,13 @@ export class SolanaWeb3Manager {
   }) {
     const balance = await this.getBalance({ publicKey })
     return balance > epsilon
+  }
+
+  async getSolBalance(address: string) {
+    const publicKey = new PublicKey(address)
+    const balance = await this.getBalance({ publicKey})
+    const balanceBN = Utils.toBN(balance * LAMPORTS_PER_SOL)
+    return balanceBN
   }
 
   async getSlot() {


### PR DESCRIPTION
### Description
Adds backend function to enable checking SOL balance of a wallet address to be used before sending WAudio to an external wallet.

### Tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
