### PR TITLE
Fix duplicate export causing TypeError

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts
@@ -353,4 +353,3 @@ async function recoverOrphanedData(
 }
 
 export default recoverOrphanedData
-module.exports = recoverOrphanedData

--- a/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
+++ b/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
@@ -150,7 +150,7 @@ describe('test recoverOrphanedData job processor', function () {
               ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS: 1
             }
       }
-    )
+    ).default
   }
 
   type VerifyJobResults = {
@@ -173,7 +173,12 @@ describe('test recoverOrphanedData job processor', function () {
 
     expect(jobResults.jobsToEnqueue)
       .to.have.nested.property(QUEUE_NAMES.RECOVER_ORPHANED_DATA)
-      .that.eqls([{ discoveryNodeEndpoint: DISCOVERY_NODE_ENDPOINT, parentSpanContext: undefined }])
+      .that.eqls([
+        {
+          discoveryNodeEndpoint: DISCOVERY_NODE_ENDPOINT,
+          parentSpanContext: undefined
+        }
+      ])
 
     expect(jobResults.metricsToRecord).to.eql([
       {


### PR DESCRIPTION
### Description
Fixes TypeError caused by exporting both CommonJS and ES6 syntax.


### Tests
Made sure the error was gone when running locally.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor logs to make sure the following error isn't present: `Error processing job: TypeError: jobProcessor is not a function`