### PR TITLE
Fix track ids after filtering premium tracks

### DIFF
--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -77,18 +77,9 @@ premium_conditions = ns.model(
         "nft-collection": fields.String,
     },
 )
-premium_content_signature_data = ns.model(
-    "premium_content_signature_data",
-    {
-        "premium_content_id": fields.Integer(required=True),
-        "premium_content_type": fields.String(required=True),
-        "user_wallet": fields.String(required=True),
-        "timestamp": fields.Integer(required=True),
-    },
-)
 premium_content_signature = ns.model(
     "premium_content_signature",
-    {"data": fields.Nested(premium_content_signature_data), "signature": fields.String},
+    {"data": fields.String, "signature": fields.String},
 )
 
 track = ns.model(

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -70,12 +70,27 @@ field_visibility = ns.model(
         "remixes": fields.Boolean,
     },
 )
+
 premium_conditions = ns.model(
     "premium_conditions",
     {
         "nft-collection": fields.String,
     },
 )
+premium_content_signature_data = ns.model(
+    "premium_content_signature_data",
+    {
+        "premium_content_id": fields.Integer(required=True),
+        "premium_content_type": fields.String(required=True),
+        "user_wallet": fields.String(required=True),
+        "timestamp": fields.Integer(required=True),
+    },
+)
+premium_content_signature = ns.model(
+    "premium_content_signature",
+    {"data": fields.Nested(premium_content_signature_data), "signature": fields.String},
+)
+
 track = ns.model(
     "Track",
     {
@@ -132,7 +147,10 @@ track_full = ns.clone(
         "remix_of": fields.Nested(full_remix_parent),
         "is_available": fields.Boolean,
         "is_premium": fields.Boolean,
-        "premium_conditions": fields.Nested(premium_conditions),
+        "premium_conditions": fields.Nested(premium_conditions, allow_null=True),
+        "premium_content_signature": fields.Nested(
+            premium_content_signature, allow_null=True
+        ),
     },
 )
 

--- a/discovery-provider/src/premium_content/signature.py
+++ b/discovery-provider/src/premium_content/signature.py
@@ -1,5 +1,6 @@
+import json
 from datetime import datetime
-from typing import TypedDict, cast
+from typing import TypedDict
 
 from src.api_helpers import generate_signature
 from src.premium_content.premium_content_types import PremiumContentType
@@ -19,7 +20,7 @@ class PremiumContentSignatureArgs(TypedDict):
 
 
 class PremiumContentSignature(TypedDict):
-    data: PremiumContentSignatureData
+    data: str
     signature: str
 
 
@@ -37,4 +38,4 @@ def get_premium_content_signature(
         "timestamp": _get_current_utc_timestamp_ms(),
     }
     signature = generate_signature(data)
-    return {"data": cast(PremiumContentSignatureData, data), "signature": signature}
+    return {"data": json.dumps(data), "signature": signature}

--- a/discovery-provider/src/premium_content/signature_unit_test.py
+++ b/discovery-provider/src/premium_content/signature_unit_test.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from src.api_helpers import recover_wallet
@@ -20,18 +21,21 @@ def test_signature():
             "user_wallet": user_wallet,
         }
     )
+    signature = result["signature"]
+    signature_data = result["data"]
+    signature_data_obj = json.loads(signature_data)
 
     after_ms = int(datetime.utcnow().timestamp() * 1000)
 
-    assert result["data"]["premium_content_id"] == premium_content_id
-    assert result["data"]["premium_content_type"] == premium_content_type
-    assert result["data"]["user_wallet"] == user_wallet
-    assert before_ms <= result["data"]["timestamp"] <= after_ms
-    assert len(result["signature"]) == 132
+    assert signature_data_obj["premium_content_id"] == premium_content_id
+    assert signature_data_obj["premium_content_type"] == premium_content_type
+    assert signature_data_obj["user_wallet"] == user_wallet
+    assert before_ms <= signature_data_obj["timestamp"] <= after_ms
+    assert len(signature) == 132
 
     discovery_node_wallet = recover_wallet(
-        result["data"],
-        result["signature"],
+        json.loads(signature_data),
+        signature,
     )
 
     assert discovery_node_wallet == shared_config["delegate"]["owner_wallet"]

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -70,6 +70,7 @@ def generate_unpopulated_trending(
     # because of the filtering out of premium tracks
     if not should_apply_limit_early:
         tracks = tracks[:limit]
+        track_ids = [track["track_id"] for track in tracks]
 
     return (tracks, track_ids)
 
@@ -129,6 +130,7 @@ def generate_unpopulated_trending_from_mat_views(
     # because of the filtering out of premium tracks
     if not should_apply_limit_early:
         tracks = tracks[:limit]
+        track_ids = [track["track_id"] for track in tracks]
 
     return (tracks, track_ids)
 

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -218,6 +218,7 @@ def make_get_unpopulated_tracks(session, redis_instance, strategy):
         # because of the filtering out of premium tracks
         if not should_apply_limit_early:
             tracks = tracks[:UNDERGROUND_TRENDING_LENGTH]
+            track_ids = [track["track_id"] for track in tracks]
 
         return (tracks, track_ids)
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -499,7 +499,7 @@ def populate_track_metadata(
 
 
 def _populate_premium_track_metadata(session, tracks, current_user_id):
-    premium_tracks = filter(lambda track: track["is_premium"], tracks)
+    premium_tracks = list(filter(lambda track: track["is_premium"], tracks))
     if not premium_tracks:
         return
 
@@ -547,7 +547,7 @@ def _populate_premium_track_metadata(session, tracks, current_user_id):
                 {
                     "id": track_id,
                     "type": "track",
-                    "user_wallet": current_user_wallet,
+                    "user_wallet": current_user_wallet[0],
                 }
             )
 


### PR DESCRIPTION
### Description

1. Since we may now apply the limit after filtering out premium tracks, it's possible that those tracks don't comprehensively match all the track ids passed in: the number of tracks and the number of track ids may not match. Thus, we recompute the track ids from the tracks after applying the limit.
This bug manifested when looking at my remote DN web server and seeing that building sorted tracks caused a KeyError because it was trying to access a track id which was not in the track map built by the tracks list after filtering out the premium tracks.

2. Also fixed the full track response model to include the premium content signature.

### Tests

1. Spin up remote DN service and check logs to make sure there is no error when building the sorted tracks from the track map.

2. Made request to get track and it include premium content signature.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->