### PR TITLE
Convert histogram observation from ms to seconds

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheusRegistry.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheusRegistry.ts
@@ -83,14 +83,14 @@ export class PrometheusRegistry {
     }
 
     // job duration in seconds
-    const jobDuration = (job.finishedOn - job.processedOn!) * 1000
+    const jobDuration = (job.finishedOn - job.processedOn!) / 1000
     this.getMetric(this.metricNames.JOBS_DURATION_SECONDS_HISTOGRAM).observe(
       jobLabels,
       jobDuration
     )
 
     // job duration in seconds
-    const waitingDuration = (job.processedOn! - job.timestamp) * 1000
+    const waitingDuration = (job.processedOn! - job.timestamp) / 1000
     this.getMetric(
       this.metricNames.JOBS_WAITING_DURATION_SECONDS_HISTOGRAM
     ).observe(jobLabels, waitingDuration)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is a mathematical error because we're trying to get seconds but we're doing (ms * 1000) instead of (ms / 1000).

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally by running the content node and making sure that queue metrics fit into buckets less than 600. Currently on stage/prod all jobs are in the 600+ bucket.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Grafana panel for job duration

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->