### PR TITLE
[CON-429] Add new network monitoring metric

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/db/sql/scratch_pad.sql
+++ b/discovery-provider/plugins/network-monitoring/src/db/sql/scratch_pad.sql
@@ -277,3 +277,14 @@ AND run_id = :run_id;
         secondary1spid = ANY ( '{1,2,3,4}'::int[] )
     AND 
         secondary2spid = ANY ( '{1,2,3,4}'::int[] );
+
+SELECT COUNT(*) as user_count
+    FROM network_monitoring_users
+    WHERE
+        run_id = 71
+    AND 
+        primaryspid != ALL('{1, 2, 3, 4, 5, 6, 7, 8, 9}'::int[])
+    AND
+        secondary1spid != ALL('{1, 2, 3, 4, 5, 6, 7, 8, 9}'::int[])
+    AND 
+        secondary2spid != ALL ('{1, 2, 3, 4, 5, 6, 7, 8, 9}'::int[]);

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -286,3 +286,28 @@ export const getUsersWithEntireReplicaSetInSpidSetCount = async (run_id: number,
 
     return usersCount
 }
+
+export const getUsersWithEntireReplicaSetNotInSpidSetCount = async (run_id: number, spidSet: number[]): Promise<number> => {
+
+    const spidSetStr = `{${spidSet.join(",")}}`
+
+    const usersResp: unknown[] = await sequelizeConn.query(`
+    SELECT COUNT(*) as user_count
+    FROM network_monitoring_users
+    WHERE
+        run_id = :run_id
+    AND 
+        primaryspid != ALL( :spidSetStr )
+    AND
+        secondary1spid != ALL( :spidSetStr )
+    AND 
+        secondary2spid != ALL( :spidSetStr );
+    `, {
+        type: QueryTypes.SELECT,
+        replacements: { run_id, spidSetStr },
+    })
+
+    const usersCount = parseInt(((usersResp as { user_count: string }[])[0] || { user_count: '0' }).user_count)
+
+    return usersCount
+}

--- a/discovery-provider/plugins/network-monitoring/src/prometheus.ts
+++ b/discovery-provider/plugins/network-monitoring/src/prometheus.ts
@@ -89,3 +89,10 @@ export const usersWithAllFoundationNodeReplicaSetGauge = new client.Gauge({
     help: 'the number of users whose entire replica set is made of foundation nodes',
     labelNames: ['run_id']
 })
+
+export const usersWithNoFoundationNodeReplicaSetGauge = new client.Gauge({
+    name: 'audius_nm_users_with_no_foundation_node_replica_set',
+    help: 'the number of users whose entire replica set is does not contain any foundation nodes',
+    labelNames: ['run_id']
+})
+


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds a new network monitoring metrics called `usersWithNoFoundationNodeReplicaSet` that'll give us the number of users whose replica set contains no foundation nodes.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally by running a test job and testing the new query on our staging network monitoring machine.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

These changes will be monitored on grafana with a new panel on the Audius - Network Monitoring dashboard

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->