### PR TITLE
Disable slack fail alerts temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,8 +1223,8 @@ jobs:
             export SLACK_DETAIL=$(awk '{printf "%s\\n", $0}' /tmp/summary.md)
             echo "export SLACK_DETAIL='${SLACK_DETAIL}'" >> "$BASH_ENV"
           when: always
-      - slack-fail:
-          detail: ${SLACK_DETAIL}
+      # - slack-fail:
+      #     detail: ${SLACK_DETAIL}
       # only send Success slack message when prod, --force, or custom args are used
       - when:
           condition:


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Autodeploy is broken, muting failed slack messages temporarily until we fix https://linear.app/audius/issue/INF-316/fix-auto-deploy-to-stage

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->