### PR TITLE
Add logs to orphaned data recovery job

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -47,13 +47,15 @@ export default async function ({
 }: DecoratedJobParams<RecoverOrphanedDataJobParams>): Promise<
   DecoratedJobReturnValue<RecoverOrphanedDataJobReturnValue>
 > {
-  const numWalletsOnNode = await _saveWalletsOnThisNodeToRedis()
+  const numWalletsOnNode = await _saveWalletsOnThisNodeToRedis(logger)
   const numWalletsWithNodeInReplicaSet =
     await _saveWalletsWithThisNodeInReplicaToRedis(
       discoveryNodeEndpoint,
       logger
     )
-  const numWalletsWithOrphanedData = await _saveWalletsWithOrphanedDataToRedis()
+  const numWalletsWithOrphanedData = await _saveWalletsWithOrphanedDataToRedis(
+    logger
+  )
   const requestsIssued = await _batchIssueReqsToRecoverOrphanedData(
     numWalletsWithOrphanedData,
     discoveryNodeEndpoint,
@@ -88,7 +90,7 @@ export default async function ({
 /**
  * Queries this node's db to find all users who have data on it and adds them to a redis set.
  */
-const _saveWalletsOnThisNodeToRedis = async () => {
+const _saveWalletsOnThisNodeToRedis = async (logger: Logger) => {
   await redisClient.del(WALLETS_ON_NODE_KEY)
 
   type WalletSqlRow = {
@@ -127,6 +129,9 @@ const _saveWalletsOnThisNodeToRedis = async () => {
   }
 
   const numWalletsOnNode = await redisClient.scard(WALLETS_ON_NODE_KEY)
+  logger.info(
+    `Orphaned data recovery found ${numWalletsOnNode} wallets with data on this node`
+  )
   return numWalletsOnNode
 }
 
@@ -184,6 +189,9 @@ const _saveWalletsWithThisNodeInReplicaToRedis = async (
   const numWalletsWithNodeInReplicaSet = await redisClient.scard(
     WALLETS_WITH_NODE_IN_REPLICA_SET_KEY
   )
+  logger.info(
+    `Orphaned data recovery found ${numWalletsWithNodeInReplicaSet} wallets with this node in their replica set`
+  )
   return numWalletsWithNodeInReplicaSet
 }
 
@@ -192,11 +200,14 @@ const _saveWalletsWithThisNodeInReplicaToRedis = async (
  * (Set of orphaned wallets) = (set of wallets on this node) - (set of wallets with this node in their replica set)
  * @returns number of wallets that have data orphaned on this node
  */
-const _saveWalletsWithOrphanedDataToRedis = async () => {
+const _saveWalletsWithOrphanedDataToRedis = async (logger: Logger) => {
   const numWalletsOrphaned: number = await redisClient.sdiffstore(
     WALLETS_ORPHANED_KEY,
     WALLETS_ON_NODE_KEY,
     WALLETS_WITH_NODE_IN_REPLICA_SET_KEY
+  )
+  logger.info(
+    `Orphaned data recovery found ${numWalletsOrphaned} wallets with data orphaned on this node`
   )
   return numWalletsOrphaned
 }
@@ -256,6 +267,9 @@ const _batchIssueReqsToRecoverOrphanedData = async (
       }
     }
 
+    logger.info(
+      `Orphaned data recovery issued /merge_primary_and_secondary requests for ${i}/${numWalletsWithOrphanedData} wallets`
+    )
     // Delay processing the next batch to avoid spamming requests
     await Utils.timeout(ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS, false)
   }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -129,9 +129,7 @@ const _saveWalletsOnThisNodeToRedis = async (logger: Logger) => {
   }
 
   const numWalletsOnNode = await redisClient.scard(WALLETS_ON_NODE_KEY)
-  logger.info(
-    `Orphaned data recovery found ${numWalletsOnNode} wallets with data on this node`
-  )
+  logger.info(`Found ${numWalletsOnNode} wallets with data on this node`)
   return numWalletsOnNode
 }
 
@@ -190,7 +188,7 @@ const _saveWalletsWithThisNodeInReplicaToRedis = async (
     WALLETS_WITH_NODE_IN_REPLICA_SET_KEY
   )
   logger.info(
-    `Orphaned data recovery found ${numWalletsWithNodeInReplicaSet} wallets with this node in their replica set`
+    `Found ${numWalletsWithNodeInReplicaSet} wallets with this node in their replica set`
   )
   return numWalletsWithNodeInReplicaSet
 }
@@ -207,7 +205,7 @@ const _saveWalletsWithOrphanedDataToRedis = async (logger: Logger) => {
     WALLETS_WITH_NODE_IN_REPLICA_SET_KEY
   )
   logger.info(
-    `Orphaned data recovery found ${numWalletsOrphaned} wallets with data orphaned on this node`
+    `Found ${numWalletsOrphaned} wallets with data orphaned on this node`
   )
   return numWalletsOrphaned
 }
@@ -268,7 +266,7 @@ const _batchIssueReqsToRecoverOrphanedData = async (
     }
 
     logger.info(
-      `Orphaned data recovery issued /merge_primary_and_secondary requests for ${i}/${numWalletsWithOrphanedData} wallets`
+      `Issued /merge_primary_and_secondary requests for ${i}/${numWalletsWithOrphanedData} wallets`
     )
     // Delay processing the next batch to avoid spamming requests
     await Utils.timeout(ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS, false)


### PR DESCRIPTION
### Description
Adds basic logs to get an idea of what an orphaned data recovery job is doing while the Bull dashboard just says it's active.


### Tests
None - just logs


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor logs from the job by filtering: `json.queue:"recover-orphaned-data-queue"`