### PR TITLE
Better logging after syncs

### DIFF
--- a/creator-node/src/services/sync/secondarySyncFromPrimary.js
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.js
@@ -23,8 +23,7 @@ const handleSyncFromPrimary = async ({
   forceWipe,
   logContext,
   secondarySyncFromPrimaryLogger,
-  blockNumber = null,
-  start = Date.now()
+  blockNumber = null
 }) => {
   const { nodeConfig, redis, libs } = serviceRegistry
   const FileSaveMaxConcurrency = nodeConfig.get(
@@ -36,7 +35,6 @@ const handleSyncFromPrimary = async ({
   const thisContentNodeEndpoint = nodeConfig.get('creatorNodeEndpoint')
 
   const logger = secondarySyncFromPrimaryLogger
-  logger.info('begin nodesync', 'time', start)
 
   let returnValue = {}
   try {
@@ -664,6 +662,8 @@ async function _secondarySyncFromPrimary({
     primary: creatorNodeEndpoint
   })
 
+  secondarySyncFromPrimaryLogger.info('begin nodesync', 'time', start)
+
   const { error, result } = await handleSyncFromPrimary({
     serviceRegistry,
     wallet,
@@ -672,7 +672,6 @@ async function _secondarySyncFromPrimary({
     forceResyncConfig,
     forceWipe,
     logContext,
-    start,
     secondarySyncFromPrimaryLogger
   })
   metricEndTimerFn({ result, mode })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
it's difficult to correlate the final log msg with a status in Prometheus as well as an error msg in case of a sync failure. This PR cleans this up by:
- Every handleSyncFromPrimary function prints some kind of standardized log at the end
- Include Prometheus status in the log to correlate type of result in metric with log

I was debating a broader refactor like not having nested catch statements but I wanted something we could get out ASAP that would normalize logs and give us correlation between prometheus + loggly. We can continue to refactor this flow for sure.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Unit + integration tests locally and mad dog passed. Ran the system locally, created a user and verified that data was synced to secondaries.

Local log (check out the prometheus result bit)
```
{"name":"audius_creator_node","hostname":"7c548c2f36f0","pid":64,"wallet":"0x7bc462eed499f0440c549ba1b12ca0cc6d6b8fb3","sync":"secondarySyncFromPrimary","primary":"http://cn4_creator-node_1:4003","level":30,"msg":"Sync complete for wallet: 0x7bc462eed499f0440c549ba1b12ca0cc6d6b8fb3. Status: Success. Duration sync: 280. From endpoint http://cn4_creator-node_1:4003. Prometheus result: success","time":"2022-09-06T15:45:53.020Z","v":0,"trace_id":"77881aa40d1c3e0446587e79c9d98a78","span_id":"eacd29fe8e08c35a","trace_flags":"01","resource.service.name":"content-node","resource.service.spid":0,"resource.service.endpoint":"http://cn1_creator-node_1:4000","logLevel":"info"}
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
This is a monitoring change, standardizes the logs in Loggly that we can search for.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->