### PR TITLE
Install ES Agent on remote-dev boxes

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -54,6 +54,8 @@ fi
 
 python3 -m pip install -r "$PROTOCOL_DIR/dev-tools/requirements.txt"
 
+$PROTOCOL_DIR/logging/bin/install-elastic-agent.sh
+
 mkdir -p "$HOME/.local/bin"
 
 ln -sf "$PROTOCOL_DIR/dev-tools/audius-compose" "$HOME/.local/bin/audius-compose"


### PR DESCRIPTION
### Description

Install ES Agent to get Docker metrics into ELK for remote-dev.


### Tests

This script was previously running with `A --fast`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->