### PR TITLE
Is fix local listen

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -53,7 +53,7 @@ def generate_env(
 
     for name, private_key in config.get("eth-accounts", {}).items():
         account = eth_account.Account.from_key(private_key)
-        env[f"{name}_PRIVATE_KEY"] = account.key.hex()
+        env[f"{name}_PRIVATE_KEY"] = account.key.hex()[2:]
         env[f"{name}_ADDRESS"] = account.address
 
         if name.startswith("ETH_RELAYER_WALLET"):

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -53,14 +53,16 @@ def generate_env(
 
     for name, private_key in config.get("eth-accounts", {}).items():
         account = eth_account.Account.from_key(private_key)
-        env[f"{name}_PRIVATE_KEY"] = account.key.hex()[2:]
+
+        # slice off 0x for hex private keys
+        env[f"{name}_PRIVATE_KEY"] = account.key.hex().replace('0x', '')
         env[f"{name}_ADDRESS"] = account.address
 
         if name.startswith("ETH_RELAYER_WALLET"):
             eth_relayer_wallets.append(
                 {
                     "publicKey": account.address,
-                    "privateKey": account.key.hex()[2:],
+                    "privateKey": account.key.hex().replace('0x', ''),
                 }
             )
 
@@ -68,7 +70,7 @@ def generate_env(
             poa_relayer_wallets.append(
                 {
                     "publicKey": account.address,
-                    "privateKey": account.key.hex()[2:],
+                    "privateKey": account.key.hex().replace('0x', ''),
                 }
             )
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Local listens were breaking at this line because private keys would include 0x which is invalid hex.
https://github.com/AudiusProject/audius-protocol/blob/master/identity-service/src/solana-client.js#L166

Making this change to fix the hex private keys for all eth-accounts. It seems like we don't rely on other private keys but doing this just in case. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested local listens successfully. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->