### PR TITLE
Update random SPs selection

### DIFF
--- a/creator-node/src/components/tracks/TrackTranscodeHandoffManager.js
+++ b/creator-node/src/components/tracks/TrackTranscodeHandoffManager.js
@@ -2,6 +2,7 @@ const axios = require('axios')
 const fs = require('fs')
 const fsExtra = require('fs-extra')
 const FormData = require('form-data')
+const _ = require('lodash')
 
 const config = require('../../config.js')
 const Utils = require('../../utils')
@@ -135,33 +136,26 @@ class TrackTranscodeHandoffManager {
   }
 
   /**
-   * Select a default number of random Content Nodes
+   * Select a default number of random Content Nodes, excluding self
    * @param {Object} libs
    * @returns array of healthy Content Nodes for transcode hand off
    */
   static async selectRandomSPs(libs) {
-    let allSPs = await libs.ethContracts.getServiceProviderList('content-node')
-    allSPs = allSPs.map((sp) => sp.endpoint)
+    let allValidSPs = await libs.ethContracts.getServiceProviderList(
+      'content-node'
+    )
+    allValidSPs = allValidSPs
+      .map((sp) => sp.endpoint)
+      .filter((endpoint) => endpoint !== CREATOR_NODE_ENDPOINT)
 
     // If there are less Content Nodes than the default number, set the cap to the number
     // of available SPs. This will probably only happen in local dev :shrugs:
-    const numberOfSps =
-      allSPs.length < NUMBER_OF_SPS_FOR_HANDOFF_TRACK
-        ? allSPs.length
+    const numOfSPsToSelect =
+      allValidSPs.length < NUMBER_OF_SPS_FOR_HANDOFF_TRACK
+        ? allValidSPs.length
         : NUMBER_OF_SPS_FOR_HANDOFF_TRACK
 
-    const validSPs = new Set()
-    while (validSPs.size < numberOfSps) {
-      const index = Utils.getRandomInt(allSPs.length)
-      const currentSP = allSPs[index]
-
-      if (currentSP === CREATOR_NODE_ENDPOINT || validSPs.has(currentSP)) {
-        continue
-      }
-      validSPs.add(currentSP)
-    }
-
-    return Array.from(validSPs)
+    return _.sampleSize(allValidSPs, numOfSPsToSelect)
   }
 
   /**

--- a/creator-node/test/TrackTranscodeHandoffManager.test.js
+++ b/creator-node/test/TrackTranscodeHandoffManager.test.js
@@ -90,7 +90,7 @@ describe('test TrackTranscodeHandoffManager', function () {
     }
   })
 
-  it('Selecting random SPs for transcode handoff works as expected', async function () {
+  it('If there are equal or more SPs returned from contract call than the default number of sps to select, return the default number of sps to select', async function () {
     const allSPs = libsMock.ethContracts.getServiceProviderList('content-node')
     const allSPsSet = new Set(allSPs.map((sp) => sp.endpoint))
 
@@ -102,16 +102,26 @@ describe('test TrackTranscodeHandoffManager', function () {
     randomSPs.forEach((sp) => {
       assert.ok(allSPsSet.has(sp))
     })
+    assert.ok(!randomSPs.includes(process.env.creatorNodeEndpoint))
+  })
 
-    // Mock libs call to only return 1 sp
+  it('If there are less than the default SPs returned from contract call, return the number of SPs returned from the contract call', async function () {
+    const allSPs = libsMock.ethContracts.getServiceProviderList('content-node')
+    const allSPsSet = new Set(allSPs.map((sp) => sp.endpoint))
+
+    // Mock libs call to only return 2 sp
     libsMock.ethContracts.getServiceProviderList = () => {
-      return allSPs.slice(0, 1)
+      return allSPs.slice(1, 3)
     }
 
-    // Return 1 SP for libs
-    const oneSP = await TrackTranscodeHandoffManager.selectRandomSPs(libsMock)
-    assert.strictEqual(oneSP.length, 1)
-    assert.ok(allSPsSet.has(oneSP[0]))
+    const randomSPs = await TrackTranscodeHandoffManager.selectRandomSPs(
+      libsMock
+    )
+    assert.strictEqual(randomSPs.length, 2)
+    randomSPs.forEach((sp) => {
+      assert.ok(allSPsSet.has(sp))
+    })
+    assert.ok(!randomSPs.includes(process.env.creatorNodeEndpoint))
   })
 
   // sendTrackToSp()

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -11,7 +11,7 @@ function getLibsMock() {
                 blockNumber: 163,
                 delegateOwnerWallet:
                   '0x1F9a71dEC0eCf3FC8E916a17458f173AC453ca33',
-                endpoint: 'http://cn1_creator-node_1:4000',
+                endpoint: 'http://mock-cn1.audius.co',
                 owner: '0x1F9a71dEC0eCf3FC8E916a17458f173AC453ca33',
                 spID: 1,
                 type: 'content-node'
@@ -20,7 +20,7 @@ function getLibsMock() {
                 blockNumber: 165,
                 delegateOwnerWallet:
                   '0xc0B03742234deFbAFaD16E1fAf5F8b069b1AeB7d',
-                endpoint: 'http://cn2_creator-node_1:4001',
+                endpoint: 'http://mock-cn2.audius.co',
                 owner: '0xc0B03742234deFbAFaD16E1fAf5F8b069b1AeB7d',
                 spID: 2,
                 type: 'content-node'
@@ -29,9 +29,18 @@ function getLibsMock() {
                 blockNumber: 167,
                 delegateOwnerWallet:
                   '0x242E1Cd7bB405941063814c241a1f046CCC9810b',
-                endpoint: 'http://cn3_creator-node_1:4002',
+                endpoint: 'http://mock-cn3.audius.co',
                 owner: '0x242E1Cd7bB405941063814c241a1f046CCC9810b',
                 spID: 3,
+                type: 'content-node'
+              },
+              {
+                blockNumber: 169,
+                delegateOwnerWallet:
+                  '0x242E1Cd7bB405941063814c241a1f046CCCaaaaa',
+                endpoint: 'http://mock-cn4.audius.co',
+                owner: '0x242E1Cd7bB405941063814c241a1f046CCCaaaaa',
+                spID: 4,
                 type: 'content-node'
               }
             ]


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The libs mock was interfering with findCIDInNetwork tests because of the actual requests that the tests were making. This PR is to:
- update the selection to use lodash + filtering out the self node immediately
- update the tests associated with selection
- update the libs mock 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
`creator-node/test/TrackTranscodeHandoffManager.test.js`

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
The current logs surrounding random content node selection will suffice. take a look at:
- `Could not select random SPs: `
- `Could not hand off track: state=`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->