### PR TITLE
Fix prune plays test cutoff time

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_prune_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_prune_plays.py
@@ -142,7 +142,6 @@ def test_prune_plays_max_batch(app):
         assert plays_archive_result[0].id == 1
         assert plays_archive_result[0].play_item_id == 1
         assert plays_archive_result[0].archived_at == CURRENT_TIMESTAMP
-    pass
 
 
 def test_prune_plays_skip_prune(app):

--- a/discovery-provider/integration_tests/tasks/test_prune_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_prune_plays.py
@@ -112,7 +112,12 @@ def test_prune_plays_max_batch(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-        _prune_plays(session, CURRENT_TIMESTAMP, max_batch=1)
+        _prune_plays(
+            session,
+            CURRENT_TIMESTAMP,
+            cutoff_timestamp=CURRENT_TIMESTAMP - timedelta(weeks=140),
+            max_batch=1,
+        )
         # verify plays
         plays_result: List[Play] = session.query(Play).order_by(Play.id).all()
         assert len(plays_result) == 3
@@ -137,6 +142,7 @@ def test_prune_plays_max_batch(app):
         assert plays_archive_result[0].id == 1
         assert plays_archive_result[0].play_item_id == 1
         assert plays_archive_result[0].archived_at == CURRENT_TIMESTAMP
+    pass
 
 
 def test_prune_plays_skip_prune(app):


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This test was missing a cutoff param and depends on current times.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->