### PR TITLE
Fix get tracks by removing shared cache

### DIFF
--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -8,7 +8,6 @@ from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.tracks.track_route import TrackRoute
 from src.models.tracks.track_with_aggregates import TrackWithAggregates
 from src.models.users.user import User
-from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import (
     SortDirection,
     SortMethod,
@@ -244,22 +243,6 @@ def get_tracks(args: GetTrackArgs):
                 # If none of the handles were found, return empty lists
                 if not args["routes"]:
                     return ([], [])
-
-            can_use_shared_cache = (
-                "id" in args
-                and "min_block_number" not in args
-                and "sort" not in args
-                and "sort_method" not in args
-                and "user_id" not in args
-            )
-
-            if can_use_shared_cache:
-                should_filter_deleted = args.get("filter_deleted", False)
-                tracks = get_unpopulated_tracks(
-                    session, args["id"], should_filter_deleted
-                )
-                track_ids = list(map(lambda track: track["track_id"], tracks))
-                return (tracks, track_ids)
 
             (limit, offset) = get_pagination_vars()
             args["limit"] = limit


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Currently get tracks does not include aggregate_tracks and shows incorrect repost / favorite counts because it relies on this shared cache.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested against prod snapshot.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check API
http://dn1_web-server_1:5000/v1/tracks/

<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->