### PR TITLE
Add check for GCP DBs in check-secrets.sh

### DIFF
--- a/check_secrets.sh
+++ b/check_secrets.sh
@@ -14,5 +14,8 @@ git secrets --register-aws
 # rds urls
 git secrets --add '.*[a-z0-9]*.rds.amazonaws.com:[0-9]*\/.*'
 
+# match any postgres db with an IP hostname
+git secrets --add 'postgres:\/\/.*\:.*@([0-9]*\.?)*:[0-9]{4}\/.*'
+
 # scan the repository
 git secrets --scan --cached


### PR DESCRIPTION
### Description

Catch any string in the shape of `postgres://<username>:<password>@<ip address>:<port>/<db_name>`

Long term we should move to something like GitGuardian to get more robust secrets checking - our current system is overly tied to AWS.


### Tests

Tested against a bad string


<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->