### PR TITLE
INF-259 Alert more often in #eng-deploys-announcements

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -644,7 +644,11 @@ def cli(
     format_artifacts(release_summary=release_summary)
 
     # report back to CircleCI that this deployment has failed
-    if release_summary["failed_post_check"]:
+    if (
+        release_summary["failed_post_check"]
+        or release_summary[FAILED_TO_SSH]
+        or release_summary["failed"]
+    ):
         exit(1)
 
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

We'll start sending failed Slack notifications more often when:

* A production post-health check fails (currently implemented).
* We're unable to SSH into a machine. (+1 vote from me).
* We failed to release to any staging or production node. (+1 vote from me, but we can also limit to only failed releases to production nodes).


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

None.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys-announcements

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->