### PR TITLE
Support unlisted track filtering in user tracks api

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -562,7 +562,7 @@ user_tracks_route_parser.add_argument(
     description="Filter by unlisted or public tracks",
     type=str,
     default="all",
-    choices=("all", "public", "unlisted")
+    choices=("all", "public", "unlisted"),
 )
 
 full_search_parser = pagination_with_current_user_parser.copy()

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -556,6 +556,14 @@ user_tracks_route_parser.add_argument(
     type=str,
     choices=SortDirection._member_names_,
 )
+user_tracks_route_parser.add_argument(
+    "filter_tracks",
+    required=False,
+    description="Filter by unlisted or public tracks",
+    type=str,
+    default="all",
+    choices=("all", "public", "unlisted")
+)
 
 full_search_parser = pagination_with_current_user_parser.copy()
 full_search_parser.add_argument("query", required=True, description="The search query")

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -228,6 +228,7 @@ class TrackList(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+        filter_tracks = args.get("filter_tracks", "all")
         sort_method = format_sort_method(args)
         sort_direction = format_sort_direction(args)
 
@@ -248,6 +249,7 @@ class TrackList(Resource):
             id=None,
             min_block_number=None,
             routes=None,
+            filter_tracks=filter_tracks,
         )
         tracks = get_tracks(args)
         tracks = list(map(extend_track, tracks))
@@ -283,6 +285,7 @@ class FullTrackList(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         query = format_query(args)
+        filter_tracks = args.get("filter_tracks", "all")
 
         sort = args.get("sort", None)  # Deprecated
         sort_method = format_sort_method(args)
@@ -307,6 +310,7 @@ class FullTrackList(Resource):
             id=None,
             min_block_number=None,
             routes=None,
+            filter_tracks=filter_tracks,
         )
         tracks = get_tracks(args)
         tracks = list(map(extend_track, tracks))
@@ -328,6 +332,7 @@ class HandleFullTrackList(Resource):
         sort = args.get("sort", None)
         offset = format_offset(args)
         limit = format_limit(args)
+        filter_tracks = args.get("filter_tracks", "all")
 
         args = {
             "handle": handle,
@@ -338,6 +343,7 @@ class HandleFullTrackList(Resource):
             "sort": sort,
             "limit": limit,
             "offset": offset,
+            "filter_tracks": filter_tracks,
         }
         tracks = get_tracks(args)
         tracks = list(map(extend_track, tracks))

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -47,6 +47,7 @@ class GetTrackArgs(TypedDict):
     filter_deleted: bool
     exclude_premium: bool
     routes: List[RouteArgs]
+    filter_tracks: str
 
     # Optional sort method for the returned results
     sort_method: Optional[SortMethod]
@@ -130,6 +131,13 @@ def _get_tracks(session, args):
                 User.name.ilike(f"%{query.lower()}%"),
             )
         )
+
+    if "filter_tracks" in args and args.get("filter_tracks") != "all":
+        filter_tracks = args.get("filter_tracks")
+        if filter_tracks == "unlisted":
+            base_query = base_query.filter(TrackWithAggregates.is_unlisted == True)
+        else:
+            base_query = base_query.filter(TrackWithAggregates.is_unlisted == False)
 
     if "sort_method" in args and args.get("sort_method") is not None:
         sort_method = args.get("sort_method")

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -61,6 +61,7 @@ def _get_tracks(session, args):
         TrackWithAggregates.is_current == True, TrackWithAggregates.stem_of == None
     )
 
+    # Filter out tracks the user is not authorized to view
     if "routes" in args and args.get("routes") is not None:
         routes = args.get("routes")
         # Join the routes table
@@ -132,6 +133,9 @@ def _get_tracks(session, args):
             )
         )
 
+    # Allow filtering of tracks by unlisted vs public.
+    # If a user is not authorized to view unlisted tracks but has specified filter_tracks=unlisted,
+    # this will filter out all results.
     if "filter_tracks" in args and args.get("filter_tracks") != "all":
         filter_tracks = args.get("filter_tracks")
         if filter_tracks == "unlisted":

--- a/libs/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -318,6 +318,10 @@ export interface GetTracksByUserRequest {
      * The sort direction
      */
     sortDirection?: GetTracksByUserSortDirectionEnum;
+    /**
+     * Filter by unlisted or public tracks
+     */
+    filterTracks?: GetTracksByUserFilterTracksEnum;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -353,6 +357,10 @@ export interface GetTracksByUserHandleRequest {
      * The sort direction
      */
     sortDirection?: GetTracksByUserHandleSortDirectionEnum;
+    /**
+     * Filter by unlisted or public tracks
+     */
+    filterTracks?: GetTracksByUserHandleFilterTracksEnum;
 }
 
 export interface GetUserRequest {
@@ -868,6 +876,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort_direction'] = requestParameters.sortDirection;
         }
 
+        if (requestParameters.filterTracks !== undefined) {
+            queryParameters['filter_tracks'] = requestParameters.filterTracks;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -914,6 +926,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.sortDirection !== undefined) {
             queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
+        if (requestParameters.filterTracks !== undefined) {
+            queryParameters['filter_tracks'] = requestParameters.filterTracks;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -1143,6 +1159,15 @@ export enum GetTracksByUserSortDirectionEnum {
     * @export
     * @enum {string}
     */
+export enum GetTracksByUserFilterTracksEnum {
+    All = 'all',
+    Public = 'public',
+    Unlisted = 'unlisted'
+}
+/**
+    * @export
+    * @enum {string}
+    */
 export enum GetTracksByUserHandleSortEnum {
     Date = 'date',
     Plays = 'plays'
@@ -1169,6 +1194,15 @@ export enum GetTracksByUserHandleSortMethodEnum {
 export enum GetTracksByUserHandleSortDirectionEnum {
     Asc = 'asc',
     Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleFilterTracksEnum {
+    All = 'all',
+    Public = 'public',
+    Unlisted = 'unlisted'
 }
 /**
     * @export

--- a/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -313,6 +313,10 @@ export interface GetTracksByUserRequest {
      * The sort direction
      */
     sortDirection?: GetTracksByUserSortDirectionEnum;
+    /**
+     * Filter by unlisted or public tracks
+     */
+    filterTracks?: GetTracksByUserFilterTracksEnum;
 }
 
 export interface GetTracksByUserHandleRequest {
@@ -348,6 +352,10 @@ export interface GetTracksByUserHandleRequest {
      * The sort direction
      */
     sortDirection?: GetTracksByUserHandleSortDirectionEnum;
+    /**
+     * Filter by unlisted or public tracks
+     */
+    filterTracks?: GetTracksByUserHandleFilterTracksEnum;
 }
 
 export interface GetUserRequest {
@@ -833,6 +841,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort_direction'] = requestParameters.sortDirection;
         }
 
+        if (requestParameters.filterTracks !== undefined) {
+            queryParameters['filter_tracks'] = requestParameters.filterTracks;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
@@ -879,6 +891,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters.sortDirection !== undefined) {
             queryParameters['sort_direction'] = requestParameters.sortDirection;
+        }
+
+        if (requestParameters.filterTracks !== undefined) {
+            queryParameters['filter_tracks'] = requestParameters.filterTracks;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -1067,6 +1083,15 @@ export enum GetTracksByUserSortDirectionEnum {
     * @export
     * @enum {string}
     */
+export enum GetTracksByUserFilterTracksEnum {
+    All = 'all',
+    Public = 'public',
+    Unlisted = 'unlisted'
+}
+/**
+    * @export
+    * @enum {string}
+    */
 export enum GetTracksByUserHandleSortEnum {
     Date = 'date',
     Plays = 'plays'
@@ -1093,6 +1118,15 @@ export enum GetTracksByUserHandleSortMethodEnum {
 export enum GetTracksByUserHandleSortDirectionEnum {
     Asc = 'asc',
     Desc = 'desc'
+}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum GetTracksByUserHandleFilterTracksEnum {
+    All = 'all',
+    Public = 'public',
+    Unlisted = 'unlisted'
 }
 /**
     * @export


### PR DESCRIPTION
### Description
Add `filter_tracks` arg to user tracks endpoints with tertiary values ("all", "public", "unlisted") and filter tracks by specified type.

Affected endpoints:
full users/id/tracks
non-full users/id/tracks
full users/handle/handle/tracks
non-full users/handle/handle/tracks

### Tests
Make sure unit/integration tests pass; test on staging

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?