### PR TITLE
set mem limit for celery workers

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -130,7 +130,7 @@ else
     audius_service=server ./scripts/prod-server.sh 2>&1 | tee >(logger -t server) &
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
-        audius_service=worker celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
 fi
 


### PR DESCRIPTION
### Description

A celery task has a memory leak.  Worker will start at around 200MB of memory usage... after 12 hours will be around 550MB.

We should find the leak, but in the short term celery has a handy setting that will spawn new process when memory usage crosses a threshold:

https://docs.celeryq.dev/en/stable/userguide/workers.html#max-memory-per-child-setting

This will set limit to around 300MB


### Tests

will test on sandbox machine.