### PR TITLE
Add storage path size prometheus gauge

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -61,6 +61,13 @@ const healthCheckController = async (req) => {
     randomBytesToSign
   )
 
+  const prometheusRegistry = req.app.get('serviceRegistry').prometheusRegistry
+  const storagePathSizeMetric = prometheusRegistry.getMetric(
+    prometheusRegistry.metricNames.STORAGE_PATH_SIZE_BYTES
+  )
+  storagePathSizeMetric.set({ type: 'total' }, response.storagePathSize)
+  storagePathSizeMetric.set({ type: 'used' }, response.storagePathUsed)
+
   if (enforceStateMachineQueueHealth) {
     const { stateMachineJobs } = response
     const {

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -58,7 +58,8 @@ const metricNames: Record<string, string> = {
   JOBS_ATTEMPTS_HISTOGRAM: 'jobs_attempts',
   RECOVER_ORPHANED_DATA_WALLET_COUNTS_GAUGE:
     'recover_orphaned_data_wallet_counts',
-  RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE: 'recover_orphaned_data_sync_counts'
+  RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE: 'recover_orphaned_data_sync_counts',
+  STORAGE_PATH_SIZE_BYTES: 'storage_path_size_bytes'
 }
 // Add a histogram for each job in the state machine queues.
 // Some have custom labels below, and all of them use the label: uncaughtError=true/false
@@ -370,6 +371,14 @@ export const METRICS: Record<string, Metric> = Object.freeze({
           1000,
         5
       )
+    }
+  },
+  [METRIC_NAMES.STORAGE_PATH_SIZE_BYTES]: {
+    metricType: METRIC_TYPES.GAUGE,
+    metricConfig: {
+      name: METRIC_NAMES.STORAGE_PATH_SIZE_BYTES,
+      help: 'Disk storage size',
+      labelNames: ['type']
     }
   }
 })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Add a storage size metric in Prometheus. This will allow us to graph % utilized disk across all content nodes and find out how much storage capacity we've used network wide.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally and verified that metric shows up correctly in prometheus_metrics endpoint
<img width="666" alt="Cursor_and_34_71_45_6_4000_prometheus_metrics" src="https://user-images.githubusercontent.com/295938/186795701-2abeb454-3763-44e6-8a54-d7711cb30f1e.png">



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Will add a grafana panel and alert on stage/prod

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->