### PR TITLE
INF-242 Fix Gauge metrics for health-check metrics. Add basic Summary support.

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -406,12 +406,25 @@ def get_elasticsearch_health_info(
 def health_check_prometheus_exporter():
     health_results, is_unhealthy = get_health({})
 
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_BLOCK_DIFFERENCE_LATEST).save(
-        health_results["block_difference"]
+    # store all top-level keys with numerical values
+    for key, value in health_results.items():
+        if isinstance(value, (int, float)):
+            PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK).save(
+                value, {"key": key}
+            )
+
+    # store a non-top-level key
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK).save(
+        health_results["web"]["blocknumber"], {"key": "blocknumber"}
     )
 
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_INDEXED_BLOCK_NUM_LATEST).save(
-        health_results["web"]["blocknumber"]
+    # store non-numeric key-value information
+    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_INFO).save(
+        {
+            "git": health_results["git"],
+            "version": health_results["version"],
+            "meets_min_requirements": health_results["meets_min_requirements"],
+        }
     )
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -418,15 +418,6 @@ def health_check_prometheus_exporter():
         health_results["web"]["blocknumber"], {"key": "blocknumber"}
     )
 
-    # store non-numeric key-value information
-    PrometheusMetric(PrometheusMetricNames.HEALTH_CHECK_INFO).save(
-        {
-            "git": health_results["git"],
-            "version": health_results["version"],
-            "meets_min_requirements": health_results["meets_min_requirements"],
-        }
-    )
-
 
 PrometheusMetric.register_collector(
     "health_check_prometheus_exporter", health_check_prometheus_exporter

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -179,7 +179,6 @@ def entity_manager_update(
                     logger.info(
                         f"entity_manager.py | failed to process tx error {e} | with event {event}"
                     )
-                    # test
                     metric_num_errors.save_time(
                         {"entity_type": params.entity_type}, start_time=start_time_tx
                     )
@@ -206,7 +205,6 @@ def entity_manager_update(
         num_total_changes += len(records_to_save)
 
         # update metrics
-        # test
         metric_latency.save_time()
         metric_num_changed.save(
             len(new_records["playlists"]), {"entity_type": EntityType.PLAYLIST.value}

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -179,6 +179,7 @@ def entity_manager_update(
                     logger.info(
                         f"entity_manager.py | failed to process tx error {e} | with event {event}"
                     )
+                    # test
                     metric_num_errors.save_time(
                         {"entity_type": params.entity_type}, start_time=start_time_tx
                     )
@@ -205,6 +206,7 @@ def entity_manager_update(
         num_total_changes += len(records_to_save)
 
         # update metrics
+        # test
         metric_latency.save_time()
         metric_num_changed.save(
             len(new_records["playlists"]), {"entity_type": EntityType.PLAYLIST.value}

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -3,7 +3,7 @@ from functools import wraps
 from time import time
 from typing import Callable, Dict
 
-from prometheus_client import Histogram, Info, Summary
+from prometheus_client import Histogram, Summary
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +100,6 @@ class PrometheusMetricNames:
     CELERY_TASK_LAST_DURATION_SECONDS = "celery_task_last_duration_seconds"
     FLASK_ROUTE_DURATION_SECONDS = "flask_route_duration_seconds"
     HEALTH_CHECK = "health_check"
-    HEALTH_CHECK_INFO = "health_check_info"
     INDEX_BLOCKS_DURATION_SECONDS = "index_blocks_duration_seconds"
     INDEX_METRICS_DURATION_SECONDS = "index_metrics_duration_seconds"
     INDEX_TRENDING_DURATION_SECONDS = "index_trending_duration_seconds"
@@ -128,7 +127,6 @@ Metric Types:
     * When looking at the raw /prometheus_metrics endpoint for
       `audius_dn_update_aggregate_table_latency_seconds_bucket`, you can see how a
       single metric explodes into multiple statistical helpers.
-* Prometheus Info: Info tracks key-value information, usually about a whole target.
 
 Labels:
 
@@ -178,10 +176,6 @@ PrometheusRegistry = {
     PrometheusMetricNames.HEALTH_CHECK: Summary(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK}",
         "Difference between the latest block and the latest indexed block",
-    ),
-    PrometheusMetricNames.HEALTH_CHECK_INFO: Info(
-        f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK_INFO}",
-        "Stores text based info",
         ("key",),
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
@@ -269,15 +263,11 @@ class PrometheusMetric:
         this_metric = self.metric
         if labels:
             this_metric = this_metric.labels(**labels)
-        logger.warn(labels)
-        logger.info(type(this_metric))
         if isinstance(this_metric, Histogram):
             # this_metric.observe(value, labels)
             this_metric.observe(value)
         elif isinstance(this_metric, Summary):
             this_metric.observe(value)
-        elif isinstance(this_metric, Info):
-            this_metric.info(value)
 
     @classmethod
     def register_collector(cls, name, collector_func):

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -146,10 +146,11 @@ A few example labels:
 * `task_name` when similar CeleryTasks use the same helper code from different callers
 """
 PrometheusRegistry = {
-    PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Summary(
+    PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",
         "How long the currently running celery task has been running",
         ("task_name",),
+        multiprocess_mode='liveall',
     ),
     PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS}",
@@ -159,7 +160,7 @@ PrometheusRegistry = {
             "success",
         ),
     ),
-    PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS: Summary(
+    PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_LAST_DURATION_SECONDS}",
         "How long the last celery_task ran",
         (
@@ -175,10 +176,11 @@ PrometheusRegistry = {
             "route",
         ),
     ),
-    PrometheusMetricNames.HEALTH_CHECK: Summary(
+    PrometheusMetricNames.HEALTH_CHECK: Gauge(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK}",
         "Metrics extracted from our health-checks, using similar keys.",
         ("key",),
+        multiprocess_mode='liveall',
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS}",
@@ -266,8 +268,7 @@ class PrometheusMetric:
         if labels:
             this_metric = this_metric.labels(**labels)
         if isinstance(this_metric, Histogram):
-            # this_metric.observe(value, labels)
-            this_metric.observe(value)
+            this_metric.observe(value, labels)
         elif isinstance(this_metric, Gauge):
             this_metric.set(value)
         elif isinstance(this_metric, Summary):

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -175,7 +175,7 @@ PrometheusRegistry = {
     ),
     PrometheusMetricNames.HEALTH_CHECK: Summary(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK}",
-        "Difference between the latest block and the latest indexed block",
+        "Metrics extracted from our health-checks, using similar keys.",
         ("key",),
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(

--- a/discovery-provider/src/utils/prometheus_metric.py
+++ b/discovery-provider/src/utils/prometheus_metric.py
@@ -150,7 +150,7 @@ PrometheusRegistry = {
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_ACTIVE_DURATION_SECONDS}",
         "How long the currently running celery task has been running",
         ("task_name",),
-        multiprocess_mode='liveall',
+        multiprocess_mode="liveall",
     ),
     PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.CELERY_TASK_DURATION_SECONDS}",
@@ -180,7 +180,7 @@ PrometheusRegistry = {
         f"{METRIC_PREFIX}_{PrometheusMetricNames.HEALTH_CHECK}",
         "Metrics extracted from our health-checks, using similar keys.",
         ("key",),
-        multiprocess_mode='liveall',
+        multiprocess_mode="liveall",
     ),
     PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS: Histogram(
         f"{METRIC_PREFIX}_{PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS}",


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Export the majority of our health-check metrics using Gauges that do not report metrics from dead pids.

For some of our existing Gauges, where the use case aligns, we will now only keep track of metrics of live processes using:

```
multiprocess_mode="liveall"
```

#### Background

Prometheus Gauges within the official Python driver do not work as assumed when running in a multiprocess environment:

* Section 4: https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
* Examples/tests in action: https://github.com/prometheus/client_python/blob/master/tests/test_multiprocess.py

As such, we may need to pivot to using Summaries to get the intended functionality that Gauges provide within Node.js' client driver. Basic summary support has been added for future usage after local testing.

#### Extra Work/Investigation Done

We also attempted adding the Info type so we can store non-numeric key value pairs as a way to track versioning within Grafana, however, this was not possible when running in multiprocessing mode:

* https://github.com/prometheus/client_python/blob/f17a8361ad3ed5bc47f193ac03b00911120a8d81/prometheus_client/metrics.py#L651

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
--> 

Working in remote-dev:

```
# HELP audius_dn_health_check Multiprocess metric
# TYPE audius_dn_health_check gauge
audius_dn_health_check{key="trending_tracks_age_sec",pid="ser"} 3547.0
audius_dn_health_check{key="trending_playlists_age_sec",pid="ser"} 367.0
audius_dn_health_check{key="challenge_last_event_age_sec",pid="ser"} 15.0
audius_dn_health_check{key="user_balances_age_sec",pid="ser"} 67.0
audius_dn_health_check{key="num_users_in_lazy_balance_refresh_queue",pid="ser"} 0.0
audius_dn_health_check{key="num_users_in_immediate_balance_refresh_queue",pid="ser"} 0.0
audius_dn_health_check{key="index_eth_age_sec",pid="ser"} 17.0
audius_dn_health_check{key="number_of_cpus",pid="ser"} 12.0
audius_dn_health_check{key="database_size",pid="ser"} 1.9721215e+07
audius_dn_health_check{key="database_connections",pid="ser"} 19.0
audius_dn_health_check{key="total_memory",pid="ser"} 2.5203990528e+010
audius_dn_health_check{key="used_memory",pid="ser"} 1.9437645824e+010
audius_dn_health_check{key="filesystem_size",pid="ser"} 2.66206101504e+011
audius_dn_health_check{key="filesystem_used",pid="ser"} 5.0249924608e+010
audius_dn_health_check{key="received_bytes_per_sec",pid="ser"} 36870.25348637986
audius_dn_health_check{key="transferred_bytes_per_sec",pid="ser"} 54982.33945271024
audius_dn_health_check{key="redis_total_memory",pid="ser"} 2.5203990528e+010
audius_dn_health_check{key="block_difference",pid="ser"} 2.0
audius_dn_health_check{key="maximum_healthy_block_difference",pid="ser"} 100.0
audius_dn_health_check{key="meets_min_requirements",pid="ser"} 1.0
audius_dn_health_check{key="blocknumber",pid="ser"} 17392.0
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->