### PR TITLE
Add aggregator config to each metric

### DIFF
--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -229,7 +229,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       name: METRIC_NAMES.RECOVER_ORPHANED_DATA_WALLET_COUNTS_GAUGE,
       help: 'Number of wallets found with data orphaned on this node',
       labelNames: [],
-      aggregator: 'sum' as AggregatorType
+      aggregator: 'max' as AggregatorType
     }
   },
   [METRIC_NAMES.RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE]: {
@@ -238,7 +238,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       name: METRIC_NAMES.RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE,
       help: 'Number of syncs enqueued to recover data orphaned on this node',
       labelNames: [],
-      aggregator: 'sum' as AggregatorType
+      aggregator: 'max' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_COMPLETED_TOTAL_GAUGE]: {
@@ -294,10 +294,10 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
       buckets: exponentialBucketsRange(1, 600, 10),
-      aggregator: 'first' as AggregatorType
+      aggregator: 'average' as AggregatorType
     }
   },
-  [METRIC_NAMES.JOBS_WAITING_DURATION_SECONDS_HISTROGRAM]: {
+  [METRIC_NAMES.JOBS_WAITING_DURATION_SECONDS_HISTOGRAM]: {
     metricType: METRIC_TYPES.HISTOGRAM,
     metricConfig: {
       name: METRIC_NAMES.JOBS_WAITING_DURATION_SECONDS_HISTOGRAM,
@@ -305,7 +305,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
       buckets: exponentialBucketsRange(1, 600, 10),
-      aggregator: 'first' as AggregatorType
+      aggregator: 'average' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_ATTEMPTS_HISTOGRAM]: {
@@ -316,7 +316,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
       buckets: exponentialBucketsRange(1, 600, 10),
-      aggregator: 'first' as AggregatorType
+      aggregator: 'average' as AggregatorType
     }
   },
   [METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM]: {
@@ -331,6 +331,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       aggregator: 'average' as AggregatorType
     }
   },
+  // TODO: This isn't used anywhere
   [METRIC_NAMES.SYNC_QUEUE_JOBS_TOTAL_GAUGE]: {
     metricType: METRIC_TYPES.GAUGE,
     metricConfig: {
@@ -356,7 +357,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
         config.get('maxSyncMonitoringDurationInMs') / 1000,
         4
       ),
-      aggregator: 'first' as AggregatorType
+      aggregator: 'max' as AggregatorType
     }
   },
 
@@ -394,7 +395,7 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       help: "Counts for each find-sync-requests job's result when looking for syncs that should be requested from a primary to a secondary",
       labelNames:
         METRIC_LABEL_NAMES[METRIC_NAMES.FIND_SYNC_REQUEST_COUNTS_GAUGE],
-      aggregator: 'first' as AggregatorType
+      aggregator: 'max' as AggregatorType
     }
   },
   [METRIC_NAMES.WRITE_QUORUM_DURATION_SECONDS_HISTOGRAM]: {

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -209,12 +209,16 @@ const METRIC_LABEL_NAMES = Object.freeze(
   )
 )
 
+type AggregatorType = 'sum' | 'first' | 'min' | 'max' | 'average' | 'omit'
 type Metric = {
   metricType: any
   metricConfig: {
     name: string
     help: string
     labelNames: string[]
+    // Function to aggregate metrics across workers.
+    // See https://github.com/siimon/prom-client/blob/96f7495d66b1a21755f745b1367d3e530668a957/lib/metricAggregators.js#L50
+    aggregator: AggregatorType
   }
 }
 
@@ -224,7 +228,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.RECOVER_ORPHANED_DATA_WALLET_COUNTS_GAUGE,
       help: 'Number of wallets found with data orphaned on this node',
-      labelNames: []
+      labelNames: [],
+      aggregator: 'sum' as AggregatorType
     }
   },
   [METRIC_NAMES.RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE]: {
@@ -232,7 +237,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE,
       help: 'Number of syncs enqueued to recover data orphaned on this node',
-      labelNames: []
+      labelNames: [],
+      aggregator: 'sum' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_COMPLETED_TOTAL_GAUGE]: {
@@ -240,7 +246,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.JOBS_COMPLETED_TOTAL_GAUGE,
       help: 'Number of completed jobs',
-      labelNames: ['queue_name', 'job_name']
+      labelNames: ['queue_name', 'job_name'],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_FAILED_TOTAL_GAUGE]: {
@@ -248,7 +255,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.JOBS_FAILED_TOTAL_GAUGE,
       help: 'Number of failed jobs',
-      labelNames: ['queue_name', 'job_name']
+      labelNames: ['queue_name', 'job_name'],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_DELAYED_TOTAL_GAUGE]: {
@@ -256,7 +264,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.JOBS_DELAYED_TOTAL_GAUGE,
       help: 'Number of delayed jobs',
-      labelNames: ['queue_name', 'job_name']
+      labelNames: ['queue_name', 'job_name'],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_ACTIVE_TOTAL_GAUGE]: {
@@ -264,7 +273,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.JOBS_ACTIVE_TOTAL_GAUGE,
       help: 'Number of active jobs',
-      labelNames: ['queue_name', 'job_name']
+      labelNames: ['queue_name', 'job_name'],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_WAITING_TOTAL_GAUGE]: {
@@ -272,7 +282,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.JOBS_WAITING_TOTAL_GAUGE,
       help: 'Number of waiting jobs',
-      labelNames: ['queue_name', 'job_name']
+      labelNames: ['queue_name', 'job_name'],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_DURATION_SECONDS_HISTOGRAM]: {
@@ -282,7 +293,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       help: 'Time to complete jobs',
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
-      buckets: exponentialBucketsRange(1, 600, 10)
+      buckets: exponentialBucketsRange(1, 600, 10),
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_WAITING_DURATION_SECONDS_HISTROGRAM]: {
@@ -292,7 +304,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       help: 'Time spent waiting for jobs to run',
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
-      buckets: exponentialBucketsRange(1, 600, 10)
+      buckets: exponentialBucketsRange(1, 600, 10),
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.JOBS_ATTEMPTS_HISTOGRAM]: {
@@ -302,7 +315,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       help: 'Job attempts made',
       labelNames: ['queue_name', 'job_name', 'status'],
       // 10 buckets in the range of 1 seconds to max to 10 minutes
-      buckets: exponentialBucketsRange(1, 600, 10)
+      buckets: exponentialBucketsRange(1, 600, 10),
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM]: {
@@ -313,7 +327,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       labelNames:
         METRIC_LABEL_NAMES[
           METRIC_NAMES.SECONDARY_SYNC_FROM_PRIMARY_DURATION_SECONDS_HISTOGRAM
-        ]
+        ],
+      aggregator: 'average' as AggregatorType
     }
   },
   [METRIC_NAMES.SYNC_QUEUE_JOBS_TOTAL_GAUGE]: {
@@ -321,7 +336,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.SYNC_QUEUE_JOBS_TOTAL_GAUGE,
       help: 'Current job counts for SyncQueue by status',
-      labelNames: ['status']
+      labelNames: ['status'],
+      aggregator: 'first' as AggregatorType
     }
   },
 
@@ -339,7 +355,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
         1,
         config.get('maxSyncMonitoringDurationInMs') / 1000,
         4
-      )
+      ),
+      aggregator: 'first' as AggregatorType
     }
   },
 
@@ -364,7 +381,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
               ]
             ] || [])
           ],
-          buckets: [1, 5, 10, 30, 60, 120] // 1 second to 2 minutes
+          buckets: [1, 5, 10, 30, 60, 120], // 1 second to 2 minutes
+          aggregator: 'average' as AggregatorType
         }
       }
     ])
@@ -375,7 +393,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       name: METRIC_NAMES.FIND_SYNC_REQUEST_COUNTS_GAUGE,
       help: "Counts for each find-sync-requests job's result when looking for syncs that should be requested from a primary to a secondary",
       labelNames:
-        METRIC_LABEL_NAMES[METRIC_NAMES.FIND_SYNC_REQUEST_COUNTS_GAUGE]
+        METRIC_LABEL_NAMES[METRIC_NAMES.FIND_SYNC_REQUEST_COUNTS_GAUGE],
+      aggregator: 'first' as AggregatorType
     }
   },
   [METRIC_NAMES.WRITE_QUORUM_DURATION_SECONDS_HISTOGRAM]: {
@@ -393,7 +412,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
         config.get('issueAndWaitForSecondarySyncRequestsPollingDurationMs') /
           1000,
         5
-      )
+      ),
+      aggregator: 'average' as AggregatorType
     }
   },
   [METRIC_NAMES.STORAGE_PATH_SIZE_BYTES]: {
@@ -401,7 +421,8 @@ export const METRICS: Record<string, Metric> = Object.freeze({
     metricConfig: {
       name: METRIC_NAMES.STORAGE_PATH_SIZE_BYTES,
       help: 'Disk storage size',
-      labelNames: ['type']
+      labelNames: ['type'],
+      aggregator: 'first' as AggregatorType
     }
   }
 })


### PR DESCRIPTION
### Description
Sets the `aggregator` property for each metric that we track. This is needed for clustering logic because otherwise it will just sum across all workers by default. This is the general rule of thumb:
* If it's a metric returned by state machine, use `'max'` because only one worker listens for state machine onComplete and subsequently updates each job's metrics. `'sum'` should technically work as well since all workers will report 0 except for the worker that listens for onComplete
* If it's a Bull metric, use `'first'` because each worker has all queues set up and gets Bull info from Redis
* Any other metric where multiple workers will report values should use `'average'`


### Tests
I ran `A up` spot checked some of these locally. The best tests will be on staging, paying particular attention to Grafana panels.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
One panel to spot check is disk usage. It previously doubled on staging, so we should see that go back down after deploying.