### PR TITLE
Fix CN mkdir called on grandparent instead of parent

### DIFF
--- a/creator-node/src/utils/fsUtils.ts
+++ b/creator-node/src/utils/fsUtils.ts
@@ -276,7 +276,8 @@ export async function computeFilePathInDirAndEnsureItExists(
 ) {
   _validateFileAndDir(dirName, fileName)
 
-  const parentDirPath = await computeFilePathAndEnsureItExists(dirName)
+  const parentDirPath = computeFilePath(dirName)
+  await ensureDirPathExists(parentDirPath)
   const absolutePath = path.join(parentDirPath, fileName)
   genericLogger.debug(`File path computed, absolutePath=${absolutePath}`)
   return absolutePath


### PR DESCRIPTION
### Description
Fixes `mkdir` being called on the grandparent of a CID instead of the parent when it's nested. This is something I noticed for some legacy CIDs after turning debug logs on for prod CN5. It didn't corrupt any data and only caused some legacy CIDs to fail to be migrated until this is merged.


### Tests
Relying on CI instead of manual tests and will use debug logs to confirm the path is still correct. It still uses the same path logic that I already double-checked, so the risk for data loss is minimal.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Look for errors with "Failed to copy some legacy files" and "ENOENT"