### PR TITLE
CON-445 Add prefixes for new exporters

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     build:
       context: grafana
       args:
-        - GF_INSTALL_IMAGE_RENDERER_PLUGIN=true
         - GF_SERVER_ROOT_URL=grafana.audius.co
     user: 0:0
     env_file:

--- a/monitoring/prometheus/generateProm.js
+++ b/monitoring/prometheus/generateProm.js
@@ -36,6 +36,11 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'postgres'
           component: '${component}'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: '(.*)'
+        replacement: 'postgres_${1}'
+        target_label: __name__
   - job_name: '${sanitizedUrl}_redis_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/redis'
@@ -46,6 +51,11 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'redis'
           component: '${component}'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: '(.*)'
+        replacement: 'redis_${1}'
+        target_label: __name__
   - job_name: '${sanitizedUrl}_linux_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/linux'
@@ -56,6 +66,11 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'linux'
           component: '${component}'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: '(.*)'
+        replacement: 'linux_${1}'
+        target_label: __name__
 `
 
   if (component == 'discovery-node') {
@@ -70,6 +85,11 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'postgres-read-replica'
           component: '${component}'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: '(.*)'
+        replacement: 'postgres_readreplica_${1}'
+        target_label: __name__
   - job_name: '${sanitizedUrl}_elasticsearch_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/elasticsearch'
@@ -80,6 +100,11 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           environment: '${env}'
           service: 'elasticsearch'
           component: '${component}'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: '(.*)'
+        replacement: 'elasticsearch_${1}'
+        target_label: __name__
   `
   }
 

--- a/monitoring/prometheus/generateProm.js
+++ b/monitoring/prometheus/generateProm.js
@@ -38,9 +38,8 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           component: '${component}'
     metric_relabel_configs:
       - source_labels: [__name__]
-        regex: '(.*)'
-        replacement: 'postgres_${1}'
         target_label: __name__
+        replacement: postgres_$1
   - job_name: '${sanitizedUrl}_redis_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/redis'
@@ -53,9 +52,8 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           component: '${component}'
     metric_relabel_configs:
       - source_labels: [__name__]
-        regex: '(.*)'
-        replacement: 'redis_${1}'
         target_label: __name__
+        replacement: redis_$1
   - job_name: '${sanitizedUrl}_linux_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/linux'
@@ -68,9 +66,8 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           component: '${component}'
     metric_relabel_configs:
       - source_labels: [__name__]
-        regex: '(.*)'
-        replacement: 'linux_${1}'
         target_label: __name__
+        replacement: linux_$1
 `
 
   if (component == 'discovery-node') {
@@ -87,9 +84,8 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           component: '${component}'
     metric_relabel_configs:
       - source_labels: [__name__]
-        regex: '(.*)'
-        replacement: 'postgres_readreplica_${1}'
         target_label: __name__
+        replacement: postgres_$1
   - job_name: '${sanitizedUrl}_elasticsearch_exporter'
     scheme: '${scheme}'
     metrics_path: '/prometheus/elasticsearch'
@@ -102,9 +98,8 @@ const generateJobYaml = ({ url, env, scheme = 'https', component = 'discovery-pr
           component: '${component}'
     metric_relabel_configs:
       - source_labels: [__name__]
-        regex: '(.*)'
-        replacement: 'elasticsearch_${1}'
         target_label: __name__
+        replacement: elastic_$1
   `
   }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Group exporter metric names by common prefix.

Also, remove `GF_INSTALL_IMAGE_RENDERER_PLUGIN` since this plugin did not offer the functionality we were looking for (due to the VPN not allowing us to unfurl Grafana previews in Slack) and that plugin is causing current grafana builds to break. 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

TODO: Regenerate configs on prod before merging.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->