### PR TITLE
Only show diff in libs folder between versions

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -21,7 +21,7 @@ function git-changelog () {
     release_commit=${1}
 
     # Print the log as "- <commmiter short date> [<commit short hash>] <commit message> <author name>"
-    git log --pretty=format:"- %cd [%h] %s [%an]" --date=short $release_commit..HEAD
+    git log --pretty=format:"- %cd [%h] %s [%an]" --date=short $release_commit..HEAD libs
 }
 
 # formats a commit message using the bumped ${VERSION} and ${CHANGE_LOG}


### PR DESCRIPTION
### Description

Only show diff in libs folder between versions

### Tests

Tested the command manually and showed that it only shows the commits that have libs changes.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Will monitor the changelog on the next libs release

================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->