### PR TITLE
Speed up local discprov tests

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -202,69 +202,73 @@ def down(protocol_dir):
     )
 
 
-@cli.command()
+@cli.group()
+def test():
+    pass
+
+
+@test.command(name="build")
+@click.pass_obj
+def test_build(protocol_dir):
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            f"--file={protocol_dir / 'docker-compose.test.yml'}",
+            f"--project-name={protocol_dir.name}-test",
+            f"--project-directory={protocol_dir}",
+            "build",
+        ],
+        env={"COMPOSE_PROFILES": "*"},
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            f"--file={protocol_dir / 'docker-compose.test.yml'}",
+            f"--project-name={protocol_dir.name}-test",
+            f"--project-directory={protocol_dir}",
+            "pull",
+        ],
+    )
+
+
+@test.command(name="run")
 @click.argument("service")
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
-def test(protocol_dir, service, args):
-    generate_env(
-        protocol_dir,
-        0,  # amount of replicas don't matter here
-        0,  # amount of replicas don't matter here
-        0,  # amount of replicas don't matter here
-        False,
+def test_run(protocol_dir, service, args):
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            f"--file={protocol_dir / 'docker-compose.test.yml'}",
+            f"--project-name={protocol_dir.name}-test",
+            f"--project-directory={protocol_dir}",
+            "run",
+            "--rm",
+            f"test-{service}",
+            *args,
+        ],
     )
 
-    project_name = f"audius-compose-{''.join(random.choice(string.ascii_lowercase) for i in range(9))}"
 
-    no_deps = False
-    if service == "discovery-provider":
-        no_deps = args and not any(arg.startswith("integration_tests") for arg in args)
-
-    try:
-        subprocess.run(
-            [
-                "docker",
-                "compose",
-                f"--project-name={project_name}",
-                f"--project-directory={protocol_dir}",
-                f"--file={protocol_dir / 'docker-compose.test.yml'}",
-                "build",
-            ],
-        )
-
-        subprocess.run(
-            [
-                "docker",
-                "compose",
-                f"--project-name={project_name}",
-                f"--project-directory={protocol_dir}",
-                f"--file={protocol_dir / 'docker-compose.test.yml'}",
-                "run",
-                "--rm",
-                *(["--no-deps"] if no_deps else []),
-                f"test-{service}",
-                *args,
-            ],
-        )
-    finally:
-        subprocess.run(
-            [
-                "docker",
-                "compose",
-                f"--project-name={project_name}",
-                f"--project-directory={protocol_dir}",
-                f"--file={protocol_dir / 'docker-compose.test.yml'}",
-                "down",
-                "--timeout=1",
-                "-v",
-            ],
-        )
-
-        subprocess.run(
-            f'docker rmi $(docker images --filter "reference={project_name}-*" -q)',
-            shell=True,
-        )
+@test.command(name="down")
+@click.pass_obj
+def test_down(protocol_dir):
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            f"--file={protocol_dir / 'docker-compose.test.yml'}",
+            f"--project-name={protocol_dir.name}-test",
+            f"--project-directory={protocol_dir}",
+            "--profile=*",
+            "down",
+            "-v",
+        ],
+    )
 
 
 @cli.command()

--- a/discovery-provider/integration_tests/conftest.py
+++ b/discovery-provider/integration_tests/conftest.py
@@ -17,8 +17,11 @@ from src.utils import helpers
 from src.utils.redis_connection import get_redis
 from web3 import HTTPProvider, Web3
 
-DB_URL = "postgresql+psycopg2://postgres:postgres@localhost:5432/audius_discovery"
-TEST_BROKER_URL = "redis://localhost:5379/0"
+DB_URL = os.getenv(
+    "audius_db_url",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/audius_discovery",
+)
+TEST_BROKER_URL = os.getenv("audius_redis_url", "redis://localhost:5379/0")
 ENGINE_ARGS_LITERAL = '{ \
     "pool_size": 10, \
     "max_overflow": 0, \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -79,17 +79,54 @@ services:
       mode: global
       replicas: 1
 
+  discovery-provider-db:
+    image: postgres:11.4
+    user: postgres
+    environment:
+      POSTGRES_DB: "discovery_provider"
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+    logging: *default-logging
+    deploy:
+      mode: global
+
+  discovery-provider-redis:
+    image: redis:5.0.5
+    healthcheck:
+      test: [ "CMD", "redis-cli", "PING" ]
+      interval: 10s
+      timeout: 5s
+    logging: *default-logging
+    deploy:
+      mode: global
+
   test-discovery-provider:
     extends:
       file: docker-compose.yml
       service: discovery-provider
-    entrypoint: scripts/test_entrypoint.sh
+    entrypoint: pytest
     command: ""
+    environment:
+      audius_db_url: "postgresql+psycopg2://postgres:postgres@discovery-provider-db:5432/discovery_provider"
+      audius_db_url_read_replica: "postgresql+psycopg2://postgres:postgres@discovery-provider-db:5432/discovery_provider"
+      audius_redis_url: "redis://discovery-provider-redis:6379/00"
+      audius_elasticsearch_url: "http://discovery-provider-elasticsearch:9200"
+      audius_elasticsearch_run_indexer: "true"
+    volumes:
+      - ./discovery-provider/integration_tests:/audius-discovery-provider/integration_tests
     depends_on:
       discovery-provider-elasticsearch:
         condition: service_healthy
+      discovery-provider-db:
+        condition: service_healthy
+      discovery-provider-redis:
+        condition: service_healthy
     deploy:
       mode: global
+    profiles:
+      - tests
 
 volumes:
   poa-contracts-abis:


### PR DESCRIPTION
### Description
Will change `audius-compose test` to
- `audius-compose test build`
- `audius-compose test run discovery-provider <pytest args>`
- `audius-compose test down`

However, you only need to run the second command to run tests and it is all inclusive.

### Tests
See commands above


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA