### PR TITLE
INF-277 Create --dry-run jobs for foundation content nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1530,18 +1530,31 @@ workflows:
             - 🚧-🎁-to-is-prod-🕹️
       # Deploy Creator Nodes to prod (for release branches)
       - noop:
-          name: 🚧-🎁-to-cn-prod-🕹️
+          name: 🚧-🎁-to-<< matrix.host >>-prod-🕹️
           type: approval
           filters:
             branches:
               only: /(^release-v.*-patch-.*$)/
+          matrix:
+            parameters:
+              host: [prod-creator-1, prod-creator-2, prod-creator-3, prod-creator-4, prod-creator-5, user-metadata]
           requires:
             - built
-      # no-op currently since Content Nodes have manual version patching
-      - noop:
-          name: 🚧-🎁-to-cn-prod
+      - deploy:
+          name: 🚧-🎁-to-<< matrix.host >>-prod
+          git_tag: ${CIRCLE_SHA1}
+          environment: prod
+          service: creator
+          params: --dry-run
+          context:
+            - slack-secrets
+            - gh-tokens
+            - open-vpn
+          matrix:
+            parameters:
+              host: [prod-creator-1, prod-creator-2, prod-creator-3, prod-creator-4, prod-creator-5, user-metadata]
           requires:
-            - 🚧-🎁-to-cn-prod-🕹️
+            - 🚧-🎁-to-<< matrix.host >>-prod-🕹️
       # Deploy to SPs (update audius-docker-compose + create/vote governance proposal, for release branches)
       - noop:
           name: 🚧-🎁-to-SPs-🕹️


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Change layout of `release-*-patch-*` workflows to only allow deploying content nodes per host.

While we're moving away from the noop job, we will continue to use `--dry-run` for the time being.

New workflow:

* https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/28491/workflows/31c1163e-31be-493f-af37-6735c00bd133


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Run through a few tests using a release


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->