### PR TITLE
Network Monitoring: fix labels for get user status by primary

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -464,7 +464,7 @@ const _getUserStatusByPrimary = async (
     partiallySyncedCount: number;
     unsyncedCount: number;
   }[] = (
-    userStatusByPrimaryResp as {
+    userStatusByPrimaryResp[0] as {
       spid: string;
       endpoint: string;
       fully_synced_count: string;


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR fixes a bug with setting labels on the metrics for UserStatusByPrimary

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested on the staging network monitoring node

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This change will be monitoring on grafana on the network monitoring dashboard

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->