### PR TITLE
Set up tracing before anything else

### DIFF
--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -1,12 +1,13 @@
+/* eslint-disable import/first */
 'use strict'
+
+const { setupTracing } = require('./tracer')
+setupTracing('content-node')
 
 import type { Cluster, Worker } from 'cluster'
 import { AggregatorRegistry } from 'prom-client'
 import { clusterUtils } from './utils'
 const cluster: Cluster = require('cluster')
-
-const { setupTracing } = require('./tracer')
-setupTracing('content-node')
 
 const ON_DEATH = require('death')
 const EthereumWallet = require('ethereumjs-wallet')


### PR DESCRIPTION
### Description
Makes sure tracing is called before everything else in Content Node since that's necessary for it to work properly. This is a followup to https://github.com/AudiusProject/audius-protocol/pull/3939#discussion_r983627595.


### Tests
This is a minor change so if tests and mad dog pass then it should be good to go.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
This would break startup, so monitor deployment to make sure the server starts up.