### PR TITLE
Fix libs type and allow setting null artist pick in backend

### DIFF
--- a/discovery-provider/src/tasks/users.py
+++ b/discovery-provider/src/tasks/users.py
@@ -378,7 +378,7 @@ def update_user_metadata(
     if "location" in metadata and metadata["location"]:
         user_record.location = metadata["location"]
 
-    if "artist_pick_track_id" in metadata and metadata["artist_pick_track_id"]:
+    if "artist_pick_track_id" in metadata:
         user_record.artist_pick_track_id = metadata["artist_pick_track_id"]
 
     # Fields with no on-chain counterpart

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -30,7 +30,7 @@ type UID = string
 export type UserMetadata = {
   user_id: number
   album_count: number
-  artist_pick_track_id: number
+  artist_pick_track_id: Nullable<number>
   bio: string | null
   cover_photo: Nullable<CID>
   creator_node_endpoint: string


### PR DESCRIPTION
### Description
Found some bugs when testing writes E2E. Allow `artist_pick_track_id` to be set to `null` (when removing an artist pick). 

Without this change, we need to be careful to always populate `artist_pick_track_id` on the user in the client correctly so that the default value (`null`) is never accidentally passed to discovery and saved to the user metadata.

### Tests
Manually test E2E with local client / libs ([client code](https://github.com/AudiusProject/audius-client/pull/2128)) against this commit deployed to staging. Should see correct artist pick when querying the user in the API.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
