### PR TITLE
[PAY-707] Block abusive users from emails

### DIFF
--- a/identity-service/sequelize/migrations/20221115014540-blocked-from-emails-column.js
+++ b/identity-service/sequelize/migrations/20221115014540-blocked-from-emails-column.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'isBlockedFromEmails', {
+      type: Sequelize.BOOLEAN,
+      allowNull: true
+    })
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('Users', 'isBlockedFromEmails')
+  }
+};

--- a/identity-service/src/models/user.js
+++ b/identity-service/src/models/user.js
@@ -50,6 +50,10 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.BOOLEAN,
         allowNull: true
       },
+      isBlockedFromEmails: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true
+      },
       appliedRules: {
         type: DataTypes.JSONB,
         allowNull: true

--- a/identity-service/src/notifications/sendNotificationEmails.js
+++ b/identity-service/src/notifications/sendNotificationEmails.js
@@ -51,6 +51,7 @@ const DEFAULT_EMAIL_FREQUENCY = EmailFrequency.LIVE
 
 const Results = Object.freeze({
   USER_TURNED_OFF: 'USER_TURNED_OFF',
+  USER_BLOCKED: 'USER_BLOCKED',
   SHOULD_SKIP: 'SHOULD_SKIP',
   ERROR: 'ERROR',
   SENT: 'SENT'
@@ -294,7 +295,19 @@ async function processEmailNotifications(expressApp, audiusLibs) {
       const chunkResults = await Promise.all(
         userInfo.slice(start, end).map(async (user) => {
           try {
-            let { email: userEmail, blockchainUserId: userId, timezone } = user
+            let {
+              email: userEmail,
+              blockchainUserId: userId,
+              timezone,
+              isBlockedFromEmails
+            } = user
+            if (isBlockedFromEmails) {
+              return {
+                result: Results.USER_BLOCKED,
+                error: `User with id ${userId} and email ${userEmail} is blocked from receiving emails`
+              }
+            }
+
             if (timezone === null) {
               timezone = DEFAULT_TIMEZONE
             }

--- a/identity-service/src/routes/relay.js
+++ b/identity-service/src/routes/relay.js
@@ -36,6 +36,7 @@ module.exports = function (app) {
           'handle',
           'isBlockedFromRelay',
           'isBlockedFromNotifications',
+          'isBlockedFromEmails',
           'appliedRules'
         ]
       })
@@ -62,7 +63,10 @@ module.exports = function (app) {
       // Handle abusive users
 
       const userFlaggedAsAbusive =
-        user && (user.isBlockedFromRelay || user.isBlockedFromNotifications)
+        user &&
+        (user.isBlockedFromRelay ||
+          user.isBlockedFromNotifications ||
+          user.isBlockedFromEmails)
       if (blockAbuseOnRelay && user && userFlaggedAsAbusive) {
         // allow previously abusive users to redeem themselves for next relays
         if (detectAbuseOnRelay) {

--- a/identity-service/src/routes/welcomeEmail.js
+++ b/identity-service/src/routes/welcomeEmail.js
@@ -63,6 +63,12 @@ module.exports = function (app) {
         )
         return successResponse({ msg: 'Welcome email forbidden', status: true })
       }
+      if (existingUser.isBlockedFromEmails) {
+        req.logger.info(
+          `User with handle ${existingUser.handle} and email ${existingUser.email} is blocked from receiving emails`
+        )
+        return successResponse({ msg: 'Welcome email forbidden', status: true })
+      }
 
       const walletAddress = existingUser.walletAddress
       const htmlTemplate = isNativeMobile

--- a/identity-service/src/utils/antiAbuse.js
+++ b/identity-service/src/utils/antiAbuse.js
@@ -9,6 +9,7 @@ const aaoEndpoint =
 const allowRules = new Set([14])
 const blockRelayAbuseErrorCodes = new Set([0, 8, 10, 13, 15])
 const blockNotificationsErrorCodes = new Set([7, 9])
+const blockEmailsErrorCodes = new Set([0, 1, 2, 3, 4, 8, 10, 13, 15])
 
 /**
  * Gets IP of a user by using the leftmost forwarded-for entry
@@ -72,10 +73,14 @@ const getAbuseData = async (handle, reqIP, abbreviated) => {
   const blockedFromNotifications = appliedFailRules.some((r) =>
     blockNotificationsErrorCodes.has(r)
   )
+  const blockedFromEmails = appliedFailRules.some((r) =>
+    blockEmailsErrorCodes.has(r)
+  )
 
   return {
     blockedFromRelay,
     blockedFromNotifications,
+    blockedFromEmails,
     appliedRules: appliedFailRules
   }
 }
@@ -87,6 +92,7 @@ const detectAbuse = async (user, reqIP, abbreviated = false) => {
 
   let blockedFromRelay = false
   let blockedFromNotifications = false
+  let blockedFromEmails = false
   let appliedRules = null
 
   try {
@@ -94,15 +100,20 @@ const detectAbuse = async (user, reqIP, abbreviated = false) => {
     await recordIP(reqIP, user.handle)
 
     // Perform abuse check conditional on environment
-    ;({ appliedRules, blockedFromRelay, blockedFromNotifications } =
-      await getAbuseData(user.handle, reqIP, abbreviated))
+    ;({
+      appliedRules,
+      blockedFromRelay,
+      blockedFromNotifications,
+      blockedFromEmails
+    } = await getAbuseData(user.handle, reqIP, abbreviated))
     logger.info(
       `detectAbuse: got info for user id ${user.blockchainUserId} handle ${
         user.handle
       }: ${JSON.stringify({
         appliedRules,
         blockedFromRelay,
-        blockedFromNotifications
+        blockedFromNotifications,
+        blockedFromEmails
       })}`
     )
   } catch (e) {
@@ -114,14 +125,16 @@ const detectAbuse = async (user, reqIP, abbreviated = false) => {
   // Use !! for nullable columns :(
   if (
     !!user.isBlockedFromRelay !== blockedFromRelay ||
-    !!user.isBlockedFromNotifications !== blockedFromNotifications
+    !!user.isBlockedFromNotifications !== blockedFromNotifications ||
+    !!user.isBlockedFromEmails !== blockedFromEmails
   ) {
     logger.info(
-      `abuse: state changed for user [${user.handle}], blocked from relay: ${blockedFromRelay} blocked from notifs: [${blockedFromNotifications}]`
+      `abuse: state changed for user [${user.handle}], blocked from relay: ${blockedFromRelay}, blocked from notifs: [${blockedFromNotifications}, blocked from emails: ${blockedFromEmails}]`
     )
     await user.update({
       isBlockedFromRelay: blockedFromRelay,
       isBlockedFromNotifications: blockedFromNotifications,
+      isBlockedFromEmails: blockedFromEmails,
       appliedRules
     })
   }


### PR DESCRIPTION
### Description

Prevent welcome emails and other email notifs from being sent to abusive users.
The welcome email is triggered to get sent by the client, right after sign up succeeds. Therefore, we rely on identity and the hereby newly added `isBlockedFromEmails` column to determine whether it is sent.

### Tests
No test yet. Goal is to test against stage by signing up with a user that would be seen as abusive, determined by the error codes for blocking emails, and making sure that user does not get emails sent to them.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
No monitoring outside of noticing much less welcome emails being sent to users, and also seeing how many users have the `isBlockedFromEmails` flag set to true.
Would be a good idea to get more visibility on this, and other blocking reasons for users sooner rather than later.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->