### PR TITLE
Add multi-root VSCode workspace

### DIFF
--- a/audius.code-workspace
+++ b/audius.code-workspace
@@ -1,0 +1,31 @@
+{
+  "folders": [
+    {
+      "path": "discovery-provider"
+    },
+    {
+      "path": "creator-node"
+    },
+    {
+      "path": "identity-service"
+    },
+    {
+      "path": "libs"
+    },
+    {
+      "path": "solana-programs"
+    },
+    {
+      "path": "service-commands"
+    },
+    {
+      "path": "eth-contracts"
+    },
+    {
+      "path": "contracts"
+    },
+    {
+      "path": "mad-dog"
+    },
+  ]
+}


### PR DESCRIPTION
### Description

Get proper linting in each audius-protocol service while still opening the base Audius-Protocol folder by using `open workspace from file` and using the new `audius.code-workspace` file.

Gone are the days of needing to open discovery-provider as workspace root in order to get proper python formatting!

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->