### PR TITLE
Fix artist dashboard on no plays

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -260,7 +260,7 @@ class UserTrackListenCountsMonthly(Resource):
         responses={200: "Success", 400: "Bad request", 500: "Server error"},
     )
     @ns.expect(user_track_listen_count_route_parser)
-    @ns.marshal_with(user_track_listen_counts_response)
+    # @ns.marshal_with(user_track_listen_counts_response)
     @cache(ttl_sec=5)
     def get(self, id):
         decoded_id = decode_with_abort(id, ns)

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -275,11 +275,18 @@ class UserTrackListenCountsMonthly(Resource):
                 "end_time": end_time,
             }
         )
+        print("\n\n\n")
+        print("user listen counts")
+        print(user_listen_counts)
+        print("\n\n\n")
 
         formatted_user_listen_counts = format_aggregate_monthly_plays_for_user(
             user_listen_counts
         )
-
+        print("\n\n\n")
+        print("formatted user listen counts")
+        print(formatted_user_listen_counts)
+        print("\n\n\n")
         return success_response(formatted_user_listen_counts)
 
 

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -276,18 +276,10 @@ class UserTrackListenCountsMonthly(Resource):
                 "end_time": end_time,
             }
         )
-        print("\n\n\n")
-        print("user listen counts")
-        print(user_listen_counts)
-        print("\n\n\n")
 
         formatted_user_listen_counts = format_aggregate_monthly_plays_for_user(
             user_listen_counts
         )
-        print("\n\n\n")
-        print("formatted user listen counts")
-        print(formatted_user_listen_counts)
-        print("\n\n\n")
         return success_response(formatted_user_listen_counts)
 
 

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -244,6 +244,7 @@ user_track_listen_counts_response = make_response(
                 ],
             }
         },
+        skip_none=True,
     ),
 )
 
@@ -260,7 +261,7 @@ class UserTrackListenCountsMonthly(Resource):
         responses={200: "Success", 400: "Bad request", 500: "Server error"},
     )
     @ns.expect(user_track_listen_count_route_parser)
-    # @ns.marshal_with(user_track_listen_counts_response)
+    @ns.marshal_with(user_track_listen_counts_response)
     @cache(ttl_sec=5)
     def get(self, id):
         decoded_id = decode_with_abort(id, ns)

--- a/discovery-provider/src/api/v1/users_unit_test.py
+++ b/discovery-provider/src/api/v1/users_unit_test.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 from flask import Flask
 from src.api.v1.users import UserTrackListenCountsMonthly
@@ -12,7 +12,23 @@ START_TIME = "2020-01-01"
 END_TIME = "2021-01-01"
 
 
-def test_user_listen_counts_monthly_get_formats_correctly(mocker):
+@patch(
+    "src.api.v1.users.get_user_listen_counts_monthly",
+    return_value=[
+        {"play_item_id": 4, "timestamp": datetime.date(2022, 2, 1), "count": 10},
+        {"play_item_id": 1, "timestamp": datetime.date(2022, 1, 1), "count": 7},
+        {"play_item_id": 5, "timestamp": datetime.date(2022, 2, 1), "count": 8},
+    ],
+)
+@patch(
+    "src.api.v1.users.success_response",
+    # Cache decorator expects a tuple response
+    side_effect=(lambda input: ({"data": input}, 200)),
+)
+@patch("src.api.v1.users.decode_with_abort", return_value=3)
+def test_user_listen_counts_monthly_get_formats_correctly(
+    mock_decoder, mock_success_response, mock_get_user_listen_counts_monthly
+):
     expected_formatted_listen_counts = {
         "2022-02-01T00:00:00 Z": {
             "totalListens": 18,
@@ -42,32 +58,18 @@ def test_user_listen_counts_monthly_get_formats_correctly(mocker):
             ],
         },
     }
-    mock_get_user_listen_counts_monthly = mocker.patch(
-        "src.api.v1.users.get_user_listen_counts_monthly",
-        return_value=[
-            {"play_item_id": 4, "timestamp": datetime.date(2022, 2, 1), "count": 10},
-            {"play_item_id": 1, "timestamp": datetime.date(2022, 1, 1), "count": 7},
-            {"play_item_id": 5, "timestamp": datetime.date(2022, 2, 1), "count": 8},
-        ],
-    )
-
-    mock_decoder = mocker.patch("src.api.v1.users.decode_with_abort", return_value=3)
-
-    mock_success_response = mocker.patch(
-        "src.api.v1.users.success_response",
-        # Cache decorator expects a tuple response
-        side_effect=(lambda input: ({"data": input}, 200)),
-    )
     with app.test_request_context(
+        "/users/3jk4l/listen_counts_monthly",
+        method="GET",
         data={"start_time": START_TIME, "end_time": END_TIME},
     ):
-        assert UserTrackListenCountsMonthly().get("id_to_decode") == (
+        assert UserTrackListenCountsMonthly().get("3jk4l") == (
             {"data": expected_formatted_listen_counts},
             200,
             # Redis metrics add this empty dict
             {},
         )
-        mock_decoder.assert_called_once_with("id_to_decode", ANY)
+        mock_decoder.assert_called_once_with("3jk4l", ANY)
         mock_get_user_listen_counts_monthly.assert_called_once_with(
             {
                 "user_id": 3,
@@ -76,3 +78,36 @@ def test_user_listen_counts_monthly_get_formats_correctly(mocker):
             }
         )
         mock_success_response.assert_called_once_with(expected_formatted_listen_counts)
+
+
+@patch("src.api.v1.users.get_user_listen_counts_monthly", return_value=[])
+@patch(
+    "src.api.v1.users.success_response",
+    # Cache decorator expects a tuple response
+    side_effect=(lambda input: ({"data": input}, 200)),
+)
+@patch("src.api.v1.users.decode_with_abort", return_value=5)
+def test_user_listen_counts_monthly_get_no_data(
+    mock_decoder, mock_success_response, mock_get_user_listen_counts_monthly
+):
+    with app.test_request_context(
+        "/users/feafda/listen_counts_monthly",
+        method="GET",
+        data={"start_time": START_TIME, "end_time": END_TIME},
+    ):
+        data = UserTrackListenCountsMonthly().get("feafda")
+        assert data == (
+            {"data": {}},
+            200,
+            # Redis metrics add this empty dict
+            {},
+        )
+        mock_decoder.assert_called_once_with("feafda", ANY)
+        mock_get_user_listen_counts_monthly.assert_called_once_with(
+            {
+                "user_id": 5,
+                "start_time": START_TIME,
+                "end_time": END_TIME,
+            }
+        )
+        mock_success_response.assert_called_once_with({})


### PR DESCRIPTION
### Description
There was a bug in the artist dashboard where empty responses would get marshalled into `{ '*': null }`, which caused the front end to crash. Adding `skip_none=True` to our marshalling model ensures we return an empty dict if there are no responses. Added a regression test as well to ensure this doesn't happen again. 

Note - fixing this uncovered another bug within the indexer for monthly play aggregates. Users are missing data around 2020-2021 which was causing empty results to be sent to the front end in the first place. So even with this PR, users may still see no data for certain years. Isaac is working on the fix for this separately. 

### Tests
Added unit test. Also deployed changes to staging to make sure it worked appropriately
