### PR TITLE
fetchFileFromNetwork bugfix + Add localOnly queryParam for CN->CN network fetches to prevent additional network fetches internally

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -2933,7 +2933,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -2948,12 +2948,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2962,27 +2962,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3548,7 +3548,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {
@@ -4810,7 +4810,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5015,7 +5015,7 @@
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -5294,7 +5294,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-layout": {
       "version": "1.2.2",
@@ -5587,7 +5587,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001241",
@@ -6282,7 +6282,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
     },
     "css-to-react-native": {
       "version": "3.0.0",
@@ -8226,7 +8226,7 @@
     "fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha1-XFVDRisiru79NtBbNOUceMuG0xM="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -10710,7 +10710,7 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -10726,7 +10726,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
     "log-driver": {
@@ -12704,7 +12704,7 @@
     "qr.js": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
     },
     "qrcode.react": {
       "version": "1.0.1",
@@ -13959,7 +13959,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw=="
     },
     "smart-buffer": {
       "version": "4.2.0",
@@ -16364,7 +16364,7 @@
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
       "requires": {
         "bs58check": "<3.0.0"
       }
@@ -16480,7 +16480,7 @@
     "write-file-atomic": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -16561,7 +16561,7 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -336,7 +336,8 @@ async function fetchFileFromTargetGatewayAndWriteToDisk({
     method: 'get',
     url: contentUrl,
     responseType: 'stream',
-    timeout: 20000 /* 20 sec - higher timeout to allow enough time to fetch copy320 */
+    timeout: 20000 /* 20 sec - higher timeout to allow enough time to fetch copy320 */,
+    params: { localOnly: true }
   }
 
   if (trackId) {

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -186,7 +186,7 @@ async function fetchFileFromNetworkAndWriteToDisk({
       `Already attempted to find from network; Currently cannot try again`
     )
 
-  for (const contentUrl of nonTargetGatewayContentRoutes.reverse()) {
+  for (const contentUrl of nonTargetGatewayContentRoutes) {
     decisionTree.recordStage({
       name: 'Fetching from non-replica set gateways from the rest of the network',
       data: { gateway: contentUrl }

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -173,6 +173,7 @@ const logGetCIDDecisionTree = (decisionTree, req) => {
 const getCID = async (req, res) => {
   const CID = req.params.CID
   const trackId = parseInt(req.query.trackId)
+  const localOnly = req.query.localOnly === 'true'
 
   const decisionTree = [{ stage: `BEGIN`, time: `${Date.now()}` }]
   const logPrefix = `[getCID] [CID=${CID}]`
@@ -486,6 +487,16 @@ const getCID = async (req, res) => {
     })
   }
 
+  if (localOnly) {
+    return sendResponse(
+      req,
+      res,
+      errorResponseNotFound(
+        `${logPrefix} No valid file found locally for provided CID`
+      )
+    )
+  }
+
   /**
    * If found in DB (means not found in FS):
    * 1. Attempt to retrieve file from network and save to file system
@@ -546,6 +557,7 @@ const getDirCID = async (req, res) => {
   // Do not act as a public gateway. Only serve files that are tracked by this creator node.
   const dirCID = req.params.dirCID
   const filename = req.params.filename
+  const localOnly = req.query.localOnly === 'true'
   const logPrefix = `[getDirCID][dirCID: ${dirCID}][fileName: ${filename}]`
 
   // We need to lookup the CID so we can correlate with the filename (eg original.jpg, 150x150.jpg)
@@ -593,6 +605,14 @@ const getDirCID = async (req, res) => {
         `${logPrefix} - Failed to retrieve ${queryResults.storagePath} from FS`
       )
     }
+  }
+
+  if (localOnly) {
+    return sendResponse(
+      req,
+      res,
+      errorResponseNotFound(`${logPrefix} No valid file found locally`)
+    )
   }
 
   // CID is the file CID, parse it from the storagePath


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Current flow:
1. client makes getCID (or getDirCID) request to CN
2. CN doesn't have it locally
3. sets attemptedStateFix locally to true
4. sequentially makes getCID (or getDirCID) requests to all other CNs
5. each other CN, if it doesn't have it:
6. sets attemptedStateFix(CID) = true
7. sequentially makes getCID requests to all other CNs
8. these other nodes, if they don't have it:
9. return 404 since attemptedStateFix(CID) = true

This is fine bc of the attemptedStateFix via Redis which ensures each CN only makes network fetches once per day for a given CID/dirCID, but its still 2x number of required requests

New flow:
1. client makes getCID (or getDirCID) request to CN
2. CN doesn't have it locally
3. sets attemptedStateFix locally to true
4. sequentially makes getCID (or getDirCID) requests to all other CNs with `localOnly = true`
5. each other CN, if it doesn't have it, immediately returns 404 bc it received `localOnly` param

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Local:
1. full stack + upload some files
2. delete one file from every node's disk except 1
3. request that file from a node
4. ensure `localOnly` query param is correctly applied to CN->CN requests, and that it correctly stops internal request propagation

DecisionTree from the node that received initial request
<img width="849" alt="Screen Shot 2022-11-16 at 6 00 17 PM" src="https://user-images.githubusercontent.com/3323835/202313097-ff33891b-e638-4a80-b4f1-e5dceb01f622.png">

Logs from node that received CN->CN request internally, confirming it did not send any further requests internally
<img width="870" alt="Screen Shot 2022-11-16 at 6 00 22 PM" src="https://user-images.githubusercontent.com/3323835/202313137-3791c6b0-6c2e-4cac-9a44-0ed8b6a37343.png">



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Should cut down on number of CID requests in network (grafana panel)

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->