### PR TITLE
[PAY-587] Add transaction metadata to identity for transaction details

### DIFF
--- a/identity-service/package.json
+++ b/identity-service/package.json
@@ -55,6 +55,7 @@
     "hashids": "^2.2.2",
     "hcaptcha": "^0.1.0",
     "ioredis": "^4.9.0",
+    "jsonschema": "^1.4.1",
     "keccak256": "^1.0.2",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",

--- a/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
+++ b/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
@@ -1,27 +1,27 @@
-"use strict";
+'use strict'
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("UserBankTransactionMetadata", {
+    return queryInterface.createTable('UserBankTransactionMetadata', {
       transactionSignature: {
         type: Sequelize.STRING,
         primaryKey: true,
-        allowNull: false,
+        allowNull: false
       },
       metadata: {
         type: Sequelize.JSONB,
-        allowNull: false,
+        allowNull: false
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE,
+        type: Sequelize.DATE
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE,
-      },
-    });
+        type: Sequelize.DATE
+      }
+    })
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("UserBankTransactionMetadata");
-  },
-};
+    return queryInterface.dropTable('UserBankTransactionMetadata')
+  }
+}

--- a/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
+++ b/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
@@ -1,0 +1,27 @@
+"use strict";
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable("UserBankTransactionMetadata", {
+      transactionSignature: {
+        type: Sequelize.STRING,
+        primaryKey: true,
+        allowNull: false,
+      },
+      metadata: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable("UserBankTransactionMetadata");
+  },
+};

--- a/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
+++ b/identity-service/sequelize/migrations/20220826063452-create-user-bank-transaction-metadata.js
@@ -1,27 +1,48 @@
 'use strict'
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('UserBankTransactionMetadata', {
-      transactionSignature: {
-        type: Sequelize.STRING,
-        primaryKey: true,
-        allowNull: false
-      },
-      metadata: {
-        type: Sequelize.JSONB,
-        allowNull: false
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      }
-    })
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.createTable(
+        'UserBankTransactionMetadata',
+        {
+          userId: {
+            type: Sequelize.INTEGER,
+            allowNull: false
+          },
+          transactionSignature: {
+            type: Sequelize.STRING,
+            primaryKey: true,
+            allowNull: false
+          },
+          metadata: {
+            type: Sequelize.JSONB,
+            allowNull: false
+          },
+          createdAt: {
+            allowNull: false,
+            type: Sequelize.DATE
+          },
+          updatedAt: {
+            allowNull: false,
+            type: Sequelize.DATE
+          }
+        }, { transaction })
+      await queryInterface.addIndex(
+        'UserBankTransactionMetadata',
+        ['userId'],
+        { transaction, name: 'idx_user_bank_transaction_metadata_user_id' }
+      )
+    }
+    )
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('UserBankTransactionMetadata')
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex(
+        'UserBankTransactionMetadata',
+        'idx_user_bank_transaction_metadata_user_id',
+        { transaction }
+      )
+      await queryInterface.dropTable('UserBankTransactionMetadata', { transaction })
+    })
   }
 }

--- a/identity-service/src/models/userBankTransactionMetadata.js
+++ b/identity-service/src/models/userBankTransactionMetadata.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict'
 module.exports = (sequelize, DataTypes) => {
   const UserBankTransactionMetadata = sequelize.define(
-    "UserBankTransactionMetadata",
+    'UserBankTransactionMetadata',
     {
       transactionSignature: {
         type: DataTypes.STRING,
         alllowNull: false,
-        primaryKey: true,
+        primaryKey: true
       },
       metadata: {
         type: DataTypes.JSONB,
-        alllowNull: false,
-      },
+        alllowNull: false
+      }
     },
     {}
-  );
+  )
   UserBankTransactionMetadata.associate = function (models) {
     // associations can be defined here
-  };
-  return UserBankTransactionMetadata;
-};
+  }
+  return UserBankTransactionMetadata
+}

--- a/identity-service/src/models/userBankTransactionMetadata.js
+++ b/identity-service/src/models/userBankTransactionMetadata.js
@@ -3,6 +3,9 @@ module.exports = (sequelize, DataTypes) => {
   const UserBankTransactionMetadata = sequelize.define(
     'UserBankTransactionMetadata',
     {
+      userId: {
+        type: DataTypes.INTEGER
+      },
       transactionSignature: {
         type: DataTypes.STRING,
         alllowNull: false,
@@ -13,7 +16,14 @@ module.exports = (sequelize, DataTypes) => {
         alllowNull: false
       }
     },
-    {}
+    {
+      indexes: [
+        {
+          fields: ['userId'],
+          name: 'idx_user_bank_transaction_metadata_user_id'
+        }
+      ]
+    }
   )
   UserBankTransactionMetadata.associate = function (models) {
     // associations can be defined here

--- a/identity-service/src/models/userBankTransactionMetadata.js
+++ b/identity-service/src/models/userBankTransactionMetadata.js
@@ -1,0 +1,22 @@
+"use strict";
+module.exports = (sequelize, DataTypes) => {
+  const UserBankTransactionMetadata = sequelize.define(
+    "UserBankTransactionMetadata",
+    {
+      transactionSignature: {
+        type: DataTypes.STRING,
+        alllowNull: false,
+        primaryKey: true,
+      },
+      metadata: {
+        type: DataTypes.JSONB,
+        alllowNull: false,
+      },
+    },
+    {}
+  );
+  UserBankTransactionMetadata.associate = function (models) {
+    // associations can be defined here
+  };
+  return UserBankTransactionMetadata;
+};

--- a/identity-service/src/routes/userBankTransactionMetadata.js
+++ b/identity-service/src/routes/userBankTransactionMetadata.js
@@ -17,26 +17,22 @@ const requestSchema = {
     metadata: { $ref: '/PurchaseMetadata' }
   },
   additionalProperties: false,
-  required: ['transactionSignature', 'metadata'],
+  required: ['transactionSignature', 'metadata']
 }
 
 const purchaseMetadataSchema = {
   id: '/PurchaseMetadata',
   type: 'object',
   properties: {
-  discriminator: { type: 'string' },
-  usd: { type: 'string' },
-  sol: { type: 'string' },
-  audio: { type: 'string' },
-  swapTransaction: { type: 'string' },
-  buyTransaction: { type: 'string' }
+    discriminator: { type: 'string' },
+    usd: { type: 'string' },
+    sol: { type: 'string' },
+    audio: { type: 'string' },
+    swapTransaction: { type: 'string' },
+    buyTransaction: { type: 'string' }
   },
   additionalProperties: false,
   required: ['discriminator', 'usd', 'sol', 'audio', 'swapTransaction', 'buyTransaction']
-}
-
-const friendlyErrors = {
-  additionalProperties: ""
 }
 
 const validator = new Validator()

--- a/identity-service/src/routes/userBankTransactionMetadata.js
+++ b/identity-service/src/routes/userBankTransactionMetadata.js
@@ -1,0 +1,94 @@
+const models = require("../models");
+const {
+  handleResponse,
+  successResponse,
+  errorResponseBadRequest,
+  errorResponseServerError,
+} = require("../apiHelpers");
+const { logger } = require("../logging");
+const { Op } = require("sequelize");
+
+const requiredPurchaseKeys = {
+  discriminator: { type: "string" },
+  usd: { type: "string" },
+  sol: { type: "string" },
+  audio: { type: "string" },
+  swapTransaction: { type: "string" },
+  buyTransaction: { type: "string" },
+};
+
+const validateMetadata = (metadata) => {
+  if (!metadata) {
+    throw new Error("Missing metadata");
+  }
+  if (!("discriminator" in metadata)) {
+    throw new Error(`Missing discriminator`);
+  }
+  if (metadata.discriminator === "PURCHASE_SOL_AUDIO_SWAP") {
+    const result = {};
+    for (let key of Object.keys(requiredPurchaseKeys)) {
+      if (!(key in metadata)) {
+        throw new Error(`Missing required property '${key}'`);
+      }
+      if (typeof metadata[key] !== requiredPurchaseKeys[key].type) {
+        throw new Error(
+          `Invalid type for property '${key}'. Found '${typeof metadata[
+            key
+          ]}', expected '${requiredPurchaseKeys[key].type}'`
+        );
+      }
+      result[key] = metadata[key];
+    }
+    return result;
+  }
+  throw new Error("Invalid discriminator");
+};
+
+module.exports = function (app) {
+  app.post(
+    "/transaction_metadata",
+    handleResponse(async (req, res, next) => {
+      const { transactionSignature, metadata } = req.body;
+      let validationResult;
+      try {
+        validationResult = validateMetadata(metadata);
+      } catch (e) {
+        return errorResponseBadRequest(`Invalid metadata: ${e.message}`);
+      }
+      try {
+        await models.UserBankTransactionMetadata.create({
+          transactionSignature,
+          metadata: validationResult,
+        });
+        return successResponse();
+      } catch (e) {
+        logger.info(e, "Error saving user bank transaction metadata");
+        return errorResponseServerError("Something went wrong!");
+      }
+    })
+  );
+
+  app.get(
+    "/transaction_metadata",
+    handleResponse(async (req, res, next) => {
+      const { id } = req.query;
+      if (!id) {
+        return errorResponseBadRequest("Missing 'id' query param");
+      }
+      const ids = typeof id === "string" ? [id] : id;
+      if (!ids.every((id) => typeof id === "string")) {
+        return errorResponseBadRequest(
+          "Invalid transaction signatures specified"
+        );
+      }
+      const metadatas = await models.UserBankTransactionMetadata.findAll({
+        where: {
+          transactionSignature: {
+            [Op.in]: ids,
+          },
+        },
+      });
+      return successResponse(metadatas);
+    })
+  );
+};

--- a/identity-service/src/routes/userBankTransactionMetadata.js
+++ b/identity-service/src/routes/userBankTransactionMetadata.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
     '/transaction_metadata',
     authMiddleware,
     handleResponse(async (req, res, next) => {
-      const userId = req.user.blockChainUserId
+      const userId = req.user.blockchainUserId
       const validationResult = validator.validate(req.body, requestSchema)
       if (!validationResult.valid) {
         logger.error(JSON.stringify(validationResult.errors))
@@ -69,7 +69,7 @@ module.exports = function (app) {
     '/transaction_metadata',
     authMiddleware,
     handleResponse(async (req, res, next) => {
-      const userId = req.user.blockChainUserId
+      const userId = req.user.blockchainUserId
       const { id } = req.query
       if (!id) {
         return errorResponseBadRequest("Missing 'id' query param")

--- a/identity-service/src/routes/userBankTransactionMetadata.js
+++ b/identity-service/src/routes/userBankTransactionMetadata.js
@@ -1,94 +1,92 @@
-const models = require("../models");
+const models = require('../models')
 const {
   handleResponse,
   successResponse,
   errorResponseBadRequest,
-  errorResponseServerError,
-} = require("../apiHelpers");
-const { logger } = require("../logging");
-const { Op } = require("sequelize");
+  errorResponseServerError
+} = require('../apiHelpers')
+const { logger } = require('../logging')
+const { Op } = require('sequelize')
 
 const requiredPurchaseKeys = {
-  discriminator: { type: "string" },
-  usd: { type: "string" },
-  sol: { type: "string" },
-  audio: { type: "string" },
-  swapTransaction: { type: "string" },
-  buyTransaction: { type: "string" },
-};
+  discriminator: { type: 'string' },
+  usd: { type: 'string' },
+  sol: { type: 'string' },
+  audio: { type: 'string' },
+  swapTransaction: { type: 'string' },
+  buyTransaction: { type: 'string' }
+}
 
 const validateMetadata = (metadata) => {
   if (!metadata) {
-    throw new Error("Missing metadata");
+    throw new Error('Missing metadata')
   }
-  if (!("discriminator" in metadata)) {
-    throw new Error(`Missing discriminator`);
+  if (!('discriminator' in metadata)) {
+    throw new Error(`Missing discriminator`)
   }
-  if (metadata.discriminator === "PURCHASE_SOL_AUDIO_SWAP") {
-    const result = {};
+  if (metadata.discriminator === 'PURCHASE_SOL_AUDIO_SWAP') {
+    const result = {}
     for (let key of Object.keys(requiredPurchaseKeys)) {
       if (!(key in metadata)) {
-        throw new Error(`Missing required property '${key}'`);
+        throw new Error(`Missing required property '${key}'`)
       }
       if (typeof metadata[key] !== requiredPurchaseKeys[key].type) {
         throw new Error(
-          `Invalid type for property '${key}'. Found '${typeof metadata[
-            key
-          ]}', expected '${requiredPurchaseKeys[key].type}'`
-        );
+          `Invalid type for property '${key}'. Found '${typeof metadata[key]}', expected '${requiredPurchaseKeys[key].type}'`
+        )
       }
-      result[key] = metadata[key];
+      result[key] = metadata[key]
     }
-    return result;
+    return result
   }
-  throw new Error("Invalid discriminator");
-};
+  throw new Error('Invalid discriminator')
+}
 
 module.exports = function (app) {
   app.post(
-    "/transaction_metadata",
+    '/transaction_metadata',
     handleResponse(async (req, res, next) => {
-      const { transactionSignature, metadata } = req.body;
-      let validationResult;
+      const { transactionSignature, metadata } = req.body
+      let validationResult
       try {
-        validationResult = validateMetadata(metadata);
+        validationResult = validateMetadata(metadata)
       } catch (e) {
-        return errorResponseBadRequest(`Invalid metadata: ${e.message}`);
+        return errorResponseBadRequest(`Invalid metadata: ${e.message}`)
       }
       try {
         await models.UserBankTransactionMetadata.create({
           transactionSignature,
-          metadata: validationResult,
-        });
-        return successResponse();
+          metadata: validationResult
+        })
+        return successResponse()
       } catch (e) {
-        logger.info(e, "Error saving user bank transaction metadata");
-        return errorResponseServerError("Something went wrong!");
+        logger.info(e, 'Error saving user bank transaction metadata')
+        return errorResponseServerError('Something went wrong!')
       }
     })
-  );
+  )
 
   app.get(
-    "/transaction_metadata",
+    '/transaction_metadata',
     handleResponse(async (req, res, next) => {
-      const { id } = req.query;
+      const { id } = req.query
       if (!id) {
-        return errorResponseBadRequest("Missing 'id' query param");
+        return errorResponseBadRequest("Missing 'id' query param")
       }
-      const ids = typeof id === "string" ? [id] : id;
-      if (!ids.every((id) => typeof id === "string")) {
+      const ids = typeof id === 'string' ? [id] : id
+      if (!ids.every((id) => typeof id === 'string')) {
         return errorResponseBadRequest(
-          "Invalid transaction signatures specified"
-        );
+          'Invalid transaction signatures specified'
+        )
       }
       const metadatas = await models.UserBankTransactionMetadata.findAll({
         where: {
           transactionSignature: {
-            [Op.in]: ids,
-          },
-        },
-      });
-      return successResponse(metadatas);
+            [Op.in]: ids
+          }
+        }
+      })
+      return successResponse(metadatas)
     })
-  );
-};
+  )
+}


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

TODO:
- [x] Fix my prettier settings so that linting isn't broke

https://www.notion.so/audiusproject/On-ramp-notes-92eaf6b5f6534489b235d6ed735d1486#202e32d21a144f5b97a577adfcaa831c

- Adds the endpoint `/transaction_metadata` which will be used to save and bulk-retrieve metadatas associated to transaction signatures.
- Adds a new table/model `UserBankTransactionMetadata` to store that metadata
- Uses some minor validation/normalization to enforce a "schema"


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested on remote using raw requests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Adds error log. No monitoring wired up here! ❗ Open to suggestions

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->