### PR TITLE
Gate disk prune behind env var + logging reductions

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -493,6 +493,12 @@ const config = convict({
     env: 'premiumContentEnabled',
     default: false
   },
+  diskPruneEnabled: {
+    doc: 'whether DiskManager.sweepSubdirectoriesInFiles() should run',
+    format: Boolean,
+    env: 'diskPruneEnabled',
+    default: true
+  },
 
   /** sync / snapback configs */
 

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -397,8 +397,11 @@ class DiskManager {
         // if fileTrimmed is a non-null string and is not just equal to base directory
         if (fileTrimmed && fileTrimmed !== filesSubdirectory) {
           const parts = fileTrimmed.split('/')
+          console.log(parts)
           // returns the last CID in the event of dirCID
           const leafCID = parts[parts.length - 1]
+          console.log(leafCID)
+          console.log(fileTrimmed)
           cidsToFilePathMap[leafCID] = fileTrimmed
         }
       }
@@ -418,9 +421,7 @@ class DiskManager {
     for (let i = 0; i < subdirectories.length; i += 1) {
       try {
         const subdirectory = subdirectories[i]
-        genericLogger.info(
-          `diskManager#sweepSubdirectoriesInFiles - iteration ${i} out of ${subdirectories.length}`
-        )
+
         const cidsToFilePathMap = await this.listNestedCIDsInFilePath(
           subdirectory
         )
@@ -434,6 +435,16 @@ class DiskManager {
             }
           }
         })
+
+        genericLogger.info(
+          `diskManager#sweepSubdirectoriesInFiles - iteration ${i} out of ${
+            subdirectories.length
+          }. got ${Object.keys(cidsToFilePathMap).length} files in folder and ${
+            queryResults.length
+          } results from db. files: ${Object.keys(
+            cidsToFilePathMap
+          ).toString()}`
+        )
 
         const cidsInDB = new Set()
         for (const file of queryResults) {

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -450,9 +450,12 @@ class DiskManager {
         }
 
         if (cidsNotToDelete.length > 0) {
-          genericLogger.info(
-            `diskmanager.js - not safe to delete ${cidsNotToDelete.toString()}`
-          )
+          // print this log 5% of the time
+          if (Math.random() < 5 / 100) {
+            genericLogger.info(
+              `diskmanager.js - not safe to delete ${cidsNotToDelete.toString()}`
+            )
+          }
         }
 
         if (cidsToDelete.length > 0) {
@@ -465,7 +468,8 @@ class DiskManager {
             await this._execShellCommand(
               `rm ${cidsToDelete
                 .map((cid) => cidsToFilePathMap[cid])
-                .join(' ')}`
+                .join(' ')}`,
+              true
             )
           }
         }
@@ -480,8 +484,11 @@ class DiskManager {
     if (redoJob) return this.sweepSubdirectoriesInFiles()
   }
 
-  static async _execShellCommand(cmd) {
-    genericLogger.info(`diskManager - about to call _execShellCommand: ${cmd}`)
+  static async _execShellCommand(cmd, log = false) {
+    if (log)
+      genericLogger.info(
+        `diskManager - about to call _execShellCommand: ${cmd}`
+      )
     const { stdout, stderr } = await exec(`${cmd}`, {
       maxBuffer: 1024 * 1024 * 5
     }) // 5mb buffer

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -462,12 +462,9 @@ class DiskManager {
         }
 
         if (cidsNotToDelete.length > 0) {
-          // print this log 5% of the time
-          if (Math.random() < 5 / 100) {
-            genericLogger.info(
-              `diskmanager.js - not safe to delete ${cidsNotToDelete.toString()}`
-            )
-          }
+          genericLogger.debug(
+            `diskmanager.js - not safe to delete ${cidsNotToDelete.toString()}`
+          )
         }
 
         if (cidsToDelete.length > 0) {
@@ -480,8 +477,7 @@ class DiskManager {
             await this._execShellCommand(
               `rm ${cidsToDelete
                 .map((cid) => cidsToFilePathMap[cid])
-                .join(' ')}`,
-              true
+                .join(' ')}`
             )
           }
         }

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -443,7 +443,7 @@ class DiskManager {
             queryResults.length
           } results from db. files: ${Object.keys(
             cidsToFilePathMap
-          ).toString()}`
+          ).toString()}. db records: ${JSON.stringify(queryResults)}`
         )
 
         const cidsInDB = new Set()
@@ -454,6 +454,7 @@ class DiskManager {
         const cidsToDelete = []
         const cidsNotToDelete = []
         for (const cid of cidsInDB) {
+          genericLogger.info(`diskManager#sweepSubdirectoriesInFiles - cidsInDB.has(cid): ${cidsInDB.has(cid)}`)
           // if db doesn't contain file, log as okay to delete
           if (!cidsInDB.has(cid)) {
             cidsToDelete.push(cid)
@@ -495,7 +496,7 @@ class DiskManager {
     if (redoJob) return this.sweepSubdirectoriesInFiles()
   }
 
-  static async _execShellCommand(cmd, log = false) {
+  static async _execShellCommand(cmd, log = true) {
     if (log)
       genericLogger.info(
         `diskManager - about to call _execShellCommand: ${cmd}`

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -174,7 +174,12 @@ const startAppForPrimary = async () => {
   })
 
   // do not await this, this should just run in background for now
-  DiskManager.sweepSubdirectoriesInFiles()
+  // wait one minute before starting this because it might cause init to degrade
+  if (config.get('diskPruneEnabled')) {
+    setTimeout(() => {
+      DiskManager.sweepSubdirectoriesInFiles()
+    }, 60_000)
+  }
 }
 
 // Workers don't share memory, so each one is its own Express instance with its own version of objects like serviceRegistry


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This PR adds
- An env var to gate disk pruning
- Removing log volume (only prints files it will delete, the rm command)
- Move where disk pruning gets kicked off. It now starts one minute after all cluster workers have been launched
- Bugfix where weren't iterating over the full list of CIDs

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Testing on stage cn7 to verify that it correctly finds and deletes content

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Logs prefixed with `diskManager` to list files we're about to delete

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->