### PR TITLE
[C-1454] When content is unavail in replica set, only try entire network once

### DIFF
--- a/libs/src/api/File.ts
+++ b/libs/src/api/File.ts
@@ -79,7 +79,8 @@ export class File extends Base {
         callback,
         responseType,
         trackId,
-        premiumContentHeaders
+        premiumContentHeaders,
+        0
       )
       return allNodesAttempt
     }
@@ -91,7 +92,8 @@ export class File extends Base {
     callback: Nullable<(url: string) => void> = null,
     responseType: ResponseType = 'blob',
     trackId = null,
-    premiumContentHeaders = {}
+    premiumContentHeaders = {},
+    retries = 3
   ) {
     const urls: string[] = []
 
@@ -169,7 +171,7 @@ export class File extends Base {
         minTimeout: 500,
         maxTimeout: 4000,
         factor: 3,
-        retries: 3,
+        retries,
         onRetry: (err: any, i) => {
           // eslint-disable-next-line no-console
           console.log(`FetchCID attempt ${i} error: ${err}`)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

When content can't be found on the user's replica set we try the entire network. This means about 60 network calls, one for each registered CN. But, we also make a request for both the new and legacy image formats. So 120 network calls. And then we retry this 3 times. So 480 network calls for each piece of content that is truly unavailable :sweat_smile:

This PR removes the retries of the entire network to limit the number of requests

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->