### PR TITLE
ES feed: dedupe track uploads that also appear in a playlist

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -15,9 +15,15 @@ basic_entities = {
     "users": [
         {"user_id": 1, "handle": "user1"},
         {"user_id": 2, "handle": "user2"},
+        {"user_id": 3, "handle": "user3"},
     ],
     "tracks": [
         {"track_id": 1, "owner_id": 1},
+        # user3 has 2 tracks that are in a playlist
+        {"track_id": 2, "owner_id": 3},
+        {"track_id": 3, "owner_id": 3},
+        # user3 has 1 track that's NOT in the playlist
+        {"track_id": 4, "owner_id": 3},
     ],
     "playlists": [
         {
@@ -29,12 +35,28 @@ basic_entities = {
                 ]
             },
         },
+        {
+            "playlist_id": 2,
+            "playlist_owner_id": 3,
+            "playlist_contents": {
+                "track_ids": [
+                    {"track": 2, "time": 2},
+                    {"track": 3, "time": 3},
+                ]
+            },
+        },
     ],
     "follows": [
+        # user 1 follows user 2
         {
             "follower_user_id": 1,
             "followee_user_id": 2,
-        }
+        },
+        # user 2 follows user 3
+        {
+            "follower_user_id": 2,
+            "followee_user_id": 3,
+        },
     ],
     "reposts": [
         {"repost_item_id": 1, "repost_type": "track", "user_id": 2},
@@ -68,7 +90,8 @@ def test_get_feed_es(app):
     )
     esclient.indices.refresh(index="*")
     search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
-    assert len(search_res) == 8
+    # actually would be more than 10, but 10 is the default `size`...
+    assert len(search_res) == 10
 
     # test feed
     with app.app_context():
@@ -81,9 +104,19 @@ def test_get_feed_es(app):
         assert feed_results[1]["track_id"] == 1
         assert feed_results[1]["save_count"] == 1
 
+        # playlist <> track dedupe:
+        # user2 follows user3
+        # user3 should have one playlist and one track
+        #   the 2 tracks in the playlist should be de-duped
         feed_results = get_feed_es({"user_id": "2"})
+        assert len(feed_results) == 2
+        assert feed_results[0]["playlist_id"] == 2
+        assert feed_results[1]["track_id"] == 4
+
+        # user 3 follows nobody
+        feed_results = get_feed_es({"user_id": "3"})
         assert len(feed_results) == 0
 
-        # user 2 with explicit IDs
-        feed_results = get_feed_es({"user_id": "2", "followee_user_ids": [1]})
+        # user 3 with explicit IDs
+        feed_results = get_feed_es({"user_id": "3", "followee_user_ids": [2]})
         assert len(feed_results) == 2

--- a/discovery-provider/src/queries/get_feed_es.py
+++ b/discovery-provider/src/queries/get_feed_es.py
@@ -121,12 +121,18 @@ def get_feed_es(args, limit=10):
         #    instead of doing it dynamically here?
         playlist["item_key"] = item_key(playlist)
         seen.add(playlist["item_key"])
-        # Q: should we add playlist tracks to seen?
-        #    get_feed will "debounce" tracks in playlist
         unsorted_feed.append(playlist)
+
+        # add playlist track_ids to seen
+        # if a user uploads an orig playlist or album
+        # surpress individual tracks from said album appearing in feed
+        for track in playlist["tracks"]:
+            seen.add(item_key(track))
 
     for track in tracks:
         track["item_key"] = item_key(track)
+        if track["item_key"] in seen:
+            continue
         seen.add(track["item_key"])
         unsorted_feed.append(track)
 


### PR DESCRIPTION
### Description

Approximates this [get_feed](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/src/queries/get_feed.py#L103-L123) code.


### Tests

✅ 
