### PR TITLE
Use max block number for trending notif query

### DIFF
--- a/identity-service/src/notifications/trendingTrackProcessing.js
+++ b/identity-service/src/notifications/trendingTrackProcessing.js
@@ -80,7 +80,7 @@ async function getTrendingTracks(trendingExperiment, discoveryNodes) {
             userId: decodeHashId(track.user.id)
           })
         )
-        const blocknumber = await models.NotificationAction.max('blocknumber')
+        const blocknumber = trendingTracksResponse.data.latest_indexed_block
         return { trendingTracks, blocknumber }
       } catch (err) {
         logger.error(`Unable to fetch trending tracks: ${err}`)

--- a/identity-service/src/notifications/trendingTrackProcessing.js
+++ b/identity-service/src/notifications/trendingTrackProcessing.js
@@ -80,7 +80,7 @@ async function getTrendingTracks(trendingExperiment, discoveryNodes) {
             userId: decodeHashId(track.user.id)
           })
         )
-        const blocknumber = trendingTracksResponse.data.latest_indexed_block
+        const blocknumber = await models.NotificationAction.max('blocknumber')
         return { trendingTracks, blocknumber }
       } catch (err) {
         logger.error(`Unable to fetch trending tracks: ${err}`)

--- a/identity-service/test/processNotifications/trendingTrackNotification.js
+++ b/identity-service/test/processNotifications/trendingTrackNotification.js
@@ -9,9 +9,7 @@ const {
   TRENDING_GENRE,
   getTrendingTracks
 } = require('../../src/notifications/trendingTrackProcessing')
-const {
-  notificationTypes
-} = require('../../src/notifications/constants')
+const { notificationTypes } = require('../../src/notifications/constants')
 
 const { clearDatabase, runMigrations } = require('../lib/app')
 const { encodeHashId } = require('../../src/notifications/utils')
@@ -25,30 +23,34 @@ const { encodeHashId } = require('../../src/notifications/utils')
  */
 const initialNotifications = [
   {
-    'trackId': 100,
-    'userId': 1,
-    'rank': 1,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 101,
-    'userId': 1,
-    'rank': 2,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 102,
-    'userId': 2,
-    'rank': 3,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 103,
-    'userId': 3,
-    'rank': 4,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 104,
-    'userId': 4,
-    'rank': 5,
-    'type': notificationTypes.TrendingTrack
+    trackId: 100,
+    userId: 1,
+    rank: 1,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 101,
+    userId: 1,
+    rank: 2,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 102,
+    userId: 2,
+    rank: 3,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 103,
+    userId: 3,
+    rank: 4,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 104,
+    userId: 4,
+    rank: 5,
+    type: notificationTypes.TrendingTrack
   }
 ]
 
@@ -61,35 +63,39 @@ const initialNotifications = [
  */
 const additionalNotifications = [
   {
-    'trackId': 103,
-    'userId': 3,
-    'rank': 1,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 104,
-    'userId': 4,
-    'rank': 2,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 100,
-    'userId': 1,
-    'rank': 3,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 110,
-    'userId': 10,
-    'rank': 4,
-    'type': notificationTypes.TrendingTrack
-  }, {
-    'trackId': 101,
-    'userId': 1,
-    'rank': 5,
-    'type': notificationTypes.TrendingTrack
+    trackId: 103,
+    userId: 3,
+    rank: 1,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 104,
+    userId: 4,
+    rank: 2,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 100,
+    userId: 1,
+    rank: 3,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 110,
+    userId: 10,
+    rank: 4,
+    type: notificationTypes.TrendingTrack
+  },
+  {
+    trackId: 101,
+    userId: 1,
+    rank: 5,
+    type: notificationTypes.TrendingTrack
   }
 ]
 
 const makeTrendingResponse = (ids) => {
-  const data = ids.map(id => ({
+  const data = ids.map((id) => ({
     title: `Track ${id}`,
     description: `Track description ${id}`,
     genre: 'Electronic',
@@ -98,10 +104,10 @@ const makeTrendingResponse = (ids) => {
       id: encodeHashId(id)
     }
   }))
-  return ({
+  return {
     data,
     latest_indexed_block: 100
-  })
+  }
 }
 
 describe('Test Trending Track Notification', () => {
@@ -126,8 +132,7 @@ describe('Test Trending Track Notification', () => {
       .get('/v1/full/tracks/trending?time=week&limit=10')
       .reply(200, makeTrendingResponse([1, 8, 6, 4, 5, 3, 2, 9, 10, 7]))
 
-    const { trendingTracks, blocknumber } = await getTrendingTracks('', endpoints)
-    assert.deepStrictEqual(blocknumber, 100)
+    const { trendingTracks } = await getTrendingTracks('', endpoints)
     assert.deepStrictEqual(trendingTracks, [
       { trackId: 1, rank: 1, userId: 1 },
       { trackId: 8, rank: 2, userId: 8 },
@@ -173,24 +178,40 @@ describe('Test Trending Track Notification', () => {
     // User 20 Should have 2 notifications
     // 1.) users 1 & 2 liked track 10 (owned by user 20)
     // 2) user 2 liked track 11 (owned by user 20)
-    const user1Notifs = await models.Notification.findAll({ where: { userId: 1 } })
+    const user1Notifs = await models.Notification.findAll({
+      where: { userId: 1 }
+    })
     assert.deepStrictEqual(user1Notifs.length, 2)
-    const track100Notification = user1Notifs.find(notif => notif.entityId === 100)
+    const track100Notification = user1Notifs.find(
+      (notif) => notif.entityId === 100
+    )
     assert.ok(track100Notification)
-    const track101Notification = user1Notifs.find(notif => notif.entityId === 101)
+    const track101Notification = user1Notifs.find(
+      (notif) => notif.entityId === 101
+    )
     assert.ok(track101Notification)
 
     // For the track 100 rank 1 check that the notification action is correct
-    const track100NotificationActions = await models.NotificationAction.findAll({ where: { notificationId: track100Notification.id } })
+    const track100NotificationActions = await models.NotificationAction.findAll(
+      { where: { notificationId: track100Notification.id } }
+    )
     assert.deepStrictEqual(track100NotificationActions.length, 1)
     assert.deepStrictEqual(track100NotificationActions[0].actionEntityId, 1)
-    assert.deepStrictEqual(track100NotificationActions[0].actionEntityType, getTimeGenreActionType(TRENDING_TIME.WEEK, TRENDING_GENRE.ALL))
+    assert.deepStrictEqual(
+      track100NotificationActions[0].actionEntityType,
+      getTimeGenreActionType(TRENDING_TIME.WEEK, TRENDING_GENRE.ALL)
+    )
 
     // For the track 100 rank 1 check that the notification action is correct
-    const track101NotificationActions = await models.NotificationAction.findAll({ where: { notificationId: track101Notification.id } })
+    const track101NotificationActions = await models.NotificationAction.findAll(
+      { where: { notificationId: track101Notification.id } }
+    )
     assert.deepStrictEqual(track101NotificationActions.length, 1)
     assert.deepStrictEqual(track101NotificationActions[0].actionEntityId, 2)
-    assert.deepStrictEqual(track101NotificationActions[0].actionEntityType, getTimeGenreActionType(TRENDING_TIME.WEEK, TRENDING_GENRE.ALL))
+    assert.deepStrictEqual(
+      track101NotificationActions[0].actionEntityType,
+      getTimeGenreActionType(TRENDING_TIME.WEEK, TRENDING_GENRE.ALL)
+    )
 
     const allNotifs = await models.Notification.findAll()
     assert.deepStrictEqual(allNotifs.length, 5)
@@ -221,12 +242,21 @@ describe('Test Trending Track Notification', () => {
 
     // Check that there is one more notification
     const allNotifsAfterUpdated = await models.Notification.findAll()
-    console.log({ allNotifsAfterUpdated: allNotifsAfterUpdated.map(n => ({ userId: n.userId, track: n.entityId })) })
+    console.log({
+      allNotifsAfterUpdated: allNotifsAfterUpdated.map((n) => ({
+        userId: n.userId,
+        track: n.entityId
+      }))
+    })
     assert.deepStrictEqual(allNotifsAfterUpdated.length, 6)
 
-    const user10Notifs = await models.Notification.findAll({ where: { userId: 10 } })
+    const user10Notifs = await models.Notification.findAll({
+      where: { userId: 10 }
+    })
     assert.deepStrictEqual(user10Notifs.length, 1)
-    const track110Notification = user10Notifs.find(notif => notif.entityId === 110)
+    const track110Notification = user10Notifs.find(
+      (notif) => notif.entityId === 110
+    )
     assert.ok(track110Notification)
 
     // Do some more checks
@@ -242,10 +272,14 @@ describe('Test Trending Track Notification', () => {
     const allNotifsAfterAll = await models.Notification.findAll()
     assert.deepStrictEqual(allNotifsAfterAll.length, 8)
 
-    const user4Notifs = await models.Notification.findAll({ where: { userId: 4 } })
+    const user4Notifs = await models.Notification.findAll({
+      where: { userId: 4 }
+    })
     assert.deepStrictEqual(user4Notifs.length, 2)
 
-    const user3Notifs = await models.Notification.findAll({ where: { userId: 3 } })
+    const user3Notifs = await models.Notification.findAll({
+      where: { userId: 3 }
+    })
     assert.deepStrictEqual(user3Notifs.length, 2)
   })
 })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This was using latest block from discovery which will cause notifs to skip down the line. Instead set it to the last block identity knows about.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->