### PR TITLE
Make init worker detection more reliable

### DIFF
--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -128,7 +128,7 @@ const startAppForPrimary = async () => {
 
   const numWorkers = clusterUtils.getNumWorkers()
   logger.info(`Spawning ${numWorkers} processes to run the Express app...`)
-  const firstWorker = cluster.fork()
+  const firstWorker = cluster.fork({ isInitWorker: true })
   // Wait for the first worker to perform one-time init logic before spawning other workers
   firstWorker.on('message', (msg) => {
     if (msg?.cmd === 'initComplete') {
@@ -189,8 +189,11 @@ const startAppForPrimary = async () => {
 
 // Workers don't share memory, so each one is its own Express instance with its own version of objects like serviceRegistry
 const startAppForWorker = async () => {
+  if (process.env.isInitWorker) clusterUtils.markThisWorkerAsInit()
   logger.info(
-    `Worker process with pid=${process.pid} and worker ID=${cluster.worker?.id} is running`
+    `Worker process with pid=${process.pid} and worker ID=${
+      cluster.worker?.id
+    } is running. Is this worker init: ${clusterUtils.isThisWorkerInit()}`
   )
   await verifyConfigAndDb()
   await startApp()

--- a/creator-node/src/utils/clusterUtils.ts
+++ b/creator-node/src/utils/clusterUtils.ts
@@ -11,6 +11,7 @@ const config = require('../config')
  * - regularly add jobs to the session expiration queue on an interval
  */
 class ClusterUtils {
+  private _isInitWorker = false
   private _specialWorkerId = 1
   get specialWorkerId(): number {
     return this._specialWorkerId
@@ -33,7 +34,15 @@ class ClusterUtils {
    * some special initialization logic that other workers don't need to duplicate.
    */
   isThisWorkerInit() {
-    return !this.isClusterEnabled() || cluster.worker?.id === 1
+    return !this.isClusterEnabled() || this._isInitWorker
+  }
+
+  /**
+   * Marks this worker process is the first worker, which performs
+   * some special initialization logic that other workers don't need to duplicate.
+   */
+  markThisWorkerAsInit() {
+    this._isInitWorker = true
   }
 
   isThisWorkerSpecial() {


### PR DESCRIPTION
### Description
Some nodes are not appearing to run logic that the init worker is supposed to run, possibly because they're starting on a pid >1. This PR makes init worker detection pid-agnostic by passing an env var to the child process. This is more reliable than only checking pid.


### Tests
Verified that the first worker's log message shows that it's marked as the init worker and that subsequent workers do not log the init worker's message.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Check the state monitoring queue on nodes that are having issues initializing (like Staked) and make sure they're adding jobs.