### PR TITLE
Add env var to gate wiping disk

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -508,6 +508,12 @@ const config = convict({
     env: 'syncForceWipeEnabled',
     default: true
   },
+  syncForceWipeDeleteDiskEnabled: {
+    doc: "whether or not this node can wipe a user's data from its disk during a sync (true = wipe allowed)",
+    format: Boolean,
+    env: 'syncForceWipeDeleteDiskEnabled',
+    default: true
+  },
   fetchCNodeEndpointToSpIdMapIntervalMs: {
     doc: 'interval (ms) to update the cNodeEndpoint->spId mapping',
     format: 'nat',


### PR DESCRIPTION
### Description
Adds `syncForceWipeDeleteDiskEnabled` env var (defaults to true) that can be turned off to disable deleting from disk during a `forceWipe` or `forceResync` sync so that only database entries get wiped.


### Tests
Created a user locally with `A seed` and verified that when the env var is true all data gets wiped from disk, but when it's false only their database rows get cleared.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
When the `syncForceWipeDeleteDiskEnabled` env var is set to false, we shouldn't see queries like the following at the `/db_check?verbose=true` endpoint:
```sql
SELECT \"storagePath\" FROM \"Files\" AS \"File\" WHERE \"File\".\"storagePath\" BETWEEN '/file_storage/files/1DG/QmRtyUvxreA4owkgS77o22frq3c3GFRRqaJbcdK5ei1DGw' AND '/file_storage/files/ZRo/QmTtupJPdYMxxgR8PmA2BeHXV47g3o4yarF2J38658ZRow' GROUP BY \"storagePath\" HAVING COUNT(DISTINCT(\"cnodeUserUUID\")) = 1;"
```