### PR TITLE
Enable reconfigs for one secondary by default

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -419,7 +419,7 @@ const config = convict({
     doc: 'Depending on the reconfig op, issue a reconfig or not. See snapbackSM.js for the modes.',
     format: String,
     env: 'snapbackHighestReconfigMode',
-    default: 'RECONFIG_DISABLED'
+    default: 'ONE_SECONDARY'
   },
   devMode: {
     doc: 'Used to differentiate production vs dev mode for node',


### PR DESCRIPTION
### Description
Changes `snapbackHighestReconfigMode` env var to `ONE_SECONDARY` so Service Providers can start issuing reconfigs.


### Tests
Will monitor -- tests pass


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Watch the Grafana reconfig panel to make sure reconfigs are happening successfully.