### PR TITLE
CON-445 add new and future exporter scrapers

### DIFF
--- a/monitoring/prometheus/generateProm.js
+++ b/monitoring/prometheus/generateProm.js
@@ -15,7 +15,7 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
   url = url.replace("https://", "").replace("http://", "")
   sanitizedUrl = url.split(".").join("-")
 
-  return `
+  let yaml = `
   - job_name: '${sanitizedUrl}'
     scheme: '${scheme}'
     metrics_path: '/prometheus_metrics'
@@ -26,7 +26,64 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'audius'
           component: '${component}'
+  - job_name: '${sanitizedUrl}_postgres_exporter'
+    scheme: '${scheme}'
+    metrics_path: '/prometheus/postgres'
+    static_configs:
+      - targets: ['${url}']
+        labels:
+          host: '${url}'
+          environment: '${env}'
+          service: 'postgres'
+          component: '${component}'
+  - job_name: '${sanitizedUrl}_redis_exporter'
+    scheme: '${scheme}'
+    metrics_path: '/prometheus/redis'
+    static_configs:
+      - targets: ['${url}']
+        labels:
+          host: '${url}'
+          environment: '${env}'
+          service: 'redis'
+          component: '${component}'
+  - job_name: '${sanitizedUrl}_linux_exporter'
+    scheme: '${scheme}'
+    metrics_path: '/prometheus/linux'
+    static_configs:
+      - targets: ['${url}']
+        labels:
+          host: '${url}'
+          environment: '${env}'
+          service: 'linux'
+          component: '${component}'
 `
+
+  if (component == 'discovery-node') {
+    yaml += `
+  - job_name: '${sanitizedUrl}_postgres_read_replica_exporter'
+    scheme: '${scheme}'
+    metrics_path: '/prometheus/postgres/read-replica'
+    static_configs:
+      - targets: ['${url}']
+        labels:
+          host: '${url}'
+          environment: '${env}'
+          service: 'postgres-read-replica'
+          component: '${component}'
+  - job_name: '${sanitizedUrl}_elasticsearch_exporter'
+    scheme: '${scheme}'
+    metrics_path: '/prometheus/elasticsearch'
+    static_configs:
+      - targets: ['${url}']
+        labels:
+          host: '${url}'
+          environment: '${env}'
+          service: 'elasticsearch'
+          component: '${component}'
+  `
+  }
+
+  return yaml
 }
 
 const generateEnv = async (stream, env) => {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Adds scrapers for all upcoming exporters. Lack of a live exporter will not affect prometheus, outside of a ping to an unresponsive URL every 30 seconds.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Compared local runs to production runs. No endpoints were dropped, only new exporter endpoints were added based on the service type.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

N/A until the next Prometheus release.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->