### PR TITLE
Decrease primarySyncFromSecondary db query limit from 10k to 1k

### DIFF
--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -18,7 +18,7 @@ const {
 } = require('../stateMachineManager/stateMachineConstants')
 
 const DEFAULT_LOG_CONTEXT = {}
-const DB_QUERY_LIMIT = config.get('devMode') ? 5 : 10000
+const DB_QUERY_LIMIT = config.get('devMode') ? 5 : 1000
 const {
   LOCAL_DB_ENTRIES_SET_KEY_PREFIX,
   FETCHED_ENTRIES_SET_KEY_PREFIX,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Reduce `DB_QUERY_LIMIT` for primarySyncFromSecondary. This is an attempt to reduce server restarts due to primarySyncFromSecondary, although I'm not confident it will materially help

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

N/A just tweaking param

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->