### PR TITLE
[CON-440] Use min concurrency instead of max for Bull

### DIFF
--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -48,22 +48,19 @@ class ClusterUtils {
     return config.get('expressAppConcurrency') || logicalCores
   }
 
-  getConcurrencyForEnvVar(envVar: string) {
-    const globalConcurrency = config.get(envVar)
-    return this.getConcurrencyPerWorker(globalConcurrency)
-  }
-
   /**
-   * Calculates the concurrency that each worker should have to achieve the given global concurrency.
+   * Calculates the concurrency that each worker should have to achieve *at least* the given global concurrency.
+   * This is a minimum global concurrency that increments by number of workers.
+   * Ex: If there are 16 workers, 1 extra job per worker = 16 extra jobs. So global concurrency of 30 would be 32
    * Note that a global concurrency of 1 is not possible with multiple workers, as per the docs:
    * https://docs.bullmq.io/guide/workers/concurrency
    * This means that if the global concurrency given is set to 1, it will have to be 1 per worker not 1 globally.
    * @param globalConcurrency the global concurrency to achieve by splitting concurrency across workers
-   * @returns concurrency that each worker process on this machine needs to achieve the desired global concurrency
+   * @returns concurrency that each worker process on this machine needs to achieve at least the desired global concurrency
    */
   getConcurrencyPerWorker(globalConcurrency: number) {
     const numWorkers = this.getNumWorkers()
-    const concurrencyPerWorker = Math.floor(globalConcurrency / numWorkers)
+    const concurrencyPerWorker = Math.ceil(globalConcurrency / numWorkers)
     return concurrencyPerWorker || 1
   }
 }


### PR DESCRIPTION
### Description
Changes concurrency to use `Math.ceil` instead of `Math.floor`, which makes the global concurrency be a function of the number of workers. Examples:

* 16 workers and min global concurrency of 30 = global concurrency of 32
* 16 workers and min global concurrency of 17 = global concurrency of 32
* 16 workers and min global concurrency of 1 = global concurrency of 16


### Tests
Mad dog passing is sufficient. I'll take this out to staging to verify higher traffic and concurrency passing.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
The number of active jobs when queues are backed up should be a factor of 16 of prod.