### PR TITLE
fix n+1 query bug in model_to_dictionary

### DIFF
--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -187,9 +187,9 @@ def model_to_dictionary(model, exclude_keys=None):
 
     for key in relationships:
         if key not in exclude_keys and not key.startswith("_"):
-            attr = getattr(model, key)
             if key in unloaded:
                 continue
+            attr = getattr(model, key)
             if isinstance(attr, list):
                 model_dict[key] = query_result_to_list(attr)
             else:


### PR DESCRIPTION
### Description

`model_to_dictionary` attempted to skip unloaded relationships... but would access the property _before_ skipping... causing a n+1 query situation.


### Tests

Verified fewer queries with sqlalchemy logger turned on.
