### PR TITLE
Change frequent sync logs from info to debug

### DIFF
--- a/creator-node/src/services/sync/secondarySyncFromPrimary.ts
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.ts
@@ -527,7 +527,7 @@ const handleSyncFromPrimary = async ({
       // Save all track files to disk in batches (to limit concurrent load)
       for (let i = 0; i < trackFiles.length; i += FileSaveMaxConcurrency) {
         const trackFilesSlice = trackFiles.slice(i, i + FileSaveMaxConcurrency)
-        logger.info(
+        logger.debug(
           `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${
             i + FileSaveMaxConcurrency
           } out of total ${trackFiles.length}...`
@@ -565,7 +565,7 @@ const handleSyncFromPrimary = async ({
           i,
           i + FileSaveMaxConcurrency
         )
-        logger.info(
+        logger.debug(
           `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${
             i + FileSaveMaxConcurrency
           } out of total ${nonTrackFiles.length}...`


### PR DESCRIPTION
### Description
Changes some sync logs from info to debug to avoid log pollution. These logs get printed for every 10 files processed, and a single sync can process thousands of files.


### Tests
CI passing is sufficient.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
We shouldn't see logs for "processing files {X} to {Y}" outside of local dev.