### PR TITLE
inf-294 only wait 1 minute when releasing to one node at a time

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -594,6 +594,8 @@ def cli(
             if environment == "prod":
                 # check healthcheck post-deploy
                 wait_time = time.time() + (30 * 60)
+                if len(release_summary["upgradeable"]) == 1:
+                    wait_time = time.time() + (1 * 60)
                 while time.time() < wait_time:
                     # throttle the amount of logs and request load during startup
                     time.sleep(30)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Don't wait for 30 minutes when deploying one node at a time.

This should speed up deploying to foundation nodes.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Testing during the next production release.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys and CircleCI logs.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->