### PR TITLE
Update storagePaths for failed blacklisted CIDs

### DIFF
--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -436,7 +436,7 @@ class DBManager {
 
   static async _getLegacyStoragePathsAndCids(cursor, batchSize, dir) {
     const queryResult = await models.File.findAll({
-      attributes: ['storagePath', 'multihash'],
+      attributes: ['storagePath', 'multihash', 'skipped'],
       where: {
         multihash: { [sequelize.Op.gte]: cursor },
         type: {
@@ -457,7 +457,11 @@ class DBManager {
     )
     if (isEmpty(queryResult)) return []
     return queryResult.map((result) => {
-      return { storagePath: result.storagePath, cid: result.multihash }
+      return {
+        storagePath: result.storagePath,
+        cid: result.multihash,
+        skipped: result.skipped
+      }
     })
   }
 
@@ -477,7 +481,8 @@ class DBManager {
         'dirMultihash',
         'fileName',
         'trackBlockchainId',
-        'fileUUID'
+        'fileUUID',
+        'skipped'
       ],
       where: {
         multihash: { [sequelize.Op.gte]: cursor },

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -25,7 +25,7 @@ import {
   getCharsInRanges
 } from './utils'
 import { fetchFileFromNetworkAndSaveToFS } from './fileManager'
-import { serviceRegistry } from './serviceRegistry'
+import BlacklistManager from './blacklistManager'
 
 const models = require('./models')
 
@@ -634,9 +634,7 @@ async function _migrateFileWithCustomStoragePath(
 
   if (error) {
     // If copying errored because the file is delisted, we can ignore the error and update the db storagePath
-    const isServable = await serviceRegistry.blacklistManager.isServable(
-      fileRecord.multihash
-    )
+    const isServable = await BlacklistManager.isServable(fileRecord.multihash)
     if (!isServable && fileRecord.skipped) {
       await models.File.update(
         { storagePath },

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -25,6 +25,7 @@ import {
   getCharsInRanges
 } from './utils'
 import { fetchFileFromNetworkAndSaveToFS } from './fileManager'
+import { serviceRegistry } from './serviceRegistry'
 
 const models = require('./models')
 
@@ -442,7 +443,7 @@ async function _touch(path: string) {
 }
 
 async function _copyLegacyFiles(
-  legacyPathsAndCids: { storagePath: string; cid: string }[],
+  legacyPathsAndCids: { storagePath: string; cid: string; skipped: boolean }[],
   prometheusRegistry: any,
   logger: Logger
 ): Promise<
@@ -456,7 +457,8 @@ async function _copyLegacyFiles(
     legacyPath: string
     nonLegacyPath: string
   }[] = []
-  for (const { storagePath: legacyPath, cid } of legacyPathsAndCids) {
+  for (const { storagePath: legacyPath, cid, skipped } of legacyPathsAndCids) {
+    let nonLegacyPath = ''
     try {
       // Compute new path
       const nonLegacyPathInfo = extractCIDsFromFSPath(legacyPath)
@@ -466,7 +468,7 @@ async function _copyLegacyFiles(
       }
 
       // Ensure new path's parent exists
-      const nonLegacyPath = await (nonLegacyPathInfo.isDir
+      nonLegacyPath = await (nonLegacyPathInfo.isDir
         ? computeFilePathInDirAndEnsureItExists(
             nonLegacyPathInfo.outer,
             nonLegacyPathInfo.inner!
@@ -511,7 +513,12 @@ async function _copyLegacyFiles(
         throw new Error('CID does not match what is expected to be')
       }
     } catch (e: any) {
-      erroredPaths[legacyPath] = e.toString()
+      // If the file is skipped (blacklisted) then we don't care if it failed to copy
+      if (skipped && nonLegacyPath?.length) {
+        copiedPaths.push({ legacyPath, nonLegacyPath })
+      } else {
+        erroredPaths[legacyPath] = e.toString()
+      }
     }
   }
 
@@ -542,7 +549,7 @@ async function _migrateNonDirFilesWithLegacyStoragePaths(
 
     // Query for legacy storagePaths in the pagination range until no new results are returned
     let newResultsFound = true
-    let results: { storagePath: string; cid: string }[] = []
+    let results: { storagePath: string; cid: string; skipped: boolean }[] = []
     while (newResultsFound) {
       const prevResults = results
       results = await DbManager.getNonDirLegacyStoragePathsAndCids(
@@ -576,7 +583,7 @@ async function _migrateDirsWithLegacyStoragePaths(
 
     // Query for legacy storagePaths in the pagination range until no new results are returned
     let newResultsFound = true
-    let results: { storagePath: string; cid: string }[] = []
+    let results: { storagePath: string; cid: string; skipped: boolean }[] = []
     while (newResultsFound) {
       const prevResults = results
       results = await DbManager.getDirLegacyStoragePathsAndCids(
@@ -605,6 +612,7 @@ async function _migrateFileWithCustomStoragePath(
     storagePath: string
     multihash: string
     fileUUID: string
+    skipped: boolean
     dirMultihash?: string
     fileName?: string
     trackBlockchainId?: number
@@ -625,15 +633,28 @@ async function _migrateFileWithCustomStoragePath(
   )
 
   if (error) {
+    // If copying errored because the file is delisted, we can ignore the error and update the db storagePath
+    const isServable = await serviceRegistry.blacklistManager.isServable(
+      fileRecord.multihash
+    )
+    if (!isServable && fileRecord.skipped) {
+      await models.File.update(
+        { storagePath },
+        {
+          where: { fileUUID: fileRecord.fileUUID }
+        }
+      )
+      return true
+    }
     logErrorWithDuration(
       { logger, startTime: fetchStartTime },
       `Error fixing fileRecord ${JSON.stringify(fileRecord)}: ${error}`
     )
     return false
   } else {
-    // Update file's storagePath in DB to newly saved location, and ensure it's not marked as skipped
+    // Update file's storagePath in DB to newly saved location
     await models.File.update(
-      { storagePath, skipped: false },
+      { storagePath },
       {
         where: { fileUUID: fileRecord.fileUUID }
       }
@@ -658,6 +679,7 @@ async function _migrateFilesWithCustomStoragePaths(
       storagePath: string
       multihash: string
       fileUUID: string
+      skipped: boolean
       dirMultihash?: string
       fileName?: string
       trackBlockchainId?: number

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -650,11 +650,11 @@ async function _migrateFileWithCustomStoragePath(
     )
     return false
   } else {
-    // Update file's storagePath in DB to newly saved location
+    // Update file's storagePath in DB to newly saved location, and ensure it's not marked as skipped
     await models.File.update(
       { storagePath },
       {
-        where: { fileUUID: fileRecord.fileUUID }
+        where: { fileUUID: fileRecord.fileUUID, skipped: false }
       }
     )
     return true


### PR DESCRIPTION
### Description
Makes storagePath migrations ignore errors and still update the storagePath db column when a skipped legacy path fails to copy or a skipped custom path fails to fetch from network.


### Tests
I did a sanity check and will do more thorough debugging on prod CN5. No data should be lost, and this will only impact skipped tracks - same logic otherwise.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I'll monitor prod CN5 with debugging enabled to spot check any failed tracks and make sure they're not failing due to being unable to copy over from a skipped track. The logs to search for this are "Failed to copy legacy" and "Error fixing fileRecord"