### PR TITLE
[CON-429]  Use QueryType.SELECT for new metrics

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -457,6 +457,7 @@ const _getUserStatusByPrimary = async (
         ORDER BY fully_synced.spid;
         `,
     {
+      type: QueryTypes.SELECT,
       replacements: { run_id },
     }
   );
@@ -468,7 +469,7 @@ const _getUserStatusByPrimary = async (
     partiallySyncedCount: number;
     unsyncedCount: number;
   }[] = (
-    userStatusByPrimaryResp[0] as {
+    userStatusByPrimaryResp as {
       spid: string;
       endpoint: string;
       fully_synced_count: string;
@@ -675,6 +676,7 @@ ON cnodes.spid = fully_synced.spid
 ORDER BY fully_synced.spid;
             `,
         {
+          type: QueryTypes.SELECT,
           replacements: { run_id },
         }
       );


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR just adds the `QueryType` onto the new network monitoring metrics so that they are consistent with the others. The QueryType changes the return type of the `sequelize.query()` function.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


Ran a netmon job locally

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This change won't be monitored anywhere but the metrics can be found on grafana

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->