### PR TITLE
revert track entity upload

### DIFF
--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -344,19 +344,13 @@ export class Track extends Base {
    * @param metadata json of the track metadata with all fields, missing fields will error
    * @param onProgress callback fired with (loaded, total) on byte upload progress
    */
-  async uploadTrack({
-    trackFile,
-    coverArtFile,
-    metadata,
-    useEntityManager,
-    onProgress
-  }: {
-    trackFile: File
-    coverArtFile: File
-    metadata: TrackMetadata
+  async uploadTrack(
+    trackFile: File,
+    coverArtFile: File,
+    metadata: TrackMetadata,
+    onProgress: () => void,
     useEntityManager: boolean
-    onProgress: () => void
-  }) {
+  ) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.FILE_IS_VALID(trackFile)
 


### PR DESCRIPTION
### Description
undoes change for upload track params in https://github.com/AudiusProject/audius-protocol/pull/3706/files#diff-866586d98c7a27e7761e288ddb9c9863059b8d5737899cfd21ffd494ef63148a

It broke the maddog tests

### Tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->