### PR TITLE
Include dev-tools in the workspace file

### DIFF
--- a/audius.code-workspace
+++ b/audius.code-workspace
@@ -27,5 +27,8 @@
     {
       "path": "mad-dog"
     },
+    {
+      "path": "dev-tools"
+    },
   ]
 }


### PR DESCRIPTION
### Description

It's sometimes useful to see some files in the dev-tools folder. Nice to have it in the workspace without having to open a new vscode window.

### Tests

n/a

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->