### PR TITLE
[PAY-672] Fix saveUserBankTransactionMetadata in SDK

### DIFF
--- a/libs/src/services/identity/IdentityService.ts
+++ b/libs/src/services/identity/IdentityService.ts
@@ -572,13 +572,22 @@ export class IdentityService {
   /**
    * Saves $AUDIO purchase metadata
    */
-  async saveUserBankTransactionMetadata(data: InAppAudioPurchaseMetadata) {
+  async saveUserBankTransactionMetadata({
+    transactionSignature,
+    metadata
+  }: {
+    transactionSignature: string
+    metadata: InAppAudioPurchaseMetadata
+  }) {
     const headers = await this._signData()
 
     return await this._makeRequest({
       url: '/transaction_metadata',
       method: 'post',
-      data,
+      data: {
+        transactionSignature,
+        metadata
+      },
       headers
     })
   }

--- a/libs/src/services/identity/IdentityService.ts
+++ b/libs/src/services/identity/IdentityService.ts
@@ -572,10 +572,7 @@ export class IdentityService {
   /**
    * Saves $AUDIO purchase metadata
    */
-  async saveUserBankTransactionMetadata({
-    transactionSignature,
-    metadata
-  }: {
+  async saveUserBankTransactionMetadata(data: {
     transactionSignature: string
     metadata: InAppAudioPurchaseMetadata
   }) {
@@ -584,10 +581,7 @@ export class IdentityService {
     return await this._makeRequest({
       url: '/transaction_metadata',
       method: 'post',
-      data: {
-        transactionSignature,
-        metadata
-      },
+      data,
       headers
     })
   }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Saving user bank metadata requires the transaction signature of the final transfer instruction, which was being omitted. Also needs the metadata wrapped into a `metadata` subfield.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested E2E with Coinbase Pay

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->