### PR TITLE
CN skip l2 registration if entity manager enabled

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -406,6 +406,14 @@ class ServiceRegistry {
       ? 10000 /** 10sec */
       : 600000 /* 10min */
 
+    if (config.get('entityManagerReplicaSetEnabled')) {
+      config.set('isRegisteredOnURSM', true)
+      this.logInfo(
+        `When EntityManager is enabled, skip register node on l2 ursm`
+      )
+      return
+    }
+
     let isInitialized = false
     while (!isInitialized) {
       this.logInfo(

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -328,9 +328,19 @@ class ServiceRegistry {
     this.syncQueue = new SyncQueue(config, this.redis, this)
     this.syncImmediateQueue = new SyncImmediateQueue(config, this.redis, this)
 
-    // L2URSMRegistration (requires L1 identity)
-    // Retries indefinitely
-    await this._registerNodeOnL2URSM()
+    // If entity manager is enabled, there's no need to register on L2 because
+    // discovery node will use L1 to validate
+    if (config.get('entityManagerReplicaSetEnabled')) {
+      config.set('isRegisteredOnURSM', true)
+      this.logInfo(
+        `When EntityManager is enabled, skip register node on l2 ursm`
+      )
+      return
+    } else {
+      // L2URSMRegistration (requires L1 identity)
+      // Retries indefinitely
+      await this._registerNodeOnL2URSM()
+    }
 
     // SkippedCIDsRetryQueue construction + init (requires SyncQueue)
     // Note - passes in reference to instance of self (serviceRegistry), a very sub-optimal workaround
@@ -405,14 +415,6 @@ class ServiceRegistry {
     let retryTimeoutMs = config.get('devMode')
       ? 10000 /** 10sec */
       : 600000 /* 10min */
-
-    if (config.get('entityManagerReplicaSetEnabled')) {
-      config.set('isRegisteredOnURSM', true)
-      this.logInfo(
-        `When EntityManager is enabled, skip register node on l2 ursm`
-      )
-      return
-    }
 
     let isInitialized = false
     while (!isInitialized) {


### PR DESCRIPTION
### Description
Skip L2 registration if entity manager enabled
This prevents initing an unneeded contract in content node while using entity manager
The issue was found when switching from poa to our own nethermind nodes on stage

### Tests
Ran the system locally and ensured the new log was printed

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->