### PR TITLE
Better get_feed_es error logging.  Fix fetch related saves + reposts

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -74,6 +74,7 @@ def test_get_feed_es(app):
     feed_results = get_feed_es({"user_id": "1"})
     assert feed_results[0]["playlist_id"] == 1
     assert feed_results[0]["save_count"] == 1
+    assert len(feed_results[0]["followee_reposts"]) == 1
 
     assert feed_results[1]["track_id"] == 1
-    assert feed_results[0]["save_count"] == 1
+    assert feed_results[1]["save_count"] == 1

--- a/discovery-provider/src/queries/get_feed.py
+++ b/discovery-provider/src/queries/get_feed.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 from flask import request
 from sqlalchemy import and_, desc, func, or_
@@ -24,6 +25,8 @@ from src.utils.elasticdsl import es_url
 
 trackDedupeMaxMinutes = 10
 
+logger = logging.getLogger(__name__)
+
 
 def get_feed(args):
     skip_es = request.args.get("es") == "0"
@@ -32,7 +35,8 @@ def get_feed(args):
         try:
             (limit, _) = get_pagination_vars()
             return get_feed_es(args, limit)
-        except:
+        except Exception as e:
+            logger.error(f"elasticsearch get_feed_es failed: {e}")
             return get_feed_sql(args)
     else:
         return get_feed_sql(args)

--- a/discovery-provider/src/queries/get_feed_es.py
+++ b/discovery-provider/src/queries/get_feed_es.py
@@ -218,7 +218,7 @@ def get_feed_es(args, limit=10):
     item_keys = [i["item_key"] for i in sorted_feed]
 
     (follow_saves, follow_reposts) = fetch_followed_saves_and_reposts(
-        current_user_id, item_keys, limit * 20
+        current_user_id, item_keys, limit
     )
 
     for item in sorted_feed:
@@ -266,7 +266,7 @@ def fetch_followed_saves_and_reposts(current_user_id, item_keys, limit):
                 ]
             }
         },
-        "size": limit * 20,  # how much to overfetch?
+        "size": limit * 10,  # how much to overfetch?
         "sort": {"created_at": "desc"},
     }
     mdsl = [

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -280,10 +280,9 @@ def finalize_response(
             users_by_id[id] = populate_user_metadata_es(user, current_user)
 
     # fetch followed saves + reposts
-    # TODO: instead of limit param (20) should do an agg to get 3 saves / reposts per item_key
     if not is_auto_complete:
         (follow_saves, follow_reposts) = fetch_followed_saves_and_reposts(
-            current_user_id, item_keys, 20
+            current_user_id, item_keys
         )
 
     # tracks: finalize

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -26,27 +26,15 @@ def listify(things):
 
 
 def pluck_hits(found):
+    if "error" in found:
+        raise Exception(found["error"])
+
     res = [h["_source"] for h in found["hits"]["hits"]]
 
     # add score for search_quality.py script
     for i in range(len(found["hits"]["hits"])):
         res[i]["_score"] = found["hits"]["hits"][i]["_score"]
     return res
-
-
-def docs_and_ids(found, id_set=False):
-    docs = []
-    ids = []
-    for hit in found["hits"]["hits"]:
-        docs.append(hit["_source"])
-        ids.append(hit["_id"])
-    if id_set:
-        ids = set(ids)
-    return docs, ids
-
-
-def hits_by_id(found):
-    return {h["_id"]: h["_source"] for h in found["hits"]["hits"]}
 
 
 def populate_user_metadata_es(user, current_user):

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -382,6 +382,9 @@ hashids = Hashids(min_length=5, salt=HASH_SALT)
 
 
 def encode_int_id(id: int):
+    # if id is already a string, assume it has already been encoded
+    if isinstance(id, str):
+        return id
     return cast(str, hashids.encode(id))
 
 


### PR DESCRIPTION
### Description

* Log out ES error reason when get_feed_es fails
* Fixes fetching of followed save + repost records to use [collapse](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html) to get most recent 5 saves / reposts for each feed item.
* Fixes bug in search code path that was causing followed saves + reposts to be `extend_favorite` twice.  Makes `encode_int_id` idempotent.



Initial motivation was hitting this error in feed because the overfetching math was wrong and it was overfetching too much:

```
type': 'illegal_argument_exception', 'reason': 'Result window is too large, from + size must be less than or equal to: [10000] but was [40000]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting
```



### Tests

Confirmed feed doesn't break with higher `limit`.

Tested with client pointed at a sandbox machine.  Confirmed search page shows follow activity correctly:

<img width="755" alt="image" src="https://user-images.githubusercontent.com/97163/187940398-0d25fd57-800a-4abe-977e-bac5f32c28a8.png">


