### PR TITLE
[PAY-646] Prevent the adding of a premium track to playlist in DN indexing

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -269,10 +269,14 @@ def collect_entities_to_fetch(update_task, entity_manager_txs, metadata):
             # Add playlist track ids in entities to fetch
             # to prevent playlists from including premium tracks
             metadata_cid = helpers.get_tx_arg(event, "_metadata")
-            metadata = metadata[metadata_cid]
-            tracks = metadata.get("playlist_contents", {}).get("track_ids", [])
-            for track in tracks:
-                entities_to_fetch[EntityType.TRACK].add(track["track"])
+            if metadata_cid in metadata:
+                tracks = (
+                    metadata[metadata_cid]
+                    .get("playlist_contents", {})
+                    .get("track_ids", [])
+                )
+                for track in tracks:
+                    entities_to_fetch[EntityType.TRACK].add(track["track"])
 
     return entities_to_fetch
 

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -80,7 +80,9 @@ def entity_manager_update(
         )
 
         # collect events by entity type and action
-        entities_to_fetch = collect_entities_to_fetch(update_task, entity_manager_txs)
+        entities_to_fetch = collect_entities_to_fetch(
+            update_task, entity_manager_txs, metadata
+        )
 
         # fetch existing tracks and playlists
         existing_records: ExistingRecordDict = fetch_existing_entities(
@@ -244,10 +246,7 @@ def copy_original_records(existing_records):
 entity_types_to_fetch = set([EntityType.USER, EntityType.TRACK, EntityType.PLAYLIST])
 
 
-def collect_entities_to_fetch(
-    update_task,
-    entity_manager_txs,
-):
+def collect_entities_to_fetch(update_task, entity_manager_txs, metadata):
     entities_to_fetch: Dict[EntityType, Set] = defaultdict(set)
 
     for tx_receipt in entity_manager_txs:
@@ -261,11 +260,19 @@ def collect_entities_to_fetch(
             entities_to_fetch[EntityType.USER].add(user_id)
             action = helpers.get_tx_arg(event, "_action")
 
-            # Query follow operations as needed
+            # Query social operations as needed
             if action in action_to_record_type.keys():
                 record_type = action_to_record_type[action]
                 entity_key = get_record_key(user_id, entity_type, entity_id)
                 entities_to_fetch[record_type].add(entity_key)
+
+            # Add playlist track ids in entities to fetch
+            # to prevent playlists from including premium tracks
+            metadata_cid = helpers.get_tx_arg(event, "_metadata")
+            metadata = metadata[metadata_cid]
+            tracks = metadata.get("playlist_contents", {}).get("track_ids", [])
+            for track in tracks:
+                entities_to_fetch[EntityType.TRACK].add(track["track"])
 
     return entities_to_fetch
 

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -31,7 +31,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
 
     premium_tracks = list(
         filter(
-            lambda track: track["is_premium"],
+            lambda track: track.is_premium,
             params.existing_records[EntityType.TRACK].values(),
         )
     )

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -29,6 +29,15 @@ def validate_playlist_tx(params: ManageEntityParameters):
     if params.entity_type != EntityType.PLAYLIST:
         raise Exception(f"Entity type {params.entity_type} is not a playlist")
 
+    premium_tracks = list(
+        filter(
+            lambda track: track["is_premium"],
+            params.existing_records[EntityType.TRACK].values(),
+        )
+    )
+    if premium_tracks:
+        raise Exception("Cannot add premium tracks to playlist")
+
     if params.action == Action.CREATE:
         if playlist_id in params.existing_records[EntityType.PLAYLIST]:
             raise Exception(f"Cannot create playlist {playlist_id} that already exists")

--- a/discovery-provider/src/tasks/playlists.py
+++ b/discovery-provider/src/tasks/playlists.py
@@ -7,6 +7,7 @@ from src.challenges.challenge_event import ChallengeEvent
 from src.database_task import DatabaseTask
 from src.models.playlists.playlist import Playlist
 from src.models.playlists.playlist_route import PlaylistRoute
+from src.models.tracks.track import Track
 from src.queries.skipped_transactions import add_node_level_skipped_transaction
 from src.tasks.entity_manager.utils import PLAYLIST_ID_OFFSET
 from src.tasks.task_helpers import generate_slug_and_collision_id
@@ -124,6 +125,10 @@ def playlist_state_update(
                 playlist_event_types_lookup["playlist_track_added"]
                 in value_obj["events"]
             ):
+                # parse_playlist_event would have raised an exception if
+                # the playlist included premium tracks, so we're safe to dispatch
+                # this challenge event here.
+
                 challenge_bus.dispatch(
                     ChallengeEvent.first_playlist,
                     value_obj["playlist"].blocknumber,
@@ -281,6 +286,20 @@ def parse_playlist_event(
         playlist_record.is_private = event_args._isPrivate
         playlist_record.is_album = event_args._isAlbum
 
+        # Raise an exception if playlist includes premium tracks
+        premium_tracks = (
+            session.query(Track)
+            .filter(
+                Track.track_id.in_(event_args._trackIds),
+                Track.is_premium == True,
+                Track.is_current == True,
+                Track.is_delete == False,
+            )
+            .all()
+        )
+        if premium_tracks:
+            raise Exception("Cannot add premium tracks to playlist")
+
         playlist_content_array = []
         for track_id in event_args._trackIds:
             playlist_content_array.append(
@@ -297,6 +316,22 @@ def parse_playlist_event(
         playlist_record.is_delete = True
 
     if event_type == playlist_event_types_lookup["playlist_track_added"]:
+        track_id = event_args._addedTrackId
+
+        # Raise exception if track is premium
+        premium_track = (
+            session.query(Track)
+            .filter(
+                Track.track_id == track_id,
+                Track.is_premium == True,
+                Track.is_current == True,
+                Track.is_delete == False,
+            )
+            .one_or_none()
+        )
+        if premium_track:
+            raise Exception("Cannot add premium track to playlist")
+
         if getattr(playlist_record, "playlist_contents") is not None:
             logger.info(
                 f"index.py | playlists.py | Adding track {event_args._addedTrackId} to playlist \


### PR DESCRIPTION
### Description

When creating or updating a playlist, premium tracks cannot be included. This PR handles that, both in old indexing flow and entity manager.

### Tests

Not yet tested but going to... Will update this part afterwards.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Exceptions raised would be included in the logs.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->