### PR TITLE
INF Skip deploying to cn11 temporarily + short slack notifications

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -30,7 +30,7 @@ STAGE_CREATOR_NODES = (
     "stage-creator-8",
     "stage-creator-9",
     "stage-creator-10",
-    "stage-creator-11",
+#     "stage-creator-11",
     "stage-user-metadata",
 )
 PROD_CREATOR_NODES = (

--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -411,8 +411,11 @@ def format_artifacts(
     if hosts:
         hosts.sort()
         summary = [f"{heading}:"]
-        for h in hosts:
-            summary.append(f"• {h}")
+        if "Upgraded to" in heading:
+            summary.append(", ".join(hosts))
+        else:
+            for h in hosts:
+                summary.append(f"• {h}")
 
         print("\n".join(summary))
         with open("/tmp/summary.md", "a") as f:

--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -30,7 +30,7 @@ STAGE_CREATOR_NODES = (
     "stage-creator-8",
     "stage-creator-9",
     "stage-creator-10",
-#     "stage-creator-11",
+    #     "stage-creator-11",
     "stage-user-metadata",
 )
 PROD_CREATOR_NODES = (

--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -412,7 +412,7 @@ def format_artifacts(
         hosts.sort()
         summary = [f"{heading}:"]
         for h in hosts:
-            summary.append(f"* {h}")
+            summary.append(f"• {h}")
 
         print("\n".join(summary))
         with open("/tmp/summary.md", "a") as f:


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Stop deploying to cn11 until it has recovered. Lower vertical height of slack notifications.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

#eng-deploy


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
#eng-deploy


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->