### PR TITLE
CON-490 Consolidate CN /health_check and /health_check/verbose

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -72,7 +72,7 @@ http {
         }
 
         # Regex matches any path that begins with /health_check (case-sensitive)
-        # Note this will also include other health check routes /health_check/verbose, /health_check/sync, /health_check/duration, /health_check/duration/heartbeat, /health_check/fileupload
+        # Note this will also include other health check routes /health_check/sync, /health_check/duration, /health_check/duration/heartbeat, /health_check/fileupload
         location ~ (/health_check) {
             proxy_cache cache;
 

--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3566,7 +3566,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -180,10 +180,9 @@ const configCheckController = async (_req) => {
 
 const router = express.Router()
 
-// TODO once all calls to /health_check/verbose are removed, can remove this route
+// TODO once all calls to /health_check/verbose are removed, can remove
 router.get(
-  '/health_check',
-  '/health_check/verbose',
+  ['/health_check', '/health_check/verbose'],
   handleResponse(healthCheckController)
 )
 router.get('/health_check/sync', handleResponse(syncHealthCheckController))

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
@@ -248,17 +248,17 @@ async function resetEarliestUnhealthyTimestamp(
 }
 
 /**
- * Returns /health_check/verbose response.
+ * Returns /health_check response.
  * TODO: - consider moving this pure function to libs
  *
  * @param {string} endpoint the endpoint to query
- * @returns {Object} the /health_check/verbose response from the endpoint
+ * @returns {Object} the response from /health_check endpoint
  */
 async function _queryVerboseHealthCheck(endpoint: string) {
   // Axios request will throw on timeout or non-200 response
   const resp = await axios({
     baseURL: endpoint,
-    url: '/health_check/verbose',
+    url: '/health_check',
     method: 'get',
     timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
     headers: {

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
@@ -38,7 +38,7 @@ const CNodeHealthManager = {
   getEarliestFailedHealthCheckTimestamp,
   setHealthCheckTimestampToNow,
   resetEarliestUnhealthyTimestamp,
-  _queryVerboseHealthCheck,
+  _queryHealthCheck,
   _computeContentNodePeerSet
 }
 
@@ -82,7 +82,7 @@ async function getUnhealthyPeers(
 async function isNodeHealthy(node: string) {
   try {
     const verboseHealthCheckResp =
-      await CNodeHealthManager._queryVerboseHealthCheck(node)
+      await CNodeHealthManager._queryHealthCheck(node)
     // if node returns healthy: false consider that unhealthy just like non-200 response
     const { healthy } = verboseHealthCheckResp
     if (!healthy) {
@@ -254,7 +254,7 @@ async function resetEarliestUnhealthyTimestamp(
  * @param {string} endpoint the endpoint to query
  * @returns {Object} the response from /health_check endpoint
  */
-async function _queryVerboseHealthCheck(endpoint: string) {
+async function _queryHealthCheck(endpoint: string) {
   // Axios request will throw on timeout or non-200 response
   const resp = await axios({
     baseURL: endpoint,

--- a/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
+++ b/creator-node/src/services/stateMachineManager/CNodeHealthManager.ts
@@ -81,14 +81,13 @@ async function getUnhealthyPeers(
 
 async function isNodeHealthy(node: string) {
   try {
-    const verboseHealthCheckResp =
-      await CNodeHealthManager._queryHealthCheck(node)
+    const healthCheckResp = await CNodeHealthManager._queryHealthCheck(node)
     // if node returns healthy: false consider that unhealthy just like non-200 response
-    const { healthy } = verboseHealthCheckResp
+    const { healthy } = healthCheckResp
     if (!healthy) {
       throw new Error(`Node health check returned healthy: false`)
     }
-    CNodeHealthManager.determinePeerHealth(verboseHealthCheckResp)
+    CNodeHealthManager.determinePeerHealth(healthCheckResp)
   } catch (e: any) {
     logger.error(`isNodeHealthy() peer=${node} is unhealthy: ${e.toString()}`)
     return false

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -225,17 +225,17 @@ class PeerSetManager {
   }
 
   /**
-   * Returns /health_check/verbose response
+   * Returns /health_check response
    * TODO: - consider moving this pure function to libs
    *
    * @param {string} endpoint
-   * @returns {Object} the /health_check/verbose response
+   * @returns {Object} the /health_check response
    */
   async queryVerboseHealthCheck(endpoint) {
     // Axios request will throw on timeout or non-200 response
     const resp = await axios({
       baseURL: endpoint,
-      url: '/health_check/verbose',
+      url: '/health_check',
       method: 'get',
       timeout: PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS,
       headers: {

--- a/creator-node/test/CNodeHealthManager.test.js
+++ b/creator-node/test/CNodeHealthManager.test.js
@@ -112,7 +112,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const node = 'http://some_content_node.co'
     const verboseHealthCheckResp = { healthy: true }
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .resolves(verboseHealthCheckResp)
     const determinePeerHealthStub = sandbox.stub(
       CNodeHealthManager,
@@ -131,7 +131,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const node = 'http://some_content_node.co'
     const error = new Error('test error')
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .rejects(error)
     const determinePeerHealthStub = sandbox.stub(
       CNodeHealthManager,
@@ -151,7 +151,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const node = 'http://some_content_node.co'
     const error = new Error('test error')
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .rejects(error)
     const determinePeerHealthStub = sandbox.stub(
       CNodeHealthManager,
@@ -175,7 +175,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const determinePeerHealthError = new Error('test determinePeerHealthError')
     const verboseHealthCheckResp = { healthy: false }
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .resolves(verboseHealthCheckResp)
     const determinePeerHealthStub = sandbox
       .stub(CNodeHealthManager, 'determinePeerHealth')
@@ -193,7 +193,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const node = 'http://some_content_node.co'
     const verboseHealthCheckResp = { healthy: true }
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .resolves(verboseHealthCheckResp)
     const determinePeerHealthStub = sandbox.stub(
       CNodeHealthManager,
@@ -214,7 +214,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
     const node = 'http://some_content_node.co'
     const verboseHealthCheckResp = { healthy: true }
     const queryVerboseHealthCheckStub = sandbox
-      .stub(CNodeHealthManager, '_queryVerboseHealthCheck')
+      .stub(CNodeHealthManager, '_queryHealthCheck')
       .resolves(verboseHealthCheckResp)
     const determinePeerHealthStub = sandbox.stub(
       CNodeHealthManager,
@@ -231,7 +231,7 @@ describe('test CNodeHealthManager -- isNodeHealthy()', function () {
   })
 })
 
-describe('test CNodeHealthManager -- _queryVerboseHealthCheck()', function () {
+describe('test CNodeHealthManager -- _queryHealthCheck()', function () {
   let sandbox
   beforeEach(function () {
     sandbox = sinon.createSandbox()
@@ -254,7 +254,7 @@ describe('test CNodeHealthManager -- _queryVerboseHealthCheck()', function () {
       .get('/health_check')
       .reply(200, { data: verboseHealthResp })
 
-    await CNodeHealthManager._queryVerboseHealthCheck(endpoint)
+    await CNodeHealthManager._queryHealthCheck(endpoint)
     expect(nock.isDone()).to.be.true
   })
 })

--- a/creator-node/test/CNodeHealthManager.test.js
+++ b/creator-node/test/CNodeHealthManager.test.js
@@ -251,7 +251,7 @@ describe('test CNodeHealthManager -- _queryVerboseHealthCheck()', function () {
       verboseData: 'data'
     }
     nock(endpoint)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: verboseHealthResp })
 
     await CNodeHealthManager._queryVerboseHealthCheck(endpoint)

--- a/creator-node/test/healthChecks.test.js
+++ b/creator-node/test/healthChecks.test.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const { getApp } = require('./lib/app')
 const { getLibsMock } = require('./lib/libsMock')
 const BlacklistManager = require('../src/blacklistManager')
+const config = require('../src/config')
 
 describe('Test health checks', () => {
   let app, server
@@ -20,6 +21,22 @@ describe('Test health checks', () => {
 
   afterEach(async () => {
     await server.close()
+  })
+
+  it('Ensure /health_check and /health_check/verbose both work, and return identical responses', async () => {
+    const healthCheckResp = await request(app).get('/health_check')
+      .expect(200)
+      .expect(resp => {
+        assert.strictEqual(resp.body.data.creatorNodeEndpoint, config.get('creatorNodeEndpoint'))
+      })
+    
+    const healthCheckVerboseResp = await request(app).get('/health_check/verbose')
+      .expect(200)
+
+    assert.deepStrictEqual(
+      healthCheckResp.body.data,
+      healthCheckVerboseResp.body.data
+    )
   })
 
   it('Ensure GET /config_check works, and hides sensitive configs', async () => {

--- a/libs/src/api/ServiceProvider.ts
+++ b/libs/src/api/ServiceProvider.ts
@@ -74,7 +74,7 @@ export class ServiceProvider extends Base {
     const timings = await timeRequests({
       requests: creatorNodes.map((node) => ({
         id: node.endpoint,
-        url: `${node.endpoint}/health_check/verbose`
+        url: `${node.endpoint}/health_check`
       })),
       sortByVersion: true,
       timeout,

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
@@ -70,18 +70,18 @@ describe('test CreatorNodeSelection', () => {
   it('selects the fastest healthy service as primary and rest as secondaries', async () => {
     const healthy = 'https://healthy.audius.co'
     nock(healthy)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlow = 'https://healthybutslow.audius.co'
     nock(healthyButSlow)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlowest = 'https://healthybutslowest.audius.co'
     nock(healthyButSlowest)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(200)
       .reply(200, { data: defaultHealthCheckData })
 
@@ -114,18 +114,18 @@ describe('test CreatorNodeSelection', () => {
   it('Return nothing if whitelist is empty set', async function () {
     const healthy = 'https://healthy.audius.co'
     nock(healthy)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlow = 'https://healthybutslow.audius.co'
     nock(healthyButSlow)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlowest = 'https://healthybutslowest.audius.co'
     nock(healthyButSlowest)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(200)
       .reply(200, { data: defaultHealthCheckData })
 
@@ -151,18 +151,18 @@ describe('test CreatorNodeSelection', () => {
   it('Does not select healthy: false node even if status code is 200', async function () {
     const healthy = 'https://healthy.audius.co'
     nock(healthy)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: defaultHealthCheckData })
 
     const healthyButSlow = 'https://healthybutslow.audius.co'
     nock(healthyButSlow)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: defaultHealthCheckData })
 
     const notHealthyButReturns200 = 'https://notHealthyButReturns200.audius.co'
     nock(notHealthyButReturns200)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(200)
       .reply(200, { data: { ...defaultHealthCheckData, healthy: false } })
 
@@ -186,22 +186,22 @@ describe('test CreatorNodeSelection', () => {
   it('select healthy nodes as the primary and secondary, and do not select unhealthy nodes', async () => {
     const upToDate = 'https://upToDate.audius.co'
     nock(upToDate)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: defaultHealthCheckData })
 
     const behindMajor = 'https://behindMajor.audius.co'
     nock(behindMajor)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: { ...defaultHealthCheckData, version: '0.2.3' } })
 
     const behindMinor = 'https://behindMinor.audius.co'
     nock(behindMinor)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: { ...defaultHealthCheckData, version: '1.0.3' } })
 
     const behindPatch = 'https://behindPatch.audius.co'
     nock(behindPatch)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
     const cns = new CreatorNodeSelection({
@@ -231,19 +231,19 @@ describe('test CreatorNodeSelection', () => {
 
   it('return nothing if no services are healthy', async () => {
     const unhealthy1 = 'https://unhealthy1.audius.co'
-    nock(unhealthy1).get('/health_check/verbose').reply(500, {})
+    nock(unhealthy1).get('/health_check').reply(500, {})
 
     const unhealthy2 = 'https://unhealthy2.audius.co'
-    nock(unhealthy2).get('/health_check/verbose').delay(100).reply(500, {})
+    nock(unhealthy2).get('/health_check').delay(100).reply(500, {})
 
     const unhealthy3 = 'https://unhealthy3.audius.co'
-    nock(unhealthy3).get('/health_check/verbose').delay(200).reply(500, {})
+    nock(unhealthy3).get('/health_check').delay(200).reply(500, {})
 
     const unhealthy4 = 'https://unhealthy4.audius.co'
-    nock(unhealthy4).get('/health_check/verbose').delay(300).reply(500, {})
+    nock(unhealthy4).get('/health_check').delay(300).reply(500, {})
 
     const unhealthy5 = 'https://unhealthy5.audius.co'
-    nock(unhealthy5).get('/health_check/verbose').delay(400).reply(500, {})
+    nock(unhealthy5).get('/health_check').delay(400).reply(500, {})
 
     const cns = new CreatorNodeSelection({
       creatorNode: mockCreatorNode,
@@ -270,31 +270,31 @@ describe('test CreatorNodeSelection', () => {
     // the cream of the crop -- up to date version, slow. you want this
     const shouldBePrimary = 'https://shouldBePrimary.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(200)
       .reply(200, { data: defaultHealthCheckData })
 
     // cold, overnight pizza -- behind by minor version, fast. nope
     const unhealthy2 = 'https://unhealthy2.audius.co'
     nock(unhealthy2)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: { ...defaultHealthCheckData, version: '1.0.3' } })
 
     // stale chips from 2 weeks ago -- behind by major version, kinda slow. still nope
     const unhealthy3 = 'https://unhealthy3.audius.co'
     nock(unhealthy3)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: { ...defaultHealthCheckData, version: '0.2.3' } })
 
     // moldy canned beans -- not available/up at all. for sure nope
     const unhealthy1 = 'https://unhealthy1.audius.co'
-    nock(unhealthy1).get('/health_check/verbose').reply(500, {})
+    nock(unhealthy1).get('/health_check').reply(500, {})
 
     // your house mate's leftovers from her team outing -- behind by patch, kinda slow. solid
     const shouldBeSecondary = 'https://secondary.audius.co'
     nock(shouldBeSecondary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
@@ -343,7 +343,7 @@ describe('test CreatorNodeSelection', () => {
       const healthyUrl = `https://healthy${i}.audius.co`
       nock(healthyUrl)
         .persist()
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: defaultHealthCheckData })
       contentNodes.push(healthyUrl)
     }
@@ -369,18 +369,18 @@ describe('test CreatorNodeSelection', () => {
   it('selects 1 secondary if only 1 secondary is available', async () => {
     const shouldBePrimary = 'https://shouldBePrimary.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(200)
       .reply(200, { data: defaultHealthCheckData })
 
     const shouldBeSecondary = 'https://secondary.audius.co'
     nock(shouldBeSecondary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .delay(100)
       .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
     const unhealthy = 'https://unhealthy.audius.co'
-    nock(unhealthy).get('/health_check/verbose').reply(500, {})
+    nock(unhealthy).get('/health_check').reply(500, {})
 
     const cns = new CreatorNodeSelection({
       creatorNode: mockCreatorNode,
@@ -410,7 +410,7 @@ describe('test CreatorNodeSelection', () => {
   it('filters out nodes if over 95% of storage is used', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -421,7 +421,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary1 = 'https://secondary1.audius.co'
     nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -433,7 +433,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary2 = 'https://secondary2.audius.co'
     nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -445,7 +445,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used95PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used95PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -456,7 +456,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used99PercentStorage = 'https://used99PercentStorage.audius.co'
     nock(used99PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -506,7 +506,7 @@ describe('test CreatorNodeSelection', () => {
   it('overrides with health check resp `maxStorageUsedPercent` even if it is passed into constructor', async () => {
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -517,7 +517,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary1 = 'https://secondary1.audius.co'
     nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -529,7 +529,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary2 = 'https://secondary2.audius.co'
     nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -541,7 +541,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used50PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used50PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -553,7 +553,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used70PercentStorage = 'https://used70PercentStorage.audius.co'
     nock(used70PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...defaultHealthCheckData,
@@ -613,7 +613,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBePrimary = 'https://primary.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckResponseWithNoMaxStorageUsedPercent,
@@ -624,7 +624,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary1 = 'https://secondary1.audius.co'
     nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckResponseWithNoMaxStorageUsedPercent,
@@ -636,7 +636,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary2 = 'https://secondary2.audius.co'
     nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckResponseWithNoMaxStorageUsedPercent,
@@ -648,7 +648,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used50PercentStorage = 'https://used95PercentStorage.audius.co'
     nock(used50PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckResponseWithNoMaxStorageUsedPercent,
@@ -659,7 +659,7 @@ describe('test CreatorNodeSelection', () => {
 
     const used70PercentStorage = 'https://used70PercentStorage.audius.co'
     nock(used70PercentStorage)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckResponseWithNoMaxStorageUsedPercent,
@@ -718,12 +718,12 @@ describe('test CreatorNodeSelection', () => {
     const shouldBePrimary =
       'https://missingStoragePathUsedAndStoragePathSize.audius.co'
     nock(shouldBePrimary)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, { data: healthCheckDataWithNoStorageInfo })
 
     const shouldBeSecondary1 = 'https://missingStoragePathUsed.audius.co'
     nock(shouldBeSecondary1)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckDataWithNoStorageInfo,
@@ -734,7 +734,7 @@ describe('test CreatorNodeSelection', () => {
 
     const shouldBeSecondary2 = 'https://missingStoragePathSize.audius.co'
     nock(shouldBeSecondary2)
-      .get('/health_check/verbose')
+      .get('/health_check')
       .reply(200, {
         data: {
           ...healthCheckDataWithNoStorageInfo,
@@ -781,13 +781,13 @@ describe('test CreatorNodeSelection', () => {
     for (let i = 0; i < 20; ++i) {
       const one = 'https://one.audius.co'
       nock(one)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(100)
         .reply(200, { data: defaultHealthCheckData })
 
       const two = 'https://two.audius.co'
       nock(two)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(200)
         .reply(200, { data: defaultHealthCheckData })
 
@@ -813,18 +813,18 @@ describe('test CreatorNodeSelection', () => {
     it('Selects highest version nodes when preferHigherPatchForPrimary and preferHigherPatchForSecondaries are enabled', async () => {
       const aheadPatch = 'https://aheadPatch.audius.co'
       nock(aheadPatch)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.6' } })
 
       const aheadPatchButSlow = 'https://aheadPatchButSlow.audius.co'
       nock(aheadPatchButSlow)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(100)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.6' } })
 
       const healthy = 'https://healthy.audius.co'
       nock(healthy)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: defaultHealthCheckData })
 
       const cns = new CreatorNodeSelection({
@@ -857,23 +857,23 @@ describe('test CreatorNodeSelection', () => {
     it('Selects highest version node for primary with preferHigherPatchForPrimary enabled and fastest node for secondaries with preferHigherPatchForSecondaries disabled', async () => {
       const aheadPatch = 'https://aheadPatch.audius.co'
       nock(aheadPatch)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.6' } })
 
       const aheadPatchButSlow = 'https://aheadPatchButSlow.audius.co'
       nock(aheadPatchButSlow)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(100)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.6' } })
 
       const healthyButBehindPatch = 'https://healthyButBehindPatch.audius.co'
       nock(healthyButBehindPatch)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.0' } })
 
       const healthy = 'https://healthy.audius.co'
       nock(healthy)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.3' } })
 
       const cns = new CreatorNodeSelection({
@@ -912,24 +912,24 @@ describe('test CreatorNodeSelection', () => {
     it('Selects fastest node for primary with preferHigherPatchForPrimary disabled and highest version nodes for secondaries with preferHigherPatchForSecondaries enabled', async () => {
       const higherPatchAndSlow = 'https://higherPatchAndSlow.audius.co'
       nock(higherPatchAndSlow)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(50)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.4' } })
 
       const highestPatchAndSlowest = 'https://highestPatchAndSlowest.audius.co'
       nock(highestPatchAndSlowest)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(100)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.5' } })
 
       const healthyAndBehindPatch = 'https://healthyAndBehindPatch.audius.co'
       nock(healthyAndBehindPatch)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.2' } })
 
       const healthy = 'https://healthy.audius.co'
       nock(healthy)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.3' } })
 
       const cns = new CreatorNodeSelection({
@@ -973,24 +973,24 @@ describe('test CreatorNodeSelection', () => {
     it('Selects fastest nodes when preferHigherPatchForPrimary and preferHigherPatchForSecondaries are disabled', async () => {
       const higherPatchAndSlow = 'https://higherPatchAndSlow.audius.co'
       nock(higherPatchAndSlow)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(50)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.4' } })
 
       const highestPatchAndSlowest = 'https://highestPatchAndSlowest.audius.co'
       nock(highestPatchAndSlowest)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .delay(100)
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.5' } })
 
       const healthyAndBehindPatch = 'https://healthyAndBehindPatch.audius.co'
       nock(healthyAndBehindPatch)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.2' } })
 
       const healthy = 'https://healthy.audius.co'
       nock(healthy)
-        .get('/health_check/verbose')
+        .get('/health_check')
         .reply(200, { data: { ...defaultHealthCheckData, version: '1.2.3' } })
 
       const cns = new CreatorNodeSelection({

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -118,7 +118,7 @@ export class CreatorNodeSelection extends ServiceSelection {
     this.preferHigherPatchForSecondaries = preferHigherPatchForSecondaries
     this.logger = logger
 
-    this.healthCheckPath = 'health_check/verbose'
+    this.healthCheckPath = 'health_check'
     // String array of healthy Content Node endpoints
     this.backupsList = []
     this.backupTimings = []


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

**Note - please read PR description carefully**

1. Move all calls to `<CN>/health_check/verbose` to `/health_check`
2. Remove `/health_check/verbose` custom code, and re-point route to `/health_check` for back-compat
3. expose OS version string in format `#28~20.04.1-Ubuntu`
4. change `isReadOnlyMode` health_check response to still return full object
5. Removed fields from health_check that are now in `/config_check`:
  - snapbackUsersPerJob
  - snapbackModuloBase
  - manualSyncsDisabled
  - currentSnapbackReconfigMode
  - stateMonitoringQueueRateLimitInterval
  - stateMonitoringQueueRateLimitJobsPerInterval
  - recoverOrphanedDataQueueRateLimitInterval
  - recoverOrphanedDataQueueRateLimitJobsPerInterval
6. Removed unnecessary `asyncProcessingQueueJobs` object field

NOTE - I manually checked every call to CN /health_check and /health_check/verbose, to identify which fields were used where. See associated linear card for full documentation

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Updated existing tests + added new test, specifically to confirm legacy `/health_check/verbose` route is still available

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->