### PR TITLE
INF-224 remove unneeded mount, since we don't load these modules

### DIFF
--- a/logging/docker-compose.yml
+++ b/logging/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # for system and auth modules
-      - /var/log/:/var/log/:ro
 
   metricbeat:
     image: audius/metricbeat:8.2.0


### PR DESCRIPTION
### Description

Remove unneeded mount points since we do not activate those modules:

* https://gist.github.com/krainboltgreene/6209955ed4a647e7b936863111c5d62b#file-docker-compose-yml-L388
* https://discuss.elastic.co/t/filebeat-with-services-inside-of-docker-compose-via-autodiscover/154886


### Tests

Run `A up` and still get logs into ELK.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->