### PR TITLE
Fix EM flag for replica sets

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -698,9 +698,9 @@ const _issueUpdateReplicaSetOp = async (
       // First try updateReplicaSet via URSM
       // Fallback to EntityManager when relay errors
       try {
-        if (!config.get('entityManagerReplicaSetEnabled')) {
+        if (config.get('entityManagerReplicaSetEnabled')) {
           throw new Error(
-            'Fallback to URSM writes because EntityManager is disabled'
+            'Fallback to EntityManager when enabled'
           )
         }
         await audiusLibs.contracts.UserReplicaSetManagerClient._updateReplicaSet(

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -698,11 +698,6 @@ const _issueUpdateReplicaSetOp = async (
       // First try updateReplicaSet via URSM
       // Fallback to EntityManager when relay errors
       try {
-        if (config.get('entityManagerReplicaSetEnabled')) {
-          throw new Error(
-            'Fallback to EntityManager when enabled'
-          )
-        }
         await audiusLibs.contracts.UserReplicaSetManagerClient._updateReplicaSet(
           userId,
           newReplicaSetSPIds[0], // new primary
@@ -715,6 +710,10 @@ const _issueUpdateReplicaSetOp = async (
           ]
         )
       } catch (err) {
+        if (!config.get('entityManagerReplicaSetEnabled')) {
+          throw err
+        }
+
         logger.info(
           `[_issueUpdateReplicaSetOp] updating replica set now ${
             Date.now() - startTimeMs

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -850,22 +850,17 @@ const _canReconfig = async ({
   let error
   try {
     let chainPrimarySpId, chainSecondarySpIds
-    // Attempt to get replica set from DN when entity manager is enabled
-    // Fallback to URSM
-    try {
+    if (config.get('entityManagerReplicaSetEnabled')) {
       const encodedUserId = libs.Utils.encodeHashId(userId)
       const spResponse = await libs.discoveryProvider.getUserReplicaSet({
         encodedUserId
       })
-      if (!spResponse) {
-        throw new Error('User replica set is not on discovery')
-      }
       chainPrimarySpId = spResponse?.primarySpID
       chainSecondarySpIds = [
         spResponse?.secondary1SpID,
         spResponse?.secondary2SpID
       ]
-    } catch (err) {
+    } else {
       const response =
         await libs.contracts.UserReplicaSetManagerClient.getUserReplicaSet(
           userId


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fix flag so entity manager txs only go through when URSM fails relay and flag is enabled.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->