### PR TITLE
Add hook to bunyan to create tracer events

### DIFF
--- a/creator-node/src/tracer.ts
+++ b/creator-node/src/tracer.ts
@@ -104,7 +104,10 @@ export const setupTracing = () => {
           record['resource.service.spid'] = SPID
           record['resource.service.endpoint'] = ENDPOINT
 
-          span.addEvent(record.msg, record)
+          const logLevel = record.logLevel || 'debug'
+          if (logLevel !== 'debug') {
+            span.addEvent(record.msg, record)
+          }
         }
       })
     ]

--- a/creator-node/src/tracer.ts
+++ b/creator-node/src/tracer.ts
@@ -103,6 +103,8 @@ export const setupTracing = () => {
             provider.resource.attributes['service.name']
           record['resource.service.spid'] = SPID
           record['resource.service.endpoint'] = ENDPOINT
+
+          span.addEvent(record.msg, record)
         }
       })
     ]


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR wraps the bunyan log to send add logs as trace events that'll get send to CloudTrace.

<img width="745" alt="Screen Shot 2022-09-15 at 11 12 21" src="https://user-images.githubusercontent.com/17736112/190440981-af6e28e4-9161-418f-8452-2c03837f40b3.png">


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Run locally and used the dev CloudTrace instance to make sure logs were forwarded properly.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

These changes will be monitored on our tracing visualization service. Logs are show as events.

Screenshot above for reference

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->