### PR TITLE
Fix identity redis rate limit error and improve logging

### DIFF
--- a/identity-service/src/app.js
+++ b/identity-service/src/app.js
@@ -303,7 +303,7 @@ class App {
     // Create a rate limiter for listens  based on IP
     const listenCountIPRequestLimiter = getRateLimiter({
       prefix: `listenCountLimiter:::${interval}-ip-exclusive:::`,
-      expiry: interval,
+      expiry: timeInSeconds,
       max: config.get(`rateLimitingListensPerIPPer${interval}`), // max requests per interval
       keyGenerator: function (req) {
         const { ip } = getIP(req)

--- a/identity-service/src/rateLimiter.js
+++ b/identity-service/src/rateLimiter.js
@@ -4,7 +4,11 @@ const config = require('./config.js')
 const rateLimit = require('express-rate-limit')
 const express = require('express')
 const { isIPFromContentNode } = require('./utils/contentNodeIPCheck')
-const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
+const redisClient = new Redis(
+  config.get('redisPort'),
+  config.get('redisHost'),
+  { showFriendlyErrorStack: config.get('environment') !== 'production' }
+)
 
 const DEFAULT_EXPIRY = 60 * 60 // one hour in seconds
 

--- a/identity-service/src/redis.js
+++ b/identity-service/src/redis.js
@@ -1,6 +1,10 @@
 const Redis = require('ioredis')
 const config = require('./config.js')
-const redisClient = new Redis(config.get('redisPort'), config.get('redisHost'))
+const redisClient = new Redis(
+  config.get('redisPort'),
+  config.get('redisHost'),
+  { showFriendlyErrorStack: config.get('environment') !== 'production' }
+)
 const { logger } = require('./logging')
 
 /**


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Resolves this consistent redis error in identity. Maybe the IP rate limiter was never working? If so, will need to monitor when deploying.

```
UnhandledPromiseRejectionWarning: ReplyError: ERR value is not an integer or out of range
    at parseError (/usr/src/app/node_modules/redis-parser/lib/parser.js:179:12)
    at parseType (/usr/src/app/node_modules/redis-parser/lib/parser.js:302:14)
```
Used `showFriendlyErrorStack` to help narrow down the issue to the rate limiter and found we were using "Hour" "Day "Week" here.

`showFriendlyErrorStack` has some impact on performance but still seems worth putting on stage.
https://github.com/luin/ioredis/issues/829


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally. Confirmed errors disappeared.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->