### PR TITLE
Make another gigantic log a debug

### DIFF
--- a/creator-node/src/services/stateMachineManager/processJob.ts
+++ b/creator-node/src/services/stateMachineManager/processJob.ts
@@ -38,7 +38,7 @@ async function processJob(
   const { id: jobId, data: jobData } = job
 
   const jobLogger = createChildLogger(parentLogger, { jobId })
-  jobLogger.info(`New job: ${JSON.stringify(job)}`)
+  jobLogger.debug(`New job: ${JSON.stringify(job)}`)
 
   let result
   const jobDurationSecondsHistogram = prometheusRegistry.getMetric(

--- a/creator-node/test/processJob.test.js
+++ b/creator-node/test/processJob.test.js
@@ -64,6 +64,7 @@ describe('test processJob() util function', function () {
   it('handles error when processing job', async function () {
     // Mock the logger that processJob() uses
     const loggerStub = {
+      debug: sandbox.stub(),
       info: sandbox.stub(),
       warn: sandbox.stub(),
       error: sandbox.stub()

--- a/creator-node/test/processJob.test.js
+++ b/creator-node/test/processJob.test.js
@@ -21,6 +21,7 @@ describe('test processJob() util function', function () {
   it('requires logger to have a queue property to filter by', async function () {
     // Mock the logger that processJob() uses
     const loggerStub = {
+      debug: sandbox.stub(),
       info: sandbox.stub(),
       warn: sandbox.stub(),
       error: sandbox.stub()


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Saw another log that printed a gigantic object for bull. Converting to debug since this might be useful for local dev but also open to removing.

https://audius.loggly.com/search#terms=%22new%20job%22&from=2022-10-11T20:20:58.349Z&until=2022-10-12T20:20:58.349Z&source_group=&filter=json.name;audius_creator_node&event=97de548a-4a67-11ed-80da-02ec14fc4836,1665604430000,138848972308370570

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Unit tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Loggly should not show this for stage/prod instances. 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->