### PR TITLE
[PAY-722] Check if audio_tx_hist backfilling complete

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -629,6 +629,10 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_TRACK_IS_AVAILABLE_LOCK)
 
+    redis_inst.delete("index_user_bank_backfill_complete")
+    redis_inst.delete("index_rewards_manager_backfill_complete")
+    redis_inst.delete("index_spl_token_backfill_complete")
+
     logger.info("Redis instance initialized!")
 
     # Initialize custom task context with database object

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -629,10 +629,6 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_TRACK_IS_AVAILABLE_LOCK)
 
-    redis_inst.delete("index_user_bank_backfill_complete")
-    redis_inst.delete("index_rewards_manager_backfill_complete")
-    redis_inst.delete("index_spl_token_backfill_complete")
-
     logger.info("Redis instance initialized!")
 
     # Initialize custom task context with database object

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -19,6 +19,11 @@ from src.queries.get_sol_plays import get_sol_play_health_info
 from src.queries.get_sol_rewards_manager import get_sol_rewards_manager_health_info
 from src.queries.get_sol_user_bank import get_sol_user_bank_health_info
 from src.queries.get_spl_audio import get_spl_audio_health_info
+from src.tasks.index_rewards_manager_backfill import (
+    index_rewards_manager_backfill_complete,
+)
+from src.tasks.index_spl_token_backfill import index_spl_token_backfill_complete
+from src.tasks.index_user_bank_backfill import index_user_bank_backfill_complete
 from src.utils import db_session, helpers, redis_connection, web3_provider
 from src.utils.config import shared_config
 from src.utils.elasticdsl import ES_INDEXES, esclient
@@ -152,6 +157,9 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     latest_indexed_block_hash: Optional[str] = None
     last_track_unavailability_job_start_time: Optional[str] = None
     last_track_unavailability_job_end_time: Optional[str] = None
+    is_index_user_bank_backfill_complete: Optional[str] = None
+    is_index_rewards_manager_backfill_complete: Optional[str] = None
+    is_spl_token_backfill_complete: Optional[str] = None
 
     if use_redis_cache:
         # get latest blockchain state from redis cache, or fallback to chain if None
@@ -250,6 +258,24 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
         last_track_unavailability_job_end_time = None
 
+    try:
+        is_index_user_bank_backfill_complete = str(
+            redis.get(index_user_bank_backfill_complete).decode()
+        )
+        is_index_rewards_manager_backfill_complete = str(
+            redis.get(index_rewards_manager_backfill_complete).decode()
+        )
+        is_spl_token_backfill_complete = str(
+            redis.get(index_spl_token_backfill_complete).decode()
+        )
+    except Exception as e:
+        logger.error(
+            f"Could not check whether audio_transactions_history backfilling is complete: {e}"
+        )
+        is_index_user_bank_backfill_complete = None
+        is_index_rewards_manager_backfill_complete = None
+        is_spl_token_backfill_complete = None
+
     # Get system information monitor values
     sys_info = monitors.get_monitors(
         [
@@ -299,6 +325,11 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         # Temp
         "latest_block_num": latest_block_num,
         "latest_indexed_block_num": latest_indexed_block_num,
+        "zz_audio_transactions_history_backfill": {
+            "index_user_backfilling_complete": is_index_user_bank_backfill_complete,
+            "rewards_manager_backfilling_complete": is_index_rewards_manager_backfill_complete,
+            "spl_token_backfilling_complete": is_spl_token_backfill_complete,
+        },
     }
 
     if latest_block_num is not None and latest_indexed_block_num is not None:

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -157,9 +157,9 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     latest_indexed_block_hash: Optional[str] = None
     last_track_unavailability_job_start_time: Optional[str] = None
     last_track_unavailability_job_end_time: Optional[str] = None
-    is_index_user_bank_backfill_complete: Optional[str] = None
-    is_index_rewards_manager_backfill_complete: Optional[str] = None
-    is_spl_token_backfill_complete: Optional[str] = None
+    is_index_user_bank_backfill_complete: bool = False
+    is_index_rewards_manager_backfill_complete: bool = False
+    is_index_spl_token_backfill_complete: bool = False
 
     if use_redis_cache:
         # get latest blockchain state from redis cache, or fallback to chain if None
@@ -259,34 +259,34 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         last_track_unavailability_job_end_time = None
 
     try:
-        redis_result = redis.get(index_user_bank_backfill_complete)
-        if redis_result:
-            is_index_user_bank_backfill_complete = str(redis_result.decode())
+        is_index_user_bank_backfill_complete = bool(
+            redis.get(index_user_bank_backfill_complete)
+        )
     except Exception as e:
         logger.error(
             f"Could not check whether index_user_bank backfilling is complete: {e}"
         )
-        is_index_user_bank_backfill_complete = None
+        is_index_user_bank_backfill_complete = False
 
     try:
-        redis_result = redis.get(index_rewards_manager_backfill_complete)
-        if redis_result:
-            is_index_rewards_manager_backfill_complete = str(redis_result.decode())
+        is_index_rewards_manager_backfill_complete = bool(
+            redis.get(index_rewards_manager_backfill_complete)
+        )
     except Exception as e:
         logger.error(
             f"Could not check whether index_rewards_manager backfilling is complete: {e}"
         )
-        is_index_rewards_manager_backfill_complete = None
+        is_index_rewards_manager_backfill_complete = False
 
     try:
-        redis_result = redis.get(index_spl_token_backfill_complete)
-        if redis_result:
-            is_spl_token_backfill_complete = str(redis_result.decode())
+        is_index_spl_token_backfill_complete = bool(
+            redis.get(index_spl_token_backfill_complete)
+        )
     except Exception as e:
         logger.error(
             f"Could not check whether index_spl_token backfilling is complete: {e}"
         )
-        is_spl_token_backfill_complete = None
+        is_index_spl_token_backfill_complete = False
 
     # Get system information monitor values
     sys_info = monitors.get_monitors(
@@ -340,7 +340,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "transactions_history_backfill": {
             "index_user_backfilling_complete": is_index_user_bank_backfill_complete,
             "rewards_manager_backfilling_complete": is_index_rewards_manager_backfill_complete,
-            "spl_token_backfilling_complete": is_spl_token_backfill_complete,
+            "spl_token_backfilling_complete": is_index_spl_token_backfill_complete,
         },
     }
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -259,21 +259,33 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         last_track_unavailability_job_end_time = None
 
     try:
-        is_index_user_bank_backfill_complete = str(
-            redis.get(index_user_bank_backfill_complete).decode()
-        )
-        is_index_rewards_manager_backfill_complete = str(
-            redis.get(index_rewards_manager_backfill_complete).decode()
-        )
-        is_spl_token_backfill_complete = str(
-            redis.get(index_spl_token_backfill_complete).decode()
-        )
+        redis_result = redis.get(index_user_bank_backfill_complete)
+        if redis_result:
+            is_index_user_bank_backfill_complete = str(redis_result.decode())
     except Exception as e:
         logger.error(
-            f"Could not check whether audio_transactions_history backfilling is complete: {e}"
+            f"Could not check whether index_user_bank backfilling is complete: {e}"
         )
         is_index_user_bank_backfill_complete = None
+
+    try:
+        redis_result = redis.get(index_rewards_manager_backfill_complete)
+        if redis_result:
+            is_index_rewards_manager_backfill_complete = str(redis_result.decode())
+    except Exception as e:
+        logger.error(
+            f"Could not check whether index_rewards_manager backfilling is complete: {e}"
+        )
         is_index_rewards_manager_backfill_complete = None
+
+    try:
+        redis_result = redis.get(index_spl_token_backfill_complete)
+        if redis_result:
+            is_spl_token_backfill_complete = str(redis_result.decode())
+    except Exception as e:
+        logger.error(
+            f"Could not check whether index_spl_token backfilling is complete: {e}"
+        )
         is_spl_token_backfill_complete = None
 
     # Get system information monitor values
@@ -325,7 +337,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         # Temp
         "latest_block_num": latest_block_num,
         "latest_indexed_block_num": latest_indexed_block_num,
-        "zz_audio_transactions_history_backfill": {
+        "transactions_history_backfill": {
             "index_user_backfilling_complete": is_index_user_bank_backfill_complete,
             "rewards_manager_backfilling_complete": is_index_rewards_manager_backfill_complete,
             "spl_token_backfilling_complete": is_spl_token_backfill_complete,

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Callable, Dict, List, Optional, TypedDict
 
 import base58
+from redis import Redis
 from sqlalchemy import asc, desc, or_
 from sqlalchemy.orm.session import Session
 from src.models.indexing.indexing_checkpoints import IndexingCheckpoint
@@ -100,6 +101,7 @@ class RewardManagerTransactionInfo(TypedDict):
 
 challenge_type_map_global: Dict[str, TransactionType] = {}
 index_rewards_manager_backfill_tablename = "index_rewards_manager_backfill"
+index_rewards_manager_backfill_complete = "index_rewards_manager_backfill_complete"
 
 
 def get_challenge_type_map(
@@ -581,35 +583,58 @@ def process_solana_rewards_manager(
 
 
 def check_if_backfilling_complete(
-    session: Session, solana_client_manager: SolanaClientManager
+    session: Session, solana_client_manager: SolanaClientManager, redis: Redis
 ) -> bool:
-    stop_sig_tuple = (
-        session.query(IndexingCheckpoint.signature)
-        .filter(
-            IndexingCheckpoint.tablename == index_rewards_manager_backfill_tablename
+    try:
+        redis_complete = redis.get(index_rewards_manager_backfill_complete)
+        if redis_complete:
+            redis_complete = str(redis_complete.decode())
+        if redis_complete == "true":
+            return True
+
+        stop_sig_tuple = (
+            session.query(IndexingCheckpoint.signature)
+            .filter(
+                IndexingCheckpoint.tablename == index_rewards_manager_backfill_tablename
+            )
+            .first()
         )
-        .first()
-    )
-    if not stop_sig_tuple:
+        if not stop_sig_tuple:
+            logger.error(
+                "index_rewards_manager_backfill.py | Tried to check if complete, but no stop_sig"
+            )
+            return False
+        else:
+            stop_sig = stop_sig_tuple[0]
+
+        one_sig_before_stop_result = solana_client_manager.get_signatures_for_address(
+            REWARDS_MANAGER_PROGRAM,
+            before=stop_sig,
+            limit=1,
+        )
+        if one_sig_before_stop_result:
+            one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
+            one_sig_before_stop = one_sig_before_stop_result["signature"]
+        else:
+            logger.error("index_rewards_manager_backfill.py | No sigs before stop_sig")
+            return False
+
+        sig_before_stop_in_db = (
+            session.query(RewardsManagerBackfillTransaction)
+            .filter(RewardsManagerBackfillTransaction.signature == one_sig_before_stop)
+            .first()
+        )
+        complete = bool(sig_before_stop_in_db)
+        redis.set(
+            index_rewards_manager_backfill_complete, "true" if complete else "false"
+        )
+        return complete
+    except Exception as e:
         logger.error(
-            "index_rewards_manager_backfill.py | Tried to check if complete, but no stop_sig"
+            "index_rewards_manager_backfill.py | Error during check_if_backfilling_complete",
+            exc_info=True,
         )
-        return False
-    else:
-        stop_sig = stop_sig_tuple[0]
-    one_sig_before_stop = solana_client_manager.get_signatures_for_address(
-        REWARDS_MANAGER_PROGRAM,
-        before=stop_sig,
-        limit=1,
-    )
-    if one_sig_before_stop:
-        one_sig_before_stop = one_sig_before_stop["result"][0]["signature"]
-    sig_before_stop_in_db = (
-        session.query(RewardsManagerBackfillTransaction)
-        .filter(RewardsManagerBackfillTransaction.signature == one_sig_before_stop)
-        .first()
-    )
-    return bool(sig_before_stop_in_db)
+        raise e
 
 
 def find_true_stop_sig(
@@ -707,7 +732,7 @@ def index_rewards_manager_backfill(self):
         )
         return
 
-    if check_if_backfilling_complete(session, solana_client_manager):
+    if check_if_backfilling_complete(session, solana_client_manager, redis):
         logger.info("index_rewards_manager_backfill.py | Backfill indexing complete!")
         return
 

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -714,7 +714,7 @@ def index_rewards_manager_backfill(self):
         if not stop_sig:
             stop_sig = find_true_stop_sig(session, solana_client_manager, stop_sig)
             if not stop_sig:
-                logger.error(
+                logger.info(
                     "index_rewards_manager_backfill.py | Failed to find true stop signature"
                 )
                 return

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -583,10 +583,8 @@ def check_if_backfilling_complete(
     session: Session, solana_client_manager: SolanaClientManager, redis: Redis
 ) -> bool:
     try:
-        redis_complete = redis.get(index_rewards_manager_backfill_complete)
+        redis_complete = bool(redis.get(index_rewards_manager_backfill_complete))
         if redis_complete:
-            redis_complete = str(redis_complete.decode())
-        if redis_complete == "true":
             return True
 
         stop_sig_tuple = (
@@ -620,9 +618,8 @@ def check_if_backfilling_complete(
             .first()
         )
         complete = bool(sig_before_stop_in_db)
-        redis.set(
-            index_rewards_manager_backfill_complete, "true" if complete else "false"
-        )
+        if complete:
+            redis.set(index_rewards_manager_backfill_complete, int(complete))
         return complete
     except Exception as e:
         logger.error(

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -453,9 +453,6 @@ def get_transaction_signatures(
                     logger.debug(
                         f"index_rewards_manager_backfill.py | Processing tx={tx_sig} | slot={tx_slot}"
                     )
-                    logger.info(
-                        f"index_rewards_manager_backfill.py | Adding tx to be processed: tx={tx_sig} | slot={tx_slot}"
-                    )
                     if tx_info["slot"] > latest_processed_slot:
                         transaction_signature_batch.append(tx_sig)
                     elif tx_info["slot"] <= latest_processed_slot and (

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -604,20 +604,18 @@ def check_if_backfilling_complete(
                 "index_rewards_manager_backfill.py | Tried to check if complete, but no stop_sig"
             )
             return False
-        else:
-            stop_sig = stop_sig_tuple[0]
+        stop_sig = stop_sig_tuple[0]
 
         one_sig_before_stop_result = solana_client_manager.get_signatures_for_address(
             REWARDS_MANAGER_PROGRAM,
             before=stop_sig,
             limit=1,
         )
-        if one_sig_before_stop_result:
-            one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
-            one_sig_before_stop = one_sig_before_stop_result["signature"]
-        else:
+        if not one_sig_before_stop_result:
             logger.error("index_rewards_manager_backfill.py | No sigs before stop_sig")
             return False
+        one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
+        one_sig_before_stop = one_sig_before_stop_result["signature"]
 
         sig_before_stop_in_db = (
             session.query(RewardsManagerBackfillTransaction)

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -468,10 +468,8 @@ def check_if_backfilling_complete(
     session: Session, solana_client_manager: SolanaClientManager, redis: Redis
 ) -> bool:
     try:
-        redis_complete = redis.get(index_spl_token_backfill_complete)
+        redis_complete = bool(redis.get(index_spl_token_backfill_complete))
         if redis_complete:
-            redis_complete = str(redis_complete.decode())
-        if redis_complete == "true":
             return True
 
         stop_sig_tuple = (
@@ -503,7 +501,8 @@ def check_if_backfilling_complete(
             .first()
         )
         complete = bool(sig_before_stop_in_db)
-        redis.set(index_spl_token_backfill_complete, "true" if complete else "false")
+        if complete:
+            redis.set(index_spl_token_backfill_complete, int(complete))
         return complete
     except Exception as e:
         logger.error(

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -598,7 +598,7 @@ def index_spl_token_backfill(self):
         if not stop_sig:
             stop_sig = find_true_stop_sig(session, solana_client_manager, stop_sig)
             if not stop_sig:
-                logger.error(
+                logger.info(
                     "index_spl_token_backfill.py | Failed to find true stop signature"
                 )
                 return

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, List, Optional, Set, TypedDict
 
 import base58
+from redis import Redis
 from solana.publickey import PublicKey
 from sqlalchemy import and_, asc, or_
 from sqlalchemy.orm.session import Session
@@ -64,6 +65,7 @@ purchase_vendor_map = {
     "Unknown": TransactionType.purchase_unknown,
 }
 index_spl_token_backfill_tablename = "index_spl_token_backfill"
+index_spl_token_backfill_complete = "index_spl_token_backfill_complete"
 
 logger = logging.getLogger(__name__)
 
@@ -464,33 +466,54 @@ purchase_types = [
 
 
 def check_if_backfilling_complete(
-    session: Session, solana_client_manager: SolanaClientManager
+    session: Session, solana_client_manager: SolanaClientManager, redis: Redis
 ) -> bool:
-    stop_sig_tuple = (
-        session.query(IndexingCheckpoint.signature)
-        .filter(IndexingCheckpoint.tablename == index_spl_token_backfill_tablename)
-        .first()
-    )
-    if not stop_sig_tuple:
-        logger.error(
-            "index_spl_token_backfill.py | Tried to check if complete, but no stop_sig"
+    try:
+        redis_complete = redis.get(index_spl_token_backfill_complete)
+        if redis_complete:
+            redis_complete = str(redis_complete.decode())
+        if redis_complete == "true":
+            return True
+
+        stop_sig_tuple = (
+            session.query(IndexingCheckpoint.signature)
+            .filter(IndexingCheckpoint.tablename == index_spl_token_backfill_tablename)
+            .first()
         )
-        return False
-    else:
-        stop_sig = stop_sig_tuple[0]
-    one_sig_before_stop = solana_client_manager.get_signatures_for_address(
-        SPL_TOKEN_PROGRAM,
-        before=stop_sig,
-        limit=1,
-    )
-    if one_sig_before_stop:
-        one_sig_before_stop = one_sig_before_stop["result"][0]["signature"]
-    sig_before_stop_in_db = (
-        session.query(SPLTokenBackfillTransaction)
-        .filter(SPLTokenBackfillTransaction.signature == one_sig_before_stop)
-        .first()
-    )
-    return bool(sig_before_stop_in_db)
+        if not stop_sig_tuple:
+            logger.error(
+                "index_spl_token_backfill.py | Tried to check if complete, but no stop_sig"
+            )
+            return False
+        else:
+            stop_sig = stop_sig_tuple[0]
+
+        one_sig_before_stop_result = solana_client_manager.get_signatures_for_address(
+            SPL_TOKEN_PROGRAM,
+            before=stop_sig,
+            limit=1,
+        )
+        if one_sig_before_stop_result:
+            one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
+            one_sig_before_stop = one_sig_before_stop_result["signature"]
+        else:
+            logger.error("index_spl_token_backfill.py | No sigs before stop_sig")
+            return False
+
+        sig_before_stop_in_db = (
+            session.query(SPLTokenBackfillTransaction)
+            .filter(SPLTokenBackfillTransaction.signature == one_sig_before_stop)
+            .first()
+        )
+        complete = bool(sig_before_stop_in_db)
+        redis.set(index_spl_token_backfill_complete, "true" if complete else "false")
+        return complete
+    except Exception as e:
+        logger.error(
+            "index_spl_token_backfill.py | Error during check_if_backfilling_complete",
+            exc_info=True,
+        )
+        raise e
 
 
 def find_true_stop_sig(
@@ -591,7 +614,7 @@ def index_spl_token_backfill(self):
         logger.info(f"index_spl_token_backfill.py | Error with stop_sig: {stop_sig}")
         return
 
-    if check_if_backfilling_complete(session, solana_client_manager):
+    if check_if_backfilling_complete(session, solana_client_manager, redis):
         logger.info("index_spl_token_backfill.py | Backfill indexing complete!")
         return
 

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -485,20 +485,18 @@ def check_if_backfilling_complete(
                 "index_spl_token_backfill.py | Tried to check if complete, but no stop_sig"
             )
             return False
-        else:
-            stop_sig = stop_sig_tuple[0]
+        stop_sig = stop_sig_tuple[0]
 
         one_sig_before_stop_result = solana_client_manager.get_signatures_for_address(
             SPL_TOKEN_PROGRAM,
             before=stop_sig,
             limit=1,
         )
-        if one_sig_before_stop_result:
-            one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
-            one_sig_before_stop = one_sig_before_stop_result["signature"]
-        else:
+        if not one_sig_before_stop_result:
             logger.error("index_spl_token_backfill.py | No sigs before stop_sig")
             return False
+        one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
+        one_sig_before_stop = one_sig_before_stop_result["signature"]
 
         sig_before_stop_in_db = (
             session.query(SPLTokenBackfillTransaction)

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -403,7 +403,6 @@ def process_spl_token_tx(
             if latest_processed_slot is None:
                 logger.debug("index_spl_token_backfill.py | setting from none")
                 transaction_signature_batch = transactions_array
-                intersection_found = True
             else:
                 for tx in transactions_array:
                     if tx["slot"] > latest_processed_slot:

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -521,20 +521,18 @@ def check_if_backfilling_complete(
                 "index_user_bank_backfill.py | Tried to check if complete, but no stop_sig"
             )
             return False
-        else:
-            stop_sig = stop_sig_tuple[0]
+        stop_sig = stop_sig_tuple[0]
 
         one_sig_before_stop_result = solana_client_manager.get_signatures_for_address(
             USER_BANK_ADDRESS,
             before=stop_sig,
             limit=1,
         )
-        if one_sig_before_stop_result:
-            one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
-            one_sig_before_stop = one_sig_before_stop_result["signature"]
-        else:
+        if not one_sig_before_stop_result:
             logger.error("index_user_bank_backfill.py | No sigs before stop_sig")
             return False
+        one_sig_before_stop_result = one_sig_before_stop_result["result"][0]
+        one_sig_before_stop = one_sig_before_stop_result["signature"]
 
         sig_before_stop_in_db = (
             session.query(UserBankBackfillTx)

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -413,9 +413,6 @@ def process_user_bank_txs(stop_sig: str):
                     logger.debug(
                         f"index_user_bank_backfill.py | Processing tx={tx_sig} | slot={tx_slot}"
                     )
-                    logger.info(
-                        f"index_user_bank_backfill.py | Processing tx={tx_sig} | slot={tx_slot}"
-                    )
                     if tx_info["slot"] > latest_processed_slot:
                         transaction_signature_batch.append(tx_sig)
                     elif (

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -58,6 +58,7 @@ TRANSFER_SENDER_ACCOUNT_INDEX = 1
 TRANSFER_RECEIVER_ACCOUNT_INDEX = 2
 
 index_user_bank_backfill_tablename = "index_user_bank_backfill"
+index_user_bank_backfill_complete = "index_user_bank_backfill_complete"
 
 
 # Recover ethereum public key from bytes array

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -502,10 +502,8 @@ def check_if_backfilling_complete(
     session: Session, solana_client_manager: SolanaClientManager, redis: Redis
 ) -> bool:
     try:
-        redis_complete = redis.get(index_user_bank_backfill_complete)
+        redis_complete = bool(redis.get(index_user_bank_backfill_complete))
         if redis_complete:
-            redis_complete = str(redis_complete.decode())
-        if redis_complete == "true":
             return True
 
         stop_sig_tuple = (
@@ -537,7 +535,8 @@ def check_if_backfilling_complete(
             .first()
         )
         complete = bool(sig_before_stop_in_db)
-        redis.set(index_user_bank_backfill_complete, "true" if complete else "false")
+        if complete:
+            redis.set(index_user_bank_backfill_complete, int(complete))
         return complete
     except Exception as e:
         logger.error(

--- a/discovery-provider/src/tasks/index_user_bank_backfill.py
+++ b/discovery-provider/src/tasks/index_user_bank_backfill.py
@@ -634,7 +634,7 @@ def index_user_bank_backfill(self):
         if not stop_sig:
             stop_sig = find_true_stop_sig(session, solana_client_manager, stop_sig)
             if not stop_sig:
-                logger.error(
+                logger.info(
                     "index_user_bank_backfill.py | Failed to find true stop signature"
                 )
                 return


### PR DESCRIPTION
### Description
Adds fields in health check that tell us whether the backfill indexing for `audio_tx_history` is complete by caching the results of each indexer's `check_if_backfilling_complete` fns in redis. Also checks the redis cache in the `check_if_backfilling_complete` functions themselves to return early if we've already determined that indexer is complete.


### Tests
Observed behavior in remote-dev that is indexing prod.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Lots of error logs if something goes south.