### PR TITLE
Gate reconfig of primary to node endpoint changing

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -592,7 +592,16 @@ const _issueUpdateReplicaSetOp = async (
       throw new Error(errorMsg)
     }
 
-    if (!issueReconfig) {
+    /**
+     * TODO: Remove this after rollout. This is an extra gating condition to NOT issue reconfigs of primaries
+     * except when the cause of the reconfig is that the primary endpoint was deregistered or changed.
+     */
+    const causeOfReconfigIsPrimaryChanged =
+      !!ContentNodeInfoManager.getCNodeEndpointToSpIdMap()[primary]
+    const dontIssueEvenIfEnabled =
+      causeOfReconfigIsPrimaryChanged &&
+      reconfigType === RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES
+    if (!issueReconfig || dontIssueEvenIfEnabled) {
       response.result = UpdateReplicaSetJobResult.SuccessIssueReconfigDisabled
       return response
     }


### PR DESCRIPTION
### Description
Makes it so that regardless of which reconfig mode is enabled, a reconfig will *not* be issued if:
- The primary is being updated in the reconfig
- The cause of the update is anything except the primary's endpoint changing (as determined by its absence in our CNodeEndpoint->SP_ID map)


### Tests
- Automated tests pass
- Manual testing of taking down a user's primary locally shows that it skips issuing the reconfig:
```
{
  "data": {
    "enqueuedBy": "find-replica-set-updates-queue#12",
    "wallet": "0x95a670da5e5fa236ddb586c71670cbf88f3b502d",
    "userId": 2,
    "primary": "http://cn1_creator-node_1:4000",
    "secondary1": "http://cn3_creator-node_1:4002",
    "secondary2": "http://cn4_creator-node_1:4003",
    "unhealthyReplicas": [
      "http://cn1_creator-node_1:4000"
    ],
    "replicaToUserInfoMap": {
      "http://cn4_creator-node_1:4003": {
        "clock": 2,
        "filesHash": "c7f7aaa9a7d02e52ebad83e616f9081b"
      },
      "http://cn1_creator-node_1:4000": {
        "clock": -1
      },
      "http://cn3_creator-node_1:4002": {
        "clock": 2,
        "filesHash": "c7f7aaa9a7d02e52ebad83e616f9081b"
      }
    },
    "parentSpanContext": {
      "traceId": "a2bc2b46719f8c064b357d30f42b1d9d",
      "spanId": "06abd97381ae7ae6",
      "traceFlags": 1
    },
    "enabledReconfigModes": [
      "RECONFIG_DISABLED",
      "ONE_SECONDARY",
      "MULTIPLE_SECONDARIES",
      "PRIMARY_AND_OR_SECONDARIES"
    ]
  },
  "returnValue": {
    "errorMsg": "",
    "issuedReconfig": false,
    "newReplicaSet": {
      "newPrimary": "http://cn3_creator-node_1:4002",
      "newSecondary1": "http://cn4_creator-node_1:4003",
      "newSecondary2": "http://cn2_creator-node_1:4001",
      "issueReconfig": true,
      "reconfigType": "PRIMARY_AND_OR_SECONDARIES"
    },
    "healthyNodes": [
      "http://cn3_creator-node_1:4002",
      "http://cn2_creator-node_1:4001",
      "http://cn4_creator-node_1:4003"
    ],
    "metricsToRecord": [
      {
        "metricName": "audius_cn_state_machine_update_replica_set_queue_job_duration_seconds",
        "metricType": "HISTOGRAM_OBSERVE",
        "metricValue": 5.603,
        "metricLabels": {
          "result": "skip_update_replica_set",
          "issuedReconfig": "false",
          "reconfigType": "primary_and_or_secondaries"
        }
      }
    ]
  }
}
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor logs for primaries being reconfiged: search for `"PRIMARY_AND_OR_SECONDARIES"` and then see if `issuedReconfig` is true or false.