### PR TITLE
Add artist pick field to user metadata types in libs

### DIFF
--- a/discovery-provider/src/schemas/user_schema.json
+++ b/discovery-provider/src/schemas/user_schema.json
@@ -56,6 +56,10 @@
                 "is_deactivated": {
                     "type": "boolean",
                     "default": false
+                },
+                "artist_pick_track_id": {
+                    "type": ["integer", "null"],
+                    "default": null
                 }
             },
             "required": [
@@ -65,7 +69,8 @@
                 "location",
                 "name",
                 "profile_picture",
-                "profile_picture_sizes"
+                "profile_picture_sizes",
+                "artist_pick_track_id"
             ],
             "title": "User"
         },

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -22,6 +22,7 @@ const USER_PROPS = [
   'cover_photo_sizes',
   'bio',
   'location',
+  'artist_pick_track_id',
   'creator_node_endpoint',
   'associated_wallets',
   'associated_sol_wallets',

--- a/libs/src/services/schemaValidator/schemas/userSchema.json
+++ b/libs/src/services/schemaValidator/schemas/userSchema.json
@@ -56,6 +56,10 @@
                 "is_deactivated": {
                     "type": "boolean",
                     "default": false
+                },
+                "artist_pick_track_id": {
+                    "type": ["integer", "null"],
+                    "default": null
                 }
             },
             "required": [
@@ -65,7 +69,8 @@
                 "location",
                 "name",
                 "profile_picture",
-                "profile_picture_sizes"
+                "profile_picture_sizes",
+                "artist_pick_track_id"
             ],
             "title": "User"
         },

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -30,6 +30,7 @@ type UID = string
 export type UserMetadata = {
   user_id: number
   album_count: number
+  artist_pick_track_id: number
   bio: string | null
   cover_photo: Nullable<CID>
   creator_node_endpoint: string


### PR DESCRIPTION
### Description
Add `artist_pick_track_id` field to user metadata types in libs.
Will call `updateCreator` from the client; entity manager path is already implemented in that method.

### Tests
Make sure existing tests pass.