### PR TITLE
Fix SP ID related bugs

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -273,16 +273,16 @@ const manuallyUpdateReplicaSetController = async (req, res) => {
       userId: parseInt(userId),
       primary: parseInt(newPrimarySpId),
       secondaries: [parseInt(newSecondary1SpId), parseInt(newSecondary2SpId)],
-      oldPrimary: parseInt(currentSpIds[0]),
-      oldSecondaries: [parseInt(currentSpIds[1]), parseInt(currentSpIds[2])]
+      oldPrimary: currentSpIds.primaryId,
+      oldSecondaries: currentSpIds.secondaryIds
     })
   } else {
     await audiusLibs.contracts.UserReplicaSetManagerClient._updateReplicaSet(
       parseInt(userId),
       parseInt(newPrimarySpId),
       [parseInt(newSecondary1SpId), parseInt(newSecondary2SpId)],
-      parseInt(currentSpIds[0]),
-      [parseInt(currentSpIds[1]), parseInt(currentSpIds[2])]
+      currentSpIds.primaryId,
+      currentSpIds.secondaryIds
     )
   }
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -238,13 +238,7 @@ async function _handleIssueSyncRequest({
       return { result: 'success_mode_disabled', syncReqsToEnqueue }
     }
 
-    const libs = await initAudiusLibs({
-      enableEthContracts: true,
-      enableContracts: false,
-      enableDiscovery: true,
-      enableIdentity: false,
-      logger
-    })
+    const libs = await initAudiusLibs({ logger })
     const userReplicaSet: ReplicaSetEndpoints =
       await getReplicaSetEndpointsByWallet({
         libs,


### PR DESCRIPTION
### Description
Fixes some bugs caused by refactoring scattered SP ID functionality into ContentNodeInfoManager: 
* `ERROR || Failed to retrieve user from EntityManager during sync` - this was caused by not initting libs with contracts, which it needs when URSM is enabled
* `/manually_update_replica_set` route not updating to reflect a type change


### Tests
Integration tests and mad dog should be sufficient


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
The error in the description should not be present in logs