### PR TITLE
CON-380 CN make primarySyncFromSecondary work for multi-page exports against nodes without export bugfix

### DIFF
--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -205,6 +205,15 @@ async function _primarySyncFromSecondary({
       if (fetchedLocalClockMax < requestedClockRangeMax) {
         completed = true
       } else {
+        decisionTree.recordStage({
+          name: 'About to process next page of multi-page export',
+          data: {
+            fetchedLocalClockMax,
+            requestedClockRangeMin: exportClockRangeMin,
+            requestedClockRangeMax
+          },
+          log: true
+        })
         exportClockRangeMin = requestedClockRangeMax + 1
       }
     }

--- a/creator-node/src/services/sync/syncUtil.ts
+++ b/creator-node/src/services/sync/syncUtil.ts
@@ -101,7 +101,8 @@ async function fetchExportFromNode({
   if (
     !_.has(fetchedCNodeUser, 'walletPublicKey') ||
     !_.has(fetchedCNodeUser, 'clock') ||
-    !_.has(fetchedCNodeUser, 'clockInfo')
+    !_.has(fetchedCNodeUser, ['clockInfo', 'localClockMax']) ||
+    !_.has(fetchedCNodeUser, ['clockInfo', 'requestedClockRangeMax'])
   ) {
     return {
       error: {

--- a/creator-node/src/services/sync/syncUtil.ts
+++ b/creator-node/src/services/sync/syncUtil.ts
@@ -96,17 +96,23 @@ async function fetchExportFromNode({
     }
   }
 
-  // Validate wallet from cnodeUsers array matches the wallet we requested in the /export request
+  // Ensure all required properties are present
   const fetchedCNodeUser: any = Object.values(cnodeUsers)[0]
-  if (!_.has(fetchedCNodeUser, 'walletPublicKey')) {
+  if (
+    !_.has(fetchedCNodeUser, 'walletPublicKey') ||
+    !_.has(fetchedCNodeUser, 'clock') ||
+    !_.has(fetchedCNodeUser, 'clockInfo')
+  ) {
     return {
       error: {
         message:
-          '"walletPublicKey" property not found on CNodeUser in response object',
+          'Required properties not found on CNodeUser in response object',
         code: 'failure_malformed_export'
       }
     }
   }
+
+  // Validate wallet from cnodeUsers array matches the wallet we requested in the /export request
   if (wallet !== fetchedCNodeUser.walletPublicKey) {
     return {
       error: {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Problem: nodes currently have an export bug where they will not indicate in the response `cnodeUser.clockInfo` that there is more data to be fetched, breaking `primarySyncFromSecondary()` calls to those nodes.
This code change circumvents that issue by ensuring that primary will always fetch subsequent export. See code change for details

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

We don't have sufficient test coverage here, so will rely on manual testing. I did this against a local dev stack:
1. Create user with a track
2. Set `exportMaxClockRange` to < above created user's clock val
3. Set one of the secondaries to return the incorrect export data i.e. `cnodeUser.clockInfo.localClockMax = cnodeUser.clockInfo.requestedClockRangeMax`
4. Call `POST /merge_primary_and_secondary` on primary against the good secondary -> confirm it correctly runs multi-page export
5. Call `POST /merge_primary_and_secondary` on primary against the bad secondary -> confirm it still correctly runs multi-page export

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Check instances of log `About to process next page of multi-page export`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->