### PR TITLE
search: boost exact track title match

### DIFF
--- a/discovery-provider/scripts/search_quality.py
+++ b/discovery-provider/scripts/search_quality.py
@@ -33,14 +33,26 @@ Here is what I do:
 
     PYTHONPATH=. python scripts/search_quality.py 
 
+If you want to focus on a specific search, specify a filter as second arg:
 
+    PYTHONPATH=. python scripts/search_quality.py stereo
 
 """
 
+import sys
+
 from src.queries.search_es import search_es_full
+
+filter = ""
+if len(sys.argv) == 2:
+    filter = sys.argv[1].lower()
+    print("filter:", filter)
 
 
 def test_search(args, asserts=None):
+    if filter and filter not in args["query"].lower():
+        return
+
     print("\n\n==========", args)
     found = search_es_full(args)
     search_type = args.get("kind", "all")
@@ -230,6 +242,19 @@ test_search(
     {
         "tracks": ["Sunny Side of the Street stereosteve stereosteve"],
         "saved_tracks": ["Sunny Side of the Street stereosteve stereosteve"],
+    },
+)
+
+test_search(
+    {
+        "query": "guitar garbage",
+        "limit": 4,
+        "current_user_id": 1,
+        "is_auto_complete": True,
+    },
+    {
+        # still comes in second place... but I'm okay with that :(
+        # "tracks": ["Guitar Garbage stereosteve stereosteve"],
     },
 )
 

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -387,6 +387,14 @@ def track_dsl(
         ],
         "should": [
             *base_match(search_str, operator="and"),
+            {
+                "match": {
+                    "title.searchable": {
+                        "query": search_str,
+                        "minimum_should_match": "100%",
+                    },
+                }
+            },
         ],
     }
 


### PR DESCRIPTION
### Description

* improves search_quality.py tool
* adds a `should` that will boost exact track title match (when all query terms are in track title)


### Tests

ran search_quality.py
testing on sandbox env
