### PR TITLE
Add gzip to discovery

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -45,6 +45,8 @@ http {
 
     server {
         listen 5000;
+        gzip on;
+        gzip_types text/plain application/xml application/json;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
### Description
Add gzip to discovery endpoints - it's currently not compressed

Fixes PLAT-428

### Tests
Tested by in 3 cases on stage:
* openresty disabled
  * On the box set the env var `audius_openresty_enable=`
* openresty enabled without public url
  * On the box set the env var `audius_openresty_enable=true` and `audius_discprov_url=`
* openresty enabled with public url
  * On the box set the env var `audius_openresty_enable=true` and `audius_discprov_url=https://discoveryprovider3.staging.audius.co`

In each case made this request and checked for gzip
<img width="999" alt="Screen Shot 2022-10-27 at 12 00 50 PM" src="https://user-images.githubusercontent.com/7064122/198340771-967b57a3-1c8d-4e3e-b6e3-d2e9bb8f8e2a.png">

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->