### PR TITLE
Use sliding window for disk deletion query and fix SP ID bugs

### DIFF
--- a/creator-node/sequelize/migrations/20191014204226-add-index-storage-path.js
+++ b/creator-node/sequelize/migrations/20191014204226-add-index-storage-path.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('Files', ['storagePath'], {
+      name: 'Files_storagePath_idx',
+      using: 'btree',
+      concurrently: true
+    })
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Files', 'Files_storagePath_idx')
+  }
+}

--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -273,16 +273,16 @@ const manuallyUpdateReplicaSetController = async (req, res) => {
       userId: parseInt(userId),
       primary: parseInt(newPrimarySpId),
       secondaries: [parseInt(newSecondary1SpId), parseInt(newSecondary2SpId)],
-      oldPrimary: parseInt(currentSpIds[0]),
-      oldSecondaries: [parseInt(currentSpIds[1]), parseInt(currentSpIds[2])]
+      oldPrimary: currentSpIds.primaryId,
+      oldSecondaries: currentSpIds.secondaryIds
     })
   } else {
     await audiusLibs.contracts.UserReplicaSetManagerClient._updateReplicaSet(
       parseInt(userId),
       parseInt(newPrimarySpId),
       [parseInt(newSecondary1SpId), parseInt(newSecondary2SpId)],
-      parseInt(currentSpIds[0]),
-      [parseInt(currentSpIds[1]), parseInt(currentSpIds[2])]
+      currentSpIds.primaryId,
+      currentSpIds.secondaryIds
     )
   }
 

--- a/creator-node/src/models/file.js
+++ b/creator-node/src/models/file.js
@@ -72,6 +72,9 @@ module.exports = (sequelize, DataTypes) => {
           fields: ['multihash']
         },
         {
+          fields: ['storagePath']
+        },
+        {
           fields: ['dirMultihash']
         },
         {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -238,13 +238,7 @@ async function _handleIssueSyncRequest({
       return { result: 'success_mode_disabled', syncReqsToEnqueue }
     }
 
-    const libs = await initAudiusLibs({
-      enableEthContracts: true,
-      enableContracts: false,
-      enableDiscovery: true,
-      enableIdentity: false,
-      logger
-    })
+    const libs = await initAudiusLibs({ logger })
     const userReplicaSet: ReplicaSetEndpoints =
       await getReplicaSetEndpointsByWallet({
         libs,


### PR DESCRIPTION
### Description
* Adds an index on `storagePath` in the Files table so we can use it in a faster query (second bullet point)
* Changes SQL query to find unique files to delete for a user by using a sliding window (adds an extra query per pagination but is significantly faster and less CPU intensive)
* Fixes a couple small bugs (see PR comments for details)


### Tests
* Used the debugger and manual route to verify that the correct data is queried and deleted when a node is orphaned
* Tested manually creating the `storagePath` index on CN8 and verified that this new query was orders of magnitude faster than the previous approach
TODO: Verify again with creating users with the same tracks via the client (instead of `A seed`) and checking the files in Docker


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
* Monitor active SQL queries when rolling out to staging. None should run for more than ~30 seconds.
* Check active queries on the node: `/db_check?verbose=true`
* Manually view active queries in the db:
```sql
SELECT pid, age(clock_timestamp(), query_start), usename, query
FROM pg_stat_activity
WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%'
ORDER BY query_start desc;
```