### PR TITLE
Refactor findCIDInNetwork to have retries on certain cases

### DIFF
--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -102,7 +102,10 @@ async function validateStateForImageDirCIDAndReturnFileUUID(req, imageDirCID) {
 }
 
 /**
- * Fetches a CID from the Content Node network, verifies content, and writes to disk up to numRetries times
+ * Fetches a CID from the Content Node network, verifies content, and writes to disk up to numRetries times.
+ * If the fetch request is unauthorized or bad, or if the target content is delisted or not found, do not retry on
+ * the particular Content Node.
+ * Also do not retry if after content verifications that recently written content is not what is expected.
  *
  * @param {String} filePath location of the file on disk
  * @param {String} cid content hash of the file

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -171,7 +171,7 @@ async function findCIDInNetwork(
             ) {
               bail(
                 new Error(
-                  `Content multihash=${cid} is delisted, request is unauthorized, or request is bad on ${endpoint} with statusCode=${e.response?.status}`
+                  `Content multihash=${cid} not available on ${endpoint} with statusCode=${e.response?.status}`
                 )
               )
               return


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The intent of this PR is to add retries to fetching a cid in the network. 
This flow only retries:
- if gets 500 from fetching from content node
- an empty response is served from content node

No retry if:
- fetching content fails with other status codes (401, 403, 400, 404)
- content verification fails

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->