### PR TITLE
[CON-517] Add a route to translate trackBlockchainId to copy320 CID

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -925,7 +925,7 @@ router.post(
 
     // make query
     const queryResults = await models.File.findAll({
-      attributes: ['multihash'],
+      attributes: ['multihash', 'trackBlockchainId'],
       raw: true,
       where: {
         trackBlockchainId: {
@@ -935,12 +935,15 @@ router.post(
       }
     })
 
-    const response = {
-      cids: queryResults.map(({ multihash }) => multihash)
-    }
+    const trackIdMapping = Object.fromEntries(
+      queryResults.map(({ trackBlockchainId, multihash }) => [
+        trackBlockchainId,
+        multihash
+      ])
+    )
 
     // return results
-    return successResponse(response)
+    return successResponse(trackIdMapping)
   })
 )
 

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -923,7 +923,6 @@ router.post(
       )
     }
 
-    // make query
     const queryResults = await models.File.findAll({
       attributes: ['multihash', 'trackBlockchainId'],
       raw: true,

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -936,7 +936,7 @@ router.post(
     })
 
     const response = {
-      cids: queryResults
+      cids: queryResults.map(({ multihash }) => multihash)
     }
 
     // return results

--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -925,7 +925,7 @@ router.post(
 
     // make query
     const queryResults = await models.File.findAll({
-      attributes: ['multihash', 'storagePath'],
+      attributes: ['multihash'],
       raw: true,
       where: {
         trackBlockchainId: {

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -38,6 +38,7 @@ const BlacklistManager = require('../blacklistManager')
 const TranscodingQueue = require('../TranscodingQueue')
 const { tracing } = require('../tracer')
 
+
 const router = express.Router()
 
 /**
@@ -927,5 +928,6 @@ router.get(
   },
   getCID
 )
+
 
 module.exports = router

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -38,7 +38,6 @@ const BlacklistManager = require('../blacklistManager')
 const TranscodingQueue = require('../TranscodingQueue')
 const { tracing } = require('../tracer')
 
-
 const router = express.Router()
 
 /**

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -929,5 +929,4 @@ router.get(
   getCID
 )
 
-
 module.exports = router


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds a new route `/batch_id_to_cid` that translates a batch of trackBlockchainIds to copy320 CIDs.

The return schema looks like 
```
{
    'trackBlockchainId': 'multihash'
}
```


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally by creating a user, uploading a track, and running curl to fetch the copy320.

And he's a test on the node cli to remove any suspicion that the functional code used to create the actually does work. 
<img width="828" alt="Screenshot 2022-11-18 at 16 45 39" src="https://user-images.githubusercontent.com/17736112/202745489-090a8dc0-53f7-444f-9b47-0493c5551028.png">


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->