### PR TITLE
[PAY-664] Backfill audio_tx_history userbank indexing

### DIFF
--- a/discovery-provider/alembic/versions/3e99d419fd63_add_sig_to_indexing_checkpoints.py
+++ b/discovery-provider/alembic/versions/3e99d419fd63_add_sig_to_indexing_checkpoints.py
@@ -1,0 +1,25 @@
+"""add_sig_to_indexing_checkpoints
+
+Revision ID: 3e99d419fd63
+Revises: 93fc0b994aba
+Create Date: 2022-11-02 18:01:28.499717
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3e99d419fd63"
+down_revision = "93fc0b994aba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "indexing_checkpoints", sa.Column("signature", sa.String(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("indexing_checkpoints", "signature")

--- a/discovery-provider/alembic/versions/93fc0b994aba_spl_token_backfill.py
+++ b/discovery-provider/alembic/versions/93fc0b994aba_spl_token_backfill.py
@@ -1,0 +1,30 @@
+"""spl_token_backfill
+
+Revision ID: 93fc0b994aba
+Revises: fcb40409e0a4
+Create Date: 2022-11-01 05:59:50.434959
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "93fc0b994aba"
+down_revision = "fcb40409e0a4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "spl_token_backfill_txs",
+        sa.Column("last_scanned_slot", sa.Integer, nullable=False),
+        sa.Column("signature", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("last_scanned_slot"),
+    )
+
+
+def downgrade():
+    op.drop_table("spl_token_backfill_txs")

--- a/discovery-provider/alembic/versions/93fc0b994aba_spl_token_backfill.py
+++ b/discovery-provider/alembic/versions/93fc0b994aba_spl_token_backfill.py
@@ -18,7 +18,7 @@ depends_on = None
 def upgrade():
     op.create_table(
         "spl_token_backfill_txs",
-        sa.Column("last_scanned_slot", sa.Integer, nullable=False),
+        sa.Column("last_scanned_slot", sa.Integer(), nullable=False),
         sa.Column("signature", sa.String(), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),

--- a/discovery-provider/alembic/versions/ab4f1c314c43_user_bank_backfill.py
+++ b/discovery-provider/alembic/versions/ab4f1c314c43_user_bank_backfill.py
@@ -1,0 +1,42 @@
+"""user_bank_backfill
+
+Revision ID: ab4f1c314c43
+Revises: 42d5afb85d42
+Create Date: 2022-10-31 23:05:10.795098
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ab4f1c314c43"
+down_revision = "42d5afb85d42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_bank_backfill_txs",
+        sa.Column("signature", sa.String(), nullable=False),
+        sa.Column("slot", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("signature"),
+    )
+
+    # idx_user_bank_txs_slots slots
+    op.create_index(
+        op.f("idx_user_bank_backfill_txs_slot"),
+        "user_bank_backfill_txs",
+        ["slot"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_table("user_bank_backfill_txs")
+    op.drop_index(
+        op.f("idx_user_bank_backfill_txs_slot"),
+        table_name="user_bank_backfill_txs",
+        info={"if_exists": True},
+    )

--- a/discovery-provider/alembic/versions/ab4f1c314c43_user_bank_backfill.py
+++ b/discovery-provider/alembic/versions/ab4f1c314c43_user_bank_backfill.py
@@ -1,7 +1,7 @@
 """user_bank_backfill
 
 Revision ID: ab4f1c314c43
-Revises: 42d5afb85d42
+Revises: 03dbd1b775c5
 Create Date: 2022-10-31 23:05:10.795098
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ab4f1c314c43"
-down_revision = "42d5afb85d42"
+down_revision = "03dbd1b775c5"
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/fcb40409e0a4_rewards_manager_backfill.py
+++ b/discovery-provider/alembic/versions/fcb40409e0a4_rewards_manager_backfill.py
@@ -1,0 +1,42 @@
+"""rewards_manager_backfill
+
+Revision ID: fcb40409e0a4
+Revises: ab4f1c314c43
+Create Date: 2022-11-01 04:01:38.951152
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fcb40409e0a4"
+down_revision = "ab4f1c314c43"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "rewards_manager_backfill_txs",
+        sa.Column("signature", sa.String(), nullable=False),
+        sa.Column("slot", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("signature"),
+    )
+
+    # idx_user_bank_txs_slots slots
+    op.create_index(
+        op.f("idx_rewards_manager_backfill_txs_slot"),
+        "rewards_manager_backfill_txs",
+        ["slot"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_table("rewards_manager_backfill_txs")
+    op.drop_index(
+        op.f("idx_rewards_manager_backfill_txs_slot"),
+        table_name="rewards_manager_backfill_txs",
+        info={"if_exists": True},
+    )

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -17,7 +17,6 @@ trending_refresh_seconds = 3600
 infra_setup =
 indexing_transaction_index_sort_order_start_block =
 get_users_cnode_ttl_sec = 5
-backfill_stop_sig = 
 
 [flask]
 debug = true

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -17,6 +17,7 @@ trending_refresh_seconds = 3600
 infra_setup =
 indexing_transaction_index_sort_order_start_block =
 get_users_cnode_ttl_sec = 5
+backfill_stop_sig = 
 
 [flask]
 debug = true

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -429,6 +429,7 @@ def configure_celery(celery, test_config=None):
             "src.tasks.user_listening_history.index_user_listening_history",
             "src.tasks.prune_plays",
             "src.tasks.index_spl_token",
+            "src.tasks.index_spl_token_backfill",
             "src.tasks.index_solana_user_data",
             "src.tasks.index_aggregate_tips",
             "src.tasks.index_reactions",
@@ -539,6 +540,11 @@ def configure_celery(celery, test_config=None):
             "index_spl_token": {
                 "task": "index_spl_token",
                 "schedule": timedelta(seconds=5),
+            },
+            "index_spl_token_backfill": {
+                "task": "index_spl_token_backfill",
+                "schedule": timedelta(seconds=5),
+                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_aggregate_tips": {
                 "task": "index_aggregate_tips",

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -400,7 +400,6 @@ def configure_celery(celery, test_config=None):
     indexing_interval_sec = int(
         shared_config["discprov"]["block_processing_interval_sec"]
     )
-    backfill_stop_sig = shared_config["discprov"]["backfill_stop_sig"]
 
     # Update celery configuration
     celery.conf.update(
@@ -495,7 +494,6 @@ def configure_celery(celery, test_config=None):
             "index_user_bank_backfill": {
                 "task": "index_user_bank_backfill",
                 "schedule": timedelta(seconds=5),
-                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_challenges": {
                 "task": "index_challenges",
@@ -516,7 +514,6 @@ def configure_celery(celery, test_config=None):
             "index_rewards_manager_backfill": {
                 "task": "index_rewards_manager_backfill",
                 "schedule": timedelta(seconds=5),
-                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_related_artists": {
                 "task": "index_related_artists",
@@ -544,7 +541,6 @@ def configure_celery(celery, test_config=None):
             "index_spl_token_backfill": {
                 "task": "index_spl_token_backfill",
                 "schedule": timedelta(seconds=5),
-                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_aggregate_tips": {
                 "task": "index_aggregate_tips",
@@ -629,6 +625,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("index_user_listening_history_lock")
     redis_inst.delete("prune_plays_lock")
     redis_inst.delete("update_aggregate_table:aggregate_user_tips")
+    redis_inst.delete("spl_token_backfill_lock")
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_TRACK_IS_AVAILABLE_LOCK)
 

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -423,6 +423,7 @@ def configure_celery(celery, test_config=None):
             "src.tasks.index_eth",
             "src.tasks.index_oracles",
             "src.tasks.index_rewards_manager",
+            "src.tasks.index_rewards_manager_backfill",
             "src.tasks.index_related_artists",
             "src.tasks.calculate_trending_challenges",
             "src.tasks.user_listening_history.index_user_listening_history",
@@ -510,6 +511,11 @@ def configure_celery(celery, test_config=None):
             "index_rewards_manager": {
                 "task": "index_rewards_manager",
                 "schedule": timedelta(seconds=5),
+            },
+            "index_rewards_manager_backfill": {
+                "task": "index_rewards_manager_backfill",
+                "schedule": timedelta(seconds=5),
+                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_related_artists": {
                 "task": "index_related_artists",
@@ -612,6 +618,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("index_eth_lock")
     redis_inst.delete("index_oracles_lock")
     redis_inst.delete("solana_rewards_manager_lock")
+    redis_inst.delete("solana_rewards_manager_backfill_lock")
     redis_inst.delete("calculate_trending_challenges_lock")
     redis_inst.delete("index_user_listening_history_lock")
     redis_inst.delete("prune_plays_lock")

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -400,6 +400,7 @@ def configure_celery(celery, test_config=None):
     indexing_interval_sec = int(
         shared_config["discprov"]["block_processing_interval_sec"]
     )
+    backfill_stop_sig = shared_config["discprov"]["backfill_stop_sig"]
 
     # Update celery configuration
     celery.conf.update(
@@ -418,6 +419,7 @@ def configure_celery(celery, test_config=None):
             "src.tasks.index_solana_plays",
             "src.tasks.index_challenges",
             "src.tasks.index_user_bank",
+            "src.tasks.index_user_bank_backfill",
             "src.tasks.index_eth",
             "src.tasks.index_oracles",
             "src.tasks.index_rewards_manager",
@@ -487,6 +489,11 @@ def configure_celery(celery, test_config=None):
             "index_user_bank": {
                 "task": "index_user_bank",
                 "schedule": timedelta(seconds=5),
+            },
+            "index_user_bank_backfill": {
+                "task": "index_user_bank_backfill",
+                "schedule": timedelta(seconds=5),
+                "kwargs": {"stop_sig": backfill_stop_sig},
             },
             "index_challenges": {
                 "task": "index_challenges",
@@ -601,6 +608,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("solana_plays_lock")
     redis_inst.delete("index_challenges_lock")
     redis_inst.delete("user_bank_lock")
+    redis_inst.delete("user_bank_backfill_lock")
     redis_inst.delete("index_eth_lock")
     redis_inst.delete("index_oracles_lock")
     redis_inst.delete("solana_rewards_manager_lock")

--- a/discovery-provider/src/models/indexing/indexing_checkpoints.py
+++ b/discovery-provider/src/models/indexing/indexing_checkpoints.py
@@ -8,3 +8,4 @@ class IndexingCheckpoint(Base, RepresentableMixin):
 
     tablename = Column(String, primary_key=True)
     last_checkpoint = Column(Integer, nullable=False)
+    signature = Column(String, nullable=True)

--- a/discovery-provider/src/models/indexing/spl_token_backfill_transaction.py
+++ b/discovery-provider/src/models/indexing/spl_token_backfill_transaction.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, DateTime, Integer, String, func
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class SPLTokenBackfillTransaction(Base, RepresentableMixin):
+    __tablename__ = "spl_token_backfill_txs"
+    last_scanned_slot = Column(Integer, primary_key=True, nullable=False)
+    signature = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )

--- a/discovery-provider/src/models/rewards/rewards_manager_backfill.py
+++ b/discovery-provider/src/models/rewards/rewards_manager_backfill.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, DateTime, Integer, String
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class RewardsManagerBackfillTransaction(Base, RepresentableMixin):
+    __tablename__ = "rewards_manager_backfill_txs"
+    signature = Column(String, nullable=False, primary_key=True)
+    slot = Column(Integer, nullable=False)
+    created_at = Column(DateTime, nullable=False)

--- a/discovery-provider/src/models/users/user_bank_backfill.py
+++ b/discovery-provider/src/models/users/user_bank_backfill.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, DateTime, Integer, String
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class UserBankBackfillTx(Base, RepresentableMixin):
+    __tablename__ = "user_bank_backfill_txs"
+
+    signature = Column(String, primary_key=True)
+    slot = Column(Integer, nullable=False, index=True)
+    created_at = Column(DateTime, nullable=False)

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -1,0 +1,648 @@
+import concurrent.futures
+import datetime
+import logging
+import time
+from decimal import Decimal
+from typing import Callable, Dict, List, Optional, TypedDict
+
+import base58
+from redis import Redis
+from sqlalchemy import desc
+from sqlalchemy.orm.session import Session
+from src.models.rewards.challenge import Challenge, ChallengeType
+from src.models.rewards.rewards_manager_backfill import (
+    RewardsManagerBackfillTransaction,
+)
+from src.models.rewards.user_challenge import UserChallenge
+from src.models.users.audio_transactions_history import (
+    AudioTransactionsHistory,
+    TransactionMethod,
+    TransactionType,
+)
+from src.models.users.user import User
+from src.models.users.user_bank import UserBankAccount
+from src.solana.constants import (
+    FETCH_TX_SIGNATURES_BATCH_SIZE,
+    TX_SIGNATURES_MAX_BATCHES,
+    TX_SIGNATURES_RESIZE_LENGTH,
+)
+from src.solana.solana_client_manager import SolanaClientManager
+from src.solana.solana_parser import (
+    InstructionFormat,
+    SolanaInstructionType,
+    parse_instruction_data,
+)
+from src.solana.solana_transaction_types import (
+    ResultMeta,
+    TransactionInfoResult,
+    TransactionMessage,
+    TransactionMessageInstruction,
+)
+from src.tasks.celery_app import celery
+from src.utils.cache_solana_program import (
+    cache_latest_sol_db_tx,
+    fetch_and_cache_latest_program_tx_redis,
+)
+from src.utils.config import shared_config
+from src.utils.helpers import get_solana_tx_token_balances
+from src.utils.prometheus_metric import save_duration_metric
+from src.utils.redis_constants import (
+    latest_sol_rewards_manager_backfill_db_tx_key,
+    latest_sol_rewards_manager_backfill_program_tx_key,
+    latest_sol_rewards_manager_backfill_slot_key,
+)
+from src.utils.session_manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+REWARDS_MANAGER_PROGRAM = shared_config["solana"]["rewards_manager_program_address"]
+REWARDS_MANAGER_ACCOUNT = shared_config["solana"]["rewards_manager_account"]
+MIN_SLOT = int(shared_config["solana"]["rewards_manager_min_slot"])
+
+# Used to find the correct accounts for sender/receiver in the transaction
+TRANSFER_RECEIVER_ACCOUNT_INDEX = 4
+
+
+def check_valid_rewards_manager_program():
+    try:
+        base58.b58decode(REWARDS_MANAGER_PROGRAM)
+        return True
+    except ValueError:
+        logger.error(
+            f"index_rewards_manager_backfill.py"
+            f"Invalid Rewards Manager program ({REWARDS_MANAGER_PROGRAM}) configured, exiting."
+        )
+        return False
+
+
+is_valid_rewards_manager_program = check_valid_rewards_manager_program()
+
+
+rewards_manager_transfer_instr: List[InstructionFormat] = [
+    {"name": "amount", "type": SolanaInstructionType.u64},
+    {"name": "id", "type": SolanaInstructionType.string},
+    {"name": "eth_recipient", "type": SolanaInstructionType.EthereumAddress},
+]
+
+
+class RewardsManagerTransfer(TypedDict):
+    amount: int
+    id: str
+    eth_recipient: str
+
+
+class RewardTransferInstruction(TypedDict):
+    amount: int
+    challenge_id: str
+    specifier: str
+    eth_recipient: str
+    prebalance: int
+    postbalance: int
+
+
+class RewardManagerTransactionInfo(TypedDict):
+    tx_sig: str
+    slot: int
+    timestamp: int
+    transfer_instruction: Optional[RewardTransferInstruction]
+
+
+# Cache the latest value committed to DB in redis
+# Used for quick retrieval in health check
+def cache_latest_sol_rewards_manager_db_tx(redis: Redis, latest_tx):
+    cache_latest_sol_db_tx(
+        redis, latest_sol_rewards_manager_backfill_db_tx_key, latest_tx
+    )
+
+
+challenge_type_map_global: Dict[str, TransactionType] = {}
+
+
+def get_challenge_type_map(
+    session: Session,
+):
+    # pylint: disable=W0603
+    global challenge_type_map_global
+    if not bool(challenge_type_map_global):
+        challenges = (
+            session.query(Challenge.id, Challenge.type)
+            .filter(bool(Challenge.active))
+            .all()
+        )
+        challenge_type_map_global = {
+            challenge[0]: TransactionType.trending_reward
+            if challenge[1] == ChallengeType.trending
+            else TransactionType.user_reward
+            for challenge in challenges
+        }
+
+    return challenge_type_map_global
+
+
+def parse_transfer_instruction_data(data: str) -> RewardsManagerTransfer:
+    """Parse Transfer instruction data submitted to Audius Rewards Manager program
+
+    Instruction struct:
+    pub struct TransferArgs {
+        /// Amount to transfer
+        pub amount: u64,
+        /// ID generated on backend
+        pub id: String,
+        /// Recipient's Eth address
+        pub eth_recipient: EthereumAddress,
+    }
+
+    Decodes the data and parses each param into the correct type
+    """
+
+    return parse_instruction_data(data, rewards_manager_transfer_instr)
+
+
+def parse_transfer_instruction_id(transfer_id: str) -> Optional[List[str]]:
+    """Parses the transfer instruction id into [challenge_id, specifier]
+    The id in the transfer instruction is formatted as "<CHALLENGE_ID>:<SPECIFIER>"
+    """
+    id_parts = transfer_id.split(":", 1)
+    if len(id_parts) != 2:
+        logger.error(
+            "index_rewards_manager_backfill.py | Unable to parse transfer instruction id"
+            f"into challenge_id and specifier {transfer_id}"
+        )
+        return None
+    return id_parts
+
+
+def get_valid_instruction(
+    tx_message: TransactionMessage, meta: ResultMeta
+) -> Optional[TransactionMessageInstruction]:
+    """Checks that the tx is valid
+    checks for the transaction message for correct instruction log
+    checks accounts keys for rewards manager account
+    checks for rewards manager program in instruction
+    """
+    try:
+        account_keys = tx_message["accountKeys"]
+        has_transfer_instruction = any(
+            log == "Program log: Instruction: Transfer" for log in meta["logMessages"]
+        )
+
+        if not has_transfer_instruction:
+            return None
+
+        if not any(REWARDS_MANAGER_ACCOUNT == key for key in account_keys):
+            logger.error(
+                "index_rewards_manager_backfill.py | Rewards manager account missing from account keys"
+            )
+            return None
+
+        instructions = tx_message["instructions"]
+        rewards_manager_program_index = account_keys.index(REWARDS_MANAGER_PROGRAM)
+        for instruction in instructions:
+            if instruction["programIdIndex"] == rewards_manager_program_index:
+                return instruction
+
+        return None
+    except Exception as e:
+        logger.error(
+            f"index_rewards_manager_backfill.py | Error processing instruction valid, {e}",
+            exc_info=True,
+        )
+        return None
+
+
+def fetch_and_parse_sol_rewards_transfer_instruction(
+    solana_client_manager: SolanaClientManager, tx_sig: str
+) -> RewardManagerTransactionInfo:
+    """Fetches metadata for rewards transfer transactions and parses data
+
+    Fetches the transaction metadata from solana using the tx signature
+    Checks the metadata for a transfer instruction
+    Decodes and parses the transfer instruction metadata
+    Validates the metadata fields
+    """
+    try:
+        tx_info = solana_client_manager.get_sol_tx_info(tx_sig)
+        result: TransactionInfoResult = tx_info["result"]
+        # Create transaction metadata
+        tx_metadata: RewardManagerTransactionInfo = {
+            "tx_sig": tx_sig,
+            "slot": result["slot"],
+            "timestamp": result["blockTime"],
+            "transfer_instruction": None,
+        }
+        meta = result["meta"]
+        if meta["err"]:
+            logger.info(
+                f"index_rewards_manager_backfill.py | Skipping error transaction from chain {tx_info}"
+            )
+            return tx_metadata
+        tx_message = result["transaction"]["message"]
+        instruction = get_valid_instruction(tx_message, meta)
+        if instruction is None:
+            return tx_metadata
+        transfer_instruction_data = parse_transfer_instruction_data(instruction["data"])
+        amount = transfer_instruction_data["amount"]
+        eth_recipient = transfer_instruction_data["eth_recipient"]
+        id = transfer_instruction_data["id"]
+        transfer_instruction = parse_transfer_instruction_id(id)
+        if transfer_instruction is None:
+            return tx_metadata
+
+        challenge_id, specifier = transfer_instruction
+        receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
+        pre_balance, post_balance = get_solana_tx_token_balances(meta, receiver_index)
+        if pre_balance == -1 or post_balance == -1:
+            raise Exception("Reward recipient balance missing!")
+        tx_metadata["transfer_instruction"] = {
+            "amount": amount,
+            "eth_recipient": eth_recipient,
+            "challenge_id": challenge_id,
+            "specifier": specifier,
+            "prebalance": pre_balance,
+            "postbalance": post_balance,
+        }
+        return tx_metadata
+    except Exception as e:
+        logger.error(
+            f"index_rewards_manager_backfill.py | Error processing {tx_sig}, {e}",
+            exc_info=True,
+        )
+        raise e
+
+
+def process_batch_sol_reward_manager_txs(
+    session: Session,
+    reward_manager_txs: List[RewardManagerTransactionInfo],
+):
+    """Validates that the transfer instruction is consistent with DB and inserts ChallengeDisbursement DB entries"""
+    try:
+        logger.info(f"index_rewards_manager | processing {reward_manager_txs}")
+        eth_recipients = [
+            tx["transfer_instruction"]["eth_recipient"]
+            for tx in reward_manager_txs
+            if tx["transfer_instruction"] is not None
+        ]
+        users = (
+            session.query(User.wallet, User.user_id, UserBankAccount.bank_account)
+            .join(UserBankAccount, UserBankAccount.ethereum_address == User.wallet)
+            .filter(User.wallet.in_(eth_recipients), User.is_current == True)
+            .all()
+        )
+
+        users_map = {
+            user[0]: {"user_id": user[1], "user_bank": user[2]} for user in users
+        }
+
+        specifiers = [
+            tx["transfer_instruction"]["specifier"]
+            for tx in reward_manager_txs
+            if tx["transfer_instruction"] is not None
+        ]
+        user_challenges = (
+            session.query(UserChallenge.specifier)
+            .filter(
+                UserChallenge.specifier.in_(specifiers),
+            )
+            .all()
+        )
+        user_challenge_specifiers = {challenge[0] for challenge in user_challenges}
+        challenge_type_map = get_challenge_type_map(session)
+
+        audio_tx_histories = []
+        for tx in reward_manager_txs:
+            timestamp = datetime.datetime.utcfromtimestamp(tx["timestamp"])
+            # Add transaction
+            session.add(
+                RewardsManagerBackfillTransaction(
+                    signature=tx["tx_sig"], slot=tx["slot"], created_at=timestamp
+                )
+            )
+            session.flush()
+            # No instruction found
+            if tx["transfer_instruction"] is None:
+                logger.warning(
+                    f"index_rewards_manager_backfill.py | No transfer instruction found in {tx}"
+                )
+                continue
+            transfer_instr: RewardTransferInstruction = tx["transfer_instruction"]
+            specifier = transfer_instr["specifier"]
+            eth_recipient = transfer_instr["eth_recipient"]
+            if specifier not in user_challenge_specifiers:
+                logger.error(
+                    f"index_rewards_manager_backfill.py | Challenge specifier {specifier} not found"
+                    "while processing disbursement"
+                )
+            if eth_recipient not in users_map:
+                logger.error(
+                    f"index_rewards_manager_backfill.py | eth_recipient {eth_recipient} not found while processing disbursement"
+                )
+                tx_signature = tx["tx_sig"]
+                tx_slot = tx["slot"]
+                logger.error(
+                    f"index_rewards_manager_backfill.py | eth_recipient {eth_recipient} not found processing disbursement"
+                    f"tx signature={tx_signature}"
+                    f"tx slot={tx_slot}"
+                    f"specifier = {specifier}"
+                )
+                # Set this user's id and user bank to 0 instead of blocking indexing
+                # This state can be rectified asynchronously
+                users_map[eth_recipient] = {"user_id": 0, "user_bank": 0}
+
+            user_id = users_map[eth_recipient]["user_id"]
+            challenge_id = transfer_instr["challenge_id"]
+            logger.info(
+                f"index_rewards_manager_backfill.py | found successful disbursement for user_id: [{user_id}]"
+            )
+
+            prebalance = transfer_instr["prebalance"]
+            postbalance = transfer_instr["postbalance"]
+            balance_change = postbalance - prebalance
+            audio_tx_histories.append(
+                AudioTransactionsHistory(
+                    user_bank=users_map[eth_recipient]["user_bank"],
+                    slot=tx["slot"],
+                    signature=tx["tx_sig"],
+                    transaction_type=challenge_type_map[challenge_id],
+                    method=TransactionMethod.receive,
+                    transaction_created_at=timestamp,
+                    change=Decimal(balance_change),
+                    balance=Decimal(postbalance),
+                    tx_metadata=challenge_id,
+                )
+            )
+
+        if audio_tx_histories:
+            # Save out the transaction history list
+            session.bulk_save_objects(audio_tx_histories)
+
+    except Exception as e:
+        logger.error(
+            f"index_rewards_manager_backfill.py | Error processing {e}", exc_info=True
+        )
+        raise e
+
+
+def get_latest_reward_disbursment_slot(session: Session):
+    """Fetches the most recent slot for Challenge Disburements"""
+    latest_slot = None
+    highest_slot_query = (
+        session.query(RewardsManagerBackfillTransaction.slot).order_by(
+            desc(RewardsManagerBackfillTransaction.slot)
+        )
+    ).first()
+    # Can be None prior to first write operations
+    if highest_slot_query is not None:
+        latest_slot = highest_slot_query[0]
+
+    # If no slots have yet been recorded, assume all are valid
+    if latest_slot is None:
+        latest_slot = 0
+
+    return latest_slot
+
+
+def get_tx_in_db(session: Session, tx_sig: str) -> bool:
+    """Checks if the transaction signature already exists for Challenge Disburements"""
+    tx_sig_db_count = (
+        session.query(RewardsManagerBackfillTransaction).filter(
+            RewardsManagerBackfillTransaction.signature == tx_sig
+        )
+    ).count()
+    exists = tx_sig_db_count > 0
+    return exists
+
+
+def get_transaction_signatures(
+    solana_client_manager: SolanaClientManager,
+    db: SessionManager,
+    program: str,
+    get_latest_slot: Callable[[Session], int],
+    check_tx_exists: Callable[[Session, str], bool],
+    stop_sig: str,
+    min_slot=None,
+) -> List[List[str]]:
+    """Fetches next batch of transaction signature offset from the previous latest processed slot
+
+    Fetches the latest processed slot for the rewards manager program
+    Iterates backwards from the current tx until an intersection is found with the latest processed slot
+    Returns the next set of transaction signature from the current offset slot to process
+    """
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures = []
+
+    last_tx_signature = stop_sig
+
+    # Loop exit condition
+    intersection_found = False
+
+    # Query for solana transactions until an intersection is found
+    with db.scoped_session() as session:
+        latest_processed_slot = get_latest_slot(session)
+        while not intersection_found:
+            transactions_history = solana_client_manager.get_signatures_for_address(
+                program, before=last_tx_signature, limit=FETCH_TX_SIGNATURES_BATCH_SIZE
+            )
+
+            transactions_array = transactions_history["result"]
+            if not transactions_array:
+                intersection_found = True
+                logger.info(
+                    f"index_rewards_manager_backfill.py | No transactions found before {last_tx_signature}"
+                )
+            else:
+                # Current batch of transactions
+                transaction_signature_batch = []
+                for tx_info in transactions_array:
+                    tx_sig = tx_info["signature"]
+                    tx_slot = tx_info["slot"]
+                    logger.debug(
+                        f"index_rewards_manager_backfill.py | Processing tx={tx_sig} | slot={tx_slot}"
+                    )
+                    if tx_info["slot"] > latest_processed_slot:
+                        transaction_signature_batch.append(tx_sig)
+                    elif tx_info["slot"] <= latest_processed_slot and (
+                        min_slot is None or tx_info["slot"] > min_slot
+                    ):
+                        # Check the tx signature for any txs in the latest batch,
+                        # and if not present in DB, add to processing
+                        logger.info(
+                            f"index_rewards_manager_backfill.py | Latest slot re-traversal\
+                            slot={tx_slot}, sig={tx_sig},\
+                            latest_processed_slot(db)={latest_processed_slot}"
+                        )
+                        exists = check_tx_exists(session, tx_sig)
+                        if exists:
+                            intersection_found = True
+                            break
+                        # Ensure this transaction is still processed
+                        transaction_signature_batch.append(tx_sig)
+
+                # Restart processing at the end of this transaction signature batch
+                last_tx = transactions_array[-1]
+                last_tx_signature = last_tx["signature"]
+
+                # Append batch of processed signatures
+                if transaction_signature_batch:
+                    transaction_signatures.append(transaction_signature_batch)
+
+                # Ensure processing does not grow unbounded
+                if len(transaction_signatures) > TX_SIGNATURES_MAX_BATCHES:
+                    # Only take the oldest transaction from the transaction_signatures array
+                    # transaction_signatures is sorted from newest to oldest
+                    transaction_signatures = transaction_signatures[
+                        -TX_SIGNATURES_RESIZE_LENGTH:
+                    ]
+
+    # Reverse batches aggregated so oldest transactions are processed first
+    transaction_signatures.reverse()
+    return transaction_signatures
+
+
+def process_transaction_signatures(
+    solana_client_manager: SolanaClientManager,
+    db: SessionManager,
+    redis: Redis,
+    transaction_signatures: List[List[str]],
+):
+    """Concurrently processes the transactions to update the DB state for reward transfer instructions"""
+    last_tx_sig: Optional[str] = None
+    last_tx: Optional[RewardManagerTransactionInfo] = None
+    if transaction_signatures and transaction_signatures[-1]:
+        last_tx_sig = transaction_signatures[-1][0]
+
+    for tx_sig_batch in transaction_signatures:
+        logger.info(f"index_rewards_manager_backfill.py | processing {tx_sig_batch}")
+        batch_start_time = time.time()
+
+        transfer_instructions: List[RewardManagerTransactionInfo] = []
+        # Process each batch in parallel
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            parse_sol_tx_futures = {
+                executor.submit(
+                    fetch_and_parse_sol_rewards_transfer_instruction,
+                    solana_client_manager,
+                    tx_sig,
+                ): tx_sig
+                for tx_sig in tx_sig_batch
+            }
+            for future in concurrent.futures.as_completed(parse_sol_tx_futures):
+                try:
+                    # No return value expected here so we just ensure all futures are resolved
+                    parsed_solana_transfer_instruction = future.result()
+                    if parsed_solana_transfer_instruction is not None:
+                        transfer_instructions.append(parsed_solana_transfer_instruction)
+                        if (
+                            last_tx_sig
+                            and last_tx_sig
+                            == parsed_solana_transfer_instruction["tx_sig"]
+                        ):
+                            last_tx = parsed_solana_transfer_instruction
+                except Exception as exc:
+                    logger.error(f"index_rewards_manager_backfill.py | {exc}")
+                    raise exc
+        with db.scoped_session() as session:
+            process_batch_sol_reward_manager_txs(session, transfer_instructions)
+        batch_end_time = time.time()
+        batch_duration = batch_end_time - batch_start_time
+        logger.info(
+            f"index_rewards_manager_backfill.py | processed batch {len(tx_sig_batch)} txs in {batch_duration}s"
+        )
+
+    if last_tx:
+        cache_latest_sol_rewards_manager_db_tx(
+            redis,
+            {
+                "signature": last_tx["tx_sig"],
+                "slot": last_tx["slot"],
+                "timestamp": last_tx["timestamp"],
+            },
+        )
+    return last_tx
+
+
+def process_solana_rewards_manager(
+    solana_client_manager: SolanaClientManager,
+    db: SessionManager,
+    redis: Redis,
+    stop_sig: str,
+):
+    """Fetches the next set of reward manager transactions and updates the DB with Challenge Disbursements"""
+    if not is_valid_rewards_manager_program:
+        logger.error(
+            "index_rewards_manager_backfill.py | no valid reward manager program passed"
+        )
+        return
+    if not REWARDS_MANAGER_ACCOUNT:
+        logger.error(
+            "index_rewards_manager_backfill.py | reward manager account missing"
+        )
+        return
+
+    # Get the latests slot available globally before fetching txs to keep track of indexing progress
+    try:
+        latest_global_slot = solana_client_manager.get_slot()
+    except:
+        logger.error("index_rewards_manager_backfill.py | Failed to get slot")
+
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures = get_transaction_signatures(
+        solana_client_manager,
+        db,
+        REWARDS_MANAGER_PROGRAM,
+        get_latest_reward_disbursment_slot,
+        get_tx_in_db,
+        stop_sig,
+        MIN_SLOT,
+    )
+    logger.info(f"index_rewards_manager_backfill.py | {transaction_signatures}")
+
+    last_tx = process_transaction_signatures(
+        solana_client_manager, db, redis, transaction_signatures
+    )
+    if last_tx:
+        redis.set(latest_sol_rewards_manager_backfill_slot_key, last_tx["slot"])
+    elif latest_global_slot is not None:
+        redis.set(latest_sol_rewards_manager_backfill_slot_key, latest_global_slot)
+
+
+# ####### CELERY TASKS ####### #
+@celery.task(name="index_rewards_manager_backfill", bind=True)
+@save_duration_metric(metric_group="celery_task")
+def index_rewards_manager(self, stop_sig=None):
+    redis = index_rewards_manager.redis
+    solana_client_manager = index_rewards_manager.solana_client_manager
+    db = index_rewards_manager.db
+
+    # Define lock acquired boolean
+    have_lock = False
+    # Max duration of lock is 4hrs or 14400 seconds
+    update_lock = redis.lock("solana_rewards_manager_backfill_lock", timeout=14400)
+
+    if not stop_sig:
+        return
+
+    try:
+        # Cache latest tx outside of lock
+        fetch_and_cache_latest_program_tx_redis(
+            solana_client_manager,
+            redis,
+            REWARDS_MANAGER_PROGRAM,
+            latest_sol_rewards_manager_backfill_program_tx_key,
+        )
+
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info("index_rewards_manager_backfill.py | Acquired lock")
+            process_solana_rewards_manager(solana_client_manager, db, redis, stop_sig)
+        else:
+            logger.info("index_rewards_manager_backfill.py | Failed to acquire lock")
+    except Exception as e:
+        logger.error(
+            "index_rewards_manager_backfill.py | Fatal error in main loop",
+            exc_info=True,
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -1,0 +1,556 @@
+import concurrent.futures
+import datetime
+import json
+import logging
+import time
+from decimal import Decimal
+from typing import Any, List, Optional, Set, TypedDict
+
+import base58
+from redis import Redis
+from solana.publickey import PublicKey
+from src.models.indexing.spl_token_backfill_transaction import (
+    SPLTokenBackfillTransaction,
+)
+from src.models.users.audio_transactions_history import (
+    AudioTransactionsHistory,
+    TransactionMethod,
+    TransactionType,
+)
+from src.models.users.user import User
+from src.models.users.user_bank import UserBankAccount
+from src.queries.get_balances import enqueue_immediate_balance_refresh
+from src.solana.constants import (
+    FETCH_TX_SIGNATURES_BATCH_SIZE,
+    TX_SIGNATURES_MAX_BATCHES,
+    TX_SIGNATURES_RESIZE_LENGTH,
+)
+from src.solana.solana_client_manager import SolanaClientManager
+from src.solana.solana_transaction_types import (
+    ConfirmedSignatureForAddressResult,
+    ConfirmedTransaction,
+)
+from src.tasks.celery_app import celery
+from src.utils.cache_solana_program import (
+    CachedProgramTxInfo,
+    cache_latest_sol_db_tx,
+    fetch_and_cache_latest_program_tx_redis,
+)
+from src.utils.config import shared_config
+from src.utils.helpers import get_solana_tx_owner, get_solana_tx_token_balances
+from src.utils.prometheus_metric import save_duration_metric
+from src.utils.redis_constants import (
+    latest_sol_spl_token_backfill_db_key,
+    latest_sol_spl_token_backfill_program_tx_key,
+)
+from src.utils.session_manager import SessionManager
+from src.utils.solana_indexing_logger import SolanaIndexingLogger
+
+SPL_TOKEN_PROGRAM = shared_config["solana"]["waudio_mint"]
+SPL_TOKEN_PUBKEY = PublicKey(SPL_TOKEN_PROGRAM) if SPL_TOKEN_PROGRAM else None
+USER_BANK_ADDRESS = shared_config["solana"]["user_bank_program_address"]
+USER_BANK_PUBKEY = PublicKey(USER_BANK_ADDRESS) if USER_BANK_ADDRESS else None
+PURCHASE_AUDIO_MEMO_PROGRAM = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
+
+REDIS_TX_CACHE_QUEUE_PREFIX = "spl-token-backfill-tx-cache-queue"
+
+# Number of signatures that are fetched from RPC and written at once
+# For example, in a batch of 1000 only 100 will be fetched and written in parallel
+# Intended to relieve RPC and DB pressure
+TX_SIGNATURES_PROCESSING_SIZE = 100
+
+# Index of memo instruction in instructions list
+MEMO_INSTRUCTION_INDEX = 4
+# Index of receiver account in solana transaction pre/post balances
+# Note: the receiver index is currently the same for purchase and transfer instructions
+# but this assumption could change in the future.
+RECEIVER_ACCOUNT_INDEX = 1
+# Thought we don't index transfers from the sender's side in this task, we must still
+# enqueue the sender's accounts for balance refreshes if they are Audius accounts.
+SENDER_ACCOUNT_INDEX = 2
+
+purchase_vendor_map = {
+    "Link by Stripe": TransactionType.purchase_stripe,
+    "Coinbase Pay": TransactionType.purchase_coinbase,
+    "Unknown": TransactionType.purchase_unknown,
+}
+
+logger = logging.getLogger(__name__)
+
+
+class SplTokenTransactionInfo(TypedDict):
+    user_bank: str
+    signature: str
+    slot: int
+    timestamp: datetime.datetime
+    vendor: Optional[str]
+    prebalance: int
+    postbalance: int
+    sender_wallet: str
+    root_accounts: List[str]
+    token_accounts: List[str]
+
+
+# Cache the latest value committed to DB in redis
+# Used for quick retrieval in health check
+def cache_latest_spl_audio_db_tx(redis: Redis, latest_tx: CachedProgramTxInfo):
+    cache_latest_sol_db_tx(redis, latest_sol_spl_token_backfill_db_key, latest_tx)
+
+
+def parse_memo_instruction(result: Any) -> str:
+    try:
+        txs = result["transaction"]
+        memo_instruction = next(
+            (
+                inst
+                for inst in txs["message"]["instructions"]
+                if inst["programIdIndex"] == MEMO_INSTRUCTION_INDEX
+            ),
+            None,
+        )
+        if not memo_instruction:
+            return ""
+
+        memo_account = txs["message"]["accountKeys"][MEMO_INSTRUCTION_INDEX]
+        if not memo_account or memo_account != PURCHASE_AUDIO_MEMO_PROGRAM:
+            return ""
+        return memo_instruction["data"]
+    except Exception as e:
+        logger.error(
+            f"index_spl_token_backfill.py | Error parsing memo, {e}", exc_info=True
+        )
+        raise e
+
+
+def decode_memo_and_extract_vendor(memo_encoded: str) -> str:
+    try:
+        memo = str(base58.b58decode(memo_encoded))
+        if not memo or "In-App $AUDIO Purchase:" not in memo:
+            return ""
+
+        vendor = memo[1:-1].split(":")[1][1:]
+        if vendor not in purchase_vendor_map:
+            return ""
+        return vendor
+    except Exception as e:
+        logger.error(
+            f"index_spl_token_backfill.py | Error decoding memo, {e}", exc_info=True
+        )
+        raise e
+
+
+def parse_spl_token_transaction(
+    solana_client_manager: SolanaClientManager,
+    tx_sig: ConfirmedSignatureForAddressResult,
+) -> Optional[SplTokenTransactionInfo]:
+    try:
+        tx_info = solana_client_manager.get_sol_tx_info(tx_sig["signature"])
+        result = tx_info["result"]
+        meta = result["meta"]
+        error = meta["err"]
+        if error:
+            return None
+
+        memo_encoded = parse_memo_instruction(result)
+        vendor = decode_memo_and_extract_vendor(memo_encoded) if memo_encoded else None
+
+        sender_root_account = get_solana_tx_owner(meta, SENDER_ACCOUNT_INDEX)
+        receiver_root_account = get_solana_tx_owner(meta, RECEIVER_ACCOUNT_INDEX)
+        account_keys = result["transaction"]["message"]["accountKeys"]
+        receiver_token_account = account_keys[RECEIVER_ACCOUNT_INDEX]
+        sender_token_account = account_keys[SENDER_ACCOUNT_INDEX]
+        prebalance, postbalance = get_solana_tx_token_balances(
+            meta, RECEIVER_ACCOUNT_INDEX
+        )
+        # Skip if there is no balance change.
+        if postbalance - prebalance == 0:
+            return None
+        receiver_spl_tx_info: SplTokenTransactionInfo = {
+            "user_bank": receiver_token_account,
+            "signature": tx_sig["signature"],
+            "slot": result["slot"],
+            "timestamp": datetime.datetime.utcfromtimestamp(result["blockTime"]),
+            "vendor": vendor,
+            "prebalance": prebalance,
+            "postbalance": postbalance,
+            "sender_wallet": sender_root_account,
+            "root_accounts": [sender_root_account, receiver_root_account],
+            "token_accounts": [sender_token_account, receiver_token_account],
+        }
+        return receiver_spl_tx_info
+
+    except Exception as e:
+        signature = tx_sig["signature"]
+        logger.error(
+            f"index_spl_token_backfill.py | Error processing {signature}, {e}",
+            exc_info=True,
+        )
+        raise e
+
+
+def process_spl_token_transactions(
+    txs: List[SplTokenTransactionInfo], user_bank_set: Set[str]
+) -> List[AudioTransactionsHistory]:
+    try:
+        audio_txs = []
+        for tx_info in txs:
+            # Disregard if recipient account is not a user_bank
+            if tx_info["user_bank"] not in user_bank_set:
+                continue
+
+            logger.info(
+                f"index_spl_token_backfill.py | processing transaction: {tx_info['signature']} | slot={tx_info['slot']}"
+            )
+            vendor = tx_info["vendor"]
+            # Index as an external receive transaction
+            # Note: external sends are under a different program, see index_user_bank.py
+            if not vendor:
+                audio_txs.append(
+                    AudioTransactionsHistory(
+                        user_bank=tx_info["user_bank"],
+                        slot=tx_info["slot"],
+                        signature=tx_info["signature"],
+                        transaction_type=(TransactionType.transfer),
+                        method=TransactionMethod.receive,
+                        transaction_created_at=tx_info["timestamp"],
+                        change=Decimal(tx_info["postbalance"] - tx_info["prebalance"]),
+                        balance=Decimal(tx_info["postbalance"]),
+                        tx_metadata=tx_info["sender_wallet"],
+                    )
+                )
+            # Index as purchase transaction
+            else:
+                audio_txs.append(
+                    AudioTransactionsHistory(
+                        user_bank=tx_info["user_bank"],
+                        slot=tx_info["slot"],
+                        signature=tx_info["signature"],
+                        transaction_type=purchase_vendor_map[vendor],
+                        method=TransactionMethod.receive,
+                        transaction_created_at=tx_info["timestamp"],
+                        change=Decimal(tx_info["postbalance"] - tx_info["prebalance"]),
+                        balance=Decimal(tx_info["postbalance"]),
+                        tx_metadata=None,
+                    )
+                )
+        return audio_txs
+
+    except Exception as e:
+        logger.error(
+            f"index_spl_token_backfill.py | Error processing transaction {tx_info}, {e}",
+            exc_info=True,
+        )
+        raise e
+
+
+# Query the highest traversed solana slot
+def get_latest_slot(db):
+    latest_slot = None
+    with db.scoped_session() as session:
+        highest_slot_query = session.query(
+            SPLTokenBackfillTransaction.last_scanned_slot
+        ).first()
+        # Can be None prior to first write operations
+        if highest_slot_query is not None:
+            latest_slot = highest_slot_query[0]
+
+    # Return None if not yet cached
+    return latest_slot
+
+
+def parse_sol_tx_batch(
+    db: SessionManager,
+    solana_client_manager: SolanaClientManager,
+    redis: Redis,
+    tx_sig_batch_records: List[ConfirmedSignatureForAddressResult],
+    solana_logger: SolanaIndexingLogger,
+):
+    """
+    Parse a batch of solana transactions in parallel by calling parse_spl_token_transaction
+    with a ThreaPoolExecutor
+
+    This function also has a recursive retry upto a certain limit in case a future doesn't complete
+    within the alloted time. It clears the futures thread queue and the batch is retried
+    """
+    batch_start_time = time.time()
+    # Last record in this batch to be cached
+    # Important to note that the batch records are in time DESC order
+    updated_token_accounts: Set[str] = set()
+    spl_token_txs: List[ConfirmedTransaction] = []
+    # Process each batch in parallel
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        parse_sol_tx_futures = {
+            executor.submit(
+                parse_spl_token_transaction,
+                solana_client_manager,
+                tx_sig,
+            ): tx_sig
+            for tx_sig in tx_sig_batch_records
+        }
+        try:
+            for future in concurrent.futures.as_completed(
+                parse_sol_tx_futures, timeout=45
+            ):
+                tx_info = future.result()
+                if not tx_info:
+                    continue
+                updated_token_accounts.update(tx_info["token_accounts"])
+                spl_token_txs.append(tx_info)
+
+        except Exception as exc:
+            logger.error(
+                f"index_spl_token_backfill.py | Error parsing sol spl token transaction: {exc}"
+            )
+            raise exc
+
+    with db.scoped_session() as session:
+        if updated_token_accounts:
+            user_result = (
+                session.query(User.user_id, UserBankAccount.bank_account)
+                .join(UserBankAccount, UserBankAccount.ethereum_address == User.wallet)
+                .filter(
+                    UserBankAccount.bank_account.in_(list(updated_token_accounts)),
+                    User.is_current == True,
+                )
+                .all()
+            )
+            user_bank_set = {user[1] for user in user_result}
+
+            audio_txs = process_spl_token_transactions(spl_token_txs, user_bank_set)
+            session.bulk_save_objects(audio_txs)
+
+        if tx_sig_batch_records:
+            last_tx = tx_sig_batch_records[0]
+
+            last_scanned_slot = last_tx["slot"]
+            last_scanned_signature = last_tx["signature"]
+            solana_logger.add_log(
+                f"Updating last_scanned_slot to {last_scanned_slot} and signature to {last_scanned_signature}"
+            )
+            cache_latest_spl_audio_db_tx(
+                redis,
+                {
+                    "signature": last_scanned_signature,
+                    "slot": last_scanned_slot,
+                    "timestamp": last_tx["blockTime"],
+                },
+            )
+
+            record = session.query(SPLTokenBackfillTransaction).first()
+            if record:
+                record.last_scanned_slot = last_scanned_slot
+                record.signature = last_scanned_signature
+            else:
+                record = SPLTokenBackfillTransaction(
+                    last_scanned_slot=last_scanned_slot,
+                    signature=last_scanned_signature,
+                )
+            session.add(record)
+
+    batch_end_time = time.time()
+    batch_duration = batch_end_time - batch_start_time
+    solana_logger.add_log(
+        f"processed batch {len(tx_sig_batch_records)} txs in {batch_duration}s"
+    )
+
+    return updated_token_accounts
+
+
+def split_list(list, n):
+    for i in range(0, len(list), n):
+        yield list[i : i + n]
+
+
+# Push to head of array containing seen transactions
+# Used to avoid re-traversal from chain tail when slot diff > certain number
+def cache_traversed_tx(redis: Redis, tx: ConfirmedSignatureForAddressResult):
+    redis.lpush(REDIS_TX_CACHE_QUEUE_PREFIX, json.dumps(tx))
+
+
+# Fetch the cached transaction from redis queue
+# Eliminates transactions one by one if they are < latest db slot
+def fetch_traversed_tx_from_cache(redis: Redis, latest_db_slot: Optional[int]):
+    if latest_db_slot is None:
+        return None
+    cached_offset_tx_found = False
+    while not cached_offset_tx_found:
+        last_cached_tx_raw = redis.lrange(REDIS_TX_CACHE_QUEUE_PREFIX, 0, 1)
+        if last_cached_tx_raw:
+            last_cached_tx: ConfirmedSignatureForAddressResult = json.loads(
+                last_cached_tx_raw[0]
+            )
+            redis.ltrim(REDIS_TX_CACHE_QUEUE_PREFIX, 1, -1)
+            # If a single element is remaining, clear the list to avoid dupe processing
+            if redis.llen(REDIS_TX_CACHE_QUEUE_PREFIX) == 1:
+                redis.delete(REDIS_TX_CACHE_QUEUE_PREFIX)
+            # Return if a valid signature is found
+            if last_cached_tx["slot"] > latest_db_slot:
+                cached_offset_tx_found = True
+                last_tx_signature = last_cached_tx["signature"]
+                return last_tx_signature
+        else:
+            break
+    return None
+
+
+def process_spl_token_tx(
+    solana_client_manager: SolanaClientManager,
+    db: SessionManager,
+    redis: Redis,
+    stop_sig: str,
+):
+    solana_logger = SolanaIndexingLogger("index_spl_token")
+    solana_logger.start_time("fetch_batches")
+    try:
+        base58.b58decode(SPL_TOKEN_PROGRAM)
+    except ValueError:
+        logger.error(
+            f"index_spl_token_backfill.py"
+            f"Invalid Token program ({SPL_TOKEN_PROGRAM}) configured, exiting."
+        )
+        return
+
+    # Highest currently processed slot in the DB
+    latest_processed_slot = get_latest_slot(db)
+    solana_logger.add_log(f"latest used slot: {latest_processed_slot}")
+
+    # Utilize the cached tx to offset
+    # cached_offset_tx = fetch_traversed_tx_from_cache(redis, latest_processed_slot)
+
+    # The 'before' value from where we start querying transactions
+    # last_tx_signature = cached_offset_tx
+    last_tx_signature = stop_sig
+
+    # Loop exit condition
+    intersection_found = False
+
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures: List[ConfirmedSignatureForAddressResult] = []
+
+    # Current batch of transactions
+    transaction_signature_batch = []
+
+    # Current batch
+    page_count = 0
+
+    # Traverse recent records until an intersection is found with latest slot
+    while not intersection_found:
+        solana_logger.add_log(f"Requesting transactions before {last_tx_signature}")
+        transactions_history = solana_client_manager.get_signatures_for_address(
+            SPL_TOKEN_PROGRAM,
+            before=last_tx_signature,
+            limit=FETCH_TX_SIGNATURES_BATCH_SIZE,
+        )
+        solana_logger.add_log(f"Retrieved transactions before {last_tx_signature}")
+        transactions_array = transactions_history["result"]
+        if not transactions_array:
+            # This is considered an 'intersection' since there are no further transactions to process but
+            # really represents the end of known history for this ProgramId
+            intersection_found = True
+            solana_logger.add_log(f"No transactions found before {last_tx_signature}")
+        else:
+            # handle initial case where no there is no stored latest processed slot and start from current
+            if latest_processed_slot is None:
+                logger.debug("index_spl_token_backfill.py | setting from none")
+                transaction_signature_batch = transactions_array
+                intersection_found = True
+            else:
+                for tx in transactions_array:
+                    if tx["slot"] > latest_processed_slot:
+                        transaction_signature_batch.append(tx)
+                    elif tx["slot"] <= latest_processed_slot:
+                        intersection_found = True
+                        break
+            # Restart processing at the end of this transaction signature batch
+            last_tx = transactions_array[-1]
+            last_tx_signature = last_tx["signature"]
+
+            # Append to recently seen cache
+            cache_traversed_tx(redis, last_tx)
+
+            # Append batch of processed signatures
+            if transaction_signature_batch:
+                transaction_signatures.append(transaction_signature_batch)
+
+            # Ensure processing does not grow unbounded
+            if len(transaction_signatures) > TX_SIGNATURES_MAX_BATCHES:
+                solana_logger.add_log(
+                    f"slicing tx_sigs from {len(transaction_signatures)} entries"
+                )
+                transaction_signatures = transaction_signatures[
+                    -TX_SIGNATURES_RESIZE_LENGTH:
+                ]
+
+            # Reset batch state
+            transaction_signature_batch = []
+
+        solana_logger.add_log(
+            f"intersection_found={intersection_found},\
+            last_tx_signature={last_tx_signature},\
+            page_count={page_count}"
+        )
+        page_count = page_count + 1
+
+    transaction_signatures.reverse()
+    totals = {"user_ids": 0, "root_accts": 0, "token_accts": 0}
+    solana_logger.end_time("fetch_batches")
+    solana_logger.start_time("parse_batches")
+    for tx_sig_batch in transaction_signatures:
+        for tx_sig_batch_records in split_list(
+            tx_sig_batch, TX_SIGNATURES_PROCESSING_SIZE
+        ):
+            token_accounts = parse_sol_tx_batch(
+                db, solana_client_manager, redis, tx_sig_batch_records, solana_logger
+            )
+            totals["token_accts"] += len(token_accounts)
+
+    solana_logger.end_time("parse_batches")
+    solana_logger.add_context("total_token_accts_updated", totals["token_accts"])
+
+    logger.info("index_spl_token_backfill.py", extra=solana_logger.get_context())
+
+
+index_spl_token_backfill_lock = "spl_token_backfill_lock"
+
+
+@celery.task(name="index_spl_token_backfill", bind=True)
+@save_duration_metric(metric_group="celery_task")
+def index_spl_token(self, stop_sig=None):
+    if not stop_sig:
+        return
+
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/app.py
+    redis = index_spl_token.redis
+    solana_client_manager = index_spl_token.solana_client_manager
+    db = index_spl_token.db
+    # Define lock acquired boolean
+    have_lock = False
+    # Define redis lock object
+    # Max duration of lock is 4hrs or 14400 seconds
+    update_lock = redis.lock(
+        index_spl_token_backfill_lock, blocking_timeout=25, timeout=14400
+    )
+
+    try:
+        # Cache latest tx outside of lock
+        fetch_and_cache_latest_program_tx_redis(
+            solana_client_manager,
+            redis,
+            SPL_TOKEN_PROGRAM,
+            latest_sol_spl_token_backfill_program_tx_key,
+        )
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info("index_spl_token_backfill.py | Acquired lock")
+            process_spl_token_tx(solana_client_manager, db, redis, stop_sig)
+    except Exception as e:
+        logger.error(
+            "index_spl_token_backfill.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -19,7 +19,6 @@ from src.models.users.audio_transactions_history import (
 )
 from src.models.users.user import User
 from src.models.users.user_bank import UserBankAccount
-from src.queries.get_balances import enqueue_immediate_balance_refresh
 from src.solana.constants import (
     FETCH_TX_SIGNATURES_BATCH_SIZE,
     TX_SIGNATURES_MAX_BATCHES,

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -1,0 +1,570 @@
+import concurrent.futures
+import datetime
+import logging
+import re
+import time
+from decimal import Decimal
+from typing import List, Optional, TypedDict
+
+import base58
+from redis import Redis
+from solana.publickey import PublicKey
+from sqlalchemy import and_, desc
+from sqlalchemy.orm.session import Session
+from src.database_task import DatabaseTask
+from src.models.users.audio_transactions_history import (
+    AudioTransactionsHistory,
+    TransactionMethod,
+    TransactionType,
+)
+from src.models.users.user import User
+from src.models.users.user_bank import UserBankAccount
+from src.models.users.user_bank_backfill import UserBankBackfillTx
+from src.queries.get_balances import enqueue_immediate_balance_refresh
+from src.solana.constants import (
+    FETCH_TX_SIGNATURES_BATCH_SIZE,
+    TX_SIGNATURES_MAX_BATCHES,
+    TX_SIGNATURES_RESIZE_LENGTH,
+)
+from src.solana.solana_client_manager import SolanaClientManager
+from src.solana.solana_helpers import SPL_TOKEN_ID_PK, get_address_pair
+from src.solana.solana_parser import (
+    InstructionFormat,
+    SolanaInstructionType,
+    parse_instruction_data,
+)
+from src.solana.solana_transaction_types import (
+    ConfirmedTransaction,
+    ResultMeta,
+    TransactionInfoResult,
+    TransactionMessage,
+    TransactionMessageInstruction,
+)
+from src.tasks.celery_app import celery
+from src.utils.cache_solana_program import (
+    cache_latest_sol_db_tx,
+    fetch_and_cache_latest_program_tx_redis,
+)
+from src.utils.config import shared_config
+from src.utils.helpers import get_solana_tx_token_balances
+from src.utils.prometheus_metric import save_duration_metric
+from src.utils.redis_constants import (
+    latest_sol_user_bank_backfill_db_tx_key,
+    latest_sol_user_bank_backfill_program_tx_key,
+    latest_sol_user_bank_backfill_slot_key,
+)
+
+logger = logging.getLogger(__name__)
+
+# Populate values used in UserBank indexing from config
+USER_BANK_ADDRESS = shared_config["solana"]["user_bank_program_address"]
+WAUDIO_MINT = shared_config["solana"]["waudio_mint"]
+USER_BANK_KEY = PublicKey(USER_BANK_ADDRESS) if USER_BANK_ADDRESS else None
+WAUDIO_MINT_PUBKEY = PublicKey(WAUDIO_MINT) if WAUDIO_MINT else None
+
+# Used to limit tx history if needed
+MIN_SLOT = int(shared_config["solana"]["user_bank_min_slot"])
+
+# Used to find the correct accounts for sender/receiver in the transaction
+TRANSFER_SENDER_ACCOUNT_INDEX = 1
+TRANSFER_RECEIVER_ACCOUNT_INDEX = 2
+
+
+# Recover ethereum public key from bytes array
+# Message formatted as follows:
+# EthereumAddress = [214, 237, 135, 129, 143, 240, 221, 138, 97, 84, 199, 236, 234, 175, 81, 23, 114, 209, 118, 39]
+def parse_eth_address_from_msg(msg: str):
+    res = re.findall(r"\[.*?\]", msg)
+    # Remove brackets
+    inner_res = res[0][1:-1]
+    # Convert to public key hex for ethereum
+    arr_val = [int(s) for s in inner_res.split(",")]
+    public_key_bytes = bytes(arr_val)
+    public_key = public_key_bytes.hex()
+    public_key_str = f"0x{public_key}"
+    return public_key_str, public_key_bytes
+
+
+# Return highest user bank slot that has been processed
+def get_highest_user_bank_tx_slot(session: Session):
+    slot = MIN_SLOT
+    tx_query = (
+        session.query(UserBankBackfillTx.slot).order_by(desc(UserBankBackfillTx.slot))
+    ).first()
+    if tx_query:
+        slot = tx_query[0]
+    return slot
+
+
+# Cache the latest value committed to DB in redis
+# Used for quick retrieval in health check
+def cache_latest_sol_user_bank_db_tx(redis: Redis, tx):
+    cache_latest_sol_db_tx(redis, latest_sol_user_bank_backfill_db_tx_key, tx)
+
+
+# Query a tx signature and confirm its existence
+def get_tx_in_db(session: Session, tx_sig: str) -> bool:
+    exists = False
+    tx_sig_db_count = (
+        session.query(UserBankBackfillTx).filter(UserBankBackfillTx.signature == tx_sig)
+    ).count()
+    exists = tx_sig_db_count > 0
+    return exists
+
+
+def refresh_user_balances(session: Session, redis: Redis, accts=List[str]):
+    results = (
+        session.query(User.user_id, UserBankAccount.bank_account)
+        .join(
+            UserBankAccount,
+            and_(
+                UserBankAccount.bank_account.in_(accts),
+                UserBankAccount.ethereum_address == User.wallet,
+            ),
+        )
+        .filter(User.is_current == True)
+        .all()
+    )
+    return results
+
+
+create_token_account_instr: List[InstructionFormat] = [
+    {"name": "eth_address", "type": SolanaInstructionType.EthereumAddress},
+]
+
+
+def process_transfer_instruction(
+    session: Session,
+    redis: Redis,
+    instruction: TransactionMessageInstruction,
+    account_keys: List[str],
+    meta: ResultMeta,
+    tx_sig: str,
+    slot: int,
+    timestamp: datetime.datetime,
+):
+    # The transaction might list sender/receiver in a different order in the pubKeys.
+    # The "accounts" field of the instruction has the mapping of accounts to pubKey index
+    sender_index = instruction["accounts"][TRANSFER_SENDER_ACCOUNT_INDEX]
+    receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
+    sender_account = account_keys[sender_index]
+    receiver_account = account_keys[receiver_index]
+    # Accounts to refresh balance
+    logger.info(
+        f"index_user_bank_backfill.py | Balance refresh accounts: {sender_account}, {receiver_account}"
+    )
+    user_id_accounts = refresh_user_balances(
+        session, redis, [sender_account, receiver_account]
+    )
+    if not user_id_accounts:
+        logger.error(
+            "index_user_bank_backfill.py | ERROR: Neither accounts are user banks"
+        )
+        return
+
+    sender_user_id: Optional[int] = None
+    receiver_user_id: Optional[int] = None
+    for user_id_account in user_id_accounts:
+        if user_id_account[1] == sender_account:
+            sender_user_id = user_id_account[0]
+        elif user_id_account[1] == receiver_account:
+            receiver_user_id = user_id_account[0]
+    if sender_user_id is None:
+        logger.error(
+            f"index_user_bank_backfill.py | ERROR: Unexpected user ids in results: {user_id_accounts}"
+        )
+        return
+
+    pre_sender_balance, post_sender_balance = get_solana_tx_token_balances(
+        meta, sender_index
+    )
+    pre_receiver_balance, post_receiver_balance = get_solana_tx_token_balances(
+        meta, receiver_index
+    )
+    if (
+        pre_sender_balance is None
+        or pre_receiver_balance is None
+        or post_sender_balance is None
+        or post_receiver_balance is None
+    ):
+        logger.error(
+            "index_user_bank_backfill.py | ERROR: Sender or Receiver balance missing!"
+        )
+        return
+    sent_amount = pre_sender_balance - post_sender_balance
+    received_amount = post_receiver_balance - pre_receiver_balance
+    if sent_amount != received_amount:
+        logger.error(
+            f"index_user_bank_backfill.py | ERROR: Sent and received amounts don't match. Sent = {sent_amount}, Received = {received_amount}"
+        )
+        return
+
+    # If there was only 1 user bank, index as a send external transfer
+    # Cannot index receive external transfers this way as those use the spl-token program
+    if len(user_id_accounts) == 1:
+        audio_transfer_sent = AudioTransactionsHistory(
+            user_bank=sender_account,
+            slot=slot,
+            signature=tx_sig,
+            transaction_type=TransactionType.transfer,
+            method=TransactionMethod.send,
+            transaction_created_at=timestamp,
+            change=Decimal(sent_amount),
+            balance=Decimal(post_sender_balance),
+            tx_metadata=receiver_account,
+        )
+        logger.debug(
+            f"index_user_bank_backfill.py | Creating audio_transfer_sent {audio_transfer_sent}"
+        )
+        session.add(audio_transfer_sent)
+
+    # If there are two userbanks to update, it was a transfer from user to user
+    # Index as a user_tip
+    elif len(user_id_accounts) == 2:
+        if receiver_user_id is None:
+            logger.error(
+                f"index_user_bank_backfill.py | ERROR: Unexpected user ids in results: {user_id_accounts}"
+            )
+            return
+
+        audio_tx_sent = AudioTransactionsHistory(
+            user_bank=sender_account,
+            slot=slot,
+            signature=tx_sig,
+            transaction_type=TransactionType.tip,
+            method=TransactionMethod.send,
+            transaction_created_at=timestamp,
+            change=Decimal(sent_amount),
+            balance=Decimal(post_sender_balance),
+            tx_metadata=str(receiver_user_id),
+        )
+        logger.debug(
+            f"index_user_bank_backfill.py | Creating audio_tx_history send tx for tip {audio_tx_sent}"
+        )
+        session.add(audio_tx_sent)
+        audio_tx_received = AudioTransactionsHistory(
+            user_bank=receiver_account,
+            slot=slot,
+            signature=tx_sig,
+            transaction_type=TransactionType.tip,
+            method=TransactionMethod.receive,
+            transaction_created_at=timestamp,
+            change=Decimal(received_amount),
+            balance=Decimal(post_receiver_balance),
+            tx_metadata=str(sender_user_id),
+        )
+        session.add(audio_tx_received)
+        logger.debug(
+            f"index_user_bank_backfill.py | Creating audio_tx_history received tx for tip {audio_tx_received}"
+        )
+
+
+class CreateTokenAccount(TypedDict):
+    eth_address: str
+
+
+def parse_create_token_data(data: str) -> CreateTokenAccount:
+    """Parse Transfer instruction data submitted to Audius Claimable Token program
+
+    Instruction struct:
+    pub struct TransferArgs {
+        pub eth_address: EthereumAddress,
+    }
+
+    Decodes the data and parses each param into the correct type
+    """
+
+    return parse_instruction_data(data, create_token_account_instr)
+
+
+def get_valid_instruction(
+    tx_message: TransactionMessage, meta: ResultMeta
+) -> Optional[TransactionMessageInstruction]:
+    """Checks that the tx is valid
+    checks for the transaction message for correct instruction log
+    checks accounts keys for claimable token program
+    """
+    try:
+        account_keys = tx_message["accountKeys"]
+        instructions = tx_message["instructions"]
+        user_bank_program_index = account_keys.index(USER_BANK_ADDRESS)
+        for instruction in instructions:
+            if instruction["programIdIndex"] == user_bank_program_index:
+                return instruction
+
+        return None
+    except Exception as e:
+        logger.error(
+            f"index_user_bank_backfill.py | Error processing instruction valid, {e}",
+            exc_info=True,
+        )
+        return None
+
+
+def process_user_bank_tx_details(
+    session: Session,
+    redis: Redis,
+    tx_info: ConfirmedTransaction,
+    tx_sig,
+    timestamp,
+):
+    result: TransactionInfoResult = tx_info["result"]
+    meta = result["meta"]
+    error = meta["err"]
+    if error:
+        logger.info(
+            f"index_user_bank_backfill.py | Skipping error transaction from chain {tx_info}"
+        )
+        return
+    account_keys = tx_info["result"]["transaction"]["message"]["accountKeys"]
+    tx_message = result["transaction"]["message"]
+
+    # Check for valid instruction
+    has_create_token_instruction = any(
+        log == "Program log: Instruction: CreateTokenAccount"
+        for log in meta["logMessages"]
+    )
+    has_transfer_instruction = any(
+        log == "Program log: Instruction: Transfer" for log in meta["logMessages"]
+    )
+
+    if not has_create_token_instruction and not has_transfer_instruction:
+        return
+
+    instruction = get_valid_instruction(tx_message, meta)
+    if instruction is None:
+        logger.error(
+            f"index_user_bank_backfill.py | {tx_sig} No Valid instruction found"
+        )
+        return
+
+    if has_transfer_instruction:
+        process_transfer_instruction(
+            session=session,
+            redis=redis,
+            instruction=instruction,
+            account_keys=account_keys,
+            meta=meta,
+            tx_sig=tx_sig,
+            slot=result["slot"],
+            timestamp=timestamp,
+        )
+
+
+def parse_user_bank_transaction(
+    session: Session,
+    solana_client_manager: SolanaClientManager,
+    tx_sig,
+    redis,
+):
+    tx_info = solana_client_manager.get_sol_tx_info(tx_sig)
+    tx_slot = tx_info["result"]["slot"]
+    timestamp = tx_info["result"]["blockTime"]
+    parsed_timestamp = datetime.datetime.utcfromtimestamp(timestamp)
+
+    logger.debug(
+        f"index_user_bank_backfill.py | parse_user_bank_transaction |\
+    {tx_slot}, {tx_sig} | {tx_info} | {parsed_timestamp}"
+    )
+
+    process_user_bank_tx_details(session, redis, tx_info, tx_sig, parsed_timestamp)
+    session.add(
+        UserBankBackfillTx(signature=tx_sig, slot=tx_slot, created_at=parsed_timestamp)
+    )
+    return (tx_info["result"], tx_sig)
+
+
+def process_user_bank_txs(stop_sig: str):
+    solana_client_manager: SolanaClientManager = (
+        index_user_bank_backfill.solana_client_manager
+    )
+    db = index_user_bank_backfill.db
+    redis = index_user_bank_backfill.redis
+    logger.info("index_user_bank_backfill.py | Acquired lock")
+
+    # Exit if required configs are not found
+    if not WAUDIO_MINT_PUBKEY or not USER_BANK_KEY:
+        logger.error(
+            f"index_user_bank_backfill.py | Missing required configuration"
+            f"WAUDIO_PROGRAM_PUBKEY: {WAUDIO_MINT_PUBKEY} USER_BANK_KEY: {USER_BANK_KEY}- exiting."
+        )
+        return
+
+    # List of signatures that will be populated as we traverse recent operations
+    transaction_signatures = []
+
+    last_tx_signature = stop_sig
+
+    # Loop exit condition
+    intersection_found = False
+
+    # Get the latests slot available globally before fetching txs to keep track of indexing progress
+    try:
+        latest_global_slot = solana_client_manager.get_slot()
+    except:
+        logger.error("index_user_bank_backfill.py | Failed to get block height")
+
+    # Query for solana transactions until an intersection is found
+    with db.scoped_session() as session:
+        latest_processed_slot = get_highest_user_bank_tx_slot(session)
+        logger.info(f"index_user_bank_backfill.py | high tx = {latest_processed_slot}")
+        while not intersection_found:
+            transactions_history = solana_client_manager.get_signatures_for_address(
+                USER_BANK_ADDRESS,
+                before=last_tx_signature,
+                limit=FETCH_TX_SIGNATURES_BATCH_SIZE,
+            )
+            transactions_array = transactions_history["result"]
+            if not transactions_array:
+                intersection_found = True
+                logger.info(
+                    f"index_user_bank_backfill.py | No transactions found before {last_tx_signature}"
+                )
+            else:
+                # Current batch of transactions
+                transaction_signature_batch = []
+                for tx_info in transactions_array:
+                    tx_sig = tx_info["signature"]
+                    tx_slot = tx_info["slot"]
+                    logger.debug(
+                        f"index_user_bank_backfill.py | Processing tx={tx_sig} | slot={tx_slot}"
+                    )
+                    if tx_info["slot"] > latest_processed_slot:
+                        transaction_signature_batch.append(tx_sig)
+                    elif (
+                        tx_info["slot"] <= latest_processed_slot
+                        and tx_info["slot"] > MIN_SLOT
+                    ):
+                        # Check the tx signature for any txs in the latest batch,
+                        # and if not present in DB, add to processing
+                        logger.info(
+                            f"index_user_bank_backfill.py | Latest slot re-traversal\
+                            slot={tx_slot}, sig={tx_sig},\
+                            latest_processed_slot(db)={latest_processed_slot}"
+                        )
+                        exists = get_tx_in_db(session, tx_sig)
+                        if exists:
+                            intersection_found = True
+                            break
+                        # Ensure this transaction is still processed
+                        transaction_signature_batch.append(tx_sig)
+
+                # Restart processing at the end of this transaction signature batch
+                last_tx = transactions_array[-1]
+                last_tx_signature = last_tx["signature"]
+
+                # Append batch of processed signatures
+                if transaction_signature_batch:
+                    transaction_signatures.append(transaction_signature_batch)
+
+                # Ensure processing does not grow unbounded
+                if len(transaction_signatures) > TX_SIGNATURES_MAX_BATCHES:
+                    prev_len = len(transaction_signatures)
+                    # Only take the oldest transaction from the transaction_signatures array
+                    # transaction_signatures is sorted from newest to oldest
+                    transaction_signatures = transaction_signatures[
+                        -TX_SIGNATURES_RESIZE_LENGTH:
+                    ]
+                    logger.info(
+                        f"index_user_bank_backfill.py | sliced tx_sigs from {prev_len} to {len(transaction_signatures)} entries"
+                    )
+
+    # Reverse batches aggregated so oldest transactions are processed first
+    transaction_signatures.reverse()
+
+    last_tx_sig: Optional[str] = None
+    last_tx = None
+    if transaction_signatures and transaction_signatures[-1]:
+        last_tx_sig = transaction_signatures[-1][0]
+
+    num_txs_processed = 0
+    for tx_sig_batch in transaction_signatures:
+        logger.info(f"index_user_bank_backfill.py | processing {tx_sig_batch}")
+        batch_start_time = time.time()
+        # Process each batch in parallel
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            with db.scoped_session() as session:
+                parse_sol_tx_futures = {
+                    executor.submit(
+                        parse_user_bank_transaction,
+                        session,
+                        solana_client_manager,
+                        tx_sig,
+                        redis,
+                    ): tx_sig
+                    for tx_sig in tx_sig_batch
+                }
+                for future in concurrent.futures.as_completed(parse_sol_tx_futures):
+                    try:
+                        # No return value expected here so we just ensure all futures are resolved
+                        tx_info, tx_sig = future.result()
+                        if tx_info and last_tx_sig and last_tx_sig == tx_sig:
+                            last_tx = tx_info
+
+                        num_txs_processed += 1
+                    except Exception as exc:
+                        logger.error(
+                            f"index_user_bank_backfill.py | error {exc}", exc_info=True
+                        )
+                        raise
+
+        batch_end_time = time.time()
+        batch_duration = batch_end_time - batch_start_time
+        logger.info(
+            f"index_user_bank_backfill.py | processed batch {len(tx_sig_batch)} txs in {batch_duration}s"
+        )
+
+    if last_tx and last_tx_sig:
+        cache_latest_sol_user_bank_db_tx(
+            redis,
+            {
+                "signature": last_tx_sig,
+                "slot": last_tx["slot"],
+                "timestamp": last_tx["blockTime"],
+            },
+        )
+    if last_tx:
+        redis.set(latest_sol_user_bank_backfill_slot_key, last_tx["slot"])
+    elif latest_global_slot is not None:
+        redis.set(latest_sol_user_bank_backfill_slot_key, latest_global_slot)
+
+
+# ####### CELERY TASKS ####### #
+@celery.task(name="index_user_bank_backfill", bind=True)
+@save_duration_metric(metric_group="celery_task")
+def index_user_bank_backfill(self, stop_sig=None):
+    if not stop_sig:
+        return
+
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/__init__.py
+    redis = index_user_bank_backfill.redis
+    # Define lock acquired boolean
+    have_lock = False
+    # Define redis lock object
+    update_lock = redis.lock("user_bank_backfill_lock", timeout=10 * 60)
+
+    try:
+        # Cache latest tx outside of lock
+        fetch_and_cache_latest_program_tx_redis(
+            index_user_bank_backfill.solana_client_manager,
+            redis,
+            USER_BANK_ADDRESS,
+            latest_sol_user_bank_backfill_program_tx_key,
+        )
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            process_user_bank_txs(stop_sig)
+        else:
+            logger.info("index_user_bank_backfill.py | Failed to acquire lock")
+
+    except Exception as e:
+        logger.error(
+            "index_user_bank_backfill.py | Fatal error in main loop", exc_info=True
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -43,6 +43,10 @@ latest_sol_user_bank_backfill_db_tx_key = "latest_sol_program_tx:user_bank_backf
 
 latest_sol_spl_token_program_tx_key = "latest_sol_program_tx:spl_token:chain"
 latest_sol_spl_token_db_key = "latest_sol_program_tx:spl_token:db"
+latest_sol_spl_token_backfill_program_tx_key = (
+    "latest_sol_program_tx:spl_token_backfill:chain"
+)
+latest_sol_spl_token_backfill_db_key = "latest_sol_program_tx:spl_token_backfill:db"
 
 # Solana latest slot per indexer
 # Used to get the latest processed slot of each indexing task, using the global slots instead of the per-program slots

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -32,9 +32,6 @@ latest_sol_rewards_manager_backfill_program_tx_key = (
 latest_sol_rewards_manager_backfill_db_tx_key = (
     "latest_sol_program_tx:rewards_manager_backfill:db"
 )
-latest_sol_rewards_manager_backfill_stop_sig_key = (
-    "latest_sol_program_tx:rewards_manager_backfill:stop_sig"
-)
 
 latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:chain"
 latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"
@@ -43,15 +40,9 @@ latest_sol_user_bank_backfill_program_tx_key = (
     "latest_sol_program_tx:user_bank_backfill:chain"
 )
 latest_sol_user_bank_backfill_db_tx_key = "latest_sol_program_tx:user_bank_backfill:db"
-latest_sol_user_bank_backfill_stop_sig_key = (
-    "latest_sol_program_tx:user_bank_backfill:stop_sig"
-)
 
 latest_sol_spl_token_program_tx_key = "latest_sol_program_tx:spl_token:chain"
 latest_sol_spl_token_db_key = "latest_sol_program_tx:spl_token:db"
-latest_sol_spl_token_backfill_stop_sig_key = (
-    "latest_sol_program_tx:spl_token_backfill:stop_sig"
-)
 
 # Solana latest slot per indexer
 # Used to get the latest processed slot of each indexing task, using the global slots instead of the per-program slots

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -32,6 +32,9 @@ latest_sol_rewards_manager_backfill_program_tx_key = (
 latest_sol_rewards_manager_backfill_db_tx_key = (
     "latest_sol_program_tx:rewards_manager_backfill:db"
 )
+latest_sol_rewards_manager_backfill_stop_sig_key = (
+    "latest_sol_program_tx:rewards_manager_backfill:stop_sig"
+)
 
 latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:chain"
 latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"
@@ -40,13 +43,15 @@ latest_sol_user_bank_backfill_program_tx_key = (
     "latest_sol_program_tx:user_bank_backfill:chain"
 )
 latest_sol_user_bank_backfill_db_tx_key = "latest_sol_program_tx:user_bank_backfill:db"
+latest_sol_user_bank_backfill_stop_sig_key = (
+    "latest_sol_program_tx:user_bank_backfill:stop_sig"
+)
 
 latest_sol_spl_token_program_tx_key = "latest_sol_program_tx:spl_token:chain"
 latest_sol_spl_token_db_key = "latest_sol_program_tx:spl_token:db"
-latest_sol_spl_token_backfill_program_tx_key = (
-    "latest_sol_program_tx:spl_token_backfill:chain"
+latest_sol_spl_token_backfill_stop_sig_key = (
+    "latest_sol_program_tx:spl_token_backfill:stop_sig"
 )
-latest_sol_spl_token_backfill_db_key = "latest_sol_program_tx:spl_token_backfill:db"
 
 # Solana latest slot per indexer
 # Used to get the latest processed slot of each indexing task, using the global slots instead of the per-program slots

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -30,12 +30,18 @@ latest_sol_rewards_manager_db_tx_key = "latest_sol_program_tx:rewards_manager:db
 latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:chain"
 latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"
 
+latest_sol_user_bank_backfill_program_tx_key = (
+    "latest_sol_program_tx:user_bank_backfill:chain"
+)
+latest_sol_user_bank_backfill_db_tx_key = "latest_sol_program_tx:user_bank_backfill:db"
+
 latest_sol_spl_token_program_tx_key = "latest_sol_program_tx:spl_token:chain"
 latest_sol_spl_token_db_key = "latest_sol_program_tx:spl_token:db"
 
 # Solana latest slot per indexer
 # Used to get the latest processed slot of each indexing task, using the global slots instead of the per-program slots
 latest_sol_user_bank_slot_key = "latest_sol_slot:user_bank"
+latest_sol_user_bank_backfill_slot_key = "latest_sol_slot:user_bank_backfill"
 latest_sol_aggregate_tips_slot_key = "latest_sol_slot:aggregate_tips"
 latest_sol_plays_slot_key = "latest_sol_slot:plays"
 latest_sol_rewards_manager_slot_key = "latest_sol_slot:rewards_manager"

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -26,6 +26,12 @@ latest_sol_rewards_manager_program_tx_key = (
     "latest_sol_program_tx:rewards_manager:chain"
 )
 latest_sol_rewards_manager_db_tx_key = "latest_sol_program_tx:rewards_manager:db"
+latest_sol_rewards_manager_backfill_program_tx_key = (
+    "latest_sol_program_tx:rewards_manager_backfill:chain"
+)
+latest_sol_rewards_manager_backfill_db_tx_key = (
+    "latest_sol_program_tx:rewards_manager_backfill:db"
+)
 
 latest_sol_user_bank_program_tx_key = "latest_sol_program_tx:user_bank:chain"
 latest_sol_user_bank_db_tx_key = "latest_sol_program_tx:user_bank:db"
@@ -45,6 +51,9 @@ latest_sol_user_bank_backfill_slot_key = "latest_sol_slot:user_bank_backfill"
 latest_sol_aggregate_tips_slot_key = "latest_sol_slot:aggregate_tips"
 latest_sol_plays_slot_key = "latest_sol_slot:plays"
 latest_sol_rewards_manager_slot_key = "latest_sol_slot:rewards_manager"
+latest_sol_rewards_manager_backfill_slot_key = (
+    "latest_sol_slot:rewards_manager_backfill"
+)
 
 # Reactions
 LAST_REACTIONS_INDEX_TIME_KEY = "reactions_last_index_time"


### PR DESCRIPTION
### Description

Backfill user bank transaction data into `audio_transactions_history` by making a *duplicates* of `index_user_bank.py` that stops at the transaction whose signature matches the`backfill_stop_sig` arg.

The following commits do the same for `index_rewards_manager.py` and `index_spl_token.py`.

### Tests
Tested on remote-dev that is indexing prod. Set `backfill_stop_sig` to a known signature and observed the backfilling occurring.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Adds logs for the backfilling indexer.