### PR TITLE
Fix followers API for users without replica set

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -23,6 +23,8 @@ def make_image(endpoint, cid, width="", height=""):
 
 def get_primary_endpoint(user):
     raw_endpoint = user["creator_node_endpoint"]
+    if not raw_endpoint:
+        return ""
     return raw_endpoint.split(",")[0]
 
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Quick fix for followers API. Users without replica sets would fail here when getting their images.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on staging. API returns 500 on other DNs.
<img width="662" alt="Screen Shot 2022-10-12 at 2 08 39 PM" src="https://user-images.githubusercontent.com/6413636/195448755-b7d3e172-653b-4ed8-ac24-a06cf022f2ff.png">



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->