### PR TITLE
[CON-481] Remove tmp track artifacts on Content Node startup

### DIFF
--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -80,6 +80,9 @@ if [[ "$devMode" == "true" ]]; then
         npx nodemon --exec 'node --inspect=0.0.0.0:${debuggerPort} --require ts-node/register src/index.ts' --watch src/ | tee >(logger)
     fi
 else
+    # Remove tmp track artifacts before starting the server so there are no incoming uploads
+    rm -rf /file_storage/files/tmp_track_artifacts
+
     node --max-old-space-size=4096 build/src/index.js | tee >(logger)
 fi
 

--- a/creator-node/scripts/start.sh
+++ b/creator-node/scripts/start.sh
@@ -80,9 +80,6 @@ if [[ "$devMode" == "true" ]]; then
         npx nodemon --exec 'node --inspect=0.0.0.0:${debuggerPort} --require ts-node/register src/index.ts' --watch src/ | tee >(logger)
     fi
 else
-    # Remove tmp track artifacts before starting the server so there are no incoming uploads
-    rm -rf /file_storage/files/tmp_track_artifacts
-
     node --max-old-space-size=4096 build/src/index.js | tee >(logger)
 fi
 

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -31,6 +31,14 @@ class DiskManager {
   }
 
   /**
+   * Empties the tmp track artifacts directory of any old artifacts
+   */
+  static async emptyTmpTrackUploadArtifacts() {
+    const dirPath = this.getTmpTrackUploadArtifactsPath()
+    await fs.emptyDir(dirPath)
+  }
+
+  /**
    * Returns the folder that stores track artifacts uploaded by creators. The reason this is all stored together
    * is we should be able to delete the contents of this folder without scanning through other folders with the
    * naming scheme.

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -34,7 +34,7 @@ class DiskManager {
    * Empties the tmp track artifacts directory of any old artifacts
    */
   static async emptyTmpTrackUploadArtifacts() {
-    const dirPath = this.getTmpTrackUploadArtifactsPath()
+    const dirPath = await this.getTmpTrackUploadArtifactsPath()
     await fs.emptyDir(dirPath)
   }
 

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -110,7 +110,11 @@ const startAppForPrimary = async () => {
 
   await setupDbAndRedis()
 
+  const startTime = Date.now()
   await DiskManager.emptyTmpTrackUploadArtifacts()
+  logger.info(
+    `old tmp track artifacts deleted : ${(Date.now() - startTime) * 1000}sec`
+  )
 
   // Don't await - run in background. Remove after v0.3.69
   // See https://linear.app/audius/issue/CON-477/use-proper-migration-for-storagepath-index-on-files-table

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -113,7 +113,7 @@ const startAppForPrimary = async () => {
   const startTime = Date.now()
   await DiskManager.emptyTmpTrackUploadArtifacts()
   logger.info(
-    `old tmp track artifacts deleted : ${(Date.now() - startTime) * 1000}sec`
+    `old tmp track artifacts deleted : ${(Date.now() - startTime) / 1000}sec`
   )
 
   // Don't await - run in background. Remove after v0.3.69

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -20,6 +20,7 @@ import DBManager from './dbManager'
 
 import { logger } from './logging'
 import { sequelize } from './models'
+import DiskManager from './diskManager'
 
 const EthereumWallet = require('ethereumjs-wallet')
 const redisClient = require('./redis')
@@ -108,6 +109,8 @@ const startAppForPrimary = async () => {
   logger.info(`Primary process with pid=${process.pid} is running`)
 
   await setupDbAndRedis()
+
+  await DiskManager.emptyTmpTrackUploadArtifacts()
 
   // Don't await - run in background. Remove after v0.3.69
   // See https://linear.app/audius/issue/CON-477/use-proper-migration-for-storagepath-index-on-files-table


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR removes any tmp track artifacts before starting the server in non-devmode. This ensures that the directory is cleared before accepting any uploads.

We should run this as an ad hoc command first before deploying this to make sure it doesn't take forever to clear the directory.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Testing the script locally to make sure nothing breaks and making sure the server actually doesn't start until the command finishes. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This will partly be monitored with the disk space metrics on our grafana dashboards to see if this makes a difference in clearing disk space

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->