### PR TITLE
INF-295 Fix release-week logic checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,9 @@ parameters:
   slack_mentions_user:
     type: string
     default: ""
+  sp_release:
+    type: string
+    default: ""
   full_ci:
     type: boolean
     default: false
@@ -286,16 +289,6 @@ jobs:
     steps:
       - bi-weekly:
           odd_week: false
-
-  not-release-week:
-    docker:
-      - image: alpine
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASS
-    steps:
-      - bi-weekly:
-          odd_week: true
 
   bake-gcp-dev-image:
     docker:
@@ -1334,6 +1327,7 @@ workflows:
          - not: << pipeline.parameters.deploy_args >>
          - not: << pipeline.parameters.reservations >>
          - not: << pipeline.parameters.slash_address >>
+         - not: << pipeline.parameters.sp_release >>
     jobs:
       - noop:
           name: tests
@@ -1825,19 +1819,24 @@ workflows:
             branches:
               only: /(^master$)/
 
-  joaquins-cron-test:
+  # in order to trigger this job
+  # 1. go to the CircleCI dashboard
+  # 2. click "Trigger Pipeline"
+  # 3. Add string parameter "sp_release" with any non-null value
+  release-to-service-providers:
+    when: << pipeline.parameters.sp_release >>
     jobs:
       - release-week
-      - noop:
-          name: special-release-job
+      - release-scripts:
+          name: release-to-service-providers
+          target: release-to-service-providers
+          context:
+            - slack-secrets
+            - gh-tokens.releases
+            - discord
+            - governance
           requires:
             - release-week
-    triggers:
-      - schedule:
-          cron: '34 * * * *'
-          filters:
-            branches:
-              only: /(^jc-inf-295.*$)/
 
   # release-to-service-providers-cron:
   #   jobs:
@@ -1859,44 +1858,44 @@ workflows:
   #           branches:
   #             only: /(^master$)/
 
-  # evaluate-proposal-cron:
-  #   jobs:
-  #     - release-week
-  #     - release-scripts:
-  #         name: evaluate-proposal
-  #         target: evaluate-proposal
-  #         context:
-  #           - slack-secrets
-  #           - governance
-  #         requires:
-  #           - release-week
-  #   triggers:
-  #     - schedule:
-  #         cron: '0 19 * * 5'
-  #         filters:
-  #           branches:
-  #             only: /(^master$)/
+  evaluate-proposal-cron:
+    jobs:
+      - release-week
+      - release-scripts:
+          name: evaluate-proposal
+          target: evaluate-proposal
+          context:
+            - slack-secrets
+            - governance
+          requires:
+            - release-week
+    triggers:
+      - schedule:
+          cron: '0 19 * * 5'
+          filters:
+            branches:
+              only: /(^master$)/
 
-  # cut-release-cron:
-  #   jobs:
-  #     - release-week
-  #     - release-scripts:
-  #         name: cut-release
-  #         target: cut-release
-  #         context:
-  #           - slack-secrets
-  #           - gh-tokens.releases
-  #         requires:
-  #           - release-week
-  #     - generate-release-checklist:
-  #         requires:
-  #           - cut-release
-  #   triggers:
-  #     - schedule:
-  #         cron: '0 7 * * 6'
-  #         filters:
-  #           branches:
-  #             only: /(^master$)/
+  cut-release-cron:
+    jobs:
+      - release-week
+      - release-scripts:
+          name: cut-release
+          target: cut-release
+          context:
+            - slack-secrets
+            - gh-tokens.releases
+          requires:
+            - release-week
+      - generate-release-checklist:
+          requires:
+            - cut-release
+    triggers:
+      - schedule:
+          cron: '0 7 * * 6'
+          filters:
+            branches:
+              only: /(^master$)/
 
   # in order to run a job in hold-workflows
   # 1. go to the CircleCI dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1835,6 +1835,9 @@ workflows:
             - gh-tokens.releases
             - discord
             - governance
+          filters:
+            branches:
+              only: /(^master$)/
           requires:
             - release-week
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1827,14 +1827,14 @@ workflows:
 
   joaquins-cron-test:
     jobs:
-      - not-release-week
+      - release-week
       - noop:
           name: special-release-job
           requires:
-            - not-release-week
+            - release-week
     triggers:
       - schedule:
-          cron: '32 * * * *'
+          cron: '34 * * * *'
           filters:
             branches:
               only: /(^jc-inf-295.*$)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
           password: $DOCKERHUB_PASS
     steps:
       - bi-weekly:
-          odd_week: true
+          odd_week: false
 
   not-release-week:
     docker:
@@ -295,7 +295,7 @@ jobs:
           password: $DOCKERHUB_PASS
     steps:
       - bi-weekly:
-          odd_week: false
+          odd_week: true
 
   bake-gcp-dev-image:
     docker:
@@ -1834,7 +1834,7 @@ workflows:
             - not-release-week
     triggers:
       - schedule:
-          cron: '9,11,13,15 * * * *'
+          cron: '32 * * * *'
           filters:
             branches:
               only: /(^jc-inf-295.*$)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1824,10 +1824,10 @@ workflows:
             - release-week
     triggers:
       - schedule:
-          cron: '1,3,5,7,9,11 * * * 1'
+          cron: '15 * * * 1'
           filters:
             branches:
-              only: master
+              only: /(^jc-inf-295.*$)/
 
   # release-to-service-providers-cron:
   #   jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,16 @@ jobs:
       - bi-weekly:
           odd_week: true
 
+  not-release-week:
+    docker:
+      - image: alpine
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
+    steps:
+      - bi-weekly:
+          odd_week: false
+
   bake-gcp-dev-image:
     docker:
       - image: audius/circleci-gcloud-bake:latest
@@ -1817,14 +1827,14 @@ workflows:
 
   joaquins-cron-test:
     jobs:
-      - release-week
+      - not-release-week
       - noop:
           name: special-release-job
           requires:
-            - release-week
+            - not-release-week
     triggers:
       - schedule:
-          cron: '21,23,25,27,29 * * * *'
+          cron: '9,11,13,15 * * * *'
           filters:
             branches:
               only: /(^jc-inf-295.*$)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1824,7 +1824,7 @@ workflows:
             - release-week
     triggers:
       - schedule:
-          cron: '15 * * * 1'
+          cron: '19 * * * 1'
           filters:
             branches:
               only: /(^jc-inf-295.*$)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1824,7 +1824,7 @@ workflows:
             - release-week
     triggers:
       - schedule:
-          cron: '19 * * * 1'
+          cron: '21,23,25,27,29 * * * *'
           filters:
             branches:
               only: /(^jc-inf-295.*$)/


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

* Confirm that `release-week` logic works as intended.
* Remove test that confirms `release-week` logic.
* Offset release week to account for off-site.
* Add `release-to-service-providers` job that's triggered by the `sp_release` field.
* Re-enable previously commented jobs.
* Leave `release-to-service-providers-cron` commented out for now.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

* https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/30121/workflows/e327d8df-e153-478d-8a71-597bb8033b8e
* https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/30119/workflows/eca0232f-6453-4a3b-a582-cc71ceac152c


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Monitoring #eng-deploys


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->