### PR TITLE
Remove unused sync env vars

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -829,18 +829,6 @@ const config = convict({
     env: 'reconfigSPIdBlacklistString',
     default: '1,4,33,37,39,40,41,42,43,52,56,58,59,60,61,64,65'
   },
-  recordSyncResults: {
-    doc: 'Flag to record sync results. If enabled sync results (successes and failures) will be recorded. This flag is not intended to be permanent.',
-    format: Boolean,
-    env: 'recordSyncResults',
-    default: true
-  },
-  processSyncResults: {
-    doc: 'Flag to process sync results. If enabled, syncs may be capped for a day depending on sync results. Else, do not process sync results. This flag is not intended to be permanent.',
-    format: Boolean,
-    env: 'processSyncResults',
-    default: true
-  },
   syncOverridePassword: {
     doc: 'Used to allow manual syncs to be issued on foundation nodes only, and still requires password',
     format: String,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is part of the cleanup with the [SecondarySyncHealthTracker refactor](https://github.com/AudiusProject/audius-protocol/pull/4353)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Variables not used so no impact on functionality 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Monitor `SecondarySyncHealthTracker` logs but this change shouldnt impact anything

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->