### PR TITLE
INF-266 reroute nginx paths to new prometheus exporter sidecar containers

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -96,6 +96,12 @@ http {
             add_header X-Cache-Status $upstream_cache_status always;
         }
 
+        location /prometheus/postgres {
+            proxy_pass http://127.0.0.1:9187;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         # Pass all other requests to upstream server
         location / {
             proxy_pass http://127.0.0.1:3000;

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -68,6 +68,24 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location /prometheus/postgres {
+            proxy_pass http://127.0.0.1:9187;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/postgres_readonly {
+            proxy_pass http://127.0.0.1:9188;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/elasticsearch {
+            proxy_pass http://127.0.0.1:9114;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         # Do not redirect any /v1/challenges/... requests, which need to resolve
         # to the node that the request was intended for. Selection of
         # nodes to respond to challenge attestations is intentional.


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Since we're adding new Prometheus exporter sidecar containers, and we're restricted to only one open port per node, we'll use nginx to re-route our request to the local IP:port of the exporter.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

TBD.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->