### PR TITLE
Remove error from proxy_cach_use_stale

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -83,7 +83,7 @@ http {
 
             # proxy_cache_use_stale + proxy_cache_background_update -> deliver stale content when client requests
             # an item that is expired or in the process of being updated from origin server
-            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            proxy_cache_use_stale timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
 
             # Cache all responses for 1s


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Remove error from proxy_cach_use_stale for /health_check in openresty. What this directive does is return a stale version of the response while the origin server encounters the listed errors. With health_check in particular we never want to return a stale value when the origin server errors after the 1s cache expiry. I left the error in for /ipfs because that's probably fine to cache.

Verified this bug by 
1. with the node server is running, make sure /health_check returns a value
2. kill -9 the node server
3. make sure /health_check returns the same value with the same signature as before

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally by 
1. with the node server is running, make sure /health_check returns a value
2. kill -9 the node server
3. make sure /health_check returns an error
4. bring node server back up
5. make sure /health_check returns a value


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->