### PR TITLE
Narrow pagination windows for storagePath migrations

### DIFF
--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -545,7 +545,7 @@ async function _copyLegacyFiles(
  *
  * We don't have any CIDs that start with Qm[0,9], so that's why we:
  * - start at Qma00 instead of Qm000; and
- * - end at Qmz90 instead of Qm999
+ * - end at Qmz99 instead of Qm999
  * @param func the function to call on each pagination window (there are 1872 windows)
  */
 async function _callFuncOnAllCidsPaginated(


### PR DESCRIPTION
### Description
The current storagePath migration db query runs for unreasonably long after reaching the `Qmw` cursor because there are too many CIDs that are `>= Qmw`, and it tries to order and match storagePath regex against all of these CIDs. After manually running some queries, I found that an acceptable runtime is when narrowing the window from `>= Qm*` to `BETWEEN Qm**a AND Qm**z`. This limits the number of CIDs that the query has to match storagePath regex against.

[Here's a sandbox](https://codesandbox.io/s/crimson-waterfall-c7rmhw) showing the pagination windows (open console).


### Tests
I manually tested in the same way the original pagination was tested --

for legacy:
1. `A up; A seed clear; A seed create-user; A seed upload-track`
2. In db: `UPDATE "Files" SET "storagePath" = CONCAT('/file_storage', SUBSTRING("storagePath" FROM 20)) WHERE true;`
3. `docker exec -it cn1_creator-node_1 /bin/sh` and move each file manually: `cd /file_storage/files; ls` then for each dir: `mv <dir>/<CID> /file_storage`
4. 'storagePath' in the db should be updated to what it was before, and in the container /file_storage should only have /files. Also each file in 'storagePath' under the db should exist on disk. I double-checked logs as well to verify that these were found in the correct pagination windows.

for custom:
1. `A up; A seed clear; A seed create-user; A seed upload-track`
2. In db: `UPDATE "Files" SET "storagePath" = CONCAT('/home/customStorage', SUBSTRING("storagePath" FROM 20)) WHERE true;`
3. `docker exec -it cn1_creator-node_1 /bin/sh` and move each file manually: `mkdir -p /home/customStorage; cd /file_storage/files; ls` then for each dir: `mv <dir>/<CID> /home/customStorage`
4. 'storagePath' in the db should be updated to what it was before, and in the container /file_storage should only have /files. Also each file in 'storagePath' under the db should exist on disk. I double-checked logs as well to verify that these were found in the correct pagination windows.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
After staging, I'll deploy to prod CN5 and monitor for:
- `fileRecords for` logs to verify the correct CIDs/storagePaths are being returned for each window with acceptable speed
- `Error migrating legacy storagePaths` (legacy storagePath migration errors)
- `Error fixing fileRecord` (custom storagePath migration errors)