### PR TITLE
[CON-487] Make state machine error recovery more reliable

### DIFF
--- a/creator-node/src/services/stateMachineManager/index.js
+++ b/creator-node/src/services/stateMachineManager/index.js
@@ -134,12 +134,14 @@ class StateMachineManager {
         // Recurring queues need to re-enqueue jobs when they fail/error
         else if (queueName === QUEUE_NAMES.MONITOR_STATE) {
           queueEvents.on('failed', (_args, _id) => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             stateMonitoringManager.recoverFromJobFailure(
               monitorStateQueue,
               audiusLibs.discoveryProvider.discoveryProviderEndpoint
             )
           })
           queueEvents.on('error', (_args) => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             stateMonitoringManager.recoverFromJobFailure(
               monitorStateQueue,
               audiusLibs.discoveryProvider.discoveryProviderEndpoint

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -120,6 +120,8 @@ class StateMonitoringManager {
 
   /**
    * Enqueues a job that starts at a random user.
+   * Bull's onError doesn't pass in the previous job's info so there's no way to know where it left off.
+   * Otherwise this should start where the failed job left off
    * @param monitoringQueue the queue to re-add the job to
    */
   async recoverFromJobFailure(monitoringQueue, discoveryNodeEndpoint) {

--- a/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
+++ b/creator-node/src/services/stateMachineManager/stateMonitoring/index.js
@@ -52,12 +52,6 @@ class StateMonitoringManager {
       limiter: {
         max: 1,
         duration: config.get('fetchCNodeEndpointToSpIdMapIntervalMs')
-      },
-      onFailCallback: (job, error, _prev) => {
-        cNodeEndpointToSpIdMapQueueLogger.error(
-          `Queue Job Failed - ID ${job?.id} - Error ${error}`
-        )
-        cNodeEndpointToSpIdMapQueue.add('retry-after-fail', {})
       }
     })
 
@@ -77,13 +71,6 @@ class StateMonitoringManager {
         // Bull doesn't allow either of these to be set to 0, so we'll pause the queue later if the jobs per interval is 0
         max: config.get('stateMonitoringQueueRateLimitJobsPerInterval') || 1,
         duration: config.get('stateMonitoringQueueRateLimitInterval') || 1
-      },
-      onFailCallback: (job, error, _prev) => {
-        const logger = createChildLogger(monitorStateLogger, {
-          jobId: job?.id || 'unknown'
-        })
-        logger.error(`Job failed to complete. ID=${job?.id}. Error=${error}`)
-        this.enqueueMonitorStateJobAfterFailure(monitorStateQueue, job)
       }
     })
 
@@ -132,14 +119,14 @@ class StateMonitoringManager {
   }
 
   /**
-   * Enqueues a job that picks up where the previous failed job left off.
+   * Enqueues a job that starts at a random user.
    * @param monitoringQueue the queue to re-add the job to
-   * @param failedJob the jobData for the previous job that failed
    */
-  enqueueMonitorStateJobAfterFailure(monitoringQueue, failedJob) {
-    const {
-      data: { lastProcessedUserId, discoveryNodeEndpoint }
-    } = failedJob
+  async recoverFromJobFailure(monitoringQueue, discoveryNodeEndpoint) {
+    const latestUserId = await getLatestUserIdFromDiscovery(
+      discoveryNodeEndpoint
+    )
+    const lastProcessedUserId = _.random(0, latestUserId)
 
     monitoringQueue.add('retry-after-fail', {
       lastProcessedUserId,

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/index.js
@@ -97,19 +97,6 @@ class StateReconciliationManager {
         max:
           config.get('recoverOrphanedDataQueueRateLimitJobsPerInterval') || 1,
         duration: config.get('recoverOrphanedDataQueueRateLimitInterval') || 1
-      },
-      onFailCallback: (job, error, _prev) => {
-        const logger = createChildLogger(recoverOrphanedDataLogger, {
-          jobId: job?.id || 'unknown'
-        })
-        logger.error(`Job failed to complete. ID=${job?.id}. Error=${error}`)
-        // This is a recurring job that re-enqueues itself on success, so we want to also re-enqueue on failure
-        const {
-          data: { discoveryNodeEndpoint }
-        } = job
-        recoverOrphanedDataQueue.add('retry-after-fail', {
-          discoveryNodeEndpoint
-        })
       }
     })
 

--- a/creator-node/test/StateMonitoringManager.test.js
+++ b/creator-node/test/StateMonitoringManager.test.js
@@ -9,7 +9,6 @@ const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')
 
 const config = require('../src/config')
-const StateMonitoringManager = require('../src/services/stateMachineManager/stateMonitoring')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
@@ -114,32 +113,5 @@ describe('test StateMonitoringManager initialization, events, and re-enqueuing',
     expect(isQueuePaused).to.be.true
     return expect(monitorStateQueue.getJobs('delayed')).to.eventually.be
       .fulfilled.and.be.empty
-  })
-
-  it('re-enqueues a new job with the correct data after a job fails', async function () {
-    // Initialize StateMonitoringManager and stubbed queue.add()
-    const discoveryNodeEndpoint = 'http://test_dn.co'
-    const stateMonitoringManager = new StateMonitoringManager()
-    await stateMonitoringManager.init(getPrometheusRegistry())
-    const queueAdd = sandbox.stub()
-
-    // Call function that enqueues a new job after the previous job failed
-    const prevJobProcessedUserId = 100
-    const failedJob = {
-      data: {
-        lastProcessedUserId: prevJobProcessedUserId,
-        discoveryNodeEndpoint: discoveryNodeEndpoint
-      }
-    }
-    stateMonitoringManager.enqueueMonitorStateJobAfterFailure(
-      { add: queueAdd },
-      failedJob
-    )
-
-    // Verify that the queue has the correct initial job in it
-    expect(queueAdd).to.have.been.calledOnceWithExactly('retry-after-fail', {
-      lastProcessedUserId: prevJobProcessedUserId,
-      discoveryNodeEndpoint: discoveryNodeEndpoint
-    })
   })
 })


### PR DESCRIPTION
### Description

- Fixes `onFailure` not being recognized due to calling `queue.on` instead of `worker.on` (this is most likely what made jobs not re-enqueue properly)
- Makes `onError` run the same recovery code as `onFailure` (`onError` catches "missing lock for job" errors, so we want to recover from those instead of only relying on onFailure)
- Adds global `onFailure` and `onError` callbacks using QueueEvents. This should be more reliable than per-worker events because it uses Redis streams instead of pub-sub



### Tests
Tested 2 failure scenarios with debugger:
1. Job throws an error in its processor - it recovers and re-enqueues
2. Job throws an error in its onComplete callback - it's not able to recover but logs  `Fatal: onComplete errored. Cron queues may be broken`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
* Look out for the following error log: `Fatal: onComplete errored. Cron queues may be broken`
* Check state machine queues on `/health/bull` to make sure they all have active or waiting jobs