### PR TITLE
INF-251 use set-tag for prod

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -468,36 +468,26 @@ def cli(
             # perform release
             # NOTE: `git pull` and `docker pull` write to stderr,
             # so we can't readily catch "errors"
-            if environment == "prod":
-                dry_run = True
-                ssh(
-                    host,
-                    "yes | audius-cli upgrade",
-                    show_output=True,
-                    exit_on_error=IGNORE,
-                    dry_run=dry_run,
-                )
-            else:
-                ssh(
-                    host,
-                    "yes | audius-cli pull",
-                    show_output=True,
-                    exit_on_error=IGNORE,
-                    dry_run=dry_run,
-                )
-                ssh(
-                    host,
-                    f"yes | audius-cli set-tag {git_tag}",
-                    show_output=True,
-                    dry_run=dry_run,
-                )
-                ssh(
-                    host,
-                    f"yes | audius-cli launch {service}",
-                    show_output=True,
-                    exit_on_error=IGNORE,
-                    dry_run=dry_run,
-                )
+            ssh(
+                host,
+                "yes | audius-cli pull",
+                show_output=True,
+                exit_on_error=IGNORE,
+                dry_run=dry_run,
+            )
+            ssh(
+                host,
+                f"yes | audius-cli set-tag {git_tag}",
+                show_output=True,
+                dry_run=dry_run,
+            )
+            ssh(
+                host,
+                f"yes | audius-cli launch {service}",
+                show_output=True,
+                exit_on_error=IGNORE,
+                dry_run=dry_run,
+            )
 
             release_summary["upgraded"].append(host)
         except:


### PR DESCRIPTION
### Description

Update our prod deployment flow to use correct commands.


### Tests

--dry-runs off `master`.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

CircleCI Logs

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->