### PR TITLE
CN Clean up `saveFileForMultihashToFS` logs

### DIFF
--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -130,8 +130,7 @@ async function fetchFileFromNetworkAndWriteToDisk({
 }) {
   // First try to fetch from other cnode gateways if user has non-empty replica set.
   decisionTree.recordStage({
-    name: 'About to fetch content via gateways',
-    data: { gatewayContentRoutes }
+    name: 'About to fetch content via gateways'
   })
 
   // Note - Requests are intentionally not parallel to minimize additional load on gateways
@@ -370,12 +369,11 @@ async function saveFileForMultihashToFS(
       name: 'About to start running saveFileForMultihashToFS()',
       data: {
         multihash,
-        targetGateways,
-        gatewayContentRoutes,
         expectedStoragePath,
         parsedStoragePath
       },
-      log: true
+      log: true,
+      logLevel: 'debug'
     })
 
     // Create dir at expected storage path in which to store retrieved data
@@ -418,8 +416,7 @@ async function saveFileForMultihashToFS(
           }/${fileNameForImage}`
       )
       decisionTree.recordStage({
-        name: 'Updated gatewayUrlsMapped',
-        data: { gatewayContentRoutes }
+        name: 'Updated gatewayUrlsMapped'
       })
     }
 
@@ -457,7 +454,7 @@ async function saveFileForMultihashToFS(
 
     return e
   } finally {
-    decisionTree.printTree()
+    decisionTree.printTree({ logLevel: 'debug' })
   }
 
   // If no error, return nothing

--- a/creator-node/src/utils/decisionTree.ts
+++ b/creator-node/src/utils/decisionTree.ts
@@ -69,33 +69,36 @@ module.exports = class DecisionTree {
     this.tree.push(stage)
 
     if (log) {
-      this.printLastStage(logLevel)
+      this.printLastStage({ logLevel })
     }
   }
 
   printTree({ logLevel = 'info' }) {
-    this._log(
-      `DecisionTree Full - ${JSON.stringify(this.tree, null, 2)}`,
+    this._log({
+      msg: `DecisionTree Full - ${JSON.stringify(this.tree, null, 2)}`,
       logLevel
-    )
+    })
   }
 
-  printLastStage(logLevel = 'info') {
+  printLastStage({ logLevel = 'info' }) {
     if (this.tree.length > 0) {
-      this._log(
-        `DecisionTree Last Stage - ${JSON.stringify(
+      this._log({
+        msg: `DecisionTree Last Stage - ${JSON.stringify(
           this.tree[this.tree.length - 1],
           null,
           2
         )}`,
         logLevel
-      )
+      })
     } else {
-      this._log('DecisionTree Last Stage - empty', logLevel)
+      this._log({
+        msg: 'DecisionTree Last Stage - empty',
+        logLevel
+      })
     }
   }
 
-  private _log(msg: string, logLevel = 'info') {
+  private _log({ msg = '', logLevel = 'info' }) {
     let logFn
     switch (logLevel) {
       case 'error':

--- a/creator-node/src/utils/decisionTree.ts
+++ b/creator-node/src/utils/decisionTree.ts
@@ -19,6 +19,7 @@ type RecordStageParams = {
   name: string
   data: object | null
   log: boolean
+  logLevel?: 'error' | 'warn' | 'info' | 'debug'
 }
 
 /**
@@ -36,7 +37,12 @@ module.exports = class DecisionTree {
     this.name = name
   }
 
-  recordStage = ({ name, data = null, log = false }: RecordStageParams) => {
+  recordStage = ({
+    name,
+    data = null,
+    log = false,
+    logLevel = 'info'
+  }: RecordStageParams) => {
     const timestamp = Date.now()
 
     let stage: Stage
@@ -63,29 +69,51 @@ module.exports = class DecisionTree {
     this.tree.push(stage)
 
     if (log) {
-      this.printLastStage()
+      this.printLastStage(logLevel)
     }
   }
 
-  printTree() {
-    this._logInfo(`DecisionTree Full - ${JSON.stringify(this.tree, null, 2)}`)
+  printTree({ logLevel = 'info' }) {
+    this._log(
+      `DecisionTree Full - ${JSON.stringify(this.tree, null, 2)}`,
+      logLevel
+    )
   }
 
-  printLastStage() {
+  printLastStage(logLevel = 'info') {
     if (this.tree.length > 0) {
-      this._logInfo(
+      this._log(
         `DecisionTree Last Stage - ${JSON.stringify(
           this.tree[this.tree.length - 1],
           null,
           2
-        )}`
+        )}`,
+        logLevel
       )
     } else {
-      this._logInfo('DecisionTree Last Stage - empty')
+      this._log('DecisionTree Last Stage - empty', logLevel)
     }
   }
 
-  private _logInfo(msg: string) {
-    this.logger.info(`${this.name} - ${msg}`)
+  private _log(msg: string, logLevel = 'info') {
+    let logFn
+    switch (logLevel) {
+      case 'error':
+        logFn = this.logger.error
+        break
+      case 'warn':
+        logFn = this.logger.warn
+        break
+      case 'info':
+        logFn = this.logger.info
+        break
+      case 'debug':
+        logFn = this.logger.debug
+        break
+      default:
+        logFn = this.logger.debug
+    }
+
+    logFn(`${this.name} - ${msg}`)
   }
 }

--- a/creator-node/src/utils/decisionTree.ts
+++ b/creator-node/src/utils/decisionTree.ts
@@ -69,18 +69,18 @@ module.exports = class DecisionTree {
     this.tree.push(stage)
 
     if (log) {
-      this.printLastStage({ logLevel })
+      this._printLastStage({ logLevel })
     }
   }
 
-  printTree({ logLevel = 'info' }) {
+  printTree({ logLevel = 'info' } = {}) {
     this._log({
       msg: `DecisionTree Full - ${JSON.stringify(this.tree, null, 2)}`,
       logLevel
     })
   }
 
-  printLastStage({ logLevel = 'info' }) {
+  private _printLastStage({ logLevel = 'info' } = {}) {
     if (this.tree.length > 0) {
       this._log({
         msg: `DecisionTree Last Stage - ${JSON.stringify(
@@ -98,7 +98,7 @@ module.exports = class DecisionTree {
     }
   }
 
-  private _log({ msg = '', logLevel = 'info' }) {
+  private _log({ msg = '', logLevel = 'info' } = {}) {
     let logFn
     switch (logLevel) {
       case 'error':


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

<img width="1728" alt="Screen Shot 2022-10-26 at 5 17 09 PM" src="https://user-images.githubusercontent.com/3323835/198139974-72cdbad4-c755-42aa-ac03-72c837fe537e.png">

current `saveFileForMultihashToFS` logs are way too big. Remove big chunk of those logs, plus downgrade to debug
Some associated decisionTree changes but should be fully back-compat

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

TODO test on staging

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Should no longer see any `saveFileForMultihashToFS` logs on loggly, and when tailing logs in container, the logs should be much smaller

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->