### PR TITLE
Fix issueSyncRequest libs not having ethContracts

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -238,7 +238,7 @@ async function _handleIssueSyncRequest({
     const userReplicaSet: ReplicaSet =
       await getUserReplicaSetEndpointsFromDiscovery({
         libs: await initAudiusLibs({
-          enableEthContracts: false,
+          enableEthContracts: true,
           enableContracts: false,
           enableDiscovery: true,
           enableIdentity: false,


### PR DESCRIPTION
### Description
Fix a bug in DSR+orphaned data recovery flow: libs wasn't told to init ethContracts, which it needed for creator node selection. This was added/broken as part of new sync guardrails to ensure we don't sync between the wrong nodes based on sync mode.


### Tests
I manually verified that hitting the `/merge_primary_and_secondary` endpoint stopped causing the following error: `Cannot read property 'getCurrentVersion' of null`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Verify that there are no occurrences of `Cannot read property 'getCurrentVersion' of null` errors.