### PR TITLE
Test apply early limit true

### DIFF
--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -58,7 +58,7 @@ def generate_unpopulated_trending(
     # tracks we return later may be smaller than the limit.
     # If we don't limit it here, we limit it later after getting the
     # unpopulated tracks.
-    should_apply_limit_early = not exclude_premium
+    should_apply_limit_early = True  # not exclude_premium
     if should_apply_limit_early:
         sorted_track_scores = sorted_track_scores[:limit]
 
@@ -108,7 +108,7 @@ def generate_unpopulated_trending_from_mat_views(
     # tracks we return later may be smaller than the limit.
     # If we don't limit it here, we limit it later after getting the
     # unpopulated tracks.
-    should_apply_limit_early = not exclude_premium
+    should_apply_limit_early = True  # not exclude_premium
     if should_apply_limit_early:
         trending_track_ids = (
             trending_track_ids_query.order_by(

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -202,7 +202,7 @@ def make_get_unpopulated_tracks(session, redis_instance, strategy):
         # tracks we return later may be smaller than the limit.
         # If we don't limit it here, we limit it later after getting the
         # unpopulated tracks.
-        should_apply_limit_early = not SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS
+        should_apply_limit_early = True  # not SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS
         if should_apply_limit_early:
             sorted_tracks = sorted_tracks[:UNDERGROUND_TRENDING_LENGTH]
 


### PR DESCRIPTION
### Description
Temporary fix so discovery does not run out of memory calculating trending when limiting after

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->