### PR TITLE
Add IdentitiesOnly to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,13 +232,13 @@ commands:
             GCLOUD_IP_ADDRESS=$(gcloud compute instances describe $GCLOUD_VM_NAME --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
 
             # Run interactive command on remotebox
-            ssh -o "StrictHostKeyChecking no" -i ~/.ssh/google_compute_engine -t ubuntu@$GCLOUD_IP_ADDRESS \<< EOF
+            ssh -o "StrictHostKeyChecking no" -o IdentitiesOnly=yes -i ~/.ssh/google_compute_engine -t ubuntu@$GCLOUD_IP_ADDRESS \<< EOF
               << parameters.interactive-command >>
               exit;
             EOF
 
             # Run command on remote box
-            ssh -o "StrictHostKeyChecking no" -i ~/.ssh/google_compute_engine -tt ubuntu@$GCLOUD_IP_ADDRESS \<< EOF
+            ssh -o "StrictHostKeyChecking no" -o IdentitiesOnly=yes -i ~/.ssh/google_compute_engine -tt ubuntu@$GCLOUD_IP_ADDRESS \<< EOF
               << parameters.command >>
               exit;
             EOF


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Seeing `Too many authentication failures` error trying to SSH into GCP machines. I followed [this guide](https://www.tecmint.com/fix-ssh-too-many-authentication-failures-error/) to only use the identity specified in the ssh command vs try all ssh keys and fail. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Try GCP image bake on CI and make sure it works. CI run to look out for https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/27703/workflows/b98b9c74-0d0d-4c8b-a429-fd7fc2b33496/jobs/333714

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
We have a slack alert when the image bake fails

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->