### PR TITLE
Set reconfig blacklist

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -69,3 +69,5 @@ discoveryNodeUnhealthyBlockDiff=500
 
 # Maximum number of wallets the /users/batch_clock_status route will accept at one time
 maxBatchClockStatusBatchSize=5
+
+reconfigSPIdBlacklistString=

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -747,7 +747,7 @@ const config = convict({
   reconfigSPIdBlacklistString: {
     doc: 'A comma separated list of sp ids of nodes to not reconfig onto. Used to create the `reconfigSPIdBlacklist` number[] config',
     format: String,
-    env: 'reconfigSPIdBlocklistString',
+    env: 'reconfigSPIdBlacklistString',
     default: ''
   }
   /**

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -743,6 +743,12 @@ const config = convict({
     format: String,
     env: 'otelCollectorUrl',
     default: ''
+  },
+  reconfigSPIdBlacklistString: {
+    doc: 'A comma separated list of sp ids of nodes to not reconfig onto. Used to create the `reconfigSPIdBlacklist` string[] config',
+    format: String,
+    env: 'reconfigSPIdBlocklistString',
+    default: ''
   }
   /**
    * unsupported options at the moment
@@ -795,6 +801,17 @@ if (fs.existsSync(pathTo('contract-config.json'))) {
     dataRegistryAddress: dataContractConfig.registryAddress
   })
 }
+
+// Set reconfigSPIdBlacklist based off of reconfigSPIdBlacklistString
+config.set(
+  'reconfigSPIdBlacklist',
+  config.get('reconfigSPIdBlacklistString') === ''
+    ? []
+    : config
+        .get('reconfigSPIdBlacklistString')
+        .split(',')
+        .filter((e) => e)
+)
 
 // Perform validation and error any properties are not present on schema
 config.validate()

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -811,6 +811,7 @@ config.set(
         .get('reconfigSPIdBlacklistString')
         .split(',')
         .filter((e) => e)
+        .map((e) => parseInt(e))
 )
 
 // Perform validation and error any properties are not present on schema

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -745,7 +745,7 @@ const config = convict({
     default: ''
   },
   reconfigSPIdBlacklistString: {
-    doc: 'A comma separated list of sp ids of nodes to not reconfig onto. Used to create the `reconfigSPIdBlacklist` string[] config',
+    doc: 'A comma separated list of sp ids of nodes to not reconfig onto. Used to create the `reconfigSPIdBlacklist` number[] config',
     format: String,
     env: 'reconfigSPIdBlocklistString',
     default: ''

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const process = require('process')
 const path = require('path')
 const os = require('os')
+const _ = require('lodash')
 
 // can't import logger here due to possible circular dependency, use console
 
@@ -805,7 +806,7 @@ if (fs.existsSync(pathTo('contract-config.json'))) {
 // Set reconfigSPIdBlacklist based off of reconfigSPIdBlacklistString
 config.set(
   'reconfigSPIdBlacklist',
-  config.get('reconfigSPIdBlacklistString') === ''
+  _.isEmpty(config.get('reconfigSPIdBlacklistString'))
     ? []
     : config
         .get('reconfigSPIdBlacklistString')

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -134,7 +134,7 @@ const updateReplicaSetJobProcessor = async function ({
       const reconfigNodeBlacklist = new Set()
       RECONFIG_SP_IDS_BLACKLIST.forEach((spId) => {
         const info = spInfoMap.get(spId)
-        if (info) {
+        if (info?.endpoint) {
           reconfigNodeBlacklist.add(info.endpoint)
         }
       })

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -15,7 +15,10 @@ import type {
 import { makeHistogramToRecord } from '../stateMachineUtils'
 import { UpdateReplicaSetJobResult } from '../stateMachineConstants'
 import { stringifyMap } from '../../../utils'
-import { getMapOfCNodeEndpointToSpId } from '../../ContentNodeInfoManager'
+import {
+  getMapOfCNodeEndpointToSpId,
+  getMapOfSpIdToChainInfo
+} from '../../ContentNodeInfoManager'
 import { instrumentTracing, tracing } from '../../../tracer'
 
 const _ = require('lodash')
@@ -36,9 +39,7 @@ const reconfigNodeWhitelist = config.get('reconfigNodeWhitelist')
   ? new Set(config.get('reconfigNodeWhitelist').split(','))
   : null
 
-const RECONFIG_SP_IDS_BLACKLIST_SET = new Set(
-  config.get('reconfigSPIdBlacklist')
-)
+const RECONFIG_SP_IDS_BLACKLIST: number[] = config.get('reconfigSPIdBlacklist')
 
 /**
  * Updates replica sets of a user who has one or more unhealthy nodes as their primary or secondaries.
@@ -128,12 +129,24 @@ const updateReplicaSetJobProcessor = async function ({
     }
 
     try {
+      const spInfoMap = await getMapOfSpIdToChainInfo(logger)
+
+      const reconfigNodeBlacklist = new Set()
+      RECONFIG_SP_IDS_BLACKLIST.forEach((spId) => {
+        const info = spInfoMap.get(spId)
+        if (info) {
+          reconfigNodeBlacklist.add(info.endpoint)
+        }
+      })
+
       const { services: healthyServicesMap } =
         await audiusLibs.ServiceProvider.autoSelectCreatorNodes({
           performSyncCheck: false,
           whitelist: reconfigNodeWhitelist,
+          blacklist: reconfigNodeBlacklist,
           log: true
         })
+
       healthyNodes = Object.keys(healthyServicesMap || {})
       if (healthyNodes.length === 0) {
         throw new Error(
@@ -478,11 +491,8 @@ const _selectRandomReplicaSetNodes = async (
 
   const newReplicaNodesSet = new Set<string>()
 
-  const spInfoMap = await getMapOfCNodeEndpointToSpId(logger)
   const viablePotentialReplicas = healthyNodes.filter(
-    (node) =>
-      !healthyReplicaSet.has(node) &&
-      !RECONFIG_SP_IDS_BLACKLIST_SET.has(spInfoMap.get(node))
+    (node) => !healthyReplicaSet.has(node)
   )
 
   let selectNewReplicaSetAttemptCounter = 0

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -36,6 +36,10 @@ const reconfigNodeWhitelist = config.get('reconfigNodeWhitelist')
   ? new Set(config.get('reconfigNodeWhitelist').split(','))
   : null
 
+const RECONFIG_SP_IDS_BLACKLIST_SET = new Set(
+  config.get('reconfigSPIdBlacklist')
+)
+
 /**
  * Updates replica sets of a user who has one or more unhealthy nodes as their primary or secondaries.
  *
@@ -474,8 +478,11 @@ const _selectRandomReplicaSetNodes = async (
 
   const newReplicaNodesSet = new Set<string>()
 
+  const spInfoMap = await getMapOfCNodeEndpointToSpId(logger)
   const viablePotentialReplicas = healthyNodes.filter(
-    (node) => !healthyReplicaSet.has(node)
+    (node) =>
+      !healthyReplicaSet.has(node) &&
+      !RECONFIG_SP_IDS_BLACKLIST_SET.has(spInfoMap.get(node))
   )
 
   let selectNewReplicaSetAttemptCounter = 0


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Adds a configurable blacklist for reconfig via an env var. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- Manually added the array via config.js to see if in selection that explicitly passed in nodes do not get reconfigured
- Test via setting env var in base.env 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Look for the log `[_selectRandomReplicaSetNodes] wallet=` prefix

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->