### PR TITLE
Deploy EM to nethermind + tx script

### DIFF
--- a/contracts/contract-config.js
+++ b/contracts/contract-config.js
@@ -109,5 +109,7 @@ module.exports = {
     ],
     userReplicaSetBootstrapAddress: '0x3d2563ACCD9E6D189bA2a61F116905D520054286',
     registryAddress: '0x793373aBF96583d5eb71a15d86fFE732CD04D452'
+  },
+  nethermind: {
   }
 }

--- a/contracts/migrations/6_nethermind_entity_manager_migration.js
+++ b/contracts/migrations/6_nethermind_entity_manager_migration.js
@@ -1,0 +1,7 @@
+const EntityManager = artifacts.require('./EntityManager.sol')
+
+module.exports = (deployer) => {
+  deployer.then(async () => {
+    await deployer.deploy(EntityManager)
+  })
+}

--- a/contracts/scripts/nethermind_entity_manager_tx.js
+++ b/contracts/scripts/nethermind_entity_manager_tx.js
@@ -1,0 +1,76 @@
+let { generators, getNonce } = require("../signature_schemas/signatureSchemas");
+let sigUtil = require("eth-sig-util");
+let { Buffer } = require("safe-buffer");
+let entityManagerABI = require("../build/contracts/EntityManager.json");
+var Contract = require("web3-eth-contract");
+
+async function main() {
+  try {
+    let entityManagerAddress = process.env.ENTITY_MANAGER_ADDRESS;
+    let privateKey = process.env.SENDER_PRIVATE_KEY;
+    let senderAccount = web3.eth.accounts.privateKeyToAccount(
+      "0x" + privateKey
+    );
+    let contract = new Contract(entityManagerABI.abi, entityManagerAddress);
+
+    while (true) {
+      let chainId = 1056800;
+      let userId = 1;
+      let entityType = "Track";
+      let entityId = 2;
+      let action = "Save";
+      let metadataMultihash = "";
+      let txCount = await web3.eth.getTransactionCount(senderAccount.address);
+      console.log("txCount", txCount);
+      let sigNonce = getNonce();
+      let signatureData = generators.getManageEntityData(
+        chainId,
+        entityManagerAddress,
+        userId,
+        entityType,
+        entityId,
+        action,
+        metadataMultihash,
+        sigNonce
+      );
+      let sig = sigUtil.signTypedData(Buffer.from(privateKey, "hex"), {
+        data: signatureData,
+      });
+      let method = contract.methods
+        .manageEntity(
+          userId,
+          entityType,
+          entityId,
+          action,
+          metadataMultihash,
+          sigNonce,
+          sig
+        )
+        .encodeABI();
+
+      let transaction = {
+        to: entityManagerAddress,
+        value: 0,
+        gas: "100880", // some high gas value
+        nonce: txCount,
+        data: method,
+      };
+      let signedTx = await web3.eth.accounts.signTransaction(
+        transaction,
+        privateKey
+      );
+      console.log("sending tx");
+      let receipt = await web3.eth.sendSignedTransaction(
+        signedTx.rawTransaction
+      );
+      console.log("receipt", receipt.transactionHash);
+    }
+  } catch (err) {
+    console.log("error", err);
+  }
+}
+
+module.exports = async function (callback) {
+  await main();
+  callback();
+};

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -71,7 +71,14 @@ module.exports = {
       gas: 8000000,
       gasPrice: 1000000000,
       skipDryRun: true
-    }
+    },
+    nethermind: {
+      provider: () => new HDWalletProvider("private key", "staging chain RPC"), // fill in values 
+      network_id: "*",
+      gas: 0,
+      gasPrice: 0,
+      gasLimit: 0,
+    },
   },
   mocha: {
     enableTimeouts: false


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Deploy EM to chain on stage DN.
`./node_modules/.bin/truffle migrate --f 6 --to 6 --network nethermind --skip-dry-run`

Send transactions to chain, to be randomized later. requires setting env vars for entity manager address and private key for sending txs.
`./node_modules/.bin/truffle --network nethermind exec scripts/nethermind_entity_manager_tx.js`

https://www.notion.so/audiusproject/Nethermind-Truffle-Setup-ba989185ca724b818bc064294dd48357
### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->