### PR TITLE
[CON-455] - Fix content blacklist tests and mocks

### DIFF
--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -6,7 +6,9 @@ const _ = require('lodash')
 
 const Utils = require('../src/utils')
 const BlacklistManager = require('../src/blacklistManager')
-const { StubPremiumContentAccessChecker } = require('../src/premiumContent/stubPremiumContentAccessChecker')
+const {
+  StubPremiumContentAccessChecker
+} = require('../src/premiumContent/stubPremiumContentAccessChecker')
 const models = require('../src/models')
 const redis = require('../src/redis')
 const { generateTimestampAndSignature } = require('../src/apiSigning')
@@ -16,7 +18,8 @@ const { getLibsMock } = require('./lib/libsMock')
 const {
   createStarterCNodeUser,
   getCNodeUser,
-  destroyUsers
+  destroyUsers,
+  testEthereumConstants
 } = require('./lib/dataSeeds')
 const { generateRandomCID } = require('./lib/utils')
 const { uploadTrack } = require('./lib/helpers')
@@ -36,8 +39,13 @@ const trustedNotifierConfig = {
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
-describe('test ContentBlacklist', function () {
-  let app, server, libsMock, mockServiceRegistry, userId, stubPremiumContentAccessChecker
+describe.only('test ContentBlacklist', function () {
+  let app,
+    server,
+    libsMock,
+    mockServiceRegistry,
+    userId,
+    stubPremiumContentAccessChecker
 
   beforeEach(async () => {
     libsMock = setupLibsMock(libsMock)
@@ -61,7 +69,8 @@ describe('test ContentBlacklist', function () {
       isPremium: false,
       error: null
     }
-    mockServiceRegistry.premiumContentAccessChecker = stubPremiumContentAccessChecker
+    mockServiceRegistry.premiumContentAccessChecker =
+      stubPremiumContentAccessChecker
   })
 
   afterEach(async () => {
@@ -811,18 +820,19 @@ describe('test ContentBlacklist', function () {
     )
   })
 
-  // TODO: fix :(
   it('should not throw an error when streaming a blacklisted CID of a non-blacklisted track at /ipfs/:CID?trackId=<trackIdOfNonBlacklistedTrack>', async () => {
     // Create user and upload track
-    const track1 = await createUserAndUploadTrack()
-    const track2 = await createUserAndUploadTrack({
-      inputUserId: 2,
-      trackId: 2,
-      pubKey: '0x3f8f51ed837b15af580eb96cee740c723d340e7f'
-    })
-    const ids = [track1.track.blockchainId]
+    const data1 = await createUserAndUploadTrack()
 
-    // Blacklist trackId
+    // Upload a second track for the user
+    const track2 = await uploadTrackForUser({
+      cnodeUserUUID: data1.cnodeUser.cnodeUserUUID,
+      userId,
+      sessionToken: data1.sessionToken
+    })
+
+    // Blacklist the first track only
+    const ids = [data1.track.blockchainId]
     const type = BlacklistManager._getTypes().track
     const { signature, timestamp } = generateTimestampAndSignature(
       { type, values: ids },
@@ -833,7 +843,7 @@ describe('test ContentBlacklist', function () {
       .query({ type, 'values[]': ids, signature, timestamp })
       .expect(200)
 
-    // Hit /ipfs/:CID route for all track CIDs and ensure no error response is returned
+    // Successfully stream the second track
     await Promise.all(
       track2.track.trackSegments.map((segment) =>
         request(app)
@@ -1020,7 +1030,98 @@ describe('test ContentBlacklist', function () {
     }
   })
 
-  /** Helper setup method to test ContentBlacklist.  */
+  // Uploads a track for a user at the specifeid pubKey input. Defaulted to
+  // the default wallet used in these tests
+  // NOTE: This assumes the user is already created. If the user is not created,
+  // use `createUserAndUploadTrack()`
+  async function uploadTrackForUser({
+    cnodeUserUUID,
+    userId,
+    sessionToken,
+    trackId = Utils.getRandomInt(MAX_ID)
+  }) {
+    // Upload a track
+    const trackUploadResponse = await uploadTrack(
+      testAudioFilePath,
+      cnodeUserUUID,
+      mockServiceRegistry.blacklistManager
+    )
+
+    const {
+      transcodedTrackUUID,
+      track_segments: trackSegments,
+      source_file: sourceFile
+    } = trackUploadResponse
+
+    // set track metadata
+    const trackMetadata = {
+      test: 'field1',
+      owner_id: userId,
+      track_segments: trackSegments
+    }
+    const {
+      body: {
+        data: { metadataFileUUID: trackMetadataFileUUID }
+      }
+    } = await request(app)
+      .post('/tracks/metadata')
+      .set('X-Session-ID', sessionToken)
+      .set('User-Id', userId)
+      .set('Enforce-Write-Quorum', false)
+      .send({ metadata: trackMetadata, source_file: sourceFile })
+      .expect(200)
+
+    // Make chain recognize wallet as owner of track
+    const getTracksStub = sinon.stub().callsFake((_, __, trackIds) => {
+      let trackOwnerId = -1
+      if (trackIds[0] === trackId) {
+        trackOwnerId = userId
+      }
+      return [
+        {
+          blocknumber: 99999,
+          owner_id: trackOwnerId
+        }
+      ]
+    })
+    const getTracksVerboseStub = sinon.stub().callsFake((_, __, trackIds) => {
+      let trackOwnerId = -1
+      if (trackIds[0] === trackId) {
+        trackOwnerId = userId
+      }
+      return {
+        latest_indexed_block: 10,
+        latest_chain_block: 10,
+        data: [
+          {
+            blocknumber: 99999,
+            owner_id: trackOwnerId
+          }
+        ]
+      }
+    })
+    libsMock.Track = {
+      getTracks: getTracksStub,
+      getTracksVerbose: getTracksVerboseStub
+    }
+
+    // associate track metadata with track
+    await request(app)
+      .post('/tracks')
+      .set('X-Session-ID', sessionToken)
+      .set('User-Id', userId)
+      .send({
+        blockchainTrackId: trackId,
+        blockNumber: 10,
+        metadataFileUUID: trackMetadataFileUUID,
+        transcodedTrackUUID
+      })
+      .expect(200)
+
+    return { track: { trackSegments, blockchainId: trackId } }
+  }
+
+  /** Helper setup method to test ContentBlacklist. */
   async function createUserAndUploadTrack(
     { inputUserId, trackId, pubKey } = {
       inputUserId: userId,
@@ -1058,6 +1159,7 @@ describe('test ContentBlacklist', function () {
       .set('User-Id', inputUserId)
       .set('Enforce-Write-Quorum', false)
       .send(metadata)
+      .expect(200)
 
     const associateRequest = {
       blockchainUserId: inputUserId,
@@ -1071,81 +1173,17 @@ describe('test ContentBlacklist', function () {
       .set('X-Session-ID', sessionToken)
       .set('User-Id', inputUserId)
       .send(associateRequest)
+      .expect(200)
 
     // Upload a track
-    const trackUploadResponse = await uploadTrack(
-      testAudioFilePath,
+    const trackUploadResp = await uploadTrackForUser({
       cnodeUserUUID,
-      mockServiceRegistry.blacklistManager
-    )
-
-    const {
-      transcodedTrackUUID,
-      track_segments: trackSegments,
-      source_file: sourceFile
-    } = trackUploadResponse
-
-    // set track metadata
-    const trackMetadata = {
-      test: 'field1',
-      owner_id: inputUserId,
-      track_segments: trackSegments
-    }
-    const {
-      body: {
-        data: { metadataFileUUID: trackMetadataFileUUID }
-      }
-    } = await request(app)
-      .post('/tracks/metadata')
-      .set('X-Session-ID', sessionToken)
-      .set('User-Id', inputUserId)
-      .set('Enforce-Write-Quorum', false)
-      .send({ metadata: trackMetadata, source_file: sourceFile })
-
-    // Make chain recognize wallet as owner of track
-    const getTracksStub = sinon.stub().callsFake((_, __, trackIds) => {
-      let trackOwnerId = -1
-      if (trackIds[0] === trackId) {
-        trackOwnerId = inputUserId
-      }
-      return [
-        {
-          blocknumber: 99999,
-          owner_id: trackOwnerId
-        }
-      ]
+      userId: inputUserId,
+      sessionToken
     })
-    const getTracksVerboseStub = sinon.stub().callsFake((_, __, trackIds) => {
-      let trackOwnerId = -1
-      if (trackIds[0] === trackId) {
-        trackOwnerId = inputUserId
-      }
-      return {
-        latest_indexed_block: 10,
-        latest_chain_block: 10,
-        data: [
-        {
-          blocknumber: 99999,
-          owner_id: trackOwnerId
-        }
-      ]}
-    })
-    libsMock.Track = { getTracks: getTracksStub, getTracksVerbose: getTracksVerboseStub }
-
-    // associate track metadata with track
-    await request(app)
-      .post('/tracks')
-      .set('X-Session-ID', sessionToken)
-      .set('User-Id', inputUserId)
-      .send({
-        blockchainTrackId: trackId,
-        blockNumber: 10,
-        metadataFileUUID: trackMetadataFileUUID,
-        transcodedTrackUUID
-      })
 
     // Return user and some track data
-    return { cnodeUser, track: { trackSegments, blockchainId: trackId } }
+    return { cnodeUser, ...trackUploadResp, sessionToken }
   }
 })
 
@@ -1179,5 +1217,12 @@ const setupLibsMock = (libsMock) => {
     })
   })
   libsMock.Track.getTracks.atLeast(0)
+
+  // Set the return wallet to the dummy wallet constant
+  libsMock.contracts.UserFactoryClient = {}
+  libsMock.contracts.UserFactoryClient.getUser = sinon
+    .mock()
+    .returns({ wallet: testEthereumConstants.pubKey })
+
   return libsMock
 }

--- a/creator-node/test/contentBlacklist.test.js
+++ b/creator-node/test/contentBlacklist.test.js
@@ -39,7 +39,7 @@ const trustedNotifierConfig = {
 
 const testAudioFilePath = path.resolve(__dirname, 'testTrack.mp3')
 
-describe.only('test ContentBlacklist', function () {
+describe('test ContentBlacklist', function () {
   let app,
     server,
     libsMock,

--- a/creator-node/test/lib/dataSeeds.js
+++ b/creator-node/test/lib/dataSeeds.js
@@ -26,23 +26,31 @@ const destroyUsers = async () => {
   }
 }
 
-async function createStarterCNodeUser (userId = null, pubKey = testEthereumConstants.pubKey.toLowerCase()) {
+async function createStarterCNodeUser(
+  userId = null,
+  pubKey = testEthereumConstants.pubKey.toLowerCase()
+) {
   return createStarterCNodeUserWithKey(pubKey, userId)
 }
 
-async function createStarterCNodeUserWithKey (walletPublicKey, userId = null) {
+async function createStarterCNodeUserWithKey(walletPublicKey, userId = null) {
   const cnodeUser = await CNodeUser.create({ walletPublicKey, clock: 0 })
-  const sessionToken = await sessionManager.createSession(cnodeUser.cnodeUserUUID)
-  const resp = {
-    cnodeUserUUID: cnodeUser.cnodeUserUUID,
-    sessionToken: sessionToken,
-    walletPublicKey
-  }
+  const resp = await createUserSession(cnodeUser.cnodeUserUUID, walletPublicKey)
   if (userId) resp.userId = userId
   return resp
 }
 
-async function createSession () {
+async function createUserSession(cnodeUserUUID, walletPublicKey) {
+  const sessionToken = await sessionManager.createSession(cnodeUserUUID)
+
+  return {
+    cnodeUserUUID,
+    sessionToken: sessionToken,
+    walletPublicKey
+  }
+}
+
+async function createSession() {
   const dummyKey = uuid()
   const user = await createStarterCNodeUserWithKey(dummyKey, null)
   const tokenObject = await SessionToken.findOne({
@@ -51,4 +59,11 @@ async function createSession () {
   return tokenObject
 }
 
-module.exports = { createStarterCNodeUser, createStarterCNodeUserWithKey, testEthereumConstants, getCNodeUser, destroyUsers, createSession }
+module.exports = {
+  createStarterCNodeUser,
+  createStarterCNodeUserWithKey,
+  testEthereumConstants,
+  getCNodeUser,
+  destroyUsers,
+  createSession
+}

--- a/creator-node/test/lib/libsMock.js
+++ b/creator-node/test/lib/libsMock.js
@@ -93,20 +93,21 @@ function getLibsMock() {
     return encode(id)
   })
 
-  libsMock.discoveryProvider.getUserReplicaSet.callsFake(({ encodedUserId }) => {
-    const user_id = decode(encodedUserId)
-    return {
-      user_id,
-      "wallet": '0xadd36bad12002f1097cdb7ee24085c28e960fc32',
-      "primary": 'http://mock-cn1.audius.co',
-      "secondary1": 'http://mock-cn2.audius.co',
-      "secondary2": 'http://mock-cn3.audius.co',
-      "primarySpID": 1,
-      "secondary1SpID": 2,
-      "secondary2SpID": 3
+  libsMock.discoveryProvider.getUserReplicaSet.callsFake(
+    ({ encodedUserId }) => {
+      const user_id = decode(encodedUserId)
+      return {
+        user_id,
+        wallet: '0xadd36bad12002f1097cdb7ee24085c28e960fc32',
+        primary: 'http://mock-cn1.audius.co',
+        secondary1: 'http://mock-cn2.audius.co',
+        secondary2: 'http://mock-cn3.audius.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
     }
-  })
-
+  )
 
   libsMock.contracts.UserReplicaSetManagerClient.getUserReplicaSet.returns({
     primaryId: 1,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
There were changes to the /audius_users flow where `libs.contracts.UserFactoryClient.getUser()` was called but not mocked in the content blacklist tests. 

This PR is to:
- assert that creating the user results in status code 200 (e.g. what is expected)
- fix the tests by mocking `libs.contracts.UserFactoryClient.getUser()`
- refactor data seeds to be re-usable
- some styling/lint

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
This PR is to fix tests.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Unit tests results will reflect if tests are still failing

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->