### PR TITLE
Bump try higher so that lock is always released

### DIFF
--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -42,6 +42,7 @@ const handleSyncFromPrimary = async ({
   })
   logger.info('begin nodesync', 'time', start)
 
+  let returnValue = {}
   try {
     try {
       await redis.WalletWriteLock.acquire(
@@ -88,8 +89,6 @@ const handleSyncFromPrimary = async ({
         result: 'failure_force_resync_check'
       }
     }
-
-    let returnValue = {}
 
     let localMaxClockVal
     if (forceResync || forceWipe) {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
TL;DR - Code throws not in try/catch/finally. lock never released. thanks @theoilie 

We've been seeing a lot of errors surrounding `Node is not one of the secondaries`
```
[secondarySyncFromPrimary][wallet=0xc7f07925a89df181c92a7f3b0110fa776f982f0a] Sync complete for wallet: 0xc7f07925a89df181c92a7f3b0110fa776f982f0a. Status: Error, message: This node is not one of the user's secondaries. This node: https://creatornode6.staging.audius.co Secondaries: [https://creatornode5.staging.audius.co,https://creatornode11.staging.audius.co]. Duration sync: 190. From endpoint https://creatornode8.staging.audius.co.
```

It's bc sync jobs take a while sometimes, and when a reconfig happens, the sync job will get stale and fail.

But, because we never wrapped the replica set check in the try/catch/finally, and threw immediately after getting the lock, the lock never got released 👹 

So it looks a little like this:
1. sync gets enqueued
2. sync job is stale and throws when checking replica set
3. lock never released
4. sync queue re-enqueues jobs cus syncs are failing
5. queue grows super big cus locks are never re-acquired

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Staging will tell us

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
The current logs surrounding `secondarySyncFromPrimary` will suffice. 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->