### PR TITLE
Remove redis cache indexing

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -56,11 +56,6 @@ from src.utils.prometheus_metric import (
     PrometheusMetricNames,
     save_duration_metric,
 )
-from src.utils.redis_cache import (
-    remove_cached_playlist_ids,
-    remove_cached_track_ids,
-    remove_cached_user_ids,
-)
 from src.utils.redis_constants import (
     latest_block_hash_redis_key,
     latest_block_redis_key,
@@ -509,13 +504,6 @@ def process_state_changes(
         "number", "hash", "timestamp"
     )(block)
 
-    changed_entity_ids_map = {
-        USER_FACTORY: [],
-        TRACK_FACTORY: [],
-        PLAYLIST_FACTORY: [],
-        USER_REPLICA_SET_MANAGER: [],
-    }
-
     for tx_type, bulk_processor in TX_TYPE_TO_HANDLER_MAP.items():
 
         txs_to_process = tx_type_to_grouped_lists_map[tx_type]
@@ -532,34 +520,13 @@ def process_state_changes(
 
         (
             total_changes_for_tx_type,
-            changed_entity_ids,
+            _,
         ) = bulk_processor(*tx_processing_args)
-
-        if tx_type in changed_entity_ids_map.keys():
-            changed_entity_ids_map[tx_type] = changed_entity_ids
 
         logger.info(
             f"index.py | {bulk_processor.__name__} completed"
             f" {tx_type}_state_changed={total_changes_for_tx_type > 0} for block={block_number}"
         )
-
-    return changed_entity_ids_map
-
-
-def remove_updated_entities_from_cache(redis, changed_entity_type_to_updated_ids_map):
-    CONTRACT_TYPE_TO_CLEAR_CACHE_HANDLERS = {
-        USER_FACTORY: remove_cached_user_ids,
-        USER_REPLICA_SET_MANAGER: remove_cached_user_ids,
-        TRACK_FACTORY: remove_cached_track_ids,
-        PLAYLIST_FACTORY: remove_cached_playlist_ids,
-    }
-    for (
-        contract_type,
-        clear_cache_handler,
-    ) in CONTRACT_TYPE_TO_CLEAR_CACHE_HANDLERS.items():
-        changed_entity_ids = changed_entity_type_to_updated_ids_map[contract_type]
-        if changed_entity_ids:
-            clear_cache_handler(redis, changed_entity_ids)
 
 
 def create_and_raise_indexing_error(err, redis):
@@ -587,7 +554,6 @@ def index_blocks(self, db, blocks_list):
     num_blocks = len(blocks_list)
     block_order_range = range(len(blocks_list) - 1, -1, -1)
     latest_block_timestamp = None
-    changed_entity_ids_map = {}
     metric = PrometheusMetric(PrometheusMetricNames.INDEX_BLOCKS_DURATION_SECONDS)
     for i in block_order_range:
         start_time = time.time()
@@ -729,7 +695,7 @@ def index_blocks(self, db, blocks_list):
                     # bulk process operations once all tx's for block have been parsed
                     # and get changed entity IDs for cache clearing
                     # after session commit
-                    changed_entity_ids_map = process_state_changes(
+                    process_state_changes(
                         self,
                         session,
                         cid_metadata,
@@ -785,13 +751,6 @@ def index_blocks(self, db, blocks_list):
                 )
             if skip_tx_hash:
                 clear_indexing_error(redis)
-
-        if changed_entity_ids_map:
-            remove_updated_entities_from_cache(redis, changed_entity_ids_map)
-
-        logger.info(
-            f"index.py | redis cache clean operations complete for block=${block_number}"
-        )
 
         add_indexed_block_to_redis(block, redis)
         logger.info(

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -184,30 +184,6 @@ def get_dn_sp_id_key(id):
     return f"sp:dn:id:{id}"
 
 
-def remove_cached_user_ids(redis, user_ids):
-    try:
-        user_keys = list(map(get_user_id_cache_key, user_ids))
-        redis.delete(*user_keys)
-    except Exception as e:
-        logger.error("Unable to remove cached users: %s", e, exc_info=True)
-
-
-def remove_cached_track_ids(redis, track_ids):
-    try:
-        track_keys = list(map(get_track_id_cache_key, track_ids))
-        redis.delete(*track_keys)
-    except Exception as e:
-        logger.error("Unable to remove cached tracks: %s", e, exc_info=True)
-
-
-def remove_cached_playlist_ids(redis, playlist_ids):
-    try:
-        playlist_keys = list(map(get_playlist_id_cache_key, playlist_ids))
-        redis.delete(*playlist_keys)
-    except Exception as e:
-        logger.error("Unable to remove cached playlists: %s", e, exc_info=True)
-
-
 def get_trending_cache_key(request_items, request_path):
     request_items.pop("limit", None)
     request_items.pop("offset", None)


### PR DESCRIPTION
### Description
Removes the removal of cached users/tracks/playlists from indexing

Fixes PLAT-425

### Tests
Ran locally and tested that indexing still works after user creations, track upload and playlist creation

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->