### PR TITLE
INF-259 only allow one parallel deployment per host at a time

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -572,9 +572,7 @@ def cli(
             output = ssh(host, "cat /tmp/deploy.lock", exit_on_error=RAISE)
             if output != deployment_id:
                 release_summary[UPDATE_IN_PROGRESS].append(host)
-                logger.error(
-                    f"{host} is now being upgraded by another deployment job."
-                )
+                logger.error(f"{host} is now being upgraded by another deployment job.")
                 continue
 
             # log additional information


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Use the file `/tmp/deploy.lock` to ensure we're only ever running one deployment on a host at any given time.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Local --dry-runs with manually created `/tmp/deploy.lock` on staging nodes.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Keep an eye out for failed deployment jobs in #eng-deploys-announcements.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->