### PR TITLE
INF Extend timeout for `audius-cli launch`

### DIFF
--- a/.circleci/bin/deploy-ci.py
+++ b/.circleci/bin/deploy-ci.py
@@ -589,6 +589,7 @@ def cli(
                 show_output=True,
                 exit_on_error=IGNORE,
                 dry_run=dry_run,
+                timeout_sec=180
             )
 
             if environment == "prod":


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Sometimes, pulling from Docker Hub can take up to 165 seconds as seen here in a manual deployment:

```
ubuntu@creator-8:~$ audius-cli launch creator-node
ethOwnerWallet is not set
CPUs:	8	(required: 8)
Memory:	31GB	(required: 16GB)
Storage:	247GB	(required: 2048GB)
System does not meet requirements
Do you want to continue? [y/N]: y
[+] Running 19/19
 ⠿ autoheal Pulled                                                                       0.6s
 ⠿ logspout Pulled                                                                       0.5s
 ⠿ exporter_linux Pulled                                                                 0.6s
 ⠿ db Pulled                                                                             0.6s
 ⠿ exporter_postgres Pulled                                                              0.5s
 ⠿ cache Pulled                                                                          0.6s
 ⠿ exporter_redis Pulled                                                                 0.5s
 ⠿ backend Pulled                                                                      122.8s
   ⠿ 72cfd02ff4d0 Already exists                                                         0.0s
   ⠿ 8619c458d4f8 Pull complete                                                          1.6s
   ⠿ 992ac27ffc5d Pull complete                                                          2.4s
   ⠿ 67ec23373e3c Pull complete                                                         29.3s
   ⠿ c787306cd7f9 Pull complete                                                         31.3s
   ⠿ fa5a5bc0fbc0 Pull complete                                                         31.8s
   ⠿ 67035aa211c9 Pull complete                                                         32.9s
   ⠿ a8570af7ae75 Pull complete                                                         33.3s
   ⠿ b31e23c8b166 Pull complete                                                        118.8s
   ⠿ b7b43513211f Pull complete                                                        121.9s
   ⠿ 2a368226c256 Pull complete                                                        122.2s
[+] Running 8/8
 ⠿ Container redis              Running                                                  0.0s
 ⠿ Container exporter_postgres  Running                                                  0.0s
 ⠿ Container logspout           Running                                                  0.0s
 ⠿ Container exporter_redis     Running                                                  0.0s
 ⠿ Container autoheal           Running                                                  0.0s
 ⠿ Container postgres           Running                                                  0.0s
 ⠿ Container server             Started                                                165.0s
 ⠿ Container exporter_linux     Running                                                  0.0s
```

Let's extend our expected timeout for this command.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

#eng-deploys


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->