### PR TITLE
raise exception if ES is stale

### DIFF
--- a/discovery-provider/src/queries/get_feed_es.py
+++ b/discovery-provider/src/queries/get_feed_es.py
@@ -10,10 +10,13 @@ from src.utils.elasticdsl import (
     pluck_hits,
     populate_track_or_playlist_metadata_es,
     populate_user_metadata_es,
+    raise_if_es_is_stale,
 )
 
 
 def get_feed_es(args, limit=10):
+    raise_if_es_is_stale()
+
     current_user_id = str(args.get("user_id"))
     feed_filter = args.get("filter", "all")
     load_reposts = feed_filter in ["repost", "all"]

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -12,6 +12,7 @@ from src.utils.elasticdsl import (
     pluck_hits,
     populate_track_or_playlist_metadata_es,
     populate_user_metadata_es,
+    raise_if_es_is_stale,
 )
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,8 @@ logger = logging.getLogger(__name__)
 def search_es_full(args: dict):
     if not esclient:
         raise Exception("esclient is None")
+
+    raise_if_es_is_stale()
 
     search_str = args.get("query")
     current_user_id = args.get("current_user_id")

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 import os
 
 from elasticsearch import Elasticsearch
@@ -17,6 +18,20 @@ ES_TRACKS = "tracks"
 ES_USERS = "users"
 
 ES_INDEXES = [ES_PLAYLISTS, ES_REPOSTS, ES_SAVES, ES_TRACKS, ES_USERS]
+
+STALE_THRESHOLD_SECONDS = 4 * 60 * 60  # 4 hours
+
+
+def raise_if_es_is_stale():
+    # get most recent repost
+    # if the created_at is > 4 hours old, ES is stale so raise an exception
+    found = esclient.search(index="reposts", size=1, sort="created_at:desc")
+    ts_str = found["hits"]["hits"][0]["_source"]["created_at"]
+    ts = datetime.datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    age = datetime.datetime.now() - ts
+    is_prod = os.getenv("audius_discprov_env") == "prod"
+    if is_prod and age.seconds > STALE_THRESHOLD_SECONDS:
+        raise Exception(f"ES data is stale. Last repost: {ts_str}")
 
 
 def listify(things):


### PR DESCRIPTION
### Description

es-indexer index creation failed on some nodes where disk was >90% full.
API would continue to serve feed and search from old indices.
We'll need to fix root cause, but this PR will throw exception if newest repost in ES is > 4 hours old.
This is only enabled in prod as dev + stage have old data normally.

