### PR TITLE
Hotfix index_spl_token_backfill.py

### DIFF
--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -505,9 +505,7 @@ def process_transaction_signatures(
         last_tx_sig = transaction_signatures[-1][0]
 
     for tx_sig_batch in transaction_signatures:
-        logger.info(
-            f"index_rewards_manager_backfill.py | considering for processing: past {tx_sig_batch}"
-        )
+        logger.info(f"index_rewards_manager_backfill.py | processing {tx_sig_batch}")
         batch_start_time = time.time()
 
         transfer_instructions: List[RewardManagerTransactionInfo] = []

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -140,6 +140,8 @@ def parse_spl_token_transaction(
     tx_sig: ConfirmedSignatureForAddressResult,
 ) -> Optional[SplTokenTransactionInfo]:
     try:
+        if tx_sig["err"]:
+            return None
         tx_info = solana_client_manager.get_sol_tx_info(tx_sig["signature"])
         result = tx_info["result"]
         meta = result["meta"]


### PR DESCRIPTION
### Description
Fixes an issue that breaks the backfilling spl-token indexer - it would fail if the transaction failed. This fix makes it skip the failed transaction instead.

+ a little logging wording change

### Tests
Observed it working on remote-dev that is indexing prod.