### PR TITLE
Add better logging around outgoing syncs

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -120,7 +120,9 @@ async function issueSyncRequest({
   })
   if (errorResp) {
     error = errorResp
-    logger.error(error.message)
+    logger.error(
+      `Issuing sync request error: ${error.message}. Prometheus result: ${result}`
+    )
   }
 
   // Enqueue a new sync request if one needs to be enqueued and we haven't retried too many times yet
@@ -260,7 +262,7 @@ async function _handleIssueSyncRequest({
     if (syncCorrectnessError) {
       return {
         result: 'failure_sync_correctness',
-        error: syncCorrectnessError,
+        error: `${logMsgString}: ${syncCorrectnessError}`,
         syncReqsToEnqueue
       }
     }
@@ -273,7 +275,7 @@ async function _handleIssueSyncRequest({
     if (error) {
       return {
         result: 'failure_primary_sync_from_secondary',
-        error,
+        error: `${logMsgString}: ${error}`,
         syncReqsToEnqueue
       }
     }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -69,7 +69,7 @@ type HandleIssueSyncReqParams = {
 }
 type HandleIssueSyncReqResult = {
   result: string
-  error?: any
+  error?: { message: string }
   syncReqsToEnqueue: IssueSyncRequestJobParams[]
   additionalSync?: IssueSyncRequestJobParams
 }
@@ -262,7 +262,9 @@ async function _handleIssueSyncRequest({
     if (syncCorrectnessError) {
       return {
         result: 'failure_sync_correctness',
-        error: `${logMsgString}: ${syncCorrectnessError}`,
+        error: {
+          message: `${logMsgString}: ${syncCorrectnessError}`
+        },
         syncReqsToEnqueue
       }
     }
@@ -275,7 +277,9 @@ async function _handleIssueSyncRequest({
     if (error) {
       return {
         result: 'failure_primary_sync_from_secondary',
-        error: `${logMsgString}: ${error.message}`,
+        error: {
+          message: `${logMsgString}: ${error.message}`
+        },
         syncReqsToEnqueue
       }
     }

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -275,7 +275,7 @@ async function _handleIssueSyncRequest({
     if (error) {
       return {
         result: 'failure_primary_sync_from_secondary',
-        error: `${logMsgString}: ${error}`,
+        error: `${logMsgString}: ${error.message}`,
         syncReqsToEnqueue
       }
     }

--- a/creator-node/test/issueSyncRequest.jobProcessor.test.js
+++ b/creator-node/test/issueSyncRequest.jobProcessor.test.js
@@ -231,7 +231,7 @@ describe('test issueSyncRequest job processor', function () {
     )
     expect(result.metricsToRecord[0].metricValue).to.be.a('number')
     expect(logger.error).to.have.been.calledOnceWithExactly(
-      expectedErrorMessage
+      `Issuing sync request error: ${expectedErrorMessage}. Prometheus result: failure_secondary_failure_count_threshold_met`
     )
     expect(getNewOrExistingSyncReqStub).to.not.have.been.called
   })
@@ -557,6 +557,8 @@ describe('test issueSyncRequest job processor', function () {
         )
       })
 
+      const expectedErrorMessage = `_handleIssueSyncRequest() (${syncType})(${syncMode}) User ${wallet} | Secondary: ${secondary}: ${primarySyncFromSecondaryError.message}`
+
       const issueSyncRequestJobProcessor = getJobProcessorStub({
         getNewOrExistingSyncReqStub,
         getSecondaryUserSyncFailureCountForTodayStub,
@@ -571,10 +573,9 @@ describe('test issueSyncRequest job processor', function () {
         syncMode,
         syncRequestParameters
       })
-      expect(result).to.have.deep.property(
-        'error',
-        primarySyncFromSecondaryError
-      )
+      expect(result).to.have.deep.property('error', {
+        message: expectedErrorMessage
+      })
       expect(result).to.have.deep.property('jobsToEnqueue', {
         [QUEUE_NAMES.MANUAL_SYNC]: [],
         [QUEUE_NAMES.RECURRING_SYNC]: []


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This pr is to standardize error logging like we do in secondary sync from primary where we also log the prometheus result. This is so we can query the logs by error code.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
No tests, just updating logs 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
This is for monitoring

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->