### PR TITLE
Add directory size to tmp track artifacts deletion logs

### DIFF
--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -35,11 +35,24 @@ class DiskManager {
   }
 
   /**
+   *
+   * @param {string} path the path to get the size for
+   * @returns the string output of stdout
+   */
+  static async getDirSize(path) {
+    const stdout = await this._execShellCommand(`du -sh ${path}`)
+    return stdout
+  }
+
+  /**
    * Empties the tmp track artifacts directory of any old artifacts
    */
   static async emptyTmpTrackUploadArtifacts() {
     const dirPath = await this.getTmpTrackUploadArtifactsPath()
+    const dirSize = await this.getDirSize(path)
     await fs.emptyDir(dirPath)
+
+    return dirSize
   }
 
   /**

--- a/creator-node/src/diskManager.js
+++ b/creator-node/src/diskManager.js
@@ -49,7 +49,7 @@ class DiskManager {
    */
   static async emptyTmpTrackUploadArtifacts() {
     const dirPath = await this.getTmpTrackUploadArtifactsPath()
-    const dirSize = await this.getDirSize(path)
+    const dirSize = await this.getDirSize(dirPath)
     await fs.emptyDir(dirPath)
 
     return dirSize

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -111,9 +111,11 @@ const startAppForPrimary = async () => {
   await setupDbAndRedis()
 
   const startTime = Date.now()
-  await DiskManager.emptyTmpTrackUploadArtifacts()
+  const size = await DiskManager.emptyTmpTrackUploadArtifacts()
   logger.info(
-    `old tmp track artifacts deleted : ${(Date.now() - startTime) / 1000}sec`
+    `old tmp track artifacts deleted : ${size} : ${
+      (Date.now() - startTime) / 1000
+    }sec`
   )
 
   // Don't await - run in background. Remove after v0.3.69


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds the tmp track artifacts dir size to the log for it

https://stackoverflow.com/questions/7529228/how-to-get-totalsize-of-files-in-directory

log sample
```
{"name":"audius_creator_node","clusterWorker":"master","hostname":"df4216f4bd7d","pid":89,"level":30,"msg":"old tmp track artifacts deleted : 4.0K\t/file_storage/files/tmp_track_artifacts\n : 0.054sec","time":"2022-10-26T21:02:38.585Z","v":0,"logLevel":"info"}
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Testing locally and on CI to make sure the log shows up


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This change will be monitored on loggly

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->