### PR TITLE
Use env vars for ODR and make other env vars consistent

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -520,6 +520,18 @@ const config = convict({
     env: 'recoverOrphanedDataQueueRateLimitJobsPerInterval',
     default: 1
   },
+  recoverOrphanedDataNumUsersPerBatch: {
+    doc: 'number of users to fetch from redis and issue requests for (sequentially) in each batch',
+    format: 'nat',
+    env: 'recoverOrphanedDataNumUsersPerBatch',
+    default: 2
+  },
+  recoverOrphanedDataDelayMsBetweenBatches: {
+    doc: 'milliseconds to wait between processing each recoverOrphanedDataNumUsersPerBatch users',
+    format: 'nat',
+    env: 'recoverOrphanedDataDelayMsBetweenBatches',
+    default: 60_000 // 1m
+  },
   debounceTime: {
     doc: 'sync debounce time in ms',
     format: 'nat',
@@ -578,19 +590,19 @@ const config = convict({
     doc: 'Max bull queue concurrency for manual sync request jobs',
     format: 'nat',
     env: 'maxManualRequestSyncJobConcurrency',
-    default: 15
+    default: 30
   },
   maxRecurringRequestSyncJobConcurrency: {
     doc: 'Max bull queue concurrency for recurring sync request jobs',
     format: 'nat',
     env: 'maxRecurringRequestSyncJobConcurrency',
-    default: 50
+    default: 20
   },
   maxUpdateReplicaSetJobConcurrency: {
     doc: 'Max bull queue concurrency for update replica set jobs',
     format: 'nat',
     env: 'maxUpdateReplicaSetJobConcurrency',
-    default: 25
+    default: 10
   },
   peerHealthCheckRequestTimeout: {
     doc: 'Timeout [ms] for checking health check route',

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -179,11 +179,6 @@ export enum UpdateReplicaSetJobResult {
 // Number of users to query in each orphaned data recovery query to Discovery and to its own db
 export const ORPHANED_DATA_NUM_USERS_PER_QUERY = 2000
 
-// Number of users to fetch from redis and issue requests for (sequentially) in each batch
-export const ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH = 2
-// Milliseconds to wait between processing every ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH users
-export const ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS = 60 /* seconds */ * 1000
-
 // Milliseconds after which to gracefully end a recover-orphaned-data job early
 export const MAX_MS_TO_ISSUE_RECOVER_ORPHANED_DATA_REQUESTS =
   2 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000

--- a/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
+++ b/creator-node/test/recoverOrphanedData.jobProcessor.test.ts
@@ -45,6 +45,7 @@ describe('test recoverOrphanedData job processor', function () {
   let server: any,
     sandbox: sinon.SinonSandbox,
     originalContentNodeEndpoint: string
+  let initialNumUsersPerBatch = 1
 
   beforeEach(async function () {
     const appInfo = await getApp(getLibsMock())
@@ -52,6 +53,7 @@ describe('test recoverOrphanedData job processor', function () {
     server = appInfo.server
     sandbox = sinon.createSandbox()
     originalContentNodeEndpoint = config.get('creatorNodeEndpoint')
+    initialNumUsersPerBatch = config.get('recoverOrphanedDataNumUsersPerBatch')
     config.set('creatorNodeEndpoint', THIS_CONTENT_NODE_ENDPOINT)
     nock.disableNetConnect()
   })
@@ -61,6 +63,7 @@ describe('test recoverOrphanedData job processor', function () {
     await server.close()
     sandbox.restore()
     config.set('creatorNodeEndpoint', originalContentNodeEndpoint)
+    config.set('recoverOrphanedDataNumUsersPerBatch', initialNumUsersPerBatch)
     nock.cleanAll()
     nock.enableNetConnect()
   })
@@ -131,6 +134,13 @@ describe('test recoverOrphanedData job processor', function () {
         .reply(200)
     }
 
+    if (pagination) {
+      config.set(
+        'recoverOrphanedDataNumUsersPerBatch',
+        pagination.ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH
+      )
+    }
+    config.set('recoverOrphanedDataDelayMsBetweenBatches', 1)
     return proxyquire(
       '../src/services/stateMachineManager/stateReconciliation/recoverOrphanedData.jobProcessor.ts',
       {
@@ -140,15 +150,9 @@ describe('test recoverOrphanedData job processor', function () {
           ? {
               ...stateMachineConstants,
               ORPHANED_DATA_NUM_USERS_PER_QUERY:
-                pagination.ORPHANED_DATA_NUM_USERS_PER_QUERY,
-              ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH:
-                pagination.ORPHANED_DATA_NUM_USERS_TO_RECOVER_PER_BATCH,
-              ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS: 1
+                pagination.ORPHANED_DATA_NUM_USERS_PER_QUERY
             }
-          : {
-              ...stateMachineConstants,
-              ORPHAN_DATA_DELAY_BETWEEN_BATCHES_MS: 1
-            }
+          : stateMachineConstants
       }
     ).default
   }


### PR DESCRIPTION
### Description
- Adds env vars to control orphaned data recovery speed instead of relying on code changes to the constants (no change in prod values here)
- Updates config.js defaults to be consistent with env vars in https://github.com/AudiusProject/audius-docker-compose/pull/107



### Tests
Made sure mad dog passes and orphaned data recovery queue works the same as before


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Orphaned data recovery jobs should continue completing. Monitor the metrics for number of orphaned data syncs (at the bottom of the syncs dashboard).