### PR TITLE
INF clear exporter's tallies for new proposals

### DIFF
--- a/monitoring/exporters/sdk/main.js
+++ b/monitoring/exporters/sdk/main.js
@@ -73,6 +73,12 @@ const OUTCOME = Object.freeze({
 let PREVIOUSLY_SEEN_PROPOSAL_ID = 0
 const PROPOSAL_OUTCOME_TALLY = {}
 
+const clearTally = () => {
+  for (const outcome in PROPOSAL_OUTCOME_TALLY) {
+    delete PROPOSAL_OUTCOME_TALLY[outcome];
+  }
+}
+
 const tallyProposalOutcomes = (outcome) => {
   if (!PROPOSAL_OUTCOME_TALLY[outcome]) {
     PROPOSAL_OUTCOME_TALLY[outcome] = 0
@@ -89,6 +95,7 @@ const scanGovernanceProposals = async () => {
   // and export new metrics
   if (PREVIOUSLY_SEEN_PROPOSAL_ID !== parseInt(lastProposal.proposalId)) {
     let unknownProposerCount = 0
+    clearTally()
 
     // scan all proposals and...
     for (const proposal of proposals) {


### PR DESCRIPTION
### Description

Our current exporter keeps a running tally of open proposals, but this tally should be cleared each time we scan all proposals.


### Tests

Manually running exporter locally and ensuring populated metrics match.

Will have to revisit upon new proposals to ensure running metrics remain valid.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->