### PR TITLE
[INF-292] Auto delete CI spot instances

### DIFF
--- a/service-commands/scripts/auto-delete-gcloud-instance.sh
+++ b/service-commands/scripts/auto-delete-gcloud-instance.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-default_timeout=${default_timeout:-600s} # change this to 6 hours
+default_timeout=${default_timeout:-43200s} # 12 hours
 sleep $default_timeout
 export NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
 export ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')

--- a/service-commands/scripts/auto-delete-gcloud-instance.sh
+++ b/service-commands/scripts/auto-delete-gcloud-instance.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+default_timeout=${default_timeout:-600s} # change this to 6 hours
+sleep $default_timeout
+export NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
+export ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
+gcloud --quiet compute firewall-rules delete $NAME --zone=$ZONE
+gcloud --quiet compute instances delete $NAME --zone=$ZONE

--- a/service-commands/scripts/create-instance.sh
+++ b/service-commands/scripts/create-instance.sh
@@ -112,7 +112,7 @@ case "$provider" in
 	gcp)
 		if [[ "$spot_instance" == true ]]; then
 		# https://cloud.google.com/community/tutorials/create-a-self-deleting-virtual-machine
-		# delete spot instances (used in CI for mad dog/sdk tests) after 6 hours by default
+		# delete spot instances (used in CI for mad dog/sdk tests) after 12 hours by default
 			spot_flag="--provisioning-model=SPOT --metadata-from-file=startup-script=$PROTOCOL_DIR/service-commands/scripts/auto-delete-gcloud-instance.sh --scopes=compute-rw"
 		fi
 		gcloud compute instances create \

--- a/service-commands/scripts/create-instance.sh
+++ b/service-commands/scripts/create-instance.sh
@@ -111,7 +111,9 @@ case "$provider" in
 		;;
 	gcp)
 		if [[ "$spot_instance" == true ]]; then
-			spot_flag=--provisioning-model=SPOT
+		# https://cloud.google.com/community/tutorials/create-a-self-deleting-virtual-machine
+		# delete spot instances (used in CI for mad dog/sdk tests) after 6 hours by default
+			spot_flag="--provisioning-model=SPOT --metadata-from-file=startup-script=$PROTOCOL_DIR/service-commands/scripts/auto-delete-gcloud-instance.sh --scopes=compute-rw"
 		fi
 		gcloud compute instances create \
 			$name $(gcp_image_to_flags $image) \


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Add auto-cleanup to GCP spot instances triggered via CI from mad-dog/sdk. This auto deletes instances after 12 hours so we don't have a buildup of dozens or more instances in our dashboard.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested with a 10 minute window here and I checked the VM and firewall manually and it's been deleted https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/28965/workflows/d9f71e03-d771-4a9b-8bdf-1db26f7b4006/jobs/356241

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
VM instances and firewall page in GCloud console.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->