### PR TITLE
Retry on cid verification

### DIFF
--- a/creator-node/src/utils/legacyUtils.js
+++ b/creator-node/src/utils/legacyUtils.js
@@ -218,8 +218,7 @@ export async function findCIDInNetwork(
               logger.error(`Could not remove file at path=${path}`)
             }
 
-            bail(new Error('CID does not match what is expected to be'))
-            return
+            throw new Error('CID does not match what is expected to be')
           }
 
           logger.info(


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Sometimes, writing CIDs get corrupted. We should retry on these errors instead of bailing. This PR is to retry if cid verification fails

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
No change in functionality, just adding retries to this flow

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Monitor the log `CID does not match what is expected to be`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->