### PR TITLE
Clean up storage path logs

### DIFF
--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -508,7 +508,7 @@ async function _deleteFiles(filePaths: string[], logger: Logger) {
     try {
       await fs.unlink(filePath)
     } catch (e) {
-      logger.error(`Failed to delete file at ${filePath}`)
+      logger.error(`Failed to delete file at ${filePath} because: ${e}`)
     }
   }
 }

--- a/creator-node/src/utils/fsUtils.ts
+++ b/creator-node/src/utils/fsUtils.ts
@@ -262,7 +262,7 @@ export function computeFilePathInDir(dirName: string, fileName: string) {
 
   const parentDirPath = computeFilePath(dirName)
   const absolutePath = path.join(parentDirPath, fileName)
-  genericLogger.info(`File path computed, absolutePath=${absolutePath}`)
+  genericLogger.debug(`File path computed, absolutePath=${absolutePath}`)
   return absolutePath
 }
 
@@ -278,7 +278,7 @@ export async function computeFilePathInDirAndEnsureItExists(
 
   const parentDirPath = await computeFilePathAndEnsureItExists(dirName)
   const absolutePath = path.join(parentDirPath, fileName)
-  genericLogger.info(`File path computed, absolutePath=${absolutePath}`)
+  genericLogger.debug(`File path computed, absolutePath=${absolutePath}`)
   return absolutePath
 }
 

--- a/creator-node/src/utils/utils.ts
+++ b/creator-node/src/utils/utils.ts
@@ -44,7 +44,6 @@ export function getCharsInRange(startChar: string, endChar: string): string[] {
 export function getCharsInRanges(...ranges: string[]): string[] {
   const charsInRanges = []
   for (const range of ranges) {
-    console.log('theo range: ', range)
     charsInRanges.push(...getCharsInRange(range.charAt(0), range.charAt(1)))
   }
   return charsInRanges

--- a/libs/src/utils/fileHasher.ts
+++ b/libs/src/utils/fileHasher.ts
@@ -246,7 +246,7 @@ export const fileHasher = {
       hrtime.bigint() - startHashing
     )
 
-    logger.info(
+    logger.debug(
       `[fileHasher - generateNonImageCid()] CID=${cid} hashDurationMs=${hashDurationMs}ms`
     )
 
@@ -270,7 +270,7 @@ export const fileHasher = {
     )
 
     const hashedImagesStr = JSON.stringify(hashedImages)
-    logger.info(
+    logger.debug(
       `[fileHasher - generateImageCids()] hashedImages=${hashedImagesStr} hashImagesDurationMs=${hashDurationMs}ms`
     )
     return hashedImages


### PR DESCRIPTION
### Description
- Changes spammy logs from info to debug
- Removes a testing log that slipped through
- Logs error message when disk deletion fails


### Tests
N/A - just logs


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
This is a fast follow that I'll deploy to CN5 to make sure log spam is reduced and deletion errors are informative (expecting them all to be "File not found"). FileHasher log spam won't be reduced until the next libs release.