### PR TITLE
Read subscriptions from discovery in notifications system in identity

### DIFF
--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -11,7 +11,8 @@ const FEATURE_FLAGS = Object.freeze({
   BLOCK_ABUSE_ON_RELAY: 'block_abuse_on_relay',
   TIPPING_ENABLED: 'tipping_enabled',
   SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED:
-    'supporter_dethroned_push_notifs_enabled'
+    'supporter_dethroned_push_notifs_enabled',
+  READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED: 'read_subscribers_from_discovery_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded
@@ -26,7 +27,8 @@ const DEFAULTS = Object.freeze({
   [FEATURE_FLAGS.DETECT_ABUSE_ON_RELAY]: false,
   [FEATURE_FLAGS.BLOCK_ABUSE_ON_RELAY]: false,
   [FEATURE_FLAGS.TIPPING_ENABLED]: false,
-  [FEATURE_FLAGS.SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED]: false
+  [FEATURE_FLAGS.SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED]: false,
+  [FEATURE_FLAGS.READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED]: false,
 })
 
 /**

--- a/identity-service/src/featureFlag.js
+++ b/identity-service/src/featureFlag.js
@@ -12,7 +12,8 @@ const FEATURE_FLAGS = Object.freeze({
   TIPPING_ENABLED: 'tipping_enabled',
   SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED:
     'supporter_dethroned_push_notifs_enabled',
-  READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED: 'read_subscribers_from_discovery_enabled'
+  READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED:
+    'read_subscribers_from_discovery_enabled'
 })
 
 // Default values for feature flags while optimizely has not loaded
@@ -28,7 +29,7 @@ const DEFAULTS = Object.freeze({
   [FEATURE_FLAGS.BLOCK_ABUSE_ON_RELAY]: false,
   [FEATURE_FLAGS.TIPPING_ENABLED]: false,
   [FEATURE_FLAGS.SUPPORTER_DETHRONED_PUSH_NOTIFS_ENABLED]: false,
-  [FEATURE_FLAGS.READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED]: false,
+  [FEATURE_FLAGS.READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED]: false
 })
 
 /**

--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -441,7 +441,7 @@ class NotificationProcessor {
       const listenCountWithOwners = []
 
       // Insert the notifications into the DB to make it easy for users to query for their grouped notifications
-      await processNotifications(notifications, tx)
+      await processNotifications(notifications, tx, optimizelyClient)
       logger.info(
         `notifications main indexAll job - processNotifications complete in ${
           Date.now() - time
@@ -561,7 +561,8 @@ class NotificationProcessor {
       // Insert the solana notifications into the DB
       const processedNotifications = await processNotifications(
         notifications,
-        tx
+        tx,
+        optimizelyClient
       )
       logger.info(
         `${logLabel} - processNotifications complete in ${Date.now() - time}ms`

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -39,8 +39,8 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
 
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
-  const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
-
+  const readSubscribersFromDiscovery =
+    shouldReadSubscribersFromDiscovery(optimizelyClient)
   let userSubscribersMap = {}
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -70,6 +70,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
 
     // Notifications go to all users subscribing to this content uploader
     let subscribers = userSubscribersMap.get(notification.initiator) || []
+    logger.info(`processCreateNotifications: subscribers from map: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {
       // Query user IDs from subscriptions table
       subscribers = await models.Subscription.findAll({
@@ -104,6 +105,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     if (!readSubscribersFromDiscovery) {
       subscriberIds = subscribers.map((s) => s.subscriberId)
     }
+    logger.info(`processCreateNotifications: subscriberIds: ${subscriberIds.toString()}`)
     const unreadSubscribers = await models.Notification.findAll({
       where: {
         isViewed: false,

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -52,7 +52,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
       `processCreateNotifications: userIds: ${JSON.stringify([...userIds])}, size: ${userIds.size}`
     )
     if (userIds.size > 0) {
-      userSubscribersMap = bulkGetSubscribersFromDiscovery(userIds)
+      userSubscribersMap = await bulkGetSubscribersFromDiscovery(userIds)
     }
   }
 
@@ -69,9 +69,10 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     )
 
     // Notifications go to all users subscribing to this content uploader
-    logger.info(`processCreateNotifications: type of map: ${typeof userSubscribersMap}`)
     let subscribers = userSubscribersMap[notification.initiator] || []
-    logger.info(`processCreateNotifications: subscribers from map: ${subscribers.toString()}`)
+    logger.info(`processCreateNotifications: userSubscribersMap: ${JSON.stringify(userSubscribersMap)}`)
+    logger.info(`processCreateNotifications: typeof notif initiator: ${typeof notification.initiator}`)
+    logger.info(`processCreateNotifications: subscribers from map for notif initiator ${notification.initiator}: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {
       // Query user IDs from subscriptions table
       subscribers = await models.Subscription.findAll({

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -100,10 +100,8 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
         : notification.metadata.entity_owner_id
 
     // Query all subscribers for a un-viewed notification - is no un-view notification exists a new one is created
-    let subscriberIds = []
-    if (readSubscribersFromDiscovery) {
-      subscriberIds = subscribers
-    } else {
+    let subscriberIds = subscribers
+    if (!readSubscribersFromDiscovery) {
       subscriberIds = subscribers.map((s) => s.subscriberId)
     }
     const unreadSubscribers = await models.Notification.findAll({

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -1,5 +1,6 @@
 const models = require('../../models')
 const { bulkGetSubscribersFromDiscovery, shouldReadSubscribersFromDiscovery } = require('../utils')
+const { logger } = require('../../logging')
 const { notificationTypes, actionEntityTypes } = require('../constants')
 
 const getNotifType = (entityType) => {
@@ -40,7 +41,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
   logger.info(`processCreateNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`)
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))
-    logger.info(`processCreateNotifications: userIds: ${userIds}`)
+    logger.info(`processCreateNotifications: userIds: ${JSON.stringify([...userIds])}`)
     const userSubscribersMap = (userIds.length > 0 ? bulkGetSubscribersFromDiscovery(userIds) : new Map())
   }
 

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -69,6 +69,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     )
 
     // Notifications go to all users subscribing to this content uploader
+    logger.info(`processCreateNotifications: type of map: ${typeof userSubscribersMap}`)
     let subscribers = userSubscribersMap.get(notification.initiator) || []
     logger.info(`processCreateNotifications: subscribers from map: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -53,6 +53,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     )
     if (userIds.size > 0) {
       userSubscribersMap = await bulkGetSubscribersFromDiscovery(userIds)
+      logger.info(`processCreateNotifications: userSubscribersMap: ${JSON.stringify(userSubscribersMap)}`)
     }
   }
 
@@ -69,9 +70,8 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     )
 
     // Notifications go to all users subscribing to this content uploader
-    let subscribers = userSubscribersMap[notification.initiator] || []
-    logger.info(`processCreateNotifications: userSubscribersMap: ${JSON.stringify(userSubscribersMap)}`)
     logger.info(`processCreateNotifications: typeof notif initiator: ${typeof notification.initiator}`)
+    let subscribers = userSubscribersMap[notification.initiator] || []
     logger.info(`processCreateNotifications: subscribers from map for notif initiator ${notification.initiator}: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {
       // Query user IDs from subscriptions table

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -45,7 +45,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
   logger.info(
     `processCreateNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`
   )
-  let userSubscribersMap = new Map()
+  let userSubscribersMap = {}
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))
     logger.info(

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -37,7 +37,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
-  logger.info(`processCreateNotifications: shouldReadSubscribersFromDiscovery: ${shouldReadSubscribersFromDiscovery}`)
+  logger.info(`processCreateNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`)
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))
     logger.info(`processCreateNotifications: userIds: ${userIds}`)

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -1,6 +1,5 @@
 const models = require('../../models')
 const { bulkGetSubscribersFromDiscovery, shouldReadSubscribersFromDiscovery } = require('../utils')
-const { getFeatureFlag, FEATURE_FLAGS } = require('../../featureFlag')
 const { notificationTypes, actionEntityTypes } = require('../constants')
 
 const getNotifType = (entityType) => {

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -37,8 +37,10 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
+  logger.info(`processCreateNotifications: shouldReadSubscribersFromDiscovery: ${shouldReadSubscribersFromDiscovery}`)
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))
+    logger.info(`processCreateNotifications: userIds: ${userIds}`)
     const userSubscribersMap = (userIds.length > 0 ? bulkGetSubscribersFromDiscovery(userIds) : new Map())
   }
 

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -70,7 +70,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
 
     // Notifications go to all users subscribing to this content uploader
     logger.info(`processCreateNotifications: type of map: ${typeof userSubscribersMap}`)
-    let subscribers = userSubscribersMap.get(notification.initiator) || []
+    let subscribers = userSubscribersMap[notification.initiator] || []
     logger.info(`processCreateNotifications: subscribers from map: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {
       // Query user IDs from subscriptions table

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -3,7 +3,6 @@ const {
   bulkGetSubscribersFromDiscovery,
   shouldReadSubscribersFromDiscovery
 } = require('../utils')
-const { logger } = require('../../logging')
 const { notificationTypes, actionEntityTypes } = require('../constants')
 
 const getNotifType = (entityType) => {
@@ -42,18 +41,11 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
 
-  logger.info(
-    `processCreateNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`
-  )
   let userSubscribersMap = {}
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.map((notif) => notif.initiator))
-    logger.info(
-      `processCreateNotifications: userIds: ${JSON.stringify([...userIds])}, size: ${userIds.size}`
-    )
     if (userIds.size > 0) {
       userSubscribersMap = await bulkGetSubscribersFromDiscovery(userIds)
-      logger.info(`processCreateNotifications: userSubscribersMap: ${JSON.stringify(userSubscribersMap)}`)
     }
   }
 
@@ -70,9 +62,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     )
 
     // Notifications go to all users subscribing to this content uploader
-    logger.info(`processCreateNotifications: typeof notif initiator: ${typeof notification.initiator}`)
     let subscribers = userSubscribersMap[notification.initiator] || []
-    logger.info(`processCreateNotifications: subscribers from map for notif initiator ${notification.initiator}: ${subscribers.toString()}`)
     if (!readSubscribersFromDiscovery) {
       // Query user IDs from subscriptions table
       subscribers = await models.Subscription.findAll({
@@ -107,7 +97,6 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     if (!readSubscribersFromDiscovery) {
       subscriberIds = subscribers.map((s) => s.subscriberId)
     }
-    logger.info(`processCreateNotifications: subscriberIds: ${subscriberIds.toString()}`)
     const unreadSubscribers = await models.Notification.findAll({
       where: {
         isViewed: false,

--- a/identity-service/src/notifications/processNotifications/index.js
+++ b/identity-service/src/notifications/processNotifications/index.js
@@ -38,9 +38,10 @@ const notificationMapping = {
  * Write notifications into the DB. Group the notifications by type to be batch processed together
  * @param {Array<Object>} notifications Array of notifications from DP
  * @param {*} tx The transaction to add to each of the DB lookups/inserts/deletes
+ * @param {*} optimizelyClient Optimizely client for feature flags
  */
 
-async function processNotifications(notifications, tx) {
+async function processNotifications(notifications, tx, optimizelyClient) {
   // Group the notifications by type
   const notificationCategories = notifications.reduce(
     (categories, notification) => {
@@ -61,7 +62,11 @@ async function processNotifications(notifications, tx) {
         logger.debug(
           `Processing: ${notifications.length} notifications of type ${notifType}`
         )
-        return processType(notifications, tx)
+        if (notifType === notificationTypes.Create.base) {
+          return processType(notifications, tx, optimizelyClient)
+        } else {
+          return processType(notifications, tx)
+        }
       } else {
         logger.error(
           'processNotifications - no handler defined for notification type',

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -271,7 +271,7 @@ async function formatNotifications(
 
     // Handle the 'create' notification type, track/album/playlist
     if (notif.type === notificationTypes.Create.base) {
-      const subscribers = userSubscribersMap.get(notif.initiator) || []
+      const subscribers = userSubscribersMap[notif.initiator] || []
       await _processCreateNotifications(
         notif,
         tx,

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -57,9 +57,6 @@ async function formatNotifications(
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
 
-  logger.info(
-    `formatNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`
-  )
   let userSubscribersMap = new Map()
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(
@@ -70,7 +67,6 @@ async function formatNotifications(
         return filtered
       }, [])
     )
-    logger.info(`formatNotifications: userIds: ${JSON.stringify([...userIds])}, size: ${userIds.size}`)
     if (userIds.size > 0) {
       userSubscribersMap = bulkGetSubscribersFromDiscovery(userIds)
     }

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -55,12 +55,12 @@ async function formatNotifications(
 ) {
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
-  const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
-
+  const readSubscribersFromDiscovery =
+    shouldReadSubscribersFromDiscovery(optimizelyClient)
   let userSubscribersMap = {}
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(
-      notifications.reduce(function(filtered, notif) {
+      notifications.reduce((filtered, notif) => {
         if (notif.type === notificationTypes.Create.base) {
           filtered.push(notif.initiator)
         }

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -56,7 +56,7 @@ async function formatNotifications(notifications, notificationSettings, tx, opti
       }
       return filtered
     }, []))
-    logger.info(`formatNotifications: userIds: ${userIds}`)
+    logger.info(`formatNotifications: userIds: ${JSON.stringify([...userIds])}`)
     const userSubscribersMap = (userIds.length > 0 ? bulkGetSubscribersFromDiscovery(userIds) : new Map())
   }
 

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -48,7 +48,7 @@ async function formatNotifications(notifications, notificationSettings, tx, opti
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
-  logger.info(`formatNotifications: shouldReadSubscribersFromDiscovery: ${shouldReadSubscribersFromDiscovery}`)
+  logger.info(`formatNotifications: readSubscribersFromDiscovery: ${readSubscribersFromDiscovery}`)
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.reduce(function(filtered, notif) {
       if (notif.type === notificationTypes.Create.base) {

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -57,7 +57,7 @@ async function formatNotifications(
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
 
-  let userSubscribersMap = new Map()
+  let userSubscribersMap = {}
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(
       notifications.reduce(function(filtered, notif) {

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -68,7 +68,7 @@ async function formatNotifications(
       }, [])
     )
     if (userIds.size > 0) {
-      userSubscribersMap = bulkGetSubscribersFromDiscovery(userIds)
+      userSubscribersMap = await bulkGetSubscribersFromDiscovery(userIds)
     }
   }
 

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -48,6 +48,7 @@ async function formatNotifications(notifications, notificationSettings, tx, opti
   // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
   // from discovery for the initiators of create notifications.
   const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
+  logger.info(`formatNotifications: shouldReadSubscribersFromDiscovery: ${shouldReadSubscribersFromDiscovery}`)
   if (readSubscribersFromDiscovery) {
     const userIds = new Set(notifications.reduce(function(filtered, notif) {
       if (notif.type === notificationTypes.Create.base) {
@@ -55,6 +56,7 @@ async function formatNotifications(notifications, notificationSettings, tx, opti
       }
       return filtered
     }, []))
+    logger.info(`formatNotifications: userIds: ${userIds}`)
     const userSubscribersMap = (userIds.length > 0 ? bulkGetSubscribersFromDiscovery(userIds) : new Map())
   }
 

--- a/identity-service/src/notifications/sendNotifications/formatNotification.js
+++ b/identity-service/src/notifications/sendNotifications/formatNotification.js
@@ -1,4 +1,5 @@
 const models = require('../../models')
+const { bulkGetSubscribersFromDiscovery, shouldReadSubscribersFromDiscovery } = require('../utils')
 const { logger } = require('../../logging')
 const { notificationTypes, actionEntityTypes } = require('../constants')
 const notificationUtils = require('./utils')
@@ -43,10 +44,22 @@ const getFavoriteType = (type) => {
 
 let subscriberPushNotifications = []
 
-async function formatNotifications(notifications, notificationSettings, tx) {
+async function formatNotifications(notifications, notificationSettings, tx, optimizelyClient) {
+  // If READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED is enabled, bulk fetch all subscriber IDs
+  // from discovery for the initiators of create notifications.
+  const readSubscribersFromDiscovery = shouldReadSubscribersFromDiscovery(optimizelyClient)
+  if (readSubscribersFromDiscovery) {
+    const userIds = new Set(notifications.reduce(function(filtered, notif) {
+      if (notif.type === notificationTypes.Create.base) {
+        filtered.push(notif.initiator)
+      }
+      return filtered
+    }, []))
+    const userSubscribersMap = (userIds.length > 0 ? bulkGetSubscribersFromDiscovery(userIds) : new Map())
+  }
+
   // Loop through notifications to get the formatted notification
   const formattedNotifications = []
-
   for (const notif of notifications) {
     // blocknumber parsed for all notification types
     const blocknumber = notif.blocknumber
@@ -244,7 +257,11 @@ async function formatNotifications(notifications, notificationSettings, tx) {
 
     // Handle the 'create' notification type, track/album/playlist
     if (notif.type === notificationTypes.Create.base) {
-      await _processCreateNotifications(notif, tx)
+      let subscribers = []
+      if (readSubscribersFromDiscovery) {
+        subscribers = userSubscribersMap.get(notif.initiator) || []
+      }
+      await _processCreateNotifications(notif, tx, readSubscribersFromDiscovery, subscribers)
     }
 
     // Handle the 'track added to playlist' notification type
@@ -330,7 +347,7 @@ async function _processSubscriberPushNotifications() {
   return [filteredFormattedCreateNotifications, users]
 }
 
-async function _processCreateNotifications(notif, tx) {
+async function _processCreateNotifications(notif, tx, readSubscribersFromDiscovery, subscribersFromDiscovery) {
   const blocknumber = notif.blocknumber
   let createType = null
   let actionEntityType = null
@@ -357,14 +374,17 @@ async function _processCreateNotifications(notif, tx) {
     return []
   }
 
-  // Query user IDs from subscriptions table
   // Notifications go to all users subscribing to this track uploader
-  const subscribers = await models.Subscription.findAll({
-    where: {
-      userId: notif.initiator
-    },
-    transaction: tx
-  })
+  let subscribers = subscribersFromDiscovery
+  if (!readSubscribersFromDiscovery) {
+    // Query user IDs from subscriptions table
+    subscribers = await models.Subscription.findAll({
+      where: {
+        userId: notif.initiator
+      },
+      transaction: tx
+    })
+  }
 
   // No operation if no users subscribe to this creator
   if (subscribers.length === 0) {
@@ -403,7 +423,7 @@ async function _processCreateNotifications(notif, tx) {
       time: Date.now(),
       pending: true,
       // Add notification for this user indicating the uploader has added a track
-      subscriberId: s.subscriberId,
+      subscriberId: (readSubscribersFromDiscovery ? s : s.subscriberId),
       // we're going to overwrite this property so fetchNotificationMetadata can use it
       type: createType
     }

--- a/identity-service/src/notifications/sendNotifications/index.js
+++ b/identity-service/src/notifications/sendNotifications/index.js
@@ -109,7 +109,7 @@ async function sendNotifications(
 
   // Format the notifications, so that the extra information needed to build the notification is in a standard format
   const { notifications: formattedNotifications, users } =
-    await formatNotifications(notifications, userNotificationSettings, tx)
+    await formatNotifications(notifications, userNotificationSettings, tx, optimizelyClient)
 
   // Get the metadata for the notifications - users/tracks/playlists from DP that are in the notification
   const metadata = await fetchNotificationMetadata(

--- a/identity-service/src/notifications/sendNotifications/index.js
+++ b/identity-service/src/notifications/sendNotifications/index.js
@@ -109,7 +109,12 @@ async function sendNotifications(
 
   // Format the notifications, so that the extra information needed to build the notification is in a standard format
   const { notifications: formattedNotifications, users } =
-    await formatNotifications(notifications, userNotificationSettings, tx, optimizelyClient)
+    await formatNotifications(
+      notifications,
+      userNotificationSettings,
+      tx,
+      optimizelyClient
+    )
 
   // Get the metadata for the notifications - users/tracks/playlists from DP that are in the notification
   const metadata = await fetchNotificationMetadata(

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -124,15 +124,19 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
 
     const userSubscribers = response.data.data
     logger.info(`users/subscribers userSubscribers ${JSON.stringify(userSubscribers)}`)
+    logger.info(`bulkGetSubscribersFromDiscovery userSubscribers is array: ${Array.isArray(userSubscribers)}`)
 
-    for (const entry in userSubscribers) {
-      const encodedUserId = entry["user_id"]
-      const encodedSubscriberIds = entry["subscriber_ids"]
+    userSubscribers.forEach((entry) => {
+      logger.info(`bulkGetSubscribersFromDiscovery entry: ${JSON.stringify(entry)}`)
+      const encodedUserId = entry.user_id
+      const encodedSubscriberIds = entry.subscriber_ids
+      logger.info(`bulkGetSubscribersFromDiscovery encodedUserId: ${encodedUserId}`)
+      logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
       userSubscribersMap.set(userId, subscriberIds)
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds}`)
-    }
+    })
   } catch (e) {
     logger.error('Error when fetching subscribers from discovery', e)
   }

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -112,18 +112,25 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
 
   try {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
-    const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
+    // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
     const ids = JSON.stringify([...userIds].map((id) => encodeHashId(id)))
     logger.info(`getting subscribers from discovery for userIds ${ids}`)
-    const subscribersFromDN = await discoveryProvider.getSubscribers(
-      ids,
-      timeout
-    )
-    logger.info(`users/subscribers response ${subscribersFromDN}`)
-    logger.info(`users/subscribers response data ${subscribersFromDN.data}`)
-    logger.info(`users/subscribers response data data ${subscribersFromDN.data.data}`)
+    // const subscribersFromDN = await discoveryProvider.getSubscribers(
+    //   ids,
+    //   timeout
+    // )
+    const response = await axios({
+      method: 'post',
+      url: `${discoveryProvider.discoveryProviderEndpoint}/users/subscribers`,
+      params: {
+        ids: ids
+      }
+    })
 
-    const userSubscribers = subscribersFromDN.data
+    const userSubscribers = response.data.data
+    logger.info(`users/subscribers response ${response}`)
+    logger.info(`users/subscribers userSubscribers ${userSubscribers}`)
+
     for (const entry in userSubscribers) {
       encodedUserId = entry["user_id"]
       encodedSubscriberIds = entry["subscriber_ids"]

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -102,16 +102,20 @@ async function calculateTrackListenMilestonesFromDiscovery(discoveryProvider) {
  * @returns Map {userId: Array [subscriberIds]}
  */
 async function bulkGetSubscribersFromDiscovery(userIds) {
-  const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
-  const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
-  const notificationsFromDN = await discoveryProvider.getSubscribers(
-    userIds,
-    timeout
-  )
-  const userSubscribers = notificationsFromDN.data
   const userSubscribersMap = new Map()
-  for (const entry in userSubscribers) {
-    userSubscribersMap[entry["user_id"]] = entry["subscriber_ids"]
+  try {
+    const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
+    const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
+    const notificationsFromDN = await discoveryProvider.getSubscribers(
+      userIds,
+      timeout
+    )
+    const userSubscribers = notificationsFromDN.data
+    for (const entry in userSubscribers) {
+      userSubscribersMap[entry["user_id"]] = entry["subscriber_ids"]
+    }
+  } catch (e) {
+    logger.error('Error when fetching subscribers from discovery', e)
   }
   return userSubscribersMap
 }

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -129,8 +129,8 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      logger.info(`bulkGetSubscribersFromDiscovery decodedUserId: ${userId}`)
-      logger.info(`bulkGetSubscribersFromDiscovery decodedSubscriberIds: ${subscriberIds.toString()}`)
+      logger.info(`bulkGetSubscribersFromDiscovery decodedUserId: ${userId}, type: ${typeof userId}`)
+      logger.info(`bulkGetSubscribersFromDiscovery decodedSubscriberIds: ${subscriberIds.toString()}, type: ${typeof subscriberIds}`)
       userSubscribersMap[userId] = subscriberIds
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${userSubscribersMap[userId].toString()}`)
       return userSubscribersMap

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -111,28 +111,26 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
 
   try {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
-    // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
     const ids = [...userIds].map((id) => encodeHashId(id))
+    const response = await axios.post(
+      `${discoveryProvider.discoveryProviderEndpoint}/v1/full/users/subscribers`,
+      { ids: ids }
+    )
+
+    // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
     // const subscribersFromDN = await discoveryProvider.getSubscribers(
     //   ids,
     //   timeout
     // )
 
-    const response = await axios.post('https://discoveryprovider3.staging.audius.co/v1/full/users/subscribers', { ids: ids })
-
     const userSubscribers = response.data.data
     userSubscribers.forEach((entry) => {
-      logger.info(`bulkGetSubscribersFromDiscovery entry: ${JSON.stringify(entry)}`)
       const encodedUserId = entry.user_id
       const encodedSubscriberIds = entry.subscriber_ids
-      logger.info(`bulkGetSubscribersFromDiscovery encodedUserId: ${encodedUserId}`)
-      logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      logger.info(`bulkGetSubscribersFromDiscovery decodedUserId: ${userId}, type: ${typeof userId}`)
-      logger.info(`bulkGetSubscribersFromDiscovery decodedSubscriberIds: ${subscriberIds.toString()}, type: ${typeof subscriberIds}`)
+
       userSubscribersMap[userId] = subscriberIds
-      logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${userSubscribersMap[userId].toString()}`)
     })
 
     return userSubscribersMap

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -140,8 +140,12 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
   }
 }
 
-/** Checks whether to retrieve subscribers from discovery DB using
-* the READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED feature flag */
+/**
+ * Checks whether to retrieve subscribers from discovery DB using
+ * the READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED feature flag.
+ *
+ * @returns Boolean
+ */
 const shouldReadSubscribersFromDiscovery = (optimizelyClient) => {
   if (!optimizelyClient) {
     return false

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -7,7 +7,7 @@ const models = require('../models')
 const config = require('../config')
 const { logger } = require('../logging')
 const audiusLibsWrapper = require('../audiusLibsInstance')
-const { getFeatureFlag, FEATURE_FLAGS } = require('../../featureFlag')
+const { getFeatureFlag, FEATURE_FLAGS } = require('../featureFlag')
 
 // default configs
 const startBlock = config.get('notificationStartBlock')

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -118,7 +118,7 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
     )
 
     // const timeout = 1 /* min */ * 60 /* sec */ * 1000 /* ms */
-    // const subscribersFromDN = await discoveryProvider.getSubscribers(
+    // const subscribersFromDN = await discoveryProvider.bulkGetSubscribers(
     //   ids,
     //   timeout
     // )

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -123,7 +123,6 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
     const response = await axios.post('https://discoveryprovider3.staging.audius.co/v1/full/users/subscribers', { ids: ids })
 
     const userSubscribers = response.data.data
-    logger.info(`users/subscribers response ${JSON.stringify(response)}`)
     logger.info(`users/subscribers userSubscribers ${JSON.stringify(userSubscribers)}`)
 
     for (const entry in userSubscribers) {

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -132,12 +132,12 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`subscriberIds isArray ${Array.isArray(subscriberIds)}`)
       userSubscribersMap.set(userId, subscriberIds)
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds.toString()}`)
+      return userSubscribersMap
     })
   } catch (e) {
     logger.error('Error when fetching subscribers from discovery', e)
+    return new Map()
   }
-
-  return userSubscribersMap
 }
 
 /** Checks whether to retrieve subscribers from discovery DB using

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -7,6 +7,7 @@ const models = require('../models')
 const config = require('../config')
 const { logger } = require('../logging')
 const audiusLibsWrapper = require('../audiusLibsInstance')
+const { getFeatureFlag, FEATURE_FLAGS } = require('../../featureFlag')
 
 // default configs
 const startBlock = config.get('notificationStartBlock')

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -133,8 +133,9 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery decodedSubscriberIds: ${subscriberIds.toString()}, type: ${typeof subscriberIds}`)
       userSubscribersMap[userId] = subscriberIds
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${userSubscribersMap[userId].toString()}`)
-      return userSubscribersMap
     })
+
+    return userSubscribersMap
   } catch (e) {
     logger.error('Error when fetching subscribers from discovery', e)
     return {}

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -105,7 +105,7 @@ async function calculateTrackListenMilestonesFromDiscovery(discoveryProvider) {
  */
 async function bulkGetSubscribersFromDiscovery(userIds) {
   const userSubscribersMap = {}
-  if (userIds.size == 0){
+  if (userIds.size === 0) {
     return userSubscribersMap
   }
 
@@ -141,7 +141,7 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
 }
 
 /** Checks whether to retrieve subscribers from discovery DB using
-  * the READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED feature flag */
+* the READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED feature flag */
 const shouldReadSubscribersFromDiscovery = (optimizelyClient) => {
   if (!optimizelyClient) {
     return false

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -117,7 +117,7 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       { ids: ids }
     )
 
-    // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
+    // const timeout = 1 /* min */ * 60 /* sec */ * 1000 /* ms */
     // const subscribersFromDN = await discoveryProvider.getSubscribers(
     //   ids,
     //   timeout

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -129,7 +129,7 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      logger.info(`subscriberIds isArray ${Arrays.isArray(subscriberIds)}`)
+      logger.info(`subscriberIds isArray ${Array.isArray(subscriberIds)}`)
       userSubscribersMap.set(userId, subscriberIds)
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds.toString()}`)
     })

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -116,13 +116,6 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       `${discoveryProvider.discoveryProviderEndpoint}/v1/full/users/subscribers`,
       { ids: ids }
     )
-
-    // const timeout = 1 /* min */ * 60 /* sec */ * 1000 /* ms */
-    // const subscribersFromDN = await discoveryProvider.bulkGetSubscribers(
-    //   ids,
-    //   timeout
-    // )
-
     const userSubscribers = response.data.data
     userSubscribers.forEach((entry) => {
       const encodedUserId = entry.user_id

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -123,15 +123,15 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
     const response = await axios.post('https://discoveryprovider3.staging.audius.co/v1/full/users/subscribers', { ids: ids })
 
     const userSubscribers = response.data.data
-    logger.info(`users/subscribers response ${response}`)
-    logger.info(`users/subscribers userSubscribers ${userSubscribers}`)
+    logger.info(`users/subscribers response ${JSON.stringify(response)}`)
+    logger.info(`users/subscribers userSubscribers ${JSON.stringify(userSubscribers)}`)
 
     for (const entry in userSubscribers) {
-      encodedUserId = entry["user_id"]
-      encodedSubscriberIds = entry["subscriber_ids"]
-      userId = decodeHashId(encodedUserId)
-      subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      userSubscribersMap[userId] = subscriberIds
+      const encodedUserId = entry["user_id"]
+      const encodedSubscriberIds = entry["subscriber_ids"]
+      const userId = decodeHashId(encodedUserId)
+      const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
+      userSubscribersMap.set(userId, subscriberIds)
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds}`)
     }
   } catch (e) {

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -113,7 +113,7 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
   try {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
     const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
-    ids = JSON.stringify([...userIds].map((id) => encodeHashId(id)))
+    const ids = JSON.stringify([...userIds].map((id) => encodeHashId(id)))
     logger.info(`getting subscribers from discovery for userIds ${ids}`)
     const subscribersFromDN = await discoveryProvider.getSubscribers(
       ids,

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -106,7 +106,6 @@ async function calculateTrackListenMilestonesFromDiscovery(discoveryProvider) {
 async function bulkGetSubscribersFromDiscovery(userIds) {
   const userSubscribersMap = new Map()
   if (userIds.size == 0){
-    logger.info("bulkGetSubscribersFromDiscovery: userIds is size 0")
     return userSubscribersMap
   }
 
@@ -114,7 +113,6 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
     // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
     const ids = [...userIds].map((id) => encodeHashId(id))
-    logger.info(`getting subscribers from discovery for userIds ${JSON.stringify(ids)}`)
     // const subscribersFromDN = await discoveryProvider.getSubscribers(
     //   ids,
     //   timeout
@@ -123,9 +121,6 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
     const response = await axios.post('https://discoveryprovider3.staging.audius.co/v1/full/users/subscribers', { ids: ids })
 
     const userSubscribers = response.data.data
-    logger.info(`users/subscribers userSubscribers ${JSON.stringify(userSubscribers)}`)
-    logger.info(`bulkGetSubscribersFromDiscovery userSubscribers is array: ${Array.isArray(userSubscribers)}`)
-
     userSubscribers.forEach((entry) => {
       logger.info(`bulkGetSubscribersFromDiscovery entry: ${JSON.stringify(entry)}`)
       const encodedUserId = entry.user_id
@@ -134,8 +129,9 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
+      logger.info(`subscriberIds isArray ${Arrays.isArray(subscriberIds)}`)
       userSubscribersMap.set(userId, subscriberIds)
-      logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds}`)
+      logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds.toString()}`)
     })
   } catch (e) {
     logger.error('Error when fetching subscribers from discovery', e)

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -120,6 +120,8 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       timeout
     )
     logger.info(`users/subscribers response ${subscribersFromDN}`)
+    logger.info(`users/subscribers response data ${subscribersFromDN.data}`)
+    logger.info(`users/subscribers response data data ${subscribersFromDN.data.data}`)
 
     const userSubscribers = subscribersFromDN.data
     for (const entry in userSubscribers) {

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -105,15 +105,15 @@ async function calculateTrackListenMilestonesFromDiscovery(discoveryProvider) {
  */
 async function bulkGetSubscribersFromDiscovery(userIds) {
   const userSubscribersMap = new Map()
-  if (userIds.length == 0){
+  if (userIds.size == 0){
+    logger.info("bulkGetSubscribersFromDiscovery: userIds is size 0")
     return userSubscribersMap
   }
 
   try {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
     const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
-    ids = [...userIds].map((id) => encodeHashId(id))
-    ids = JSON.stringify(ids)
+    ids = JSON.stringify([...userIds].map((id) => encodeHashId(id)))
     logger.info(`getting subscribers from discovery for userIds ${ids}`)
     const subscribersFromDN = await discoveryProvider.getSubscribers(
       ids,

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -113,19 +113,14 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
   try {
     const { discoveryProvider } = audiusLibsWrapper.getAudiusLibs()
     // const timeout = 2 /* min */ * 60 /* sec */ * 1000 /* ms */
-    const ids = JSON.stringify([...userIds].map((id) => encodeHashId(id)))
-    logger.info(`getting subscribers from discovery for userIds ${ids}`)
+    const ids = [...userIds].map((id) => encodeHashId(id))
+    logger.info(`getting subscribers from discovery for userIds ${JSON.stringify(ids)}`)
     // const subscribersFromDN = await discoveryProvider.getSubscribers(
     //   ids,
     //   timeout
     // )
-    const response = await axios({
-      method: 'post',
-      url: `${discoveryProvider.discoveryProviderEndpoint}/users/subscribers`,
-      params: {
-        ids: ids
-      }
-    })
+
+    const response = await axios.post('https://discoveryprovider3.staging.audius.co/v1/full/users/subscribers', { ids: ids })
 
     const userSubscribers = response.data.data
     logger.info(`users/subscribers response ${response}`)

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -129,7 +129,6 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      logger.info(`subscriberIds isArray ${Array.isArray(subscriberIds)}`)
       userSubscribersMap.set(userId, subscriberIds)
       logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds.toString()}`)
       return userSubscribersMap

--- a/identity-service/src/notifications/utils.js
+++ b/identity-service/src/notifications/utils.js
@@ -101,10 +101,10 @@ async function calculateTrackListenMilestonesFromDiscovery(discoveryProvider) {
  * userIds.
  *
  * @param {Set<number>} userIds to fetch subscribers for
- * @returns Map {userId: Array [subscriberIds]}
+ * @returns Object {userId: Array[subscriberIds]}
  */
 async function bulkGetSubscribersFromDiscovery(userIds) {
-  const userSubscribersMap = new Map()
+  const userSubscribersMap = {}
   if (userIds.size == 0){
     return userSubscribersMap
   }
@@ -129,13 +129,15 @@ async function bulkGetSubscribersFromDiscovery(userIds) {
       logger.info(`bulkGetSubscribersFromDiscovery encodedSubscriberIds: ${encodedSubscriberIds}`)
       const userId = decodeHashId(encodedUserId)
       const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
-      userSubscribersMap.set(userId, subscriberIds)
-      logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${subscriberIds.toString()}`)
+      logger.info(`bulkGetSubscribersFromDiscovery decodedUserId: ${userId}`)
+      logger.info(`bulkGetSubscribersFromDiscovery decodedSubscriberIds: ${subscriberIds.toString()}`)
+      userSubscribersMap[userId] = subscriberIds
+      logger.info(`user -> subscribers entry in map: user id ${userId}: subscriber ids ${userSubscribersMap[userId].toString()}`)
       return userSubscribersMap
     })
   } catch (e) {
     logger.error('Error when fetching subscribers from discovery', e)
-    return new Map()
+    return {}
   }
 }
 


### PR DESCRIPTION
### Description
Read subscriptions from discovery DB in identity behind the `READ_SUBSCRIBERS_FROM_DISCOVERY_ENABLED` flag. If flag is off: reads from `Subscriptions` in identity (current behavior)

### Tests
Tested against staging DB with debug log statements:
- Turn flag on
- Subscribe account 1 to account 2 and vice versa. Verify subscriptions with API
- On each account:
    - Upload a track
    - Watch logs to verify discprov path is being hit
    - Verify the other account received a notification
![image](https://user-images.githubusercontent.com/25782182/201453254-75bf1a7e-0467-4415-82c1-3b06be1d9fe4.png)
- Turn flag off
- Same flow as above. Verify parity.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Fails silently with error in logs. No create notifications are sent.