### PR TITLE
[CON-486] Optional chain potentially null syncStatus

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -623,7 +623,7 @@ const _additionalSyncIsRequired = async (
     }
   }
 
-  if (syncStatus.startsWith('success')) {
+  if (syncStatus?.startsWith('success')) {
     await SecondarySyncHealthTracker.recordSuccess(
       targetNode,
       userWallet,


### PR DESCRIPTION
### Description
Fixes a TypeError caused by calling a function on `syncStatus`, which is sometimes null - for example, when the processing node expired the redis key.


### Tests
CI passing should suffice.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Make sure no more errors are logged for: `TypeError: Cannot read property 'startsWith' of null`.