### PR TITLE
[CON-471] Remove leftover active sync jobs during `syncQueue` start up

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -325,8 +325,10 @@ class ServiceRegistry {
 
     // SyncQueue construction (requires L1 identity)
     // Note - passes in reference to instance of self (serviceRegistry), a very sub-optimal workaround
-    this.syncQueue = new SyncQueue(config, this.redis, this)
-    this.syncImmediateQueue = new SyncImmediateQueue(config, this.redis, this)
+    this.syncQueue = new SyncQueue()
+    this.syncQueue.init(config, this.redis, this)
+    this.syncImmediateQueue = new SyncImmediateQueue()
+    this.syncImmediateQueue.init(config, this.redis, this)
 
     // If entity manager is enabled, there's no need to register on L2 because
     // discovery node will use L1 to validate

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -326,9 +326,9 @@ class ServiceRegistry {
     // SyncQueue construction (requires L1 identity)
     // Note - passes in reference to instance of self (serviceRegistry), a very sub-optimal workaround
     this.syncQueue = new SyncQueue()
-    this.syncQueue.init(config, this.redis, this)
+    await this.syncQueue.init(config, this.redis, this)
     this.syncImmediateQueue = new SyncImmediateQueue()
-    this.syncImmediateQueue.init(config, this.redis, this)
+    await this.syncImmediateQueue.init(config, this.redis, this)
 
     // If entity manager is enabled, there's no need to register on L2 because
     // discovery node will use L1 to validate

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -44,6 +44,12 @@ class SyncImmediateQueue {
       connection
     })
 
+    // any leftover active jobs need to be deleted when a new queue
+    // is created since they'll never get processed
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.deleteOldActiveJobs()
+
     const worker = new Worker(
       'sync-immediate-processing-queue',
       async (job) => {
@@ -88,12 +94,6 @@ class SyncImmediateQueue {
     if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
-
-    // any leftover active jobs need to be deleted when a new queue
-    // is created since they'll never get processed
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.deleteOldActiveJobs()
   }
 
   async deleteOldActiveJobs() {

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -88,6 +88,10 @@ class SyncImmediateQueue {
     if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
+
+    // any leftover active jobs need to be deleted when a new queue
+    // is created since they'll never get processed
+
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.deleteOldActiveJobs()
   }

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -88,6 +88,16 @@ class SyncImmediateQueue {
     if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.deleteOldActiveJobs()
+  }
+
+  async deleteOldActiveJobs() {
+    const oldActiveJobs = await this.queue.getJobs(['active'])
+    for (const job of oldActiveJobs) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      job.remove()
+    }
   }
 
   async processTask(job) {

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -98,6 +98,9 @@ class SyncImmediateQueue {
 
   async deleteOldActiveJobs() {
     const oldActiveJobs = await this.queue.getJobs(['active'])
+    logger.debug(
+      `[sync-immediate-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
+    )
     for (const job of oldActiveJobs) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       job.remove()

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -102,7 +102,7 @@ class SyncImmediateQueue {
     logger.info(
       `[sync-immediate-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
     )
-    await Promise.all(oldActiveJobs.map((job) => job.remove()))
+    await Promise.allSettled(oldActiveJobs.map((job) => job.remove()))
   }
 
   async processTask(job) {

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -98,7 +98,7 @@ class SyncImmediateQueue {
 
   async deleteOldActiveJobs() {
     const oldActiveJobs = await this.queue.getJobs(['active'])
-    logger.debug(
+    logger.info(
       `[sync-immediate-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
     )
     for (const job of oldActiveJobs) {

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -46,9 +46,10 @@ class SyncImmediateQueue {
 
     // any leftover active jobs need to be deleted when a new queue
     // is created since they'll never get processed
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.deleteOldActiveJobs()
+    if (clusterUtils.isThisWorkerInit()) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.deleteOldActiveJobs()
+    }
 
     const worker = new Worker(
       'sync-immediate-processing-queue',

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -47,7 +47,6 @@ class SyncImmediateQueue {
     // any leftover active jobs need to be deleted when a new queue
     // is created since they'll never get processed
     if (clusterUtils.isThisWorkerInit()) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await this.deleteOldActiveJobs()
     }
 

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -63,9 +63,10 @@ export class SyncQueue {
 
     // any leftover active jobs need to be deleted when a new queue
     // is created since they'll never get processed
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.deleteOldActiveJobs()
+    if (clusterUtils.isThisWorkerInit()) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.deleteOldActiveJobs()
+    }
 
     /**
      * Queue will process tasks concurrently if provided a concurrency number, and will process all on

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -117,6 +117,9 @@ export class SyncQueue {
 
   private async deleteOldActiveJobs() {
     const oldActiveJobs = await this.queue.getJobs(['active'])
+    logger.debug(
+      `[sync-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
+    )
     for (const job of oldActiveJobs) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       job.remove()

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -61,6 +61,12 @@ export class SyncQueue {
       }
     })
 
+    // any leftover active jobs need to be deleted when a new queue
+    // is created since they'll never get processed
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.deleteOldActiveJobs()
+
     /**
      * Queue will process tasks concurrently if provided a concurrency number, and will process all on
      *    main thread if provided an in-line job processor function; it will distribute across child processes
@@ -107,12 +113,6 @@ export class SyncQueue {
     if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
-
-    // any leftover active jobs need to be deleted when a new queue
-    // is created since they'll never get processed
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.deleteOldActiveJobs()
   }
 
   private async deleteOldActiveJobs() {

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -107,6 +107,17 @@ export class SyncQueue {
     if (prometheusRegistry !== null && prometheusRegistry !== undefined) {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.deleteOldActiveJobs()
+  }
+
+  private async deleteOldActiveJobs() {
+    const oldActiveJobs = await this.queue.getJobs(['active'])
+    for (const job of oldActiveJobs) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      job.remove()
+    }
   }
 
   private async processTask(job: Job) {

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -108,6 +108,9 @@ export class SyncQueue {
       prometheusRegistry.startQueueMetrics(this.queue, worker)
     }
 
+    // any leftover active jobs need to be deleted when a new queue
+    // is created since they'll never get processed
+
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.deleteOldActiveJobs()
   }

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -64,7 +64,6 @@ export class SyncQueue {
     // any leftover active jobs need to be deleted when a new queue
     // is created since they'll never get processed
     if (clusterUtils.isThisWorkerInit()) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await this.deleteOldActiveJobs()
     }
 

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -117,7 +117,7 @@ export class SyncQueue {
 
   private async deleteOldActiveJobs() {
     const oldActiveJobs = await this.queue.getJobs(['active'])
-    logger.debug(
+    logger.info(
       `[sync-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
     )
     for (const job of oldActiveJobs) {

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -122,7 +122,7 @@ export class SyncQueue {
     logger.info(
       `[sync-processing-queue] removing ${oldActiveJobs.length} leftover active sync jobs`
     )
-    await Promise.all(oldActiveJobs.map((job) => job.remove()))
+    await Promise.allSettled(oldActiveJobs.map((job) => job.remove()))
   }
 
   private async processTask(job: Job) {

--- a/creator-node/test/AsyncProcessingQueue.test.js
+++ b/creator-node/test/AsyncProcessingQueue.test.js
@@ -9,9 +9,9 @@ const {
   ProcessNames
 } = require('../src/AsyncProcessingQueue')
 
-describe('test AsyncProcessingQueue', function () {
+describe('test AsyncProcessingQueue', async function () {
   let apq, libsMock, doneMock
-  const serviceRegistryMock = getServiceRegistryMock()
+  const serviceRegistryMock = await getServiceRegistryMock()
   before(function () {
     libsMock = {}
     doneMock = () => {}

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -31,6 +31,8 @@ export async function getApp(
 
   const prometheusRegistry = new PrometheusRegistry()
   const apq = new AsyncProcessingQueueMock(libsClient, prometheusRegistry)
+  const syncQueue = new SyncQueue()
+  syncQueue.init(nodeConfig, redisClient)
   const mockServiceRegistry = {
     libs: libsClient,
     blacklistManager,
@@ -39,7 +41,7 @@ export async function getApp(
     asyncProcessingQueue: apq,
     imageProcessingQueue: new ImageProcessingQueue(),
     nodeConfig,
-    syncQueue: new SyncQueue(nodeConfig, redisClient),
+    syncQueue: syncQueue,
     trustedNotifierManager: new TrustedNotifierManager(nodeConfig, libsClient),
     prometheusRegistry
   }
@@ -57,13 +59,15 @@ export async function getApp(
   return appInfo
 }
 
-export function getServiceRegistryMock(libsClient, blacklistManager) {
+export async function getServiceRegistryMock(libsClient, blacklistManager) {
+  const syncQueue = new SyncQueue()
+  await syncQueue.init()
   return {
     libs: libsClient,
     blacklistManager: blacklistManager,
     redis: redisClient,
     monitoringQueue: new MonitoringQueueMock(),
-    syncQueue: new SyncQueue(nodeConfig, redisClient),
+    syncQueue: syncQueue,
     nodeConfig,
     initLibs: async function () {},
     prometheusRegistry: new PrometheusRegistry()

--- a/creator-node/test/lib/app.js
+++ b/creator-node/test/lib/app.js
@@ -61,7 +61,7 @@ export async function getApp(
 
 export async function getServiceRegistryMock(libsClient, blacklistManager) {
   const syncQueue = new SyncQueue()
-  await syncQueue.init()
+  await syncQueue.init(nodeConfig, redisClient)
   return {
     libs: libsClient,
     blacklistManager: blacklistManager,

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -1083,7 +1083,10 @@ describe('Test secondarySyncFromPrimary()', async function () {
       server = appInfo.server
       app = appInfo.app
 
-      serviceRegistryMock = getServiceRegistryMock(libsMock, BlacklistManager)
+      serviceRegistryMock = await getServiceRegistryMock(
+        libsMock,
+        BlacklistManager
+      )
     })
 
     afterEach(function () {
@@ -1818,7 +1821,10 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
 
     // Define mocks
 
-    serviceRegistryMock = getServiceRegistryMock(libsMock, BlacklistManager)
+    serviceRegistryMock = await getServiceRegistryMock(
+      libsMock,
+      BlacklistManager
+    )
 
     primarySyncFromSecondaryStub = proxyquire(
       '../src/services/sync/primarySyncFromSecondary',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds an extra step in the constructor for the `syncQueue` and `immediateSyncQueue` to clear any old/leftover active queue jobs. 

These active jobs are usually garbage leftover from previous runs when the server restarts or crashes in the middle of a sync. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally by looking for the log msg saying active jobs were being deleted. 

Other than that, no new tests were added.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

This change will be monitored using the Bull Dashboard on Grafana and we _should_ see a steady decrease in active bull queue jobs to a ore realistic number.

This can also be monitored with logs with the msg
`removing ${oldActiveJobs.length} leftover active sync jobs`

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->