### PR TITLE
INF-263 minimize status noise on `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1443,6 +1443,14 @@ workflows:
             - test-identity
       # Force deploy `main` to staging (by service)
       - noop:
+          name: unreserve-stage-<< matrix.service >>-hold
+          type: approval
+          filters:
+            branches:
+              only: /(^main$)/
+          requires:
+            - autodeploy-stage-<< matrix.service >>
+      - noop:
           name: unreserve-stage-<< matrix.service >>-all
           type: approval
           matrix:
@@ -1452,7 +1460,7 @@ workflows:
             branches:
               only: /(^main$)/
           requires:
-            - autodeploy-stage-<< matrix.service >>
+            - unreserve-stage-<< matrix.service >>-hold
       - deploy:
           name: unreserving-stage-<< matrix.service >>-all
           git_tag: ${CIRCLE_SHA1}
@@ -1481,7 +1489,7 @@ workflows:
             branches:
               only: /(^main$)/
           requires:
-            - autodeploy-stage-discovery
+            - unreserve-stage-discovery-hold
       - deploy:
           name: unreserving-<< matrix.host >>
           service: discovery
@@ -1511,7 +1519,7 @@ workflows:
             branches:
               only: /(^main$)/
           requires:
-            - autodeploy-stage-creator
+            - unreserve-stage-creator-hold
       - deploy:
           name: unreserving-<< matrix.host >>
           service: creator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1443,7 +1443,7 @@ workflows:
             - test-identity
       # Force deploy `main` to staging (by service)
       - noop:
-          name: unreserve-stage-<< matrix.service >>
+          name: unreserve-stage-<< matrix.service >>-all
           type: approval
           matrix:
             parameters:
@@ -1454,7 +1454,7 @@ workflows:
           requires:
             - autodeploy-stage-<< matrix.service >>
       - deploy:
-          name: unreserving-stage-<< matrix.service >>
+          name: unreserving-stage-<< matrix.service >>-all
           git_tag: ${CIRCLE_SHA1}
           params: --force
           context:
@@ -1469,7 +1469,7 @@ workflows:
             branches:
               only: /(^main$)/
           requires:
-            - unreserve-stage-<< matrix.service >>
+            - unreserve-stage-<< matrix.service >>-all
       # Force deploy `main` to staging (by host) - discovery
       - noop:
           name: unreserve-<< matrix.host >>
@@ -1533,7 +1533,7 @@ workflows:
 
       # Deploy branch to staging (by service)
       - noop:
-          name: reserve-stage-<< matrix.service >>
+          name: reserve-stage-<< matrix.service >>-all
           type: approval
           matrix:
             parameters:
@@ -1544,7 +1544,7 @@ workflows:
           requires:
             - << matrix.service >>-deploy-hold
       - deploy:
-          name: reserving-stage-<< matrix.service >>
+          name: reserving-stage-<< matrix.service >>-all
           git_tag: ${CIRCLE_SHA1}
           params: --force
           context:
@@ -1559,7 +1559,7 @@ workflows:
             branches:
               ignore: /(^main|release-.*$)/
           requires:
-            - reserve-stage-<< matrix.service >>
+            - reserve-stage-<< matrix.service >>-all
       # Deploy branch to staging (by host) - discovery
       - noop:
           name: reserve-<< matrix.host >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1445,6 +1445,9 @@ workflows:
       - noop:
           name: unreserve-stage-<< matrix.service >>-hold
           type: approval
+          matrix:
+            parameters:
+              service: [discovery, creator, identity]
           filters:
             branches:
               only: /(^main$)/


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add an additional hold job before exposing all `unreserve-*` jobs. This minimizes the number of pending jobs from 17 to 3 for commits on `main`.

Additionally add the `-all` suffix to denote jobs that deploy to all nodes within a service.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Need to merge into `main` and see Github Status Checks for newer commits.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->