### PR TITLE
Fix incomplete replica set for deregistered node

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -288,17 +288,19 @@ const _determineNewReplicaSet = async ({
 }: DetermineNewReplicaSetParams) => {
   const currentReplicaSet = [primary, secondary1, secondary2]
   const healthyReplicaSet = new Set(
-    currentReplicaSet.filter((node) => !unhealthyReplicasSet.has(node))
+    currentReplicaSet.filter((node) => node && !unhealthyReplicasSet.has(node))
   )
+  const numberOfEmptyReplicas = currentReplicaSet.filter((node) => !node).length
   const newReplicaNodes = await _selectRandomReplicaSetNodes(
     healthyReplicaSet,
     unhealthyReplicasSet,
+    numberOfEmptyReplicas,
     healthyNodes,
     wallet,
     logger
   )
 
-  if (unhealthyReplicasSet.size === 1) {
+  if (unhealthyReplicasSet.size + numberOfEmptyReplicas === 1) {
     return _determineNewReplicaSetWhenOneNodeIsUnhealthy(
       primary,
       secondary1,
@@ -308,7 +310,7 @@ const _determineNewReplicaSet = async ({
       newReplicaNodes[0],
       enabledReconfigModes
     )
-  } else if (unhealthyReplicasSet.size === 2) {
+  } else if (unhealthyReplicasSet.size + numberOfEmptyReplicas === 2) {
     return _determineNewReplicaSetWhenTwoNodesAreUnhealthy(
       primary,
       secondary1,
@@ -350,7 +352,7 @@ const _determineNewReplicaSetWhenOneNodeIsUnhealthy = (
 ) => {
   // If we already already checked this primary and it failed the health check, select the higher clock
   // value of the two secondaries as the new primary, leave the other as the first secondary, and select a new second secondary
-  if (unhealthyReplicasSet.has(primary)) {
+  if (unhealthyReplicasSet.has(primary) || !primary) {
     const secondary1Clock = replicaToUserInfoMap[secondary1]?.clock || -1
     const secondary2Clock = replicaToUserInfoMap[secondary2]?.clock || -1
     const [newPrimary, currentHealthySecondary] =
@@ -370,9 +372,10 @@ const _determineNewReplicaSetWhenOneNodeIsUnhealthy = (
   }
 
   // If one secondary is unhealthy, select a new secondary
-  const currentHealthySecondary = !unhealthyReplicasSet.has(secondary1)
-    ? secondary1
-    : secondary2
+  const currentHealthySecondary =
+    unhealthyReplicasSet.has(secondary1) || !secondary1
+      ? secondary2
+      : secondary1
   return {
     newPrimary: primary,
     newSecondary1: currentHealthySecondary,
@@ -403,7 +406,7 @@ const _determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
   enabledReconfigModes: string[]
 ) => {
   // If primary + secondary is unhealthy, use other healthy secondary as primary and 2 random secondaries
-  if (unhealthyReplicasSet.has(primary)) {
+  if (unhealthyReplicasSet.has(primary) || !primary) {
     return {
       newPrimary: !unhealthyReplicasSet.has(secondary1)
         ? secondary1
@@ -437,6 +440,7 @@ const _determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
  * If an insufficient amount of new replica set nodes are chosen, this method will throw an error.
  * @param {Set<string>} healthyReplicaSet a set of the healthy replica set endpoints
  * @param {Set<string>} unhealthyReplicasSet a set of the unhealthy replica set endpoints
+ * @param {number} numberOfEmptyReplicas the number of the user's replicas that are an empty string (deregistered SP ID)
  * @param {string[]} healthyNodes an array of all the healthy nodes available on the network
  * @param {string} wallet the wallet of the current user
  * @param {Object} logger a logger that can be filtered on jobName and jobId
@@ -445,6 +449,7 @@ const _determineNewReplicaSetWhenTwoNodesAreUnhealthy = (
 const _selectRandomReplicaSetNodes = async (
   healthyReplicaSet: Set<string>,
   unhealthyReplicasSet: Set<string>,
+  numberOfEmptyReplicas: number,
   healthyNodes: string[],
   wallet: string,
   logger: Logger
@@ -452,7 +457,7 @@ const _selectRandomReplicaSetNodes = async (
   const numberOfUnhealthyReplicas = unhealthyReplicasSet.size
   const logStr = `[_selectRandomReplicaSetNodes] wallet=${wallet} healthyReplicaSet=[${[
     ...healthyReplicaSet
-  ]}] numberOfUnhealthyReplicas=${numberOfUnhealthyReplicas} healthyNodes=${[
+  ]}] numberOfUnhealthyReplicas=${numberOfUnhealthyReplicas} numberOfEmptyReplicas=${numberOfEmptyReplicas} healthyNodes=${[
     ...healthyNodes
   ]} ||`
 
@@ -464,7 +469,8 @@ const _selectRandomReplicaSetNodes = async (
 
   let selectNewReplicaSetAttemptCounter = 0
   while (
-    newReplicaNodesSet.size < numberOfUnhealthyReplicas &&
+    newReplicaNodesSet.size <
+      numberOfUnhealthyReplicas + numberOfEmptyReplicas &&
     selectNewReplicaSetAttemptCounter++ < MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS
   ) {
     const randomHealthyNode = _.sample(viablePotentialReplicas)
@@ -500,7 +506,10 @@ const _selectRandomReplicaSetNodes = async (
     }
   }
 
-  if (newReplicaNodesSet.size < numberOfUnhealthyReplicas) {
+  if (
+    newReplicaNodesSet.size <
+    numberOfUnhealthyReplicas + numberOfEmptyReplicas
+  ) {
     throw new Error(
       `${logStr} Not enough healthy nodes found to issue new replica set after ${MAX_SELECT_NEW_REPLICA_SET_ATTEMPTS} attempts`
     )
@@ -564,6 +573,14 @@ const _issueUpdateReplicaSetOp = async (
         newReplicaSetEndpoints
       )}`
     )
+
+    if (newReplicaSetEndpoints.length !== 3) {
+      const errorMsg = `Tried to reconfig to an incomplete replica set: ${JSON.stringify(
+        newReplicaSetEndpoints
+      )}`
+      logger.error(errorMsg)
+      throw new Error(errorMsg)
+    }
 
     if (!issueReconfig) {
       response.result = UpdateReplicaSetJobResult.SuccessIssueReconfigDisabled

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -288,7 +288,11 @@ const _determineNewReplicaSet = async ({
 }: DetermineNewReplicaSetParams) => {
   const currentReplicaSet = [primary, secondary1, secondary2]
   const healthyReplicaSet = new Set(
-    currentReplicaSet.filter((node) => node && !unhealthyReplicasSet.has(node))
+    currentReplicaSet
+      // Ensure exists
+      .filter((node) => Boolean)
+      // Node is not marked unhealthy
+      .filter((node) => !unhealthyReplicasSet.has(node))
   )
   const numberOfEmptyReplicas = currentReplicaSet.filter((node) => !node).length
   const newReplicaNodes = await _selectRandomReplicaSetNodes(


### PR DESCRIPTION
### Description
- Fixes a rare scenario where both of a user's secondaries got deregistered and the user's `creator_node_endpoint` has only a primary and a deregistered secondary (but no other secondary)
- When this happens, the reconfig fails to replace the secondary that was an empty string, so it likely gets rejected on chain (or something that results in a 500 error)
  - Search `tag:"audius-prod-creator-1" json.jobId:"1547" json.queue:"update-replica-set-queue"` in the logs to see an example. This is the user from this example: https://discoveryprovider2.audius.co/users?wallet=0x5a591630747ceeac9b6f917e44074b2c3af905db 
- The fix is to ensure that every reconfig replaces empty nodes and throws early if the new replica set is incomplete


### Tests
- Added a new test for this scenario and slightly increased general coverage for reconfigs with another related test


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Ensure no logs for the error: `"Tried to reconfig to an incomplete replica set"`
- Look for general errors that start with `"Reconfig ERROR"`
- Look for this user to see if they're now able to reconfig successfully: https://discoveryprovider2.audius.co/users?wallet=0x5a591630747ceeac9b6f917e44074b2c3af905db 