### PR TITLE
Fix deletion query and add debug

### DIFF
--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -202,8 +202,13 @@ class DBManager {
       order: [['storagePath', 'ASC']],
       limit: batchSize
     })
-    if (isEmpty(userFilesQueryResult?.dataValues)) return []
-    for (const file of userFilesQueryResult.dataValues) {
+    logger.debug(
+      `userFilesQueryResult for ${cnodeUserUUID}: ${JSON.stringify(
+        userFilesQueryResult || {}
+      )}`
+    )
+    if (isEmpty(userFilesQueryResult)) return []
+    for (const file of userFilesQueryResult) {
       userFiles.push(path.normalize(file.storagePath))
     }
 
@@ -222,8 +227,13 @@ class DBManager {
       group: 'storagePath',
       having: sequelize.literal(`COUNT(DISTINCT("cnodeUserUUID")) = 1`)
     })
-    if (isEmpty(allUniqueFilesQueryResult?.dataValues)) return []
-    for (const file of allUniqueFilesQueryResult.dataValues) {
+    logger.debug(
+      `allUniqueFilesQueryResult for ${cnodeUserUUID}: ${JSON.stringify(
+        allUniqueFilesQueryResult || {}
+      )}`
+    )
+    if (isEmpty(allUniqueFilesQueryResult)) return []
+    for (const file of allUniqueFilesQueryResult) {
       allUniqueFiles.push(path.normalize(file.storagePath))
     }
 
@@ -231,6 +241,7 @@ class DBManager {
     const userUniqueFiles = allUniqueFiles.filter((file) =>
       userFiles.includes(file)
     )
+    logger.debug(`userUniqueFiles for ${cnodeUserUUID}: ${userUniqueFiles}`)
     return userUniqueFiles
   }
 


### PR DESCRIPTION
### Description
* Fixes last-minute changes that forgot to remove `.dataValues` since the query result for disk deletion can be used directly
* Adds debug logs for each step of the disk deletion query


### Tests
Integration tests are planned for disk deletion in the future. I tested locally with a debugger to make sure it's actually deleting now -- no more "Deleted 0/0" on staging


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
* There shouldn't be any logs that start with `"Deleted 0/0`
* Debug steps of disk deletion by searching for `userFilesQueryResult`, `allUniqueFilesQueryResult`, and `userUniqueFiles`