### PR TITLE
INF-298 fix race conditions for autodeploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,7 +1040,7 @@ jobs:
             - run:
                 name: Check for Changes
                 command: |
-                  [[ $(git diff main --dirstat=files -- << parameters.service >>*) ]] || (echo "no diff" && circleci-agent step halt)
+                  [[ $(git diff $(git rev-parse HEAD)~1 --dirstat=files -- << parameters.service >>*) ]] || (echo "no diff" && circleci-agent step halt)
       # only send Starting slack message when prod, --force, or custom args are used
       - when:
           condition:
@@ -1399,6 +1399,7 @@ workflows:
       - deploy:
           name: autodeploy-stage-discovery
           service: discovery
+          git_tag: ${CIRCLE_SHA1}
           context:
             - slack-secrets
             - gh-tokens
@@ -1413,6 +1414,7 @@ workflows:
       - deploy:
           name: autodeploy-stage-creator
           service: creator
+          git_tag: ${CIRCLE_SHA1}
           context:
             - slack-secrets
             - gh-tokens
@@ -1427,6 +1429,7 @@ workflows:
       - deploy:
           name: autodeploy-stage-identity
           service: identity
+          git_tag: ${CIRCLE_SHA1}
           context:
             - slack-secrets
             - gh-tokens
@@ -1452,6 +1455,7 @@ workflows:
             - autodeploy-stage-<< matrix.service >>
       - deploy:
           name: unreserving-stage-<< matrix.service >>
+          git_tag: ${CIRCLE_SHA1}
           params: --force
           context:
             - slack-secrets
@@ -1481,6 +1485,7 @@ workflows:
       - deploy:
           name: unreserving-<< matrix.host >>
           service: discovery
+          git_tag: ${CIRCLE_SHA1}
           params: --force
           context:
             - slack-secrets
@@ -1510,6 +1515,7 @@ workflows:
       - deploy:
           name: unreserving-<< matrix.host >>
           service: creator
+          git_tag: ${CIRCLE_SHA1}
           params: --force
           context:
             - slack-secrets


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

* Always compare current commit to previous commit, not `main` (since the commit has already been merged into `main`).
* Always provide `git_tag` parameter for deploy jobs, to eliminate race condition where we deploy latest master tag before `master` tag has been built.
  * Previous concerns of deploying an old version are no longer valid due to #4024 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Reproduced `git diff` situation locally.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->