### PR TITLE
[INF-292] Cleanup GCP VMs created in CI pt. 2

### DIFF
--- a/service-commands/scripts/create-instance.sh
+++ b/service-commands/scripts/create-instance.sh
@@ -111,9 +111,16 @@ case "$provider" in
 		;;
 	gcp)
 		if [[ "$spot_instance" == true ]]; then
-		# https://cloud.google.com/community/tutorials/create-a-self-deleting-virtual-machine
-		# delete spot instances (used in CI for mad dog/sdk tests) after 12 hours by default
-			spot_flag="--provisioning-model=SPOT --metadata-from-file=startup-script=$PROTOCOL_DIR/service-commands/scripts/auto-delete-gcloud-instance.sh --scopes=compute-rw"
+			# https://cloud.google.com/community/tutorials/create-a-self-deleting-virtual-machine
+			# delete spot instances (used in CI for mad dog/sdk tests) after 12 hours by default
+			# --provision-model=SPOT choose a pre-emptible VM so GCP can delete at any time
+			# --metadata-from-file=startup-script= allows us to pass in a script to run on VM start
+			# --instance-termination-action=DELETE will delete the VM when GCP preempts it vs just stopping
+			# --scopes=compute-rw are permissions for this node to make requests to gcloud compute API
+			spot_flag="--provisioning-model=SPOT \
+				--metadata-from-file=startup-script=$PROTOCOL_DIR/service-commands/scripts/auto-delete-gcloud-instance.sh \
+				--instance-termination-action=DELETE \
+				--scopes=compute-rw"
 		fi
 		gcloud compute instances create \
 			$name $(gcp_image_to_flags $image) \


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
My last PR https://github.com/AudiusProject/audius-protocol/pull/4057 didn't handle if GCP pre-empts the VM and stops it before the cleanup script runs. This adds a flag to set instance termination action to delete (default is stop).

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested using gcloud API to make a VM and verify termination action in console is terminate.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
No dangling instances in CI project

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->