### PR TITLE
Reduce discoveryNodeUnhealthyBlockDiff from 500 to 15

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -419,7 +419,7 @@ const config = convict({
     doc: 'Number of missed blocks after which a discovery node would be considered unhealthy',
     format: 'nat',
     env: 'discoveryNodeUnhealthyBlockDiff',
-    default: 500
+    default: 15
   },
   identityService: {
     doc: 'Identity service endpoint to record creator-node driven plays against',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Reduce discoveryNodeUnhealthyBlockDiff from 500 to 15 to ensure CN cycles off of unhealthy DN more quickly
DN blockdiff is now in critical path with entity manager migration

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

n/a

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->