### PR TITLE
[CON-382] Track metrics for sync queues

### DIFF
--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -84,6 +84,10 @@ class SyncImmediateQueue {
         )
       }
     )
+    const prometheusRegistry = serviceRegistry?.prometheusRegistry
+    if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
+      prometheusRegistry.startQueueMetrics(this.queue, worker)
+    }
   }
 
   async processTask(job) {

--- a/creator-node/src/services/sync/syncQueue.js
+++ b/creator-node/src/services/sync/syncQueue.js
@@ -81,6 +81,10 @@ class SyncQueue {
         )
       }
     )
+    const prometheusRegistry = serviceRegistry?.prometheusRegistry
+    if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
+      prometheusRegistry.startQueueMetrics(this.queue, worker)
+    }
   }
 
   async processTask(job) {


### PR DESCRIPTION
### Description
Adds active/waiting job metrics for sync and sync-immediate queues, which we're currently missing from Grafana


### Tests
Made sure tests pass and I see the appropriate metrics locally at `/prometheus_metrics` after bringing up the stack locally and creating a user to sync


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
We should see Grafana drop-down options in the Bull dashboard for "sync-processing-queue" and "sync-immediate-processing-queue"