### PR TITLE
[CON-395] Add start time to network monitoring slack alert

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -21,6 +21,7 @@ import {
   getUsersWithNullPrimaryClock,
   getUsersWithEntireReplicaSetInSpidSetCount,
   getUserCount,
+  getRunStartTime,
 } from "./queries";
 
 export const generateMetrics = async (run_id: number) => {
@@ -29,6 +30,8 @@ export const generateMetrics = async (run_id: number) => {
   console.log(`[${run_id}] generating metrics`);
 
   const endTimer = generatingMetricsDurationGauge.startTimer();
+
+  const runStartTime = await getRunStartTime(run_id);
 
   const userCount = await getUserCount(run_id);
 
@@ -69,6 +72,7 @@ export const generateMetrics = async (run_id: number) => {
 
   if (userCount > 0) {
     await publishSlackReport({
+      runStartTime: runStartTime.toString(),
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",
       partiallySyncedUsersCount:

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -30,6 +30,24 @@ export const getUserCount = async (run_id: number): Promise<number> => {
  * Core metrics
  */
 
+export const getRunStartTime = async (run_id: number): Promise<Date> => {
+    const runStartTimeResp: unknown[] = await sequelizeConn.query(`
+        SELECT created_at
+        FROM 
+            network_monitoring_index_blocks
+        WHERE
+            run_id = :run_id 
+    `, {
+        type: QueryTypes.SELECT,
+        replacements: { run_id }
+    })
+
+    const runStartTimeStr = runStartTimeResp[0] as string
+    const runStartTime = new Date(runStartTimeStr)
+
+    return runStartTime
+}
+
 export const getCidsReplicatedAtLeastOnce = async (run_id: number): Promise<{ content_node_spid: string, cid_count: number }[]> => {
 
     const cidsListResp = await sequelizeConn.query(`

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -42,7 +42,7 @@ export const getRunStartTime = async (run_id: number): Promise<Date> => {
         replacements: { run_id }
     })
 
-    const runStartTimeStr = runStartTimeResp[0] as string
+    const runStartTimeStr = (runStartTimeResp[0] as { created_at: string }).created_at as string
     const runStartTime = new Date(runStartTimeStr)
 
     return runStartTime


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds the run start time to the network monitoring run slack alert


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

This was tested on the staging network monitoring instance by running a job and console logging the alert


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This will be monitoring in the slack channel #eng-network-monitoring-alerts

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->