### PR TITLE
Patch staging CN

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -299,13 +299,13 @@ const config = convict({
     doc: 'wallet address',
     format: String,
     env: 'oldDelegateOwnerWallet',
-    default: null
+    default: ''
   },
   oldDelegatePrivateKey: {
     doc: 'private key string',
     format: String,
     env: 'oldDelegatePrivateKey',
-    default: null
+    default: ''
   },
   solDelegatePrivateKeyBase64: {
     doc: 'Base64-encoded Solana private key created using delegatePrivateKey as the seed (auto-generated -- any input here will be overwritten)',

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -362,12 +362,6 @@ const config = convict({
     env: 'spOwnerWallet',
     default: null
   },
-  oldSpOwnerWallet: {
-    doc: 'Service provider owner wallet',
-    format: String,
-    env: 'oldSpOwnerWallet',
-    default: null
-  },
   ethWallets: {
     doc: 'all unlocked accounts from eth chain',
     format: Array,

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -294,6 +294,19 @@ const config = convict({
     env: 'delegatePrivateKey',
     default: null
   },
+  // wallet information
+  oldDelegateOwnerWallet: {
+    doc: 'wallet address',
+    format: String,
+    env: 'oldDelegateOwnerWallet',
+    default: null
+  },
+  oldDelegatePrivateKey: {
+    doc: 'private key string',
+    format: String,
+    env: 'oldDelegatePrivateKey',
+    default: null
+  },
   solDelegatePrivateKeyBase64: {
     doc: 'Base64-encoded Solana private key created using delegatePrivateKey as the seed (auto-generated -- any input here will be overwritten)',
     format: String,
@@ -347,6 +360,12 @@ const config = convict({
     doc: 'Service provider owner wallet',
     format: String,
     env: 'spOwnerWallet',
+    default: null
+  },
+  oldSpOwnerWallet: {
+    doc: 'Service provider owner wallet',
+    format: String,
+    env: 'oldSpOwnerWallet',
     default: null
   },
   ethWallets: {

--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -120,10 +120,12 @@ class URSMRegistrationManager {
       )
     ).delegateOwnerWallet.toLowerCase()
 
+    this.logError(`oldDelegateOwnerWallet: ${this.oldDelegateOwnerWallet.toLowerCase()} // delegateOwnerWalletFromURSM: ${delegateOwnerWalletFromURSM}`)
+
     /**
      * 2-a. Short-circuit if L2 record for node already matches L1 record (i.e. delegateOwnerWallets match)
      */
-    if (this.oldDelegateOwnerWallet === delegateOwnerWalletFromURSM) {
+    if (this.oldDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM) {
       // Update config
       this.nodeConfig.set('isRegisteredOnURSM', true)
 

--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -120,12 +120,16 @@ class URSMRegistrationManager {
       )
     ).delegateOwnerWallet.toLowerCase()
 
-    this.logError(`oldDelegateOwnerWallet: ${this.oldDelegateOwnerWallet.toLowerCase()} // delegateOwnerWalletFromURSM: ${delegateOwnerWalletFromURSM}`)
+    this.logError(
+      `oldDelegateOwnerWallet: ${this.oldDelegateOwnerWallet.toLowerCase()} // delegateOwnerWalletFromURSM: ${delegateOwnerWalletFromURSM}`
+    )
 
     /**
      * 2-a. Short-circuit if L2 record for node already matches L1 record (i.e. delegateOwnerWallets match)
      */
-    if (this.oldDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM) {
+    if (
+      this.oldDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM
+    ) {
       // Update config
       this.nodeConfig.set('isRegisteredOnURSM', true)
 

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -13,8 +13,7 @@ module.exports = async ({
   enableContracts = true,
   enableDiscovery = true,
   enableIdentity = true,
-  logger = genericLogger,
-  delegatePrivateKeyOverride
+  logger = genericLogger
 }) => {
   /**
    * Define all config variables
@@ -33,7 +32,6 @@ module.exports = async ({
   const ethOwnerWallet = config.get('ethOwnerWallet')
   const dataRegistryAddress = config.get('dataRegistryAddress')
   const dataProviderUrl = config.get('dataProviderUrl')
-  const delegatePrivateKey = config.get('delegatePrivateKey')
   const oldDelegatePrivateKey = config.get('oldDelegatePrivateKey')
   const creatorNodeIsDebug = config.get('creatorNodeIsDebug')
 

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -13,7 +13,8 @@ module.exports = async ({
   enableContracts = true,
   enableDiscovery = true,
   enableIdentity = true,
-  logger = genericLogger
+  logger = genericLogger,
+  delegatePrivateKeyOverride
 }) => {
   /**
    * Define all config variables
@@ -33,6 +34,7 @@ module.exports = async ({
   const dataRegistryAddress = config.get('dataRegistryAddress')
   const dataProviderUrl = config.get('dataProviderUrl')
   const delegatePrivateKey = config.get('delegatePrivateKey')
+  const oldDelegatePrivateKey = config.get('oldDelegatePrivateKey')
   const creatorNodeIsDebug = config.get('creatorNodeIsDebug')
 
   const discoveryProviderWhitelist = discoveryProviderWhitelistConfig
@@ -72,7 +74,7 @@ module.exports = async ({
           // pass as array
           [dataProviderUrl],
           // TODO - formatting this private key here is not ideal
-          delegatePrivateKey.replace('0x', '')
+          oldDelegatePrivateKey.replace('0x', '')
         )
       : null,
     discoveryProviderConfig: enableDiscovery

--- a/creator-node/src/services/initAudiusLibs.js
+++ b/creator-node/src/services/initAudiusLibs.js
@@ -32,6 +32,7 @@ module.exports = async ({
   const ethOwnerWallet = config.get('ethOwnerWallet')
   const dataRegistryAddress = config.get('dataRegistryAddress')
   const dataProviderUrl = config.get('dataProviderUrl')
+  const delegatePrivateKey = config.get('delegatePrivateKey')
   const oldDelegatePrivateKey = config.get('oldDelegatePrivateKey')
   const creatorNodeIsDebug = config.get('creatorNodeIsDebug')
 
@@ -72,7 +73,7 @@ module.exports = async ({
           // pass as array
           [dataProviderUrl],
           // TODO - formatting this private key here is not ideal
-          oldDelegatePrivateKey.replace('0x', '')
+          (oldDelegatePrivateKey || delegatePrivateKey).replace('0x', '')
         )
       : null,
     discoveryProviderConfig: enableDiscovery


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Due to Goerli eth migration, the delegate owner wallet values for content nodes on EthContracts
To fix this, we add new envvars, only meant to be used on staging

**NOTE: this means no new nodes can be registered on staging until entity manager migration (this is fine)**

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tests pass - this is already running on staging, maddog confirms local dev unaffected, and prod will be unaffected as long as it never sets the oldDelegateOwnerWallet / oldDelegatePrivateKey values

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

All registered content nodes should show `"isRegisteredOnURSM": true` in health check

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->