### PR TITLE
Fix last_added_to field for uploaded collections

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_entity_manager.py
@@ -235,13 +235,11 @@ def test_index_valid_playlists(app, mocker):
             .all()
         )
         assert len(albums) == 1
-        albums = albums[0]
-        assert albums.last_added_to == 1660927554
-        assert albums.playlist_name == "album"
-        assert playlist_3.is_delete == False
-        assert playlist_3.is_current == True
-
-    pass
+        album = albums[0]
+        assert datetime.timestamp(album.last_added_to) == 1585336422
+        assert album.playlist_name == "album"
+        assert album.is_delete == False
+        assert album.is_current == True
 
 
 def test_index_invalid_playlists(app, mocker):

--- a/discovery-provider/integration_tests/tasks/test_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/test_entity_manager.py
@@ -91,6 +91,20 @@ def test_index_valid_playlists(app, mocker):
                 )
             },
         ],
+        "CreateAlbumTx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": PLAYLIST_ID_OFFSET + 3,
+                        "_entityType": "Playlist",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": "QmCreateAlbum4",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
     }
 
     entity_manager_txs = [
@@ -131,6 +145,13 @@ def test_index_valid_playlists(app, mocker):
             "playlist_image_sizes_multihash": "",
             "playlist_name": "playlist 3 updated",
         },
+        "QmCreateAlbum4": {
+            "playlist_contents": {"track_ids": [{"time": 1660927554, "track": 1}]},
+            "description": "",
+            "playlist_image_sizes_multihash": "",
+            "playlist_name": "album",
+            "is_album": True,
+        },
     }
 
     entities = {
@@ -162,7 +183,7 @@ def test_index_valid_playlists(app, mocker):
 
         # validate db records
         all_playlists: List[Playlist] = session.query(Playlist).all()
-        assert len(all_playlists) == 6
+        assert len(all_playlists) == 7
 
         playlists_1: List[Playlist] = (
             session.query(Playlist)
@@ -207,6 +228,20 @@ def test_index_valid_playlists(app, mocker):
         assert playlist_3.playlist_name == "playlist 3 updated"
         assert playlist_3.is_delete == False
         assert playlist_3.is_current == True
+
+        albums: List[Playlist] = (
+            session.query(Playlist)
+            .filter(Playlist.is_current == True, Playlist.is_album == True)
+            .all()
+        )
+        assert len(albums) == 1
+        albums = albums[0]
+        assert albums.last_added_to == 1660927554
+        assert albums.playlist_name == "album"
+        assert playlist_3.is_delete == False
+        assert playlist_3.is_current == True
+
+    pass
 
 
 def test_index_invalid_playlists(app, mocker):

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -58,7 +58,7 @@ def create_playlist(params: ManageEntityParameters):
                 "time": params.block_integer_time,
             }
         )
-        last_added_to = params.block_integer_time
+        last_added_to = params.block_datetime
     create_playlist_record = Playlist(
         playlist_id=playlist_id,
         metadata_multihash=params.metadata_cid,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

last_added_to field needs a date not int for uploading collections.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Added tests around uploading collections.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Indexing stalls without this change when uploading collection.
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->