### PR TITLE
Clean up unused libs param

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -441,7 +441,6 @@ async function saveFileForMultihashToFS(
     }
 
     await fetchFileFromNetworkAndWriteToDisk({
-      libs,
       gatewayContentRoutes,
       targetGateways,
       multihash,

--- a/creator-node/test/fileManager.test.js
+++ b/creator-node/test/fileManager.test.js
@@ -119,7 +119,6 @@ describe('test fileManager', () => {
           name: 'fetchFileFromNetworkAndWriteToDisk'
         })
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),
@@ -182,7 +181,6 @@ describe('test fileManager', () => {
           name: 'fetchFileFromNetworkAndWriteToDisk'
         })
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),
@@ -258,7 +256,6 @@ describe('test fileManager', () => {
           name: 'fetchFileFromNetworkAndWriteToDisk'
         })
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),
@@ -335,7 +332,6 @@ describe('test fileManager', () => {
           name: 'fetchFileFromNetworkAndWriteToDisk'
         })
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),
@@ -401,7 +397,6 @@ describe('test fileManager', () => {
           name: 'fetchFileFromNetworkAndWriteToDisk'
         })
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),
@@ -463,7 +458,6 @@ describe('test fileManager', () => {
       })
       try {
         await fetchFileFromNetworkAndWriteToDisk({
-          libs: libsMock,
           gatewayContentRoutes: [MOCK_CN1, MOCK_CN2, MOCK_CN3].map(
             (e) => `${e}/ipfs/${DUMMY_MULTIHASH}`
           ),


### PR DESCRIPTION
### Description
Cleans up references to a libs param that is no longer used - no need to pass it in anymore from other consumers and tests.


### Tests
CI passing is sufficient.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A