### PR TITLE
Add unclaimed user ID API

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -35,6 +35,7 @@ from src.queries.get_trending_playlists import (
     get_full_trending_playlists,
     get_trending_playlists,
 )
+from src.queries.get_unclaimed_id import get_unclaimed_id
 from src.queries.search_queries import SearchKind, search
 from src.trending_strategies.trending_strategy_factory import (
     DEFAULT_TRENDING_VERSIONS,
@@ -454,3 +455,13 @@ def playlist_stream(playlist_id):
         status=200,
         mimetype="application/mpegurl",
     )
+
+
+@ns.route("/unclaimed_id", doc=False)
+class GetUnclaimedPlaylistId(Resource):
+    @ns.doc(
+        id="""Get unclaimed playlist ID""",
+        description="""Gets an unclaimed blockchain playlist ID""",
+    )
+    def get(self):
+        return get_unclaimed_id("playlist")

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -63,6 +63,7 @@ from src.queries.get_tracks_including_unlisted import get_tracks_including_unlis
 from src.queries.get_trending import get_full_trending, get_trending
 from src.queries.get_trending_ids import get_trending_ids
 from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
+from src.queries.get_unclaimed_id import get_unclaimed_id
 from src.queries.get_underground_trending import get_underground_trending
 from src.queries.search_queries import SearchKind, search
 from src.trending_strategies.trending_strategy_factory import (
@@ -1329,3 +1330,13 @@ class SubsequentTrack(Resource):
 
         subsequent_tracks = get_subsequent_tracks(decoded_track_id, limit)
         return success_response(subsequent_tracks)
+
+
+@ns.route("/unclaimed_id", doc=False)
+class GetUnclaimedTrackId(Resource):
+    @ns.doc(
+        id="""Get unclaimed track ID""",
+        description="""Gets an unclaimed blockchain track ID""",
+    )
+    def get(self):
+        return get_unclaimed_id("track")

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -81,6 +81,7 @@ from src.queries.get_top_genre_users import get_top_genre_users
 from src.queries.get_top_user_track_tags import get_top_user_track_tags
 from src.queries.get_top_users import get_top_users
 from src.queries.get_tracks import GetTrackArgs, get_tracks
+from src.queries.get_unclaimed import get_unclaimed
 from src.queries.get_user_listen_counts_monthly import get_user_listen_counts_monthly
 from src.queries.get_user_listening_history import (
     GetUserListeningHistoryArgs,
@@ -1791,3 +1792,20 @@ class GetReplicaSet(FullGetReplicaSet):
     @ns.marshal_with(user_replica_set_response)
     def get(self, id: str):
         return super()._get(id)
+
+
+verify_token_response = make_response(
+    "verify_token", ns, fields.Nested(decoded_user_token)
+)
+
+UNCLAIMED_USER_ID = "/unclaimed_id"
+
+
+@ns.route(UNCLAIMED_USER_ID, doc=False)
+class GetUnclaimedUserId(Resource):
+    @ns.doc(
+        id="""Get unclaimed user ID""",
+        description="""Gets an unclaimed blockchain user ID""",
+    )
+    def get(self):
+        return get_unclaimed("user")

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -81,7 +81,7 @@ from src.queries.get_top_genre_users import get_top_genre_users
 from src.queries.get_top_user_track_tags import get_top_user_track_tags
 from src.queries.get_top_users import get_top_users
 from src.queries.get_tracks import GetTrackArgs, get_tracks
-from src.queries.get_unclaimed import get_unclaimed
+from src.queries.get_unclaimed_id import get_unclaimed_id
 from src.queries.get_user_listen_counts_monthly import get_user_listen_counts_monthly
 from src.queries.get_user_listening_history import (
     GetUserListeningHistoryArgs,
@@ -1798,14 +1798,12 @@ verify_token_response = make_response(
     "verify_token", ns, fields.Nested(decoded_user_token)
 )
 
-UNCLAIMED_USER_ID = "/unclaimed_id"
 
-
-@ns.route(UNCLAIMED_USER_ID, doc=False)
+@ns.route("/unclaimed_id", doc=False)
 class GetUnclaimedUserId(Resource):
     @ns.doc(
         id="""Get unclaimed user ID""",
         description="""Gets an unclaimed blockchain user ID""",
     )
     def get(self):
-        return get_unclaimed("user")
+        return get_unclaimed_id("user")

--- a/discovery-provider/src/queries/get_unclaimed.py
+++ b/discovery-provider/src/queries/get_unclaimed.py
@@ -1,10 +1,11 @@
-from random import randrange
+import random
 
 from src import exceptions
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.users.aggregate_user import AggregateUser
 from src.utils.db_session import get_db_read_replica
+from src.tasks.entity_manager.utils import TRACK_ID_OFFSET, PLAYLIST_ID_OFFSET, USER_ID_OFFSET
 
 MAX_USER_ID = 999999999  # max for reward specifier id
 MAX_POSTGRES_ID = 2147483647
@@ -21,9 +22,9 @@ def get_unclaimed(type):
     with db.scoped_session() as session:
         for _ in range(10):
             is_claimed = True
-            random_id = randrange(MAX_POSTGRES_ID)
+            random_id = None
             if type == "user":
-                random_id = randrange(MAX_USER_ID)
+                random_id = random.randint(USER_ID_OFFSET, MAX_USER_ID)
                 is_claimed = (
                     session.query(AggregateUser.user_id).filter(
                         AggregateUser.user_id == random_id
@@ -31,6 +32,8 @@ def get_unclaimed(type):
                 ).first()
 
             if type == "track":
+                random_id = random.randint(TRACK_ID_OFFSET, MAX_POSTGRES_ID)
+
                 is_claimed = (
                     session.query(AggregateTrack.track_id).filter(
                         AggregateTrack.track_id == random_id
@@ -38,6 +41,8 @@ def get_unclaimed(type):
                 ).first()
 
             if type == "playlist":
+                random_id = random.randint(PLAYLIST_ID_OFFSET, MAX_POSTGRES_ID)
+
                 is_claimed = (
                     session.query(AggregatePlaylist.playlist_id).filter(
                         AggregatePlaylist.playlist_id == random_id

--- a/discovery-provider/src/queries/get_unclaimed.py
+++ b/discovery-provider/src/queries/get_unclaimed.py
@@ -10,6 +10,7 @@ from src.tasks.entity_manager.utils import (
     USER_ID_OFFSET,
 )
 from src.utils.db_session import get_db_read_replica
+from src.utils.helpers import encode_int_id
 
 MAX_USER_ID = 999999999  # max for reward specifier id
 MAX_POSTGRES_ID = 2147483647
@@ -54,4 +55,4 @@ def get_unclaimed(type):
                 ).first()
 
             if not is_claimed:
-                return random_id
+                return encode_int_id(random_id)

--- a/discovery-provider/src/queries/get_unclaimed.py
+++ b/discovery-provider/src/queries/get_unclaimed.py
@@ -4,8 +4,12 @@ from src import exceptions
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.users.aggregate_user import AggregateUser
+from src.tasks.entity_manager.utils import (
+    PLAYLIST_ID_OFFSET,
+    TRACK_ID_OFFSET,
+    USER_ID_OFFSET,
+)
 from src.utils.db_session import get_db_read_replica
-from src.tasks.entity_manager.utils import TRACK_ID_OFFSET, PLAYLIST_ID_OFFSET, USER_ID_OFFSET
 
 MAX_USER_ID = 999999999  # max for reward specifier id
 MAX_POSTGRES_ID = 2147483647

--- a/discovery-provider/src/queries/get_unclaimed.py
+++ b/discovery-provider/src/queries/get_unclaimed.py
@@ -1,0 +1,48 @@
+from random import randrange
+
+from src import exceptions
+from src.models.playlists.aggregate_playlist import AggregatePlaylist
+from src.models.tracks.aggregate_track import AggregateTrack
+from src.models.users.aggregate_user import AggregateUser
+from src.utils.db_session import get_db_read_replica
+
+MAX_USER_ID = 999999999  # max for reward specifier id
+MAX_POSTGRES_ID = 2147483647
+
+
+def get_unclaimed(type):
+
+    if type not in ["track", "playlist", "user"]:
+        raise exceptions.ArgumentError(
+            "Invalid type provided, must be one of 'track', 'playlist', 'user'"
+        )
+
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        for _ in range(10):
+            is_claimed = True
+            random_id = randrange(MAX_POSTGRES_ID)
+            if type == "user":
+                random_id = randrange(MAX_USER_ID)
+                is_claimed = (
+                    session.query(AggregateUser.user_id).filter(
+                        AggregateUser.user_id == random_id
+                    )
+                ).first()
+
+            if type == "track":
+                is_claimed = (
+                    session.query(AggregateTrack.track_id).filter(
+                        AggregateTrack.track_id == random_id
+                    )
+                ).first()
+
+            if type == "playlist":
+                is_claimed = (
+                    session.query(AggregatePlaylist.playlist_id).filter(
+                        AggregatePlaylist.playlist_id == random_id
+                    )
+                ).first()
+
+            if not is_claimed:
+                return random_id

--- a/discovery-provider/src/queries/get_unclaimed_id.py
+++ b/discovery-provider/src/queries/get_unclaimed_id.py
@@ -16,7 +16,7 @@ MAX_USER_ID = 999999999  # max for reward specifier id
 MAX_POSTGRES_ID = 2147483647
 
 
-def get_unclaimed(type):
+def get_unclaimed_id(type):
 
     if type not in ["track", "playlist", "user"]:
         raise exceptions.ArgumentError(


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Add unclaimed ID API. Will be used in client/libs to fetch an unclaimed ID rather than optimistically generate one. 

After 10 tries if every randomly generated ID exists, it'll return null. The client will error appropriately.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->