### PR TITLE
[CON-363] Skip replica set updates for users w/o URSM data

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -67,7 +67,7 @@ export const QUEUE_NAMES = {
   // Queue to find replica set updates
   FIND_REPLICA_SET_UPDATES: 'find-replica-set-updates-queue',
   // Queue that only processes jobs to fetch the cNodeEndpoint->spId mapping,
-  FETCH_C_NODE_ENDPOINT_TO_SP_ID_MAP: 'c-node-to-endpoint-sp-id-map-queue',
+  FETCH_C_NODE_ENDPOINT_TO_SP_ID_MAP: 'c-node-endpoint-to-sp-id-map-queue',
   // Queue to issue a manual sync
   MANUAL_SYNC: 'manual-sync-queue',
   // Queue to issue a recurring sync

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findReplicaSetUpdates.jobProcessor.ts
@@ -183,6 +183,20 @@ const _findReplicaSetUpdatesForUser = async (
     secondary2SpID
   } = user
 
+  // If the user was on an old client (pre-URSM), they could have a null replica set on URSM.
+  // This will be resolved by client-side sanity checks next time they use the client.
+  // Any replica set update we issue here will fail because they have no primary SP ID that can be verified from chain.
+  if (
+    primarySpID === null &&
+    secondary1SpID === null &&
+    secondary1SpID === null
+  ) {
+    logger.error(
+      `User ${wallet} has null SP IDs for their entire replica set. Replica set endpoints: [${primary},${secondary1},${secondary2}]`
+    )
+    return requiredUpdateReplicaSetOps
+  }
+
   /**
    * If this node is primary for user, check both secondaries for health
    * Enqueue SyncRequests against healthy secondaries, and enqueue UpdateReplicaSetOps against unhealthy secondaries
@@ -267,6 +281,17 @@ const _findReplicaSetUpdatesForUser = async (
         ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[replica.endpoint] !==
         replica.spId
       ) {
+        logger.error(
+          `_findReplicaSetUpdatesForUser(): Replica ${
+            replica.endpoint
+          } for user ${wallet} mismatched spID. Expected ${
+            replica.spId
+          }, found ${
+            ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[replica.endpoint]
+          }. Marking replica as unhealthy. Endpoint to spID mapping: ${JSON.stringify(
+            ContentNodeInfoManager.getCNodeEndpointToSpIdMap()
+          )}`
+        )
         unhealthyReplicas.add(replica.endpoint)
       } else if (unhealthyPeersSet.has(replica.endpoint)) {
         // Else, continue with conducting extra health check if the current observed node is a primary, and
@@ -280,6 +305,9 @@ const _findReplicaSetUpdatesForUser = async (
         }
 
         if (addToUnhealthyReplicas) {
+          logger.error(
+            `_findReplicaSetUpdatesForUser(): Replica ${replica.endpoint} for user ${wallet} was already marked unhealthy and failed an additional health check if it was primary.`
+          )
           unhealthyReplicas.add(replica.endpoint)
         }
       }

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -152,7 +152,11 @@ module.exports = async function ({
       _addToDecisionTree(
         decisionTree,
         'retrieveUserInfoFromReplicaSet Success',
-        logger
+        logger,
+        {
+          newUnhealthyPeerSetLength: retrieveUserInfoResp.unhealthyPeers.size,
+          newUnhealthyPeers: Array.from(retrieveUserInfoResp.unhealthyPeers)
+        }
       )
     } catch (e: any) {
       logger.error(e.stack)


### PR DESCRIPTION
### Description

- Skip enqueuing replica set updates in the edge case where a user with a very old client has no replica set on UserReplicaSetManager. This bug will resolve itself via sanity checks the next time the user logs in with a newer client
  - This didn't seem worth an entirely new metric since it happens in find-replica-set-updates rather than issue-replica-set-update (so we can't just add a label to an existing metric). We can get an idea of the frequency of these errors by searching logs for `"has null SP IDs for their entire replica set"`
- Log unhealthy peers in the `retrieveUserInfoFromReplicaSet` step of monitor-state job
- Log scenarios in findReplicaSetUpdates where a node is marked unhealthy (having this log would've saved a lot of time during investigation of this bug)



### Tests
Tests pass. The null check is straightforward / minimally risky, and the other changes are added logging.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Search for `"has null SP IDs for their entire replica set"` and see how many times this happens. Spot check a few runs to make sure the users really did have null replica sets on URSM. This should reduce the number of issue-replica-set-update failures.