### PR TITLE
[CON-313] Network Monitoring: Differentiate between missed users and users with -1 clock values

### DIFF
--- a/discovery-provider/plugins/network-monitoring/src/content/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/content/index.ts
@@ -316,6 +316,20 @@ const checkIfCIDsExistOnCN = instrumentTracing({
     fn: _checkIfCIDsExistOnCN,
 })
 
+/**
+ * 
+ * @param endpoint the content node http endpoint
+ * @param walletPublicKeys the list of wallet public keys
+ * @param deregisteredCN the list of deregistered content nodes
+ * @param signatureSpID the signaturespid of the network monitoring job
+ * @param signatureSPDelegatePrivateKey the priv key of the network monitoring job
+ * @returns And object with the number of canceled users and a mapping between a user's wallet and their clock value
+ * 
+ * Clock value significant
+ * >0 = the user has data on that content node
+ * -1 = the user has no data on that content node
+ * -2 = the content node was unresponsive, deregistered, or there was an error
+ */
 const _getUserClockValues = async (
     endpoint: string,
     walletPublicKeys: string[],
@@ -353,12 +367,11 @@ const _getUserClockValues = async (
 
         if (batchClockStatusResp.canceled) {
             tracing.info(`[getUsersClockValues canceled] - ${endpoint}`)
-            // Return map of wallets to -1 clock (default value)
             return {
                 canceledUsers: walletPublicKeys.length,
                 results: walletPublicKeys.map(walletPublicKey => ({
                     walletPublicKey,
-                    clock: -1
+                    clock: -2 
                 }))
             }
         }
@@ -373,12 +386,11 @@ const _getUserClockValues = async (
         tracing.recordException(e)
         tracing.error(`[getUserClockValues Error] - ${endpoint} - ${e.message}`)
 
-        // Return map of wallets to -1 clock (default value)
         return {
             canceledUsers: walletPublicKeys.length,
             results: walletPublicKeys.map(walletPublicKey => ({
                 walletPublicKey,
-                clock: -1
+                clock: -2
             })),
         }
     }

--- a/discovery-provider/plugins/network-monitoring/src/db/sql/scratch_pad.sql
+++ b/discovery-provider/plugins/network-monitoring/src/db/sql/scratch_pad.sql
@@ -468,3 +468,15 @@ JOIN (
 ) AS cnodes
 ON cnodes.spid = fully_synced.spid
 -- ORDER BY fully_synced.spid;
+
+SELECT COUNT(*) as user_count
+    FROM network_monitoring_users
+    WHERE 
+        run_id = 168
+    AND (
+        primary_clock_value = -1
+        OR
+        secondary1_clock_value = -1
+        OR 
+        secondary2_clock_value = -1
+    );

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -142,6 +142,10 @@ const _generateMetrics = async (run_id: number) => {
         ((usersWithNoFoundationNodeReplicaSetCount / userCount) * 100).toFixed(
           2
         ) + "%",
+        usersWithUnhealthyReplica:
+        ((usersWithUnhealthyReplica / userCount) * 100).toFixed(
+          2
+        ) + "%",
       runDuration: msToTime(endTime - runStartTime.getTime()),
     });
   }

--- a/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/index.ts
@@ -11,6 +11,7 @@ import {
   partiallySyncedUsersByReplicaCountGauge,
   partiallySyncedUsersCountGauge,
   primaryUserCountGauge,
+  unhealthyReplicaUsersCountGauge,
   unsyncedUsersByPrimaryCountGauge,
   unsyncedUsersByReplicaCountGauge,
   unsyncedUsersCountGauge,
@@ -32,6 +33,7 @@ import {
   getUsersWithEntireReplicaSetNotInSpidSetCount,
   getUserStatusByPrimary,
   getUserStatusByReplica,
+  getUsersWithUnhealthyReplica,
 } from "./queries";
 import { instrumentTracing, tracing } from "..//tracer"
 
@@ -57,6 +59,8 @@ const _generateMetrics = async (run_id: number) => {
   const unsyncedUsersCount = await getUnsyncedUsersCount(run_id);
 
   const usersWithNullPrimaryClock = await getUsersWithNullPrimaryClock(run_id);
+
+  const usersWithUnhealthyReplica = await getUsersWithUnhealthyReplica(run_id);
 
   const usersWithAllFoundationNodeReplicaSetCount =
     await getUsersWithEntireReplicaSetInSpidSetCount(run_id, foundationNodes);
@@ -106,6 +110,7 @@ const _generateMetrics = async (run_id: number) => {
   partiallySyncedUsersCountGauge.set({ run_id }, partiallySyncedUserCount);
   unsyncedUsersCountGauge.set({ run_id }, unsyncedUsersCount);
   nullPrimaryUsersCountGauge.set({ run_id }, usersWithNullPrimaryClock);
+  unhealthyReplicaUsersCountGauge.set({ run_id }, usersWithUnhealthyReplica);
   usersWithAllFoundationNodeReplicaSetGauge.set(
     { run_id },
     usersWithAllFoundationNodeReplicaSetCount

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -320,6 +320,34 @@ export const getUsersWithNullPrimaryClock = instrumentTracing({
     fn: _getUsersWithNullPrimaryClock,
 })
 
+// The number of users who have a recorded clock value of -2
+const _getUsersWithUnhealthyReplica = async (run_id: number): Promise<number> => {
+    const usersResp: unknown[] = await sequelizeConn.query(`
+    SELECT COUNT(*) as user_count
+    FROM network_monitoring_users
+    WHERE 
+        run_id = :run_id
+    AND (
+        primary_clock_value = -2
+        OR
+        secondary1_clock_value = -2
+        OR 
+        secondary2_clock_value = -2
+    );
+    `, {
+        type: QueryTypes.SELECT,
+        replacements: { run_id },
+    })
+
+    const usersCount = parseInt(((usersResp as { user_count: string }[])[0] || { user_count: '0' }).user_count)
+
+    return usersCount
+}
+
+export const getUsersWithUnhealthyReplica = instrumentTracing({
+    fn: _getUsersWithUnhealthyReplica,
+})
+
 const _getUsersWithEntireReplicaSetInSpidSetCount = async (run_id: number, spidSet: number[]): Promise<number> => {
 
     const spidSetStr = `{${spidSet.join(",")}}`

--- a/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
+++ b/discovery-provider/plugins/network-monitoring/src/metrics/queries.ts
@@ -210,6 +210,8 @@ const _getFullySyncedUsersCount = async (run_id: number): Promise<number> => {
             run_id = :run_id
         AND 
             primary_clock_value IS NOT NULL
+        AND 
+            primary_clock_value != -2
         AND
             primary_clock_value = secondary1_clock_value
         AND
@@ -243,6 +245,8 @@ const _getPartiallySyncedUsersCount = async (run_id: number): Promise<number> =>
             run_id = :run_id
         AND 
             primary_clock_value IS NOT NULL
+        AND 
+            primary_clock_value != -2
         AND ( 
             primary_clock_value = secondary1_clock_value
             OR
@@ -274,6 +278,8 @@ const _getUnsyncedUsersCount = async (run_id: number): Promise<number> => {
             run_id = :run_id
         AND 
             primary_clock_value IS NOT NULL
+        AND 
+            primary_clock_value != -2
         AND 
             primary_clock_value != secondary1_clock_value
         AND

--- a/discovery-provider/plugins/network-monitoring/src/prometheus.ts
+++ b/discovery-provider/plugins/network-monitoring/src/prometheus.ts
@@ -48,6 +48,12 @@ export const nullPrimaryUsersCountGauge = new client.Gauge({
     labelNames: ['run_id']
 })
 
+export const unhealthyReplicaUsersCountGauge = new client.Gauge({
+    name: 'audius_nm_unhealthy_replica_users_count',
+    help: 'the number of users who have an unhealthy replica',
+    labelNames: ['run_id']
+})
+
 export const missedUsersCountGauge = new client.Gauge({
     name: 'audius_nm_missed_users_count',
     help: 'the number of users that got skipped while indexing content nodes',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR records the clock value `-2` when a node is unhealthy rather than defaulting to `-1` so we can tell is the user is empty vs if there was an error from the content node.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

This was tested on staging network monitoring by doing a test run

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This will be monitored on grafana on the network monitoring dashboard as well as from our slack alerts 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->