### PR TITLE
Modify user API endpoints to accommodate artist pick tracks

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_tracks.py
+++ b/discovery-provider/integration_tests/queries/test_get_tracks.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from integration_tests.utils import populate_mock_db
 from src.queries.get_remixable_tracks import get_remixable_tracks
 from src.queries.get_tracks import _get_tracks
-from src.queries.query_helpers import SortMethod
+from src.queries.query_helpers import SortDirection, SortMethod
 from src.utils.db_session import get_db
 
 
@@ -253,13 +253,20 @@ def test_get_tracks_with_pinned_track_and_sort_method(app):
 
     with db.scoped_session() as session:
         tracks = _get_tracks(
-            session, {"user_id": 5, "offset": 0, "limit": 10, "sort_method": SortMethod.release_date}
+            session,
+            {
+                "user_id": 5,
+                "offset": 0,
+                "limit": 10,
+                "sort_method": SortMethod.release_date,
+                "sort_direction": SortDirection.desc,
+            },
         )
 
         assert len(tracks) == 3
-        assert tracks[0]["track_id"] == 14
+        assert tracks[0]["track_id"] == 13
         assert tracks[1]["track_id"] == 12
-        assert tracks[2]["track_id"] == 13
+        assert tracks[2]["track_id"] == 14
 
 
 def test_get_track_by_route(app):

--- a/discovery-provider/integration_tests/queries/test_get_tracks.py
+++ b/discovery-provider/integration_tests/queries/test_get_tracks.py
@@ -236,8 +236,8 @@ def test_get_tracks_with_pinned_track(app):
 
         assert len(tracks) == 3
         assert tracks[0]["track_id"] == 12
-        assert tracks[1]["track_id"] == 14
-        assert tracks[2]["track_id"] == 13
+        assert tracks[1]["track_id"] == 13
+        assert tracks[2]["track_id"] == 14
 
 
 def test_get_tracks_with_pinned_track_and_sort_method(app):
@@ -257,9 +257,9 @@ def test_get_tracks_with_pinned_track_and_sort_method(app):
         )
 
         assert len(tracks) == 3
-        assert tracks[0]["track_id"] == 13
+        assert tracks[0]["track_id"] == 14
         assert tracks[1]["track_id"] == 12
-        assert tracks[2]["track_id"] == 14
+        assert tracks[2]["track_id"] == 13
 
 
 def test_get_track_by_route(app):

--- a/discovery-provider/integration_tests/queries/test_get_tracks.py
+++ b/discovery-provider/integration_tests/queries/test_get_tracks.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from integration_tests.utils import populate_mock_db
 from src.queries.get_remixable_tracks import get_remixable_tracks
 from src.queries.get_tracks import _get_tracks
+from src.queries.query_helpers import SortMethod
 from src.utils.db_session import get_db
 
 
@@ -88,6 +89,27 @@ def populate_tracks(db):
                 "created_at": datetime(2018, 5, 17),
                 "is_unlisted": True,
             },
+            {
+                "track_id": 12,
+                "title": "track 12",
+                "owner_id": 5,
+                "release_date": "Fri Jun 19 2020 12:00:00 GMT-0800",
+                "created_at": datetime(2018, 5, 21),
+            },
+            {
+                "track_id": 13,
+                "title": "track 13",
+                "owner_id": 5,
+                "release_date": "Fri Oct 7 2022 12:00:00 GMT-0800",
+                "created_at": datetime(2018, 5, 17),
+            },
+            {
+                "track_id": 14,
+                "title": "track 14",
+                "owner_id": 5,
+                "release_date": "Wed Dec 25 2019 12:00:00 GMT-0800",
+                "created_at": datetime(2020, 5, 17),
+            },
         ],
         "track_routes": [
             {"slug": "track-1", "owner_id": 1287289},
@@ -116,6 +138,7 @@ def populate_tracks(db):
         "users": [
             {"user_id": 1287289, "handle": "some-test-user"},
             {"user_id": 4, "handle": "some-other-user"},
+            {"user_id": 5, "handle": "test-user-5", "artist_pick_track_id": 12},
         ],
     }
 
@@ -193,6 +216,50 @@ def test_get_tracks_by_date_authed(app):
         assert tracks[3]["track_id"] == 5
         assert tracks[4]["track_id"] == 4
         assert tracks[5]["track_id"] == 2
+
+
+def test_get_tracks_with_pinned_track(app):
+    """
+    Test getting tracks for a user with a pinned track. The
+    pinned track should be the first result, with all other tracks
+    sorted according to the sort parameter.
+    """
+    with app.app_context():
+        db = get_db()
+
+    populate_tracks(db)
+
+    with db.scoped_session() as session:
+        tracks = _get_tracks(
+            session, {"user_id": 5, "offset": 0, "limit": 10, "sort": "date"}
+        )
+
+        assert len(tracks) == 3
+        assert tracks[0]["track_id"] == 12
+        assert tracks[1]["track_id"] == 14
+        assert tracks[2]["track_id"] == 13
+
+
+def test_get_tracks_with_pinned_track_and_sort_method(app):
+    """
+    Test getting tracks for a user with a pinned track. All tracks
+    should be sorted according the sort method. The pinned track is
+    not necessarily the first result.
+    """
+    with app.app_context():
+        db = get_db()
+
+    populate_tracks(db)
+
+    with db.scoped_session() as session:
+        tracks = _get_tracks(
+            session, {"user_id": 5, "offset": 0, "limit": 10, "sort_method": SortMethod.release_date}
+        )
+
+        assert len(tracks) == 3
+        assert tracks[0]["track_id"] == 13
+        assert tracks[1]["track_id"] == 12
+        assert tracks[2]["track_id"] == 14
 
 
 def test_get_track_by_route(app):

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -212,6 +212,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 is_current=user_meta.get("is_current", True),
                 handle=user_meta.get("handle", str(i)),
                 handle_lc=user_meta.get("handle", str(i)).lower(),
+                artist_pick_track_id=user_meta.get("artist_pick_track_id"),
                 wallet=user_meta.get("wallet", str(i)),
                 bio=user_meta.get("bio", str(i)),
                 profile_picture=user_meta.get("profile_picture"),

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -28,6 +28,7 @@ user_model = ns.model(
     "user",
     {
         "album_count": fields.Integer(required=True),
+        "artist_pick_track_id": fields.Integer(allow_null=True),
         "bio": fields.String,
         "cover_photo": fields.Nested(cover_photo, allow_null=True),
         "followee_count": fields.Integer(required=True),

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -1,7 +1,7 @@
 import logging  # pylint: disable=C0302
 from typing import List, Optional, TypedDict
 
-from sqlalchemy import and_, asc, desc, func, or_, case
+from sqlalchemy import and_, asc, case, desc, func, or_
 from sqlalchemy.sql.functions import coalesce
 from src.models.social.aggregate_plays import AggregatePlay
 from src.models.tracks.aggregate_track import AggregateTrack
@@ -181,9 +181,17 @@ def _get_tracks(session, args):
         # Return the user's pinned track first if there is no specified sort_method
         if "user_id" in args and args.get("user_id") is not None:
             user_id = args.get("user_id")
-            pinned_track_id = session.query(User.artist_pick_track_id).filter(User.is_current == True, User.user_id == user_id).scalar()
+            pinned_track_id = (
+                session.query(User.artist_pick_track_id)
+                .filter(User.is_current == True, User.user_id == user_id)
+                .scalar()
+            )
             if pinned_track_id:
-                base_query = base_query.order_by(case(((TrackWithAggregates.track_id == pinned_track_id, 0),), else_=1))
+                base_query = base_query.order_by(
+                    case(
+                        ((TrackWithAggregates.track_id == pinned_track_id, 0),), else_=1
+                    )
+                )
 
     # Deprecated, use sort_method and sort_direction
     if "sort" in args and args.get("sort") is not None:
@@ -214,7 +222,7 @@ def _get_tracks(session, args):
             base_query = parse_sort_param(
                 base_query, TrackWithAggregates, whitelist_params
             )
- 
+
     query_results = add_query_pagination(base_query, args["limit"], args["offset"])
     tracks = helpers.query_result_to_list(query_results.all())
     return tracks

--- a/libs/src/sdk/api/generated/default/models/User.ts
+++ b/libs/src/sdk/api/generated/default/models/User.ts
@@ -40,6 +40,12 @@ export interface User {
     album_count: number;
     /**
      * 
+     * @type {number}
+     * @memberof User
+     */
+    artist_pick_track_id?: number;
+    /**
+     * 
      * @type {string}
      * @memberof User
      */

--- a/libs/src/sdk/api/generated/full/models/UserFull.ts
+++ b/libs/src/sdk/api/generated/full/models/UserFull.ts
@@ -46,6 +46,12 @@ export interface UserFull {
     album_count: number;
     /**
      * 
+     * @type {number}
+     * @memberof UserFull
+     */
+    artist_pick_track_id?: number;
+    /**
+     * 
      * @type {string}
      * @memberof UserFull
      */


### PR DESCRIPTION
### Description
For the track endpoints, return the artist pick first, with the remaining tracks sorted according to the `sort` parameter (`sort` has a default value and setting a different `sort` value is deprecated). However, if the `sort_method` param is defined, sort all tracks according to that.

Also return the `artist_pick_track_id` as part of the user object.

### Tests
- New integration tests
- Test endpoints locally
![image](https://user-images.githubusercontent.com/25782182/195234460-ef86ec80-b72d-470d-a14f-922fb0c620e2.png)
Manually updated artist pick value in psql:
![image](https://user-images.githubusercontent.com/25782182/195239240-1a6f798e-e832-4983-82ca-b78ba672a358.png)
Was not able to test user tracks tracks endpoint manually because I couldn't create tracks locally and the artist pick write path in the client is not done yet, but the integration tests should cover this case.

