### PR TITLE
Index spl-token for audio_tx_history

### DIFF
--- a/discovery-provider/alembic/versions/42d5afb85d42_create_audio_transactions_history.py
+++ b/discovery-provider/alembic/versions/42d5afb85d42_create_audio_transactions_history.py
@@ -45,7 +45,7 @@ def upgrade():
             ),
             sa.Column("change", sa.Numeric(), nullable=False),
             sa.Column("balance", sa.Numeric(), nullable=False),
-            sa.Column("tx_metadata", sa.String(), nullable=False),
+            sa.Column("tx_metadata", sa.String(), nullable=True),
             sa.PrimaryKeyConstraint("user_bank", "signature"),
         )
         op.create_index(

--- a/discovery-provider/integration_tests/tasks/test_index_spl_token.py
+++ b/discovery-provider/integration_tests/tasks/test_index_spl_token.py
@@ -350,7 +350,7 @@ mock_purchase_tx_info = {
 
 def test_parse_memo_instruction():
     memo = parse_memo_instruction(mock_transfer_checked_meta)
-    assert memo == None
+    assert not memo
     memo = parse_memo_instruction(mock_purchase_meta)
     assert memo == "Bs2CZBUGWJZV5kqF3ecfJisidP9WQtCpeeWCzk6AUyYLQWgLdHPz"
     vendor = decode_memo_and_extract_vendor(memo)

--- a/discovery-provider/integration_tests/tasks/test_index_spl_token.py
+++ b/discovery-provider/integration_tests/tasks/test_index_spl_token.py
@@ -2,12 +2,14 @@ from unittest.mock import create_autospec
 
 from integration_tests.utils import populate_mock_db
 from src.models.indexing.spl_token_transaction import SPLTokenTransaction
+from src.models.users.audio_transactions_history import (
+    AudioTransactionsHistory,
+    TransactionMethod,
+    TransactionType,
+)
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks.cache_user_balance import get_immediate_refresh_user_ids
-from src.tasks.index_spl_token import (
-    get_token_balance_change_owners,
-    parse_sol_tx_batch,
-)
+from src.tasks.index_spl_token import parse_sol_tx_batch, parse_spl_token_transaction
 from src.utils.config import shared_config
 from src.utils.db_session import get_db
 from src.utils.redis_connection import get_redis
@@ -15,92 +17,6 @@ from src.utils.solana_indexing_logger import SolanaIndexingLogger
 
 REWARDS_MANAGER_PROGRAM = shared_config["solana"]["rewards_manager_program_address"]
 REWARDS_MANAGER_ACCOUNT = shared_config["solana"]["rewards_manager_account"]
-
-
-transfer_meta = {
-    "meta": {
-        "postTokenBalances": [
-            {
-                "accountIndex": 1,
-                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-                "uiTokenAmount": {
-                    "amount": "100000000",
-                    "decimals": 8,
-                    "uiAmount": 1.0,
-                    "uiAmountString": "1",
-                },
-            },
-            {
-                "accountIndex": 2,
-                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-                "uiTokenAmount": {
-                    "amount": "700000000",
-                    "decimals": 8,
-                    "uiAmount": 7.0,
-                    "uiAmountString": "7",
-                },
-            },
-        ],
-        "preTokenBalances": [
-            {
-                "accountIndex": 1,
-                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-                "uiTokenAmount": {
-                    "amount": "600000000",
-                    "decimals": 8,
-                    "uiAmount": 6.0,
-                    "uiAmountString": "6",
-                },
-            },
-            {
-                "accountIndex": 2,
-                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-                "uiTokenAmount": {
-                    "amount": "200000000",
-                    "decimals": 8,
-                    "uiAmount": 2.0,
-                    "uiAmountString": "2",
-                },
-            },
-        ],
-    },
-    "transaction": {
-        "message": {
-            "accountKeys": [
-                "CgJhbUdHQNN5HBeNEN7J69Z89emh6BtyYX1CPEGwaeqi",
-                "3fh1U93FEtZJK3uRtRuQ2ocYQApRZQ7g1AmVr9WcrHHv",
-                "2mDP3qspXi1wJUdnaFf2Xa3oSQJZUzqfPZ69zZtee3Sb",
-                "E4rr6UXzeVoaA8Ae7Fm6sEV1dXEuWeuHDBwRnvicUcbu",
-                "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-                "SysvarRent111111111111111111111111111111111",
-                "Sysvar1nstructions1111111111111111111111111",
-                "11111111111111111111111111111111",
-                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-                "KeccakSecp256k11111111111111111111111111111",
-                "Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ",
-            ],
-            "recentBlockhash": "FZbtQTxcSnhyLALk6SFXGrE2omGhhyCns8yFWDvpGYFw",
-        },
-        "signatures": [
-            "arAQYgyyHVG2CS5PZuQC1G83vfi5HmHVWMchC1tXg1S9qebC2jdsbqyLfmX1cfjefk3S5NLhoE8r3pTzvCthxUc"
-        ],
-    },
-}
-
-
-def test_get_token_balance_change_owners_bank_accts():
-    (root_accounts, token_accounts) = get_token_balance_change_owners(transfer_meta)
-    assert root_accounts == set(["5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx"])
-    assert token_accounts == set(
-        [
-            "3fh1U93FEtZJK3uRtRuQ2ocYQApRZQ7g1AmVr9WcrHHv",
-            "2mDP3qspXi1wJUdnaFf2Xa3oSQJZUzqfPZ69zZtee3Sb",
-        ]
-    )
 
 
 mock_create_account_meta = {
@@ -160,16 +76,37 @@ mock_create_account_meta = {
     },
 }
 
+mock_create_account_tx_info = {
+    "jsonrpc": "2.0",
+    "result": mock_create_account_meta,
+    "id": 2,
+}
 
-def test_get_token_balance_change_owners_no_results():
-    (root_accounts, token_accounts) = get_token_balance_change_owners(
-        mock_create_account_meta
+mock_confirmed_signature_for_address = {
+    "err": None,
+    "memo": None,
+    "signature": "2DUH6nXnS4EXCqPdgxGvAiLyemZ8WkB69VyjhiGgE3HZxsbXWdk8SuZbGCkyV7oN6b7DHHVggaB8QSCKp5YNk7QJ",
+    "slot": 123209431,
+    "blockTime": 1646261596,
+    "confirmationStatus": "finalized",
+}
+
+
+def test_parse_spl_token_transaction_no_results():
+    solana_client_manager_mock = create_autospec(SolanaClientManager)
+    solana_client_manager_mock.get_sol_tx_info.return_value = (
+        mock_create_account_tx_info
     )
-    assert root_accounts == set()
-    assert token_accounts == set()
+    (tx_info, root_accounts, token_accounts) = parse_spl_token_transaction(
+        solana_client_manager_mock, mock_confirmed_signature_for_address
+    )
+    assert tx_info == None
+    assert root_accounts == []
+    assert token_accounts == []
 
 
 mock_transfer_checked_meta = {
+    "blockTime": 1646261596,
     "meta": {
         "err": None,
         "fee": 5000,
@@ -261,29 +198,150 @@ mock_transfer_checked_meta = {
     },
 }
 
-
-def test_get_token_balance_change_owners():
-    (root_accounts, token_accounts) = get_token_balance_change_owners(
-        mock_transfer_checked_meta
-    )
-    assert root_accounts == set(
-        [
-            "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
-            "iVsXfN4oZnARo6AYwm8FFXBnDQYnwhkPxJiuPHDzfJ4",
-        ]
-    )
-    assert token_accounts == set(
-        [
-            "9f79QvW5XQ1XCXGLeCCHjBZkPet51yAPxtU7fcaY6UxD",
-            "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9",
-        ]
-    )
-
-
-mock_tx_info = {
+mock_transfer_tx_info = {
     "jsonrpc": "2.0",
     "result": mock_transfer_checked_meta,
     "id": 3,
+}
+
+
+def test_parse_spl_token_transaction():
+    solana_client_manager_mock = create_autospec(SolanaClientManager)
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_transfer_tx_info
+    (tx_info, root_accounts, token_accounts) = parse_spl_token_transaction(
+        solana_client_manager_mock, mock_confirmed_signature_for_address
+    )
+    assert tx_info["user_bank"] == "9f79QvW5XQ1XCXGLeCCHjBZkPet51yAPxtU7fcaY6UxD"
+    assert root_accounts == [
+        "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+        "iVsXfN4oZnARo6AYwm8FFXBnDQYnwhkPxJiuPHDzfJ4",
+    ]
+    assert token_accounts == [
+        "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9",
+        "9f79QvW5XQ1XCXGLeCCHjBZkPet51yAPxtU7fcaY6UxD",
+    ]
+
+
+mock_purchase_meta = {
+    "blockTime": 1665685554,
+    "meta": {
+        "err": None,
+        "fee": 5000,
+        "innerInstructions": [],
+        "loadedAddresses": {"readonly": None, "writable": None},
+        "logMessages": [
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo invoke [1]",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo consumed 651 of 400000 compute units",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6172 of 399349 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+        ],
+        "postBalances": [
+            2935160,
+            2039280,
+            2039280,
+            260042654,
+            121159680,
+            934087680,
+        ],
+        "postTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "5623032749",
+                    "decimals": 8,
+                    "uiAmount": 56.23032749,
+                    "uiAmountString": "56.23032749",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "0",
+                    "decimals": 8,
+                    "uiAmount": None,
+                    "uiAmountString": "0",
+                },
+            },
+        ],
+        "preBalances": [2940160, 2039280, 2039280, 260042654, 121159680, 934087680],
+        "preTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "500000000",
+                    "decimals": 8,
+                    "uiAmount": 5.0,
+                    "uiAmountString": "5",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "5123032749",
+                    "decimals": 8,
+                    "uiAmount": 51.23032749,
+                    "uiAmountString": "51.23032749",
+                },
+            },
+        ],
+        "rewards": [],
+        "status": {"Ok": None},
+    },
+    "slot": 155160519,
+    "transaction": {
+        "message": {
+            "accountKeys": [
+                "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+                "7dw7W4Yv7F1uWb9dVH1CFPm39mePyypuCji2zxcFA556",
+                "C4qrWm6kkLwUNExA2Ldt6uXLroRfcTGXJLx1zGvEt5DB",
+                "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo",
+                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            ],
+            "header": {
+                "numReadonlySignedAccounts": 0,
+                "numReadonlyUnsignedAccounts": 3,
+                "numRequiredSignatures": 1,
+            },
+            "instructions": [
+                {
+                    "accounts": [0],
+                    "data": "Bs2CZBUGWJZV5kqF3ecfJisidP9WQtCpeeWCzk6AUyYLQWgLdHPz",
+                    "programIdIndex": 4,
+                },
+                {
+                    "accounts": [2, 3, 1, 0],
+                    "data": "iJsU9Sk8HPLQP",
+                    "programIdIndex": 5,
+                },
+            ],
+            "recentBlockhash": "CChCbrfGJgYkqSf3FUHqMmhEd3TXxBoKDAk6ZZx9QGfZ",
+        },
+        "signatures": [
+            "2n4gYtnZLFjEnv3gSEoTHwoUsi5pbj4xu1LmETex1P5tbrSafCEkBDNXM9hmBGBb7AH5VUJtMsYDoeo8TpskJ7pw"
+        ],
+    },
+}
+
+mock_purchase_tx_info = {
+    "jsonrpc": "2.0",
+    "result": mock_purchase_meta,
+    "id": 4,
 }
 
 
@@ -293,7 +351,7 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
         redis = get_redis()
 
     solana_client_manager_mock = create_autospec(SolanaClientManager)
-    solana_client_manager_mock.get_sol_tx_info.return_value = mock_tx_info
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_transfer_tx_info
 
     test_entries = {
         "users": [
@@ -307,6 +365,11 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
                 "handle": "piazzatron",
                 "wallet": "0x0403be3560116a12b467855cb29a393174a59875",
             },
+            {
+                "user_id": 3,
+                "handle": "asdf33",
+                "wallet": "0x7d12457bd24ce79b62e66e915dbc0a469a6b59ba",
+            },
         ],
         "user_bank_accounts": [
             {  # user 1
@@ -314,9 +377,14 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
                 "ethereum_address": "0x0403be3560116a12b467855cb29a393174a59876",
                 "bank_account": "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9",
             },
+            {
+                "signature": "hellothere",
+                "ethereum_address": "0x7d12457bd24ce79b62e66e915dbc0a469a6b59ba",
+                "bank_account": "AoY7fgjKanf2bmrjLgK21xdAVpfVjBc4poT92nexxi8K",
+            },
         ],
         "associated_wallets": [
-            {"user_id": 2, "wallet": "iVsXfN4oZnARo6AYwm8FFXBnDQYnwhkPxJiuPHDzfJ4"}
+            {"user_id": 2, "wallet": "iVsXfN4oZnARo6AYwm8FFXBnDQYnwhkPxJiuPHDzfJ4"},
         ],
     }
     mock_confirmed_signature_for_address = {
@@ -353,3 +421,42 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
         refresh_user_ids.sort()
         assert len(refresh_user_ids) == 2
         assert refresh_user_ids == [1, 2]
+
+    mock_confirmed_signature_for_address = {
+        "err": None,
+        "memo": None,
+        "signature": "2n4gYtnZLFjEnv3gSEoTHwoUsi5pbj4xu1LmETex1P5tbrSafCEkBDNXM9hmBGBb7AH5VUJtMsYDoeo8TpskJ7pw",
+        "slot": 155160519,
+        "blockTime": 1665685554,
+        "confirmationStatus": "finalized",
+    }
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_purchase_tx_info
+    parse_sol_tx_batch(
+        db,
+        solana_client_manager_mock,
+        redis,
+        [mock_confirmed_signature_for_address],
+        solana_logger,
+    )
+
+    with db.scoped_session() as session:
+        audio_tx = (
+            session.query(
+                AudioTransactionsHistory.user_bank,
+                AudioTransactionsHistory.transaction_type,
+                AudioTransactionsHistory.balance,
+                AudioTransactionsHistory.change,
+                AudioTransactionsHistory.method,
+            )
+            .filter(
+                AudioTransactionsHistory.signature
+                == mock_purchase_meta["transaction"]["signatures"][0]
+            )
+            .first()
+        )
+
+        assert audio_tx.user_bank == "7dw7W4Yv7F1uWb9dVH1CFPm39mePyypuCji2zxcFA556"
+        assert audio_tx.balance == 5623032749
+        assert audio_tx.change == 5123032749
+        assert audio_tx.transaction_type == TransactionType.purchase_stripe
+        assert audio_tx.method == TransactionMethod.receive

--- a/discovery-provider/integration_tests/utils/test_helpers.py
+++ b/discovery-provider/integration_tests/utils/test_helpers.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+from src.utils.helpers import get_solana_tx_root_account, get_solana_tx_token_balances
+
+RECEIVER_ACCOUNT_INDEX = 1
+SENDER_ACCOUNT_INDEX = 2
+
+
+mock_meta: Any = {
+    "meta": {
+        "err": None,
+        "fee": 5000,
+        "innerInstructions": [],
+        "loadedAddresses": {"readonly": None, "writable": None},
+        "logMessages": [
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo invoke [1]",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo consumed 651 of 400000 compute units",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6172 of 399349 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+        ],
+        "postBalances": [
+            2935160,
+            2039280,
+            2039280,
+            260042654,
+            121159680,
+            934087680,
+        ],
+        "postTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "5623032749",
+                    "decimals": 8,
+                    "uiAmount": 56.23032749,
+                    "uiAmountString": "56.23032749",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "0",
+                    "decimals": 8,
+                    "uiAmount": None,
+                    "uiAmountString": "0",
+                },
+            },
+        ],
+        "preBalances": [2940160, 2039280, 2039280, 260042654, 121159680, 934087680],
+        "preTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "500000000",
+                    "decimals": 8,
+                    "uiAmount": 5.0,
+                    "uiAmountString": "5",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "5123032749",
+                    "decimals": 8,
+                    "uiAmount": 51.23032749,
+                    "uiAmountString": "51.23032749",
+                },
+            },
+        ],
+        "rewards": [],
+        "status": {"Ok": None},
+    },
+}
+
+
+def test_get_solana_tx_token_balances():
+    prebalance, postbalance = get_solana_tx_token_balances(
+        mock_meta["meta"], RECEIVER_ACCOUNT_INDEX
+    )
+    assert prebalance == 500000000
+    assert postbalance == 5623032749
+
+
+def test_get_solana_tx_root_account():
+    root_account = get_solana_tx_root_account(mock_meta["meta"], RECEIVER_ACCOUNT_INDEX)
+    assert root_account == "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx"
+    root_account = get_solana_tx_root_account(mock_meta["meta"], SENDER_ACCOUNT_INDEX)
+    assert root_account == "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX"

--- a/discovery-provider/integration_tests/utils/test_helpers.py
+++ b/discovery-provider/integration_tests/utils/test_helpers.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from src.utils.helpers import get_solana_tx_root_account, get_solana_tx_token_balances
+from src.utils.helpers import get_solana_tx_owner, get_solana_tx_token_balances
 
 RECEIVER_ACCOUNT_INDEX = 1
 SENDER_ACCOUNT_INDEX = 2
@@ -96,8 +96,8 @@ def test_get_solana_tx_token_balances():
     assert postbalance == 5623032749
 
 
-def test_get_solana_tx_root_account():
-    root_account = get_solana_tx_root_account(mock_meta["meta"], RECEIVER_ACCOUNT_INDEX)
+def test_get_solana_tx_owner():
+    root_account = get_solana_tx_owner(mock_meta["meta"], RECEIVER_ACCOUNT_INDEX)
     assert root_account == "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx"
-    root_account = get_solana_tx_root_account(mock_meta["meta"], SENDER_ACCOUNT_INDEX)
+    root_account = get_solana_tx_owner(mock_meta["meta"], SENDER_ACCOUNT_INDEX)
     assert root_account == "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX"

--- a/discovery-provider/src/models/users/audio_transactions_history.py
+++ b/discovery-provider/src/models/users/audio_transactions_history.py
@@ -12,6 +12,7 @@ class TransactionType(str, enum.Enum):
     transfer = "TRANSFER"
     purchase_stripe = "PURCHASE_STRIPE"
     purchase_coinbase = "PURCHASE_COINBASE"
+    unknown = "UNKNOWN"
 
 
 class TransactionMethod(str, enum.Enum):
@@ -36,4 +37,4 @@ class AudioTransactionsHistory(Base, RepresentableMixin):
     transaction_created_at = Column(DateTime, nullable=False)
     change = Column(Numeric, nullable=False)
     balance = Column(Numeric, nullable=False)
-    tx_metadata = Column(String, nullable=False)
+    tx_metadata = Column(String, nullable=True)

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -44,7 +44,7 @@ from src.utils.cache_solana_program import (
     fetch_and_cache_latest_program_tx_redis,
 )
 from src.utils.config import shared_config
-from src.utils.helpers import get_solana_tx_balances
+from src.utils.helpers import get_solana_tx_token_balances
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
     latest_sol_rewards_manager_db_tx_key,
@@ -248,7 +248,7 @@ def fetch_and_parse_sol_rewards_transfer_instruction(
 
         challenge_id, specifier = transfer_instruction
         receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
-        pre_balance, post_balance = get_solana_tx_balances(meta, receiver_index)
+        pre_balance, post_balance = get_solana_tx_token_balances(meta, receiver_index)
         if pre_balance == -1 or post_balance == -1:
             raise Exception("Reward recipient balance missing!")
         tx_metadata["transfer_instruction"] = {

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 from decimal import Decimal
-from typing import List, Optional, Set, Tuple, TypedDict
+from typing import List, Optional, Set, TypedDict
 
 import base58
 from redis import Redis
@@ -37,7 +37,7 @@ from src.utils.cache_solana_program import (
     fetch_and_cache_latest_program_tx_redis,
 )
 from src.utils.config import shared_config
-from src.utils.helpers import get_solana_tx_root_account, get_solana_tx_token_balances
+from src.utils.helpers import get_solana_tx_owner, get_solana_tx_token_balances
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
     latest_sol_spl_token_db_key,
@@ -50,6 +50,7 @@ SPL_TOKEN_PROGRAM = shared_config["solana"]["waudio_mint"]
 SPL_TOKEN_PUBKEY = PublicKey(SPL_TOKEN_PROGRAM) if SPL_TOKEN_PROGRAM else None
 USER_BANK_ADDRESS = shared_config["solana"]["user_bank_program_address"]
 USER_BANK_PUBKEY = PublicKey(USER_BANK_ADDRESS) if USER_BANK_ADDRESS else None
+PURCHASE_AUDIO_MEMO_PROGRAM = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
 
 REDIS_TX_CACHE_QUEUE_PREFIX = "spl-token-tx-cache-queue"
 
@@ -82,10 +83,12 @@ class SplTokenTransactionInfo(TypedDict):
     signature: str
     slot: int
     timestamp: datetime.datetime
-    memo: str
+    vendor: Optional[str]
     prebalance: int
     postbalance: int
     sender_wallet: str
+    root_accounts: List[str]
+    token_accounts: List[str]
 
 
 # Cache the latest value committed to DB in redis
@@ -94,55 +97,83 @@ def cache_latest_spl_audio_db_tx(redis: Redis, latest_tx: CachedProgramTxInfo):
     cache_latest_sol_db_tx(redis, latest_sol_spl_token_db_key, latest_tx)
 
 
+def parse_memo_instruction(result):
+    try:
+        txs = result["transaction"]
+        memo_instruction = next(
+            (
+                inst
+                for inst in txs["message"]["instructions"]
+                if inst["programIdIndex"] == MEMO_INSTRUCTION_INDEX
+            ),
+            None,
+        )
+        if not memo_instruction:
+            return None
+
+        memo_account = txs["message"]["accountKeys"][MEMO_INSTRUCTION_INDEX]
+        if not memo_account or memo_account != PURCHASE_AUDIO_MEMO_PROGRAM:
+            return None
+        return memo_instruction["data"]
+    except Exception as e:
+        logger.error(f"index_spl_token.py | Error parsing memo, {e}", exc_info=True)
+        raise e
+
+
+def decode_memo_and_extract_vendor(memo_encoded):
+    try:
+        memo = str(base58.b58decode(memo_encoded))
+        if not memo or "In-App $AUDIO Purchase:" not in memo:
+            return None
+
+        vendor = memo[1:-1].split(":")[1][1:]
+        if vendor not in purchase_vendor_map:
+            return None
+        return vendor
+    except Exception as e:
+        logger.error(f"index_spl_token.py | Error decoding memo, {e}", exc_info=True)
+        raise e
+
+
 def parse_spl_token_transaction(
     solana_client_manager: SolanaClientManager,
     tx_sig: ConfirmedSignatureForAddressResult,
-) -> Tuple[Optional[SplTokenTransactionInfo], List[str], List[str]]:
+) -> Optional[SplTokenTransactionInfo]:
     try:
         tx_info = solana_client_manager.get_sol_tx_info(tx_sig["signature"])
         result = tx_info["result"]
         meta = result["meta"]
         error = meta["err"]
-
         if error:
-            return (None, [], [])
+            return None
 
-        sender_root_account = get_solana_tx_root_account(meta, SENDER_ACCOUNT_INDEX)
-        receiver_root_account = get_solana_tx_root_account(meta, RECEIVER_ACCOUNT_INDEX)
+        memo_encoded = parse_memo_instruction(result)
+        vendor = decode_memo_and_extract_vendor(memo_encoded) if memo_encoded else None
+
+        sender_root_account = get_solana_tx_owner(meta, SENDER_ACCOUNT_INDEX)
+        receiver_root_account = get_solana_tx_owner(meta, RECEIVER_ACCOUNT_INDEX)
         account_keys = result["transaction"]["message"]["accountKeys"]
         receiver_token_account = account_keys[RECEIVER_ACCOUNT_INDEX]
         sender_token_account = account_keys[SENDER_ACCOUNT_INDEX]
-        memo_instruction = next(
-            (
-                inst
-                for inst in result["transaction"]["message"]["instructions"]
-                if inst["programIdIndex"] == MEMO_INSTRUCTION_INDEX
-            ),
-            None,
-        )
-        # Not a transfer receive or purchase instruction, no need to refresh balances
-        if not memo_instruction:
-            return (None, [], [])
-        memo_encoded = memo_instruction["data"]
-        memo = str(base58.b58decode(memo_encoded))
         prebalance, postbalance = get_solana_tx_token_balances(
             meta, RECEIVER_ACCOUNT_INDEX
         )
+        # Skip if there is no balance change.
+        if postbalance - prebalance == 0:
+            return None
         receiver_spl_tx_info: SplTokenTransactionInfo = {
             "user_bank": receiver_token_account,
             "signature": tx_sig["signature"],
             "slot": result["slot"],
             "timestamp": datetime.datetime.utcfromtimestamp(result["blockTime"]),
-            "memo": memo,
+            "vendor": vendor,
             "prebalance": prebalance,
             "postbalance": postbalance,
             "sender_wallet": sender_root_account,
+            "root_accounts": [sender_root_account, receiver_root_account],
+            "token_accounts": [sender_token_account, receiver_token_account],
         }
-        return (
-            receiver_spl_tx_info,
-            [sender_root_account, receiver_root_account],
-            [sender_token_account, receiver_token_account],
-        )
+        return receiver_spl_tx_info
 
     except Exception as e:
         signature = tx_sig["signature"]
@@ -153,17 +184,22 @@ def parse_spl_token_transaction(
 
 
 def process_spl_token_transactions(
-    txs: List[ConfirmedTransaction], session
+    txs: List[SplTokenTransactionInfo], user_bank_set: Set[str]
 ) -> List[AudioTransactionsHistory]:
     try:
         audio_txs = []
         for tx_info in txs:
+            # Disregard if recipient account is not a user_bank
+            if tx_info["user_bank"] not in user_bank_set:
+                continue
+
             logger.info(
                 f"index_spl_token.py | processing transaction: {tx_info['signature']} | slot={tx_info['slot']}"
             )
+            vendor = tx_info["vendor"]
             # Index as an external receive transaction
             # Note: external sends are under a different program, see index_user_bank.py
-            if tx_info["memo"] and "In-App $AUDIO Purchase:" not in tx_info["memo"]:
+            if not vendor:
                 audio_txs.append(
                     AudioTransactionsHistory(
                         user_bank=tx_info["user_bank"],
@@ -177,15 +213,8 @@ def process_spl_token_transactions(
                         tx_metadata=tx_info["sender_wallet"],
                     )
                 )
-
             # Index as purchase transaction
             else:
-                vendor = tx_info["memo"][1:-1].split(":")[1][1:]
-                if vendor not in purchase_vendor_map.keys():
-                    raise Exception(
-                        f"Purchase instruction from unsupported vendor: {vendor}"
-                    )
-
                 audio_txs.append(
                     AudioTransactionsHistory(
                         user_bank=tx_info["user_bank"],
@@ -260,12 +289,12 @@ def parse_sol_tx_batch(
             for future in concurrent.futures.as_completed(
                 parse_sol_tx_futures, timeout=45
             ):
-                tx_info, root_accounts, token_accounts = future.result()
-                if root_accounts or token_accounts:
-                    updated_root_accounts.update(root_accounts)
-                    updated_token_accounts.update(token_accounts)
-                if tx_info:
-                    spl_token_txs.append(tx_info)
+                tx_info = future.result()
+                if not tx_info:
+                    continue
+                updated_root_accounts.update(tx_info["root_accounts"])
+                updated_token_accounts.update(tx_info["token_accounts"])
+                spl_token_txs.append(tx_info)
 
         except Exception as exc:
             logger.error(
@@ -276,16 +305,17 @@ def parse_sol_tx_batch(
     update_user_ids: Set[int] = set()
     with db.scoped_session() as session:
         if updated_token_accounts:
-            user_bank_subquery = session.query(UserBankAccount.ethereum_address).filter(
-                UserBankAccount.bank_account.in_(list(updated_token_accounts))
-            )
-
             user_result = (
-                session.query(User.user_id)
-                .filter(User.is_current == True, User.wallet.in_(user_bank_subquery))
+                session.query(User.user_id, UserBankAccount.bank_account)
+                .join(UserBankAccount, UserBankAccount.ethereum_address == User.wallet)
+                .filter(
+                    UserBankAccount.bank_account.in_(list(updated_token_accounts)),
+                    User.is_current == True,
+                )
                 .all()
             )
-            user_set = {user_id for [user_id] in user_result}
+            user_set = {user[0] for user in user_result}
+            user_bank_set = {user[1] for user in user_result}
             update_user_ids.update(user_set)
 
         if updated_root_accounts:
@@ -311,7 +341,7 @@ def parse_sol_tx_batch(
             )
             enqueue_immediate_balance_refresh(redis, user_ids)
 
-        audio_txs = process_spl_token_transactions(spl_token_txs, session)
+        audio_txs = process_spl_token_transactions(spl_token_txs, user_bank_set)
         session.bulk_save_objects(audio_txs)
 
         if tx_sig_batch_records:

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 from decimal import Decimal
-from typing import List, Optional, Set, TypedDict
+from typing import Any, List, Optional, Set, TypedDict
 
 import base58
 from redis import Redis
@@ -97,7 +97,7 @@ def cache_latest_spl_audio_db_tx(redis: Redis, latest_tx: CachedProgramTxInfo):
     cache_latest_sol_db_tx(redis, latest_sol_spl_token_db_key, latest_tx)
 
 
-def parse_memo_instruction(result):
+def parse_memo_instruction(result: Any) -> str:
     try:
         txs = result["transaction"]
         memo_instruction = next(
@@ -109,26 +109,26 @@ def parse_memo_instruction(result):
             None,
         )
         if not memo_instruction:
-            return None
+            return ""
 
         memo_account = txs["message"]["accountKeys"][MEMO_INSTRUCTION_INDEX]
         if not memo_account or memo_account != PURCHASE_AUDIO_MEMO_PROGRAM:
-            return None
+            return ""
         return memo_instruction["data"]
     except Exception as e:
         logger.error(f"index_spl_token.py | Error parsing memo, {e}", exc_info=True)
         raise e
 
 
-def decode_memo_and_extract_vendor(memo_encoded):
+def decode_memo_and_extract_vendor(memo_encoded: str) -> str:
     try:
         memo = str(base58.b58decode(memo_encoded))
         if not memo or "In-App $AUDIO Purchase:" not in memo:
-            return None
+            return ""
 
         vendor = memo[1:-1].split(":")[1][1:]
         if vendor not in purchase_vendor_map:
-            return None
+            return ""
         return vendor
     except Exception as e:
         logger.error(f"index_spl_token.py | Error decoding memo, {e}", exc_info=True)

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -46,7 +46,7 @@ from src.utils.cache_solana_program import (
     fetch_and_cache_latest_program_tx_redis,
 )
 from src.utils.config import shared_config
-from src.utils.helpers import get_solana_tx_balances
+from src.utils.helpers import get_solana_tx_token_balances
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
     latest_sol_user_bank_db_tx_key,
@@ -179,8 +179,10 @@ def process_transfer_instruction(
         )
         return
 
-    pre_sender_balance, post_sender_balance = get_solana_tx_balances(meta, sender_index)
-    pre_receiver_balance, post_receiver_balance = get_solana_tx_balances(
+    pre_sender_balance, post_sender_balance = get_solana_tx_token_balances(
+        meta, sender_index
+    )
+    pre_receiver_balance, post_receiver_balance = get_solana_tx_token_balances(
         meta, receiver_index
     )
     if (

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import re
 import time
+from decimal import Decimal
 from typing import List, Optional, TypedDict
 
 import base58
@@ -211,8 +212,8 @@ def process_transfer_instruction(
             transaction_type=TransactionType.transfer,
             method=TransactionMethod.send,
             transaction_created_at=timestamp,
-            change=sent_amount,
-            balance=post_sender_balance,
+            change=Decimal(sent_amount),
+            balance=Decimal(post_sender_balance),
             tx_metadata=receiver_account,
         )
         logger.debug(
@@ -248,8 +249,8 @@ def process_transfer_instruction(
             transaction_type=TransactionType.tip,
             method=TransactionMethod.send,
             transaction_created_at=timestamp,
-            change=sent_amount,
-            balance=post_sender_balance,
+            change=Decimal(sent_amount),
+            balance=Decimal(post_sender_balance),
             tx_metadata=str(receiver_user_id),
         )
         logger.debug(
@@ -263,8 +264,8 @@ def process_transfer_instruction(
             transaction_type=TransactionType.tip,
             method=TransactionMethod.receive,
             transaction_created_at=timestamp,
-            change=received_amount,
-            balance=post_receiver_balance,
+            change=Decimal(received_amount),
+            balance=Decimal(post_receiver_balance),
             tx_metadata=str(sender_user_id),
         )
         session.add(audio_tx_received)

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -484,7 +484,7 @@ def split_list(list, n):
 
 
 # Extracts the pre and post balances for a given index from a solana transaction metadata
-def get_solana_tx_balances(meta: Any, idx: int) -> Tuple[int, int]:
+def get_solana_tx_token_balances(meta: Any, idx: int) -> Tuple[int, int]:
     pre_balance_dict = next(
         (
             balance

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -508,7 +508,7 @@ def get_solana_tx_balances(meta: Any, idx: int) -> Tuple[int, int]:
     return (pre_balance, post_balance)
 
 
-def get_solana_tx_root_account(meta, idx) -> str:
+def get_solana_tx_owner(meta, idx) -> str:
     return next(
         (
             balance["owner"]

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -506,3 +506,14 @@ def get_solana_tx_balances(meta: Any, idx: int) -> Tuple[int, int]:
     pre_balance = int(pre_balance_dict["uiTokenAmount"]["amount"])
     post_balance = int(post_balance_dict["uiTokenAmount"]["amount"])
     return (pre_balance, post_balance)
+
+
+def get_solana_tx_root_account(meta, idx) -> str:
+    return next(
+        (
+            balance["owner"]
+            for balance in meta["preTokenBalances"]
+            if balance["accountIndex"] == idx
+        ),
+        "",
+    )


### PR DESCRIPTION
Note: this PR picked up changes in rewards indexing which were already reviewed, please disregard. Please just review the last 2 commits!

### Description
spl-token indexing for audio_transactions_history table. Includes external transfer receive instructions and purchase $AUDIO instructions. Ignores create-account instructions.

Also refactored some helper functions for handling solana tx metadata.

### Tests
Modified/added unit tests.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
