### PR TITLE
es-indexer: if red index, delete all indices

### DIFF
--- a/discovery-provider/es-indexer/src/main.ts
+++ b/discovery-provider/es-indexer/src/main.ts
@@ -10,6 +10,7 @@ import { setupTriggers } from './setup'
 import {
   ensureSaneCluterSettings,
   getBlocknumberCheckpoints,
+  recoverFromRedIndex,
   waitForHealthyCluster,
 } from './conn'
 import { program } from 'commander'
@@ -41,6 +42,7 @@ async function start() {
     .opts()
 
   logger.info(cliFlags, 'booting')
+  await recoverFromRedIndex()
   const health = await waitForHealthyCluster()
   await ensureSaneCluterSettings()
   logger.info(`starting: health ${health.status}`)


### PR DESCRIPTION
### Description

for nodes over 90% disk usage, if a red index is found delete all indexes before starting indexer.

This should provide enough headroom to make new indices.
