### PR TITLE
dm-restructure-fetchCIDInNetwork Changes

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -587,7 +587,7 @@ const config = convict({
     default: 10000
   },
   nodeSyncFileSaveMaxConcurrency: {
-    doc: 'Max concurrency of saveFileForMultihashToFS calls inside nodesync',
+    doc: 'Max concurrency of fetchFileFromNetworkAndSaveToFS calls inside nodesync',
     format: 'nat',
     env: 'nodeSyncFileSaveMaxConcurrency',
     default: 10

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -396,7 +396,7 @@ async function fetchFileFromTargetGatewayAndWriteToDisk({
  *                  eg original.jpg or 150x150.jpg
  * @param {number?} trackId if the CID is of a segment type, the trackId to which it belongs to
  * @param {number?} numRetries optional number of times to retry this function if there was an error during content verification
- * @return {Error || String} error object or storagePath string
+ * @return {error?: Error, storagePath?: String} object with nested fields containing error object or storagePath string
  */
 async function fetchFileFromNetworkAndSaveToFS(
   libs,

--- a/creator-node/src/services/sync/primarySyncFromSecondary.js
+++ b/creator-node/src/services/sync/primarySyncFromSecondary.js
@@ -8,7 +8,7 @@ const { logger: genericLogger } = require('../../logging')
 const DBManager = require('../../dbManager')
 const { computeFilePath, computeFilePathInDir } = require('../../diskManager')
 const { getReplicaSetEndpointsByWallet } = require('../ContentNodeInfoManager')
-const { saveFileForMultihashToFS } = require('../../fileManager')
+const { fetchFileFromNetworkAndSaveToFS } = require('../../fileManager')
 const SyncHistoryAggregator = require('../../snapbackSM/syncHistoryAggregator')
 const initAudiusLibs = require('../initAudiusLibs')
 const DecisionTree = require('../../utils/decisionTree')
@@ -330,7 +330,7 @@ const primarySyncFromSecondary = instrumentTracing({
 /**
  * Fetch data for all files & save to disk
  *
- * - `saveFileForMultihashToFS` will short-circuit if file already exists on disk
+ * - `fetchFileFromNetworkAndSaveToFS` will short-circuit if file already exists on disk
  * - Performed in batches to limit concurrent load
  */
 async function saveFilesToDisk({ files, gatewaysToTry, libs, logger }) {
@@ -355,11 +355,11 @@ async function saveFilesToDisk({ files, gatewaysToTry, libs, logger }) {
      * Fetch content for each CID + save to FS
      * Record any CIDs that failed retrieval/saving for later use
      *
-     * - `saveFileForMultihashToFS()` should never reject - it will return error indicator for post processing
+     * - `fetchFileFromNetworkAndSaveToFS()` should never reject - it will return error indicator for post processing
      */
     await Promise.all(
       trackFilesSlice.map(async (trackFile) => {
-        const error = await saveFileForMultihashToFS(
+        const { error } = await fetchFileFromNetworkAndSaveToFS(
           libs,
           logger,
           trackFile.multihash,
@@ -400,22 +400,22 @@ async function saveFilesToDisk({ files, gatewaysToTry, libs, logger }) {
         // need to also check fileName is not null to make sure it's a dir-style image. non-dir images won't have a 'fileName' db column
         let error
         if (nonTrackFile.type === 'image' && nonTrackFile.fileName !== null) {
-          error = await saveFileForMultihashToFS(
+          ;({ error } = await fetchFileFromNetworkAndSaveToFS(
             libs,
             logger,
             multihash,
             nonTrackFile.dirMultihash,
             gatewaysToTry,
             nonTrackFile.fileName
-          )
+          ))
         } else {
-          error = await saveFileForMultihashToFS(
+          ;({ error } = await fetchFileFromNetworkAndSaveToFS(
             libs,
             logger,
             multihash,
             nonTrackFile.dirMultihash,
             gatewaysToTry
-          )
+          ))
         }
 
         // If saveFile op failed, record CID for later processing

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.ts
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.ts
@@ -10,7 +10,7 @@ import {
   getStartTime,
   logInfoWithDuration
 } from '../../logging'
-import { saveFileForMultihashToFS } from '../../fileManager'
+import { fetchFileFromNetworkAndSaveToFS } from '../../fileManager'
 import {
   gatherCNodeUserDataToDelete,
   clearFilePathsToDelete,
@@ -311,7 +311,7 @@ const handleSyncFromPrimary = async ({
      * Replace CNodeUser's local DB state with retrieved data + fetch + save missing files.
      */
 
-    // Use user's replica set as gateways for content fetching in saveFileForMultihashToFS.
+    // Use user's replica set as gateways for content fetching in fetchFileFromNetworkAndSaveToFS.
     // Note that sync is only called on secondaries so `myCnodeEndpoint` below always represents a secondary.
     let gatewaysToTry: string[] = []
     try {
@@ -332,11 +332,11 @@ const handleSyncFromPrimary = async ({
     } catch (e: any) {
       tracing.recordException(e)
       logger.error(
-        `Couldn't filter out own endpoint from user's replica set to use as cnode gateways in saveFileForMultihashToFS - ${e.message}`
+        `Couldn't filter out own endpoint from user's replica set to use as cnode gateways in fetchFileFromNetworkAndSaveToFS - ${e.message}`
       )
 
       error = new Error(
-        `Couldn't filter out own endpoint from user's replica set to use as cnode gateways in saveFileForMultihashToFS - ${e.message}`
+        `Couldn't filter out own endpoint from user's replica set to use as cnode gateways in fetchFileFromNetworkAndSaveToFS - ${e.message}`
       )
       errorResponse = {
         error,
@@ -542,7 +542,7 @@ const handleSyncFromPrimary = async ({
       for (let i = 0; i < trackFiles.length; i += FileSaveMaxConcurrency) {
         const trackFilesSlice = trackFiles.slice(i, i + FileSaveMaxConcurrency)
         logger.debug(
-          `TrackFiles saveFileForMultihashToFS - processing trackFiles ${i} to ${
+          `TrackFiles fetchFileFromNetworkAndSaveToFS - processing trackFiles ${i} to ${
             i + FileSaveMaxConcurrency
           } out of total ${trackFiles.length}...`
         )
@@ -550,11 +550,11 @@ const handleSyncFromPrimary = async ({
         /**
          * Fetch content for each CID + save to FS
          * Record any CIDs that failed retrieval/saving for later use
-         * @notice `saveFileForMultihashToFS()` should never reject - it will return error indicator for post processing
+         * @notice `fetchFileFromNetworkAndSaveToFS()` should never reject - it will return error indicator for post processing
          */
         await Promise.all(
           trackFilesSlice.map(async (trackFile: any) => {
-            const error = await saveFileForMultihashToFS(
+            const { error } = await fetchFileFromNetworkAndSaveToFS(
               libs,
               logger,
               trackFile.multihash,
@@ -580,7 +580,7 @@ const handleSyncFromPrimary = async ({
           i + FileSaveMaxConcurrency
         )
         logger.debug(
-          `NonTrackFiles saveFileForMultihashToFS - processing files ${i} to ${
+          `NonTrackFiles fetchFileFromNetworkAndSaveToFS - processing files ${i} to ${
             i + FileSaveMaxConcurrency
           } out of total ${nonTrackFiles.length}...`
         )
@@ -598,22 +598,22 @@ const handleSyncFromPrimary = async ({
                 nonTrackFile.type === 'image' &&
                 nonTrackFile.fileName !== null
               ) {
-                error = await saveFileForMultihashToFS(
+                ;({ error } = await fetchFileFromNetworkAndSaveToFS(
                   libs,
                   logger,
                   multihash,
                   nonTrackFile.dirMultihash,
                   gatewaysToTry,
                   nonTrackFile.fileName
-                )
+                ))
               } else {
-                error = await saveFileForMultihashToFS(
+                ;({ error } = await fetchFileFromNetworkAndSaveToFS(
                   libs,
                   logger,
                   multihash,
                   nonTrackFile.dirMultihash,
                   gatewaysToTry
-                )
+                ))
               }
 
               // If saveFile op failed, record CID for later processing

--- a/creator-node/src/services/sync/skippedCIDsRetryService.js
+++ b/creator-node/src/services/sync/skippedCIDsRetryService.js
@@ -7,7 +7,7 @@ const { clusterUtils } = require('../../utils')
 const {
   getAllRegisteredCNodes
 } = require('../../services/ContentNodeInfoManager')
-const { saveFileForMultihashToFS } = require('../../fileManager')
+const { fetchFileFromNetworkAndSaveToFS } = require('../../fileManager')
 
 const LogPrefix = '[SkippedCIDsRetryQueue]'
 
@@ -117,7 +117,7 @@ class SkippedCIDsRetryQueue {
     const savedFileUUIDs = []
     for await (const file of skippedFiles) {
       // Returns boolean success indicator
-      const error = await saveFileForMultihashToFS(
+      const { error } = await fetchFileFromNetworkAndSaveToFS(
         libs,
         logger,
         file.multihash,

--- a/creator-node/test/sync.test.js
+++ b/creator-node/test/sync.test.js
@@ -26,7 +26,7 @@ const sessionManager = require('../src/sessionManager')
 const redisClient = require('../src/redis')
 const { stringifiedDateFields } = require('./lib/utils')
 
-const { saveFileForMultihashToFS } = require('../src/fileManager')
+const { fetchFileFromNetworkAndSaveToFS } = require('../src/fileManager')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
@@ -1454,7 +1454,7 @@ describe('Test secondarySyncFromPrimary()', async function () {
             }
           },
           '../../fileManager': {
-            saveFileForMultihashToFS: async function (
+            fetchFileFromNetworkAndSaveToFS: async function (
               libs,
               logger,
               multihash,
@@ -1463,7 +1463,7 @@ describe('Test secondarySyncFromPrimary()', async function () {
               fileNameForImage = null,
               trackId = null
             ) {
-              return saveFileForMultihashToFS(
+              return fetchFileFromNetworkAndSaveToFS(
                 libs,
                 logger,
                 multihash,
@@ -2329,7 +2329,7 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
         '../initAudiusLibs': async () => libsMock,
         './../../config': config,
         '../../fileManager': {
-          saveFileForMultihashToFS: async function (
+          fetchFileFromNetworkAndSaveToFS: async function (
             libs,
             logger,
             multihash,
@@ -2338,7 +2338,7 @@ describe('Test primarySyncFromSecondary() with mocked export', async () => {
             fileNameForImage = null,
             trackId = null
           ) {
-            return saveFileForMultihashToFS(
+            return fetchFileFromNetworkAndSaveToFS(
               libs,
               logger,
               multihash,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

- rename `saveFileForMultihashToFS()` to `fetchFileFromNetworkAndSaveToFS()` for accuracy
- change return format from `Error?` to `{error?: Error, storagePath?: String}` and update all references
- remove redundant `fs.mkdir` in `getDirCID()`
- remove unnecessary redis cache `getStoragePathQueryCacheKey` step in `getDirCID()`
- minor getDirCID() code cleanup / re-orgs

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

TODO

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

TODO

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->