### PR TITLE
Update import for computing legacy CIDs

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -35,7 +35,12 @@ const {
   ensureStorageMiddleware
 } = require('../middlewares')
 const { getAllRegisteredCNodes } = require('../services/ContentNodeInfoManager')
-const { timeout, computeFilePath, computeFilePathInDir } = require('../utils')
+const {
+  timeout,
+  computeFilePath,
+  computeFilePathInDir,
+  computeLegacyFilePath
+} = require('../utils')
 const DBManager = require('../dbManager')
 const DiskManager = require('../diskManager')
 const { libs } = require('@audius/sdk')
@@ -291,7 +296,7 @@ const getCID = async (req, res) => {
     // Compute expected legacyStoragePath for CID
     let legacyStoragePath
     try {
-      legacyStoragePath = DiskManager.computeLegacyFilePath(CID)
+      legacyStoragePath = computeLegacyFilePath(CID)
       decisionTree.push({
         stage: `COMPUTE_LEGACY_FILE_PATH_COMPLETE`
       })

--- a/creator-node/src/utils/index.ts
+++ b/creator-node/src/utils/index.ts
@@ -32,7 +32,8 @@ import {
   computeFilePath,
   computeFilePathInDir,
   computeFilePathAndEnsureItExists,
-  computeFilePathInDirAndEnsureItExists
+  computeFilePathInDirAndEnsureItExists,
+  computeLegacyFilePath
 } from './fsUtils'
 import { runShellCommand, execShellCommand } from './runShellCommand'
 import { currentNodeShouldHandleTranscode } from './contentNodeUtils'
@@ -74,6 +75,7 @@ export {
   computeFilePathInDir,
   computeFilePathAndEnsureItExists,
   computeFilePathInDirAndEnsureItExists,
+  computeLegacyFilePath,
   getCharsInRange,
   getCharsInRanges
 }
@@ -108,6 +110,7 @@ module.exports = {
   computeFilePathInDir,
   computeFilePathAndEnsureItExists,
   computeFilePathInDirAndEnsureItExists,
+  computeLegacyFilePath,
   getCharsInRange,
   getCharsInRanges
 }


### PR DESCRIPTION
### Description
Fixes an import for a function that was moved. This went unnoticed because it only impacts file retrieval when the file isn't able to be found at the standard path and so it tries to recompute the legacy path for the CID.


### Tests
CI is sufficient.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
There shouldn't be any more errors for `COMPUTE_LEGACY_FILE_PATH_FAILURE`.