### PR TITLE
Check backfillers progress

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -20,7 +20,16 @@ from src.queries.get_sol_rewards_manager import get_sol_rewards_manager_health_i
 from src.queries.get_sol_user_bank import get_sol_user_bank_health_info
 from src.queries.get_spl_audio import get_spl_audio_health_info
 from src.tasks.index_rewards_manager_backfill import (
+    check_progress as rewards_manager_backfill_check_progress,
+)
+from src.tasks.index_rewards_manager_backfill import (
+    check_progress as user_bank_backfill_check_progress,
+)
+from src.tasks.index_rewards_manager_backfill import (
     index_rewards_manager_backfill_complete,
+)
+from src.tasks.index_spl_token_backfill import (
+    check_progress as spl_token_backfill_check_progress,
 )
 from src.tasks.index_spl_token_backfill import index_spl_token_backfill_complete
 from src.tasks.index_user_bank_backfill import index_user_bank_backfill_complete
@@ -287,6 +296,14 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
         is_index_spl_token_backfill_complete = False
 
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        spl_token_backfill_progress = spl_token_backfill_check_progress(session)
+        rewards_manager_backfill_progress = rewards_manager_backfill_check_progress(
+            session
+        )
+        user_bank_backfill_progress = user_bank_backfill_check_progress(session)
+
     # Get system information monitor values
     sys_info = monitors.get_monitors(
         [
@@ -340,9 +357,12 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "latest_indexed_block_num": latest_indexed_block_num,
         "final_poa_block": final_poa_block,
         "transactions_history_backfill": {
-            "index_user_backfilling_complete": is_index_user_bank_backfill_complete,
+            "user_bank_backfilling_complete": is_index_user_bank_backfill_complete,
+            "user_bank_backfilling_progress": user_bank_backfill_progress,
             "rewards_manager_backfilling_complete": is_index_rewards_manager_backfill_complete,
+            "rewards_manager_backfill_progress": rewards_manager_backfill_progress,
             "spl_token_backfilling_complete": is_index_spl_token_backfill_complete,
+            "spl_token_backfill_progress": spl_token_backfill_progress,
         },
     }
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -23,15 +23,15 @@ from src.tasks.index_rewards_manager_backfill import (
     check_progress as rewards_manager_backfill_check_progress,
 )
 from src.tasks.index_rewards_manager_backfill import (
-    check_progress as user_bank_backfill_check_progress,
-)
-from src.tasks.index_rewards_manager_backfill import (
     index_rewards_manager_backfill_complete,
 )
 from src.tasks.index_spl_token_backfill import (
     check_progress as spl_token_backfill_check_progress,
 )
 from src.tasks.index_spl_token_backfill import index_spl_token_backfill_complete
+from src.tasks.index_user_bank_backfill import (
+    check_progress as user_bank_backfill_check_progress,
+)
 from src.tasks.index_user_bank_backfill import index_user_bank_backfill_complete
 from src.utils import db_session, helpers, redis_connection, web3_provider
 from src.utils.config import shared_config

--- a/discovery-provider/src/queries/get_health_unit_test.py
+++ b/discovery-provider/src/queries/get_health_unit_test.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from hexbytes import HexBytes
 from src.models.indexing.block import Block
+from src.models.indexing.indexing_checkpoints import IndexingCheckpoint
 from src.queries.get_health import get_health
 from src.utils.redis_constants import (
     challenges_last_processed_event_redis_key,
@@ -469,6 +470,7 @@ def test_get_health_verbose(web3_mock, redis_mock, db_mock, get_monitors_mock):
                 is_current=True,
             )
         )
+        IndexingCheckpoint.__table__.create(db_mock._engine)
 
     args = {"verbose": True}
     health_results, error = get_health(args)

--- a/discovery-provider/src/tasks/index_rewards_manager_backfill.py
+++ b/discovery-provider/src/tasks/index_rewards_manager_backfill.py
@@ -505,9 +505,7 @@ def process_transaction_signatures(
         last_tx_sig = transaction_signatures[-1][0]
 
     for tx_sig_batch in transaction_signatures:
-        logger.info(
-            f"index_rewards_manager_backfill.py | considering for processing: past {tx_sig_batch}"
-        )
+        logger.info(f"index_rewards_manager_backfill.py | processing {tx_sig_batch}")
         batch_start_time = time.time()
 
         transfer_instructions: List[RewardManagerTransactionInfo] = []

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional, Set, TypedDict
 import base58
 from redis import Redis
 from solana.publickey import PublicKey
-from sqlalchemy import and_, asc, or_
+from sqlalchemy import and_, asc, desc, or_
 from sqlalchemy.orm.session import Session
 from src.models.indexing.indexing_checkpoints import IndexingCheckpoint
 from src.models.indexing.spl_token_backfill_transaction import (
@@ -569,6 +569,50 @@ def find_true_stop_sig(
         f"index_spl_token_backfill.py | Added new stop_sig to indexing_checkpoints: {stop_sig}"
     )
     return stop_sig
+
+
+def check_progress(session: Session):
+    stop_row = (
+        session.query(IndexingCheckpoint)
+        .filter(IndexingCheckpoint.tablename == index_spl_token_backfill_tablename)
+        .first()
+    )
+    if not stop_row:
+        return None
+    ret: Any = {}
+    ret["stop_slot"] = stop_row.last_checkpoint
+    ret["stop_sig"] = stop_row.signature
+    latest_processed_row = (
+        session.query(SPLTokenBackfillTransaction)
+        .order_by(desc(SPLTokenBackfillTransaction.last_scanned_slot))
+        .first()
+    )
+    if not latest_processed_row:
+        return ret
+    ret["latest_processed_sig"] = latest_processed_row.signature
+    ret["latest_processed_slot"] = latest_processed_row.last_scanned_slot
+    min_row = (
+        session.query(AudioTransactionsHistory)
+        .filter(
+            and_(
+                or_(
+                    AudioTransactionsHistory.transaction_type.in_(purchase_types),
+                    and_(
+                        AudioTransactionsHistory.transaction_type
+                        == TransactionType.transfer,
+                        AudioTransactionsHistory.method == TransactionMethod.receive,
+                    ),
+                ),
+                AudioTransactionsHistory.slot < ret["stop_slot"],
+            )
+        )
+        .order_by(asc(AudioTransactionsHistory.slot))
+    ).first()
+    if not min_row:
+        return ret
+    ret["min_slot"] = min_row.slot
+    ret["min_sig"] = min_row.signature
+    return ret
 
 
 @celery.task(name="index_spl_token_backfill", bind=True)

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -140,6 +140,8 @@ def parse_spl_token_transaction(
     tx_sig: ConfirmedSignatureForAddressResult,
 ) -> Optional[SplTokenTransactionInfo]:
     try:
+        if tx_sig["err"]:
+            return None
         tx_info = solana_client_manager.get_sol_tx_info(tx_sig["signature"])
         result = tx_info["result"]
         meta = result["meta"]


### PR DESCRIPTION
### Description
Adds checks in get_health to check progress of each backfill indexer.

For each of the indexers:
`stop_sig` and `stop_slot` are the sig/slot that the backfill indexer should stop at. Taken from IndexingCheckpoints table. Won't exist until the backfill indexer has started.
`latest_processed_sig` and `latest_processed_slot` are the last sig/slot that the backfill indexer has processed. Taken from row in `xxx_backfill_tx` that has the highest slot number. Won't exist until the backfill indexer has started processing txs, which can be a while after it has started.
`min_slot` and `min_sig` come from the row in `AudioTransactionsHistory` that are of the correct type, have the lowest slot number, and are also less than the `stop_slot`. Represents the first row that the backfill indexer added to the table. Won't exist until the backfill indexer has successfully added a row to `AudioTransactionsHistory`.

These can be used to confirm the backfill indexer is functioning correctly and to monitor progress.

### Tests
Tested on remote-dev

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->