### PR TITLE
Remove performSimpleCheck flag

### DIFF
--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
@@ -55,8 +55,7 @@ const CNodeHealthManager = {
  */
 async function getUnhealthyPeers(
   nodeUsers: StateMonitoringUser[],
-  thisContentNodeEndpoint: string,
-  performSimpleCheck = false
+  thisContentNodeEndpoint: string
 ) {
   // Compute content node peerset from nodeUsers (all nodes that are in a shared replica set with this node)
   const peerSet = CNodeHealthManager._computeContentNodePeerSet(
@@ -71,10 +70,7 @@ async function getUnhealthyPeers(
   const unhealthyPeers = new Set()
 
   for await (const peer of peerSet) {
-    const isHealthy = await CNodeHealthManager.isNodeHealthy(
-      peer,
-      performSimpleCheck
-    )
+    const isHealthy = await CNodeHealthManager.isNodeHealthy(peer)
     if (!isHealthy) {
       unhealthyPeers.add(peer)
     }
@@ -83,7 +79,7 @@ async function getUnhealthyPeers(
   return unhealthyPeers
 }
 
-async function isNodeHealthy(node: string, performSimpleCheck = false) {
+async function isNodeHealthy(node: string) {
   try {
     const verboseHealthCheckResp =
       await CNodeHealthManager._queryVerboseHealthCheck(node)
@@ -92,9 +88,7 @@ async function isNodeHealthy(node: string, performSimpleCheck = false) {
     if (!healthy) {
       throw new Error(`Node health check returned healthy: false`)
     }
-    if (!performSimpleCheck) {
-      CNodeHealthManager.determinePeerHealth(verboseHealthCheckResp)
-    }
+    CNodeHealthManager.determinePeerHealth(verboseHealthCheckResp)
   } catch (e: any) {
     logger.error(`isNodeHealthy() peer=${node} is unhealthy: ${e.toString()}`)
     return false
@@ -190,7 +184,7 @@ function determinePeerHealth(verboseHealthCheckResp: any) {
  * - unhealthy but in a grace period (extra time where it can be unhealthy before being reconfiged)
  */
 async function isNodeHealthyOrInGracePeriod(node: string, isPrimary: boolean) {
-  const isHealthy = await CNodeHealthManager.isNodeHealthy(node, isPrimary)
+  const isHealthy = await CNodeHealthManager.isNodeHealthy(node)
   if (isHealthy) {
     // If a node ever becomes healthy again and was once marked as unhealthy, remove tracker
     await CNodeHealthManager.resetEarliestUnhealthyTimestamp(node, isPrimary)

--- a/creator-node/test/CNodeHealthManager.test.js
+++ b/creator-node/test/CNodeHealthManager.test.js
@@ -123,7 +123,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const isHealthy = await CNodeHealthManager.isNodeHealthy(node, true)
     expect(isHealthy).to.be.true
     expect(queryVerboseHealthCheckStub).to.have.been.calledOnceWithExactly(node)
-    expect(determinePeerHealthStub).to.not.have.been.called
+    expect(determinePeerHealthStub).to.have.been.called
   })
 
   it('returns false when health check fails with performSimpleCheck=true', async function () {
@@ -419,7 +419,7 @@ describe('test CNodeHealthManager -- isNodeHealthyOrInGracePeriod()', function (
       true
     )
     expect(isHealthy).to.be.true
-    expect(isNodeHealthyStub).to.have.been.calledOnceWithExactly(primary, true)
+    expect(isNodeHealthyStub).to.have.been.calledOnceWithExactly(primary)
   })
 
   it('returns true (healthy) when secondary is healthy', async function () {
@@ -434,8 +434,7 @@ describe('test CNodeHealthManager -- isNodeHealthyOrInGracePeriod()', function (
     )
     expect(isHealthy).to.be.true
     expect(isNodeHealthyStub).to.have.been.calledOnceWithExactly(
-      secondary,
-      false
+      secondary
     )
   })
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Remove the distinction between simple and full peer health checks in CNodeHealthManager. All health check requests will check health, storage and file descriptors.

This was necessary to reconfig off primaries that ran out of storage. Without this, we never checked storage available on primaries.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
This flow has good test coverage so made sure unit tests all pass.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
In bull dashboard unhealthPeers correctly returns unhealthy nodes 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->