### PR TITLE
Revert "Fix track ids after filtering premium tracks (#3850)"

### DIFF
--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -70,18 +70,12 @@ field_visibility = ns.model(
         "remixes": fields.Boolean,
     },
 )
-
 premium_conditions = ns.model(
     "premium_conditions",
     {
         "nft-collection": fields.String,
     },
 )
-premium_content_signature = ns.model(
-    "premium_content_signature",
-    {"data": fields.String, "signature": fields.String},
-)
-
 track = ns.model(
     "Track",
     {
@@ -138,10 +132,7 @@ track_full = ns.clone(
         "remix_of": fields.Nested(full_remix_parent),
         "is_available": fields.Boolean,
         "is_premium": fields.Boolean,
-        "premium_conditions": fields.Nested(premium_conditions, allow_null=True),
-        "premium_content_signature": fields.Nested(
-            premium_content_signature, allow_null=True
-        ),
+        "premium_conditions": fields.Nested(premium_conditions),
     },
 )
 

--- a/discovery-provider/src/premium_content/signature.py
+++ b/discovery-provider/src/premium_content/signature.py
@@ -1,6 +1,5 @@
-import json
 from datetime import datetime
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from src.api_helpers import generate_signature
 from src.premium_content.premium_content_types import PremiumContentType
@@ -20,7 +19,7 @@ class PremiumContentSignatureArgs(TypedDict):
 
 
 class PremiumContentSignature(TypedDict):
-    data: str
+    data: PremiumContentSignatureData
     signature: str
 
 
@@ -38,4 +37,4 @@ def get_premium_content_signature(
         "timestamp": _get_current_utc_timestamp_ms(),
     }
     signature = generate_signature(data)
-    return {"data": json.dumps(data), "signature": signature}
+    return {"data": cast(PremiumContentSignatureData, data), "signature": signature}

--- a/discovery-provider/src/premium_content/signature_unit_test.py
+++ b/discovery-provider/src/premium_content/signature_unit_test.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 
 from src.api_helpers import recover_wallet
@@ -21,21 +20,18 @@ def test_signature():
             "user_wallet": user_wallet,
         }
     )
-    signature = result["signature"]
-    signature_data = result["data"]
-    signature_data_obj = json.loads(signature_data)
 
     after_ms = int(datetime.utcnow().timestamp() * 1000)
 
-    assert signature_data_obj["premium_content_id"] == premium_content_id
-    assert signature_data_obj["premium_content_type"] == premium_content_type
-    assert signature_data_obj["user_wallet"] == user_wallet
-    assert before_ms <= signature_data_obj["timestamp"] <= after_ms
-    assert len(signature) == 132
+    assert result["data"]["premium_content_id"] == premium_content_id
+    assert result["data"]["premium_content_type"] == premium_content_type
+    assert result["data"]["user_wallet"] == user_wallet
+    assert before_ms <= result["data"]["timestamp"] <= after_ms
+    assert len(result["signature"]) == 132
 
     discovery_node_wallet = recover_wallet(
-        json.loads(signature_data),
-        signature,
+        result["data"],
+        result["signature"],
     )
 
     assert discovery_node_wallet == shared_config["delegate"]["owner_wallet"]

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -70,7 +70,6 @@ def generate_unpopulated_trending(
     # because of the filtering out of premium tracks
     if not should_apply_limit_early:
         tracks = tracks[:limit]
-        track_ids = [track["track_id"] for track in tracks]
 
     return (tracks, track_ids)
 
@@ -130,7 +129,6 @@ def generate_unpopulated_trending_from_mat_views(
     # because of the filtering out of premium tracks
     if not should_apply_limit_early:
         tracks = tracks[:limit]
-        track_ids = [track["track_id"] for track in tracks]
 
     return (tracks, track_ids)
 

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -218,7 +218,6 @@ def make_get_unpopulated_tracks(session, redis_instance, strategy):
         # because of the filtering out of premium tracks
         if not should_apply_limit_early:
             tracks = tracks[:UNDERGROUND_TRENDING_LENGTH]
-            track_ids = [track["track_id"] for track in tracks]
 
         return (tracks, track_ids)
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -499,7 +499,7 @@ def populate_track_metadata(
 
 
 def _populate_premium_track_metadata(session, tracks, current_user_id):
-    premium_tracks = list(filter(lambda track: track["is_premium"], tracks))
+    premium_tracks = filter(lambda track: track["is_premium"], tracks)
     if not premium_tracks:
         return
 
@@ -547,7 +547,7 @@ def _populate_premium_track_metadata(session, tracks, current_user_id):
                 {
                     "id": track_id,
                     "type": "track",
-                    "user_wallet": current_user_wallet[0],
+                    "user_wallet": current_user_wallet,
                 }
             )
 


### PR DESCRIPTION
Causing OOM on discovery nodes in indexer process

This reverts commit a417f73c904f508c240acfed19e1978d13fe9551.

### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->