### PR TITLE
Remove handle relay blocking logic

### DIFF
--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -815,6 +815,12 @@ const config = convict({
     format: String,
     env: 'stripeSecretKey',
     default: ''
+  },
+  skipAbuseCheck: {
+    doc: 'Skip AAO abuse check on relay and notifs',
+    format: Boolean,
+    env: 'skipAbuseCheck',
+    default: false
   }
 })
 


### PR DESCRIPTION
### Description

Had some issues with AAO integration:
- Was missing the required config for skipAbuseCheck, causing the recovery flow to get skipped
- Was incorrectly blocking users if they don't have a handle, which is to be expected early on in the signup flow

<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests

Tested on prod 😬 
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->