### PR TITLE
INF-272 Replace noop jobs with new release-scripts jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1225,7 +1225,7 @@ jobs:
       - image: cimg/go:1.17
     parameters:
       target:
-        description: REQUIRED. Name of the script, without .sh, like bump-hotfix or cut-release
+        description: Name of the script, without .sh, like bump-hotfix or cut-release
         type: enum
         enum: [cut-release, bump-hotfix, release-to-service-providers, execute-proposal]
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1239,6 +1239,7 @@ jobs:
       - run: |
           git clone git@github.com:AudiusProject/audius-tooling.git --branch jc-inf-246
           audius-tooling/release-scripts/<< parameters.target >>.sh
+      - slack-fail
       - when:
           condition:
             equal: [ release-to-service-providers, << parameters.target >> ]
@@ -1247,6 +1248,12 @@ jobs:
                 text: ":gift: Deployment Released to Service Providers! :tada:"
                 detail: "New Governance Proposals are out. :vote:"
                 slack_mentions_user: "@Dheeraj @ray @roneil @Forrest "
+      - when:
+          condition:
+            equal: [ execute-proposal, << parameters.target >> ]
+          steps:
+            - slack-success:
+                text: "Governance Proposal has been executed! :done:"
 
 workflows:
   workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1247,7 +1247,7 @@ jobs:
             - slack-success:
                 text: ":gift: Deployment Released to Service Providers! :tada:"
                 detail: "New Governance Proposals are out. :vote:"
-                slack_mentions_user: "@Dheeraj @ray @roneil @Forrest "
+                slack_mentions_user: "@Dheeraj @ray @roneil @Forrest"
       - when:
           condition:
             equal: [ execute-proposal, << parameters.target >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1239,6 +1239,14 @@ jobs:
       - run: |
           git clone git@github.com:AudiusProject/audius-tooling.git --branch jc-inf-246
           audius-tooling/release-scripts/<< parameters.target >>.sh
+      - when:
+          condition:
+            equal: [ release-to-service-providers, << parameters.target >> ]
+          steps:
+            - slack-success:
+                text: ":gift: Deployment Released to Service Providers! :tada:"
+                detail: "New Governance Proposals are out. :vote:"
+                slack_mentions_user: "@Dheeraj @ray @roneil @Forrest "
 
 workflows:
   workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1242,10 +1242,16 @@ jobs:
       - slack-fail
       - when:
           condition:
+            equal: [ cut-release, << parameters.target >> ]
+          steps:
+            - slack-success:
+                text: "Release branch has been cut! :git-fork:"
+      - when:
+          condition:
             equal: [ release-to-service-providers, << parameters.target >> ]
           steps:
             - slack-success:
-                text: ":gift: Deployment Released to Service Providers! :tada:"
+                text: "Deployment Released to Service Providers! :gift:"
                 detail: "New Governance Proposals are out. :vote:"
                 slack_mentions_user: "@Dheeraj @ray @roneil @Forrest"
       - when:
@@ -1431,6 +1437,9 @@ workflows:
       - release-scripts:
           name: cut-release
           target: cut-release
+          context:
+            - slack-secrets
+            - gh-tokens.releases
           requires:
             - cut-release-🕹️
 
@@ -1520,6 +1529,9 @@ workflows:
       - release-scripts:
           name: bump-hotfix
           target: bump-hotfix
+          context:
+            - slack-secrets
+            - gh-tokens.releases
           filters:
             branches:
               only: /(^release-v\d*.\d*.\d*$)/
@@ -1591,6 +1603,9 @@ workflows:
       - release-scripts:
           name: 🚧-🎁-to-SPs
           target: release-to-service-providers
+          context:
+            - slack-secrets
+            - gh-tokens.releases
           requires:
             - 🚧-🎁-to-SPs-🕹️
       # Execute Governance Proposal (for release branches)
@@ -1605,6 +1620,8 @@ workflows:
       - release-scripts:
           name: execute-proposal
           target: execute-proposal
+          context:
+            - slack-secrets
           requires:
             - execute-proposal-🕹️
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1226,8 +1226,8 @@ jobs:
     parameters:
       target:
         description: REQUIRED. Name of the script, without .sh, like bump-hotfix or cut-release
-        type: string
-        default: ""
+        type: enum
+        enum: [cut-release, bump-hotfix, release-to-service-providers, execute-proposal]
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1515,7 +1515,7 @@ workflows:
             branches:
               only: /(^release-v\d*.\d*.\d*$)/
           requires:
-            - bump-hotfix-tags
+            - bump-hotfix
       - deploy:
           name: 🚧-🎁-to-dn-prod
           git_tag: ${CIRCLE_SHA1}
@@ -1535,7 +1535,7 @@ workflows:
             branches:
               only: /(^release-v\d*.\d*.\d*$)/
           requires:
-            - bump-hotfix-tags
+            - bump-hotfix
       - deploy:
           name: 🚧-🎁-to-is-prod
           git_tag: ${CIRCLE_SHA1}
@@ -1569,7 +1569,7 @@ workflows:
             branches:
               only: /(^release-v\d*.\d*.\d*$)/
           requires:
-            - bump-hotfix-tags
+            - bump-hotfix
       - release-scripts:
           name: 🚧-🎁-to-SPs
           target: release-to-service-providers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,9 @@ jobs:
   noop:
     docker:
       - image: alpine
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - run: echo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,9 +286,6 @@ jobs:
   noop:
     docker:
       - image: alpine
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASS
     steps:
       - run: echo
 
@@ -1220,6 +1217,26 @@ jobs:
             sudo killall openvpn || true
           when: always
 
+  release-scripts:
+    docker:
+      - image: cimg/go:1.17
+    parameters:
+      target:
+        description: REQUIRED. Name of the script, without .sh, like bump-hotfix or cut-release
+        type: string
+        default: ""
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            # github.com
+            - "d0:0b:a0:19:ac:46:58:e4:6c:ac:34:99:f6:1b:31:bb"
+      - setup_remote_docker:
+          version: 20.10.14
+          docker_layer_caching: true
+      - run: |
+          git clone git@github.com:AudiusProject/audius-tooling.git --branch jc-inf-246
+          audius-tooling/release-scripts/<< parameters.target >>.sh
+
 workflows:
   workflows:
     when:
@@ -1393,8 +1410,9 @@ workflows:
               only: /(^master$)/
           requires:
             - verified
-      - noop:
+      - release-scripts:
           name: cut-release
+          target: cut-release
           requires:
             - cut-release-🕹️
 
@@ -1481,8 +1499,9 @@ workflows:
             - 💪-🚧-🌿-<< matrix.host >>-🕹️
 
       # Bump Tags (for release branch hot-fixes)
-      - noop:
-          name: bump-hotfix-tags
+      - release-scripts:
+          name: bump-hotfix
+          target: bump-hotfix
           filters:
             branches:
               only: /(^release-v\d*.\d*.\d*$)/
@@ -1551,9 +1570,9 @@ workflows:
               only: /(^release-v\d*.\d*.\d*$)/
           requires:
             - bump-hotfix-tags
-      - noop:
-          # ensure Slack pings Dheeraj, Ray, Roneil, Forrest
+      - release-scripts:
           name: 🚧-🎁-to-SPs
+          target: release-to-service-providers
           requires:
             - 🚧-🎁-to-SPs-🕹️
       # Execute Governance Proposal (for release branches)
@@ -1565,8 +1584,9 @@ workflows:
               only: /(^release-v\d*.\d*.\d*$)/
           requires:
             - 🚧-🎁-to-SPs
-      - noop:
+      - release-scripts:
           name: execute-proposal
+          target: execute-proposal
           requires:
             - execute-proposal-🕹️
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Replace no-op job placeholders with a new release-scripts job that calls `audius-tooling/release-scripts/*.sh`


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


Will confirm cut-release.sh can get to the last steps before breaking. Will then update `gh-tokens.releases` to use a non-noop token when dry run looks good on Monday.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Look at dry runs of release-scripts, which don't currently push changes to our git repos. Some success messages and all failures will hit #eng-deploys-announcements.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->