### PR TITLE
[PAY-489] Add endpoint to get ethereum-nft-gated premium track signatures

### DIFF
--- a/discovery-provider/integration_tests/premium_content/test_access.py
+++ b/discovery-provider/integration_tests/premium_content/test_access.py
@@ -17,13 +17,25 @@ def test_access(app):
         "track_id": 2,
         "owner_id": 3,
         "is_premium": True,
-        "premium_conditions": {"nft_collection": "some-nft-collection"},
+        "premium_conditions": {
+            "nft_collection": {
+                "chain": "eth",
+                "standard": "ERC721",
+                "address": "some-nft-collection",
+            }
+        },
     }
     premium_track_entity_2 = {
         "track_id": 3,
         "owner_id": 2,
         "is_premium": True,
-        "premium_conditions": {"nft_collection": "some-nft-collection"},
+        "premium_conditions": {
+            "nft_collection": {
+                "chain": "eth",
+                "standard": "ERC721",
+                "address": "some-nft-collection",
+            }
+        },
     }
     track_entities = [
         non_premium_track_entity,
@@ -98,13 +110,25 @@ def test_batch_access(app):
         premium_track_entity_1 = {
             "track_id": 3,
             "is_premium": True,
-            "premium_conditions": {"nft_collection": "some-nft-collection"},
+            "premium_conditions": {
+                "nft_collection": {
+                    "chain": "eth",
+                    "standard": "ERC721",
+                    "address": "some-nft-collection",
+                }
+            },
         }
         premium_track_entity_2 = {
             "track_id": 4,
             "owner_id": user_entity_3["user_id"],
             "is_premium": True,
-            "premium_conditions": {"nft_collection": "some-nft-collection"},
+            "premium_conditions": {
+                "nft_collection": {
+                    "chain": "eth",
+                    "standard": "ERC721",
+                    "address": "some-nft-collection",
+                }
+            },
         }
         track_entities = [
             non_premium_track_entity,

--- a/discovery-provider/src/abis/ERC1155.json
+++ b/discovery-provider/src/abis/ERC1155.json
@@ -1,0 +1,314 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "URI",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "uri",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/discovery-provider/src/abis/ERC721.json
+++ b/discovery-provider/src/abis/ERC721.json
@@ -1,0 +1,333 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/discovery-provider/src/api/v1/models/tracks.py
+++ b/discovery-provider/src/api/v1/models/tracks.py
@@ -71,13 +71,6 @@ field_visibility = ns.model(
     },
 )
 
-premium_conditions = ns.model(
-    "premium_conditions",
-    {
-        "nft_collection": fields.String,
-        "follow_user_id": fields.Integer,
-    },
-)
 premium_content_signature = ns.model(
     "premium_content_signature",
     {"data": fields.String, "signature": fields.String},
@@ -139,7 +132,7 @@ track_full = ns.clone(
         "remix_of": fields.Nested(full_remix_parent),
         "is_available": fields.Boolean,
         "is_premium": fields.Boolean,
-        "premium_conditions": fields.Nested(premium_conditions, allow_null=True),
+        "premium_conditions": fields.Raw(allow_null=True),
         "premium_content_signature": fields.Nested(
             premium_content_signature, allow_null=True
         ),

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1211,7 +1211,7 @@ track_signatures_parser.add_argument(
 )
 
 
-@full_ns.route("/<string:user_id>/signatures")
+@full_ns.route("/<string:user_id>/nft-gated-signatures")
 class NFTGatedPremiumTrackSignatures(Resource):
     @record_metrics
     @full_ns.doc(

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1201,7 +1201,13 @@ class FeelingLucky(Resource):
 
 track_signatures_parser = reqparse.RequestParser(argument_class=DescriptiveArgument)
 track_signatures_parser.add_argument(
-    "track_ids", description="The premium track ids and user's respective nft token ids"
+    "track_ids",
+    description="""A string representation of track ids and corresponding nft token ids from user for that track's nft collection.
+        For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.
+        Example: '1-1.2_2_3-1' represents track ids 1, 2, and 3 (separated by '_').
+        Track id and its token ids are separated by a dash '-'.
+        In the above example, the user claims to own token ids 1 and 2 (separated by '.') for track id 1.
+        Similarly, the user claims to own token id 1 for track id 3.""",
 )
 
 
@@ -1212,12 +1218,7 @@ class NFTGatedPremiumTrackSignatures(Resource):
         id="""Get Premium Track Signatures""",
         description="""Gets premium track signatures for passed in premium track ids""",
         params={
-            "track_ids": """A string representation of track ids and corresponding nft token ids from user for that track's nft collection.
-            For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.
-            Example: '1-1.2_2_3-1' represents track ids 1, 2, and 3 (separated by '_').
-            Track id and its token ids are separarted by a dash '-'.
-            In the above example, the user claims to own token ids 1 and 2 (separated by '.') for track id 1.
-            Similarly, the user claims to own token id 1 for track id 3.""",
+            "user_id": """The user for whom we are generating premium track signatures."""
         },
     )
     @full_ns.expect(track_signatures_parser)

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -67,7 +67,6 @@ from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
-from .models.tracks import premium_content_signature
 from .models.tracks import remixes_response as remixes_response_model
 from .models.tracks import stem_full, track, track_full
 
@@ -1204,9 +1203,6 @@ track_signatures_parser = reqparse.RequestParser(argument_class=DescriptiveArgum
 track_signatures_parser.add_argument(
     "track_ids", description="The premium track ids and user's respective nft token ids"
 )
-track_signatures = make_response(
-    "track_signatures", full_ns, fields.List(fields.Nested(premium_content_signature))
-)
 
 
 @full_ns.route("/<string:user_id>/signatures")
@@ -1225,7 +1221,6 @@ class NFTGatedPremiumTrackSignatures(Resource):
         },
     )
     @full_ns.expect(track_signatures_parser)
-    @full_ns.marshal_with(track_signatures)
     @cache(ttl_sec=5)
     def get(self, user_id):
         decoded_user_id = decode_with_abort(user_id, full_ns)

--- a/discovery-provider/src/premium_content/helpers.py
+++ b/discovery-provider/src/premium_content/helpers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from src.models.social.follow import Follow
 from src.utils import db_session
@@ -6,7 +7,7 @@ from src.utils import db_session
 logger = logging.getLogger(__name__)
 
 
-def does_user_have_nft_collection(user_id: int, nft_collection: str):
+def does_user_have_nft_collection(user_id: int, nft_collection: Any):
     # todo: check whether user has the nft from some user_wallet_nfts table
     # which is populated during nft indexing
     # db = db_session.get_db_read_replica()
@@ -14,7 +15,7 @@ def does_user_have_nft_collection(user_id: int, nft_collection: str):
     return True
 
 
-def does_user_follow_artist(user_id: int, artist_id: int):
+def does_user_follow_artist(user_id: int, follow_user_id: int):
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
         result = (
@@ -22,7 +23,7 @@ def does_user_follow_artist(user_id: int, artist_id: int):
             .filter(Follow.is_current == True)
             .filter(Follow.is_delete == False)
             .filter(Follow.follower_user_id == user_id)
-            .filter(Follow.followee_user_id == artist_id)
+            .filter(Follow.followee_user_id == follow_user_id)
             .one_or_none()
         )
         return True if result else False

--- a/discovery-provider/src/premium_content/premium_content_access_checker.py
+++ b/discovery-provider/src/premium_content/premium_content_access_checker.py
@@ -82,7 +82,7 @@ class PremiumContentAccessChecker:
         # premium_conditions should always be true here because we know
         # that is_premium is true if we get here and it makes no sense
         # to have a premium track with no conditions
-        if not premium_conditions:
+        if premium_conditions is None:
             logger.warn(
                 f"premium_content_access_checker.py | check_access | premium content with id {premium_content_id} and type {premium_content_type} has no premium conditions."
             )
@@ -166,7 +166,7 @@ class PremiumContentAccessChecker:
             # premium_conditions should always be true here because we know
             # that is_premium is true if we get here and it makes no sense
             # to have a premium track with no conditions
-            elif not premium_conditions:
+            elif premium_conditions is None:
                 logger.warn(
                     f"premium_content_access_checker.py | check_access_for_batch | premium content with id {track_id} and type 'track' has no premium conditions."
                 )

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -46,7 +46,7 @@ def _does_user_own_erc721_nft_collection(
                 return True
         except Exception as e:
             logger.error(
-                f"Could not get nft balance for erc721 nft collection {contract_address} and user wallet {wallet}."
+                f"Could not get nft balance for erc721 nft collection {contract_address} and user wallet {wallet}. Error: {e}"
             )
     return False
 
@@ -67,7 +67,7 @@ def _does_user_own_erc1155_nft_collection(
                 return True
         except Exception as e:
             logger.error(
-                f"Could not get nft balance for erc1155 nft collection {contract_address} and user wallet {wallet}."
+                f"Could not get nft balance for erc1155 nft collection {contract_address} and user wallet {wallet}. Error: {e}"
             )
     return False
 
@@ -102,7 +102,7 @@ def _get_eth_nft_gated_track_signatures(
         map(Web3.toChecksumAddress, eth_associated_wallets + [user_wallet])
     )
 
-    ### Handle premium tracks gated by ERC721 nft collections
+    # Handle premium tracks gated by ERC721 nft collections
     erc721_gated_tracks = list(
         filter(
             lambda track: track.premium_conditions["nft_collection"]["standard"]
@@ -144,12 +144,12 @@ def _get_eth_nft_gated_track_signatures(
                                 "user_wallet": user_wallet,
                             }
                         )
-            except Exception as exc:
+            except Exception as e:
                 logger.error(
-                    f"Could not future result for erc721 contract_address {contract_address}. Error: {exc}"
+                    f"Could not future result for erc721 contract_address {contract_address}. Error: {e}"
                 )
 
-    ### Handle premium tracks gated by ERC1155 nft collections
+    # Handle premium tracks gated by ERC1155 nft collections
     erc1155_gated_tracks = list(
         filter(
             lambda track: track.premium_conditions["nft_collection"]["standard"]
@@ -202,9 +202,9 @@ def _get_eth_nft_gated_track_signatures(
                                 "user_wallet": user_wallet,
                             }
                         )
-            except Exception as exc:
+            except Exception as e:
                 logger.error(
-                    f"Could not future result for erc1155 contract_address {contract_address}. Error: {exc}"
+                    f"Could not future result for erc1155 contract_address {contract_address}. Error: {e}"
                 )
 
     return track_signature_map

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -85,7 +85,9 @@ def _get_nft_gated_tracks(track_ids: List[int], session: Session):
         .all()
     )
     nft_gated_tracks = list(
-        filter(lambda track: "nft_collection" in track, premium_tracks)
+        filter(
+            lambda track: "nft_collection" in track.premium_conditions, premium_tracks  # type: ignore
+        )
     )
     return nft_gated_tracks
 
@@ -105,7 +107,7 @@ def _get_eth_nft_gated_track_signatures(
     # Handle premium tracks gated by ERC721 nft collections
     erc721_gated_tracks = list(
         filter(
-            lambda track: track.premium_conditions["nft_collection"]["standard"]
+            lambda track: track.premium_conditions["nft_collection"]["standard"]  # type: ignore
             == "ERC721",
             tracks,
         )
@@ -117,7 +119,7 @@ def _get_eth_nft_gated_track_signatures(
     erc721_collection_track_map = defaultdict(list)
     for track in erc721_gated_tracks:
         contract_address = Web3.toChecksumAddress(
-            track.premium_conditions["nft_collection"]["address"]
+            track.premium_conditions["nft_collection"]["address"]  # type: ignore
         )
         erc721_collection_track_map[contract_address].append(track.track_id)
 
@@ -152,7 +154,7 @@ def _get_eth_nft_gated_track_signatures(
     # Handle premium tracks gated by ERC1155 nft collections
     erc1155_gated_tracks = list(
         filter(
-            lambda track: track.premium_conditions["nft_collection"]["standard"]
+            lambda track: track.premium_conditions["nft_collection"]["standard"]  # type: ignore
             == "ERC1155",
             tracks,
         )
@@ -168,7 +170,7 @@ def _get_eth_nft_gated_track_signatures(
     contract_address_token_id_map: Dict[str, Set[int]] = defaultdict(set)
     for track in erc1155_gated_tracks:
         contract_address = Web3.toChecksumAddress(
-            track.premium_conditions["nft_collection"]["address"]
+            track.premium_conditions["nft_collection"]["address"]  # type: ignore
         )
         erc1155_collection_track_map[contract_address].append(track.track_id)
         track_token_id_set = set(map(int, track_token_id_map[track.track_id]))

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -1,0 +1,255 @@
+import logging
+from collections import defaultdict
+from typing import Dict, List, Set
+
+from sqlalchemy.orm.session import Session
+from src.models.tracks.track import Track
+from src.models.users.user import User
+from src.premium_content.premium_content_access_checker import (
+    premium_content_access_checker,
+)
+from src.premium_content.signature import get_premium_content_signature
+from src.queries.get_associated_user_wallet import get_associated_user_wallet
+from src.utils import db_session, web3_provider
+
+logger = logging.getLogger(__name__)
+
+erc721_abi = '[{"constant":true,"inputs":[{"internalType":"address","name":"owner","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}]'
+erc1155_abi = '[{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"id","type":"uint256"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address[]","name":"accounts","type":"address[]"},{"internalType":"uint256[]","name":"ids","type":"uint256[]"}],"name":"balanceOfBatch","outputs":[{"internalType":"uint256[]","name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"}]'
+
+eth_web3 = web3_provider.get_eth_web3()
+
+
+def _get_user_wallet(user_id: int, session: Session):
+    user_wallet = (
+        session.query(User.wallet)
+        .filter(
+            User.user_id == user_id,
+            User.is_current == True,
+        )
+        .one_or_none()
+    )
+    return user_wallet[0] if user_wallet else None
+
+
+def _get_nft_gated_tracks(track_ids: List[int], session: Session):
+    premium_tracks = (
+        session.query(Track)
+        .filter(
+            Track.is_premium == True,
+            Track.track_id.in_(track_ids),
+            Track.is_current == True,
+            Track.is_delete == False,
+        )
+        .all()
+    )
+    nft_gated_tracks = list(
+        filter(lambda track: "nft_collection" in track, premium_tracks)
+    )
+    return nft_gated_tracks
+
+
+def _get_eth_nft_gated_track_signatures(
+    user_id: int,
+    user_wallet: str,
+    eth_associated_wallets: List[str],
+    tracks: List[Track],
+    track_token_id_map: Dict[int, List[str]],
+):
+    track_signature_map = {}
+
+    user_eth_wallets = eth_associated_wallets + [user_wallet]
+    erc721_gated_tracks = list(
+        filter(
+            lambda track: track.premium_conditions["nft_collection"]["standard"]
+            == "ERC721",
+            tracks,
+        )
+    )
+    erc721_collection_track_map = defaultdict(list)
+    for track in erc721_gated_tracks:
+        contract_address = track.premium_conditions["nft_collection"]["address"]
+        erc721_collection_track_map[contract_address].append(track.track_id)
+
+    for contract_address, track_ids in erc721_collection_track_map.items():
+        for wallet in user_eth_wallets:
+            try:
+                contract = eth_web3.eth.contract(
+                    address=contract_address, abi=erc721_abi
+                )
+                nft_balance = contract.functions.balanceOf(wallet).call()
+                if int(nft_balance):
+                    for track_id in track_ids:
+                        track_signature_map[track_id] = get_premium_content_signature(
+                            {
+                                "id": track_id,
+                                "type": "track",
+                                "user_wallet": user_wallet,
+                            }
+                        )
+                    break
+            except Exception as e:
+                logger.error(
+                    f"Could not get nft balance for erc721 nft collection {contract_address} and user wallet {wallet}."
+                )
+
+    erc1155_gated_tracks = list(
+        filter(
+            lambda track: track.premium_conditions["nft_collection"]["standard"]
+            == "ERC1155",
+            tracks,
+        )
+    )
+    erc1155_collection_track_map = defaultdict(list)
+    contract_address_token_id_map: Dict[str, Set[str]] = {}
+    for track in erc1155_gated_tracks:
+        contract_address = track.premium_conditions["nft_collection"]["address"]
+        erc1155_collection_track_map[contract_address].append(track.track_id)
+        contract_address_token_id_map[contract_address] = contract_address_token_id_map[
+            contract_address
+        ].union(set(track_token_id_map[track.track_id]))
+
+    for track_id, token_ids in track_token_id_map.items():
+        pass
+
+    for contract_address, track_ids in erc1155_collection_track_map.items():
+        for wallet in user_eth_wallets:
+            try:
+                contract = eth_web3.eth.contract(
+                    address=contract_address, abi=erc1155_abi
+                )
+                token_ids = list(contract_address_token_id_map[contract_address])
+                nft_balances = contract.functions.balanceOfBatch(
+                    [wallet] * len(token_ids), token_ids
+                ).call()
+                positive_nft_balances = list(
+                    filter(lambda nft_balance: int(nft_balance), nft_balances)
+                )
+                if positive_nft_balances:
+                    for track_id in erc721_collection_track_map[contract_address]:
+                        track_signature_map[track_id] = get_premium_content_signature(
+                            {
+                                "id": track_id,
+                                "type": "track",
+                                "user_wallet": user_wallet,
+                            }
+                        )
+                    break
+            except Exception as e:
+                logger.error(
+                    f"Could not get nft balance for erc1155 nft collection {contract_address} and user wallet {wallet}."
+                )
+
+    return track_signature_map
+
+
+def _get_sol_nft_gated_track_signatures(
+    user_id: int,
+    user_wallet: str,
+    sol_associated_wallets: List[str],
+    tracks: List[Track],
+):
+    return {}
+
+
+# Generates a premium content signature for each of the nft-gated tracks
+# in the map that the given user should have access to.
+def get_nft_gated_premium_track_signatures(
+    user_id: int, track_token_id_map: Dict[int, List[str]]
+):
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        user_wallet = _get_user_wallet(user_id, session)
+        associated_wallets = get_associated_user_wallet({"user_id": user_id})
+        if not user_wallet:
+            logger.warn(
+                f"get_premium_track_signatures.py | get_nft_gated_premium_track_signatures | no wallet for user_id {user_id}"
+            )
+            return {}
+
+        nft_gated_tracks = _get_nft_gated_tracks(
+            list(track_token_id_map.keys()), session
+        )
+        eth_nft_gated_tracks = list(
+            filter(
+                lambda track: track["nft_collection"]["chain"] == "eth",
+                nft_gated_tracks,
+            )
+        )
+        sol_nft_gated_tracks = list(
+            filter(
+                lambda track: track["nft_collection"]["chain"] == "sol",
+                nft_gated_tracks,
+            )
+        )
+        eth_nft_gated_track_signatures = _get_eth_nft_gated_track_signatures(
+            user_id=user_id,
+            user_wallet=user_wallet,
+            eth_associated_wallets=associated_wallets["eth"],
+            tracks=eth_nft_gated_tracks,
+            track_token_id_map=track_token_id_map,
+        )
+        sol_nft_gated_track_signatures = _get_sol_nft_gated_track_signatures(
+            user_id=user_id,
+            user_wallet=user_wallet,
+            sol_associated_wallets=associated_wallets["sol"],
+            tracks=sol_nft_gated_tracks,
+        )
+
+        result = {}
+        for track_id, signature in eth_nft_gated_track_signatures.items():
+            result[track_id] = signature
+        for track_id, signature in sol_nft_gated_track_signatures.items():
+            result[track_id] = signature
+
+        return result
+
+
+# Generates a premium content signature for each of the tracks
+# in the map that the given user should have access to.
+def get_premium_track_signatures(user_id: int, track_ids: List[int]):
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        user_wallet = _get_user_wallet(user_id, session)
+        if not user_wallet:
+            logger.warn(
+                f"get_premium_track_signatures.py | get_premium_track_signatures | no wallet for user_id {user_id}"
+            )
+            return {}
+
+        args = list(
+            map(
+                lambda track_id: {
+                    "user_id": user_id,
+                    "premium_content_id": track_id,
+                    "premium_content_type": "track",
+                },
+                track_ids,
+            )
+        )
+        premium_track_batch_access = (
+            premium_content_access_checker.check_access_for_batch(session, args)
+        )
+
+        if (
+            "track" not in premium_track_batch_access
+            or user_id not in premium_track_batch_access["track"]
+        ):
+            return []
+
+        track_access_for_user = premium_track_batch_access["track"][user_id]
+        track_ids_with_access = list(
+            filter(
+                lambda track_id: track_access_for_user[track_id][
+                    "does_user_have_access"
+                ],
+                track_access_for_user.keys(),
+            )
+        )
+
+        track_signature_map = {}
+        for track_id in track_ids_with_access:
+            track_signature_map[track_id] = get_premium_content_signature(
+                {"id": track_id, "type": "track", "user_wallet": user_wallet}
+            )
+        return track_signature_map

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -1,5 +1,7 @@
 import concurrent.futures
+import json
 import logging
+import pathlib
 from collections import defaultdict
 from typing import Dict, List, Set
 
@@ -17,8 +19,8 @@ from web3 import Web3
 
 logger = logging.getLogger(__name__)
 
-erc721_abi = '[{"constant":true,"inputs":[{"internalType":"address","name":"owner","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}]'
-erc1155_abi = '[{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"id","type":"uint256"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address[]","name":"accounts","type":"address[]"},{"internalType":"uint256[]","name":"ids","type":"uint256[]"}],"name":"balanceOfBatch","outputs":[{"internalType":"uint256[]","name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"}]'
+erc721_abi = None
+erc1155_abi = None
 
 eth_web3 = web3_provider.get_eth_web3()
 
@@ -320,3 +322,16 @@ def get_premium_track_signatures(user_id: int, track_ids: List[int]):
                 {"id": track_id, "type": "track", "user_wallet": user_wallet}
             )
         return track_signature_map
+
+
+def _load_abis():
+    global erc721_abi
+    global erc1155_abi
+    ERC721_ABI_PATH = pathlib.Path(__file__).parent / "../abis" / "ERC721.json"
+    ERC1155_ABI_PATH = pathlib.Path(__file__).parent / "../abis" / "ERC1155.json"
+    with open(ERC721_ABI_PATH) as f721, open(ERC1155_ABI_PATH) as f1155:
+        erc721_abi = json.dumps(json.load(f721))
+        erc1155_abi = json.dumps(json.load(f1155))
+
+
+_load_abis()

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -341,18 +341,89 @@
             "title": "CID"
         },
         "PremiumConditions": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/PremiumConditionsNFTCollection"
+                },
+                {
+                    "$ref": "#/definitions/PremiumConditionsFollowUserId"
+                }
+            ],
+            "title": "PremiumConditions"
+        },
+        "PremiumConditionsNFTCollection": {
+            "type": "object",
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
+                },
+                {
+                    "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+                }
+            ],
+            "title": "PremiumConditionsNFTCollection"
+        },
+        "PremiumConditionsEthNFTCollection": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "nft_collection": {
+                "chain": {
+                    "type": "string",
+                    "const": "eth"
+                },
+                "address": {
                     "type": "string"
                 },
+                "standard": {
+                    "enum": [
+                        "ERC721",
+                        "ERC1155"
+                    ]
+                }
+            },
+            "required": [
+                "chain",
+                "address",
+                "standard"
+            ],
+            "title": "PremiumConditionsEthNFTCollection"
+        },
+        "PremiumConditionsSolNFTCollection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chain": {
+                    "type": "string",
+                    "const": "sol"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "chain",
+                "name"
+            ],
+            "title": "PremiumConditionsSolNFTCollection"
+        },
+        "PremiumConditionsFollowUserId": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
                 "follow_user_id": {
                     "type": "number"
                 }
             },
-            "required": [],
-            "title": "PremiumConditions"
+            "required": [
+                "follow_user_id"
+            ],
+            "title": "PremiumConditionsFollowUserId"
         }
     }
 }

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -200,7 +200,9 @@
                 "stem_of",
                 "tags",
                 "title",
-                "track_segments"
+                "track_segments",
+                "is_premium",
+                "premium_conditions"
             ],
             "title": "Track"
         },
@@ -341,12 +343,11 @@
             "title": "CID"
         },
         "PremiumConditions": {
-            "type": [
-                "object",
-                "null"
-            ],
             "additionalProperties": false,
             "oneOf": [
+                {
+                    "type": "null"
+                },
                 {
                     "$ref": "#/definitions/PremiumConditionsNFTCollection"
                 },

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -359,13 +359,23 @@
         "PremiumConditionsNFTCollection": {
             "type": "object",
             "additionalProperties": false,
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+            "properties": {
+                "nft_collection": {
+                    "type": "object",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+                            }
+                        ]
+                    }
                 }
+            },
+            "required": [
+                "nft_collection"
             ],
             "title": "PremiumConditionsNFTCollection"
         },

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -175,8 +175,19 @@
                         "object",
                         "null"
                     ],
-                    "$ref": "#/definitions/PremiumConditions",
-                    "default": null
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsNFTCollection"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsFollowUserId"
+                            }
+                        ]
+                    }
                 }
             },
             "required": [
@@ -341,21 +352,6 @@
             "maxLength": 46,
             "pattern": "^Qm[a-zA-Z0-9]{44}$",
             "title": "CID"
-        },
-        "PremiumConditions": {
-            "additionalProperties": false,
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsNFTCollection"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsFollowUserId"
-                }
-            ],
-            "title": "PremiumConditions"
         },
         "PremiumConditionsNFTCollection": {
             "type": "object",

--- a/libs/src/sdk/api/generated/full/.openapi-generator/FILES
+++ b/libs/src/sdk/api/generated/full/.openapi-generator/FILES
@@ -38,7 +38,6 @@ models/PlaylistAddedTimestamp.ts
 models/PlaylistArtwork.ts
 models/PlaylistFull.ts
 models/PlaylistLibrary.ts
-models/PremiumConditions.ts
 models/PremiumContentSignature.ts
 models/ProfilePicture.ts
 models/RelatedArtistResponseFull.ts

--- a/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -89,11 +89,11 @@ export interface GetMostLovedTracksRequest {
 
 export interface GetPremiumTrackSignaturesRequest {
     /**
-     * 
+     * The user for whom we are generating premium track signatures.
      */
     userId: string;
     /**
-     * A string representation of track ids and corresponding nft token ids from user for that track\&#39;s nft collection.             For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.             Example: \&#39;1-1.2_2_3-1\&#39; represents track ids 1, 2, and 3 (separated by \&#39;_\&#39;).             Track id and its token ids are separated by a dash \&#39;-\&#39;.             In the above example, the user claims to own token ids 1 and 2 (separated by \&#39;.\&#39;) for track id 1.             Similarly, the user claims to own token id 1 for track id 3.
+     * A string representation of track ids and corresponding nft token ids from user for that track\&#39;s nft collection.         For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.         Example: \&#39;1-1.2_2_3-1\&#39; represents track ids 1, 2, and 3 (separated by \&#39;_\&#39;).         Track id and its token ids are separated by a dash \&#39;-\&#39;.         In the above example, the user claims to own token ids 1 and 2 (separated by \&#39;.\&#39;) for track id 1.         Similarly, the user claims to own token id 1 for track id 3.
      */
     trackIds?: string;
 }

--- a/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -87,6 +87,17 @@ export interface GetMostLovedTracksRequest {
     withUsers?: boolean;
 }
 
+export interface GetPremiumTrackSignaturesRequest {
+    /**
+     * 
+     */
+    userId: string;
+    /**
+     * A string representation of track ids and corresponding nft token ids from user for that track\&#39;s nft collection.             For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.             Example: \&#39;1-1.2_2_3-1\&#39; represents track ids 1, 2, and 3 (separated by \&#39;_\&#39;).             Track id and its token ids are separated by a dash \&#39;-\&#39;.             In the above example, the user claims to own token ids 1 and 2 (separated by \&#39;.\&#39;) for track id 1.             Similarly, the user claims to own token id 1 for track id 3.
+     */
+    trackIds?: string;
+}
+
 export interface GetRecommendedTracksRequest {
     /**
      * The number of items to fetch

--- a/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -93,9 +93,13 @@ export interface GetPremiumTrackSignaturesRequest {
      */
     userId: string;
     /**
-     * A string representation of track ids and corresponding nft token ids from user for that track\&#39;s nft collection.         For tracks gated with the ERC1155 nft token standard, we also need the nft token ids claimed to be owned by the user.         Example: \&#39;1-1.2_2_3-1\&#39; represents track ids 1, 2, and 3 (separated by \&#39;_\&#39;).         Track id and its token ids are separated by a dash \&#39;-\&#39;.         In the above example, the user claims to own token ids 1 and 2 (separated by \&#39;.\&#39;) for track id 1.         Similarly, the user claims to own token id 1 for track id 3.
+     * A list of track ids. The order of these track ids will match the order of the token ids.
      */
-    trackIds?: string;
+    trackIds?: Array<number>;
+    /**
+     * A list of ERC1155 token ids. The order of these token ids will match the order of the track ids.         There may be multiple token ids for a given track id, so we use a \&#39;-\&#39; as the delimiter for a track id\&#39;s token ids.
+     */
+    tokenIds?: Array<string>;
 }
 
 export interface GetRecommendedTracksRequest {

--- a/libs/src/sdk/api/generated/full/models/TrackFull.ts
+++ b/libs/src/sdk/api/generated/full/models/TrackFull.ts
@@ -38,12 +38,6 @@ import {
     FullRemixParentToJSON,
 } from './FullRemixParent';
 import {
-    PremiumConditions,
-    PremiumConditionsFromJSON,
-    PremiumConditionsFromJSONTyped,
-    PremiumConditionsToJSON,
-} from './PremiumConditions';
-import {
     PremiumContentSignature,
     PremiumContentSignatureFromJSON,
     PremiumContentSignatureFromJSONTyped,
@@ -335,10 +329,10 @@ export interface TrackFull
         is_premium?: boolean;
         /**
         * 
-        * @type {PremiumConditions}
+        * @type {object}
         * @memberof TrackFull
         */
-        premium_conditions?: PremiumConditions;
+        premium_conditions?: object;
         /**
         * 
         * @type {PremiumContentSignature}

--- a/libs/src/sdk/api/generated/full/models/index.ts
+++ b/libs/src/sdk/api/generated/full/models/index.ts
@@ -31,7 +31,6 @@ export * from './PlaylistAddedTimestamp';
 export * from './PlaylistArtwork';
 export * from './PlaylistFull';
 export * from './PlaylistLibrary';
-export * from './PremiumConditions';
 export * from './PremiumContentSignature';
 export * from './ProfilePicture';
 export * from './RelatedArtistResponseFull';

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -121,8 +121,19 @@
                 },
                 "premium_conditions": {
                     "type": ["object", "null"],
-                    "$ref": "#/definitions/PremiumConditions",
-                    "default": null
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsNFTCollection"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsFollowUserId"
+                            }
+                        ]
+                    }
                 }
             },
             "required": [
@@ -273,21 +284,6 @@
             "maxLength": 46,
             "pattern": "^Qm[a-zA-Z0-9]{44}$",
             "title": "CID"
-        },
-        "PremiumConditions": {
-            "additionalProperties": false,
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsNFTCollection"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsFollowUserId"
-                }
-            ],
-            "title": "PremiumConditions"
         },
         "PremiumConditionsNFTCollection": {
             "type": "object",

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -275,9 +275,11 @@
             "title": "CID"
         },
         "PremiumConditions": {
-            "type": ["object", "null"],
             "additionalProperties": false,
             "oneOf": [
+                {
+                    "type": "null"
+                },
                 {
                     "$ref": "#/definitions/PremiumConditionsNFTCollection"
                 },

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -290,13 +290,23 @@
         "PremiumConditionsNFTCollection": {
             "type": "object",
             "additionalProperties": false,
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
-                },
-                {
-                    "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+            "properties": {
+                "nft_collection": {
+                    "type": "object",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
+                            },
+                            {
+                                "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+                            }
+                        ]
+                    }
                 }
+            },
+            "required": [
+                "nft_collection"
             ],
             "title": "PremiumConditionsNFTCollection"
         },

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -277,16 +277,84 @@
         "PremiumConditions": {
             "type": ["object", "null"],
             "additionalProperties": false,
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/PremiumConditionsNFTCollection"
+                },
+                {
+                    "$ref": "#/definitions/PremiumConditionsFollowUserId"
+                }
+            ],
+            "title": "PremiumConditions"
+        },
+        "PremiumConditionsNFTCollection": {
+            "type": "object",
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/PremiumConditionsEthNFTCollection"
+                },
+                {
+                    "$ref": "#/definitions/PremiumConditionsSolNFTCollection"
+                }
+            ],
+            "title": "PremiumConditionsNFTCollection"
+        },
+        "PremiumConditionsEthNFTCollection": {
+            "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "nft_collection": {
+                "chain": {
+                    "type": "string",
+                    "const": "eth"
+                },
+                "address": {
                     "type": "string"
                 },
+                "standard": {
+                    "enum": [
+                        "ERC721",
+                        "ERC1155"
+                    ]
+                }
+            },
+            "required": [
+                "chain",
+                "address",
+                "standard"
+            ],
+            "title": "PremiumConditionsEthNFTCollection"
+        },
+        "PremiumConditionsSolNFTCollection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chain": {
+                    "type": "string",
+                    "const": "sol"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "chain",
+                "name"
+            ],
+            "title": "PremiumConditionsSolNFTCollection"
+        },
+        "PremiumConditionsFollowUserId": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
                 "follow_user_id": {
                     "type": "number"
                 }
             },
-            "required": [],
-            "title": "PremiumConditions"
+            "required": [
+                "follow_user_id"
+            ],
+            "title": "PremiumConditionsFollowUserId"
         }
     }
 }

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -85,8 +85,23 @@ export interface Download {
   cid: Nullable<string>
 }
 
+export type TokenStandard = 'ERC721' | 'ERC1155'
+
+export type PremiumConditionsEthNFTCollection = {
+  chain: 'eth'
+  standard: TokenStandard
+  address: string
+}
+
+export type PremiumConditionsSolNFTCollection = {
+  chain: 'sol'
+  name: string
+}
+
 export type PremiumConditions = {
-  nft_collection?: string
+  nft_collection?:
+    | PremiumConditionsEthNFTCollection
+    | PremiumConditionsSolNFTCollection
   follow_user_id?: number
 }
 


### PR DESCRIPTION
### Description

Add endpoint to get etheurem-nft-gated premium track signatures. It works by checking for a positive balance for any of the user's ethereum wallets for a given ethereum nft collection contract address. For the collections that the user owns, signatures are generated for all premium tracks that are gated by that nft collection.

This PR also updates the premium conditions types accordingly.

Solana nfts access check is not implemented in this PR.

### Tests

Spun up services on remote box and pointed to the mainnet ethereum chain within the new endpoint helper function, passed in corresponding user wallet <> contract address <> token ids combinations and made sure that signatures were generated accordingly.

Need to test again with the latest parallelization commit added.
Edit: tested with the concurrency implementation and it works too. With 1 user wallet that owns 1 ERC721 nft (one contract address) and 5 ERC1155 nfts (one contract address), the calls to check the ownership for those 2 contract address averaged to about 0.4 seconds after about 10 tries. I realize this is a small sample size, can do more tests but we should be good here.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

Logs are added in case of errors.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->