### PR TITLE
[PAY-604] Use /abuse endpoint in Identity

### DIFF
--- a/identity-service/sequelize/migrations/20220912160855-abuse-columns.js
+++ b/identity-service/sequelize/migrations/20220912160855-abuse-columns.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
@@ -17,7 +17,7 @@ module.exports = {
 
       await queryInterface.addColumn('Users', 'appliedRules', {
         type: Sequelize.JSONB,
-        allowNull: true,
+        allowNull: true
       }, { transaction })
 
       await queryInterface.sequelize.query(
@@ -51,9 +51,9 @@ module.exports = {
       await queryInterface.addColumn(
         'Users',
         'isAbusiveErrorCode', {
-          type: Sequelize.STRING,
+          type: Sequelize.STRING
         }
       )
     })
   }
-};
+}

--- a/identity-service/sequelize/migrations/20220912160855-abuse-columns.js
+++ b/identity-service/sequelize/migrations/20220912160855-abuse-columns.js
@@ -1,0 +1,59 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn('Users', 'isBlockedFromRelay', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        default: false
+      }, { transaction })
+
+      await queryInterface.addColumn('Users', 'isBlockedFromNotifications', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        default: false
+      }, { transaction })
+
+      await queryInterface.addColumn('Users', 'appliedRules', {
+        type: Sequelize.JSONB,
+        allowNull: true,
+      }, { transaction })
+
+      await queryInterface.sequelize.query(
+        'UPDATE "Users" SET "isBlockedFromRelay" = true WHERE "isAbusive" = true AND "isAbusiveErrorCode" != \'9\'',
+        { transaction }
+      )
+
+      await queryInterface.sequelize.query(
+        'UPDATE "Users" SET "isBlockedFromNotifications" = true WHERE "isAbusive" = true AND "isAbusiveErrorCode" = \'9\'',
+        { transaction }
+      )
+
+      // Safe to drop this now since we've moved users to
+      await queryInterface.removeColumn('Users', 'isAbusive', { transaction })
+      await queryInterface.removeColumn('Users', 'isAbusiveErrorCode', { transaction })
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('Users', 'isBlockedFromRelay', { transaction })
+      await queryInterface.removeColumn('Users', 'isBlockedFromNotifications', { transaction })
+      await queryInterface.removeColumn('Users', 'appliedRules', { transaction })
+      await queryInterface.addColumn(
+        'Users',
+        'isAbusive', {
+          type: Sequelize.BOOLEAN,
+          defaultValue: false
+        }
+      )
+      await queryInterface.addColumn(
+        'Users',
+        'isAbusiveErrorCode', {
+          type: Sequelize.STRING,
+        }
+      )
+    })
+  }
+};

--- a/identity-service/src/models/user.js
+++ b/identity-service/src/models/user.js
@@ -52,7 +52,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     appliedRules: {
       type: DataTypes.JSONB,
-      allowNull: true,
+      allowNull: true
     },
     isEmailDeliverable: {
       type: DataTypes.BOOLEAN,

--- a/identity-service/src/models/user.js
+++ b/identity-service/src/models/user.js
@@ -40,15 +40,19 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: false
     },
-    isAbusive: {
+    isBlockedFromRelay: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false
     },
-    isAbusiveErrorCode: {
-      type: DataTypes.STRING,
+    isBlockedFromNotifications: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
+    appliedRules: {
+      type: DataTypes.JSONB,
       allowNull: true,
-      defaultValue: null
     },
     isEmailDeliverable: {
       type: DataTypes.BOOLEAN,

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -459,11 +459,11 @@ async function filterOutAbusiveUsers (notifications) {
     where: {
       blockchainUserId: { [ models.Sequelize.Op.in ]: allUserIds }
     },
-    attributes: ['blockchainUserId', 'isAbusive']
+    attributes: ['blockchainUserId', 'isBlockedFromNotifications']
   })
   const usersAbuseMap = {}
   users.forEach(user => {
-    usersAbuseMap[user.blockchainUserId] = user.isAbusive
+    usersAbuseMap[user.blockchainUserId] = user.isBlockedFromNotifications
   })
   const result = notifications.filter(notification => {
     const isInitiatorAbusive = usersAbuseMap[notification.initiator.toString()]

--- a/identity-service/src/notifications/sendNotifications/publishNotifications.js
+++ b/identity-service/src/notifications/sendNotifications/publishNotifications.js
@@ -184,7 +184,7 @@ const publishNotifications = async (notifications, metadata, userNotificationSet
 
     // Don't publish events for deactivated users
     const isReceiverDeactivated = metadata.users[userId] && metadata.users[userId].is_deactivated
-    const isInitiatorAbusive = initiatorMap[initiatorUserId] && initiatorMap[initiatorUserId].isAbusive
+    const isInitiatorAbusive = initiatorMap[initiatorUserId] && initiatorMap[initiatorUserId].isBlockedFromNotifications
     if (isReceiverDeactivated) {
       continue
     }

--- a/identity-service/src/routes/relay.js
+++ b/identity-service/src/routes/relay.js
@@ -8,7 +8,6 @@ const { getFeatureFlag, FEATURE_FLAGS } = require('../featureFlag')
 const models = require('../models')
 const { getIP } = require('../utils/antiAbuse')
 
-
 module.exports = function (app) {
   // TODO(roneilr): authenticate that user controls senderAddress somehow, potentially validate that
   // method sig has come from sender address as well

--- a/identity-service/src/utils/antiAbuse.js
+++ b/identity-service/src/utils/antiAbuse.js
@@ -51,7 +51,6 @@ const getAbuseData = async (handle, reqIP) => {
   return { blockedFromRelay, blockedFromNotifications, rules, appliedRules }
 }
 
-
 const detectAbuse = async (user, reqIP) => {
   let blockedFromRelay = false
   let blockedFromNotifications = false

--- a/identity-service/src/utils/antiAbuse.js
+++ b/identity-service/src/utils/antiAbuse.js
@@ -5,6 +5,9 @@ const models = require('../models')
 
 const aaoEndpoint = config.get('aaoEndpoint') || 'https://antiabuseoracle.audius.co'
 
+const blockRelayAbuseErrorCodes = new Set([0, 8, 10])
+const blockNotificationsErrorCodes = new Set([9])
+
 /**
  * Gets IP of a user by using the leftmost forwarded-for entry
  * or defaulting to req.ip
@@ -34,54 +37,48 @@ const recordIP = async (userIP, handle) => {
   }
 }
 
-const getAbuseAttestation = async (challengeId, handle, reqIP) => {
-  const res = await axios.post(`${aaoEndpoint}/attestation/${handle}`, {
-    challengeId,
-    challengeSpecifier: handle,
-    amount: 0
-  }, {
+const getAbuseData = async (handle, reqIP) => {
+  const res = await axios.get(`${aaoEndpoint}/abuse/${handle}`, {
     headers: {
       'X-Forwarded-For': reqIP
     }
   })
 
-  const data = res.data
-  logger.info(`antiAbuse: aao response: ${JSON.stringify(data)}`)
-  return data
+  const { data: rules } = res
+  const appliedRules = rules.filter(r => r.trigger && r.action !== 'pass').map(r => r.rule)
+  const blockedFromRelay = appliedRules.some(r => blockRelayAbuseErrorCodes.has(r))
+  const blockedFromNotifications = appliedRules.some(r => blockNotificationsErrorCodes.has(r))
+  return { blockedFromRelay, blockedFromNotifications, rules, appliedRules }
 }
 
-const detectAbuse = async (user, challengeId, reqIP) => {
-  let isAbusive = false
-  let isAbusiveErrorCode = null
+
+const detectAbuse = async (user, reqIP) => {
+  let blockedFromRelay = false
+  let blockedFromNotifications = false
+  let appliedRules = null
 
   if (!user.handle) {
     // Something went wrong during sign up and identity has no knowledge
     // of this user's handle. Flag them as abusive.
-    isAbusive = true
+    blockedFromRelay = true
   } else {
     try {
       // Write out the latest user IP to Identity DB - AAO will request it back
       await recordIP(reqIP, user.handle)
 
-      const { result, errorCode } = await getAbuseAttestation(challengeId, user.handle, reqIP)
-      if (!result) {
-        // The anti abuse system deems them abusive. Flag them as such.
-        isAbusive = true
-        if (errorCode || errorCode === 0) {
-          isAbusiveErrorCode = `${errorCode}`
-        }
-      }
+      ;({ appliedRules, blockedFromRelay, blockedFromNotifications } = await getAbuseData(user.handle, reqIP))
     } catch (e) {
       logger.warn(`antiAbuse: aao request failed ${e.message}`)
     }
   }
-  if (user.isAbusive !== isAbusive || user.isAbusiveErrorCode !== isAbusiveErrorCode) {
-    await user.update({ isAbusive, isAbusiveErrorCode })
+
+  if (user.isBlockedFromRelay !== blockedFromRelay || user.isBlockedFromNotifications !== blockedFromNotifications) {
+    await user.update({ isBlockedFromRelay: blockedFromRelay, isBlockedFromNotifications: blockedFromNotifications, appliedRules })
   }
 }
 
 module.exports = {
-  getAbuseAttestation,
+  getAbuseAttestation: getAbuseData,
   detectAbuse,
   getIP,
   recordIP


### PR DESCRIPTION
### Description

Switch to new `/abuse` endpoint in Identity, creating new columns for isBlockedFromRelay and isBlockedFromNotifications.

All previously blocked users are set to block on relay except users with error code 9, which are set to only block notifs.

Requires a corresponding change in AAO (in PR) to return 



### Tests

Tested on remote. Testing the migration on stage with more users to ensure it categorizes them as expected.

<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->