### PR TITLE
INF-251 don't send Starting nor Success slack messages for auto-deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,7 +1016,14 @@ jobs:
         type: string
         default: ""
     steps:
-      - slack-basic
+      # only send Starting slack message when prod and/or --force
+      - when:
+          condition:
+            or:
+              - equal: [ prod, << parameters.environment >> ]
+              - << parameters.params >>
+          steps:
+            - slack-basic
       - add_ssh_keys:
           fingerprints:
             # ~/.ssh/audius_infrastructure
@@ -1166,8 +1173,15 @@ jobs:
             export SLACK_DETAIL=$(awk '{printf "%s\\n", $0}' /tmp/summary.md)
             echo "export SLACK_DETAIL='${SLACK_DETAIL}'" >> "$BASH_ENV"
       - slack-fail
-      - slack-success:
-          detail: ${SLACK_DETAIL}
+      # only send Success slack message when prod and/or --force
+      - when:
+          condition:
+            or:
+              - equal: [ prod, << parameters.environment >> ]
+              - << parameters.params >>
+          steps:
+            - slack-success:
+                detail: ${SLACK_DETAIL}
       - store_artifacts:
           path: /tmp/summary.md
           destination: summary.md

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,12 +1016,13 @@ jobs:
         type: string
         default: ""
     steps:
-      # only send Starting slack message when prod and/or --force
+      # only send Starting slack message when prod, --force, or custom args are used
       - when:
           condition:
             or:
               - equal: [ prod, << parameters.environment >> ]
               - << parameters.params >>
+              - << parameters.deploy_args >>
           steps:
             - slack-basic
       - add_ssh_keys:
@@ -1173,12 +1174,13 @@ jobs:
             export SLACK_DETAIL=$(awk '{printf "%s\\n", $0}' /tmp/summary.md)
             echo "export SLACK_DETAIL='${SLACK_DETAIL}'" >> "$BASH_ENV"
       - slack-fail
-      # only send Success slack message when prod and/or --force
+      # only send Success slack message when prod, --force, or custom args are used
       - when:
           condition:
             or:
               - equal: [ prod, << parameters.environment >> ]
               - << parameters.params >>
+              - << parameters.deploy_args >>
           steps:
             - slack-success:
                 detail: ${SLACK_DETAIL}


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Always send Slack notifications when:

* "taking over" a node
* deploying to production
* using custom params
* a deployment failed, in all cases


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Monitoring #eng-deploys-announcements


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Same as above.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->