### PR TITLE
[CON-395] Add duration to network monitoring metrics

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -68,11 +68,14 @@ export const generateMetrics = async (run_id: number) => {
   );
 
   // Record duration for generating metrics and export to prometheus
+  const endTime = Date.now()
   endTimer({ run_id: run_id });
 
   if (userCount > 0) {
     await publishSlackReport({
-      runStartTime: runStartTime.toString(),
+      runStartTimeView: runStartTime.toString(),
+      // duration in milliseconds / (60_000 milliseconds in a minute)
+      runDuration: `${(endTime - runStartTime.getTime()) / 60_000.0} minutes`, 
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",
       partiallySyncedUsersCount:

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -74,7 +74,6 @@ export const generateMetrics = async (run_id: number) => {
   if (userCount > 0) {
     await publishSlackReport({
       runStartTime: runStartTime.toString(),
-      // duration in milliseconds / (60_000 milliseconds in a minute)
       runDuration: msToTime(endTime - runStartTime.getTime()),
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -73,9 +73,9 @@ export const generateMetrics = async (run_id: number) => {
 
   if (userCount > 0) {
     await publishSlackReport({
-      runStartTimeView: runStartTime.toString(),
+      runStartTime: runStartTime.toString(),
       // duration in milliseconds / (60_000 milliseconds in a minute)
-      runDuration: `${(endTime - runStartTime.getTime()) / 60_000.0} minutes`, 
+      runDuration: msToTime(endTime - runStartTime.getTime()),
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",
       partiallySyncedUsersCount:
@@ -126,3 +126,16 @@ const publishSlackReport = async (metrics: Object) => {
     );
   }
 };
+
+const msToTime = (duration: number) => {
+  const milliseconds = Math.floor((duration % 1000) / 100)
+  const seconds = Math.floor((duration / 1000) % 60)
+  const minutes = Math.floor((duration / (1000 * 60)) % 60)
+  const hours = Math.floor((duration / (1000 * 60 * 60)) % 24)
+
+  const hoursStr = (hours < 10) ? "0" + hours : hours;
+  const minutesStr = (minutes < 10) ? "0" + minutes : minutes;
+  const secondsStr = (seconds < 10) ? "0" + seconds : seconds;
+
+  return `${hoursStr}:${minutesStr}:${secondsStr}:${milliseconds.toString()}`
+}


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds run duration to the slack alert for network monitoring


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

tested locally in the node REPL to make sure the math was right.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This will be monitored in our slack channel eng-network-monitoring-alert

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->