### PR TITLE
Make orphaned data fixes + improvements

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -104,6 +104,8 @@ export const METRIC_LABELS = Object.freeze({
       'success_mode_disabled',
       'success_secondary_caught_up',
       'success_secondary_partially_caught_up',
+      'success_orphan_wiped',
+      'failure_orphan_not_wiped',
       'failure_sync_correctness',
       'failure_missing_wallet',
       'failure_secondary_failure_count_threshold_met',

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -177,7 +177,10 @@ export enum UpdateReplicaSetJobResult {
 }
 
 // Number of users to query in each orphaned data recovery query to Discovery and to its own db
-export const ORPHANED_DATA_NUM_USERS_PER_QUERY = 10_000
+export const ORPHANED_DATA_NUM_USERS_PER_QUERY = 2000
 
 // Number of users to fetch from redis and issue requests for (sequentially) in each batch
-export const ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH = 1000
+export const ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH = 50
+
+// Milliseconds to wait between processing every ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH users
+export const ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS = 1000

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -465,7 +465,10 @@ const _additionalSyncIsRequired = async (
        * Note - secondaryClockValue can be greater than primaryClockValue if additional
        *    data was written to primary after primaryClockValue was computed
        */
-      if (secondaryClockValue >= primaryClockValue) {
+      if (
+        secondaryClockValue >= primaryClockValue &&
+        syncMode !== SYNC_MODES.MergePrimaryAndSecondary
+      ) {
         secondaryCaughtUpToPrimary = true
         break
       }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -467,7 +467,7 @@ const _additionalSyncIsRequired = async (
        */
       if (
         secondaryClockValue >= primaryClockValue &&
-        syncMode !== SYNC_MODES.MergePrimaryAndSecondary
+        syncMode !== SYNC_MODES.MergePrimaryThenWipeSecondary
       ) {
         secondaryCaughtUpToPrimary = true
         break

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -13,7 +13,8 @@ import { StateMonitoringUser } from '../stateMonitoring/types'
 
 import {
   ORPHANED_DATA_NUM_USERS_PER_QUERY,
-  ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH
+  ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH,
+  ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS
 } from '../stateMachineConstants'
 
 const { QUEUE_NAMES } = require('../stateMachineConstants')
@@ -22,6 +23,7 @@ const config = require('../../../config')
 const redisClient: Redis = require('../../../redis')
 const models = require('../../../models')
 const asyncRetry = require('../../../utils/asyncRetry')
+const Utils = require('../../../utils')
 
 const WALLETS_ON_NODE_KEY = 'orphanedDataWalletsWithStateOnNode'
 const WALLETS_WITH_NODE_IN_REPLICA_SET_KEY =
@@ -253,6 +255,9 @@ const _batchIssueReqsToRecoverOrphanedData = async (
         )
       }
     }
+
+    // Delay processing the next batch to avoid spamming requests
+    await Utils.timeout(ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS, false)
   }
   return requestsIssued
 }

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -85,7 +85,9 @@ const handleSyncFromPrimary = async ({
   try {
     let localMaxClockVal
     if (forceResync || forceWipe) {
-      genericLogger.warn(`${logPrefix} Forcing resync..`)
+      genericLogger.warn(
+        `${logPrefix} Forcing ${forceResync ? 'resync' : 'wipe'}..`
+      )
 
       // Ensure we never wipe the data of a primary
       if (thisContentNodeEndpoint === userReplicaSet.primary) {

--- a/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
+++ b/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
@@ -87,7 +87,7 @@ describe('test recoverOrphanedData job processor', function () {
         .query({
           creator_node_endpoint: THIS_CONTENT_NODE_ENDPOINT,
           prev_user_id: 0,
-          max_users: 10000
+          max_users: 2000
         })
         .reply(200, { data: usersWithNodeInReplicaSet })
     }


### PR DESCRIPTION
### Description

- Fixed `Error: Metric label has invalid value: 'failure_orphan_not_wiped'` - caused by label value missing from prometheus.constants, so the fix was just to add the label to the array of expected values
- Resolved issueSyncRequest job processor thinking orphan node failing to wipe when it did in fact wipe by fixing a clock value check condition in `additionalSyncIsRequired()`
- Batch size was too high – lowered from 10k to 2k (2k users is about 0.5MB, so we shouldn't fetch more than this at once)
- Added a delay between batches of requests to /merge_primary_and_secondary routes. There are >100K users with orphaned data on staging, so to avoid spamming our nodes we now wait 1 second after every 50 requests (effectively rate limiting to 50 requests per second)
  - Note that these requests are spread out among 8 staging nodes, but each /merge_primary_and_secondary request ends up sending a /sync request back to this node to delete orphaned data from it. So it's really 50 requests per second to the node processing this job


### Tests
- Basic sanity check locally -- made sure the queue runs with some users created by `A seed create-user`
- Most testing will be on staging (where I observed these errors) via calling the `/merge_primary_and_secondary` route and monitoring logs
  - Exact POST request to test on staging: `https://creatornode8.staging.audius.co/merge_primary_and_secondary?wallet=0x000022ca364d158620f6b9326b0178e300952621&endpoint=https://creatornode5.staging.audius.co&forceWipe=true`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Make sure there are no logs for the error: `Metric label has invalid value`
- Look out for `failure_orphan_not_wiped` results in the `audius_cn_issue_sync_request_duration_seconds` metric