### PR TITLE
Add subscriptions to entity manager

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -340,7 +340,7 @@ def test_index_invalid_social_features(app, mocker):
                 )
             },
         ],
-        "UserCannotSubscribeToThemselfTx4": [
+        "UserCannotSubscribeToThemselfTx5": [
             {
                 "args": AttributeDict(
                     {

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -16,6 +16,7 @@ from src.models.social.play import Play
 from src.models.social.reaction import Reaction
 from src.models.social.repost import Repost
 from src.models.social.save import Save
+from src.models.social.subscription import Subscription
 from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.tracks.remix import Remix
 from src.models.tracks.stem import Stem
@@ -102,6 +103,7 @@ def populate_mock_db(db, entities, block_offset=None):
         playlists = entities.get("playlists", [])
         users = entities.get("users", [])
         follows = entities.get("follows", [])
+        subscriptions = entities.get("subscriptions", [])
         reposts = entities.get("reposts", [])
         saves = entities.get("saves", [])
         track_routes = entities.get("track_routes", [])
@@ -128,7 +130,7 @@ def populate_mock_db(db, entities, block_offset=None):
         challenge_disbursements = entities.get("challenge_disbursements", [])
 
         num_blocks = max(
-            len(tracks), len(users), len(follows), len(saves), len(reposts)
+            len(tracks), len(users), len(follows), len(saves), len(reposts), len(subscriptions)
         )
         for i in range(block_offset, block_offset + num_blocks):
             max_block = session.query(Block).filter(Block.number == i).first()
@@ -248,6 +250,17 @@ def populate_mock_db(db, entities, block_offset=None):
                 created_at=follow_meta.get("created_at", datetime.now()),
             )
             session.add(follow)
+        for i, subscription_meta in enumerate(subscriptions):
+            subscription = Subscription(
+                blockhash=hex(i + block_offset),
+                blocknumber=subscription_meta.get("blocknumber", i + block_offset),
+                subscriber_id=subscription_meta.get("subscriber_id", i + 1),
+                user_id=subscription_meta.get("user_id", i),
+                is_current=subscription_meta.get("is_current", True),
+                is_delete=subscription_meta.get("is_delete", False),
+                created_at=subscription_meta.get("created_at", datetime.now()),
+            )
+            session.add(subscription)
         for i, repost_meta in enumerate(reposts):
             repost = Repost(
                 blockhash=hex(i + block_offset),

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -130,7 +130,12 @@ def populate_mock_db(db, entities, block_offset=None):
         challenge_disbursements = entities.get("challenge_disbursements", [])
 
         num_blocks = max(
-            len(tracks), len(users), len(follows), len(saves), len(reposts), len(subscriptions)
+            len(tracks),
+            len(users),
+            len(follows),
+            len(saves),
+            len(reposts),
+            len(subscriptions),
         )
         for i in range(block_offset, block_offset + num_blocks):
             max_block = session.query(Block).filter(Block.number == i).first()

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -389,12 +389,18 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
             entity_id = subscription_to_fetch[2]
             and_queries.append(
                 and_(
-                    Subscription.user_id == user_id,
-                    Subscription.repost_type == entity_type.lower(),
-                    Repost.repost_item_id == entity_id,
-                    Repost.is_current == True,
+                    Subscription.subscriber_id == user_id,
+                    Subscription.user_id == entity_type.lower(),
+                    Subscription.is_current == True,
                 )
             )
+        subscriptions: List[Subscription] = session.query(Subscription).filter(or_(*and_queries)).all()
+        existing_entities[EntityType.SUBSCRIPTION] = {
+            get_record_key(
+                subscription.subscriber_id, EntityType.USER, subscription.user_id
+            ): subscription
+            for subscription in subscriptions
+        }
 
     return existing_entities
 

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -385,12 +385,12 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
         and_queries = []
         for subscription_to_fetch in subscriptions_to_fetch:
             user_id = subscription_to_fetch[0]
-            entity_type = subscription_to_fetch[1]
+            # subscriptions does not need entity type in subscription_to_fetch[1]
             entity_id = subscription_to_fetch[2]
             and_queries.append(
                 and_(
                     Subscription.subscriber_id == user_id,
-                    Subscription.user_id == entity_type.lower(),
+                    Subscription.user_id == entity_id,
                     Subscription.is_current == True,
                 )
             )

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -394,7 +394,9 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
                     Subscription.is_current == True,
                 )
             )
-        subscriptions: List[Subscription] = session.query(Subscription).filter(or_(*and_queries)).all()
+        subscriptions: List[Subscription] = (
+            session.query(Subscription).filter(or_(*and_queries)).all()
+        )
         existing_entities[EntityType.SUBSCRIPTION] = {
             get_record_key(
                 subscription.subscriber_id, EntityType.USER, subscription.user_id

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -11,6 +11,7 @@ from src.models.playlists.playlist import Playlist
 from src.models.social.follow import Follow
 from src.models.social.repost import Repost
 from src.models.social.save import Save
+from src.models.social.subscription import Subscription
 from src.models.tracks.track import Track
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.user import User
@@ -377,6 +378,23 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
             ): repost
             for repost in reposts
         }
+
+    # SUBSCRIPTIONS
+    if entities_to_fetch[EntityType.SUBSCRIPTION]:
+        subscriptions_to_fetch: Set[Tuple] = entities_to_fetch[EntityType.SUBSCRIPTION]
+        and_queries = []
+        for subscription_to_fetch in subscriptions_to_fetch:
+            user_id = subscription_to_fetch[0]
+            entity_type = subscription_to_fetch[1]
+            entity_id = subscription_to_fetch[2]
+            and_queries.append(
+                and_(
+                    Subscription.user_id == user_id,
+                    Subscription.repost_type == entity_type.lower(),
+                    Repost.repost_item_id == entity_id,
+                    Repost.is_current == True,
+                )
+            )
 
     return existing_entities
 

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -20,8 +20,18 @@ action_to_record_type = {
     Action.UNSUBSCRIBE: EntityType.SUBSCRIPTION,
 }
 
-create_social_action_types = {Action.FOLLOW, Action.SAVE, Action.REPOST, Action.SUBSCRIBE}
-delete_social_action_types = {Action.UNFOLLOW, Action.UNSAVE, Action.UNREPOST, Action.UNSUBSCRIBE}
+create_social_action_types = {
+    Action.FOLLOW,
+    Action.SAVE,
+    Action.REPOST,
+    Action.SUBSCRIBE,
+}
+delete_social_action_types = {
+    Action.UNFOLLOW,
+    Action.UNSAVE,
+    Action.UNREPOST,
+    Action.UNSUBSCRIBE,
+}
 
 premium_content_validation_actions = {
     Action.SAVE,
@@ -171,6 +181,10 @@ def validate_social_feature(params: ManageEntityParameters):
     if params.action == Action.FOLLOW or params.action == Action.UNFOLLOW:
         if params.user_id == params.entity_id:
             raise Exception("User cannot follow themself")
+
+    if params.action == Action.SUBSCRIBE or params.action == Action.UNSUBSCRIBE:
+        if params.user_id == params.entity_id:
+            raise Exception("User cannot subscribe to themself")
 
     if should_check_entity_access(params.action, params.entity_type):
         premium_content_access = premium_content_access_checker.check_access(

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -3,6 +3,7 @@ from typing import Union
 from src.models.social.follow import Follow
 from src.models.social.repost import Repost
 from src.models.social.save import Save
+from src.models.social.subscription import Subscription
 from src.premium_content.premium_content_access_checker import (
     premium_content_access_checker,
 )
@@ -15,10 +16,12 @@ action_to_record_type = {
     Action.UNSAVE: EntityType.SAVE,
     Action.REPOST: EntityType.REPOST,
     Action.UNREPOST: EntityType.REPOST,
+    Action.SUBSCRIBE: EntityType.SUBSCRIPTION,
+    Action.UNSUBSCRIBE: EntityType.SUBSCRIPTION,
 }
 
-create_social_action_types = {Action.FOLLOW, Action.SAVE, Action.REPOST}
-delete_social_action_types = {Action.UNFOLLOW, Action.UNSAVE, Action.UNREPOST}
+create_social_action_types = {Action.FOLLOW, Action.SAVE, Action.REPOST, Action.SUBSCRIBE}
+delete_social_action_types = {Action.UNFOLLOW, Action.UNSAVE, Action.UNREPOST, Action.UNSUBSCRIBE}
 
 premium_content_validation_actions = {
     Action.SAVE,
@@ -33,7 +36,7 @@ def create_social_record(params: ManageEntityParameters):
 
     validate_social_feature(params)
 
-    create_record: Union[Save, Follow, Repost, None] = None
+    create_record: Union[Save, Follow, Repost, Subscription, None] = None
     if params.action == Action.FOLLOW:
         create_record = Follow(
             blockhash=params.event_blockhash,
@@ -66,6 +69,17 @@ def create_social_record(params: ManageEntityParameters):
             user_id=params.user_id,
             repost_item_id=params.entity_id,
             repost_type=params.entity_type.lower(),
+            is_current=True,
+            is_delete=False,
+        )
+    if params.action == Action.SUBSCRIBE:
+        create_record = Subscription(
+            blockhash=params.event_blockhash,
+            blocknumber=params.block_number,
+            created_at=params.block_datetime,
+            txhash=params.txhash,
+            user_id=params.entity_id,
+            subscriber_id=params.user_id,
             is_current=True,
             is_delete=False,
         )
@@ -117,6 +131,17 @@ def delete_social_record(params):
             user_id=params.user_id,
             repost_item_id=params.entity_id,
             repost_type=params.entity_type.lower(),
+            is_current=True,
+            is_delete=True,
+        )
+    elif params.action == Action.UNSUBSCRIBE:
+        deleted_record = Subscription(
+            blockhash=params.event_blockhash,
+            blocknumber=params.block_number,
+            created_at=params.block_datetime,
+            txhash=params.txhash,
+            user_id=params.entity_id,
+            subscriber_id=params.user_id,
             is_current=True,
             is_delete=True,
         )

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -31,6 +31,8 @@ class Action(str, Enum):
     REPOST = "Repost"
     UNREPOST = "Unrepost"
     VERIFY = "Verify"
+    SUBSCRIBE = "Subscribe"
+    UNSUBSCRIBE = "Unsubscribe"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -44,6 +46,7 @@ class EntityType(str, Enum):
     FOLLOW = "Follow"
     SAVE = "Save"
     REPOST = "Repost"
+    SUBSCRIPTION = "Subscription"
 
     def __str__(self) -> str:
         return str.__str__(self)

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -7,6 +7,7 @@ from src.models.playlists.playlist import Playlist
 from src.models.social.follow import Follow
 from src.models.social.repost import Repost
 from src.models.social.save import Save
+from src.models.social.subscription import Subscription
 from src.models.tracks.track import Track
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.user import User
@@ -59,6 +60,7 @@ class RecordDict(TypedDict):
     Follow: Dict[Tuple, List[Follow]]
     Save: Dict[Tuple, List[Save]]
     Repost: Dict[Tuple, List[Repost]]
+    Subscription: Dict[Tuple, List[Subscription]]
 
 
 class ExistingRecordDict(TypedDict):
@@ -67,6 +69,7 @@ class ExistingRecordDict(TypedDict):
     User: Dict[int, User]
     Follow: Dict[Tuple, Follow]
     Save: Dict[Tuple, Save]
+    Subscription: Dict[Tuple, Subscription]
 
 
 class EntitiesToFetchDict(TypedDict):
@@ -75,6 +78,7 @@ class EntitiesToFetchDict(TypedDict):
     User: Set[int]
     Follow: Set[Tuple]
     Save: Set[Tuple]
+    Subscription: Set[Tuple]
 
 
 MANAGE_ENTITY_EVENT_TYPE = "ManageEntity"

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -770,6 +770,54 @@ export class Users extends Base {
   }
 
   /**
+   * Adds a user subscribe for a given subscriber and user
+   */
+  async addUserSubscribe(userId: number) {
+    try {
+      const subscriberUserId = this.userStateManager.getCurrentUserId()
+      const response = await this.contracts.EntityManagerClient!.manageEntity(
+        subscriberUserId!,
+        EntityManagerClient.EntityType.USER,
+        userId,
+        EntityManagerClient.Action.SUBSCRIBE,
+        ''
+      )
+      return {
+        blockHash: response.txReceipt.blockHash,
+        blockNumber: response.txReceipt.blockNumber
+      }
+    } catch (e) {
+      return {
+        error: (e as Error).message
+      }
+    }
+  }
+
+  /**
+   * Delete a user subscribe for a given subscriber and user
+   */
+  async deleteUserSubscribe(userId: number) {
+    try {
+      const subscriberUserId = this.userStateManager.getCurrentUserId()
+      const response = await this.contracts.EntityManagerClient!.manageEntity(
+        subscriberUserId!,
+        EntityManagerClient.EntityType.USER,
+        userId,
+        EntityManagerClient.Action.UNSUBSCRIBE,
+        ''
+      )
+      return {
+        blockHash: response.txReceipt.blockHash,
+        blockNumber: response.txReceipt.blockNumber
+      }
+    } catch (e) {
+      return {
+        error: (e as Error).message
+      }
+    }
+  }
+
+  /**
    * Gets listen count data for a user's tracks grouped by month
    * @returns Dictionary of listen count data where keys are requested months
    */

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -770,7 +770,7 @@ export class Users extends Base {
   }
 
   /**
-   * Adds a user subscribe for a given subscriber and user
+   * Adds a user subscription for a given subscriber and user
    */
   async addUserSubscribe(userId: number) {
     try {
@@ -794,7 +794,7 @@ export class Users extends Base {
   }
 
   /**
-   * Delete a user subscribe for a given subscriber and user
+   * Delete a user subscription for a given subscriber and user
    */
   async deleteUserSubscribe(userId: number) {
     try {

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -91,11 +91,6 @@ export class EntityManager extends Base {
 
   followUser = this.createSocialMethod(EntityType.USER, Action.FOLLOW)
   unfollowUser = this.createSocialMethod(EntityType.USER, Action.UNFOLLOW)
-  subscribeToUser = this.createSocialMethod(EntityType.USER, Action.SUBSCRIBE)
-  unsubscribeFromUser = this.createSocialMethod(
-    EntityType.USER,
-    Action.UNSUBSCRIBE
-  )
   saveTrack = this.createSocialMethod(EntityType.TRACK, Action.SAVE)
   unsaveTrack = this.createSocialMethod(EntityType.TRACK, Action.UNSAVE)
   savePlaylist = this.createSocialMethod(EntityType.PLAYLIST, Action.SAVE)

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -91,6 +91,11 @@ export class EntityManager extends Base {
 
   followUser = this.createSocialMethod(EntityType.USER, Action.FOLLOW)
   unfollowUser = this.createSocialMethod(EntityType.USER, Action.UNFOLLOW)
+  subscribeToUser = this.createSocialMethod(EntityType.USER, Action.SUBSCRIBE)
+  unsubscribeFromUser = this.createSocialMethod(
+    EntityType.USER,
+    Action.UNSUBSCRIBE
+  )
   saveTrack = this.createSocialMethod(EntityType.TRACK, Action.SAVE)
   unsaveTrack = this.createSocialMethod(EntityType.TRACK, Action.UNSAVE)
   savePlaylist = this.createSocialMethod(EntityType.PLAYLIST, Action.SAVE)

--- a/libs/src/services/dataContracts/EntityManagerClient.ts
+++ b/libs/src/services/dataContracts/EntityManagerClient.ts
@@ -16,7 +16,9 @@ export enum Action {
   SAVE = 'Save',
   UNSAVE = 'Unsave',
   REPOST = 'Repost',
-  UNREPOST = 'Unrepost'
+  UNREPOST = 'Unrepost',
+  SUBSCRIBE = 'Subscribe',
+  UNSUBSCRIBE = 'Unsubscribe'
 }
 
 export enum EntityType {


### PR DESCRIPTION
### Description
Add subscriptions to entity manager as a part of social actions (subscribe, unsubscribe).
Create `addUserSubscribe` and `deleteUserSubscribe` in libs user API to call `manageEntity`.

### Tests
Integration tests.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Uses existing entity manager logs.