### PR TITLE
Add flag to disable sync tracking

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -833,7 +833,7 @@ const config = convict({
   recordSyncResults: {
     doc: 'Flag to record sync results. If enabled sync results (successes and failures) will be recorded. This flag is not intended to be permanent.',
     format: Boolean,
-    env: 'processSyncResults',
+    env: 'recordSyncResults',
     default: false
   },
   processSyncResults: {

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -826,6 +826,13 @@ const config = convict({
     format: String,
     env: 'reconfigSPIdBlacklistString',
     default: '1,4,33,37,39,40,41,42,43,52,56,58,59,60,61,64,65'
+  },
+  // TODO: temporarily disable this to determine if sync tracking is a bottleneck on redis reliability
+  processSyncResults: {
+    doc: 'Flag to process sync results. If enabled, syncs may be capped for a day depending on sync results. Else, do not process sync results. This flag is not intended to be permanent.',
+    format: Boolean,
+    env: 'processSyncResults',
+    default: false
   }
   /**
    * unsupported options at the moment

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -827,7 +827,15 @@ const config = convict({
     env: 'reconfigSPIdBlacklistString',
     default: '1,4,33,37,39,40,41,42,43,52,56,58,59,60,61,64,65'
   },
-  // TODO: temporarily disable this to determine if sync tracking is a bottleneck on redis reliability
+
+  // TODO: temporarily disable these flags to determine if sync tracking is a bottleneck on redis reliability
+
+  recordSyncResults: {
+    doc: 'Flag to record sync results. If enabled sync results (successes and failures) will be recorded. This flag is not intended to be permanent.',
+    format: Boolean,
+    env: 'processSyncResults',
+    default: false
+  },
   processSyncResults: {
     doc: 'Flag to process sync results. If enabled, syncs may be capped for a day depending on sync results. Else, do not process sync results. This flag is not intended to be permanent.',
     format: Boolean,

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/SecondarySyncHealthTracker.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/SecondarySyncHealthTracker.ts
@@ -17,6 +17,7 @@ const RedisKeyPrefix = 'SecondarySyncRequestOutcomes-Daily'
 const DailyRedisKeyExpirationSec =
   90 /* days */ * 24 /* hr */ * 60 /* min */ * 60 /* s */
 
+const RECORD_SYNC_RESULTS = config.get('recordSyncResults')
 const PROCESS_SYNC_RESULTS = config.get('processSyncResults')
 
 export const Outcomes = Object.freeze({
@@ -120,7 +121,9 @@ export async function recordSuccess(
   wallet: string,
   syncType: string
 ) {
-  await _recordSyncRequestOutcome(secondary, wallet, syncType, true)
+  if (RECORD_SYNC_RESULTS) {
+    await _recordSyncRequestOutcome(secondary, wallet, syncType, true)
+  }
 }
 
 export async function recordFailure(
@@ -128,7 +131,9 @@ export async function recordFailure(
   wallet: string,
   syncType: string
 ) {
-  await _recordSyncRequestOutcome(secondary, wallet, syncType, false)
+  if (RECORD_SYNC_RESULTS) {
+    await _recordSyncRequestOutcome(secondary, wallet, syncType, false)
+  }
 }
 
 /**
@@ -140,6 +145,10 @@ export async function getSecondaryUserSyncFailureCountForToday(
   wallet: string,
   syncType: string
 ) {
+  if (!PROCESS_SYNC_RESULTS) {
+    return 0
+  }
+
   const resp = await getSyncRequestOutcomeMetrics({
     secondary,
     wallet,

--- a/creator-node/test/stateMonitoringUtils.test.js
+++ b/creator-node/test/stateMonitoringUtils.test.js
@@ -370,7 +370,7 @@ describe('test buildReplicaSetNodesToUserWalletsMap()', function () {
   })
 })
 
-describe.only('test computeUserSecondarySyncSuccessRatesMap()', function () {
+describe('test computeUserSecondarySyncSuccessRatesMap()', function () {
   let server
   beforeEach(async function () {
     const appInfo = await getApp(getLibsMock())

--- a/creator-node/test/stateMonitoringUtils.test.js
+++ b/creator-node/test/stateMonitoringUtils.test.js
@@ -370,7 +370,7 @@ describe('test buildReplicaSetNodesToUserWalletsMap()', function () {
   })
 })
 
-describe('test computeUserSecondarySyncSuccessRatesMap()', function () {
+describe.only('test computeUserSecondarySyncSuccessRatesMap()', function () {
   let server
   beforeEach(async function () {
     const appInfo = await getApp(getLibsMock())
@@ -470,90 +470,89 @@ describe('test computeUserSecondarySyncSuccessRatesMap()', function () {
   })
 })
 
-  it.skip('returns expected counts and percentages after recording successes and failures', async function () {
-    const nodeUsers = [
-      {
-        user_id: 1,
-        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
-        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
-        secondary1: 'http://cnWithSpId2.co',
-        secondary2: 'http://cnWithSpId3.co',
-        primarySpID: 1,
-        secondary1SpID: 2,
-        secondary2SpID: 3
+it.skip('returns expected counts and percentages after recording successes and failures', async function () {
+  const nodeUsers = [
+    {
+      user_id: 1,
+      wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+      primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+      secondary1: 'http://cnWithSpId2.co',
+      secondary2: 'http://cnWithSpId3.co',
+      primarySpID: 1,
+      secondary1SpID: 2,
+      secondary2SpID: 3
+    },
+    {
+      user_id: 2,
+      wallet: 'wallet2',
+      primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+      secondary1: 'http://cnWithSpId2.co',
+      secondary2: 'http://cnWithSpId3.co',
+      primarySpID: 1,
+      secondary1SpID: 2,
+      secondary2SpID: 3
+    }
+  ]
+
+  await SecondarySyncHealthTracker.recordSuccess(
+    [nodeUsers[0].secondary1],
+    [nodeUsers[0].wallet],
+    SyncType.Recurring
+  )
+  await SecondarySyncHealthTracker.recordSuccess(
+    [nodeUsers[0].secondary1],
+    [nodeUsers[0].wallet],
+    SyncType.Recurring
+  )
+  await SecondarySyncHealthTracker.recordSuccess(
+    [nodeUsers[0].secondary1],
+    [nodeUsers[0].wallet],
+    SyncType.Recurring
+  )
+  await SecondarySyncHealthTracker.recordFailure(
+    [nodeUsers[0].secondary1],
+    [nodeUsers[0].wallet],
+    SyncType.Recurring
+  )
+  await SecondarySyncHealthTracker.recordFailure(
+    [nodeUsers[0].secondary2],
+    [nodeUsers[0].wallet],
+    SyncType.Recurring
+  )
+
+  const expectedUserSecondarySyncMetricsMap = {
+    [nodeUsers[0].wallet]: {
+      [nodeUsers[0].secondary1]: {
+        successRate: 0.75,
+        successCount: 3,
+        failureCount: 1
       },
-      {
-        user_id: 2,
-        wallet: 'wallet2',
-        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
-        secondary1: 'http://cnWithSpId2.co',
-        secondary2: 'http://cnWithSpId3.co',
-        primarySpID: 1,
-        secondary1SpID: 2,
-        secondary2SpID: 3
+      [nodeUsers[0].secondary2]: {
+        successRate: 0,
+        successCount: 0,
+        failureCount: 1
       }
-    ]
-
-    await SecondarySyncHealthTracker.recordSuccess(
-      [nodeUsers[0].secondary1],
-      [nodeUsers[0].wallet],
-      SyncType.Recurring
-    )
-    await SecondarySyncHealthTracker.recordSuccess(
-      [nodeUsers[0].secondary1],
-      [nodeUsers[0].wallet],
-      SyncType.Recurring
-    )
-    await SecondarySyncHealthTracker.recordSuccess(
-      [nodeUsers[0].secondary1],
-      [nodeUsers[0].wallet],
-      SyncType.Recurring
-    )
-    await SecondarySyncHealthTracker.recordFailure(
-      [nodeUsers[0].secondary1],
-      [nodeUsers[0].wallet],
-      SyncType.Recurring
-    )
-    await SecondarySyncHealthTracker.recordFailure(
-      [nodeUsers[0].secondary2],
-      [nodeUsers[0].wallet],
-      SyncType.Recurring
-    )
-
-    const expectedUserSecondarySyncMetricsMap = {
-      [nodeUsers[0].wallet]: {
-        [nodeUsers[0].secondary1]: {
-          successRate: 0.75,
-          successCount: 3,
-          failureCount: 1
-        },
-        [nodeUsers[0].secondary2]: {
-          successRate: 0,
-          successCount: 0,
-          failureCount: 1
-        }
+    },
+    [nodeUsers[1].wallet]: {
+      [nodeUsers[1].secondary1]: {
+        successRate: 1,
+        successCount: 0,
+        failureCount: 0
       },
-      [nodeUsers[1].wallet]: {
-        [nodeUsers[1].secondary1]: {
-          successRate: 1,
-          successCount: 0,
-          failureCount: 0
-        },
-        [nodeUsers[1].secondary2]: {
-          successRate: 1,
-          successCount: 0,
-          failureCount: 0
-        }
+      [nodeUsers[1].secondary2]: {
+        successRate: 1,
+        successCount: 0,
+        failureCount: 0
       }
     }
+  }
 
-    const userSecondarySyncMetricsMap =
-      await computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+  const userSecondarySyncMetricsMap =
+    await computeUserSecondarySyncSuccessRatesMap(nodeUsers)
 
-    expect(userSecondarySyncMetricsMap).to.deep.equal(
-      expectedUserSecondarySyncMetricsMap
-    )
-  })
+  expect(userSecondarySyncMetricsMap).to.deep.equal(
+    expectedUserSecondarySyncMetricsMap
+  )
 })
 
 describe('Test computeSyncModeForUserAndReplica()', function () {

--- a/creator-node/test/stateMonitoringUtils.test.js
+++ b/creator-node/test/stateMonitoringUtils.test.js
@@ -383,7 +383,94 @@ describe('test computeUserSecondarySyncSuccessRatesMap()', function () {
     await server.close()
   })
 
-  it('returns expected counts and percentages after recording successes and failures', async function () {
+  // TODO: This test is temporary with a hardcoded number of successes, failures, and successRate of 1
+  it('returns the hardcoded number of successes, failures, and successRate', async function () {
+    const nodeUsers = [
+      {
+        user_id: 1,
+        wallet: '0x00fc5bff87afb1f15a02e82c3f671cf5c9ad9e6d',
+        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      },
+      {
+        user_id: 2,
+        wallet: 'wallet2',
+        primary: 'http://cnOriginallySpId3ReregisteredAsSpId4.co',
+        secondary1: 'http://cnWithSpId2.co',
+        secondary2: 'http://cnWithSpId3.co',
+        primarySpID: 1,
+        secondary1SpID: 2,
+        secondary2SpID: 3
+      }
+    ]
+
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordSuccess(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordFailure(
+      [nodeUsers[0].secondary1],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+    await SecondarySyncHealthTracker.recordFailure(
+      [nodeUsers[0].secondary2],
+      [nodeUsers[0].wallet],
+      SyncType.Recurring
+    )
+
+    const expectedUserSecondarySyncMetricsMap = {
+      [nodeUsers[0].wallet]: {
+        [nodeUsers[0].secondary1]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        [nodeUsers[0].secondary2]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      },
+      [nodeUsers[1].wallet]: {
+        [nodeUsers[1].secondary1]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        },
+        [nodeUsers[1].secondary2]: {
+          successRate: 1,
+          successCount: 0,
+          failureCount: 0
+        }
+      }
+    }
+
+    const userSecondarySyncMetricsMap =
+      await computeUserSecondarySyncSuccessRatesMap(nodeUsers)
+
+    expect(userSecondarySyncMetricsMap).to.deep.equal(
+      expectedUserSecondarySyncMetricsMap
+    )
+  })
+})
+
+  it.skip('returns expected counts and percentages after recording successes and failures', async function () {
     const nodeUsers = [
       {
         user_id: 1,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is to temporarily disable `SecondarySyncHealthTracker` class from recording and processing syncs because scanning redis for sync data was causing redis to become unavailable. 

In this pr:
- add 2 env vars, `recordSyncResults` and `processSyncResults` to gate `SecondarySyncHealthTracker` logic

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- Unit test updated to check hard-codes sync success/fail counts and success rate
- Check `/health/bull` for findSyncRequests and findReplicaSetUpdates queue jobs correctly processing jobs with the hardcoded values

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
- Check redis to see if `SecondarySyncRequestOutcomes-Daily*` keys exist by running `KEYS *SecondarySyncRequestOutcomes-Daily*` in redis cli
- Check `/health/bull` for findSyncRequests and findReplicaSetUpdates queue jobs correctly processing jobs with the hardcoded values

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->