### PR TITLE
INF-224 Set ${PROTOCOL_DIR} within provision-dev-env.sh

### DIFF
--- a/service-commands/scripts/provision-dev-env.sh
+++ b/service-commands/scripts/provision-dev-env.sh
@@ -9,6 +9,7 @@ export FAST_PROVISIONED=$(
     curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/tags | grep "fast" >/dev/null
     echo $?
 )
+export PROTOCOL_DIR="$HOME/audius-protocol"
 
 # Helper functions
 function setup_linux_toolchains() {


### PR DESCRIPTION
### Description

Fixes multiple uses of this undefined envar:

* https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/27296/workflows/dabc7c25-eabf-41d8-aaef-ea30ce2092cb/jobs/328040

```
+ cd /discovery-provider
audius-protocol/service-commands/scripts/provision-dev-env.sh: line 77: cd: /discovery-provider: No such file or directory
...
+ /logging/bin/install-elastic-agent.sh
audius-protocol/service-commands/scripts/provision-dev-env.sh: line 135: /logging/bin/install-elastic-agent.sh: No such file or directory
```

* https://github.com/AudiusProject/audius-protocol/blob/11ab583dd5ff778d9468525111d05af048ed4427/service-commands/scripts/provision-dev-env.sh#L78
* https://github.com/AudiusProject/audius-protocol/blob/11ab583dd5ff778d9468525111d05af048ed4427/service-commands/scripts/provision-dev-env.sh#L136

I thought this function was also affected, but it's called after a `source`:

* https://github.com/AudiusProject/audius-protocol/blob/11ab583dd5ff778d9468525111d05af048ed4427/service-commands/scripts/provision-dev-env.sh#L169



### Tests

Monitor nightly build job.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Monitor nightly build job.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->