### PR TITLE
INF-290 Nicer discord messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1295,22 +1295,6 @@ jobs:
                 -X POST \
                 "${DISCORD_WEBHOOK}"
 
-  discord-test:
-    docker:
-      - image: cimg/go:1.17
-    steps:
-      - run: |
-          VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
-          echo "${VERSION}"
-          curl -d '{
-            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/releases>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
-            "embeds": null,
-            "attachments": []
-          }' \
-          -H "Content-Type: application/json" \
-          -X POST \
-          "${DISCORD_TEST_WEBHOOK}"
-
   generate-release-checklist:
     docker:
       - image: circleci/node:14.17.5
@@ -1342,9 +1326,6 @@ workflows:
          - not: << pipeline.parameters.reservations >>
          - not: << pipeline.parameters.slash_address >>
     jobs:
-      - discord-test:
-          context:
-            - discord
       - noop:
           name: tests
       - noop:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,7 +1303,7 @@ jobs:
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
           curl -d '{
-            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+            "content": "New service version () is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,
             "attachments": []
           }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,7 +1303,7 @@ jobs:
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
           curl -d '{
-            "content": "hellos",
+            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,
             "attachments": []
           }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1285,7 +1285,7 @@ jobs:
                 detail: ":vote: New Governance Proposals are out @ https://dashboard.audius.org/#/governance"
                 slack_mentions_user: "${SLACK_RELEASE_MENTIONS}"
             - run: |
-                VERSION=$(curl -s https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json | jq -r '.version')
+                VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
                 curl -d '{
                   "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
                   "embeds": null,
@@ -1300,7 +1300,7 @@ jobs:
       - image: cimg/go:1.17
     steps:
       - run: |
-          VERSION=$(curl -s 'https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json' | jq -r '.version')
+          VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           curl -d '{
             "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1295,6 +1295,21 @@ jobs:
                 -X POST \
                 "${DISCORD_WEBHOOK}"
 
+  discord-test:
+    docker:
+      - image: cimg/go:1.17
+    steps:
+      - run: |
+          VERSION=$(curl -s https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json | jq -r '.version')
+          curl -d '{
+            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+            "embeds": null,
+            "attachments": []
+          }' \
+          -H "Content-Type: application/json" \
+          -X POST \
+          "${DISCORD_TEST_WEBHOOK}"
+
   generate-release-checklist:
     docker:
       - image: circleci/node:14.17.5
@@ -1326,6 +1341,7 @@ workflows:
          - not: << pipeline.parameters.reservations >>
          - not: << pipeline.parameters.slash_address >>
     jobs:
+      - discord-test
       - noop:
           name: tests
       - noop:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1302,7 +1302,7 @@ jobs:
       - run: |
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
-          echo curl -d '{
+          curl -d '{
             "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,
             "attachments": []
@@ -1342,7 +1342,9 @@ workflows:
          - not: << pipeline.parameters.reservations >>
          - not: << pipeline.parameters.slash_address >>
     jobs:
-      - discord-test
+      - discord-test:
+          context:
+            - discord
       - noop:
           name: tests
       - noop:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1285,8 +1285,9 @@ jobs:
                 detail: ":vote: New Governance Proposals are out @ https://dashboard.audius.org/#/governance"
                 slack_mentions_user: "${SLACK_RELEASE_MENTIONS}"
             - run: |
+                VERSION=$(curl -s https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json | jq -r '.version')
                 curl -d '{
-                  "content": "New service version is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+                  "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
                   "embeds": null,
                   "attachments": []
                 }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1286,7 +1286,7 @@ jobs:
                 slack_mentions_user: "${SLACK_RELEASE_MENTIONS}"
             - run: |
                 curl -d '{
-                  "content": "New service version is out now!\n\nCompose files have been updated [here](<https://github.com/AudiusProject/audius-docker-compose>).\n\n* [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n\n* [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+                  "content": "New service version is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
                   "embeds": null,
                   "attachments": []
                 }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1287,7 +1287,7 @@ jobs:
             - run: |
                 VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
                 curl -d '{
-                  "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+                  "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/releases>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
                   "embeds": null,
                   "attachments": []
                 }' \
@@ -1303,7 +1303,7 @@ jobs:
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
           curl -d '{
-            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+            "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/releases>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,
             "attachments": []
           }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,7 +1303,7 @@ jobs:
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
           curl -d '{
-            "content": "New service version () is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
+            "content": "hellos",
             "embeds": null,
             "attachments": []
           }' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1302,7 +1302,7 @@ jobs:
       - run: |
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
           echo "${VERSION}"
-          curl -d '{
+          echo curl -d '{
             "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,
             "attachments": []

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1300,7 +1300,7 @@ jobs:
       - image: cimg/go:1.17
     steps:
       - run: |
-          VERSION=$(curl -s https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json | jq -r '.version')
+          VERSION=$(curl -s 'https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json' | jq -r '.version')
           curl -d '{
             "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1301,6 +1301,7 @@ jobs:
     steps:
       - run: |
           VERSION=$(curl -s "https://raw.githubusercontent.com/AudiusProject/audius-protocol/master/discovery-provider/.version.json" | jq -r '.version')
+          echo "${VERSION}"
           curl -d '{
             "content": "New service version ('"${VERSION}"') is out now!\n\n• [New compose files](<https://github.com/AudiusProject/audius-docker-compose>)\n• [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n• [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
             "embeds": null,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1286,7 +1286,7 @@ jobs:
                 slack_mentions_user: "${SLACK_RELEASE_MENTIONS}"
             - run: |
                 curl -d '{
-                  "content": "New service version is out now!\n\nCompose files have been updated here:\nhttps://github.com/AudiusProject/audius-docker-compose\n\nChangelogs:\nhttps://github.com/AudiusProject/audius-protocol/releases\n\nGovernance proposals (2 days of voting left):\nhttps://dashboard.audius.org/#/governance",
+                  "content": "New service version is out now!\n\nCompose files have been updated [here](<https://github.com/AudiusProject/audius-docker-compose>).\n\n* [Changelogs](<https://github.com/AudiusProject/audius-protocol/release>)\n\n* [Governance Proposals](<https://dashboard.audius.org/#/governance>) (2 days of voting left)",
                   "embeds": null,
                   "attachments": []
                 }' \


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Nicer #node-operator messages on Discord, by:

* eliminating unfurling
* including semver

Example Discord Message:

```
New service version (0.3.69) is out now!

• [New compose files](https://github.com/AudiusProject/audius-docker-compose)
• [Changelogs](https://github.com/AudiusProject/audius-protocol/releases)
• [Governance Proposals](https://dashboard.audius.org/#/governance) (2 days of voting left)
```
![Screen Shot 2022-10-24 at 6 34 25 PM](https://user-images.githubusercontent.com/545666/197649613-4cef50e4-5a0b-4275-bfc0-79929c34740f.png)




### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Message in #audius-alerts-text:

* https://discord.com/channels/557662127305785361/1026998576066342942/1034247213888569365

Tested with this commit:

* https://github.com/AudiusProject/audius-protocol/pull/4143/commits/d66f677ed0c6ed4f195a3d554aea9bbf7d587bb9

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Monitor #node-operators.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->