### PR TITLE
get_feed_es supports explicit IDs

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -73,9 +73,17 @@ def test_get_feed_es(app):
     # test feed
     with app.app_context():
         feed_results = get_feed_es({"user_id": "1"})
+        assert len(feed_results) == 2
         assert feed_results[0]["playlist_id"] == 1
         assert feed_results[0]["save_count"] == 1
         assert len(feed_results[0]["followee_reposts"]) == 1
 
         assert feed_results[1]["track_id"] == 1
         assert feed_results[1]["save_count"] == 1
+
+        feed_results = get_feed_es({"user_id": "2"})
+        assert len(feed_results) == 0
+
+        # user 2 with explicit IDs
+        feed_results = get_feed_es({"user_id": "2", "followee_user_ids": [1]})
+        assert len(feed_results) == 2


### PR DESCRIPTION
### Description

https://linear.app/audius/issue/C-1030/empty-feed-upon-sign-up

on signup client passes in IDs for initial feed render.


### Tests

✅ 
