### PR TITLE
Update storage properties for content nodes in healthz

### DIFF
--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -99,7 +99,8 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
       )}
       <td>
         <progress value={storagePercent} />
-        <span> {fsSize} GB</span>
+        <br></br>
+        <span>{fsUsed} / {fsSize} GB</span>
       </td>
       <td>{`${dbSize} GB`}</td>
       <td>{health.block_difference}</td>

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -61,11 +61,11 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
 
   const health = data.data
   const isCompose = health.infra_setup || health.audiusContentInfraSetup
-  const fsUsed = bytesToGb(health.filesystem_used)
-  const fsSize = bytesToGb(health.filesystem_size)
+  const fsUsed = bytesToGb(health.filesystem_used) || bytesToGb(health.storagePathUsed)
+  const fsSize = bytesToGb(health.filesystem_size) || bytesToGb(health.storagePathSize)
   const storagePercent = fsUsed / fsSize
   const isBehind = health.block_difference > 5 ? 'is-behind' : ''
-  const dbSize = bytesToGb(health.database_size)
+  const dbSize = bytesToGb(health.database_size) || bytesToGb(health.databaseSize)
   const autoUpgradeEnabled =
     health.auto_upgrade_enabled || health.autoUpgradeEnabled
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fix storage use % and db size for content nodes in healthz

Current
<img width="1487" alt="healthz" src="https://user-images.githubusercontent.com/295938/204626945-000ca146-88fb-40ef-9dc8-87f2b07ab87d.png">

New
<img width="1488" alt="healthz_and_Line_break_in_HTML_with___n__-_Stack_Overflow" src="https://user-images.githubusercontent.com/295938/204629855-ca3ff4f9-7d1a-4e20-af5b-c610007cf5d1.png">



### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Ran healthz locally and verified the data is consistent with health check.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
This is the monitoring 🙂 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->