### PR TITLE
ES: whitespace tolerance, faster feed

### DIFF
--- a/discovery-provider/es-indexer/README.md
+++ b/discovery-provider/es-indexer/README.md
@@ -33,8 +33,10 @@ and then:
 
 ```
 source .env
-npm run dev
+npm run dev --drop
 ```
+
+> it's important to run with `--drop` to catch any errors in index settings. Without --drop 400 errors will be silently ignored.
 
 ## How it works
 

--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,7 +1,7 @@
 export const indexNames = {
-  playlists: 'playlists7',
-  reposts: 'reposts2',
-  saves: 'saves2',
-  tracks: 'tracks8',
-  users: 'users7',
+  playlists: 'playlists9',
+  reposts: 'reposts9',
+  saves: 'saves9',
+  tracks: 'tracks9',
+  users: 'users9',
 }

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -7,6 +7,8 @@ import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { PlaylistDoc } from '../types/docs'
 import { BaseIndexer } from './BaseIndexer'
 import {
+  lowerKeyword,
+  noWhitespaceLowerKeyword,
   sharedIndexSettings,
   standardSuggest,
   standardText,
@@ -19,13 +21,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
 
   mapping: IndicesCreateRequest = {
     index: indexNames.playlists,
-    settings: merge(sharedIndexSettings, {
-      index: {
-        number_of_shards: 1,
-        number_of_replicas: 0,
-        refresh_interval: '5s',
-      },
-    }),
+    settings: merge(sharedIndexSettings, {}),
     mappings: {
       dynamic: false,
       properties: {
@@ -38,7 +34,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
         is_delete: { type: 'boolean' },
         suggest: standardSuggest,
         playlist_name: {
-          type: 'keyword',
+          ...lowerKeyword,
           fields: {
             searchable: standardText,
           },
@@ -48,18 +44,18 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
         user: {
           properties: {
             handle: {
-              type: 'keyword',
+              ...noWhitespaceLowerKeyword,
               fields: {
                 searchable: standardText,
               },
             },
             name: {
-              type: 'keyword',
+              ...lowerKeyword,
               fields: {
                 searchable: standardText,
               },
             },
-            location: { type: 'keyword' },
+            location: lowerKeyword,
             follower_count: { type: 'integer' },
             is_verified: { type: 'boolean' },
             created_at: { type: 'date' },
@@ -78,10 +74,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
           properties: {
             mood: { type: 'keyword' },
             genre: { type: 'keyword' },
-            tags: {
-              type: 'keyword',
-              normalizer: 'lower_asciifolding',
-            },
+            tags: lowerKeyword,
             play_count: { type: 'integer' },
             repost_count: { type: 'integer' },
             save_count: { type: 'integer' },

--- a/discovery-provider/es-indexer/src/indexers/RepostIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/RepostIndexer.ts
@@ -1,8 +1,10 @@
 import { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types'
+import { merge } from 'lodash'
 import { indexNames } from '../indexNames'
 import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { RepostDoc } from '../types/docs'
 import { BaseIndexer } from './BaseIndexer'
+import { sharedIndexSettings } from './sharedIndexSettings'
 
 export class RepostIndexer extends BaseIndexer<RepostDoc> {
   constructor() {
@@ -12,13 +14,7 @@ export class RepostIndexer extends BaseIndexer<RepostDoc> {
 
   mapping: IndicesCreateRequest = {
     index: indexNames.reposts,
-    settings: {
-      index: {
-        number_of_shards: 1,
-        number_of_replicas: 0,
-        refresh_interval: '5s',
-      },
-    },
+    settings: merge(sharedIndexSettings, {}),
     mappings: {
       dynamic: false,
       properties: {

--- a/discovery-provider/es-indexer/src/indexers/SaveIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/SaveIndexer.ts
@@ -1,8 +1,10 @@
 import { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types'
+import { merge } from 'lodash'
 import { indexNames } from '../indexNames'
 import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { SaveDoc } from '../types/docs'
 import { BaseIndexer } from './BaseIndexer'
+import { sharedIndexSettings } from './sharedIndexSettings'
 
 export class SaveIndexer extends BaseIndexer<SaveDoc> {
   constructor() {
@@ -12,13 +14,7 @@ export class SaveIndexer extends BaseIndexer<SaveDoc> {
 
   mapping: IndicesCreateRequest = {
     index: indexNames.saves,
-    settings: {
-      index: {
-        number_of_shards: 1,
-        number_of_replicas: 0,
-        refresh_interval: '5s',
-      },
-    },
+    settings: merge(sharedIndexSettings, {}),
     mappings: {
       dynamic: false,
       properties: {

--- a/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
@@ -6,6 +6,8 @@ import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { TrackDoc } from '../types/docs'
 import { BaseIndexer } from './BaseIndexer'
 import {
+  lowerKeyword,
+  noWhitespaceLowerKeyword,
   sharedIndexSettings,
   standardSuggest,
   standardText,
@@ -19,29 +21,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
 
   mapping: IndicesCreateRequest = {
     index: indexNames.tracks,
-    settings: merge(sharedIndexSettings, {
-      analysis: {
-        tokenizer: {
-          comma_tokenizer: {
-            // @ts-ignore - es client typings lagging
-            type: 'simple_pattern_split',
-            pattern: ',',
-          },
-        },
-        analyzer: {
-          // @ts-ignore - es client typings lagging
-          comma_analyzer: {
-            tokenizer: 'comma_tokenizer',
-            filter: ['lowercase', 'asciifolding'],
-          },
-        },
-      },
-      index: {
-        number_of_shards: 1,
-        number_of_replicas: 0,
-        refresh_interval: '5s',
-      },
-    }),
+    settings: merge(sharedIndexSettings, {}),
     mappings: {
       dynamic: false,
       properties: {
@@ -53,16 +33,13 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
         route_id: { type: 'keyword' },
         routes: { type: 'keyword' },
         title: {
-          type: 'keyword',
+          ...lowerKeyword,
           fields: {
             searchable: standardText,
           },
         },
         length: { type: 'integer' },
-        tag_list: {
-          type: 'keyword',
-          normalizer: 'lower_asciifolding',
-        },
+        tag_list: lowerKeyword,
         genre: { type: 'keyword' },
         mood: { type: 'keyword' },
         is_delete: { type: 'boolean' },
@@ -82,18 +59,18 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
         user: {
           properties: {
             handle: {
-              type: 'keyword',
+              ...noWhitespaceLowerKeyword,
               fields: {
                 searchable: standardText,
               },
             },
             name: {
-              type: 'keyword',
+              ...lowerKeyword,
               fields: {
                 searchable: standardText,
               },
             },
-            location: { type: 'keyword' },
+            location: lowerKeyword,
             follower_count: { type: 'integer' },
             is_verified: { type: 'boolean' },
             created_at: { type: 'date' },

--- a/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/UserIndexer.ts
@@ -7,6 +7,8 @@ import { BlocknumberCheckpoint } from '../types/blocknumber_checkpoint'
 import { UserDoc } from '../types/docs'
 import { BaseIndexer } from './BaseIndexer'
 import {
+  lowerKeyword,
+  noWhitespaceLowerKeyword,
   sharedIndexSettings,
   standardSuggest,
   standardText,
@@ -19,35 +21,29 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
 
   mapping: IndicesCreateRequest = {
     index: indexNames.users,
-    settings: merge(sharedIndexSettings, {
-      index: {
-        number_of_shards: 1,
-        number_of_replicas: 0,
-        refresh_interval: '5s',
-      },
-    }),
+    settings: merge(sharedIndexSettings, {}),
     mappings: {
       dynamic: false,
       properties: {
         blocknumber: { type: 'integer' },
         created_at: { type: 'date' },
-        wallet: { type: 'keyword' },
+        wallet: lowerKeyword,
         suggest: standardSuggest,
         handle: {
-          type: 'keyword',
+          ...noWhitespaceLowerKeyword,
           fields: {
             searchable: standardText,
           },
         },
         name: {
-          type: 'keyword',
+          ...lowerKeyword,
           fields: {
             searchable: standardText,
           },
         },
         is_verified: { type: 'boolean' },
         is_deactivated: { type: 'boolean' },
-        location: { type: 'keyword' },
+        location: lowerKeyword,
 
         // following
         following_ids: { type: 'keyword' },
@@ -59,9 +55,9 @@ export class UserIndexer extends BaseIndexer<UserDoc> {
         track_count: { type: 'integer' },
         tracks: {
           properties: {
-            mood: { type: 'keyword' },
-            genre: { type: 'keyword' },
-            tags: { type: 'keyword', normalizer: 'lower_asciifolding' },
+            mood: lowerKeyword,
+            genre: lowerKeyword,
+            tags: lowerKeyword,
           },
         },
       },

--- a/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
+++ b/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
@@ -5,7 +5,7 @@ import {
 
 export const sharedIndexSettings: IndicesIndexSettings = {
   analysis: {
-    filter: {
+    char_filter: {
       whitespace_remove: {
         type: 'pattern_replace',
         pattern: `\s+`,
@@ -20,7 +20,8 @@ export const sharedIndexSettings: IndicesIndexSettings = {
       },
       lower_asciifolding_no_whitespace: {
         type: 'custom',
-        filter: ['asciifolding', 'lowercase', 'whitespace_remove'],
+        char_filter: ['whitespace_remove'],
+        filter: ['asciifolding', 'lowercase'],
       },
     },
     analyzer: {

--- a/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
+++ b/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
@@ -5,10 +5,22 @@ import {
 
 export const sharedIndexSettings: IndicesIndexSettings = {
   analysis: {
+    filter: {
+      whitespace_remove: {
+        type: 'pattern_replace',
+        pattern: `\s+`,
+        replacement: '',
+        flags: '',
+      },
+    },
     normalizer: {
       lower_asciifolding: {
         type: 'custom',
         filter: ['asciifolding', 'lowercase'],
+      },
+      lower_asciifolding_no_whitespace: {
+        type: 'custom',
+        filter: ['asciifolding', 'lowercase', 'whitespace_remove'],
       },
     },
     analyzer: {
@@ -18,6 +30,16 @@ export const sharedIndexSettings: IndicesIndexSettings = {
         filter: ['asciifolding', 'lowercase'],
       },
     },
+  },
+
+  index: {
+    number_of_shards: 1,
+    number_of_replicas: 0,
+    refresh_interval: '5s',
+    // get_feed_es uses terms lookup to get reposts by followers
+    // default limit is 65536, but there are users that follow >65k people.
+    // so set to a million
+    max_terms_count: 1000000,
   },
 }
 
@@ -29,4 +51,14 @@ export const standardSuggest: MappingProperty = {
 export const standardText: MappingProperty = {
   type: 'text',
   analyzer: 'standard_asciifolding',
+}
+
+export const lowerKeyword: MappingProperty = {
+  type: 'keyword',
+  normalizer: 'lower_asciifolding',
+}
+
+export const noWhitespaceLowerKeyword: MappingProperty = {
+  type: 'keyword',
+  normalizer: 'lower_asciifolding_no_whitespace',
 }

--- a/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
+++ b/discovery-provider/es-indexer/src/indexers/sharedIndexSettings.ts
@@ -8,7 +8,7 @@ export const sharedIndexSettings: IndicesIndexSettings = {
     char_filter: {
       whitespace_remove: {
         type: 'pattern_replace',
-        pattern: `\s+`,
+        pattern: ' ',
         replacement: '',
         flags: '',
       },

--- a/discovery-provider/scripts/search_quality.py
+++ b/discovery-provider/scripts/search_quality.py
@@ -325,7 +325,36 @@ test_search(
         "limit": 4,
         "kind": "users",
         "is_auto_complete": True,
-    }
+    },
+    # {
+    #     "users": "stereosteve",
+    # },
+)
+
+test_search(
+    {
+        "query": "stereo steve",
+        "limit": 4,
+        "kind": "users",
+        "is_auto_complete": True,
+    },
+    # {
+    #     "users": "stereosteve",
+    # },
+)
+
+# Dillon Francis
+
+test_search(
+    {
+        "query": "Dillon Francis",
+        "limit": 4,
+        "kind": "users",
+        "is_auto_complete": True,
+    },
+    {
+        "users": "DillonFrancis dillonfrancis",
+    },
 )
 
 print("\n\n")

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -429,9 +429,6 @@ def user_dsl(search_str, current_user_id, must_saved=False):
     if current_user_id:
         dsl["should"].append(be_followed(current_user_id))
 
-    # import json
-    # print(json.dumps(dsl, indent=2))
-
     return default_function_score(dsl, "follower_count")
 
 

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -252,15 +252,15 @@ def finalize_response(
         raise Exception("esclient is None")
 
     # hydrate users, saves, reposts
-    item_keys = []
+    items = []
     user_ids = set()
     if current_user_id:
         user_ids.add(current_user_id)
 
     # collect keys for fetching
-    for items in response.values():
-        for item in items:
-            item_keys.append(item_key(item))
+    for docs in response.values():
+        for item in docs:
+            items.append(item)
             user_ids.add(item.get("owner_id", item.get("playlist_owner_id")))
 
     # fetch users
@@ -279,7 +279,7 @@ def finalize_response(
     # fetch followed saves + reposts
     if not is_auto_complete:
         (follow_saves, follow_reposts) = fetch_followed_saves_and_reposts(
-            current_user_id, item_keys
+            current_user, items
         )
 
     # tracks: finalize

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -7,7 +7,7 @@ from src.utils.spl_audio import to_wei
 es_url = os.getenv("audius_elasticsearch_url")
 esclient = None
 if es_url and not esclient:
-    esclient = Elasticsearch(es_url)
+    esclient = Elasticsearch(es_url, request_timeout=60)
 
 # uses aliases
 ES_PLAYLISTS = "playlists"


### PR DESCRIPTION
### Description

* centralizes index settings
* sets `max_terms_count` to 1M so that `get_feed_es` doesn't break for users who follow >65k people
* uses `lowerKeyword` for most keyword fields where we want case insensitive matching
* uses `noWhitespaceLowerKeyword` for handle so that `Dillon Francis` search matches `DillonFrancis`
* speeds up `fetch_followed_saves_and_reposts` to use denormalized data to mget instead of doing a "collapsed" msearch 🏇 

Note: this is a "simple" PR for whitespace tolerance in search term.  It only applies to the `handle` field which we know to be spaceless by using a custom analyzer with `char_filter`.  This won't help in a cross field query if the user types `stereo steve guitar garbage` because the `handle` field would attempt to match `stereosteveguitargarbage`.

A better way to do this is to generate alternate queries with each space removed in turn, so like:
* stereosteve guitar garbage
* stereo steveguitar garbage
* stereo steve guitargarbage

By placing initial query plus alternate queries into a dismax query you can choose the one which has the best match.

For now I just wanted to handle the simple case of `handle`.

### Tests

Adds a "search quality" test for `Dillon Francis`
