### PR TITLE
Libs: Expose error details to consumer

### DIFF
--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -399,6 +399,10 @@ export class Users extends Base {
       const errorMsg = `assignReplicaSet() Error -- Phase ${phase} in ${
         Date.now() - fnStartMs
       }ms: ${e}`
+      if (e instanceof Error) {
+        e.message = errorMsg
+        throw e
+      }
       throw new Error(errorMsg)
     }
 
@@ -550,6 +554,10 @@ export class Users extends Base {
       const errorMsg = `assignReplicaSet() Error -- Phase ${phase} in ${
         Date.now() - fnStartMs
       }ms: ${e}`
+      if (e instanceof Error) {
+        e.message = errorMsg
+        throw e
+      }
       throw new Error(errorMsg)
     }
   }
@@ -1041,6 +1049,10 @@ export class Users extends Base {
       const errorMsg = `updateAndUploadMetadata() Error -- Phase ${phase} in ${
         Date.now() - fnStartMs
       }ms: ${e}`
+      if (e instanceof Error) {
+        e.message = errorMsg
+        throw e
+      }
       throw new Error(errorMsg)
     }
   }
@@ -1060,9 +1072,12 @@ export class Users extends Base {
     try {
       await this.assignReplicaSet({ userId: user.user_id })
     } catch (e) {
-      throw new Error(
-        `assignReplicaSetIfNecessary error - ${(e as any).toString()}`
-      )
+      const errorMsg = `assignReplicaSetIfNecessary error - ${e}`
+      if (e instanceof Error) {
+        e.message = errorMsg
+        throw e
+      }
+      throw new Error(errorMsg)
     }
   }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Instead of throwing (ha, no pun intended) out all the original error details and throwing our own new error, forward the error details so that the consumer can decide what to do with them. This is necessary for [PAY-724](https://linear.app/audius/issue/PAY-724/account-for-relay-403s-on-signup-analytics) so that we can have the client react differently depending on why the error was thrown.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally manually with client running changes necessary for PAY-724 against staging


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->