### PR TITLE
Fix premium conditions type in libs trackSchema.json

### DIFF
--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -275,7 +275,7 @@
             "title": "CID"
         },
         "PremiumConditions": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "nft_collection": {


### PR DESCRIPTION
### Description

Straightforward.
Going to publish new libs on circle ci.


### Tests

Tested track upload on the local dapp against prod. One upload without the change, another with the change. The latter did not produce the libs validation error.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

There is an error log that should no longer appear.
It looked like this before:
```
instrument.js:138 Error validating track metadata Error: TrackSchema validation failed with errors: [{"property":"instance.premium_conditions","message":"is not of a type(s) object","schema":{"type":"object","additionalProperties":false,"properties":{"nft_collection":{"type":"string"},"follow_user_id":{"type":"number"}},"required":[],"title":"PremiumConditions"},"name":"type","argument":["object"],"stack":"instance.premium_conditions is not of a type(s) object"}]
    at _this.schemas.<computed>.validate (legacy.js:45519:1)
    at CreatorNode._callee8$ (legacy.js:46049:1)
    at tryCatch (regeneratorRuntime.js:86:1)
    at Generator._invoke (regeneratorRuntime.js:66:1)
    at Generator.next (regeneratorRuntime.js:117:1)
    at asyncGeneratorStep (legacy.js:284:1)
    at _next (legacy.js:306:1)
    at legacy.js:313:1
    at new ZoneAwarePromise (zone.js:1653:1)
    at CreatorNode.<anonymous> (legacy.js:302:1)
    at CreatorNode.uploadTrackMetadata (legacy.js:46078:1)
    at CreatorNode._callee7$ (legacy.js:46008:1)
    at tryCatch (regeneratorRuntime.js:86:1)
    at Generator._invoke (regeneratorRuntime.js:66:1)
    at Generator.next (regeneratorRuntime.js:117:1)
    at asyncGeneratorStep (legacy.js:284:1)
    at _next (legacy.js:306:1)
    at _ZoneDelegate.invoke (zone.js:466:1)
    at Zone.run (zone.js:132:1)
    at zone.js:1623:1
    at _ZoneDelegate.invokeTask (zone.js:502:1)
    at Zone.runTask (zone.js:190:1)
    at Zone.patchRunTask (instrumentation.js:542:1)
    at drainMicroTaskQueue (zone.js:728:1)
    at ZoneTask.invokeTask [as invoke] (zone.js:657:1)
    at invokeTask (zone.js:2156:1)
    at globalCallback (zone.js:2207:1)
    at XMLHttpRequest.globalZoneAwareCallback (zone.js:2234:1)
```


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->