### PR TITLE
Fix health check relay when tx is pending

### DIFF
--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -131,8 +131,9 @@ module.exports = function (app) {
               const resp = await web3.eth.getTransactionReceipt(txHash)
               txCounter++
 
-              // tx failed
-              if (!resp || !resp.status) {
+              // note: pending txs will have null resp
+              if (resp && !resp.status) {
+                // tx failed
                 const senderAddress = await redis.hget(
                   'txHashToSenderAddress',
                   txHash

--- a/identity-service/src/routes/healthCheck.js
+++ b/identity-service/src/routes/healthCheck.js
@@ -132,7 +132,7 @@ module.exports = function (app) {
               txCounter++
 
               // tx failed
-              if (!resp.status) {
+              if (!resp || !resp.status) {
                 const senderAddress = await redis.hget(
                   'txHashToSenderAddress',
                   txHash


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
```
TypeError: Cannot read property 'status' of null
    at /usr/src/app/build/src/routes/healthCheck.js:94:35
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async /usr/src/app/build/src/apiHelpers.js:6:26
```
This check would fail when tx receipt is null which happens when tx is pending.
https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#gettransactionreceipt

We should only mark a tx as failed once it has been mined

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Unable to repro error on stage but this change works
### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->