### PR TITLE
[PAY-597] Fetch token account info with 'processed' commitment

### DIFF
--- a/libs/src/services/solana/tokenAccount.ts
+++ b/libs/src/services/solana/tokenAccount.ts
@@ -56,7 +56,13 @@ export async function getTokenAccountInfo({
     solanaTokenProgramKey,
     Keypair.generate()
   )
-  const info = await token.getAccountInfo(tokenAccountAddressKey)
+
+  // Fetch token info with 'processed commitment to get any recently changed amounts.
+  // NOTE: Our version of spl-token omits the second argument
+  // in the type definitions even though it's actually available,
+  // so we suppress error until we can upgrade.
+  // @ts-ignore
+  const info = await token.getAccountInfo(tokenAccountAddressKey, 'processed')
   return info
 }
 


### PR DESCRIPTION
### Description

We sometimes show out of date token info on reload because we were fetching with a default commitment level that was too high - this allows you to send a tip, refresh, and immediately get the correct value.


### Tests

Tested locally, confirmed that this is indeed the issue.
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->