### PR TITLE
Only record sync failures

### DIFF
--- a/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/issueSyncRequest.jobProcessor.ts
@@ -617,7 +617,7 @@ const _additionalSyncIsRequired = async (
     }
   }
 
-  if (!syncStatus?.startsWith('success')) {
+  if (syncStatus?.startsWith('failure')) {
     await secondarySyncHealthTracker.recordFailure({
       secondary: targetNode,
       wallet: userWallet,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is so that aborted syncs are not recorded. 

Current environment:
```
127.0.0.1:6379> keys PRIMARY*
1) "PRIMARY_TO_SECONDARY_SYNC_FAILURE::2022-11-30::https://creatornode9.staging.audius.co/::0xa722151fdff6dc5c94803b4712d63730ea6feb08"
2) "PRIMARY_TO_SECONDARY_SYNC_FAILURE::2022-11-30::https://creatornode8.staging.audius.co/::0xa722151fdff6dc5c94803b4712d63730ea6feb08"
127.0.0.1:6379> hgetall PRIMARY_TO_SECONDARY_SYNC_FAILURE::2022-11-30::https://creatornode9.staging.audius.co/::0xa722151fdff6dc5c94803b4712d63730ea6feb08
1) "abort_sync_in_progress"
2) "1"
127.0.0.1:6379> hgetall PRIMARY_TO_SECONDARY_SYNC_FAILURE::2022-11-30::https://creatornode8.staging.audius.co/::0xa722151fdff6dc5c94803b4712d63730ea6feb08
1) "abort_sync_in_progress"
2) "1"
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
- forced an abort and observed logs

server logs:
```
{"name":"audius_creator_node","clusterWorker":"master","hostname":"48a6f6fb4782","pid":136233,"wallet":"0xc3d1d7559356aac64ba2921ec266ce294dcdc981","sync":"secondarySyncFromPrimary","primary":"http://cn3_creator-node_1:4002","syncAllStepsDuration":0,"level":40,"msg":"Sync complete for wallet: 0xc3d1d7559356aac64ba2921ec266ce294dcdc981. Status: Abort. Duration sync: 1. From endpoint http://cn3_creator-node_1:4002. Prometheus result: abort_sync_in_progress","time":"2022-11-30T20:11:27.720Z","v":0,"trace_id":"9bbd50d6597bfbbe801a76854ae98d27","span_id":"4d9f0d0e8f0fbd10","trace_flags":"01","resource.span.name":"_secondarySyncFromPrimary","resource.span.links":[],"resource.span.attributed":{"code.filepath":"/usr/src/app/src/services/sync/secondarySyncFromPrimary.ts","code.function":"_secondarySyncFromPrimary","spid":0,"endpoint":"http://cn2_creator-node_1:4001","result":"abort_sync_in_progress","mode":"default","abort":"Cannot change state of wallet 0xc3d1d7559356aac64ba2921ec266ce294dcdc981. Node sync currently in progress"},"resource.service.name":"content-node","resource.service.spid":0,"resource.service.endpoint":"http://cn2_creator-node_1:4001","logLevel":"warn"}
```

redis:
```
127.0.0.1:6379> keys PRIMARY*
(empty list or set)
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Monitor `SecondarySyncHealthTracker` logs 

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->