### PR TITLE
Cache cn while indexing replica set

### DIFF
--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Any, List, Set, Tuple
 
-import redis
+from redis import Redis
 from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_eth_abi_values
 from src.database_task import DatabaseTask
@@ -214,7 +214,7 @@ def get_user_replica_set_mgr_tx(update_task, event_type, tx_receipt):
 # If this discrepancy occurs, a client replica set health check sweep will
 # result in a client-initiated failover operation to a valid set of replicas
 def get_endpoint_string_from_sp_ids(
-    redis: redis, primary: int, secondaries: List[int]
+    redis: Redis, primary: int, secondaries: List[int]
 ) -> str:
     sp_factory_inst = None
     endpoint_string = None
@@ -268,7 +268,7 @@ def get_ursm_cnode_endpoint(update_task, sp_id):
 
 # Initializes sp_factory if necessary and retrieves spID
 # Returns initialized instance of contract and endpoint
-def get_endpoint_from_id(redis: redis, sp_factory_inst, sp_id: int) -> Tuple[Any, str]:
+def get_endpoint_from_id(redis: Redis, sp_factory_inst, sp_id: int) -> Tuple[Any, str]:
     endpoint = None
     # Get sp_id cache key
     cache_key = get_cn_sp_id_key(sp_id)

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -19,7 +19,7 @@ from src.utils.eth_contracts_helpers import (
 )
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.redis_cache import get_cn_sp_id_key, get_json_cached_key
+from src.utils.redis_cache import get_cn_sp_id_key, get_json_cached_key, set_json_cached_key
 from src.utils.user_event_constants import (
     user_replica_set_manager_event_types_arr,
     user_replica_set_manager_event_types_lookup,

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -1,8 +1,8 @@
 import logging
-import redis
 from datetime import datetime
 from typing import Any, List, Set, Tuple
 
+import redis
 from sqlalchemy.orm.session import Session, make_transient
 from src.app import get_eth_abi_values
 from src.database_task import DatabaseTask
@@ -13,13 +13,17 @@ from src.tasks.users import invalidate_old_user, lookup_user_record
 from src.utils import helpers, web3_provider
 from src.utils.config import shared_config
 from src.utils.eth_contracts_helpers import (
+    cnode_info_redis_ttl_s,
     content_node_service_type,
     sp_factory_registry_key,
-    cnode_info_redis_ttl_s,
 )
 from src.utils.indexing_errors import EntityMissingRequiredFieldError, IndexingError
 from src.utils.model_nullable_validator import all_required_fields_present
-from src.utils.redis_cache import get_cn_sp_id_key, get_json_cached_key, set_json_cached_key
+from src.utils.redis_cache import (
+    get_cn_sp_id_key,
+    get_json_cached_key,
+    set_json_cached_key,
+)
 from src.utils.user_event_constants import (
     user_replica_set_manager_event_types_arr,
     user_replica_set_manager_event_types_lookup,

--- a/discovery-provider/src/tasks/user_replica_set.py
+++ b/discovery-provider/src/tasks/user_replica_set.py
@@ -213,7 +213,9 @@ def get_user_replica_set_mgr_tx(update_task, event_type, tx_receipt):
 # creator_node_endpoint
 # If this discrepancy occurs, a client replica set health check sweep will
 # result in a client-initiated failover operation to a valid set of replicas
-def get_endpoint_string_from_sp_ids(redis: redis, primary: int, secondaries: List[int]) -> str:
+def get_endpoint_string_from_sp_ids(
+    redis: redis, primary: int, secondaries: List[int]
+) -> str:
     sp_factory_inst = None
     endpoint_string = None
     primary_endpoint = None

--- a/discovery-provider/src/utils/eth_contracts_helpers.py
+++ b/discovery-provider/src/utils/eth_contracts_helpers.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 sp_factory_registry_key = bytes("ServiceProviderFactory", "utf-8")
 content_node_service_type = bytes("content-node", "utf-8")
 
-cnode_info_redis_ttl = 1800
+# 30 minutes = 60 sec * 30 min
+cnode_info_redis_ttl_s = 1800
 
 
 def fetch_cnode_info(sp_id, sp_factory_instance, redis):
@@ -28,9 +29,9 @@ def fetch_cnode_info(sp_id, sp_factory_instance, redis):
     cn_endpoint_info = sp_factory_instance.functions.getServiceEndpointInfo(
         content_node_service_type, sp_id
     ).call()
-    set_json_cached_key(redis, sp_id_key, cn_endpoint_info, cnode_info_redis_ttl)
+    set_json_cached_key(redis, sp_id_key, cn_endpoint_info, cnode_info_redis_ttl_s)
     logger.info(
-        f"eth_contract_helpers.py | Configured redis {sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl}"
+        f"eth_contract_helpers.py | Configured redis {sp_id_key} - {cn_endpoint_info} - TTL {cnode_info_redis_ttl_s}"
     )
     return cn_endpoint_info
 


### PR DESCRIPTION
### Description
Cache the content node info from the rpc call while indexing
This lead to intermittent indexing processing times of 40+ seconds

Fixes PLAT-427

### Tests
Ran 2e2 locally and validated that it wrote to redis

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->