### PR TITLE
Fix manual reconfig route

### DIFF
--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -976,7 +976,7 @@ export class DiscoveryProvider {
   /**
    * Retrieves the user's replica set
    * @param params.encodedUserId string of the encoded user id
-   * @param params.blocNumber optional integer pass to wait until the discovery node has indexed that block number
+   * @param params.blockNumber optional integer pass to wait until the discovery node has indexed that block number
    * @return object containing the user replica set
    */
   async getUserReplicaSet({


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Update manual reconfig route to match `updateReplicaSet.jobProcessor` - it now first tries URSM, then falls back to EM
NOTE - it polls discovery indexing for confirmation, but does not issue syncs to new secondaries (didn't feel like writing this was urgent for now)

I tested this locally with URSM and EM cases, both work

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

n/a


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->