### PR TITLE
Fix decision tree logger not bound

### DIFF
--- a/creator-node/src/utils/decisionTree.ts
+++ b/creator-node/src/utils/decisionTree.ts
@@ -117,6 +117,6 @@ module.exports = class DecisionTree {
         logFn = this.logger.debug
     }
 
-    logFn(`${this.name} - ${msg}`)
+    logFn.bind(this.logger)(`${this.name} - ${msg}`)
   }
 }


### PR DESCRIPTION
### Description
Fixes the following error which was caused by not binding the bunyan logger:
```
bunyan usage error: /usr/src/app/build/src/utils/decisionTree.js:49: attempt to log with an unbound log method: `this` is: <ref *1> Object [global] {
  global: [Circular *1],
  clearInterval: [Function: clearInterval],
  clearTimeout: [Function: clearTimeout],
  setInterval: [Function: setInterval],
  setTimeout: [Function: setTimeout] {
    [Symbol(nodejs.util.promisify.custom)]: [Getter]
  },
  queueMicrotask: [Function: queueMicrotask],
  clearImmediate: [Function: clearImmediate],
  setImmediate: [Function: setImmediate] {
    [Symbol(nodejs.util.promisify.custom)]: [Getter]
  },
  regeneratorRuntime: {
    wrap: [Function: wrap],
    isGeneratorFunction: [Function (anonymous)],
    mark: [Function (anonymous)],
    awrap: [Function (anonymous)],
    AsyncIterator: [Function: AsyncIterator],
    async: [Function (anonymous)],
    keys: [Function (anonymous)],
    values: [Function: values]
  },
  __extends: [Function: __extends],
  __assign: [Function: assign],
  __rest: [Function: __rest],
  __decorate: [Function: __decorate],
  __param: [Function: __param],
  __metadata: [Function: __metadata],
  __awaiter: [Function: __awaiter],
  __generator: [Function: __generator],
  __exportStar: [Function: __exportStar],
  __createBinding: [Function (anonymous)],
  __values: [Function: __values],
  __read: [Function: __read],
  __spread: [Function: __spread],
  __spreadArrays: [Function: __spreadArrays],
  __spreadArray: [Function: __spreadArray],
  __await: [Function: __await],
  __asyncGenerator: [Function: __asyncGenerator],
  __asyncDelegator: [Function: __asyncDelegator],
  __asyncValues: [Function: __asyncValues],
  __makeTemplateObject: [Function: __makeTemplateObject],
  __importStar: [Function: __importStar],
  __importDefault: [Function: __importDefault],
  __classPrivateFieldGet: [Function: __classPrivateFieldGet],
  __classPrivateFieldSet: [Function: __classPrivateFieldSet],
  __classPrivateFieldIn: [Function: __classPrivateFieldIn],
  [Symbol(opentelemetry.js.api.1)]: {
    version: '1.2.0',
    trace: ProxyTracerProvider { _delegate: [NodeTracerProvider] },
    context: AsyncLocalStorageContextManager {
      _kOtListeners: Symbol(OtListeners),
      _asyncLocalStorage: [AsyncLocalStorage]
    },
    propagation: CompositePropagator { _propagators: [Array], _fields: [Array] }
  }
}
```


### Tests
Manually tested printing out a decision tree before and after to make sure it actually logs now and doesn't throw the error in the description.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor for logs containing `bunyan usage error`.