### PR TITLE
Add getUserListenCountsMonthly to libs for artist dashbaord

### DIFF
--- a/creator-node/src/segmentDuration.ts
+++ b/creator-node/src/segmentDuration.ts
@@ -4,7 +4,7 @@ const fs = require('fs-extra')
 const SEGMENT_REGEXP = /(segment[0-9]*.ts)/
 
 // Parse m3u8 file from HLS output and return map(segment filePath (segmentName) => segment duration)
-async function getSegmentsDuration(filename, filedir) {
+export async function getSegmentsDuration(filename: string, filedir: string) {
   try {
     const splitResults = filename.split('.')
     const fileRandomName = splitResults[0]
@@ -12,7 +12,7 @@ async function getSegmentsDuration(filename, filedir) {
     const manifestContents = await fs.readFile(manifestPath)
     const splitManifest = manifestContents.toString().split('\n')
 
-    const segmentDurations = {}
+    const segmentDurations: Record<string, number> = {}
     for (let i = 0; i < splitManifest.length; i += 1) {
       const matchedResults = splitManifest[i].match(SEGMENT_REGEXP)
       if (matchedResults === null) {
@@ -29,5 +29,3 @@ async function getSegmentsDuration(filename, filedir) {
     throw new Error(`Failed - ${e}`)
   }
 }
-
-module.exports = { getSegmentsDuration }

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -773,7 +773,11 @@ export class Users extends Base {
    * Gets listen count data for a user's tracks grouped by month
    * @returns Dictionary of listen count data where keys are requested months
    */
-   async getUserListenCountsMonthly(encodedUserId: string, startTime: string, endTime: string) {
+  async getUserListenCountsMonthly(
+    encodedUserId: string,
+    startTime: string,
+    endTime: string
+  ) {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
     return await this.discoveryProvider.getUserListenCountsMonthly(
       encodedUserId,

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -66,6 +66,7 @@ export class Users extends Base {
     this.updateIsVerified = this.updateIsVerified.bind(this)
     this.addUserFollow = this.addUserFollow.bind(this)
     this.deleteUserFollow = this.deleteUserFollow.bind(this)
+    this.getUserListenCountsMonthly = this.getUserListenCountsMonthly.bind(this)
 
     // For adding replica set to users on sign up
     this.assignReplicaSet = this.assignReplicaSet.bind(this)
@@ -765,6 +766,19 @@ export class Users extends Base {
     return await this.contracts.SocialFeatureFactoryClient.deleteUserFollow(
       followerUserId!,
       followeeUserId
+    )
+  }
+
+  /**
+   * Gets listen count data for a user's tracks grouped by month
+   * @returns Dictionary of listen count data where keys are requested months
+   */
+   async getUserListenCountsMonthly(encodedUserId: string, startTime: string, endTime: string) {
+    this.REQUIRES(Services.DISCOVERY_PROVIDER)
+    return await this.discoveryProvider.getUserListenCountsMonthly(
+      encodedUserId,
+      startTime,
+      endTime
     )
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -928,6 +928,49 @@ export class DiscoveryProvider {
     return res.map((r) => ({ ...r, amount: parseInt(r.amount) }))
   }
 
+  /**
+   * Retrieves the user's replica se
+   * @param params.encodedUserId string of the encoded user id
+   * @param params.blocNumber optional integer pass to wait until the discovery node has indexed that block number
+   * @return object containing the user replica set
+   */
+   async getUserReplicaSet({
+    encodedUserId,
+    blockNumber
+  }: {
+    encodedUserId: string
+    blockNumber?: number
+  }): Promise<Object | null | undefined> {
+    const req = Requests.getUserReplicaSet(encodedUserId)
+
+    return await this._makeRequest<Object | null>(
+      req,
+      true,
+      0,
+      false,
+      blockNumber
+    )
+  }
+
+  /**
+   * Retrieves listen counts for all tracks of a given artist grouped by month.
+   * @param params.encodedUserId string of the encoded user id
+   * @param params.start_time start time of query
+   * @param params.end_time end time of query
+   * @return object containing listen counts for an artist's tracks grouped by month
+   */
+  async getUserListenCountsMonthly(
+    encodedUserId: string,
+    start_time: string,
+    end_time: string
+): Promise<Object | null | undefined> {
+    const req = Requests.getUserListenCountsMonthly(encodedUserId, start_time, end_time)
+
+    return await this._makeRequest<Object | null>(
+      req
+    )
+  }
+
   /* ------- INTERNAL FUNCTIONS ------- */
 
   /**
@@ -1264,30 +1307,6 @@ export class DiscoveryProvider {
 
     // Everything looks good, return the data!
     return parsedResponse
-  }
-
-  /**
-   * Retrieves the user's replica se
-   * @param params.encodedUserId string of the encoded user id
-   * @param params.blocNumber optional integer pass to wait until the discovery node has indexed that block number
-   * @return object containing the user replica set
-   */
-  async getUserReplicaSet({
-    encodedUserId,
-    blockNumber
-  }: {
-    encodedUserId: string
-    blockNumber?: number
-  }): Promise<Object | null | undefined> {
-    const req = Requests.getUserReplicaSet(encodedUserId)
-
-    return await this._makeRequest<Object | null>(
-      req,
-      true,
-      0,
-      false,
-      blockNumber
-    )
   }
 
   /**

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -929,12 +929,29 @@ export class DiscoveryProvider {
   }
 
   /**
-   * Retrieves the user's replica se
+   * Retrieves listen counts for all tracks of a given artist grouped by month.
+   * @param params.encodedUserId string of the encoded user id
+   * @param params.startTime start time of query
+   * @param params.endTime end time of query
+   * @return object containing listen counts for an artist's tracks grouped by month
+   */
+  async getUserListenCountsMonthly(
+    encodedUserId: string,
+    startTime: string,
+    endTime: string
+  ): Promise<Object | null | undefined> {
+    const req = Requests.getUserListenCountsMonthly(encodedUserId, startTime, endTime)
+
+    return await this._makeRequest<Object | null>(req)
+  }
+
+  /**
+   * Retrieves the user's replica set
    * @param params.encodedUserId string of the encoded user id
    * @param params.blocNumber optional integer pass to wait until the discovery node has indexed that block number
    * @return object containing the user replica set
    */
-   async getUserReplicaSet({
+  async getUserReplicaSet({
     encodedUserId,
     blockNumber
   }: {
@@ -949,25 +966,6 @@ export class DiscoveryProvider {
       0,
       false,
       blockNumber
-    )
-  }
-
-  /**
-   * Retrieves listen counts for all tracks of a given artist grouped by month.
-   * @param params.encodedUserId string of the encoded user id
-   * @param params.start_time start time of query
-   * @param params.end_time end time of query
-   * @return object containing listen counts for an artist's tracks grouped by month
-   */
-  async getUserListenCountsMonthly(
-    encodedUserId: string,
-    start_time: string,
-    end_time: string
-): Promise<Object | null | undefined> {
-    const req = Requests.getUserListenCountsMonthly(encodedUserId, start_time, end_time)
-
-    return await this._makeRequest<Object | null>(
-      req
     )
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -940,7 +940,11 @@ export class DiscoveryProvider {
     startTime: string,
     endTime: string
   ): Promise<Object | null | undefined> {
-    const req = Requests.getUserListenCountsMonthly(encodedUserId, startTime, endTime)
+    const req = Requests.getUserListenCountsMonthly(
+      encodedUserId,
+      startTime,
+      endTime
+    )
 
     return await this._makeRequest<Object | null>(req)
   }

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -725,10 +725,14 @@ export const getUserReplicaSet = (encodedUserId: string) => {
   }
 }
 
-export const getUserListenCountsMonthly = (encodedUserId: string, startTime: string, endTime: string) => {
+export const getUserListenCountsMonthly = (
+  encodedUserId: string,
+  startTime: string,
+  endTime: string
+) => {
   return {
     endpoint: `/v1/users/${encodedUserId}/listen_counts_monthly`,
-    timeout: 5000,
+    timeout: 10000,
     queryParams: {
       start_time: startTime,
       end_time: endTime

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -724,3 +724,14 @@ export const getUserReplicaSet = (encodedUserId: string) => {
     timeout: 5000
   }
 }
+
+export const getUserListenCountsMonthly = (encodedUserId: string, startTime: string, endTime: string) => {
+  return {
+    endpoint: `/v1/users/${encodedUserId}/listen_counts_monthly`,
+    timeout: 5000,
+    queryParams: {
+      start_time: startTime,
+      end_time: endTime
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR adds the endpoint getUserListenCountsMonthly to appropriate libs files to be called by the front end in the artist dashboard.

Also moved an endpoint that was previously tucked in an internal functions section.

I did notice the data is still slightly off from the play count generated for all time listens. E.g. in this example it says there are 140 plays, but the listen counts returned by getUserListenCountsMonthly total to 151.
<img width="951" alt="Screen Shot 2022-10-17 at 10 26 49 PM" src="https://user-images.githubusercontent.com/109105561/196323780-cc67b7e2-087b-4d78-bac4-1899db42898f.png">

### Tests
Ran my client pointed at staging data using my local libs/sdk and loaded the artist dashboard in my local client. Will also put up a PR containing my changes to the client for this.

If anyone has a staging account with listening data that goes back before 2021 that would be super helpful too!


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
n/a but would love any ideas!