### PR TITLE
Add notification seen table

### DIFF
--- a/discovery-provider/alembic/versions/21e5635c83a9_create_notification_seen.py
+++ b/discovery-provider/alembic/versions/21e5635c83a9_create_notification_seen.py
@@ -1,0 +1,84 @@
+"""create notification seen
+
+Revision ID: 21e5635c83a9
+Revises: 1eec1d124caf
+Create Date: 2022-12-01 19:58:39.403016
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '21e5635c83a9'
+down_revision = '1eec1d124caf'
+branch_labels = None
+depends_on = None
+
+
+def foreign_key_exists(table_name, foreign_key):
+    bind = op.get_context().bind
+    insp = sa.inspect(bind)
+    foreign_keys = insp.get_foreign_keys(table_name)
+    return any(fk["name"] == foreign_key for fk in foreign_keys)
+
+
+def column_exists(table_name, column_name):
+    bind = op.get_context().bind
+    insp = sa.inspect(bind)
+    columns = insp.get_columns(table_name)
+    return any(c["name"] == column_name for c in columns)
+
+
+def upgrade():
+    op.create_table(
+        "notification_seen",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("seen_at", sa.DateTime(), nullable=False),
+        sa.Column("blocknumber", sa.Integer(), nullable=True),
+        sa.Column("blockhash", sa.String(), nullable=True),
+        sa.Column("txhash", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("user_id", "seen_at"),
+        info={"if_not_exists": True},
+    )
+    if column_exists("notification", "notification_group_id"):
+        op.drop_column("notification", "notification_group_id")
+    op.drop_index(
+        op.f("ix_notification_group"),
+        table_name="notification_group",
+        info={"if_exists": True},
+    )
+
+    op.drop_table("notification_group", info={"if_exists": True})
+
+
+def downgrade():
+    op.drop_table("notification_seen", info={"if_exists": True})
+    op.create_table(
+        "notification_group",
+        sa.Column(
+            "id", sa.Integer(), primary_key=True, nullable=False, autoincrement=True
+        ),
+        sa.Column("notification_id", sa.Integer(), nullable=True),
+        sa.Column("slot", sa.Integer(), nullable=True),
+        sa.Column("blocknumber", sa.Integer(), nullable=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        info={"if_not_exists": True},
+    )
+    if not column_exists("notification", "notification_group_id"):
+        op.add_column(
+            "notification",
+            sa.Column("summed_count", sa.ForeignKey("notification_group.id")),
+        )
+    if foreign_key_exists("notification_group", "fk_notification_group_notification"):
+        op.drop_constraint(
+            "fk_notification_group_notification", "notification_group", "foreignkey"
+        )
+
+    op.create_index(
+        op.f("ix_notification_group"),
+        "notification_group",
+        ["user_id", "timestamp"],
+        unique=False,
+        info={"if_not_exists": True},
+    )

--- a/discovery-provider/integration_tests/notifications/test_challenge_disbursement.py
+++ b/discovery-provider/integration_tests/notifications/test_challenge_disbursement.py
@@ -40,7 +40,6 @@ def test_challenge_disbursement_notification(app):
 
         assert notifications[0].specifier == "1"
         assert notifications[0].group_id == "challenge_reward:1:challenge:2:specifier:2"
-        assert notifications[0].notification_group_id == None
         assert notifications[0].type == "challenge_reward"
         assert notifications[0].slot == 2
         assert notifications[0].blocknumber == None

--- a/discovery-provider/integration_tests/notifications/test_follow.py
+++ b/discovery-provider/integration_tests/notifications/test_follow.py
@@ -43,7 +43,6 @@ def test_repost_notification(app):
         assert notifications[2].specifier == "4"
         assert notifications[3].group_id == "follow:4"
         assert notifications[3].specifier == "5"
-        assert notifications[0].notification_group_id == None
         assert notifications[0].type == "follow"
         assert notifications[0].slot == None
         assert notifications[0].blocknumber == 0
@@ -63,7 +62,6 @@ def test_repost_notification(app):
             == "milestone:FOLLOWER_COUNT:id:1:threshold:25"
         )
         assert milstone_notifications[0].specifier == "1"
-        assert milstone_notifications[0].notification_group_id == None
         assert milstone_notifications[0].type == "milestone_follower_count"
         assert milstone_notifications[0].data == {
             "type": "FOLLOWER_COUNT",

--- a/discovery-provider/integration_tests/notifications/test_play_milestone.py
+++ b/discovery-provider/integration_tests/notifications/test_play_milestone.py
@@ -32,7 +32,6 @@ def test_play_milsetone_notification(app):
         assert len(notifications) == 3
         assert notifications[0].specifier == "2"
         assert notifications[0].group_id == "milestone:LISTEN_COUNT:id:100:threshold:50"
-        assert notifications[0].notification_group_id == None
         assert notifications[0].type == "milestone"
         assert notifications[0].slot == 50
         assert notifications[0].blocknumber == None

--- a/discovery-provider/integration_tests/notifications/test_playlist.py
+++ b/discovery-provider/integration_tests/notifications/test_playlist.py
@@ -57,7 +57,6 @@ def test_playlist_track_added_notification(app):
             == "track_added_to_playlist:playlist_id:0:track_id:20:blocknumber:0"
         )
         assert notifications[0].specifier == "1"
-        assert notifications[0].notification_group_id == None
         assert notifications[0].type == "track_added_to_playlist"
         assert notifications[0].slot == None
         assert notifications[0].blocknumber == 0
@@ -69,7 +68,6 @@ def test_playlist_track_added_notification(app):
             == "track_added_to_playlist:playlist_id:0:track_id:30:blocknumber:0"
         )
         assert notifications[1].specifier == "15"
-        assert notifications[1].notification_group_id == None
         assert notifications[1].type == "track_added_to_playlist"
         assert notifications[1].slot == None
         assert notifications[1].blocknumber == 0

--- a/discovery-provider/integration_tests/notifications/test_reaction.py
+++ b/discovery-provider/integration_tests/notifications/test_reaction.py
@@ -64,7 +64,6 @@ def test_reaction_notification(app):
         ).rstrip(
             "0"
         )
-        assert notifications[0].notification_group_id == None
         assert notifications[0].type == "reaction"
         assert notifications[0].slot == 0
         assert notifications[0].blocknumber == None

--- a/discovery-provider/integration_tests/notifications/test_repost.py
+++ b/discovery-provider/integration_tests/notifications/test_repost.py
@@ -40,7 +40,6 @@ def test_repost_notification(app):
         notification = notifications[0]
         assert notification.specifier == "1"
         assert notification.group_id == "repost:100:type:track"
-        assert notification.notification_group_id == None
         assert notification.type == "repost"
         assert notification.slot == None
         assert notification.blocknumber == 2

--- a/discovery-provider/integration_tests/notifications/test_save.py
+++ b/discovery-provider/integration_tests/notifications/test_save.py
@@ -38,7 +38,6 @@ def test_save_notification(app):
         notification = notifications[0]
         assert notification.specifier == "1"
         assert notification.group_id == "save:100:type:track"
-        assert notification.notification_group_id == None
         assert notification.type == "save"
         assert notification.slot == None
         assert notification.blocknumber == 2

--- a/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
+++ b/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
@@ -53,7 +53,6 @@ def test_supporter_rank_up_notification(app):
 
         assert supporter_notifications[0].specifier == "1"
         assert supporter_notifications[0].group_id == "supporter_rank_up:3:slot:2"
-        assert supporter_notifications[0].notification_group_id == None
         assert supporter_notifications[0].type == "supporter_rank_up"
         assert supporter_notifications[0].slot == 2
         assert supporter_notifications[0].blocknumber == None
@@ -66,7 +65,6 @@ def test_supporter_rank_up_notification(app):
 
         assert supporting_notifications[0].specifier == "3"
         assert supporting_notifications[0].group_id == "supporting_rank_up:3:slot:2"
-        assert supporting_notifications[0].notification_group_id == None
         assert supporting_notifications[0].type == "supporting_rank_up"
         assert supporting_notifications[0].slot == 2
         assert supporting_notifications[0].blocknumber == None

--- a/discovery-provider/integration_tests/notifications/test_track.py
+++ b/discovery-provider/integration_tests/notifications/test_track.py
@@ -36,7 +36,6 @@ def test_track_remix_notification(app):
         notification = notifications[0]
         assert notification.specifier == "2"
         assert notification.group_id == "remix:track:100:parent_track:20:blocknumber:1"
-        assert notification.notification_group_id == None
         assert notification.type == "remix"
         assert notification.slot == None
         assert notification.blocknumber == 1

--- a/discovery-provider/integration_tests/notifications/test_user_tip.py
+++ b/discovery-provider/integration_tests/notifications/test_user_tip.py
@@ -45,7 +45,6 @@ def test_supporter_rank_up_notification(app):
 
         assert send_notifications[0].specifier == "1"
         assert send_notifications[0].group_id == "tip_send:user_id:1:slot:2"
-        assert send_notifications[0].notification_group_id == None
         assert send_notifications[0].type == "tip_send"
         assert send_notifications[0].slot == 2
         assert send_notifications[0].blocknumber == None
@@ -58,7 +57,6 @@ def test_supporter_rank_up_notification(app):
 
         assert receive_notifications[0].specifier == "3"
         assert receive_notifications[0].group_id == "tip_receive:user_id:3:slot:2"
-        assert receive_notifications[0].notification_group_id == None
         assert receive_notifications[0].type == "tip_receive"
         assert receive_notifications[0].slot == 2
         assert receive_notifications[0].blocknumber == None

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_index_notification.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_index_notification.py
@@ -1,0 +1,120 @@
+from typing import List
+
+from integration_tests.challenges.index_helpers import UpdateTask
+from integration_tests.utils import populate_mock_db
+from src.models.notifications.notification import NotificationSeen
+from src.tasks.entity_manager.entity_manager import entity_manager_update
+from src.tasks.entity_manager.utils import Action, EntityType
+from src.utils.db_session import get_db
+from web3 import Web3
+from web3.datastructures import AttributeDict
+
+
+def test_index_notification_view(app, mocker):
+    "Tests notification view action"
+
+    # setup db and mocked txs
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        update_task = UpdateTask(None, web3, None)
+
+    tx_receipts = {
+        "NotificationRead1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": EntityType.NOTIFICATION,
+                        "_userId": 1,
+                        "_action": Action.VIEW,
+                        "_metadata": "QmCreatePlaylist1",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "NotificationRead2Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": EntityType.NOTIFICATION,
+                        "_userId": 1,
+                        "_action": Action.VIEW,
+                        "_metadata": "",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "NotificationRead3Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 2,
+                        "_entityType": EntityType.NOTIFICATION,
+                        "_userId": 2,
+                        "_action": Action.VIEW,
+                        "_metadata": "",
+                        "_signer": "user2wallet",
+                    }
+                )
+            },
+        ],
+        "NotificationRead4Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 3,
+                        "_entityType": EntityType.NOTIFICATION,
+                        "_userId": 3,
+                        "_action": Action.VIEW,
+                        "_metadata": "",
+                        "_signer": "user3wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    entity_manager_txs = [
+        AttributeDict({"transactionHash": update_task.web3.toBytes(text=tx_receipt)})
+        for tx_receipt in tx_receipts
+    ]
+
+    def get_events_side_effect(_, tx_receipt):
+        return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
+
+    entities = {
+        "users": [
+            {"user_id": user_id, "wallet": f"user{user_id}wallet"}
+            for user_id in range(1, 4)
+        ]
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        # index transactions
+        entity_manager_update(
+            None,
+            update_task,
+            session,
+            entity_manager_txs,
+            block_number=0,
+            block_timestamp=1000000000,
+            block_hash=0,
+            metadata={},
+        )
+
+        # validate db records
+        all_notification_seen: List[NotificationSeen] = session.query(
+            NotificationSeen
+        ).all()
+        assert len(all_notification_seen) == 3

--- a/discovery-provider/src/models/notifications/notification.py
+++ b/discovery-provider/src/models/notifications/notification.py
@@ -1,15 +1,13 @@
 from sqlalchemy import (
     Column,
     DateTime,
-    ForeignKey,
-    Index,
     Integer,
+    PrimaryKeyConstraint,
     String,
     UniqueConstraint,
     text,
 )
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import relationship
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin
 
@@ -24,7 +22,6 @@ class Notification(Base, RepresentableMixin):
     )
     specifier = Column(String, nullable=False)
     group_id = Column(String, nullable=False)
-    notification_group_id = Column(Integer, ForeignKey("notification_group.id"))  # type: ignore
     type = Column(String, nullable=False)
     slot = Column(Integer)
     blocknumber = Column(Integer)
@@ -34,28 +31,12 @@ class Notification(Base, RepresentableMixin):
     UniqueConstraint("group_id", "specifier", name="uq_notification")
 
 
-class NotificationGroup(Base, RepresentableMixin):
-    __tablename__ = "notification_group"
-    __table_args__ = (Index("ix_notification_group", "user_id", "timestamp"),)
+class NotificationSeen(Base, RepresentableMixin):
+    __tablename__ = "notification_seen"
 
-    id = Column(
-        Integer,
-        primary_key=True,
-        server_default=text("nextval('notification_group_id_seq'::regclass)"),
-    )
-    notification_id = Column(Integer, ForeignKey("notification.id"))  # type: ignore
-    slot = Column(Integer)
-    blocknumber = Column(Integer)
     user_id = Column(Integer, nullable=False)
-    timestamp = Column(DateTime, nullable=False)
-
-
-Notification.notification_group = relationship(  # type: ignore
-    "NotificationGroup",
-    primaryjoin="Notification.notification_group_id == NotificationGroup.id",
-)
-
-NotificationGroup.notification = relationship(  # type: ignore
-    "Notification",
-    primaryjoin="NotificationGroup.notification_id == Notification.id",
-)
+    blocknumber = Column(Integer)
+    blockhash = Column(String)
+    txhash = Column(String)
+    seen_at = Column(DateTime, nullable=False)
+    PrimaryKeyConstraint(user_id, seen_at)

--- a/discovery-provider/src/tasks/entity_manager/notification_seen.py
+++ b/discovery-provider/src/tasks/entity_manager/notification_seen.py
@@ -1,0 +1,39 @@
+import logging
+
+from src.models.notifications.notification import NotificationSeen
+from src.tasks.entity_manager.utils import Action, EntityType, ManageEntityParameters
+
+logger = logging.getLogger(__name__)
+
+
+def validate_notification_tx(params: ManageEntityParameters):
+    user_id = params.user_id
+    if user_id not in params.existing_records[EntityType.USER]:
+        raise Exception(f"User {user_id} does not exists")
+
+    wallet = params.existing_records[EntityType.USER][user_id].wallet
+    if wallet and wallet.lower() != params.signer.lower():
+        raise Exception(f"User {user_id} does not match signer")
+
+    if params.entity_type != EntityType.NOTIFICATION:
+        raise Exception(f"Entity type {params.entity_type} is not a notification")
+
+    if params.action == Action.VIEW:
+        return
+    else:
+        action = params.action
+        raise Exception(f"Entity action {action} is not valid")
+
+
+def view_notification(params: ManageEntityParameters):
+    validate_notification_tx(params)
+    notification_seen = NotificationSeen(
+        user_id=params.user_id,
+        seen_at=params.block_datetime,
+        txhash=params.txhash,
+        blockhash=params.event_blockhash,
+        blocknumber=params.block_number,
+    )
+    key = (params.user_id, params.block_datetime)
+
+    params.add_notification_seen_record(key, notification_seen)

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict, List, Set, Tuple, TypedDict
 
 from src.challenges.challenge_event_bus import ChallengeEventBus
+from src.models.notifications.notification import NotificationSeen
 from src.models.playlists.playlist import Playlist
 from src.models.playlists.playlist_route import PlaylistRoute
 from src.models.social.follow import Follow
@@ -35,6 +36,7 @@ class Action(str, Enum):
     VERIFY = "Verify"
     SUBSCRIBE = "Subscribe"
     UNSUBSCRIBE = "Unsubscribe"
+    VIEW = "View"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -49,6 +51,7 @@ class EntityType(str, Enum):
     SAVE = "Save"
     REPOST = "Repost"
     SUBSCRIPTION = "Subscription"
+    NOTIFICATION = "Notification"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -62,6 +65,7 @@ class RecordDict(TypedDict):
     Save: Dict[Tuple, List[Save]]
     Repost: Dict[Tuple, List[Repost]]
     Subscription: Dict[Tuple, List[Subscription]]
+    Notification: Dict[Tuple, List[NotificationSeen]]
 
 
 class ExistingRecordDict(TypedDict):
@@ -151,6 +155,15 @@ class ManageEntityParameters:
     def add_user_record(self, user_id: int, user: User):
         self.new_records[EntityType.USER][user_id].append(user)  # type: ignore
         self.existing_records[EntityType.USER][user_id] = user  # type: ignore
+
+    def add_notification_seen_record(
+        self,
+        key: Tuple[int, datetime],
+        record: NotificationSeen,
+    ):
+        if key not in self.new_records[EntityType.NOTIFICATION]:  # type: ignore
+            self.new_records[EntityType.NOTIFICATION][key].append(record)  # type: ignore
+        # If key exists, do nothing
 
 
 def get_record_key(user_id: int, entity_type: str, entity_id: int):


### PR DESCRIPTION
### Description
Adds a migration for the notifications seen
Removes the notification_group table - functionality replaced with notification seen
Adds an entity manager jobs to index notification seen 

### Tests
Test for entity manager to write to the table

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->