### PR TITLE
Fix TypeError & undefined bugs

### DIFF
--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
@@ -57,7 +57,7 @@ async function getUnhealthyPeers(
   nodeUsers: StateMonitoringUser[],
   thisContentNodeEndpoint: string,
   performSimpleCheck = false
-) {
+): Promise<Set<string>> {
   // Compute content node peerset from nodeUsers (all nodes that are in a shared replica set with this node)
   const peerSet = CNodeHealthManager._computeContentNodePeerSet(
     nodeUsers,
@@ -68,7 +68,7 @@ async function getUnhealthyPeers(
    * Determine health for every peer & build list of unhealthy peers
    * TODO: change from sequential to chunked parallel
    */
-  const unhealthyPeers = new Set()
+  const unhealthyPeers = new Set<string>()
 
   for await (const peer of peerSet) {
     const isHealthy = await CNodeHealthManager.isNodeHealthy(

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/findSyncRequests.jobProcessor.ts
@@ -253,19 +253,17 @@ async function _findSyncsForUser(
 
     // Determine if secondary requires a sync by comparing its user data against primary (this node)
     let syncMode
-    const primaryUserInfo = replicaToAllUserInfoMaps[primary][wallet]
-    const secondaryUserInfo = replicaToAllUserInfoMaps[secondary][wallet]
+    const primaryUserInfo = replicaToAllUserInfoMaps[primary]?.[wallet]
+    const secondaryUserInfo = replicaToAllUserInfoMaps[secondary]?.[wallet]
 
-    if (
-      primaryUserInfo === undefined ||
-      primaryUserInfo === null ||
-      secondaryUserInfo === undefined ||
-      secondaryUserInfo === null
-    ) {
+    if (_.isEmpty(primaryUserInfo) || _.isEmpty(secondaryUserInfo)) {
+      let missingFor
+      if (_.isEmpty(primaryUserInfo) && _.isEmpty(secondaryUserInfo)) {
+        missingFor = 'primary and secondary'
+      } else if (_.isEmpty(primaryUserInfo)) missingFor = 'primary'
+      else missingFor = 'secondary'
       tracing.error(
-        `undefined user info - primary ${JSON.stringify(
-          primaryUserInfo
-        )}, secondary ${JSON.stringify(secondaryUserInfo)}`
+        `missing user info for ${missingFor} - maybe batch_clock_status failed earlier`
       )
       outcomesBySecondary[secondary].result = 'no_sync_unexpected_error'
       continue

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -15,7 +15,7 @@ import { QUEUE_NAMES } from '../stateMachineConstants'
 import { instrumentTracing, tracing } from '../../../tracer'
 
 const config = require('../../../config')
-const NodeHealthManager = require('../CNodeHealthManager')
+const { CNodeHealthManager } = require('../CNodeHealthManager')
 const {
   getNodeUsers,
   buildReplicaSetNodesToUserWalletsMap,
@@ -109,7 +109,7 @@ async function monitorState({
     }
 
     try {
-      unhealthyPeers = await NodeHealthManager.getUnhealthyPeers(users)
+      unhealthyPeers = await CNodeHealthManager.getUnhealthyPeers(users)
       _addToDecisionTree(decisionTree, 'getUnhealthyPeers Success', logger, {
         unhealthyPeerSetLength: unhealthyPeers?.size,
         unhealthyPeers: Array.from(unhealthyPeers)

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/monitorState.jobProcessor.ts
@@ -13,15 +13,15 @@ import type {
 // eslint-disable-next-line import/no-unresolved
 import { QUEUE_NAMES } from '../stateMachineConstants'
 import { instrumentTracing, tracing } from '../../../tracer'
+import { CNodeHealthManager } from '../CNodeHealthManager'
+import config from '../../../config'
+import { retrieveUserInfoFromReplicaSet } from '../stateMachineUtils'
 
-const config = require('../../../config')
-const { CNodeHealthManager } = require('../CNodeHealthManager')
 const {
   getNodeUsers,
   buildReplicaSetNodesToUserWalletsMap,
   computeUserSecondarySyncSuccessRatesMap
 } = require('./stateMonitoringUtils')
-const { retrieveUserInfoFromReplicaSet } = require('../stateMachineUtils')
 
 // Number of users to process each time monitor-state job processor is called
 const USERS_PER_JOB = config.get('snapbackUsersPerJob')
@@ -109,7 +109,10 @@ async function monitorState({
     }
 
     try {
-      unhealthyPeers = await CNodeHealthManager.getUnhealthyPeers(users)
+      unhealthyPeers = await CNodeHealthManager.getUnhealthyPeers(
+        users,
+        config.get('creatorNodeEndpoint')
+      )
       _addToDecisionTree(decisionTree, 'getUnhealthyPeers Success', logger, {
         unhealthyPeerSetLength: unhealthyPeers?.size,
         unhealthyPeers: Array.from(unhealthyPeers)
@@ -142,7 +145,7 @@ async function monitorState({
 
     // Retrieve user info for all users and their current replica sets
     try {
-      const retrieveUserInfoResp = await retrieveUserInfoFromReplicaSet(
+      const retrieveUserInfoResp: any = await retrieveUserInfoFromReplicaSet(
         replicaSetNodesToUserWalletsMap
       )
       replicaToAllUserInfoMaps = retrieveUserInfoResp.replicaToAllUserInfoMaps

--- a/creator-node/test/monitorState.jobProcessor.test.js
+++ b/creator-node/test/monitorState.jobProcessor.test.js
@@ -121,7 +121,9 @@ describe('test monitorState job processor', function () {
             computeUserSecondarySyncSuccessRatesMapStub
         },
         '../CNodeHealthManager': {
-          getUnhealthyPeers: getUnhealthyPeersStub
+          CNodeHealthManager: {
+            getUnhealthyPeers: getUnhealthyPeersStub
+          }
         },
         '../../ContentNodeInfoManager': {
           getMapOfCNodeEndpointToSpId: getCNodeEndpointToSpIdMapStub
@@ -268,7 +270,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      'http://default_cn1.co'
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -298,7 +303,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      'http://default_cn1.co'
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -329,7 +337,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      'http://default_cn1.co'
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -359,7 +370,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      'http://default_cn1.co'
+    )
     expect(
       buildReplicaSetNodesToUserWalletsMapStub
     ).to.have.been.calledOnceWithExactly(USERS)
@@ -385,7 +399,10 @@ describe('test monitorState job processor', function () {
       LAST_PROCESSED_USER_ID,
       NUM_USERS_TO_PROCESS
     )
-    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(USERS)
+    expect(getUnhealthyPeersStub).to.have.been.calledOnceWithExactly(
+      USERS,
+      'http://default_cn1.co'
+    )
     expect(buildReplicaSetNodesToUserWalletsMapStub).to.not.have.been.called
     expect(retrieveUserInfoFromReplicaSetStub).to.not.have.been.called
     expect(computeUserSecondarySyncSuccessRatesMapStub).to.not.have.been.called


### PR DESCRIPTION
### Description
* Fixes invalid reference to NodeHealthManager (it was supposed to be updated to be a named import of CNodeHealthManager). This was causing the error `NodeHealthManager.getUnhealthyPeers is not a function`
* Catches `TypeError: Cannot read property '<any wallet public key>' of undefined at _findSyncsForUser`. This should short-circuit as `no_sync_unexpected_error` and log a more informative tracing error for the individual user instead of failing the whole findSyncRequests job



### Tests
CI passing is sufficient - just bug fixes.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
There shouldn't be any TypeErrors, and find-sync-request-queue jobs should succeed.