### PR TITLE
[CON-389] Add decision trees to more flows [content node log cleanup pt 2]

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -19,6 +19,7 @@ const {
   issueSyncRequestsUntilSynced
 } = require('./services/stateMachineManager/stateReconciliation/stateReconciliationUtils')
 const { instrumentTracing, tracing } = require('./tracer')
+const DecisionTree = require('./utils/decisionTree')
 
 /**
  * Ensure valid cnodeUser and session exist for provided session token
@@ -543,170 +544,205 @@ async function getUserReplicaSetEndpointsFromDiscovery({
   ensurePrimary,
   myCnodeEndpoint
 }) {
-  logger.info(
-    `Starting getUserReplicaSetEndpointsFromDiscovery for wallet ${wallet}`
-  )
-  const start = Date.now()
+  const decisionTree = new DecisionTree({
+    name: `getUserReplicaSetEndpointsFromDiscovery`,
+    logger
+  })
+  let userReplicaSet
 
-  let user = null
+  try {
+    decisionTree.recordStage({
+      name: 'Starting getUserReplicaSetEndpointsFromDiscovery',
+      data: {
+        wallet,
+        blockNumber,
+        ensurePrimary,
+        myCnodeEndpoint
+      }
+    })
 
-  if (blockNumber) {
-    /**
-     * If blockNumber provided, polls discprov until it has indexed that blocknumber (for up to 200 seconds)
-     */
-    const start2 = Date.now()
+    let user = null
 
-    // In total, will try for 200 seconds.
-    const MaxRetries = 201
-    const RetryTimeout = 1000 // 1 seconds
+    if (blockNumber) {
+      /**
+       * If blockNumber provided, polls discprov until it has indexed that blocknumber (for up to 200 seconds)
+       */
+      decisionTree.recordStage({
+        name: 'Starting getUserReplicaSetEndpointsFromDiscovery blocknumber flow'
+      })
+      const start2 = Date.now()
 
-    let discprovBlockNumber = -1
-    for (let retry = 1; retry <= MaxRetries; retry++) {
-      logger.info(
-        `getUserReplicaSetEndpointsFromDiscovery retry #${retry}/${MaxRetries} || time from start: ${
-          Date.now() - start2
-        } discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`
-      )
+      // In total, will try for 200 seconds.
+      const MaxRetries = 201
+      const RetryTimeout = 1000 // 1 seconds
 
-      try {
-        const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
-
-        if (
-          !fetchedUser ||
-          fetchedUser.length === 0 ||
-          !fetchedUser[0].hasOwnProperty('blocknumber') ||
-          !fetchedUser[0].hasOwnProperty('track_blocknumber')
-        ) {
-          throw new Error('Missing or malformatted user fetched from discprov.')
-        }
-
-        user = fetchedUser
-        discprovBlockNumber = Math.max(
-          user[0].blocknumber,
-          user[0].track_blocknumber
+      let discprovBlockNumber = -1
+      for (let retry = 1; retry <= MaxRetries; retry++) {
+        logger.debug(
+          `getUserReplicaSetEndpointsFromDiscovery retry #${retry}/${MaxRetries} || time from start: ${
+            Date.now() - start2
+          } discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`
         )
 
-        if (discprovBlockNumber >= blockNumber) {
-          break
+        try {
+          const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
+
+          if (
+            !fetchedUser ||
+            fetchedUser.length === 0 ||
+            !fetchedUser[0].hasOwnProperty('blocknumber') ||
+            !fetchedUser[0].hasOwnProperty('track_blocknumber')
+          ) {
+            throw new Error(
+              'Missing or malformatted user fetched from discprov.'
+            )
+          }
+
+          user = fetchedUser
+          discprovBlockNumber = Math.max(
+            user[0].blocknumber,
+            user[0].track_blocknumber
+          )
+
+          if (discprovBlockNumber >= blockNumber) {
+            break
+          }
+        } catch (e) {
+          // Ignore all errors until MaxRetries exceeded.
+          logger.debug(e)
         }
-      } catch (e) {
-        // Ignore all errors until MaxRetries exceeded.
-        logger.info(e)
+
+        await utils.timeout(RetryTimeout)
+        logger.debug(
+          `getUserReplicaSetEndpointsFromDiscovery AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${
+            Date.now() - start2
+          } discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`
+        )
       }
 
-      await utils.timeout(RetryTimeout)
-      logger.info(
-        `getUserReplicaSetEndpointsFromDiscovery AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${
-          Date.now() - start2
-        } discprovBlockNumber ${discprovBlockNumber} || blockNumber ${blockNumber}`
-      )
-    }
-
-    // Error if discprov doesn't return any user for wallet
-    if (!user) {
-      throw new Error(
-        `Failed to retrieve user from discprov after ${MaxRetries} retries. Aborting.`
-      )
-    }
-
-    // Error if discprov has still not indexed to target blockNumber
-    if (discprovBlockNumber < blockNumber) {
-      throw new Error(
-        `Discprov still outdated after ${MaxRetries}. Discprov blocknumber ${discprovBlockNumber} requested blocknumber ${blockNumber}`
-      )
-    }
-  } else if (ensurePrimary && myCnodeEndpoint) {
-    /**
-     * Else if ensurePrimary required, polls discprov until it has indexed myCnodeEndpoint (for up to 60 seconds)
-     * Errors if retrieved primary does not match myCnodeEndpoint
-     */
-    logger.info(
-      `getUserReplicaSetEndpointsFromDiscovery || no blockNumber passed, retrying until DN returns same endpoint`
-    )
-
-    const start2 = Date.now()
-
-    // Will poll every sec for up to 1 minute (60 sec)
-    const MaxRetries = 61
-    const RetryTimeout = 1000 // 1 seconds
-
-    let returnedPrimaryEndpoint = null
-    for (let retry = 1; retry <= MaxRetries; retry++) {
-      logger.info(
-        `getUserReplicaSetEndpointsFromDiscovery retry #${retry}/${MaxRetries} || time from start: ${
-          Date.now() - start2
-        } myCnodeEndpoint ${myCnodeEndpoint}`
-      )
-
-      try {
-        const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
-
-        if (
-          !fetchedUser ||
-          fetchedUser.length === 0 ||
-          !fetchedUser[0].hasOwnProperty('creator_node_endpoint')
-        ) {
-          throw new Error('Missing or malformatted user fetched from discprov.')
-        }
-
-        user = fetchedUser
-        returnedPrimaryEndpoint = user[0].creator_node_endpoint.split(',')[0]
-
-        if (returnedPrimaryEndpoint === myCnodeEndpoint) {
-          break
-        }
-      } catch (e) {
-        // Ignore all errors until MaxRetries exceeded
-        logger.info(e)
+      // Error if discprov doesn't return any user for wallet
+      if (!user) {
+        throw new Error(
+          `Failed to retrieve user from discprov after ${MaxRetries} retries. Aborting.`
+        )
       }
 
-      await utils.timeout(RetryTimeout)
-      logger.info(
-        `getUserReplicaSetEndpointsFromDiscovery AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${
-          Date.now() - start2
-        } myCnodeEndpoint ${myCnodeEndpoint}`
-      )
+      // Error if discprov has still not indexed to target blockNumber
+      if (discprovBlockNumber < blockNumber) {
+        throw new Error(
+          `Discprov still outdated after ${MaxRetries}. Discprov blocknumber ${discprovBlockNumber} requested blocknumber ${blockNumber}`
+        )
+      }
+
+      decisionTree.recordStage({
+        name: 'Successfully retrieved user from discovery for blocknumber flow'
+      })
+    } else if (ensurePrimary && myCnodeEndpoint) {
+      /**
+       * Else if ensurePrimary required, polls discprov until it has indexed myCnodeEndpoint (for up to 60 seconds)
+       * Errors if retrieved primary does not match myCnodeEndpoint
+       */
+      decisionTree.recordStage({
+        name: 'Starting getUserReplicaSetEndpointsFromDiscovery ensurePrimary && myCnodeEndpoint flow'
+      })
+
+      const start2 = Date.now()
+
+      // Will poll every sec for up to 1 minute (60 sec)
+      const MaxRetries = 61
+      const RetryTimeout = 1000 // 1 seconds
+
+      let returnedPrimaryEndpoint = null
+      for (let retry = 1; retry <= MaxRetries; retry++) {
+        logger.debug(
+          `getUserReplicaSetEndpointsFromDiscovery retry #${retry}/${MaxRetries} || time from start: ${
+            Date.now() - start2
+          } myCnodeEndpoint ${myCnodeEndpoint}`
+        )
+
+        try {
+          const fetchedUser = await libs.User.getUsers(1, 0, null, wallet)
+
+          if (
+            !fetchedUser ||
+            fetchedUser.length === 0 ||
+            !fetchedUser[0].hasOwnProperty('creator_node_endpoint')
+          ) {
+            throw new Error(
+              'Missing or malformatted user fetched from discprov.'
+            )
+          }
+
+          user = fetchedUser
+          returnedPrimaryEndpoint = user[0].creator_node_endpoint.split(',')[0]
+
+          if (returnedPrimaryEndpoint === myCnodeEndpoint) {
+            break
+          }
+        } catch (e) {
+          // Ignore all errors until MaxRetries exceeded
+          logger.debug(e)
+        }
+
+        await utils.timeout(RetryTimeout)
+        logger.debug(
+          `getUserReplicaSetEndpointsFromDiscovery AFTER TIMEOUT retry #${retry}/${MaxRetries} || time from start: ${
+            Date.now() - start2
+          } myCnodeEndpoint ${myCnodeEndpoint}`
+        )
+      }
+
+      // Error if discprov doesn't return any user for wallet
+      if (!user) {
+        throw new Error(
+          `Failed to retrieve user from discprov after ${MaxRetries} retries. Aborting.`
+        )
+      }
+
+      // Error if discprov has still not returned own endpoint as primary
+      if (returnedPrimaryEndpoint !== myCnodeEndpoint) {
+        throw new Error(
+          `Discprov still hasn't returned own endpoint as primary after ${MaxRetries} retries. Discprov primary ${returnedPrimaryEndpoint} || own endpoint ${myCnodeEndpoint}`
+        )
+      }
+
+      decisionTree.recordStage({
+        name: 'Successfully retrieved user from discovery for ensurePrimary && myCnodeEndpoint flow'
+      })
+    } else {
+      /**
+       * If neither of above conditions are met, falls back to single discprov query without polling
+       */
+      decisionTree.recordStage({
+        name: 'Starting getUserReplicaSetEndpointsFromDiscovery default flow'
+      })
+      user = await libs.User.getUsers(1, 0, null, wallet)
+      decisionTree.recordStage({
+        name: 'Successfully retrieved user from discovery for default flow'
+      })
     }
 
-    // Error if discprov doesn't return any user for wallet
-    if (!user) {
+    if (
+      !user ||
+      user.length === 0 ||
+      !user[0].hasOwnProperty('creator_node_endpoint')
+    ) {
       throw new Error(
-        `Failed to retrieve user from discprov after ${MaxRetries} retries. Aborting.`
+        `Invalid return data from discovery provider for user with wallet ${wallet}`
       )
     }
 
-    // Error if discprov has still not returned own endpoint as primary
-    if (returnedPrimaryEndpoint !== myCnodeEndpoint) {
-      throw new Error(
-        `Discprov still hasn't returned own endpoint as primary after ${MaxRetries} retries. Discprov primary ${returnedPrimaryEndpoint} || own endpoint ${myCnodeEndpoint}`
-      )
-    }
-  } else {
-    /**
-     * If neither of above conditions are met, falls back to single discprov query without polling
-     */
-    logger.info(
-      `getUserReplicaSetEndpointsFromDiscovery || ensurePrimary === false, fetching user without retries`
-    )
-    user = await libs.User.getUsers(1, 0, null, wallet)
+    const endpoint = user[0].creator_node_endpoint
+    userReplicaSet = strToReplicaSet(endpoint || ',,')
+  } catch (e) {
+    decisionTree.recordStage({
+      name: 'getUserReplicaSetEndpointsFromDiscovery error',
+      data: { error: e.message }
+    })
+    throw e
+  } finally {
+    decisionTree.printTree()
   }
-
-  if (
-    !user ||
-    user.length === 0 ||
-    !user[0].hasOwnProperty('creator_node_endpoint')
-  ) {
-    throw new Error(
-      `Invalid return data from discovery provider for user with wallet ${wallet}`
-    )
-  }
-
-  const endpoint = user[0].creator_node_endpoint
-  const userReplicaSet = strToReplicaSet(endpoint || ',,')
-
-  logger.info(
-    `getUserReplicaSetEndpointsFromDiscovery route time ${Date.now() - start}`
-  )
   return userReplicaSet
 }
 

--- a/creator-node/src/resizeImage.js
+++ b/creator-node/src/resizeImage.js
@@ -7,6 +7,7 @@ const { logger: genericLogger } = require('./logging')
 const { libs } = require('@audius/sdk')
 const Utils = libs.Utils
 const DiskManager = require('./diskManager')
+const DecisionTree = require('./utils/decisionTree')
 
 const MAX_HEIGHT = 6000 // No image should be taller than this.
 const COLOR_WHITE = 0xffffffff
@@ -21,22 +22,23 @@ const MIME_TYPE_JPEG = 'image/jpeg'
  * @return {Buffer} the converted image
  * @dev TODO - replace with child node process bc need for speed
  */
-async function resizeImage(image, maxWidth, square, logger) {
+async function resizeImage(image, maxWidth, square, decisionTree) {
   let img = image.clone()
   // eslint-disable-next-line
   let exif
-  let time = Date.now()
-  logger.info(`resize image ${maxWidth} - start`)
+
+  decisionTree.recordStage({
+    name: `Start resizeImage for maxWidth: ${maxWidth}`,
+    data: {
+      maxWidth,
+      square
+    }
+  })
   try {
     exif = ExifParser.create(img).parse()
-    logger.info(`resize image ${maxWidth} - create time ${Date.now() - time}`)
-    time = Date.now()
   } catch (error) {
-    logger.error(error)
     exif = null
   }
-
-  logger.info(`resize image ${maxWidth} - read time ${Date.now() - time}`)
 
   img = _exifRotate(img, exif)
   img.background(COLOR_WHITE)
@@ -63,6 +65,9 @@ async function resizeImage(image, maxWidth, square, logger) {
 
   // Very high quality, decent size reduction
   img.quality(IMAGE_QUALITY)
+  decisionTree.recordStage({
+    name: `Finished resizeImage for maxWidth: ${maxWidth}`
+  })
 
   return img.getBufferAsync(MIME_TYPE_JPEG)
 }
@@ -108,72 +113,92 @@ module.exports = async (job) => {
   const { file, fileName, sizes, square, logContext } = job.data
   const logger = genericLogger.child(logContext)
 
-  // Read the image once, clone it later on
-  let img
+  const decisionTree = new DecisionTree({
+    name: `resizeImage`,
+    logger
+  })
+
   try {
-    img = await Jimp.read(file)
-  } catch (e) {
-    throw new Error(`Could not generate image buffer during image resize: ${e}`)
-  }
-
-  // Resize all the images
-  const resizes = await Promise.all(
-    Object.keys(sizes).map((size) => {
-      return resizeImage(img, sizes[size], square, logger)
-    })
-  )
-
-  // Compute multihash/CID of all the images, including the original
-  const toAdd = Object.keys(sizes).map((size, i) => {
-    return {
-      path: path.join(fileName, size),
-      content: resizes[i]
+    // Read the image once, clone it later on
+    let img
+    try {
+      img = await Jimp.read(file)
+    } catch (e) {
+      throw new Error(
+        `Could not generate image buffer during image resize: ${e}`
+      )
     }
-  })
-  const original = await img.getBufferAsync(MIME_TYPE_JPEG)
-  toAdd.push({
-    path: path.join(fileName, 'original.jpg'),
-    content: original
-  })
-  resizes.push(original)
 
-  const multihashes = await Utils.fileHasher.generateImageCids(toAdd)
-
-  // Write all the images to file storage and
-  // return the CIDs and storage paths to write to db
-  // in the main thread
-  const dirCID = multihashes[multihashes.length - 1].cid
-  const dirDestPath = DiskManager.computeFilePath(dirCID)
-
-  const resp = {
-    dir: { dirCID, dirDestPath },
-    files: []
-  }
-
-  // Create dir on disk
-  await fs.ensureDir(dirDestPath)
-
-  // Save all image file buffers to disk
-  try {
-    // Slice multihashes to remove dir entry at last index
-    const multihashesMinusDir = multihashes.slice(0, multihashes.length - 1)
-
-    await Promise.all(
-      multihashesMinusDir.map(async (multihash, i) => {
-        // Save file to disk
-        const destPath = DiskManager.computeFilePathInDir(dirCID, multihash.cid)
-        await fs.writeFile(destPath, resizes[i])
-
-        // Append saved file info to response object
-        resp.files.push({
-          multihash: multihash.cid,
-          sourceFile: multihash.path,
-          storagePath: destPath
-        })
+    // Resize all the images
+    const resizes = await Promise.all(
+      Object.keys(sizes).map((size) => {
+        return resizeImage(img, sizes[size], square, decisionTree)
       })
     )
+
+    // Compute multihash/CID of all the images, including the original
+    const toAdd = Object.keys(sizes).map((size, i) => {
+      return {
+        path: path.join(fileName, size),
+        content: resizes[i]
+      }
+    })
+    const original = await img.getBufferAsync(MIME_TYPE_JPEG)
+    toAdd.push({
+      path: path.join(fileName, 'original.jpg'),
+      content: original
+    })
+    resizes.push(original)
+
+    const multihashes = await Utils.fileHasher.generateImageCids(toAdd)
+
+    // Write all the images to file storage and
+    // return the CIDs and storage paths to write to db
+    // in the main thread
+    const dirCID = multihashes[multihashes.length - 1].cid
+    const dirDestPath = DiskManager.computeFilePath(dirCID)
+
+    const resp = {
+      dir: { dirCID, dirDestPath },
+      files: []
+    }
+
+    // Create dir on disk
+    await fs.ensureDir(dirDestPath)
+
+    // Save all image file buffers to disk
+    try {
+      // Slice multihashes to remove dir entry at last index
+      const multihashesMinusDir = multihashes.slice(0, multihashes.length - 1)
+
+      await Promise.all(
+        multihashesMinusDir.map(async (multihash, i) => {
+          // Save file to disk
+          const destPath = DiskManager.computeFilePathInDir(
+            dirCID,
+            multihash.cid
+          )
+          await fs.writeFile(destPath, resizes[i])
+
+          // Append saved file info to response object
+          resp.files.push({
+            multihash: multihash.cid,
+            sourceFile: multihash.path,
+            storagePath: destPath
+          })
+        })
+      )
+    } catch (e) {
+      throw new Error(`Failed to write files to disk after resizing ${e}`)
+    }
   } catch (e) {
-    throw new Error(`Failed to write files to disk after resizing ${e}`)
+    decisionTree.recordStage({
+      name: 'resizeImage error',
+      data: { error: e.message }
+    })
+    throw e
+  } finally {
+    decisionTree.printTree()
   }
 
   return Promise.resolve(resp)

--- a/creator-node/src/resizeImage.js
+++ b/creator-node/src/resizeImage.js
@@ -118,6 +118,8 @@ module.exports = async (job) => {
     logger
   })
 
+  let resp = null
+
   try {
     // Read the image once, clone it later on
     let img
@@ -158,7 +160,7 @@ module.exports = async (job) => {
     const dirCID = multihashes[multihashes.length - 1].cid
     const dirDestPath = DiskManager.computeFilePath(dirCID)
 
-    const resp = {
+    resp = {
       dir: { dirCID, dirDestPath },
       files: []
     }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Continue log reduction and cleanup work. Add decision trees to getUserReplicaSetEndpointsFromDiscovery middleware and resizeImage.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Has not been thoroughly tested yet. Tested via content node tests and mad dog. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Loggly

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->