### PR TITLE
Fix nethermind reverse proxy config

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -178,7 +178,9 @@ http {
         }
 
         location /nethermind {
-            proxy_pass http://chain:8545/;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream chain:9187;
+            proxy_pass http://$upstream/;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }


### PR DESCRIPTION
### Description

Follow `$upstream` pattern so nginx doesn't die if upstream is down
