### PR TITLE
remove start time from slack alert

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -135,5 +135,5 @@ const msToTime = (duration: number) => {
   const minutesStr = (minutes < 10) ? "0" + minutes : minutes;
   const secondsStr = (seconds < 10) ? "0" + seconds : seconds;
 
-  return `${hoursStr}:${minutesStr}:${secondsStr}:${milliseconds.toString()}`
+  return `${hoursStr}hr ${minutesStr}min ${secondsStr}sec ${milliseconds.toString()}ms`
 }

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -73,7 +73,6 @@ export const generateMetrics = async (run_id: number) => {
 
   if (userCount > 0) {
     await publishSlackReport({
-      runStartTime: runStartTime.toString(),
       runDuration: msToTime(endTime - runStartTime.getTime()),
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -73,7 +73,6 @@ export const generateMetrics = async (run_id: number) => {
 
   if (userCount > 0) {
     await publishSlackReport({
-      runDuration: msToTime(endTime - runStartTime.getTime()),
       fullySyncedUsersCount:
         ((fullySyncedUsersCount / userCount) * 100).toFixed(2) + "%",
       partiallySyncedUsersCount:
@@ -86,6 +85,7 @@ export const generateMetrics = async (run_id: number) => {
         ((usersWithAllFoundationNodeReplicaSetCount / userCount) * 100).toFixed(
           2
         ) + "%",
+      runDuration: msToTime(endTime - runStartTime.getTime()),
     });
   }
 

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -126,14 +126,11 @@ const publishSlackReport = async (metrics: Object) => {
 };
 
 const msToTime = (duration: number) => {
-  const milliseconds = Math.floor((duration % 1000) / 100)
-  const seconds = Math.floor((duration / 1000) % 60)
   const minutes = Math.floor((duration / (1000 * 60)) % 60)
   const hours = Math.floor((duration / (1000 * 60 * 60)) % 24)
 
   const hoursStr = (hours < 10) ? "0" + hours : hours;
   const minutesStr = (minutes < 10) ? "0" + minutes : minutes;
-  const secondsStr = (seconds < 10) ? "0" + seconds : seconds;
 
-  return `${hoursStr}hr ${minutesStr}min ${secondsStr}sec ${milliseconds.toString()}ms`
+  return `${hoursStr}hr ${minutesStr}min`
 }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR remove the start time from the network monitoring slack alert since it isn't needed with "runDuration"

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Run a sample network monitoring job on staging


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

this will be monitored by our slack alerts in eng-network-monitoring-alerts

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->