### PR TITLE
INF-251 remove hold job for auto-deploying to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,10 +1016,7 @@ jobs:
         type: string
         default: ""
     steps:
-      - slack-basic:
-          channel: C03STD3UXMG
-          event: always
-          slack_mentions_user: "@joaquin"
+      - slack-basic
       - add_ssh_keys:
           fingerprints:
             # ~/.ssh/audius_infrastructure
@@ -1168,13 +1165,9 @@ jobs:
           command: |
             export SLACK_DETAIL=$(awk '{printf "%s\\n", $0}' /tmp/summary.md)
             echo "export SLACK_DETAIL='${SLACK_DETAIL}'" >> "$BASH_ENV"
-      - slack-fail:
-          channel: C03STD3UXMG
-          slack_mentions_user: "@joaquin"
+      - slack-fail
       - slack-success:
-          channel: C03STD3UXMG
           detail: ${SLACK_DETAIL}
-          slack_mentions_user: "@joaquin"
       - store_artifacts:
           path: /tmp/summary.md
           destination: summary.md

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,14 +1223,6 @@ workflows:
             # - test-sdk
 
       # Auto-deploy `master` to staging
-      - noop:
-          name: deploy-master-hold
-          type: approval
-          filters:
-            branches:
-              only: /(^master$)/
-          requires:
-            - built
       - deploy:
           name: 🚧-🏠
           service: all
@@ -1242,7 +1234,7 @@ workflows:
             branches:
               only: /(^master$)/
           requires:
-            - deploy-master-hold
+            - built
       # Force deploy `master` to staging (by service)
       - noop:
           name: 💪-🚧-🏠-<< matrix.service >>-🕹️


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Enable auto-deploying from master to staging (non-force).


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Wait until tomorrow morning and be highly aware of the first few commits.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Look at #eng-deploys-announcements.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->