### PR TITLE
Fix fallback fetch chain info for sp in dn

### DIFF
--- a/discovery-provider/src/utils/eth_manager.py
+++ b/discovery-provider/src/utils/eth_manager.py
@@ -78,8 +78,9 @@ class EthManager:
             }
 
         endpoint_info = self.sp_factory.functions.getServiceEndpointInfo(
-            sp_type, sp_id
+            sp_type.value, sp_id
         ).call()
+
         set_json_cached_key(redis, sp_id_key, endpoint_info, self.cnode_info_redis_ttl)
         logger.info(
             f"eth_manager.py | Configured redis {sp_id_key} - {endpoint_info} - TTL {self.cnode_info_redis_ttl}"


### PR DESCRIPTION
### Description
Fixes discovery fetching of Service Provider info from chain - 
The bug was that we were passing in a python enum instead of getting the value of the enum

### Tests
Ran locally with entire setup

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Will throw an error of service provider tx not valid if wrong