### PR TITLE
Fix orphaned data gte and log stack for reconfig 500s

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -110,7 +110,7 @@ const _saveWalletsOnThisNodeToRedis = async (logger: Logger) => {
       order: [['cnodeUserUUID', 'ASC']],
       where: {
         cnodeUserUUID: {
-          [models.Sequelize.Op.gte]: prevCnodeUserUUID
+          [models.Sequelize.Op.gt]: prevCnodeUserUUID
         }
       },
       limit: ORPHANED_DATA_NUM_USERS_PER_QUERY

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -697,7 +697,7 @@ const _issueUpdateReplicaSetOp = async (
     response.result = UpdateReplicaSetJobResult.FailureToUpdateReplicaSet
 
     response.errorMsg = `[_issueUpdateReplicaSetOp] Reconfig ERROR: userId=${userId} wallet=${wallet} old replica set=[${primary},${secondary1},${secondary2}] | new replica set=[${newReplicaSetEndpoints}] | Error: ${e.toString()}`
-    logger.error(response.errorMsg)
+    logger.error(`${response.errorMsg}: ${e.stack}`)
   }
 
   return response


### PR DESCRIPTION
### Description
- Fixes tiny bug where query used >= instead of > (no actual impact since values get deduped when adding to a Set, but this is technically correct)
- Adds stack trace to reconfig error logs so we can narrow down the source of error 500s that happen in a relatively large try-catch



### Tests
Tests pass. We'll monitor the 500 errors on prod.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Look for the stack trace in 500 errors on prod. Search: `"Reconfig ERROR" "status code 500"`