### PR TITLE
Temporarily remove track repost and save prevention for premium tracks

### DIFF
--- a/discovery-provider/src/tasks/social_features.py
+++ b/discovery-provider/src/tasks/social_features.py
@@ -9,9 +9,6 @@ from src.database_task import DatabaseTask
 from src.models.playlists.playlist import Playlist
 from src.models.social.follow import Follow
 from src.models.social.repost import Repost, RepostType
-from src.premium_content.premium_content_access_checker import (
-    premium_content_access_checker,
-)
 from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
@@ -208,26 +205,10 @@ def add_track_repost(
         )
     )
 
-    premium_content_access_args = []
-    for event in new_track_repost_events:
-        premium_content_access_args.append(
-            {
-                "user_id": event["args"]._userId,
-                "premium_content_id": event["args"]._trackId,
-                "premium_content_type": "track",
-            }
-        )
-    premium_content_access = premium_content_access_checker.check_access_for_batch(
-        premium_content_access_args
-    )
-
     for event in new_track_repost_events:
         event_args = event["args"]
         repost_user_id = event_args._userId
         repost_track_id = event_args._trackId
-
-        if not premium_content_access["track"][repost_user_id][repost_track_id]:
-            continue
 
         if (repost_user_id in track_repost_state_changes) and (
             repost_track_id in track_repost_state_changes[repost_user_id]
@@ -270,26 +251,10 @@ def delete_track_repost(
         )
     )
 
-    premium_content_access_args = []
-    for event in new_repost_events:
-        premium_content_access_args.append(
-            {
-                "user_id": event["args"]._userId,
-                "premium_content_id": event["args"]._trackId,
-                "premium_content_type": "track",
-            }
-        )
-    premium_content_access = premium_content_access_checker.check_access_for_batch(
-        premium_content_access_args
-    )
-
     for event in new_repost_events:
         event_args = event["args"]
         repost_user_id = event_args._userId
         repost_track_id = event_args._trackId
-
-        if not premium_content_access["track"][repost_user_id][repost_track_id]:
-            continue
 
         if (repost_user_id in track_repost_state_changes) and (
             repost_track_id in track_repost_state_changes[repost_user_id]

--- a/discovery-provider/src/tasks/user_library.py
+++ b/discovery-provider/src/tasks/user_library.py
@@ -8,9 +8,6 @@ from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.database_task import DatabaseTask
 from src.models.playlists.playlist import Playlist
 from src.models.social.save import Save, SaveType
-from src.premium_content.premium_content_access_checker import (
-    premium_content_access_checker,
-)
 from src.utils.indexing_errors import IndexingError
 
 logger = logging.getLogger(__name__)
@@ -153,26 +150,10 @@ def add_track_save(
         )
     )
 
-    premium_content_access_args = []
-    for event in new_add_track_events:
-        premium_content_access_args.append(
-            {
-                "user_id": event["args"]._userId,
-                "premium_content_id": event["args"]._trackId,
-                "premium_content_type": "track",
-            }
-        )
-    premium_content_access = premium_content_access_checker.check_access_for_batch(
-        premium_content_access_args
-    )
-
     for event in new_add_track_events:
         event_args = event["args"]
         save_user_id = event_args._userId
         save_track_id = event_args._trackId
-
-        if not premium_content_access["track"][save_user_id][save_track_id]:
-            continue
 
         if (save_user_id in track_state_changes) and (
             save_track_id in track_state_changes[save_user_id]
@@ -270,26 +251,10 @@ def delete_track_save(
         )
     )
 
-    premium_content_access_args = []
-    for event in new_delete_track_events:
-        premium_content_access_args.append(
-            {
-                "user_id": event["args"]._userId,
-                "premium_content_id": event["args"]._trackId,
-                "premium_content_type": "track",
-            }
-        )
-    premium_content_access = premium_content_access_checker.check_access_for_batch(
-        premium_content_access_args
-    )
-
     for event in new_delete_track_events:
         event_args = event["args"]
         save_user_id = event_args._userId
         save_track_id = event_args._trackId
-
-        if not premium_content_access["track"][save_user_id][save_track_id]:
-            continue
 
         if (save_user_id in track_state_changes) and (
             save_track_id in track_state_changes[save_user_id]


### PR DESCRIPTION
### Description

Temporarily remove track repost and save prevention for premium tracks. Allows mad dog to pass. The correct version of this feature will be re-included in an upcoming PR.

### Tests

Ran mad-dog tests locally and they passed. Tests should also pass in CI runs.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->