### PR TITLE
INF-288 add commit details to `reservations`

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -437,6 +437,8 @@ def format_artifacts(
             f.write("Reservation List:\n")
             for h in hosts:
                 host = release_summary[PRE_DEPLOY][h]
+                tag = host["tag"][:7]
+                branch = host["branch"]
                 if "author" in host:
                     owner = host["author"]
                     fg = "reset"
@@ -449,7 +451,7 @@ def format_artifacts(
                     else:
                         fg = "yellow"
 
-                output = f"{h.ljust(25)}{owner}"
+                output = f"{h.ljust(25)}{owner.ljust(20)}{tag.ljust(10)}{branch}"
                 click.echo(click.style(output, fg=fg))
                 f.write(f"{output}\n")
             f.write("\n\n")


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add commit and branch details to `reservations`.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Local runs that look like this:

```
$ reservations
stage-creator-10         master              4dbb42b   master
stage-creator-4          master              4dbb42b   master
stage-creator-5          Joaquin Casares     6e24564   origin/jc-inf-266
stage-creator-6          Sid Sethi           f9c6701   missing
stage-creator-7          master              4dbb42b   master
stage-creator-8          Theo Ilie           9cb8a5c   origin/theo-delete-disk-odr
stage-creator-9          master              4dbb42b   master
stage-discovery-1        master              4dbb42b   master
stage-discovery-2        master              4dbb42b   master
stage-discovery-3        master              4dbb42b   master
stage-discovery-4        master              4dbb42b   master
stage-discovery-5        Joaquin Casares     6e24564   origin/jc-inf-266
stage-identity           Joaquin Casares     6e24564   origin/jc-inf-266
stage-user-metadata      master              4dbb42b   master
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-infrastructure


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->