### PR TITLE
Better EM copying

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -3,9 +3,10 @@ from typing import List
 from integration_tests.utils import populate_mock_db
 from src.models.users.user import User
 from src.utils.db_session import get_db
-from src.tasks.entity_manager.utils import copy_user_record
+from src.tasks.entity_manager.utils import copy_record
 
-def test_copy_user_record(app):
+
+def test_copy_record(app):
     with app.app_context():
         db = get_db()
 
@@ -36,7 +37,7 @@ def test_copy_user_record(app):
         event_blockhash = hex(10)
         txhash = "0x01"
         block_datetime = datetime.now()
-        user_1_copy = copy_user_record(
+        user_1_copy = copy_record(
             user_1,
             block_number,
             event_blockhash,

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import List
+from integration_tests.utils import populate_mock_db
+from src.models.users.user import User
+from src.utils.db_session import get_db
+from src.tasks.entity_manager.utils import copy_user_record
+
+def test_copy_user_record(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "users": [
+            {
+                "user_id": 1,
+                "handle": "user-1",
+                "wallet": "user1wallet",
+                "bio": "hi",
+                "primary_id": 1,
+                "secondary_ids": [2, 3],
+                "artist_pick_track_id": 1
+            }
+        ]
+    }
+    populate_mock_db(db, entities)
+    with db.scoped_session() as session:
+        all_users: List[User] = session.query(User).all()
+        assert len(all_users) == 1
+        user_1 = all_users[1]
+        user_1_updated_at = user_1.updated_at
+        user_1_block_number = user_1.blocknumber
+        user_1_blockhash = user_1.blockhash
+        user_1_txhash = user_1.txhash
+
+        block_number = 10
+        event_blockhash = hex(10)
+        txhash = "0x01"
+        block_datetime = datetime.now()
+        user_1_copy = copy_user_record(
+            user_1,
+            block_number,
+            event_blockhash,
+            txhash,
+            block_datetime
+        )
+
+        old_user_attributes = user_1.__dict__
+        user_copy_attributes = user_1_copy.__dict__
+        for key, value in user_copy_attributes.items():
+            match key:
+                case "is_current":
+                    assert value == False
+                    assert old_user_attributes[key] == True
+                case "updated_at":
+                    assert value == block_datetime
+                    assert old_user_attributes[key] == user_1_updated_at
+                case "blocknumber":
+                    assert value == block_number
+                    assert old_user_attributes[key] == user_1_block_number
+                case "blockhash":
+                    assert value == event_blockhash
+                    assert old_user_attributes[key] == user_1_blockhash
+                case "txhash":
+                    assert value == txhash
+                    assert old_user_attributes[key] == user_1_txhash
+                case _:
+                    assert value == old_user_attributes[key]

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -26,7 +26,7 @@ def test_copy_user_record(app):
     with db.scoped_session() as session:
         all_users: List[User] = session.query(User).all()
         assert len(all_users) == 1
-        user_1 = all_users[1]
+        user_1 = all_users[0]
         user_1_updated_at = user_1.updated_at
         user_1_block_number = user_1.blocknumber
         user_1_blockhash = user_1.blockhash
@@ -44,8 +44,8 @@ def test_copy_user_record(app):
             block_datetime
         )
 
-        old_user_attributes = user_1.__dict__
-        user_copy_attributes = user_1_copy.__dict__
+        old_user_attributes = user_1.get_attributes_dict()
+        user_copy_attributes = user_1_copy.get_attributes_dict()
         for key, value in user_copy_attributes.items():
             if key == "is_current":
                 assert value == False

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -47,21 +47,20 @@ def test_copy_user_record(app):
         old_user_attributes = user_1.__dict__
         user_copy_attributes = user_1_copy.__dict__
         for key, value in user_copy_attributes.items():
-            match key:
-                case "is_current":
-                    assert value == False
-                    assert old_user_attributes[key] == True
-                case "updated_at":
-                    assert value == block_datetime
-                    assert old_user_attributes[key] == user_1_updated_at
-                case "blocknumber":
-                    assert value == block_number
-                    assert old_user_attributes[key] == user_1_block_number
-                case "blockhash":
-                    assert value == event_blockhash
-                    assert old_user_attributes[key] == user_1_blockhash
-                case "txhash":
-                    assert value == txhash
-                    assert old_user_attributes[key] == user_1_txhash
-                case _:
-                    assert value == old_user_attributes[key]
+            if key == "is_current":
+                assert value == False
+                assert old_user_attributes[key] == True
+            elif key == "updated_at":
+                assert value == block_datetime
+                assert old_user_attributes[key] == user_1_updated_at
+            elif key == "blocknumber":
+                assert value == block_number
+                assert old_user_attributes[key] == user_1_block_number
+            elif key == "blockhash":
+                assert value == event_blockhash
+                assert old_user_attributes[key] == user_1_blockhash
+            elif key == "txhash":
+                assert value == txhash
+                assert old_user_attributes[key] == user_1_txhash
+            else:
+                assert value == old_user_attributes[key]

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import List
+
 from integration_tests.utils import populate_mock_db
 from src.models.users.user import User
-from src.utils.db_session import get_db
 from src.tasks.entity_manager.utils import copy_record
+from src.utils.db_session import get_db
 
 
 def test_copy_record(app):
@@ -19,7 +20,7 @@ def test_copy_record(app):
                 "bio": "hi",
                 "primary_id": 1,
                 "secondary_ids": [2, 3],
-                "artist_pick_track_id": 1
+                "artist_pick_track_id": 1,
             }
         ]
     }
@@ -38,11 +39,7 @@ def test_copy_record(app):
         txhash = "0x01"
         block_datetime = datetime.now()
         user_1_copy = copy_record(
-            user_1,
-            block_number,
-            event_blockhash,
-            txhash,
-            block_datetime
+            user_1, block_number, event_blockhash, txhash, block_datetime
         )
 
         old_user_attributes = user_1.get_attributes_dict()

--- a/discovery-provider/src/models/playlists/playlist.py
+++ b/discovery-provider/src/models/playlists/playlist.py
@@ -51,3 +51,6 @@ class Playlist(Base, RepresentableMixin):
         return validate_field_helper(
             field, value, "Playlist", getattr(Playlist, field).type
         )
+
+    def get_attributes_dict(self):
+        return {col.name: getattr(self, col.name) for col in self.__table__.columns}

--- a/discovery-provider/src/models/tracks/track.py
+++ b/discovery-provider/src/models/tracks/track.py
@@ -114,3 +114,6 @@ class Track(Base, RepresentableMixin):
     @validates(*fields)
     def validate_field(self, field, value):
         return validate_field_helper(field, value, "Track", getattr(Track, field).type)
+
+    def get_attributes_dict(self):
+        return {col.name: getattr(self, col.name) for col in self.__table__.columns}

--- a/discovery-provider/src/models/users/user.py
+++ b/discovery-provider/src/models/users/user.py
@@ -79,3 +79,6 @@ class User(Base, RepresentableMixin):
     @validates(*fields)
     def validate_field(self, field, value):
         return validate_field_helper(field, value, "User", getattr(User, field).type)
+
+    def get_attributes_dict(self):
+        return {col.name: getattr(self, col.name) for col in self.__table__.columns}

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -11,6 +11,7 @@ from src.tasks.entity_manager.utils import (
     Action,
     EntityType,
     ManageEntityParameters,
+    copy_record,
 )
 from src.tasks.playlists import update_playlist_routes_table
 
@@ -128,7 +129,11 @@ def update_playlist(params: ManageEntityParameters):
         existing_playlist = params.new_records[EntityType.PLAYLIST][playlist_id][-1]
 
     updated_playlist = copy_record(
-        existing_playlist, params.block_number, params.event_blockhash, params.txhash
+        existing_playlist,
+        params.block_number,
+        params.event_blockhash,
+        params.txhash,
+        params.block_datetime,
     )
     process_playlist_data_event(
         updated_playlist,
@@ -161,35 +166,15 @@ def delete_playlist(params: ManageEntityParameters):
         ]
 
     deleted_playlist = copy_record(
-        existing_playlist, params.block_number, params.event_blockhash, params.txhash
+        existing_playlist,
+        params.block_number,
+        params.event_blockhash,
+        params.txhash,
+        params.block_datetime,
     )
     deleted_playlist.is_delete = True
 
     params.new_records[EntityType.PLAYLIST][params.entity_id].append(deleted_playlist)
-
-
-def copy_record(old_playlist: Playlist, block_number, event_blockhash, txhash):
-    new_playlist = Playlist(
-        playlist_id=old_playlist.playlist_id,
-        playlist_owner_id=old_playlist.playlist_owner_id,
-        is_album=old_playlist.is_album,
-        description=old_playlist.description,
-        playlist_image_multihash=old_playlist.playlist_image_multihash,
-        playlist_image_sizes_multihash=old_playlist.playlist_image_sizes_multihash,
-        playlist_name=old_playlist.playlist_name,
-        is_private=old_playlist.is_private,
-        playlist_contents=old_playlist.playlist_contents,
-        created_at=old_playlist.created_at,
-        updated_at=old_playlist.updated_at,
-        blocknumber=block_number,
-        blockhash=event_blockhash,
-        txhash=txhash,
-        last_added_to=old_playlist.last_added_to,
-        is_current=False,
-        is_delete=old_playlist.is_delete,
-        metadata_multihash=old_playlist.metadata_multihash,
-    )
-    return new_playlist
 
 
 def process_playlist_contents(playlist_record, playlist_metadata, block_integer_time):

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -51,6 +51,7 @@ def validate_track_tx(params: ManageEntityParameters):
 
     return True
 
+
 def get_handle(params: ManageEntityParameters):
     # TODO: get the track owner user handle
     handle = (
@@ -148,7 +149,7 @@ def delete_track(params: ManageEntityParameters):
         # override with last updated playlist is in this block
         existing_track = params.new_records[EntityType.TRACK][params.entity_id][-1]
 
-    deleted_track = copy_track_record(
+    deleted_track = copy_record(
         existing_track, params.block_number, params.event_blockhash, params.txhash
     )
     deleted_track.is_delete = True

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -122,7 +122,6 @@ def update_track(params: ManageEntityParameters):
     ):  # override with last updated track is in this block
         existing_track = params.new_records[EntityType.TRACK][track_id][-1]
 
-    print(f"existing_track: {existing_track}")
     updated_track = copy_record(
         existing_track,
         params.block_number,
@@ -130,7 +129,6 @@ def update_track(params: ManageEntityParameters):
         params.txhash,
         params.block_datetime,
     )
-    print(f"updated_track: {updated_track}")
 
     update_track_routes_table(
         params.session, updated_track, track_metadata, params.pending_track_routes
@@ -151,7 +149,6 @@ def delete_track(params: ManageEntityParameters):
         # override with last updated playlist is in this block
         existing_track = params.new_records[EntityType.TRACK][params.entity_id][-1]
 
-    print(f"existing_track: {existing_track}")
     deleted_track = copy_record(
         existing_track,
         params.block_number,
@@ -159,7 +156,6 @@ def delete_track(params: ManageEntityParameters):
         params.txhash,
         params.block_datetime,
     )
-    print(f"deleted_track: {deleted_track}")
     deleted_track.is_delete = True
     deleted_track.stem_of = null()
     deleted_track.remix_of = null()

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -122,6 +122,7 @@ def update_track(params: ManageEntityParameters):
     ):  # override with last updated track is in this block
         existing_track = params.new_records[EntityType.TRACK][track_id][-1]
 
+    print(f"existing_track: {existing_track}")
     updated_track = copy_record(
         existing_track,
         params.block_number,
@@ -129,6 +130,7 @@ def update_track(params: ManageEntityParameters):
         params.txhash,
         params.block_datetime,
     )
+    print(f"updated_track: {updated_track}")
 
     update_track_routes_table(
         params.session, updated_track, track_metadata, params.pending_track_routes
@@ -149,9 +151,15 @@ def delete_track(params: ManageEntityParameters):
         # override with last updated playlist is in this block
         existing_track = params.new_records[EntityType.TRACK][params.entity_id][-1]
 
+    print(f"existing_track: {existing_track}")
     deleted_track = copy_record(
-        existing_track, params.block_number, params.event_blockhash, params.txhash
+        existing_track,
+        params.block_number,
+        params.event_blockhash,
+        params.txhash,
+        params.block_datetime,
     )
+    print(f"deleted_track: {deleted_track}")
     deleted_track.is_delete = True
     deleted_track.stem_of = null()
     deleted_track.remix_of = null()

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -9,6 +9,7 @@ from src.tasks.entity_manager.utils import (
     Action,
     EntityType,
     ManageEntityParameters,
+    copy_record,
 )
 from src.tasks.tracks import (
     dispatch_challenge_track_upload,
@@ -49,50 +50,6 @@ def validate_track_tx(params: ManageEntityParameters):
             raise Exception(f"Existing track {track_id} does not match user")
 
     return True
-
-
-def copy_track_record(
-    old_track: Track, block_number: int, event_blockhash: str, txhash: str
-):
-    return Track(
-        track_id=old_track.track_id,
-        owner_id=old_track.owner_id,
-        title=old_track.title,
-        length=old_track.length,
-        cover_art=old_track.cover_art,
-        tags=old_track.tags,
-        genre=old_track.genre,
-        mood=old_track.mood,
-        credits_splits=old_track.credits_splits,
-        create_date=old_track.create_date,
-        release_date=old_track.release_date,
-        file_type=old_track.file_type,
-        metadata_multihash=old_track.metadata_multihash,
-        track_segments=old_track.track_segments,
-        description=old_track.description,
-        isrc=old_track.isrc,
-        iswc=old_track.iswc,
-        license=old_track.license,
-        cover_art_sizes=old_track.cover_art_sizes,
-        download=old_track.download,
-        is_unlisted=old_track.is_unlisted,
-        field_visibility=old_track.field_visibility,
-        route_id=old_track.route_id,
-        stem_of=old_track.stem_of,
-        remix_of=old_track.remix_of,
-        slot=old_track.slot,
-        is_premium=old_track.is_premium,
-        premium_conditions=old_track.premium_conditions,
-        is_available=old_track.is_available,
-        is_delete=old_track.is_delete,
-        created_at=old_track.created_at,
-        updated_at=old_track.updated_at,
-        blocknumber=block_number,
-        blockhash=event_blockhash,
-        txhash=txhash,
-        is_current=False,
-    )
-
 
 def get_handle(params: ManageEntityParameters):
     # TODO: get the track owner user handle
@@ -164,8 +121,12 @@ def update_track(params: ManageEntityParameters):
     ):  # override with last updated track is in this block
         existing_track = params.new_records[EntityType.TRACK][track_id][-1]
 
-    updated_track = copy_track_record(
-        existing_track, params.block_number, params.event_blockhash, params.txhash
+    updated_track = copy_record(
+        existing_track,
+        params.block_number,
+        params.event_blockhash,
+        params.txhash,
+        params.block_datetime,
     )
 
     update_track_routes_table(

--- a/discovery-provider/src/tasks/entity_manager/user.py
+++ b/discovery-provider/src/tasks/entity_manager/user.py
@@ -10,7 +10,7 @@ from src.tasks.entity_manager.utils import (
     Action,
     EntityType,
     ManageEntityParameters,
-    copy_user_record,
+    copy_record,
 )
 from src.tasks.user_replica_set import get_endpoint_string_from_sp_ids
 from src.tasks.users import (
@@ -143,7 +143,7 @@ def update_user(params: ManageEntityParameters):
     ):  # override with last updated user is in this block
         existing_user = params.new_records[EntityType.USER][user_id][-1]
 
-    user_record = copy_user_record(
+    user_record = copy_record(
         existing_user,
         params.block_number,
         params.event_blockhash,
@@ -183,7 +183,7 @@ def verify_user(params: ManageEntityParameters):
 
     user_id = params.user_id
     existing_user = params.existing_records[EntityType.USER][user_id]
-    user_record = copy_user_record(
+    user_record = copy_record(
         existing_user,
         params.block_number,
         params.event_blockhash,

--- a/discovery-provider/src/tasks/entity_manager/user_replica_set.py
+++ b/discovery-provider/src/tasks/entity_manager/user_replica_set.py
@@ -5,7 +5,7 @@ from src.tasks.entity_manager.utils import (
     Action,
     EntityType,
     ManageEntityParameters,
-    copy_user_record,
+    copy_record,
 )
 from src.tasks.user_replica_set import get_endpoint_string_from_sp_ids
 from src.utils.eth_manager import ServiceProviderType
@@ -94,7 +94,7 @@ def update_user_replica_set(params: ManageEntityParameters):
         user_id in params.new_records[EntityType.USER]
     ):  # override with last updated user is in this block
         existing_user = params.new_records[EntityType.USER][user_id][-1]
-    updated_user = copy_user_record(
+    updated_user = copy_record(
         existing_user,
         params.block_number,
         params.event_blockhash,

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -169,6 +169,7 @@ class ManageEntityParameters:
 def get_record_key(user_id: int, entity_type: str, entity_id: int):
     return (user_id, entity_type.capitalize(), entity_id)
 
+
 def copy_record(
     old_record: Union[User, Track, Playlist],
     block_number: int,

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -181,19 +181,18 @@ def copy_user_record(
     old_user_attributes = inspect.getmembers(old_user)
     user_copy = User()
     for key, value in old_user_attributes:
-        match key:
-            case "is_current":
-                setattr(user_copy, key, False)
-            case "updated_at":
-                setattr(user_copy, key, block_datetime)
-            case "blocknumber":
-                setattr(user_copy, key, block_number)
-            case "blockhash":
-                setattr(user_copy, key, event_blockhash)
-            case "txhash":
-                setattr(user_copy, key, txhash)
-            case _:
-                setattr(user_copy, key, value)
+        if key == "is_current":
+            setattr(user_copy, key, False)
+        elif key == "updated_at":
+            setattr(user_copy, key, block_datetime)
+        elif key == "blocknumber":
+            setattr(user_copy, key, block_number)
+        elif key == "blockhash":
+            setattr(user_copy, key, event_blockhash)
+        elif key == "txhash":
+            setattr(user_copy, key, txhash)
+        else:
+            setattr(user_copy, key, value)
     return user_copy
 
     # return User(

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -170,7 +170,7 @@ def get_record_key(user_id: int, entity_type: str, entity_id: int):
     return (user_id, entity_type.capitalize(), entity_id)
 
 def copy_record(
-    old_record: Union[User, Track],
+    old_record: Union[User, Track, Playlist],
     block_number: int,
     event_blockhash: str,
     txhash: str,

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Set, Tuple, TypedDict
@@ -177,35 +178,53 @@ def copy_user_record(
     txhash: str,
     block_datetime: datetime,
 ):
-    return User(
-        user_id=old_user.user_id,
-        wallet=old_user.wallet,
-        created_at=old_user.created_at,
-        handle=old_user.handle,
-        name=old_user.name,
-        profile_picture=old_user.profile_picture,
-        cover_photo=old_user.cover_photo,
-        bio=old_user.bio,
-        location=old_user.location,
-        metadata_multihash=old_user.metadata_multihash,
-        creator_node_endpoint=old_user.creator_node_endpoint,
-        is_verified=old_user.is_verified,
-        handle_lc=old_user.handle_lc,
-        cover_photo_sizes=old_user.cover_photo_sizes,
-        profile_picture_sizes=old_user.profile_picture_sizes,
-        primary_id=old_user.primary_id,
-        secondary_ids=old_user.secondary_ids,
-        replica_set_update_signer=old_user.replica_set_update_signer,
-        has_collectibles=old_user.has_collectibles,
-        playlist_library=old_user.playlist_library,
-        is_deactivated=old_user.is_deactivated,
-        slot=old_user.slot,
-        user_storage_account=old_user.user_storage_account,
-        user_authority_account=old_user.user_authority_account,
-        updated_at=block_datetime,
-        blocknumber=block_number,
-        blockhash=event_blockhash,
-        txhash=txhash,
-        artist_pick_track_id=old_user.artist_pick_track_id,
-        is_current=False,
-    )
+    old_user_attributes = inspect.getmembers(old_user)
+    user_copy = User()
+    for key, value in old_user_attributes:
+        match key:
+            case "is_current":
+                setattr(user_copy, key, False)
+            case "updated_at":
+                setattr(user_copy, key, block_datetime)
+            case "blocknumber":
+                setattr(user_copy, key, block_number)
+            case "blockhash":
+                setattr(user_copy, key, event_blockhash)
+            case "txhash":
+                setattr(user_copy, key, txhash)
+            case _:
+                setattr(user_copy, key, value)
+    return user_copy
+
+    # return User(
+    #     user_id=old_user.user_id,
+    #     wallet=old_user.wallet,
+    #     created_at=old_user.created_at,
+    #     handle=old_user.handle,
+    #     name=old_user.name,
+    #     profile_picture=old_user.profile_picture,
+    #     cover_photo=old_user.cover_photo,
+    #     bio=old_user.bio,
+    #     location=old_user.location,
+    #     metadata_multihash=old_user.metadata_multihash,
+    #     creator_node_endpoint=old_user.creator_node_endpoint,
+    #     is_verified=old_user.is_verified,
+    #     handle_lc=old_user.handle_lc,
+    #     cover_photo_sizes=old_user.cover_photo_sizes,
+    #     profile_picture_sizes=old_user.profile_picture_sizes,
+    #     primary_id=old_user.primary_id,
+    #     secondary_ids=old_user.secondary_ids,
+    #     replica_set_update_signer=old_user.replica_set_update_signer,
+    #     has_collectibles=old_user.has_collectibles,
+    #     playlist_library=old_user.playlist_library,
+    #     is_deactivated=old_user.is_deactivated,
+    #     slot=old_user.slot,
+    #     user_storage_account=old_user.user_storage_account,
+    #     user_authority_account=old_user.user_authority_account,
+    #     updated_at=block_datetime,
+    #     blocknumber=block_number,
+    #     blockhash=event_blockhash,
+    #     txhash=txhash,
+    #     artist_pick_track_id=old_user.artist_pick_track_id,
+    #     is_current=False,
+    # )

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -1,4 +1,3 @@
-import inspect
 from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Set, Tuple, TypedDict
@@ -178,9 +177,9 @@ def copy_user_record(
     txhash: str,
     block_datetime: datetime,
 ):
-    old_user_attributes = inspect.getmembers(old_user)
+    old_user_attributes = old_user.get_attributes_dict()
     user_copy = User()
-    for key, value in old_user_attributes:
+    for key, value in old_user_attributes.items():
         if key == "is_current":
             setattr(user_copy, key, False)
         elif key == "updated_at":
@@ -194,36 +193,3 @@ def copy_user_record(
         else:
             setattr(user_copy, key, value)
     return user_copy
-
-    # return User(
-    #     user_id=old_user.user_id,
-    #     wallet=old_user.wallet,
-    #     created_at=old_user.created_at,
-    #     handle=old_user.handle,
-    #     name=old_user.name,
-    #     profile_picture=old_user.profile_picture,
-    #     cover_photo=old_user.cover_photo,
-    #     bio=old_user.bio,
-    #     location=old_user.location,
-    #     metadata_multihash=old_user.metadata_multihash,
-    #     creator_node_endpoint=old_user.creator_node_endpoint,
-    #     is_verified=old_user.is_verified,
-    #     handle_lc=old_user.handle_lc,
-    #     cover_photo_sizes=old_user.cover_photo_sizes,
-    #     profile_picture_sizes=old_user.profile_picture_sizes,
-    #     primary_id=old_user.primary_id,
-    #     secondary_ids=old_user.secondary_ids,
-    #     replica_set_update_signer=old_user.replica_set_update_signer,
-    #     has_collectibles=old_user.has_collectibles,
-    #     playlist_library=old_user.playlist_library,
-    #     is_deactivated=old_user.is_deactivated,
-    #     slot=old_user.slot,
-    #     user_storage_account=old_user.user_storage_account,
-    #     user_authority_account=old_user.user_authority_account,
-    #     updated_at=block_datetime,
-    #     blocknumber=block_number,
-    #     blockhash=event_blockhash,
-    #     txhash=txhash,
-    #     artist_pick_track_id=old_user.artist_pick_track_id,
-    #     is_current=False,
-    # )

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Set, Tuple, TypedDict
+from typing import Dict, List, Set, Tuple, TypedDict, Union
 
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.models.notifications.notification import NotificationSeen
@@ -170,7 +170,7 @@ def get_record_key(user_id: int, entity_type: str, entity_id: int):
     return (user_id, entity_type.capitalize(), entity_id)
 
 def copy_record(
-    old_record: User,
+    old_record: Union[User, Track],
     block_number: int,
     event_blockhash: str,
     txhash: str,

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -169,27 +169,26 @@ class ManageEntityParameters:
 def get_record_key(user_id: int, entity_type: str, entity_id: int):
     return (user_id, entity_type.capitalize(), entity_id)
 
-
-def copy_user_record(
-    old_user: User,
+def copy_record(
+    old_record: User,
     block_number: int,
     event_blockhash: str,
     txhash: str,
     block_datetime: datetime,
 ):
-    old_user_attributes = old_user.get_attributes_dict()
-    user_copy = User()
+    old_user_attributes = old_record.get_attributes_dict()
+    record_copy = type(old_record)()
     for key, value in old_user_attributes.items():
         if key == "is_current":
-            setattr(user_copy, key, False)
+            setattr(record_copy, key, False)
         elif key == "updated_at":
-            setattr(user_copy, key, block_datetime)
+            setattr(record_copy, key, block_datetime)
         elif key == "blocknumber":
-            setattr(user_copy, key, block_number)
+            setattr(record_copy, key, block_number)
         elif key == "blockhash":
-            setattr(user_copy, key, event_blockhash)
+            setattr(record_copy, key, event_blockhash)
         elif key == "txhash":
-            setattr(user_copy, key, txhash)
+            setattr(record_copy, key, txhash)
         else:
-            setattr(user_copy, key, value)
-    return user_copy
+            setattr(record_copy, key, value)
+    return record_copy


### PR DESCRIPTION
### Description
Use getattr to copy sqlalchemy objects in the entity manager rather than manually setting each field when instantiating an object.

### Tests
Unit test. Will test manually as well.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
EM logs