### PR TITLE
Pause sending local dev logs to elk by default

### DIFF
--- a/service-commands/src/setup.js
+++ b/service-commands/src/setup.js
@@ -779,7 +779,7 @@ const allUp = async ({
   }
 
   // Add Centralized Logging
-  nodeUpCommands.push([[Service.LOGGING, SetupCommand.UP]])
+  // nodeUpCommands.push([[Service.LOGGING, SetupCommand.UP]])
 
   // Spin up local exporters, as well as standalone Prometheus/Grafana
   nodeUpCommands.push([[Service.MONITORING, SetupCommand.UP]])


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Goes along with index cleanup. Pausing until we get an ILM in place, otherwise we'll autoscale right back to a larger size

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
A up works and mad dog passes

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Elastic instance doesn't grow in size.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->