### PR TITLE
Fix playlist entity manager invalid tx logic and last_added_to

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_entity_manager.py
@@ -147,6 +147,7 @@ def test_index_valid_playlists(app, mocker):
         assert datetime.timestamp(playlist_1.last_added_to) == 1585336422
         assert playlist_1.playlist_name == "playlist 1 updated"
         assert playlist_1.is_delete == True
+        assert playlist_1.is_current == True
 
         playlist_2: Playlist = (
             session.query(Playlist)
@@ -159,6 +160,7 @@ def test_index_valid_playlists(app, mocker):
         assert playlist_2.last_added_to == None
         assert playlist_2.playlist_name == "playlist 2"
         assert playlist_2.is_delete == False
+        assert playlist_2.is_current == True
 
 
 def test_index_invalid_playlists(app, mocker):
@@ -364,3 +366,4 @@ def test_index_invalid_playlists(app, mocker):
         # validate db records
         all_playlists: List[Playlist] = session.query(Playlist).all()
         assert len(all_playlists) == 1  # no new playlists indexed
+        assert all_playlists[0].is_current == True

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -130,6 +130,9 @@ def entity_manager_update(
         # compile records_to_save
         records_to_save = []
         for playlist_records in new_records["playlists"].values():
+            # invalidate all playlists besides the last one
+            for record in playlist_records:
+                record.is_current = False
             # flip is_current to true for the last tx in each playlist
             playlist_records[-1].is_current = True
             records_to_save.extend(playlist_records)

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -103,7 +103,6 @@ def update_playlist(params: ManageEntityParameters):
     playlist_id = params.entity_id
     metadata = params.ipfs_metadata[params.metadata_cid]
     existing_playlist = params.existing_records["playlists"][playlist_id]
-    existing_playlist.is_current = False  # invalidate
     if (
         playlist_id in params.new_records["playlists"]
     ):  # override with last updated playlist is in this block
@@ -131,7 +130,6 @@ def delete_playlist(params: ManageEntityParameters):
     validate_playlist_tx(params)
 
     existing_playlist = params.existing_records["playlists"][params.entity_id]
-    existing_playlist.is_current = False  # invalidate old playlist
     if params.entity_id in params.new_records["playlists"]:
         # override with last updated playlist is in this block
         existing_playlist = params.new_records["playlists"][params.entity_id][-1]
@@ -253,12 +251,14 @@ def process_playlist_data_event(
         playlist_record, playlist_metadata, block_integer_time
     )
 
+    playlist_record.last_added_to = None
     track_ids = playlist_record.playlist_contents["track_ids"]
-    last_added_to = track_ids[0]["time"] if track_ids else None
-    for track_obj in playlist_record.playlist_contents["track_ids"]:
-        if track_obj["time"] > last_added_to:
-            last_added_to = track_obj["time"]
-    playlist_record.last_added_to = datetime.utcfromtimestamp(last_added_to)
+    if track_ids:
+        last_added_to = track_ids[0]["time"]
+        for track_obj in playlist_record.playlist_contents["track_ids"]:
+            if track_obj["time"] > last_added_to:
+                last_added_to = track_obj["time"]
+        playlist_record.last_added_to = datetime.utcfromtimestamp(last_added_to)
 
     playlist_record.updated_at = block_datetime
     playlist_record.metadata_multihash = metadata_cid


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Currently if you update an empty new playlist, no update is made and the existing playlist is marked is_current = False.

* Fix last_added_to is None bug.
* Fix invalidating of old playlists. If entity_manager skips an invalid tx, it needs to ensure at least the existing playlist or last playlist update is marked as current.
 
### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Exception is logged if an update fails to process.

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->