### PR TITLE
INF-266 Add Postgres and Redis Exporter docker images

### DIFF
--- a/monitoring/exporters/postgres/Dockerfile
+++ b/monitoring/exporters/postgres/Dockerfile
@@ -1,0 +1,6 @@
+# Manually built and pushed to https://hub.docker.com/r/audius/exporter-postgres
+FROM quay.io/prometheuscommunity/postgres-exporter:v0.10.1
+
+COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+ENTRYPOINT [ "/bin/docker-entrypoint.sh" ]
+CMD

--- a/monitoring/exporters/postgres/docker-entrypoint.sh
+++ b/monitoring/exporters/postgres/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# default case for discovery provider
+export DATA_SOURCE_NAME="${audius_db_url}?sslmode=disable"
+
+if [ "$*" = "--read-replica" ]; then
+    export DATA_SOURCE_NAME="${audius_db_url_read_replica}?sslmode=disable"
+fi
+
+if [ "$*" = "--creator-node" ]; then
+    export DATA_SOURCE_NAME=${dbUrl}?sslmode=disable
+fi
+
+if [ "$*" = "--identity-service" ]; then
+    export DATA_SOURCE_NAME=${dbUrl}?sslmode=disable
+fi
+
+# don't expose IP addresses, by overwriting the server label
+/bin/postgres_exporter --constantLabels server=server

--- a/monitoring/exporters/redis/Dockerfile
+++ b/monitoring/exporters/redis/Dockerfile
@@ -1,0 +1,6 @@
+# Manually built and pushed to https://hub.docker.com/r/audius/exporter-redis
+FROM quay.io/oliver006/redis_exporter:v1.44.0-alpine
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD

--- a/monitoring/exporters/redis/docker-entrypoint.sh
+++ b/monitoring/exporters/redis/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# default case for discovery provider
+export REDIS_ADDR=${audius_redis_url}
+
+if [ "$*" = "--creator-node" ]; then
+    export REDIS_ADDR=redis://${redisHost}:${redisPort}
+fi
+
+if [ "$*" = "--identity-service" ]; then
+    export REDIS_ADDR=redis://${redisHost}:${redisPort}
+fi
+
+/redis_exporter


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Splitting off stable changes from: #3959.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

N/A. Images were manually built and pushed to docker hub:

* https://hub.docker.com/r/audius/exporter-postgres
* https://hub.docker.com/r/audius/exporter-redis


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->