### PR TITLE
Update CN old delegate wallet patch

### DIFF
--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -30,7 +30,9 @@ class URSMRegistrationManager {
     this.spOwnerWallet = nodeConfig.get('spOwnerWallet')
     this.oldDelegateOwnerWallet = this.nodeConfig.get('oldDelegateOwnerWallet')
     this.oldDelegatePrivateKey = this.nodeConfig.get('oldDelegatePrivateKey')
-    this.entityManagerReplicaSetEnabled = this.nodeConfig.get('entityManagerReplicaSetEnabled')
+    this.entityManagerReplicaSetEnabled = this.nodeConfig.get(
+      'entityManagerReplicaSetEnabled'
+    )
 
     if (
       !this.audiusLibs ||
@@ -128,7 +130,8 @@ class URSMRegistrationManager {
       `activeDelegateOwnerWallet: ${activeDelegateOwnerWallet.toLowerCase()} // delegateOwnerWalletFromURSM: ${delegateOwnerWalletFromURSM}`
     )
     if (
-      !this.entityManagerReplicaSetEnabled && activeDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM
+      !this.entityManagerReplicaSetEnabled &&
+      activeDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM
     ) {
       // Update config
       this.nodeConfig.set('isRegisteredOnURSM', true)

--- a/creator-node/src/services/URSMRegistrationManager.js
+++ b/creator-node/src/services/URSMRegistrationManager.js
@@ -30,6 +30,7 @@ class URSMRegistrationManager {
     this.spOwnerWallet = nodeConfig.get('spOwnerWallet')
     this.oldDelegateOwnerWallet = this.nodeConfig.get('oldDelegateOwnerWallet')
     this.oldDelegatePrivateKey = this.nodeConfig.get('oldDelegatePrivateKey')
+    this.entityManagerReplicaSetEnabled = this.nodeConfig.get('entityManagerReplicaSetEnabled')
 
     if (
       !this.audiusLibs ||
@@ -127,7 +128,7 @@ class URSMRegistrationManager {
       `activeDelegateOwnerWallet: ${activeDelegateOwnerWallet.toLowerCase()} // delegateOwnerWalletFromURSM: ${delegateOwnerWalletFromURSM}`
     )
     if (
-      activeDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM
+      !this.entityManagerReplicaSetEnabled && activeDelegateOwnerWallet.toLowerCase() === delegateOwnerWalletFromURSM
     ) {
       // Update config
       this.nodeConfig.set('isRegisteredOnURSM', true)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Currently, stage DNs are not indexing Entity Manager replica set updates because the signer is the old ropsten delegate wallet not the new goerli delegate wallet.

We can simply remove the old delegate wallet env var so the goerli wallet is used. Then, we also need to skip the check against the URSM wallet when EM is enabled.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Will test on staging.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->