### PR TITLE
INF Wait 15 seconds to SSH into a node

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -193,7 +193,7 @@ def get_release_tag_by_host(snapshot, host, github_user, github_token):
     """
 
     # test ssh access
-    output = ssh(host, "hostname", exit_on_error=RAISE, timeout_sec=5)
+    output = ssh(host, "hostname", exit_on_error=RAISE, timeout_sec=15)
     if not output:
         snapshot.update(
             {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

`ssh stage-creator-9` can take longer than 5 seconds, causing our deployments to this node to fail.

My vote is fix the underlying issues with `stage-creator-9`, but we can also loosen the timeout period before our deployment jobs mark the deployment on this node as failed.

The node has plenty of postgres processes and is running at max CPU:

<img width="1199" alt="Screen Shot 2022-10-10 at 6 32 43 PM" src="https://user-images.githubusercontent.com/545666/194975606-8be619c3-9351-4e0f-8c0b-5d3df5712748.png">

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Testing on master.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->