### PR TITLE
Ability to filter out reconfigs in identity relays

### DIFF
--- a/identity-service/src/config.js
+++ b/identity-service/src/config.js
@@ -831,6 +831,12 @@ const config = convict({
     format: Boolean,
     env: 'entityManagerReplicaSetEnabled',
     default: false
+  },
+  updateReplicaSetReconfigurationLimit: {
+    doc: 'The limit of the replica set reconfiguration transactions that we will relay in 10 seconds',
+    format: Number,
+    env: 'updateReplicaSetReconfigurationLimit',
+    default: 30
   }
 })
 

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -20,6 +20,17 @@ const MIN_GAS_PRICE = config.get('minGasPrice')
 const HIGH_GAS_PRICE = config.get('highGasPrice')
 const GANACHE_GAS_PRICE = config.get('ganacheGasPrice')
 const DEFAULT_GAS_LIMIT = config.get('defaultGasLimit')
+const UPDATE_REPLICA_SET_RECONFIGURATION_LIMIT = config.get(
+  'updateReplicaSetReconfigurationLimit'
+)
+
+const transactionRateLimiter = {
+  updateReplicaSetReconfiguration: 0
+}
+
+setInterval(() => {
+  transactionRateLimiter.updateReplicaSetReconfiguration = 0
+}, 10000)
 
 async function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -72,12 +83,6 @@ const sendTransaction = async (
   return resp
 }
 
-/**
- * TODO(roneilr): this should check that in the registry, contractRegistryKey maps to
- *  contractAddress, rejecting the tx if not. Also needs to maintain a whitelist of
- *  contracts (eg. storage contracts, discovery service contract, should not be allowed
- *  to relay TXes from here but can today).
- */
 const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
   const {
     contractRegistryKey,
@@ -106,13 +111,22 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     contractRegistryKey.charAt(0).toUpperCase() + contractRegistryKey.slice(1) // uppercase the first letter
   const decodedABI = AudiusABIDecoder.decodeMethod(contractName, encodedABI)
 
+  // Rate limit replica set reconfiguration transactions
+  // A reconfiguration (as opposed to a first time selection) will have an
+  // _oldPrimaryId value of "0"
   const isReplicaSetTransaction = decodedABI.name === 'updateReplicaSet'
   if (isReplicaSetTransaction) {
     const isFirstReplicaSetConfig = decodedABI.params.find(
-      param => param.name === '_oldPrimaryId' && param.value === '0'
+      (param) => param.name === '_oldPrimaryId' && param.value === '0'
     )
     if (!isFirstReplicaSetConfig) {
-      throw new Error("Is not first replica set config")
+      transactionRateLimiter.updateReplicaSetReconfiguration += 1
+      if (
+        transactionRateLimiter.updateReplicaSetReconfiguration >
+        UPDATE_REPLICA_SET_RECONFIGURATION_LIMIT
+      ) {
+        throw new Error('Is not first replica set config')
+      }
     }
   }
 

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -125,7 +125,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
         transactionRateLimiter.updateReplicaSetReconfiguration >
         UPDATE_REPLICA_SET_RECONFIGURATION_LIMIT
       ) {
-        throw new Error('Is not first replica set config')
+        throw new Error('updateReplicaSet rate limit reached')
       }
     }
   }

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -106,6 +106,16 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     contractRegistryKey.charAt(0).toUpperCase() + contractRegistryKey.slice(1) // uppercase the first letter
   const decodedABI = AudiusABIDecoder.decodeMethod(contractName, encodedABI)
 
+  const isReplicaSetTransaction = decodedABI.name === 'updateReplicaSet'
+  if (isReplicaSetTransaction) {
+    const isFirstReplicaSetConfig = decodedABI.params.find(
+      param => param.name === '_oldPrimaryId' && param.value === '0'
+    )
+    if (!isFirstReplicaSetConfig) {
+      throw new Error("Is not first replica set config")
+    }
+  }
+
   // will be set later. necessary for code outside scope of try block
   let txReceipt
   let txParams


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
The ability to turn reconfigs off in identity was never merged to main, only to release hotfix branch. This cherry picks @raymondjacobson's commits to enable that functionality.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Was running on prod for a week.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
There should be zero reconfigs sent to chain.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->