### PR TITLE
Fix entity manager playlist invalidation

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -130,6 +130,8 @@ def entity_manager_update(
         # compile records_to_save
         records_to_save = []
         for playlist_records in new_records["playlists"].values():
+            if not playlist_records:
+                continue
             # invalidate all playlists besides the last one
             for i in range(len(playlist_records)):
                 playlist_records[i].is_current = False

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -131,8 +131,14 @@ def entity_manager_update(
         records_to_save = []
         for playlist_records in new_records["playlists"].values():
             # invalidate all playlists besides the last one
-            for record in playlist_records:
-                record.is_current = False
+            for i in range(len(playlist_records)):
+                playlist_records[i].is_current = False
+
+            # invalidate existing record only if it's being updated
+            existing_playlist_id = playlist_records[0].playlist_id
+            if existing_playlist_id in existing_records["playlists"]:
+                existing_records["playlists"][existing_playlist_id].is_current = False
+
             # flip is_current to true for the last tx in each playlist
             playlist_records[-1].is_current = True
             records_to_save.extend(playlist_records)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Invalidate existing playlist only if there's an updated record. The change below removed the invalidating for the existing playlist and assumed the existing_playlist would be in new_records. This adds a lookup of the existing record and updates it.

https://github.com/AudiusProject/audius-protocol/pull/3755

### Tests
Tested locally.
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->