### PR TITLE
Add profile backfill job

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_profile_challenge_backfill.py
+++ b/discovery-provider/integration_tests/tasks/test_index_profile_challenge_backfill.py
@@ -1,0 +1,73 @@
+import logging
+from unittest import mock
+
+from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event import ChallengeEvent
+from src.models.indexing.indexing_checkpoints import IndexingCheckpoint
+from src.tasks.index_profile_challenge_backfill import (
+    enqueue_social_rewards_check,
+    index_profile_challenge_backfill_tablename,
+)
+from src.utils.config import shared_config
+from src.utils.db_session import get_db
+from src.utils.redis_connection import get_redis
+
+REDIS_URL = shared_config["redis"]["url"]
+
+logger = logging.getLogger(__name__)
+
+
+@mock.patch(
+    "src.tasks.index_profile_challenge_backfill.get_latest_backfill", autospec=True
+)
+@mock.patch("src.challenges.challenge_event_bus.ChallengeEventBus", autospec=True)
+def test_index_related_artists(
+    bus_mock: mock.MagicMock, get_latest_mock: mock.MagicMock, app
+):
+    get_latest_mock.return_value = 0
+    with app.app_context():
+        db = get_db()
+        redis = get_redis()
+
+        entities = {
+            "users": [{}] * 100,
+            "reposts": [{"user_id": i, "blocknumber": i + 2} for i in range(1, 50)],
+            "saves": [{"user_id": i + 1, "blocknumber": i + 3} for i in range(1, 20)],
+            "follows": [
+                {
+                    "follower_user_id": i + 4,
+                    "followee_user_id": i + 4,
+                    "blocknumber": i + 7,
+                }
+                for i in range(1, 60)
+            ],
+            "tracks": [{"owner_id": i} for i in range(1, 7)],
+        }
+        populate_mock_db(db, entities)
+
+        enqueue_social_rewards_check(db, bus_mock, redis)
+        repost_calls = [
+            mock.call.dispatch(ChallengeEvent.repost, i + 2, i) for i in range(1, 50)
+        ]
+        save_calls = [
+            mock.call.dispatch(ChallengeEvent.favorite, i + 3, i + 1)
+            for i in range(1, 20)
+        ]
+        follow_calls = [
+            mock.call.dispatch(ChallengeEvent.follow, i + 7, i + 4)
+            for i in range(1, 60)
+        ]
+        calls = repost_calls + save_calls + follow_calls
+        bus_mock.assert_has_calls(calls, any_order=True)
+
+    with db.scoped_session() as session:
+        checkpoint = (
+            session.query(IndexingCheckpoint)
+            .filter(
+                IndexingCheckpoint.tablename
+                == index_profile_challenge_backfill_tablename
+            )
+            .first()
+        )
+
+        assert checkpoint.last_checkpoint == 66

--- a/discovery-provider/integration_tests/tasks/test_index_profile_challenge_backfill.py
+++ b/discovery-provider/integration_tests/tasks/test_index_profile_challenge_backfill.py
@@ -8,11 +8,7 @@ from src.tasks.index_profile_challenge_backfill import (
     enqueue_social_rewards_check,
     index_profile_challenge_backfill_tablename,
 )
-from src.utils.config import shared_config
 from src.utils.db_session import get_db
-from src.utils.redis_connection import get_redis
-
-REDIS_URL = shared_config["redis"]["url"]
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +23,6 @@ def test_index_related_artists(
     get_latest_mock.return_value = 0
     with app.app_context():
         db = get_db()
-        redis = get_redis()
 
         entities = {
             "users": [{}] * 100,
@@ -45,7 +40,7 @@ def test_index_related_artists(
         }
         populate_mock_db(db, entities)
 
-        enqueue_social_rewards_check(db, bus_mock, redis)
+        enqueue_social_rewards_check(db, bus_mock)
         repost_calls = [
             mock.call.dispatch(ChallengeEvent.repost, i + 2, i) for i in range(1, 50)
         ]

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -525,6 +525,10 @@ def configure_celery(celery, test_config=None):
             "update_track_is_available": {
                 "task": "update_track_is_available",
                 "schedule": timedelta(hours=3),
+            },
+            "index_profile_challenge_backfill": {
+                "task": "index_profile_challenge_backfill",
+                "schedule": timedelta(minutes=1),
             }
             # UNCOMMENT BELOW FOR MIGRATION DEV WORK
             # "index_solana_user_data": {
@@ -598,6 +602,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("prune_plays_lock")
     redis_inst.delete("update_aggregate_table:aggregate_user_tips")
     redis_inst.delete("spl_token_backfill_lock")
+    redis_inst.delete("profile_challenge_backfill_lock")
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_TRACK_IS_AVAILABLE_LOCK)
 

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -1,0 +1,145 @@
+import logging
+from typing import List, Optional
+
+from redis import Redis
+from sqlalchemy.orm.session import Session
+from src.challenges.challenge_event_bus import ChallengeEventBus
+from src.models.social.follow import Follow
+from src.models.social.repost import Repost
+from src.models.social.save import Save
+from src.tasks.celery_app import celery
+from src.tasks.social_features import (
+    dispatch_challenge_follow,
+    dispatch_challenge_repost,
+)
+from src.tasks.user_library import dispatch_favorite
+from src.utils.config import shared_config
+from src.utils.prometheus_metric import save_duration_metric
+from src.utils.session_manager import SessionManager
+from src.utils.update_indexing_checkpoints import (
+    get_last_indexed_checkpoint,
+    save_indexed_checkpoint,
+)
+
+logger = logging.getLogger(__name__)
+
+index_profile_challenge_backfill_tablename = "index_profile_challenge_backfill"
+
+# Number of blocks to scan through at a time
+BLOCK_INTERVAL = 1000
+
+
+def enqueue_social_rewards_check(
+    db: SessionManager, challenge_bus: ChallengeEventBus, redis: Redis
+):
+    with db.scoped_session() as session:
+        block_backfill = get_latest_backfill(session)
+        if block_backfill is None:
+            logger.info("index_profile_challenge_backfill.py | No backfill block")
+            return
+        # Do it
+        max_blocknumber_seen = block_backfill
+        # reposts of tracks and playlists reposts
+        reposts: List[Repost] = (
+            session.query(Repost)
+            .filter(
+                Repost.blocknumber > block_backfill,
+                Repost.blocknumber <= block_backfill + BLOCK_INTERVAL,
+            )
+            .all()
+        )
+        for repost in reposts:
+            dispatch_challenge_repost(challenge_bus, repost, repost.blocknumber)
+            max_blocknumber_seen = max(repost.blocknumber, max_blocknumber_seen)
+
+        saves: List[Save] = (
+            session.query(Save)
+            .filter(
+                Save.blocknumber > block_backfill,
+                Save.blocknumber <= block_backfill + BLOCK_INTERVAL,
+            )
+            .all()
+        )
+        for save in saves:
+            dispatch_favorite(challenge_bus, save, save.blocknumber)
+            max_blocknumber_seen = max(save.blocknumber, max_blocknumber_seen)
+
+        follows: List[Follow] = (
+            session.query(Follow)
+            .filter(
+                Follow.blocknumber > block_backfill,
+                Follow.blocknumber <= block_backfill + BLOCK_INTERVAL,
+            )
+            .all()
+        )
+        for follow in follows:
+            dispatch_challenge_follow(challenge_bus, follow, follow.blocknumber)
+            max_blocknumber_seen = max(follow.blocknumber, max_blocknumber_seen)
+
+        save_indexed_checkpoint(
+            session, index_profile_challenge_backfill_tablename, max_blocknumber_seen
+        )
+
+
+def get_latest_backfill(session: Session) -> Optional[int]:
+    try:
+
+        checkpoint = get_last_indexed_checkpoint(
+            index_profile_challenge_backfill_tablename
+        )
+        BACKFILL_SOCIAL_REWARDS_BLOCKNUMBER = (
+            shared_config["discprov"]["backfill_social_rewards_blocknumber"]
+            if "backfill_social_rewards_blocknumber" in shared_config["discprov"]
+            else None
+        )
+        if checkpoint == 0:
+            # check config for value
+            if not BACKFILL_SOCIAL_REWARDS_BLOCKNUMBER:
+                return None
+            return BACKFILL_SOCIAL_REWARDS_BLOCKNUMBER
+
+        # NOTE: This will continue until the next release but is fine as the
+        # dispatch of rewards events is idempotent and will validate itself
+        # Fetch the blocknumber associated with this signature
+        return checkpoint
+
+    except Exception as e:
+        logger.error(
+            "index_profile_challenge_backfill.py | Error during get_latest_backfill",
+            exc_info=True,
+        )
+        raise e
+
+
+# ####### CELERY TASKS ####### #
+@celery.task(name="index_profile_challenge_backfill", bind=True)
+@save_duration_metric(metric_group="celery_task")
+def index_profile_challenge_backfill(self):
+    redis: Redis = index_profile_challenge_backfill.redis
+    db: SessionManager = index_profile_challenge_backfill.db
+    challenge_bus: ChallengeEventBus = (
+        index_profile_challenge_backfill.challenge_event_bus
+    )
+
+    # Define lock acquired boolean
+    have_lock = False
+    # Max duration of lock is 1 hr
+    update_lock = redis.lock("profile_challenge_backfill_lock", timeout=3600)
+
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info("index_profile_challenge_backfill.py | Acquired lock")
+            enqueue_social_rewards_check(db, challenge_bus, redis)
+        else:
+            logger.info("index_profile_challenge_backfill.py | Failed to acquire lock")
+    except Exception as e:
+        logger.error(
+            "index_profile_challenge_backfill.py | Fatal error in main loop",
+            exc_info=True,
+        )
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -142,7 +142,8 @@ def index_profile_challenge_backfill(self):
         have_lock = update_lock.acquire(blocking=False)
         if have_lock:
             logger.info("index_profile_challenge_backfill.py | Acquired lock")
-            enqueue_social_rewards_check(db, challenge_bus)
+            with challenge_bus.use_scoped_dispatch_queue():
+                enqueue_social_rewards_check(db, challenge_bus)
         else:
             logger.info("index_profile_challenge_backfill.py | Failed to acquire lock")
     except Exception as e:

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -55,7 +55,9 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
-        logger.info(f"index_profile_challenge_backfill.py | calculated {len(reposts)} reposts")
+        logger.info(
+            f"index_profile_challenge_backfill.py | calculated {len(reposts)} reposts"
+        )
         for repost in reposts:
             repost_blocknumber: int = repost.blocknumber
             dispatch_challenge_repost(challenge_bus, repost, repost_blocknumber)
@@ -68,7 +70,9 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
-        logger.info(f"index_profile_challenge_backfill.py | calculated {len(saves)} saves")
+        logger.info(
+            f"index_profile_challenge_backfill.py | calculated {len(saves)} saves"
+        )
         for save in saves:
             save_blocknumber: int = save.blocknumber
             dispatch_favorite(challenge_bus, save, save_blocknumber)
@@ -81,7 +85,9 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
-        logger.info(f"index_profile_challenge_backfill.py | calculated {len(follows)} follows")
+        logger.info(
+            f"index_profile_challenge_backfill.py | calculated {len(follows)} follows"
+        )
         for follow in follows:
             follow_blocknumber: int = follow.blocknumber
             dispatch_challenge_follow(challenge_bus, follow, follow_blocknumber)

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Optional
 
 from redis import Redis
@@ -14,7 +15,6 @@ from src.tasks.social_features import (
     dispatch_challenge_repost,
 )
 from src.tasks.user_library import dispatch_favorite
-from src.utils.config import shared_config
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.session_manager import SessionManager
 from src.utils.update_indexing_checkpoints import (
@@ -89,11 +89,7 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
 
 
 def get_config_backfill():
-    return (
-        shared_config["discprov"]["backfill_social_rewards_blocknumber"]
-        if "backfill_social_rewards_blocknumber" in shared_config["discprov"]
-        else None
-    )
+    return os.getenv("audius_discprov_backfill_social_rewards_blocknumber")
 
 
 def get_latest_backfill(session: Session, backfill_blocknumber: int) -> Optional[int]:

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -55,6 +55,7 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
+        logger.info(f"index_profile_challenge_backfill.py | calculated {len(reposts)} reposts")
         for repost in reposts:
             repost_blocknumber: int = repost.blocknumber
             dispatch_challenge_repost(challenge_bus, repost, repost_blocknumber)
@@ -67,6 +68,7 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
+        logger.info(f"index_profile_challenge_backfill.py | calculated {len(saves)} saves")
         for save in saves:
             save_blocknumber: int = save.blocknumber
             dispatch_favorite(challenge_bus, save, save_blocknumber)
@@ -79,6 +81,7 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
             )
             .all()
         )
+        logger.info(f"index_profile_challenge_backfill.py | calculated {len(follows)} follows")
         for follow in follows:
             follow_blocknumber: int = follow.blocknumber
             dispatch_challenge_follow(challenge_bus, follow, follow_blocknumber)

--- a/discovery-provider/src/tasks/index_profile_challenge_backfill.py
+++ b/discovery-provider/src/tasks/index_profile_challenge_backfill.py
@@ -39,7 +39,7 @@ def enqueue_social_rewards_check(db: SessionManager, challenge_bus: ChallengeEve
                 "index_profile_challenge_backfill.py | backfill block number not set"
             )
             return None
-
+        backfill_blocknumber = int(backfill_blocknumber)
         block_backfill = get_latest_backfill(session, backfill_blocknumber)
         if block_backfill is None:
             logger.info("index_profile_challenge_backfill.py | Backfill complete")


### PR DESCRIPTION
### Description
Backfills the social actions from the env var to current - note it will continue to enqueue to the redis rewards manager even after it catches up, but that should be fine

### Tests
Wrote a test to ensure it dispatches the events

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->