### PR TITLE
CN Reconfig mode primary only override

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -2951,7 +2951,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -2966,12 +2966,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2980,27 +2980,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -4821,7 +4821,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5026,7 +5026,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -5305,7 +5305,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-layout": {
       "version": "1.2.2",
@@ -5640,7 +5640,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001241",
@@ -6327,7 +6327,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
     },
     "css-to-react-native": {
       "version": "3.0.0",
@@ -8271,7 +8271,7 @@
     "fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha1-XFVDRisiru79NtBbNOUceMuG0xM="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -12896,7 +12896,7 @@
     "qr.js": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
     },
     "qrcode.react": {
       "version": "1.0.1",
@@ -14149,7 +14149,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw=="
     },
     "smart-buffer": {
       "version": "4.2.0",
@@ -16552,7 +16552,7 @@
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
       "requires": {
         "bs58check": "<3.0.0"
       }
@@ -16668,7 +16668,7 @@
     "write-file-atomic": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -16749,7 +16749,7 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -445,6 +445,12 @@ const config = convict({
     env: 'snapbackHighestReconfigMode',
     default: 'PRIMARY_AND_OR_SECONDARIES'
   },
+  reconfigModePrimaryOnly: {
+    doc: 'Override for `snapbackHighestReconfigMode` to only reconfig primary from replica set',
+    format: Boolean,
+    env: 'reconfigModePrimaryOnly',
+    default: false
+  },
   devMode: {
     doc: 'Used to differentiate production vs dev mode for node',
     format: 'BooleanCustom',

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -40,6 +40,9 @@ const reconfigNodeWhitelist = config.get('reconfigNodeWhitelist')
   : null
 
 const RECONFIG_SP_IDS_BLACKLIST: number[] = config.get('reconfigSPIdBlacklist')
+const RECONFIG_MODE_PRIMARY_ONLY: Boolean = config.get(
+  'reconfigModePrimaryOnly'
+)
 
 /**
  * Updates replica sets of a user who has one or more unhealthy nodes as their primary or secondaries.
@@ -820,6 +823,8 @@ const _issueUpdateReplicaSetOp = async (
  */
 const _isReconfigEnabled = (enabledReconfigModes: string[], mode: string) => {
   if (mode === RECONFIG_MODES.RECONFIG_DISABLED.key) return false
+  if (RECONFIG_MODE_PRIMARY_ONLY)
+    return mode === RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
   return enabledReconfigModes.includes(mode)
 }
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -823,8 +823,15 @@ const _issueUpdateReplicaSetOp = async (
  */
 const _isReconfigEnabled = (enabledReconfigModes: string[], mode: string) => {
   if (mode === RECONFIG_MODES.RECONFIG_DISABLED.key) return false
-  if (RECONFIG_MODE_PRIMARY_ONLY)
-    return mode === RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+
+  // If primary only override is enabled, only issue reconfig if mode is in enabled modes set and indicates a primary reconfig
+  if (RECONFIG_MODE_PRIMARY_ONLY) {
+    return (
+      enabledReconfigModes.includes(mode) &&
+      mode === RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+    )
+  }
+
   return enabledReconfigModes.includes(mode)
 }
 

--- a/creator-node/test/updateReplicaSet.jobProcessor.test.js
+++ b/creator-node/test/updateReplicaSet.jobProcessor.test.js
@@ -43,6 +43,7 @@ describe('test updateReplicaSet job processor', function () {
     await server.close()
     sandbox.restore()
     config.set('creatorNodeEndpoint', originalContentNodeEndpoint)
+    config.set('reconfigModePrimaryOnly', false)
     logger = null
     nock.cleanAll()
     nock.enableNetConnect()
@@ -74,7 +75,8 @@ describe('test updateReplicaSet job processor', function () {
     getNewOrExistingSyncReqStub,
     retrieveClockValueForUserFromReplicaStub,
     maxSelectNewReplicaSetAttempts = 100,
-    cNodeEndpointToSpIdMap = DEFAULT_CNODE_ENDOINT_TO_SP_ID_MAP
+    cNodeEndpointToSpIdMap = DEFAULT_CNODE_ENDOINT_TO_SP_ID_MAP,
+    customConfig = config
   }) {
     const getCNodeEndpointToSpIdMapStub = sandbox
       .stub()
@@ -129,7 +131,7 @@ describe('test updateReplicaSet job processor', function () {
     return proxyquire(
       '../src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts',
       {
-        '../../../config': config,
+        '../../../config': customConfig,
         '../../initAudiusLibs': sandbox.stub().resolves(audiusLibsStub),
         './stateReconciliationUtils': {
           getNewOrExistingSyncReq: getNewOrExistingSyncReqStub
@@ -321,6 +323,423 @@ describe('test updateReplicaSet job processor', function () {
     }
   })
 
+  it('reconfigs primary when primary is unhealthy and all reconfigs are enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except primary
+    const healthyNodes = {
+      [secondary1]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: '',
+      [fifthHealthyNode]: ''
+    }
+
+    // Mark primary as unhealthy and fourthHealthyNode+fifthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [primary]
+    const replicaToUserInfoMap = {
+      [primary]: { clock: 1 },
+      [secondary1]: { clock: 1 },
+      [secondary2]: { clock: 1 },
+      [fourthHealthyNode]: { clock: -1 },
+      [fifthHealthyNode]: { clock: -1 }
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      healthyNodes,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    const output = await updateReplicaSetJobProcessor({
+      logger,
+      wallet,
+      userId,
+      primary,
+      secondary1,
+      secondary2,
+      nodesToReconfigOffOf: unhealthyReplicas,
+      replicaToUserInfoMap,
+      enabledReconfigModes: [RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key]
+    })
+    const { metricsToRecord, newReplicaSet, jobsToEnqueue } = output
+
+    // Verify metrics record a successful reconfig
+    expect(metricsToRecord[0].metricLabels.result).to.equal('success')
+    expect(metricsToRecord[0].metricName).to.equal(
+      'audius_cn_state_machine_update_replica_set_queue_job_duration_seconds'
+    )
+    expect(metricsToRecord[0].metricType).to.equal('HISTOGRAM_OBSERVE')
+
+    // Verify job outputs the correct results: replace primary with one of secondaries and elect new secondary
+    expect(output.errorMsg).to.equal('')
+    expect(output.issuedReconfig).to.be.true
+    expect(newReplicaSet.newPrimary).to.be.oneOf([secondary1, secondary2])
+    // Replacement nodes are randomly so we can't enforce order of secondaries
+    expect(newReplicaSet.newSecondary1).to.be.oneOf([
+      secondary1,
+      secondary2
+    ])
+    expect(newReplicaSet.newSecondary2).to.be.oneOf([
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    expect(newReplicaSet.issueReconfig).to.be.true
+    expect(newReplicaSet.reconfigType).to.equal(
+      RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+    )
+    expect(output.healthyNodes).to.eql([
+      secondary1,
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    const newSecondaries = [newReplicaSet.newSecondary1, newReplicaSet.newSecondary2]
+    expect(jobsToEnqueue).to.have.nested.property(QUEUE_NAMES.RECURRING_SYNC)
+    const jobs = jobsToEnqueue[QUEUE_NAMES.RECURRING_SYNC]
+    expect(jobs).to.have.lengthOf(2)
+    // Verify sync from primary to new secondary1 and new secondary2
+    for (let i = 0; i < 1; i++) {
+      expect(jobs[i].primaryEndpoint).to.equal(newReplicaSet.newPrimary)
+      expect(jobs[i].secondaryEndpoint).to.equal(newSecondaries[i])
+      expect(jobs[i].syncType).to.equal(SyncType.Recurring)
+      expect(jobs[i].syncMode).to.equal(SYNC_MODES.SyncSecondaryFromPrimary)
+      expect(jobs[i].userWallet).to.equal(wallet)
+    }
+  })
+
+  it('Reconfigs primary and 1 secondary when primary and 1 secondary are unhealthy and reconfigs are enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except primary and secondary2
+    const healthyNodes = {
+      [secondary1]: '',
+      [fourthHealthyNode]: '',
+      [fifthHealthyNode]: ''
+    }
+
+    // Mark primary and secondary2 as unhealthy and fourthHealthyNode+fifthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [primary, secondary2]
+    const replicaToUserInfoMap = {
+      [primary]: { clock: 1 },
+      [secondary1]: { clock: 1 },
+      [secondary2]: { clock: 1 },
+      [fourthHealthyNode]: { clock: -1 },
+      [fifthHealthyNode]: { clock: -1 }
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      healthyNodes,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    const output = await updateReplicaSetJobProcessor({
+      logger,
+      wallet,
+      userId,
+      primary,
+      secondary1,
+      secondary2,
+      nodesToReconfigOffOf: unhealthyReplicas,
+      replicaToUserInfoMap,
+      enabledReconfigModes: [RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key]
+    })
+    const { metricsToRecord, newReplicaSet, jobsToEnqueue } = output
+
+    // Verify metrics record a successful reconfig
+    expect(metricsToRecord[0].metricLabels.result).to.equal('success')
+    expect(metricsToRecord[0].metricName).to.equal(
+      'audius_cn_state_machine_update_replica_set_queue_job_duration_seconds'
+    )
+    expect(metricsToRecord[0].metricType).to.equal('HISTOGRAM_OBSERVE')
+
+    // Verify job outputs the correct results: replace primary with one of secondaries and elect new secondary
+    expect(output.errorMsg).to.equal('')
+    expect(output.issuedReconfig).to.be.true
+    expect(newReplicaSet.newPrimary).to.equal(secondary1)
+    // Replacement nodes are randomly so we can't enforce order of secondaries
+    expect(newReplicaSet.newSecondary1).to.be.oneOf([
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    expect(newReplicaSet.newSecondary2).to.be.oneOf([
+      fourthHealthyNode,
+      fifthHealthyNode
+    ]).and.not.equal(newReplicaSet.newSecondary1)
+    expect(newReplicaSet.issueReconfig).to.be.true
+    expect(newReplicaSet.reconfigType).to.equal(
+      RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+    )
+    expect(output.healthyNodes).to.eql([
+      secondary1,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    const newSecondaries = [newReplicaSet.newSecondary1, newReplicaSet.newSecondary2]
+    expect(jobsToEnqueue).to.have.nested.property(QUEUE_NAMES.RECURRING_SYNC)
+    const jobs = jobsToEnqueue[QUEUE_NAMES.RECURRING_SYNC]
+    expect(jobs).to.have.lengthOf(2)
+    // Verify sync from primary to new secondary1 and new secondary2
+    for (let i = 0; i < 1; i++) {
+      expect(jobs[i].primaryEndpoint).to.equal(newReplicaSet.newPrimary)
+      expect(jobs[i].secondaryEndpoint).to.equal(newSecondaries[i])
+      expect(jobs[i].syncType).to.equal(SyncType.Recurring)
+      expect(jobs[i].syncMode).to.equal(SYNC_MODES.SyncSecondaryFromPrimary)
+      expect(jobs[i].userWallet).to.equal(wallet)
+    }
+  })
+
+  it('Does not issue any reconfig when primary and 1 secondary are unhealthy and only secondary mode is enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except primary and secondary1
+    const healthyNodes = {
+      [secondary2]: '',
+      [fourthHealthyNode]: '',
+      [fifthHealthyNode]: ''
+    }
+
+    // Mark primary and secondary1 as unhealthy and fourthHealthyNode+fifthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [primary, secondary1]
+    const replicaToUserInfoMap = {
+      [primary]: { clock: 1 },
+      [secondary1]: { clock: 1 },
+      [secondary2]: { clock: 1 },
+      [fourthHealthyNode]: { clock: -1 },
+      [fifthHealthyNode]: { clock: -1 }
+    }
+
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      healthyNodes,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub
+    })
+
+    const output = await updateReplicaSetJobProcessor({
+      logger,
+      wallet,
+      userId,
+      primary,
+      secondary1,
+      secondary2,
+      nodesToReconfigOffOf: unhealthyReplicas,
+      replicaToUserInfoMap,
+      enabledReconfigModes: [RECONFIG_MODES.MULTIPLE_SECONDARIES.key]
+    })
+    const { metricsToRecord, errorMsg, issuedReconfig, newReplicaSet, jobsToEnqueue } = output
+
+    // Verify metrics record a successful reconfig
+    expect(metricsToRecord[0].metricLabels.result).to.equal('success_issue_reconfig_disabled')
+    expect(metricsToRecord[0].metricName).to.equal(
+      'audius_cn_state_machine_update_replica_set_queue_job_duration_seconds'
+    )
+    expect(metricsToRecord[0].metricType).to.equal('HISTOGRAM_OBSERVE')
+
+    // Verify job outputs the correct results: find update from primary to secondary1 and 2 new nodes selected, but not issued
+    expect(errorMsg).to.equal('')
+    expect(issuedReconfig).to.be.false
+    expect(newReplicaSet.newPrimary).to.equal(secondary2)
+    // Replacement nodes are randomly so we can't enforce order of secondaries
+    expect(newReplicaSet.newSecondary1).to.be.oneOf([fourthHealthyNode, fifthHealthyNode])
+    expect(newReplicaSet.newSecondary2).to.be.oneOf([
+      fourthHealthyNode,
+      fifthHealthyNode
+    ]).and.not.equal(newReplicaSet.newSecondary1)
+    expect(newReplicaSet.issueReconfig).to.be.false
+    expect(newReplicaSet.reconfigType).to.equal(
+      RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+    )
+    expect(output.healthyNodes).to.eql([
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    expect(jobsToEnqueue).to.equal(undefined)
+  })
+
+  it('Reconfigs primary when primary is unhealthy, primary only override is enabled, and all reconfig modes are enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except primary and secondary2
+    const healthyNodes = {
+      [secondary1]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: '',
+      [fifthHealthyNode]: ''
+    }
+
+    // Mark primary and secondary2 as unhealthy and fourthHealthyNode+fifthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [primary]
+    const replicaToUserInfoMap = {
+      [primary]: { clock: 1 },
+      [secondary1]: { clock: 1 },
+      [secondary2]: { clock: 1 },
+      [fourthHealthyNode]: { clock: -1 },
+      [fifthHealthyNode]: { clock: -1 }
+    }
+
+    const customConfig = config
+    customConfig.set('reconfigModePrimaryOnly', true)
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      healthyNodes,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub,
+      customConfig
+    })
+
+    const output = await updateReplicaSetJobProcessor({
+      logger,
+      wallet,
+      userId,
+      primary,
+      secondary1,
+      secondary2,
+      nodesToReconfigOffOf: unhealthyReplicas,
+      replicaToUserInfoMap,
+      enabledReconfigModes: [RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key]
+    })
+    const { metricsToRecord, newReplicaSet, jobsToEnqueue } = output
+
+    // Verify metrics record a successful reconfig
+    expect(metricsToRecord[0].metricLabels.result).to.equal('success')
+    expect(metricsToRecord[0].metricName).to.equal(
+      'audius_cn_state_machine_update_replica_set_queue_job_duration_seconds'
+    )
+    expect(metricsToRecord[0].metricType).to.equal('HISTOGRAM_OBSERVE')
+
+    // Verify job outputs the correct results: replace primary with one of secondaries and elect new secondary
+    expect(output.errorMsg).to.equal('')
+    expect(output.issuedReconfig).to.be.true
+    expect(newReplicaSet.newPrimary).to.be.oneOf([secondary1, secondary2])
+    // Replacement nodes are randomly so we can't enforce order of secondaries
+    expect(newReplicaSet.newSecondary1).to.be.oneOf([
+      secondary1,
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ]).and.not.equal(newReplicaSet.primary)
+    expect(newReplicaSet.newSecondary2).to.be.oneOf([
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ]).and.not.equal(newReplicaSet.newSecondary1)
+    expect(newReplicaSet.issueReconfig).to.be.true
+    expect(newReplicaSet.reconfigType).to.equal(
+      RECONFIG_MODES.PRIMARY_AND_OR_SECONDARIES.key
+    )
+    expect(output.healthyNodes).to.eql([
+      secondary1,
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    const newSecondaries = [newReplicaSet.newSecondary1, newReplicaSet.newSecondary2]
+    expect(jobsToEnqueue).to.have.nested.property(QUEUE_NAMES.RECURRING_SYNC)
+    const jobs = jobsToEnqueue[QUEUE_NAMES.RECURRING_SYNC]
+    expect(jobs).to.have.lengthOf(2)
+    // Verify sync from primary to new secondary1 and new secondary2
+    for (let i = 0; i < 1; i++) {
+      expect(jobs[i].primaryEndpoint).to.equal(newReplicaSet.newPrimary)
+      expect(jobs[i].secondaryEndpoint).to.equal(newSecondaries[i])
+      expect(jobs[i].syncType).to.equal(SyncType.Recurring)
+      expect(jobs[i].syncMode).to.equal(SYNC_MODES.SyncSecondaryFromPrimary)
+      expect(jobs[i].userWallet).to.equal(wallet)
+    }
+  })
+
+  it('Does not issue reconfig when secondary is unhealthy, primary only override is enabled, and all reconfig modes are enabled', async function () {
+    // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
+    const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
+      return { syncReqToEnqueue: args }
+    })
+
+    // Stub audiusLibs to return all nodes as healthy except secondary1
+    const healthyNodes = {
+      [primary]: '',
+      [secondary2]: '',
+      [fourthHealthyNode]: '',
+      [fifthHealthyNode]: ''
+    }
+
+    // Mark secondary1 as unhealthy and fourthHealthyNode+fifthHealthyNode as not having any user state
+    const retrieveClockValueForUserFromReplicaStub = sandbox.stub().resolves(-1)
+    const unhealthyReplicas = [secondary1]
+    const replicaToUserInfoMap = {
+      [primary]: { clock: 1 },
+      [secondary1]: { clock: 1 },
+      [secondary2]: { clock: 1 },
+      [fourthHealthyNode]: { clock: -1 },
+      [fifthHealthyNode]: { clock: -1 }
+    }
+
+    const customConfig = config
+    customConfig.set('reconfigModePrimaryOnly', true)
+    const updateReplicaSetJobProcessor = getJobProcessorStub({
+      healthyNodes,
+      getNewOrExistingSyncReqStub,
+      retrieveClockValueForUserFromReplicaStub,
+      customConfig
+    })
+
+    const output = await updateReplicaSetJobProcessor({
+      logger,
+      wallet,
+      userId,
+      primary,
+      secondary1,
+      secondary2,
+      nodesToReconfigOffOf: unhealthyReplicas,
+      replicaToUserInfoMap,
+      enabledReconfigModes: [RECONFIG_MODES.MULTIPLE_SECONDARIES.key]
+    })
+    const { metricsToRecord, errorMsg, issuedReconfig, newReplicaSet, jobsToEnqueue } = output
+
+    // Verify metrics record a successful reconfig
+    expect(metricsToRecord[0].metricLabels.result).to.equal('success_issue_reconfig_disabled')
+    expect(metricsToRecord[0].metricName).to.equal(
+      'audius_cn_state_machine_update_replica_set_queue_job_duration_seconds'
+    )
+    expect(metricsToRecord[0].metricType).to.equal('HISTOGRAM_OBSERVE')
+
+    // Verify job outputs the correct results: find update from primary to secondary1 and 2 new nodes selected, but not issued
+    expect(errorMsg).to.equal('')
+    expect(issuedReconfig).to.be.false
+    expect(newReplicaSet.newPrimary).to.equal(primary)
+    // Replacement nodes are randomly so we can't enforce order of secondaries
+    expect(newReplicaSet.newSecondary1).to.equal(secondary2)
+    expect(newReplicaSet.newSecondary2).to.be.oneOf([
+      fourthHealthyNode,
+      fifthHealthyNode
+    ]).and.not.equal(newReplicaSet.newSecondary1)
+    expect(newReplicaSet.issueReconfig).to.be.false
+    expect(newReplicaSet.reconfigType).to.equal(
+      RECONFIG_MODES.ONE_SECONDARY.key
+    )
+    expect(output.healthyNodes).to.eql([
+      primary,
+      secondary2,
+      fourthHealthyNode,
+      fifthHealthyNode
+    ])
+    expect(jobsToEnqueue).to.equal(undefined)
+  })
+
   it('reconfigs 2 secondaries when 1 secondaries is unhealthy, the other secondary was deregistered, and reconfigs are enabled', async function () {
     // A sync will be needed to this node, so stub returning a successful new sync and no duplicate sync
     const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
@@ -413,7 +832,7 @@ describe('test updateReplicaSet job processor', function () {
     }
   })
 
-  it('reconfigs 1 secondary when one secondary is unhealthy but reconfigs are disabled', async function () {
+  it('Does not issue any reconfigs when one secondary is unhealthy but reconfigs are disabled', async function () {
     // It should short-circuit before trying to sync -- no sync will be needed
     const getNewOrExistingSyncReqStub = sandbox.stub().callsFake((args) => {
       throw new Error('This was not supposed to be called')


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

We want ability to only cycle primary out of replica set. This is not simple in our current reconfig modes pattern, since we calculate "highest reconfig mode enabled" - this config is a quick override to get around that restriction. We should probably refactor this to be discrete reconfig modes, but for now this is fine

Note this override is defaulted to false to ensure no behavior change by default

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

New test coverage (pls review!)


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

With this override enabled, we should observe that secondary reconfigs do not occur, and only primary reconfigs are occurring

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->