### PR TITLE
Update findCIDInNetwork

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -20,8 +20,6 @@ const MAX_MEMORY_FILE_SIZE = parseInt(config.get('maxMemoryFileSizeBytes')) // D
 const ALLOWED_UPLOAD_FILE_EXTENSIONS = config.get('allowedUploadFileExtensions') // default set in config.json
 const AUDIO_MIME_TYPE_REGEX = /audio\/(.*)/
 
-const EMPTY_FILE_CID = 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH' // deterministic CID for a 0 byte, completely empty file
-
 /**
  * Saves file to disk under /multihash name
  */
@@ -45,7 +43,7 @@ async function saveFileFromBufferToDisk(req, buffer, numRetries = 5) {
     const fileSize = (await fs.stat(dstPath)).size
     const fileIsEmpty = fileSize === 0
     // there is one case where an empty file could be valid, check for that CID explicitly
-    if (fileIsEmpty && cid !== EMPTY_FILE_CID) {
+    if (fileIsEmpty && cid !== Utils.EMPTY_FILE_CID) {
       throw new Error(`File has no content, content length is 0: ${cid}`)
     }
 
@@ -342,7 +340,7 @@ async function saveFileForMultihashToFS(
 
       const fileIsEmpty = fileSize === 0
       // there is one case where an empty file could be valid, check for that CID explicitly
-      if (fileIsEmpty && multihash !== EMPTY_FILE_CID) {
+      if (fileIsEmpty && multihash !== Utils.EMPTY_FILE_CID) {
         throw new Error(
           `File has no content, content length is 0: ${multihash}`
         )
@@ -690,6 +688,5 @@ module.exports = {
   checkFileMiddleware,
   getTmpTrackUploadArtifactsPathWithInputUUID,
   getTmpSegmentsPath,
-  copyMultihashToFs,
-  EMPTY_FILE_CID
+  copyMultihashToFs
 }

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -553,7 +553,9 @@ const getDirCID = async (req, res) => {
     // CID is the file CID, parse it from the storagePath
     const CID = storagePath.split('/').slice(-1).join('')
     const libs = req.app.get('audiusLibs')
-    await findCIDInNetwork(storagePath, CID, req.logger, libs)
+    const found = await findCIDInNetwork(storagePath, CID, req.logger, libs)
+    if (!found) throw new Error(`CID=${CID} not found in network`)
+
     return await streamFromFileSystem(req, res, storagePath)
   } catch (e) {
     req.logger.error(

--- a/creator-node/src/utils.js
+++ b/creator-node/src/utils.js
@@ -5,17 +5,20 @@ const axios = require('axios')
 const spawn = require('child_process').spawn
 const stream = require('stream')
 const { promisify } = require('util')
-const pipeline = promisify(stream.pipeline)
-const { logger: genericLogger } = require('./logging.js')
+const { libs: audiusLibs } = require('@audius/sdk')
 
+const asyncRetry = require('./utils/asyncRetry')
+const { logger: genericLogger } = require('./logging')
 const models = require('./models')
 const redis = require('./redis')
 const config = require('./config')
 const { generateTimestampAndSignature } = require('./apiSigning')
-const { libs } = require('@audius/sdk')
-const LibsUtils = libs.Utils
+
+const pipeline = promisify(stream.pipeline)
+const LibsUtils = audiusLibs.Utils
 
 const THIRTY_MINUTES_IN_SECONDS = 60 * 30
+const EMPTY_FILE_CID = 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH' // deterministic CID for a 0 byte, completely empty file
 
 class Utils {
   static verifySignature(data, sig) {
@@ -102,7 +105,10 @@ async function validateStateForImageDirCIDAndReturnFileUUID(req, imageDirCID) {
 }
 
 /**
- * Fetches a CID from the Content Node network
+ * Fetches a CID from the Content Node network, verifies content, and writes to disk up to numRetries times.
+ * If the fetch request is unauthorized or bad, or if the target content is delisted or not found, do not retry on
+ * the particular Content Node.
+ * Also do not retry if after content verifications that recently written content is not what is expected.
  *
  * @param {String} filePath location of the file on disk
  * @param {String} cid content hash of the file
@@ -110,6 +116,7 @@ async function validateStateForImageDirCIDAndReturnFileUUID(req, imageDirCID) {
  * @param {Object} libs libs instance
  * @param {Integer?} trackId optional trackId that corresponds to the cid, see file_lookup route for more info
  * @param {Array?} excludeList optional array of content nodes to exclude in network wide search
+ * @param {number?} [numRetries=5] the number of retries to attempt to fetch cid, write to disk, and verify
  * @returns {Boolean} returns true if the file was found in the network
  */
 async function findCIDInNetwork(
@@ -118,74 +125,113 @@ async function findCIDInNetwork(
   logger,
   libs,
   trackId = null,
-  excludeList = []
+  excludeList = [],
+  numRetries = 5
 ) {
-  if (!config.get('findCIDInNetworkEnabled')) return
-  let found = false
+  if (!config.get('findCIDInNetworkEnabled')) return false
 
   const attemptedStateFix = await getIfAttemptedStateFix(filePath)
-  if (attemptedStateFix) return
+  if (attemptedStateFix) return false
 
-  // get list of creator nodes
+  // Get all registered Content Nodes
   const creatorNodes = await getAllRegisteredCNodes(libs)
-  if (!creatorNodes.length) return
+  if (!creatorNodes.length) return false
 
   // Remove excluded nodes from list of creator nodes, no-op if empty list or nothing passed in
   const creatorNodesFiltered = creatorNodes.filter(
     (c) => !excludeList.includes(c.endpoint)
   )
 
-  // generate signature
+  // Generate signature to auth fetching files
   const delegateWallet = config.get('delegateOwnerWallet').toLowerCase()
   const { signature, timestamp } = generateTimestampAndSignature(
     { filePath, delegateWallet },
     config.get('delegatePrivateKey')
   )
-  let node
 
-  for (let index = 0; index < creatorNodesFiltered.length; index++) {
-    node = creatorNodesFiltered[index]
+  let found = false
+  for (const { endpoint } of creatorNodesFiltered) {
     try {
-      const resp = await axios({
-        method: 'get',
-        url: `${node.endpoint}/file_lookup`,
-        params: {
-          filePath,
-          timestamp,
-          delegateWallet,
-          signature,
-          trackId
-        },
-        responseType: 'stream',
-        timeout: 1000
-      })
-      if (resp.data) {
-        await writeStreamToFileSystem(resp.data, filePath, /* createDir */ true)
+      found = await asyncRetry({
+        asyncFn: async (bail) => {
+          let response
+          try {
+            response = await axios({
+              method: 'get',
+              url: `${endpoint}/file_lookup`,
+              params: {
+                filePath,
+                timestamp,
+                delegateWallet,
+                signature,
+                trackId
+              },
+              responseType: 'stream',
+              timeout: 1000
+            })
+          } catch (e) {
+            if (
+              e.response?.status === 403 || // delist
+              e.response?.status === 401 || // unauth
+              e.response?.status === 400 || // bad req
+              e.response?.status === 404 // not found
+            ) {
+              bail(
+                new Error(
+                  `Content multihash=${cid} not available on ${endpoint} with statusCode=${e.response?.status}`
+                )
+              )
+              return
+            }
 
-        // Verify that the file written matches the hash expected
-        const expectedCID = await LibsUtils.fileHasher.generateNonImageCid(
-          filePath
-        )
+            throw new Error(
+              `Failed to fetch content multihash=${cid} with statusCode=${e.response?.status}. Retrying..`
+            )
+          }
 
-        if (cid !== expectedCID) {
-          await fs.unlink(filePath)
-          logger.error(
-            `findCIDInNetwork - File contents from ${node.endpoint} and hash don't match. CID: ${cid} expectedCID: ${expectedCID}`
+          if (!response || !response.data) {
+            throw new Error('Received empty response from file lookup')
+          }
+
+          await writeStreamToFileSystem(
+            response.data,
+            filePath,
+            /* createDir */ true
           )
-        } else {
-          found = true
+
+          const isCIDProper = await verifyCIDIsProper({
+            cid,
+            path: filePath,
+            logger
+          })
+
+          if (!isCIDProper) {
+            try {
+              await fs.unlink(filePath)
+            } catch (e) {
+              logger.error(`Could not remove file at path=${path}`)
+            }
+
+            bail(new Error(`CID=${cid} from endpoint=${endpoint} is improper`))
+            return
+          }
+
           logger.info(
-            `findCIDInNetwork - successfully fetched file ${filePath} from node ${node.endpoint}`
+            `Successfully fetched CID=${cid} file=${filePath} from node ${endpoint}`
           )
-          break
+        },
+        logger,
+        logLabel: 'fetchFileFromNetworkAndWriteToDisk',
+        options: {
+          retries: numRetries,
+          minTimeout: 3000
         }
-      }
+      })
+
+      return true
     } catch (e) {
       // Do not error and stop the flow of execution for functions that call it
-      logger.error(
-        `findCIDInNetwork fetch error from ${node.endpoint} - ${e.toString()}`
-      )
-      continue
+      logger.error(`findCIDInNetwork error from ${endpoint} - ${e.message}`)
     }
   }
 
@@ -351,6 +397,36 @@ function currentNodeShouldHandleTranscode({
   return currentNodeShouldHandleTranscode
 }
 
+/**
+ * Verify that the file written matches the hash expected
+ * @param {Object} param
+ * @param {string} param.cid target cid
+ * @param {string} param.path the path at which the cid exists
+ * @param {Object} param.logger
+ * @returns boolean if the cid is proper or not
+ */
+async function verifyCIDIsProper({ cid, path, logger }) {
+  const fileSize = (await fs.stat(path)).size
+  const fileIsEmpty = fileSize === 0
+
+  // there is one case where an empty file could be valid, check for that CID explicitly
+  if (fileIsEmpty && cid !== EMPTY_FILE_CID) {
+    logger.error(`File has no content, content length is 0: ${cid}`)
+    return false
+  }
+
+  const expectedCID = await LibsUtils.fileHasher.generateNonImageCid(path)
+
+  const isCIDProper = cid === expectedCID
+  if (!isCIDProper) {
+    logger.error(
+      `File contents and hash don't match. CID: ${cid} expectedCID: ${expectedCID}`
+    )
+  }
+
+  return isCIDProper
+}
+
 module.exports = Utils
 module.exports.validateStateForImageDirCIDAndReturnFileUUID =
   validateStateForImageDirCIDAndReturnFileUUID
@@ -360,3 +436,4 @@ module.exports.findCIDInNetwork = findCIDInNetwork
 module.exports.runShellCommand = runShellCommand
 module.exports.currentNodeShouldHandleTranscode =
   currentNodeShouldHandleTranscode
+module.exports.verifyCIDIsProper = verifyCIDIsProper

--- a/creator-node/src/utils/index.ts
+++ b/creator-node/src/utils/index.ts
@@ -12,7 +12,9 @@ import {
   createDirForFile,
   writeStreamToFileSystem,
   _streamFileToDiskHelper,
-  runShellCommand
+  runShellCommand,
+  verifyCIDMatchesExpected,
+  EMPTY_FILE_CID
 } from './legacyUtils'
 import {
   validateMetadata,
@@ -53,5 +55,7 @@ module.exports = {
   runShellCommand,
   validateAssociatedWallets,
   validateMetadata,
-  strToReplicaSet
+  strToReplicaSet,
+  verifyCIDMatchesExpected,
+  EMPTY_FILE_CID
 }

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -18,7 +18,8 @@ const pipeline = promisify(stream.pipeline)
 const LibsUtils = libs.Utils
 
 const THIRTY_MINUTES_IN_SECONDS = 60 * 30
-const EMPTY_FILE_CID = 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH' // deterministic CID for a 0 byte, completely empty file
+
+export const EMPTY_FILE_CID = 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH' // deterministic CID for a 0 byte, completely empty file
 
 export function verifySignature(data, sig) {
   return recoverPersonalSignature({ data, sig })
@@ -443,3 +444,4 @@ module.exports.runShellCommand = runShellCommand
 module.exports.currentNodeShouldHandleTranscode =
   currentNodeShouldHandleTranscode
 module.exports.verifyCIDMatchesExpected = verifyCIDMatchesExpected
+module.exports.EMPTY_FILE_CID = EMPTY_FILE_CID

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -139,9 +139,11 @@ export async function findCIDInNetwork(
   const creatorNodes = await getAllRegisteredCNodes(libs)
   if (!creatorNodes.length) return false
 
-  // Remove excluded nodes from list of creator nodes, no-op if empty list or nothing passed in
+  // Remove excluded nodes from list of creator nodes or self, no-op if empty list or nothing passed in
   const creatorNodesFiltered = creatorNodes.filter(
-    (c) => !excludeList.includes(c.endpoint)
+    (c) =>
+      !excludeList.includes(c.endpoint) ||
+      config.get('creatorNodeEndpoint') !== c.endpoint
   )
 
   // Generate signature to auth fetching files

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -187,7 +187,7 @@ export async function findCIDInNetwork(
             }
 
             throw new Error(
-              `Failed to fetch content multihash=${cid} with statusCode=${e.response?.status}. Retrying..`
+              `Failed to fetch content multihash=${cid} with statusCode=${e.response?.status} from endpoint=${endpoint}. Retrying..`
             )
           }
 

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -223,7 +223,7 @@ export async function findCIDInNetwork(
           )
         },
         logger,
-        logLabel: 'fetchFileFromNetworkAndWriteToDisk',
+        logLabel: 'findCIDInNetwork',
         options: {
           retries: numRetries,
           minTimeout: 3000

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -229,7 +229,7 @@ export async function findCIDInNetwork(
         }
       })
 
-      return true
+      found = true
     } catch (e) {
       // Do not error and stop the flow of execution for functions that call it
       logger.error(`findCIDInNetwork error from ${endpoint} - ${e.message}`)

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -7,7 +7,7 @@ const stream = require('stream')
 const { promisify } = require('util')
 
 const { logger: genericLogger } = require('../logging')
-const asyncRetry = require('./utils/asyncRetry')
+const asyncRetry = require('./asyncRetry')
 const models = require('../models')
 const redis = require('../redis')
 const config = require('../config')

--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -200,7 +200,7 @@ export async function findCIDInNetwork(
             /* createDir */ true
           )
 
-          const isCIDProper = await verifyCIDIsProper({
+          const isCIDProper = await verifyCIDMatchesExpected({
             cid,
             path: filePath,
             logger
@@ -409,7 +409,7 @@ export function currentNodeShouldHandleTranscode({
  * @param {Object} param.logger
  * @returns boolean if the cid is proper or not
  */
-export async function verifyCIDIsProper({ cid, path, logger }) {
+export async function verifyCIDMatchesExpected({ cid, path, logger }) {
   const fileSize = (await fs.stat(path)).size
   const fileIsEmpty = fileSize === 0
 
@@ -442,4 +442,4 @@ module.exports.findCIDInNetwork = findCIDInNetwork
 module.exports.runShellCommand = runShellCommand
 module.exports.currentNodeShouldHandleTranscode =
   currentNodeShouldHandleTranscode
-module.exports.verifyCIDIsProper = verifyCIDIsProper
+module.exports.verifyCIDMatchesExpected = verifyCIDMatchesExpected

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1363,15 +1363,6 @@ describe('Test secondarySyncFromPrimary()', async function () {
         )
         .reply(404)
 
-      nock(MOCK_CN2)
-        .persist()
-        .get(
-          (uri) =>
-            uri.includes('/file_lookup') &&
-            uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-        )
-        .reply(404)
-
       nock(MOCK_CN3)
         .persist()
         .get(

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1354,6 +1354,15 @@ describe('Test secondarySyncFromPrimary()', async function () {
 
       setupMocks(sampleExport, false)
 
+      nock(MOCK_CN1)
+        .persist()
+        .get(
+          (uri) =>
+            uri.includes('/file_lookup') &&
+            uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
+        )
+        .reply(404)
+
       nock(MOCK_CN3)
         .persist()
         .get(

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1336,7 +1336,7 @@ describe('Test secondarySyncFromPrimary()', async function () {
       )
     })
 
-    it('Syncs correctly from clean user state, even when content is unavailable, by skipping files', async function () {
+    it.only('Syncs correctly from clean user state, even when content is unavailable, by skipping files', async function () {
       // Set this endpoint to the user's secondary
       config.set('creatorNodeEndpoint', MOCK_CN2)
 
@@ -1356,29 +1356,35 @@ describe('Test secondarySyncFromPrimary()', async function () {
 
       nock(MOCK_CN1)
         .persist()
-        .get(
-          (uri) =>
+        .get((uri) => {
+          console.log('what is the uri mock_cn1', uri)
+          return (
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-        )
+          )
+        })
         .reply(404)
 
       nock(MOCK_CN3)
         .persist()
-        .get(
-          (uri) =>
+        .get((uri) => {
+          console.log('what is the uri mock_cn2', uri)
+          return (
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-        )
+          )
+        })
         .reply(404)
 
       nock(MOCK_CN4)
         .persist()
-        .get(
-          (uri) =>
+        .get((uri) => {
+          console.log('what is the uri mock_cn3', uri)
+          return (
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-        )
+          )
+        })
         .reply(404)
 
       const SyncRequestMaxUserFailureCountBeforeSkip = 3

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -2225,7 +2225,23 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
     )
     assert.deepStrictEqual(initialLocalCNodeUser, null)
 
-    // Mock that fetching any content via /file_lookup is unavailable
+    // Mock that fetching any content via /file_lookup is unavailables
+    nock(MOCK_CN2)
+      .persist()
+      .get('/file_lookup')
+      .query(() => {
+        return true
+      })
+      .reply(404)
+
+    nock(MOCK_CN3)
+      .persist()
+      .get('/file_lookup')
+      .query(() => {
+        return true
+      })
+      .reply(404)
+
     nock(MOCK_CN4)
       .persist()
       .get('/file_lookup')

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -34,6 +34,11 @@ const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
 const DUMMY_WALLET = testEthereumConstants.pubKey.toLowerCase()
 const DUMMY_CNODEUSER_BLOCKNUMBER = 10
+const MOCK_CN1 = 'http://mock-cn1.audius.co'
+const MOCK_CN2 = 'http://mock-cn2.audius.co'
+const MOCK_CN3 = 'http://mock-cn3.audius.co'
+const MOCK_CN4 = 'http://mock-cn4.audius.co'
+
 // Below files generated using above dummy data
 const sampleExportDummyCIDPath = path.resolve(
   __dirname,
@@ -104,7 +109,7 @@ describe('Test secondarySyncFromPrimary()', async function () {
 
     async function createUserAndTrack() {
       // Create user
-      ; ({
+      ;({
         cnodeUserUUID,
         sessionToken,
         userId,
@@ -797,9 +802,6 @@ describe('Test secondarySyncFromPrimary()', async function () {
   describe('Test secondarySyncFromPrimary function', async function () {
     let serviceRegistryMock, originalContentNodeEndpoint
 
-    const MOCK_CN1 = 'http://mock-cn1.audius.co'
-    const MOCK_CN2 = 'http://mock-cn2.audius.co'
-    const MOCK_CN3 = 'http://mock-cn3.audius.co'
     const TEST_ENDPOINT_PRIMARY = MOCK_CN1
     const USER_REPLICA_SET = `${MOCK_CN1},${MOCK_CN2},${MOCK_CN3}`
     const { pubKey } = testEthereumConstants
@@ -1351,6 +1353,24 @@ describe('Test secondarySyncFromPrimary()', async function () {
         .size
 
       setupMocks(sampleExport, false)
+
+      nock(MOCK_CN3)
+        .persist()
+        .get(
+          (uri) =>
+            uri.includes('/file_lookup') &&
+            uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
+        )
+        .reply(404)
+
+      nock(MOCK_CN4)
+        .persist()
+        .get(
+          (uri) =>
+            uri.includes('/file_lookup') &&
+            uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
+        )
+        .reply(404)
 
       const SyncRequestMaxUserFailureCountBeforeSkip = 3
       config.set(
@@ -2195,6 +2215,15 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
       USER_1_WALLET
     )
     assert.deepStrictEqual(initialLocalCNodeUser, null)
+
+    // Mock that fetching any content via /file_lookup is unavailable
+    nock(MOCK_CN4)
+      .persist()
+      .get('/file_lookup')
+      .query(() => {
+        return true
+      })
+      .reply(404)
 
     // Ensure primarySyncFromSecondary() fails until SyncRequestMaxUserFailureCountBeforeSkip reached
     for (let i = 1; i < SyncRequestMaxUserFailureCountBeforeSkip; i++) {

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1336,7 +1336,7 @@ describe('Test secondarySyncFromPrimary()', async function () {
       )
     })
 
-    it.only('Syncs correctly from clean user state, even when content is unavailable, by skipping files', async function () {
+    it('Syncs correctly from clean user state, even when content is unavailable, by skipping files', async function () {
       // Set this endpoint to the user's secondary
       config.set('creatorNodeEndpoint', MOCK_CN2)
 
@@ -1356,35 +1356,38 @@ describe('Test secondarySyncFromPrimary()', async function () {
 
       nock(MOCK_CN1)
         .persist()
-        .get((uri) => {
-          console.log('what is the uri mock_cn1', uri)
-          return (
+        .get(
+          (uri) =>
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-          )
-        })
+        )
+        .reply(404)
+
+      nock(MOCK_CN2)
+        .persist()
+        .get(
+          (uri) =>
+            uri.includes('/file_lookup') &&
+            uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
+        )
         .reply(404)
 
       nock(MOCK_CN3)
         .persist()
-        .get((uri) => {
-          console.log('what is the uri mock_cn2', uri)
-          return (
+        .get(
+          (uri) =>
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-          )
-        })
+        )
         .reply(404)
 
       nock(MOCK_CN4)
         .persist()
-        .get((uri) => {
-          console.log('what is the uri mock_cn3', uri)
-          return (
+        .get(
+          (uri) =>
             uri.includes('/file_lookup') &&
             uri.includes('QmSU6rdPHdTrVohDSfhVCBiobTMr6a3NvPz4J7nLWVDvmE')
-          )
-        })
+        )
         .reply(404)
 
       const SyncRequestMaxUserFailureCountBeforeSkip = 3

--- a/creator-node/test/utils.test.js
+++ b/creator-node/test/utils.test.js
@@ -146,7 +146,7 @@ describe('test src/utils.js', () => {
     })
 
     assert.deepStrictEqual(
-      await UtilsWithMockFs.verifyCIDIsProper({
+      await UtilsWithMockFs.verifyCIDMatchesExpected({
         cid: DUMMY_NON_EMPTY_CID_1,
         path: '/some/path',
         logger: genericLogger
@@ -178,7 +178,7 @@ describe('test src/utils.js', () => {
     })
 
     assert.deepStrictEqual(
-      await UtilsWithMockFsAndMockLibs.verifyCIDIsProper({
+      await UtilsWithMockFsAndMockLibs.verifyCIDMatchesExpected({
         cid: DUMMY_NON_EMPTY_CID_1,
         path: '/some/path',
         logger: genericLogger
@@ -210,7 +210,7 @@ describe('test src/utils.js', () => {
     })
 
     assert.deepStrictEqual(
-      await UtilsWithMockFsAndMockLibs.verifyCIDIsProper({
+      await UtilsWithMockFsAndMockLibs.verifyCIDMatchesExpected({
         cid: DUMMY_NON_EMPTY_CID_1,
         path: '/some/path',
         logger: genericLogger

--- a/creator-node/test/utils.test.js
+++ b/creator-node/test/utils.test.js
@@ -136,7 +136,7 @@ describe('test src/utils.js', () => {
   })
 
   it("If cid is empty but shouldn't be, return false", async function () {
-    const UtilsWithMockFs = proxyquire('../src/utils', {
+    const UtilsWithMockFs = proxyquire('../src/utils/legacyUtils', {
       'fs-extra': {
         // Mock fs.stat() to return size of 0
         stat: async () => {
@@ -156,7 +156,7 @@ describe('test src/utils.js', () => {
   })
 
   it('If cid is not what is expected to be, return false', async function () {
-    const UtilsWithMockFsAndMockLibs = proxyquire('../src/utils', {
+    const UtilsWithMockFsAndMockLibs = proxyquire('../src/utils/legacyUtils', {
       'fs-extra': {
         // Mock fs.stat() to return size of 1 (non-empty)
         stat: async () => {
@@ -188,7 +188,7 @@ describe('test src/utils.js', () => {
   })
 
   it('If cid is what is expected to be, return true', async function () {
-    const UtilsWithMockFsAndMockLibs = proxyquire('../src/utils', {
+    const UtilsWithMockFsAndMockLibs = proxyquire('../src/utils/legacyUtils', {
       'fs-extra': {
         // Mock fs.stat() to return size of 1 (non-empty)
         stat: async () => {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The intent of this PR is to add retries to fetching a cid in the network.

This flow only retries:
- if gets 500 from fetching from content node
- an empty response is served from content node
- writing to fs fails

No retry if:
- fetching content fails with other status codes (401, 403, 400, 404)
- content verification fails

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Functionality of `findCIDInNetwork` generally has not changed. Only difference is the retries and new verify fn that is tested in `creator-node/test/utils.test.js`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Monitor `findCIDInNetwork error from` for error logs and `Successfully fetched CID=` for success logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->