### PR TITLE
Clean up nginx rules for content caching

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -35,17 +35,12 @@ http {
         # Match the paths /ipfs/<cid: string> and /content/<cid: string>.
         # If present in cache, serve. Else, hit upstream server + update cache + serve.
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
-        location ~ (/ipfs/|/content/|/file_lookup/) {
+        location ~ (/ipfs/|/content/) {
             proxy_cache cache;
             proxy_pass http://127.0.0.1:3000;
 
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
-
-            # proxy_cache_use_stale + proxy_cache_background_update -> deliver stale content when client requests
-            # an item that is expired or in the process of being updated from origin server
-            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-            proxy_cache_background_update on;
 
             # Cache responses with certain status codes for some duration before considered stale.
             # Stale implies content will be fetched from the upstream server. Stale content WILL NOT


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This PR contains 2 changes
- Do not cache /file_lookup route anymore (route is deprecated, will be deleted after next release)
- Do not serve stale content. This was causing bugs where initially content was unavailable and the server responded with 500 and openresty would return `x-cache-status: STALE` but if the content was subsequently made available it wouldn't serve until it invalidated the stale content and it took a while to do that. I'm sure there's a better fix for this but seems better to disable since this is an simple optimistic cache. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally by disabling this option and verifying that we don't see status `STALE` anymore. Also content that was made available is returned immediately.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
No easy way to monitor this unfortunately. But can test very thoroughly because content should be served without issue through gateways.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->