### PR TITLE
Foundation node sync override for easier manual syncs for test purposes

### DIFF
--- a/creator-node/src/components/replicaSet/replicaSetController.js
+++ b/creator-node/src/components/replicaSet/replicaSetController.js
@@ -20,7 +20,11 @@ const {
   SyncType,
   SYNC_MODES
 } = require('../../services/stateMachineManager/stateMachineConstants')
-const { getSyncStatus, setSyncStatus } = require('../../services/sync/syncUtil')
+const {
+  getSyncStatus,
+  setSyncStatus,
+  checkSyncOverride
+} = require('../../services/sync/syncUtil')
 const {
   enqueueSync,
   processManualImmediateSync
@@ -96,6 +100,9 @@ const _syncRouteController = async (req, _res) => {
   const primaryEndpoint = req.body.creator_node_endpoint // string
   const immediate = req.body.immediate === true || req.body.immediate === 'true' // boolean - default false
   const blockNumber = req.body.blockNumber // integer
+  const syncOverridePassword = req.body.syncOverridePassword
+
+  const syncOverride = checkSyncOverride(syncOverridePassword)
 
   // Disable multi wallet syncs for now since in below redis logic is broken for multi wallet case
   if (walletPublicKeys.length === 0) {
@@ -141,6 +148,7 @@ const _syncRouteController = async (req, _res) => {
           wallet
         },
         forceWipe: req.body.forceWipe,
+        syncOverride,
         logContext: req.logContext,
         syncUuid,
 
@@ -180,6 +188,7 @@ const _syncRouteController = async (req, _res) => {
         },
         forceWipe: req.body.forceWipe,
         logContext: req.logContext,
+        syncOverride,
         syncUuid,
         parentSpanContext: tracing.currentSpanContext()
       })

--- a/creator-node/src/components/replicaSet/syncQueueComponentService.ts
+++ b/creator-node/src/components/replicaSet/syncQueueComponentService.ts
@@ -19,6 +19,7 @@ export const enqueueSync = async (params: {
     wallet: string
   }
   forceWipe: boolean
+  syncOverride: boolean
   logContext: LogContext
   parentSpanContext: SpanContext
   serviceRegistry: any
@@ -46,6 +47,7 @@ export const processManualImmediateSync = async (params: {
     wallet: string
   }
   forceWipe: boolean
+  syncOverride: boolean
   logContext: LogContext
   parentSpanContext: SpanContext
   serviceRegistry: any

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -850,7 +850,8 @@ const config = convict({
     doc: 'asdf',
     format: String,
     env: 'syncOverride',
-    default: null
+    default: null,
+    sensitive: true
   }
 })
 

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -847,10 +847,10 @@ const config = convict({
     default: true
   },
   syncOverridePassword: {
-    doc: 'asdf',
+    doc: 'Used to allow manual syncs to be issued on foundation nodes only, and still requires password',
     format: String,
-    env: 'syncOverride',
-    default: null,
+    env: 'syncOverridePassword',
+    default: '',
     sensitive: true
   }
 })

--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -845,6 +845,12 @@ const config = convict({
     format: Boolean,
     env: 'processSyncResults',
     default: true
+  },
+  syncOverridePassword: {
+    doc: 'asdf',
+    format: String,
+    env: 'syncOverride',
+    default: null
   }
 })
 

--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -82,7 +82,6 @@ class DBManager {
         where: cnodeUserWhereFilter,
         transaction
       })
-      log('cnodeUser', cnodeUser)
 
       // Throw if no cnodeUser found
       if (!cnodeUser) {

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.ts
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.ts
@@ -797,6 +797,7 @@ async function _secondarySyncFromPrimary({
   forceResyncConfig,
   logContext,
   forceWipe = false,
+  syncOverride = false,
   blockNumber = null,
   syncUuid = null // Could be null for backwards compatibility
 }: SecondarySyncFromPrimaryParams) {
@@ -830,6 +831,7 @@ async function _secondarySyncFromPrimary({
     blockNumber,
     forceResyncConfig,
     forceWipe,
+    syncOverride,
     logContext,
     secondarySyncFromPrimaryLogger
   })

--- a/creator-node/src/services/sync/secondarySyncFromPrimary.ts
+++ b/creator-node/src/services/sync/secondarySyncFromPrimary.ts
@@ -41,6 +41,7 @@ type SecondarySyncFromPrimaryParams = {
   forceResyncConfig: ForceResyncConfig
   logContext: LogContext
   forceWipe?: boolean
+  syncOverride?: boolean
   blockNumber?: number | null
   syncUuid?: string | null
 }
@@ -51,6 +52,7 @@ const handleSyncFromPrimary = async ({
   creatorNodeEndpoint,
   forceResyncConfig,
   forceWipe,
+  syncOverride,
   logContext,
   secondarySyncFromPrimaryLogger
 }: SecondarySyncFromPrimaryParams & {
@@ -101,7 +103,7 @@ const handleSyncFromPrimary = async ({
       throw error
     }
 
-    if (userReplicaSet.primary !== creatorNodeEndpoint) {
+    if (!syncOverride && userReplicaSet.primary !== creatorNodeEndpoint) {
       return {
         abort: `Node being synced from is not primary. Node being synced from: ${creatorNodeEndpoint} Primary: ${userReplicaSet.primary}`,
         result: 'abort_current_node_is_not_user_primary'
@@ -113,7 +115,8 @@ const handleSyncFromPrimary = async ({
      */
     const forceResync = await shouldForceResync(
       { libs, logContext },
-      forceResyncConfig
+      forceResyncConfig,
+      syncOverride
     )
     const forceResyncQueryParam = forceResyncConfig?.forceResync
     if (forceResyncQueryParam && !forceResync) {
@@ -240,6 +243,7 @@ const handleSyncFromPrimary = async ({
     // Ensure this node is one of the user's secondaries (except when wiping a node with orphaned data).
     // We know we're not wiping an orphaned node at this point because it would've returned earlier if forceWipe=true
     if (
+      !syncOverride &&
       thisContentNodeEndpoint !== userReplicaSet.secondary1 &&
       thisContentNodeEndpoint !== userReplicaSet.secondary2
     ) {

--- a/creator-node/src/services/sync/secondarySyncFromPrimaryUtils.ts
+++ b/creator-node/src/services/sync/secondarySyncFromPrimaryUtils.ts
@@ -40,7 +40,8 @@ const generateDataForSignatureRecovery = (
  */
 const shouldForceResync = async (
   { libs, logContext }: { libs: any; logContext: LogContext },
-  forceResyncConfig: ForceResyncConfig
+  forceResyncConfig: ForceResyncConfig,
+  syncOverride = false
 ) => {
   if (!forceResyncConfig) return false
 
@@ -53,6 +54,10 @@ const shouldForceResync = async (
   logger.debug(
     `Checking shouldForceResync: wallet=${wallet} forceResync=${forceResync}`
   )
+
+  if (forceResync && syncOverride) {
+    return true
+  }
 
   if (!forceResync || !signatureData) {
     return false

--- a/creator-node/src/services/sync/syncImmediateQueue.js
+++ b/creator-node/src/services/sync/syncImmediateQueue.js
@@ -110,6 +110,8 @@ class SyncImmediateQueue {
       wallet,
       creatorNodeEndpoint,
       forceResyncConfig,
+      forceWipe,
+      syncOverride,
       logContext,
       serviceRegistry,
       syncUuid
@@ -122,6 +124,8 @@ class SyncImmediateQueue {
         wallet,
         creatorNodeEndpoint,
         forceResyncConfig,
+        forceWipe,
+        syncOverride,
         logContext,
         syncUuid: syncUuid || null
       })
@@ -147,6 +151,8 @@ class SyncImmediateQueue {
     wallet,
     creatorNodeEndpoint,
     forceResyncConfig,
+    forceWipe,
+    syncOverride,
     logContext,
     parentSpanContext,
     syncUuid = null // Could be null for backwards compatibility
@@ -155,6 +161,8 @@ class SyncImmediateQueue {
       wallet,
       creatorNodeEndpoint,
       forceResyncConfig,
+      forceWipe,
+      syncOverride,
       logContext,
       parentSpanContext,
       syncUuid: syncUuid || null

--- a/creator-node/src/services/sync/syncQueue.ts
+++ b/creator-node/src/services/sync/syncQueue.ts
@@ -23,6 +23,7 @@ type EnqueueSyncArgs = {
   blockNumber: number
   forceResyncConfig: ForceResyncConfig
   forceWipe?: boolean
+  syncOverride?: boolean
   logContext: LogContext
   parentSpanContext: SpanContext
   syncUuid: string | null
@@ -132,6 +133,7 @@ export class SyncQueue {
       creatorNodeEndpoint,
       forceResyncConfig,
       forceWipe,
+      syncOverride,
       blockNumber,
       logContext,
       serviceRegistry,
@@ -148,6 +150,7 @@ export class SyncQueue {
         blockNumber,
         forceResyncConfig,
         forceWipe,
+        syncOverride,
         logContext,
         syncUuid: syncUuid || null
       })
@@ -173,6 +176,7 @@ export class SyncQueue {
     blockNumber,
     forceResyncConfig,
     forceWipe,
+    syncOverride,
     logContext,
     parentSpanContext,
     syncUuid = null // Could be null for backwards compatibility
@@ -187,6 +191,7 @@ export class SyncQueue {
         blockNumber,
         forceResyncConfig,
         forceWipe,
+        syncOverride,
         logContext,
         parentSpanContext,
         syncUuid: syncUuid || null

--- a/creator-node/src/services/sync/syncUtil.ts
+++ b/creator-node/src/services/sync/syncUtil.ts
@@ -186,3 +186,16 @@ export function getMaxSyncMonitoringMs(syncType: string) {
     ? maxManualSyncMonitoringDurationInMs
     : maxSyncMonitoringDurationInMs
 }
+
+export function checkSyncOverride(syncOverridePassword: string): boolean {
+  const syncOverridePasswordConfig = config.get('syncOverridePassword')
+  const spID = config.get('spID')
+
+  const foundationNodeSPIDs = [1, 2, 3, 4, 27]
+
+  return (
+    foundationNodeSPIDs.includes(spID) &&
+    syncOverridePasswordConfig &&
+    syncOverridePasswordConfig === syncOverridePassword
+  )
+}


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

2 factor authentication for manual sync:
1. spID must be foundation node
2. sync request body must provide password which matches locally stored password string (non-null)

Password string is set as override directly on node, and not exposed anywhere
spID check uses hardcoded IDs

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally e2e:
- rejected if spID mismatch
- rejected if password not provided
- rejected if password mismatch
- succeeds forceResync if password + spID match
- succeeds forceWipe if password + spID match
- succeeds regular sync if password + spID match
- succeeds immediate = true and immediate = false
- confirm password not visible via `/config_check`

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Should not introduce any sync regressions - monitor bull dashboards + sync metrics

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->