### PR TITLE
Fix multiple migration heads breaking builds on main

### DIFF
--- a/discovery-provider/alembic/versions/f91c041d1d8d_rebuild_aggregate_monthly_plays_table.py
+++ b/discovery-provider/alembic/versions/f91c041d1d8d_rebuild_aggregate_monthly_plays_table.py
@@ -1,7 +1,7 @@
 """Rebuild aggregate monthly plays table
 
 Revision ID: f91c041d1d8d
-Revises: 42d5afb85d42
+Revises: 3e99d419fd63
 Create Date: 2022-11-01 21:39:58.467895
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.orm import sessionmaker
 
 # revision identifiers, used by Alembic.
 revision = 'f91c041d1d8d'
-down_revision = '42d5afb85d42'
+down_revision = '3e99d419fd63'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### Description
This [migration](https://github.com/AudiusProject/audius-protocol/pull/4252/files) was generated off a stale head and is breaking builds on main. Update to be on top of correct head.
![image](https://user-images.githubusercontent.com/25782182/199886446-4c6887d0-7478-464a-a1e8-70835ac74d74.png)

Revision id 3e99d419fd63 is from https://github.com/AudiusProject/audius-protocol/pull/4242/files

### Tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
