### PR TITLE
Add cluster worker number in logger

### DIFF
--- a/creator-node/src/logging.js
+++ b/creator-node/src/logging.js
@@ -1,4 +1,5 @@
 const bunyan = require('bunyan')
+const cluster = require('cluster')
 const shortid = require('shortid')
 
 const config = require('./config')
@@ -27,6 +28,7 @@ function RawStdOutWithLevelName() {
 const logLevel = config.get('logLevel') || 'info'
 const logger = bunyan.createLogger({
   name: 'audius_creator_node',
+  clusterWorker: cluster.isMaster ? 'master' : `Worker ${cluster.worker.id}`,
   streams: [
     {
       level: logLevel,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Added a field in our logger that tells us which process in the cluster a log is printed from (master/worker 1,2,3 etc). Added while debugging https://github.com/AudiusProject/audius-protocol/pull/3770 and figured it might be useful more generally

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Ran local setup and observed that logs were being printed. Also the CircleCI tests print the clusterWorker property

Sample logs from local dev
```
{"name":"audius_creator_node","clusterWorker":"master","hostname":"2da92482d7b9","pid":365327,"level":30,"msg":"Monitoring Queue: Computed value for usedMemory 18814889984 || active: 0, waiting: 0, failed 0, delayed: 0, completed: 500 ","time":"2022-10-02T18:18:29.406Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","clusterWorker":"Worker 1","hostname":"2da92482d7b9","pid":365393,"level":50,"msg":"URSMRegistrationManager ERROR || activeDelegateOwnerWallet: 0xffcf8fdee72ac11b5c542428b35eef5769c409f0 // delegateOwnerWalletFromURSM: 0xffcf8fdee72ac11b5c542428b35eef5769c409f0","time":"2022-10-02T18:18:30.023Z","v":0,"logLevel":"error"}
{"name":"audius_creator_node","clusterWorker":"Worker 1","hostname":"2da92482d7b9","pid":365393,"level":30,"msg":"URSMRegistrationManager || Node already registered on URSM with same delegateOwnerWallet","time":"2022-10-02T18:18:30.023Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","clusterWorker":"Worker 1","hostname":"2da92482d7b9","pid":365393,"level":30,"msg":"ServiceRegistry || URSM Registration completed","time":"2022-10-02T18:18:30.023Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","clusterWorker":"Worker 1","hostname":"2da92482d7b9","pid":365393,"level":30,"msg":"[SkippedCIDsRetryQueue] Successfully initialized and enqueued initial job.","time":"2022-10-02T18:18:30.033Z","v":0,"logLevel":"info"}
{"name":"audius_creator_node","clusterWorker":"Worker 1","hostname":"2da92482d7b9","pid":365393,"level":30,"msg":"ServiceRegistry || Setting up Bull queue monitoring...","time":"2022-10-02T18:18:30.033Z","v":0,"logLevel":"info"}

```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
These will be sent to loggly so look for the clusterWorker field in logs.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->