### PR TITLE
CON-368 Fix sync duration logging bug

### DIFF
--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -3,7 +3,8 @@ const Bull = require('bull')
 const {
   logger,
   logInfoWithDuration,
-  logErrorWithDuration
+  logErrorWithDuration,
+  getStartTime
 } = require('../../logging')
 const secondarySyncFromPrimary = require('./secondarySyncFromPrimary')
 
@@ -50,7 +51,7 @@ class SyncImmediateQueue {
       const { wallet, creatorNodeEndpoint, forceResyncConfig, logContext } =
         job.data
 
-      const startTime = Date.now()
+      const startTime = getStartTime()
       try {
         await secondarySyncFromPrimary({
           serviceRegistry: this.serviceRegistry,

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -3,7 +3,8 @@ const Bull = require('bull')
 const {
   logger,
   logInfoWithDuration,
-  logErrorWithDuration
+  logErrorWithDuration,
+  getStartTime
 } = require('../../logging')
 const secondarySyncFromPrimary = require('./secondarySyncFromPrimary')
 
@@ -63,7 +64,7 @@ class SyncQueue {
       } = job.data
 
       let result = {}
-      const startTime = Date.now()
+      const startTime = getStartTime()
       try {
         result = await secondarySyncFromPrimary({
           serviceRegistry: this.serviceRegistry,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Fixes bug I introduced in https://github.com/AudiusProject/audius-protocol/commit/e74f72b0955bb9e56c803d70e8fed18ec2c30a8d
Bug caused all syncs to be recorded as failed (even though they succeeded
Larger point - we need to standardize usage of `Date.now()` vs `process.hrtime()` (the latter is preferred i think), and also desperately need typing

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested on staging already

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Check `/health/bull` failed jobs for queues `sync-processing-queue` and `sync-immediate-processing-queue` - Should not see any instances of errors
```
TypeError [ERR_INVALID_ARG_TYPE]: The "time" argument must be an instance of Array. Received type number (1661458777108)
```

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->