### PR TITLE
Remove snapback init from serviceRegistry

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -65,7 +65,6 @@ class ServiceRegistry {
     this.recurringSyncQueue = null // Handles jobs for issuing a recurring sync request
     this.updateReplicaSetQueue = null // Handles jobs for updating a replica set
     this.recoverOrphanedDataQueue = null // Handles jobs for finding+reconciling state on nodes outside of a user's replica set
-    this.stateMachineQueue = null // DEPRECATED -- being removed very soon. Handles sync jobs based on user state
 
     // Flags that indicate whether categories of services have been initialized
     this.synchronousServicesInitialized = false
@@ -196,7 +195,6 @@ class ServiceRegistry {
         new BullAdapter(this.recurringSyncQueue, { readOnlyMode: true }),
         new BullAdapter(this.updateReplicaSetQueue, { readOnlyMode: true }),
         new BullAdapter(this.recoverOrphanedDataQueue, { readOnlyMode: true }),
-        new BullAdapter(this.stateMachineQueue, { readOnlyMode: true }),
         new BullAdapter(imageProcessingQueue, { readOnlyMode: true }),
         new BullAdapter(syncProcessingQueue, { readOnlyMode: true }),
         new BullAdapter(syncImmediateProcessingQueue, { readOnlyMode: true }),
@@ -301,10 +299,6 @@ class ServiceRegistry {
     // Cannot progress without recovering spID from node's record on L1 ServiceProviderFactory contract
     // Retries indefinitely
     await this._recoverNodeL1Identity()
-
-    // SnapbackSM init (requires L1 identity)
-    // Retries indefinitely
-    await this._initSnapbackSM()
 
     // Init StateMachineManager
     this.stateMachineManager = new StateMachineManager()
@@ -462,40 +456,6 @@ class ServiceRegistry {
     }
 
     this.logInfo('URSM Registration completed')
-  }
-
-  /**
-   * Initialize SnapbackSM
-   * Requires L1 identity
-   */
-  async _initSnapbackSM() {
-    this.snapbackSM = new SnapbackSM(config, this.libs)
-    const { stateMachineQueue } = this.snapbackSM
-    this.stateMachineQueue = stateMachineQueue
-
-    let isInitialized = false
-    const retryTimeoutMs = 10000 // ms
-    while (!isInitialized) {
-      try {
-        this.logInfo(
-          `Attempting to init SnapbackSM on ${retryTimeoutMs}ms interval...`
-        )
-
-        await this.snapbackSM.init()
-
-        isInitialized = true
-        // Short circuit earlier instead of waiting for another timeout and loop iteration
-        break
-
-        // Swallow all init errors
-      } catch (e) {
-        this.logError(`_initSnapbackSM Error ${e}`)
-      }
-
-      await utils.timeout(retryTimeoutMs, false)
-    }
-
-    this.logInfo(`SnapbackSM Init completed`)
   }
 
   logInfo(msg) {


### PR DESCRIPTION
### Description
ServiceRegistry was initializing Snapback, which didn't start any queues because it's disabled. It's still best to remove this entrypoint to old code.


### Tests
- Made sure there were no other references to serviceRegistry.stateMachineQueue
- Automated tests pass


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
There shouldn't be any more logs containing "SnapbackSM"