### PR TITLE
Make server read only until spID has been recovered

### DIFF
--- a/creator-node/src/middlewares/readOnly/readOnlyMiddleware.js
+++ b/creator-node/src/middlewares/readOnly/readOnlyMiddleware.js
@@ -6,8 +6,7 @@ const config = require('../../config')
  */
 function readOnlyMiddleware(req, res, next) {
   const isReadOnlyMode = config.get('isReadOnlyMode')
-  console.log("config.get('spID')", config.get('spID'))
-  const spIDNotDefined = config.get('spID') === 0 // true if not a valid spID
+  const spIDNotDefined = !config.get('spID') || config.get('spID') <= 0 // true if not a valid spID
   const method = req.method
   const canProceed = readOnlyMiddlewareHelper(
     isReadOnlyMode,

--- a/creator-node/src/middlewares/readOnly/readOnlyMiddleware.js
+++ b/creator-node/src/middlewares/readOnly/readOnlyMiddleware.js
@@ -1,15 +1,19 @@
 const { sendResponse, errorResponseServerError } = require('../../apiHelpers')
 const config = require('../../config')
 
-const exclusionsRegex = new RegExp(/(vector_clock)/)
 /**
  * Middleware to block all non-GET api calls if the server should be in "read-only" mode
  */
 function readOnlyMiddleware(req, res, next) {
   const isReadOnlyMode = config.get('isReadOnlyMode')
+  console.log("config.get('spID')", config.get('spID'))
+  const spIDNotDefined = config.get('spID') === 0 // true if not a valid spID
   const method = req.method
-  const url = req.url
-  const canProceed = readOnlyMiddlewareHelper(isReadOnlyMode, method, url)
+  const canProceed = readOnlyMiddlewareHelper(
+    isReadOnlyMode,
+    spIDNotDefined,
+    method
+  )
 
   if (!canProceed)
     return sendResponse(
@@ -22,16 +26,12 @@ function readOnlyMiddleware(req, res, next) {
 
 /**
  * @param {Boolean} isReadOnlyMode From config.get('isReadOnlyMode')
+ * @param {Boolean} spIDNotDefined set in serviceRegistry after recovering this node's identity. true if not a valid spID
  * @param {String} method REST method for this request eg. POST, GET
  * @returns {Boolean} returns true if the request can proceed. eg GET in read only or any request in non read-only mode
  */
-function readOnlyMiddlewareHelper(isReadOnlyMode, method, url) {
-  // is an excluded route...let it pass through
-  if (exclusionsRegex.test(url)) {
-    return true
-  }
-
-  if (isReadOnlyMode && method !== 'GET') {
+function readOnlyMiddlewareHelper(isReadOnlyMode, spIDNotDefined, method) {
+  if ((isReadOnlyMode || spIDNotDefined) && method !== 'GET') {
     return false
   }
 

--- a/creator-node/src/middlewares/readOnly/readOnlyMiddleware.test.js
+++ b/creator-node/src/middlewares/readOnly/readOnlyMiddleware.test.js
@@ -9,12 +9,15 @@ const { resFactory, loggerFactory } = require('../../../test/lib/reqMock')
 describe('Test read-only middleware', function () {
   beforeEach(function () {
     config.reset('isReadOnlyMode')
+    config.reset('spID')
   })
 
   it('Should pass if read-only enabled and is GET request', function () {
     const method = 'GET'
     const isReadOnlyMode = true
+    const spIDNotDefined = false
     config.set('isReadOnlyMode', isReadOnlyMode)
+    config.set('spID', 1)
     let nextCalled = false
 
     readOnlyMiddleware({ method }, {}, function () {
@@ -22,7 +25,7 @@ describe('Test read-only middleware', function () {
     })
 
     assert.deepStrictEqual(
-      readOnlyMiddlewareHelper(isReadOnlyMode, method),
+      readOnlyMiddlewareHelper(isReadOnlyMode, spIDNotDefined, method),
       true
     )
     assert.deepStrictEqual(nextCalled, true)
@@ -30,8 +33,10 @@ describe('Test read-only middleware', function () {
 
   it('Should fail if read-only enabled and is not GET request', function () {
     const isReadOnlyMode = true
+    const spIDNotDefined = false
     const method = 'POST'
     config.set('isReadOnlyMode', isReadOnlyMode)
+    config.set('spID', 1)
     let nextCalled = false
 
     const logger = loggerFactory()
@@ -47,7 +52,7 @@ describe('Test read-only middleware', function () {
 
     assert.deepStrictEqual(res.statusCode, 500)
     assert.deepStrictEqual(
-      readOnlyMiddlewareHelper(isReadOnlyMode, method),
+      readOnlyMiddlewareHelper(isReadOnlyMode, spIDNotDefined, method),
       false
     )
     assert.deepStrictEqual(nextCalled, false)
@@ -56,17 +61,52 @@ describe('Test read-only middleware', function () {
   it('Should pass if read-only not enabled and is POST request', function () {
     const method = 'POST'
     const isReadOnlyMode = false
+    const spIDNotDefined = false
     config.set('isReadOnlyMode', isReadOnlyMode)
+    config.set('spID', 1)
     let nextCalled = false
 
-    readOnlyMiddleware({ method }, {}, function () {
+    const logger = loggerFactory()
+    const req = {
+      method,
+      logger
+    }
+    const res = resFactory()
+
+    readOnlyMiddleware(req, res, function () {
       nextCalled = true
     })
 
     assert.deepStrictEqual(
-      readOnlyMiddlewareHelper(isReadOnlyMode, method),
+      readOnlyMiddlewareHelper(isReadOnlyMode, spIDNotDefined, method),
       true
     )
     assert.deepStrictEqual(nextCalled, true)
+  })
+
+  it('Should fail if spID not defined and is POST request', function () {
+    const method = 'POST'
+    const isReadOnlyMode = false
+    const spIDNotDefined = true
+    config.set('isReadOnlyMode', isReadOnlyMode)
+    config.set('spID', 0)
+    let nextCalled = false
+
+    const logger = loggerFactory()
+    const req = {
+      method,
+      logger
+    }
+    const res = resFactory()
+
+    readOnlyMiddleware(req, res, function () {
+      nextCalled = true
+    })
+
+    assert.deepStrictEqual(
+      readOnlyMiddlewareHelper(isReadOnlyMode, spIDNotDefined, method),
+      false
+    )
+    assert.deepStrictEqual(nextCalled, false)
   })
 })

--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -95,31 +95,6 @@ class ServiceRegistry {
 
     this.synchronousServicesInitialized = true
 
-    // Cannot progress without recovering spID from node's record on L1 ServiceProviderFactory contract
-    // Retries indefinitely
-    await this._recoverNodeL1Identity()
-
-    // Init StateMachineManager
-    this.stateMachineManager = new StateMachineManager()
-    const {
-      monitorStateQueue,
-      findSyncRequestsQueue,
-      findReplicaSetUpdatesQueue,
-      cNodeEndpointToSpIdMapQueue,
-      manualSyncQueue,
-      recurringSyncQueue,
-      updateReplicaSetQueue,
-      recoverOrphanedDataQueue
-    } = await this.stateMachineManager.init(this.libs, this.prometheusRegistry)
-    this.monitorStateQueue = monitorStateQueue
-    this.findSyncRequestsQueue = findSyncRequestsQueue
-    this.findReplicaSetUpdatesQueue = findReplicaSetUpdatesQueue
-    this.cNodeEndpointToSpIdMapQueue = cNodeEndpointToSpIdMapQueue
-    this.manualSyncQueue = manualSyncQueue
-    this.recurringSyncQueue = recurringSyncQueue
-    this.updateReplicaSetQueue = updateReplicaSetQueue
-    this.recoverOrphanedDataQueue = recoverOrphanedDataQueue
-
     logInfoWithDuration(
       { logger: genericLogger, startTime: start },
       'ServiceRegistry || Initialized synchronous services'
@@ -319,9 +294,38 @@ class ServiceRegistry {
    *  - register node on L2 URSM contract (requires node L1 identity)
    *  - construct & init SkippedCIDsRetryQueue (requires SyncQueue)
    *  - create bull queue monitoring dashboard, which needs other server-dependent services to be running
+   *
+   * The server will be in read only mode at the beginning of this function. Once the L1 identity
+   * has been recovered, it will be in read + write mode
    */
   async initServicesThatRequireServer(app) {
     const start = getStartTime()
+
+    // Cannot progress without recovering spID from node's record on L1 ServiceProviderFactory contract
+    // because some queues and write routes depend on spID
+    // Retries indefinitely
+    await this._recoverNodeL1Identity()
+
+    // Init StateMachineManager
+    this.stateMachineManager = new StateMachineManager()
+    const {
+      monitorStateQueue,
+      findSyncRequestsQueue,
+      findReplicaSetUpdatesQueue,
+      cNodeEndpointToSpIdMapQueue,
+      manualSyncQueue,
+      recurringSyncQueue,
+      updateReplicaSetQueue,
+      recoverOrphanedDataQueue
+    } = await this.stateMachineManager.init(this.libs, this.prometheusRegistry)
+    this.monitorStateQueue = monitorStateQueue
+    this.findSyncRequestsQueue = findSyncRequestsQueue
+    this.findReplicaSetUpdatesQueue = findReplicaSetUpdatesQueue
+    this.cNodeEndpointToSpIdMapQueue = cNodeEndpointToSpIdMapQueue
+    this.manualSyncQueue = manualSyncQueue
+    this.recurringSyncQueue = recurringSyncQueue
+    this.updateReplicaSetQueue = updateReplicaSetQueue
+    this.recoverOrphanedDataQueue = recoverOrphanedDataQueue
 
     // SyncQueue construction (requires L1 identity)
     // Note - passes in reference to instance of self (serviceRegistry), a very sub-optimal workaround


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Previously we were in a catch 22 where we needed the server to be up before spID was recovered, but also if the server was up that means we could get incoming requests to POST routes before the spID has been recovered.

In order to alleviate these concerns we're going to make the server read only until spID has been recovered. This should be a safe change to make because for
- incoming GET requests should be resolved and POST requests error, exactly what happens when the server is down
- Outgoing requests, the node on the other end is likely up so should be fine to make requests. Plus if this is a new service it likely has no users in the replica set so likely has no requests to make anyway. In the event an outgoing request triggers an incoming request, it will behave as above.

One thing to note, the pre-registration checks include an upload test which we cannot use anymore, probably have to delete that https://github.com/AudiusProject/audius-docker-compose/blob/main/sp-utilities/creator-node/healthChecks.js#L310

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Modified and added unit tests to test

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
We return an error that `Server is in read-only mode at the moment`, can look in the logs for this error

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->