### PR TITLE
Gracefully stop recover-orphaned-data jobs

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -476,7 +476,8 @@ const config = convict({
     doc: 'interval (ms) during which at most recoverOrphanedDataQueueRateLimitJobsPerInterval recover-orphaned-data jobs will run',
     format: 'nat',
     env: 'recoverOrphanedDataQueueRateLimitInterval',
-    default: 86_400_000 // 1day
+    // default: 86_400_000 // 1day
+    default: 7_200_000 // 2hrs
   },
   recoverOrphanedDataQueueRateLimitJobsPerInterval: {
     doc: 'number of recover-orphaned-data jobs that can run in each interval (0 to pause queue)',

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -98,7 +98,7 @@ export const MAX_QUEUE_RUNTIMES = Object.freeze({
   // Max millis to run an update-replica-set job for before marking it as stalled
   UPDATE_REPLICA_SET: 5 /* min */ * 60 * 1000,
   // Max millis to run a recover-orphaned-data job for before marking it as stalled
-  RECOVER_ORPHANED_DATA: 5 /* hours */ * 60 /* min */ * 60 * 1000
+  RECOVER_ORPHANED_DATA: 3 /* hours */ * 60 /* min */ * 60 * 1000
 })
 
 /**
@@ -184,3 +184,7 @@ export const ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH = 50
 
 // Milliseconds to wait between processing every ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH users
 export const ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS = 1000
+
+// Milliseconds after which to gracefully end a recover-orphaned-data job early
+export const MAX_MS_TO_ISSUE_RECOVER_ORPHANED_DATA_REQUESTS =
+  2 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000


### PR DESCRIPTION
### Description
Tweaks settings to:
- make recover-orphaned-data jobs stop themselves after issuing requests for 2 hours
- lower rate limiter to 2 hours (this can be increased back to 1 day after rollout since the work is front loaded with a high number of initial orphaned users and very few after that)
- make jobs stall after 3 hours


### Tests
Will resume testing on staging


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor for the log `Gracefully ending job after`. The Bull dashboard should also show jobs completing successfully after ~2 hours with a lower number of syncs issued than number of orphaned users found.