### PR TITLE
[CON-468] Fix _issueAndWaitForSecondarySyncRequests bug with creatorNodeEndpoints

### DIFF
--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -178,14 +178,19 @@ async function ensurePrimaryMiddleware(req, res, next) {
    * Currently `req.session.creatorNodeEndpoints` is only used by `issueAndWaitForSecondarySyncRequests()`
    * There is a possibility of failing to retrieve endpoints for each spID, so the consumer of req.session.creatorNodeEndpoints must perform null checks
    */
-  req.session.creatorNodeEndpoints = await replicaSetSpIdsToEndpoints(
+  const replicaSetIdsToEndpointsMapping = await replicaSetSpIdsToEndpoints(
     replicaSetSpIDs
   )
+  req.session.creatorNodeEndpoints = [
+    replicaSetIdsToEndpointsMapping.primary,
+    replicaSetIdsToEndpointsMapping.secondary1,
+    replicaSetIdsToEndpointsMapping.secondary2
+  ]
 
   req.logger.info(
     `${logPrefix} succeeded ${Date.now() - start} ms. creatorNodeEndpoints: ${
       req.session.creatorNodeEndpoints
-    }`
+    }. nodeIsPrimary: ${req.session.nodeIsPrimary}`
   )
   next()
 }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This bug causes syncs triggered by _issueAndWaitForSecondarySyncRequests to fail because req.session.creatorNodeEndpoints is a mapping not an array. This fixes that.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally with a create user and verified it syncs. Also tested with mad dog and unit tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Fully synced users % should stay constant or improve

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->