### PR TITLE
Remove redundant stack trace log log

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -700,7 +700,7 @@ const _issueUpdateReplicaSetOp = async (
       throw new Error(
         `UserReplicaSetManagerClient._updateReplicaSet() Failed in ${
           Date.now() - startTimeMs
-        }ms - Error ${e.message}. Stack: ${e.stack}`
+        }ms - Error ${e.message}`
       )
     }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This inner stack trace is more precise, but still not helpful. Removing it so we don't print double logs. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->