### PR TITLE
Check that errored array has length when checking for forbidden

### DIFF
--- a/libs/src/api/File.ts
+++ b/libs/src/api/File.ts
@@ -71,10 +71,12 @@ export class File extends Base {
           )
 
           if (!response) {
-            const allForbidden = errored.every(
-              // @ts-expect-error not valid axios error
-              (error) => error.response.status === 403
-            )
+            const allForbidden =
+              errored.length &&
+              errored.every(
+                // @ts-expect-error not valid axios error
+                (error) => error.response.status === 403
+              )
             if (allForbidden) {
               // In the case for a 403, do not retry fetching
               bail(new Error('Forbidden'))


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

In fetchCID we are determining whether or not a CID is forbidden by checking if all the errors have status 403. But in some cases the error array is empty, so we need to confirm that the array has a length before assuming it is forbidden


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->