### PR TITLE
Run is_available job every 3 hours

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -502,7 +502,7 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": timedelta(hours=12),  # run every 12 hours
+                "schedule": timedelta(hours=3),
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Across all nodes, we see this task sometimes taking up to an hour (though nominally only ~5 min on discovery nodes). Bump the interval up quite a bit to remove headaches of content being slow to mark `is_available`

<img width="701" alt="Screen Shot 2022-09-19 at 6 18 13 PM" src="https://user-images.githubusercontent.com/2731362/191146390-906c2623-9967-43bc-a65a-cbe628f9408a.png">



### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Monitor via grafana charts
http://grafana.audius.co/d/r_iIq2n4z/ray-test?orgId=1&refresh=30m&from=now-7d&to=now-1m&var-env=prod&var-host=All

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->