### PR TITLE
Clear write locks on init

### DIFF
--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -119,19 +119,19 @@ const startApp = async () => {
   const appInfo = initializeApp(getPort(), serviceRegistry)
   logger.info('Initialized app and server')
 
-  // Initialize services that do not require the server, but do not need to be awaited.
-  serviceRegistry.initServicesAsynchronously()
-
-  // Some Services cannot start until server is up. Start them now
-  // No need to await on this as this process can take a while and can run in the background
-  serviceRegistry.initServicesThatRequireServer(appInfo.app)
-
   // Clear all redis locks
   try {
     await redisClient.WalletWriteLock.clearWriteLocks()
   } catch (e: any) {
     logger.warn(`Could not clear write locks. Skipping..: ${e.message}`)
   }
+
+  // Initialize services that do not require the server, but do not need to be awaited.
+  serviceRegistry.initServicesAsynchronously()
+
+  // Some Services cannot start until server is up. Start them now
+  // No need to await on this as this process can take a while and can run in the background
+  serviceRegistry.initServicesThatRequireServer(appInfo.app)
 
   // when app terminates, close down any open DB connections gracefully
   ON_DEATH((signal: any, error: any) => {

--- a/creator-node/test/redis.test.js
+++ b/creator-node/test/redis.test.js
@@ -99,7 +99,7 @@ describe('test Redis client', function () {
     assert.equal(await WalletWriteLock.isHeld(wallet), false)
   })
 
-  it.only('Clears write locks', async function () {
+  it('Clears write locks', async function () {
     const wallet1 = 'wallet1'
     const wallet2 = 'wallet2'
     const wallet3 = 'wallet3'

--- a/creator-node/test/redis.test.js
+++ b/creator-node/test/redis.test.js
@@ -20,35 +20,44 @@ describe('test Redis client', function () {
     assert.equal(await redis.get('key'), 'value')
   })
 
-  it('Confirms user write locking works', async function() {
+  it('Confirms user write locking works', async function () {
     const wallet = 'wallet'
-    const defaultExpirationSec = WalletWriteLock.WALLET_WRITE_LOCK_EXPIRATION_SEC
+    const defaultExpirationSec =
+      WalletWriteLock.WALLET_WRITE_LOCK_EXPIRATION_SEC
     const validAcquirers = WalletWriteLock.VALID_ACQUIRERS
 
     // Confirm expected initial state
-    
+
     assert.equal(await WalletWriteLock.isHeld(wallet), false)
 
     assert.equal(await WalletWriteLock.getCurrentHolder(wallet), null)
 
     // Acquire lock + confirm expected state
 
-    assert.doesNotReject(WalletWriteLock.acquire(wallet, validAcquirers.PrimarySyncFromSecondary))
+    assert.doesNotReject(
+      WalletWriteLock.acquire(wallet, validAcquirers.PrimarySyncFromSecondary)
+    )
 
     assert.equal(await WalletWriteLock.ttl(wallet), defaultExpirationSec)
 
     assert.equal(await WalletWriteLock.isHeld(wallet), true)
 
-    assert.equal(await WalletWriteLock.getCurrentHolder(wallet), validAcquirers.PrimarySyncFromSecondary)
+    assert.equal(
+      await WalletWriteLock.getCurrentHolder(wallet),
+      validAcquirers.PrimarySyncFromSecondary
+    )
 
     assert.equal(await WalletWriteLock.syncIsInProgress(wallet), true)
 
     // Confirm acquisition fails when already held
 
-    assert.rejects(WalletWriteLock.acquire(wallet, validAcquirers.PrimarySyncFromSecondary), {
-      name: 'Error',
-      message: `[acquireWriteLockForWallet][Wallet: ${wallet}] Error: Failed to acquire lock - already held.`
-    })
+    assert.rejects(
+      WalletWriteLock.acquire(wallet, validAcquirers.PrimarySyncFromSecondary),
+      {
+        name: 'Error',
+        message: `[acquireWriteLockForWallet][Wallet: ${wallet}] Error: Failed to acquire lock - already held.`
+      }
+    )
 
     // Release lock + confirm expected state
 
@@ -64,20 +73,69 @@ describe('test Redis client', function () {
 
     const expirationSec = 1
 
-    assert.doesNotReject(WalletWriteLock.acquire(wallet, validAcquirers.SecondarySyncFromPrimary, expirationSec))
+    assert.doesNotReject(
+      WalletWriteLock.acquire(
+        wallet,
+        validAcquirers.SecondarySyncFromPrimary,
+        expirationSec
+      )
+    )
 
     assert.equal(await WalletWriteLock.ttl(wallet), expirationSec)
 
     assert.equal(await WalletWriteLock.isHeld(wallet), true)
 
-    assert.equal(await WalletWriteLock.getCurrentHolder(wallet), validAcquirers.SecondarySyncFromPrimary)
+    assert.equal(
+      await WalletWriteLock.getCurrentHolder(wallet),
+      validAcquirers.SecondarySyncFromPrimary
+    )
 
     assert.equal(await WalletWriteLock.syncIsInProgress(wallet), true)
 
     // Confirm lock auto-expired after expected expiration time (plus a small buffer)
-    
+
     await utils.timeout(expirationSec * 1000 + 100)
 
     assert.equal(await WalletWriteLock.isHeld(wallet), false)
+  })
+
+  it.only('Clears write locks', async function () {
+    const wallet1 = 'wallet1'
+    const wallet2 = 'wallet2'
+    const wallet3 = 'wallet3'
+    const wallet4 = 'wallet4'
+
+    await WalletWriteLock.acquire(
+      wallet1,
+      WalletWriteLock.VALID_ACQUIRERS.PrimarySyncFromSecondary
+    )
+
+    await WalletWriteLock.acquire(
+      wallet2,
+      WalletWriteLock.VALID_ACQUIRERS.SecondarySyncFromPrimary
+    )
+
+    await WalletWriteLock.acquire(
+      wallet3,
+      WalletWriteLock.VALID_ACQUIRERS.PrimarySyncFromSecondary
+    )
+
+    await WalletWriteLock.acquire(
+      wallet4,
+      WalletWriteLock.VALID_ACQUIRERS.SecondarySyncFromPrimary
+    )
+
+    // Check that all the wallets have a sync lock
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet1), true)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet2), true)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet3), true)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet4), true)
+
+    // Clear all the locks
+    await WalletWriteLock.clearWriteLocks()
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet1), false)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet2), false)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet3), false)
+    assert.deepEqual(await WalletWriteLock.syncIsInProgress(wallet4), false)
   })
 })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is to clear sync write locks on app init so in case the app restarts that there won't be pre-existing state on redis on handling syncs.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
See `redis.test.js`

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
If clearing locks fail, look for the error msg `Could not clear write locks. Skipping..:`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->