### PR TITLE
Fix bug in fetching sync export + consolidate logic

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -9,8 +9,9 @@ const processJob = require('../processJob')
 const { logger: baseLogger, createChildLogger } = require('../../../logging')
 const handleSyncRequestJobProcessor = require('./issueSyncRequest.jobProcessor')
 const updateReplicaSetJobProcessor = require('./updateReplicaSet.jobProcessor')
-const recoverOrphanedDataJobProcessor =
-  require('./recoverOrphanedData.jobProcessor').default
+const {
+  default: recoverOrphanedDataJobProcessor
+} = require('./recoverOrphanedData.jobProcessor')
 
 const recurringSyncLogger = createChildLogger(baseLogger, {
   queue: QUEUE_NAMES.RECURRING_SYNC

--- a/creator-node/src/services/sync/syncUtil.ts
+++ b/creator-node/src/services/sync/syncUtil.ts
@@ -1,0 +1,126 @@
+import type Logger from 'bunyan'
+
+import axios from 'axios'
+import _ from 'lodash'
+
+const asyncRetry = require('../../utils/asyncRetry')
+
+const EXPORT_REQ_TIMEOUT_MS = 10000 // 10000ms = 10s
+const EXPORT_REQ_MAX_RETRIES = 3
+
+type ExportQueryParams = {
+  wallet_public_key: string
+  clock_range_min: number
+  force_export: boolean
+  source_endpoint?: string
+}
+type FetchExportParams = {
+  nodeEndpointToFetchFrom: string
+  wallet: string
+  clockRangeMin: number
+  selfEndpoint?: string
+  logger: Logger
+  forceExport: boolean
+}
+type FetchExportOutput = {
+  fetchedCNodeUser?: any
+  error?: {
+    message: string
+    code: 'failure_export_wallet' | 'failure_malformed_export'
+  }
+}
+
+async function fetchExportFromNode({
+  nodeEndpointToFetchFrom,
+  wallet,
+  clockRangeMin,
+  selfEndpoint,
+  logger,
+  forceExport = false
+}: FetchExportParams): Promise<FetchExportOutput> {
+  const exportQueryParams: ExportQueryParams = {
+    wallet_public_key: wallet,
+    clock_range_min: clockRangeMin,
+    force_export: forceExport
+  }
+
+  // This is used only for logging by primary to record endpoint of requesting node
+  if (selfEndpoint) {
+    exportQueryParams.source_endpoint = selfEndpoint
+  }
+
+  // Make request to get data from /export route
+  let exportResp
+  try {
+    exportResp = await asyncRetry({
+      // Throws on any non-200 response code
+      asyncFn: () =>
+        axios({
+          method: 'get',
+          baseURL: nodeEndpointToFetchFrom,
+          url: '/export',
+          responseType: 'json',
+          params: exportQueryParams,
+          timeout: EXPORT_REQ_TIMEOUT_MS
+        }),
+      retries: EXPORT_REQ_MAX_RETRIES,
+      log: false
+    })
+  } catch (e: any) {
+    logger.error(`Error fetching /export route: ${e.message}`)
+    return {
+      error: {
+        message: e.message,
+        code: 'failure_export_wallet'
+      }
+    }
+  }
+
+  // Validate export response has cnodeUsers array with 1 wallet
+  const { data: body } = exportResp
+  if (!_.has(body, 'data.cnodeUsers') || _.isEmpty(body.data.cnodeUsers)) {
+    return {
+      error: {
+        message: '"cnodeUsers" array is empty or missing from response body',
+        code: 'failure_malformed_export'
+      }
+    }
+  }
+  const { cnodeUsers } = body.data
+  if (Object.keys(cnodeUsers).length > 1) {
+    return {
+      error: {
+        message: 'Multiple cnodeUsers returned from export',
+        code: 'failure_malformed_export'
+      }
+    }
+  }
+
+  // Validate wallet from cnodeUsers array matches the wallet we requested in the /export request
+  const fetchedCNodeUser: any = Object.values(cnodeUsers)[0]
+  if (!_.has(fetchedCNodeUser, 'walletPublicKey')) {
+    return {
+      error: {
+        message:
+          '"walletPublicKey" property not found on CNodeUser in response object',
+        code: 'failure_malformed_export'
+      }
+    }
+  }
+  if (wallet !== fetchedCNodeUser.walletPublicKey) {
+    return {
+      error: {
+        message: `Returned data for walletPublicKey that was not requested: ${fetchedCNodeUser.walletPublicKey}`,
+        code: 'failure_malformed_export'
+      }
+    }
+  }
+
+  logger.info('Export successful')
+  return {
+    fetchedCNodeUser
+  }
+}
+
+export { fetchExportFromNode }
+export type { FetchExportParams, FetchExportOutput }

--- a/creator-node/test/stateMonitoringUtils.test.js
+++ b/creator-node/test/stateMonitoringUtils.test.js
@@ -7,7 +7,7 @@ chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
 const proxyquire = require('proxyquire')
 const _ = require('lodash')
-const { CancelToken } = require('axios').default
+const { default: CancelToken } = require('axios')
 const assert = require('assert')
 
 const DBManager = require('../src/dbManager')


### PR DESCRIPTION
### Description

- Consolidate different implementations of handling calling+validating the /export route
- Clean up sync logging: use logger properties instead of logPrefix
- Fix `Cannot read property 'walletPublicKey' of undefined` error caused by incorrect check in primarySyncFromSecondary


### Tests

- Locally ran `A seed create-user` and `A seed upload-track` to verify secondarySyncFromPrimary was successful
- Tests pass (`sync.test.js` covers primarySyncFromSecondary and was failing after initial changes until I fixed some issues)
- I'll test the bug fix with the same POST request that triggered it on staging: `https://creatornode8.staging.audius.co/merge_primary_and_secondary?wallet=0x000022ca364d158620f6b9326b0178e300952621&endpoint=https://creatornode5.staging.audius.co&forceWipe=true`



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Use the new log properties to monitor errors: `json.logLevel:"error": AND (json.sync:"secondarySyncFromPrimary" OR json.sync:"primarySyncFromSecondary")`