### PR TITLE
CN - trackUploadArtifactDeletionEnabled

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -283,20 +283,24 @@ const config = convict({
     default: true
   },
 
-  // Transcoding settings
+  /** Upload settings */
   transcodingMaxConcurrency: {
     doc: 'Maximum ffmpeg processes to spawn concurrently. If unset (-1), set to # of CPU cores available',
     format: Number,
     env: 'transcodingMaxConcurrency',
     default: -1
   },
-
-  // Image processing settings
   imageProcessingMaxConcurrency: {
     doc: 'Maximum image resizing processes to spawn concurrently. If unset (-1), set to # of CPU cores available',
     format: Number,
     env: 'imageProcessingMaxConcurrency',
     default: -1
+  },
+  trackUploadArtifactDeletionEnabled: {
+    doc: 'whether or not to delete track upload artifacts from disk in `fileManager.removeTrackFolder()`',
+    format: Boolean,
+    env: 'trackUploadArtifactDeletionEnabled',
+    default: false
   },
 
   // wallet information

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -296,10 +296,10 @@ const config = convict({
     env: 'imageProcessingMaxConcurrency',
     default: -1
   },
-  trackUploadArtifactDeletionEnabled: {
+  deleteTrackUploadArtifacts: {
     doc: 'whether or not to delete track upload artifacts from disk in `fileManager.removeTrackFolder()`',
     format: Boolean,
-    env: 'trackUploadArtifactDeletionEnabled',
+    env: 'deleteTrackUploadArtifacts',
     default: false
   },
 

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -472,6 +472,11 @@ async function saveFileForMultihashToFS(
 async function removeTrackFolder({ logContext }, fileDir) {
   const logger = genericLogger.child(logContext)
   try {
+    const trackUploadArtifactDeletionEnabled = config.get(
+      'trackUploadArtifactDeletionEnabled'
+    )
+    if (!trackUploadArtifactDeletionEnabled) return
+
     if (!fileDir) {
       throw new Error('Cannot remove null fileDir')
     }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -472,10 +472,10 @@ async function saveFileForMultihashToFS(
 async function removeTrackFolder({ logContext }, fileDir) {
   const logger = genericLogger.child(logContext)
   try {
-    const trackUploadArtifactDeletionEnabled = config.get(
-      'trackUploadArtifactDeletionEnabled'
+    const deleteTrackUploadArtifacts = config.get(
+      'deleteTrackUploadArtifacts'
     )
-    if (!trackUploadArtifactDeletionEnabled) return
+    if (!deleteTrackUploadArtifacts) return
 
     if (!fileDir) {
       throw new Error('Cannot remove null fileDir')


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Envvar `trackUploadArtifactDeletionEnabled` to control `diskManager.removeTrackFolder()`, since `backgroundDiskCleanupCheck` now already clears artifacts after some time threshold, so real-time deletion is no longer necessary and unnecessary performance overhead
The main reason for disabling this though, is bc we actually want to keep upload artifacts for a few days for debugging purposes

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

n/a

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->