### PR TITLE
Remove redis primarySyncFromSecondary fail-safes

### DIFF
--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -669,14 +669,9 @@ async function filterOutAlreadyPresentDBEntries({
       FETCHED_ENTRIES_SET_KEY,
       fetchedEntriesComparable
     )
-    // Fail-safe in case for some reason not all entries were written to redis
-    if (numFetchedEntriesAdded !== fetchedEntries.length) {
-      throw new Error(
-        `Failed to add all entries to redis set for ${FETCHED_ENTRIES_SET_KEY}`
-      )
-    }
     decisionTree.recordStage({
       name: 'filterOutAlreadyPresentDBEntries() Set FETCHED_ENTRIES_SET_KEY',
+      data: { numFetchedEntriesAdded },
       log: true
     })
 
@@ -724,12 +719,6 @@ async function filterOutAlreadyPresentDBEntries({
         LOCAL_DB_ENTRIES_SET_KEY,
         localEntriesComparable
       )
-      // Fail-safe in case for some reason not all entries were written to redis
-      if (numLocalEntriesAddedBatch !== localEntries.length) {
-        throw new Error(
-          `Failed to add all entries to redis set for ${LOCAL_DB_ENTRIES_SET_KEY}`
-        )
-      }
       numLocalEntriesAdded += numLocalEntriesAddedBatch
 
       // Move pagination cursor


### PR DESCRIPTION
### Description
Removes redis set fail-safes that were causing secondary->primary syncs to fail for users who have rows that are identical in every column except clock value.


### Tests
Ran `curl -X POST "http://cn1_creator-node_1:4000/merge_primary_and_secondary?wallet=0x7d273271690538cf855e5b3002a0dd8c154bb060&endpoint=https://audius-content-3.cultur3stake.com&syncEvenIfDisabled=true&forceWipe=true"` to sync from a prod secondary to my local CN1 as primary before and after these changes using a debugger to check each step. I also manually inspected the duplicates to ensure this change doesn't lead to any corrupted state.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
We shouldn't see the following error anymore: `Error - Failed to save entries to DB: Failed to add all entries to redis set for FILTER_OUT_ALREADY_PRESENT_DB_ENTRIES_FETCHED_ENTRIES_SET`.