### PR TITLE
Add FsInstrumentation to content node

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -2325,6 +2325,45 @@
         }
       }
     },
+    "@opentelemetry/instrumentation-fs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.5.0.tgz",
+      "integrity": "sha512-giDjhkAHXdgcF6Yv4WWtvX80rZMdO0vT1cR2fJyvRR65VNv9HktzeAwXxzkv9kcuy8yc2tNryi23Ov8QXQAyMw==",
+      "requires": {
+        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
+          "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
+          "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+          "requires": {
+            "@opentelemetry/api-metrics": "0.32.0",
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@opentelemetry/instrumentation-http": {
       "version": "0.31.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.31.0.tgz",

--- a/creator-node/package.json
+++ b/creator-node/package.json
@@ -31,6 +31,7 @@
     "@opentelemetry/instrumentation": "^0.31.0",
     "@opentelemetry/instrumentation-bunyan": "^0.29.0",
     "@opentelemetry/instrumentation-express": "^0.30.0",
+    "@opentelemetry/instrumentation-fs": "^0.5.0",
     "@opentelemetry/instrumentation-http": "^0.31.0",
     "@opentelemetry/instrumentation-pg": "^0.30.0",
     "@opentelemetry/instrumentation-redis": "^0.32.0",

--- a/creator-node/src/tracer.ts
+++ b/creator-node/src/tracer.ts
@@ -15,6 +15,7 @@ import {
   SemanticAttributes,
   SemanticResourceAttributes as ResourceAttributesSC
 } from '@opentelemetry/semantic-conventions'
+import { FsInstrumentation } from '@opentelemetry/instrumentation-fs'
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis'
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
@@ -23,7 +24,6 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 
 import config from './config'
-import FsInstrumentation from '@opentelemetry/instrumentation-fs'
 
 const SERVICE_NAME = 'content-node'
 const SPID = config.get('spID')

--- a/creator-node/src/tracer.ts
+++ b/creator-node/src/tracer.ts
@@ -23,6 +23,7 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 
 import config from './config'
+import FsInstrumentation from '@opentelemetry/instrumentation-fs'
 
 const SERVICE_NAME = 'content-node'
 const SPID = config.get('spID')
@@ -83,6 +84,9 @@ export const setupTracing = () => {
 
       // Adds spans to redis operations
       new RedisInstrumentation(),
+
+      // Adds spans to filesystem operatioons
+      new FsInstrumentation(),
 
       // Injects traceid, spanid, and SpanContext into bunyan logs
       new BunyanInstrumentation({


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds `FsInstrumentation` to content node to get spans on filesystem operations.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Since it's just an extra instrumentation, I've just run integration tests to make sure it didn't break anything.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This PR will be monitored on spans in CloudTrace

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->