### PR TITLE
Disable EM replica sets in local so mad dog passes

### DIFF
--- a/creator-node/compose/env/base.env
+++ b/creator-node/compose/env/base.env
@@ -76,7 +76,7 @@ maxBatchClockStatusBatchSize=5
 reconfigSPIdBlacklistString=
 
 entityManagerAddress=0x5b9b42d6e4B2e4Bf8d42Eba32D46918e10899B66
-entityManagerReplicaSetEnabled=true
+entityManagerReplicaSetEnabled=false
 
 # Premium content
 premiumContentEnabled=true


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
With https://github.com/AudiusProject/audius-protocol/pull/4005/files, mad dog now fails because this flag is enabled by default. However, service commands is not using entity manager yet. We can make changes https://github.com/AudiusProject/audius-protocol/pull/4013 to enable EM in service commands but this is a lot of work. For now, let's just disable replica set by default and enable when needed locally.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Mad dog passes


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->