### PR TITLE
Skip storage middleware for force wipes

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -316,7 +316,13 @@ router.get(
 )
 router.post(
   '/sync',
-  ensureStorageMiddleware,
+  // Force wipe syncs will free up storage space so we want to perform them regardless of current usage
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  async (req, res, next) => {
+    return req.body?.forceWipe
+      ? next()
+      : ensureStorageMiddleware(req, res, next)
+  },
   handleResponse(syncRouteController)
 )
 router.post(

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -197,6 +197,11 @@ async function ensurePrimaryMiddleware(req, res, next) {
 
 /** Blocks writes if node has used over `maxStorageUsedPercent` of its capacity. */
 async function ensureStorageMiddleware(req, res, next) {
+  // Force wipe syncs will free up storage space so we want to perform them regardless of current usage
+  if (req.body?.forceWipe) {
+    next()
+  }
+
   // Get storage data and max storage percentage allowed
   const [storagePathSize, storagePathUsed] = await getMonitors([
     MONITORS.STORAGE_PATH_SIZE,

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -197,11 +197,6 @@ async function ensurePrimaryMiddleware(req, res, next) {
 
 /** Blocks writes if node has used over `maxStorageUsedPercent` of its capacity. */
 async function ensureStorageMiddleware(req, res, next) {
-  // Force wipe syncs will free up storage space so we want to perform them regardless of current usage
-  if (req.body?.forceWipe) {
-    return next()
-  }
-
   // Get storage data and max storage percentage allowed
   const [storagePathSize, storagePathUsed] = await getMonitors([
     MONITORS.STORAGE_PATH_SIZE,

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -199,7 +199,7 @@ async function ensurePrimaryMiddleware(req, res, next) {
 async function ensureStorageMiddleware(req, res, next) {
   // Force wipe syncs will free up storage space so we want to perform them regardless of current usage
   if (req.body?.forceWipe) {
-    next()
+    return next()
   }
 
   // Get storage data and max storage percentage allowed


### PR DESCRIPTION
### Description
Skips the storage middleware check for forceWipe syncs because forceWipe syncs free up storage space so it doesn't matter if capacity is already reached.


### Tests
Tested with debugger to verify that the new code path is hit when data is orphaned (reached the state by creating a user with `A` and updating its replica set with the `/manually_update_replica_set` route).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Syncs with forceWipe should result in success_force_wipe in Grafana. Disk usage should drop on nodes even if they have 95%+ storage utilization.