### PR TITLE
simplify es-indexer startup behavior

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -102,10 +102,8 @@ fi
 
 # start es-indexer
 if [[ "$audius_elasticsearch_url" ]] && [[ "$audius_elasticsearch_run_indexer" ]]; then
-    # npm run catchup creates triggers + populate indexes - this blocks server / celery start
-    # npm start gets backgrounded and goes into listen mode
     (
-        cd es-indexer && npm run catchup && npm start &
+        cd es-indexer && npm start &
     )
 fi
 


### PR DESCRIPTION
before it would attempt to block server + celery start by running in catchup mode, but if this failed it would prevent es-indexer from starting and no indexer would run.

simply start es-indexer normally... if we want more coordination we can do it in application code.  This is how it will be if es-indexer is in a standalone container also.
