### PR TITLE
CN performance stabilization tweaks

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -74,11 +74,11 @@ class StateMachineManager {
         },
         [QUEUE_NAMES.RECURRING_SYNC]: {
           queue: recurringSyncQueue,
-          maxWaitingJobs: 100000
+          maxWaitingJobs: 10000
         },
         [QUEUE_NAMES.UPDATE_REPLICA_SET]: {
           queue: updateReplicaSetQueue,
-          maxWaitingJobs: 10000
+          maxWaitingJobs: 1000
         },
         [QUEUE_NAMES.RECOVER_ORPHANED_DATA]: {
           queue: recoverOrphanedDataQueue,

--- a/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
+++ b/creator-node/src/services/stateMachineManager/stateMachineConstants.ts
@@ -50,13 +50,13 @@ export const QUEUE_HISTORY = Object.freeze({
   // Max number of completed/failed jobs to keep in redis for the cNodeEndpoint->spId map queue
   FETCH_C_NODE_ENDPOINT_TO_SP_ID_MAP: 100,
   // Max number of completed/failed jobs to keep in redis for the manual sync queue
-  MANUAL_SYNC: 100_000,
+  MANUAL_SYNC: 1_000,
   // Max number of completed/failed jobs to keep in redis for the recurring sync queue
-  RECURRING_SYNC: 100_000,
+  RECURRING_SYNC: 1_000,
   // Max number of completed/failed jobs to keep in redis for the update-replica-set queue
-  UPDATE_REPLICA_SET: 100_000,
+  UPDATE_REPLICA_SET: 1_000,
   // Max number of completed/failed jobs to keep in redis for the recover-orphaned-data queue
-  RECOVER_ORPHANED_DATA: 100_000
+  RECOVER_ORPHANED_DATA: 1_000
 })
 
 export const QUEUE_NAMES = {

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -59,6 +59,10 @@ class StateReconciliationManager {
       prometheusRegistry
     })
 
+    if (config.get('maxRecurringRequestSyncJobConcurrency') === 0) {
+      await recurringSyncQueue.pause()
+    }
+
     const { queue: updateReplicaSetQueue } = makeQueue({
       name: QUEUE_NAMES.UPDATE_REPLICA_SET,
       processor: this.makeProcessJob(
@@ -72,6 +76,10 @@ class StateReconciliationManager {
       removeOnFail: QUEUE_HISTORY.UPDATE_REPLICA_SET,
       prometheusRegistry
     })
+
+    if (config.get('maxUpdateReplicaSetJobConcurrency') === 0) {
+      await updateReplicaSetQueue.pause()
+    }
 
     const { queue: recoverOrphanedDataQueue } = makeQueue({
       name: QUEUE_NAMES.RECOVER_ORPHANED_DATA,

--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -48,7 +48,7 @@ class ClusterUtils {
 
     // This is called `cpus()` but it actually returns the # of logical cores, which is possibly higher than # of physical cores if there's hyperthreading
     const logicalCores = cpus().length
-    return config.get('expressAppConcurrency') || logicalCores
+    return config.get('expressAppConcurrency') / 2 || logicalCores
   }
 
   /**

--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -48,7 +48,7 @@ class ClusterUtils {
 
     // This is called `cpus()` but it actually returns the # of logical cores, which is possibly higher than # of physical cores if there's hyperthreading
     const logicalCores = cpus().length
-    return (config.get('expressAppConcurrency') || logicalCores) / 2
+    return config.get('expressAppConcurrency') || Math.ceil(logicalCores / 2)
   }
 
   /**

--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -48,7 +48,7 @@ class ClusterUtils {
 
     // This is called `cpus()` but it actually returns the # of logical cores, which is possibly higher than # of physical cores if there's hyperthreading
     const logicalCores = cpus().length
-    return config.get('expressAppConcurrency') / 2 || logicalCores
+    return (config.get('expressAppConcurrency') || logicalCores) / 2
   }
 
   /**


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

1. Reduce `maxWaitingJobs` for `recurringSyncQueue` and `updateReplicaSetQueue` by 10x
2. Reduce queue history (num completed/failed jobs) for multiple queues from 100k to 1k
3. set default num workers to half num cores
4. Add ability to pause `recurringSyncQueue` and `updateReplicaSetQueue` based on envvars


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

automated sufficient
also tested manually on staging node

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Easy to monitor all above via bull dashboard, grafana bull dashboard, and grafana profiling dashboard

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->