### PR TITLE
Revert "Change CN db connection pool to be a function of numWorkers (#4106)"

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -10829,7 +10829,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "log-driver": {

--- a/creator-node/src/models/index.js
+++ b/creator-node/src/models/index.js
@@ -4,17 +4,16 @@ const fs = require('fs-extra')
 const path = require('path')
 const Sequelize = require('sequelize')
 
-const config = require('../config')
-const { clusterUtils } = require('../utils/clusterUtils')
+const globalConfig = require('../config')
 
 const basename = path.basename(__filename)
 const db = {}
 
-const sequelize = new Sequelize(config.get('dbUrl'), {
-  logging: config.get('printSequelizeLogs'),
+const sequelize = new Sequelize(globalConfig.get('dbUrl'), {
+  logging: globalConfig.get('printSequelizeLogs'),
   operatorsAliases: false,
   pool: {
-    max: config.get('dbConnectionPoolMax') / clusterUtils.getNumWorkers(),
+    max: globalConfig.get('dbConnectionPoolMax'),
     min: 5,
     acquire: 60000,
     idle: 10000

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -361,9 +361,7 @@ async function _handleIssueSyncRequest({
 
     return {
       result: 'failure_issue_sync_request',
-      error: `${logMsgString} || Error issuing sync request: ${
-        e.message
-      } - ${JSON.stringify(e.response?.data)}`,
+      error: `${logMsgString} || Error issuing sync request: ${e.message} - ${e.response?.data}`,
       syncReqsToEnqueue,
       additionalSync
     }

--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -43,9 +43,6 @@ class ClusterUtils {
   }
 
   getNumWorkers() {
-    // When cluster mode is disabled there's no primary and no workers, but for math we want to pretend there's 1 worker so we don't divide by 0
-    if (!this.isClusterEnabled()) return 1
-
     // This is called `cpus()` but it actually returns the # of logical cores, which is possibly higher than # of physical cores if there's hyperthreading
     const logicalCores = cpus().length
     return config.get('expressAppConcurrency') || logicalCores


### PR DESCRIPTION
This reverts commit 27cfbea6df97eb8241edb19a5edbdb7fafafe59e.

### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Broke test-creator CI

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

n/a

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->