### PR TITLE
Make Content Node tsconfig include all src files

### DIFF
--- a/creator-node/tsconfig.build.json
+++ b/creator-node/tsconfig.build.json
@@ -5,12 +5,14 @@
     "outDir": "./build",
     "types": ["node"]
   },
-  "files": ["src/index.ts"],
   "include": [
+    "src",
     "sequelize"
   ],
   "exclude": [
     "node_modules",
-    "test"
+    "test",
+    "src/**/*.test.js",
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
### Description
A recent tsconfig change was trying to include only index.ts and let it resolve imports recursively from there. However, inspection of the build output revealed it was only including the index file. This PR makes sure it includes all src files while excluding test files (before the previous change we just included the entire src folder with unit tests as well).


### Tests
- `npm run build` and verify that instead of just having `index.js`, it has all src files but no test files.
- `node build/src/index.js` and verify it starts up correctly instead of showing the previous error

Previous error was:
```bash
Error: Cannot find module './tracer'
Require stack:
- /usr/src/app/build/src/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/usr/src/app/build/src/index.js:2:26)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/usr/src/app/build/src/index.js' ]
}
``` 


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Just make sure the app starts up again on staging.