### PR TITLE
Add copy320 cid to header

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 const express = require('express')
 const path = require('path')
 const fs = require('fs-extra')
@@ -930,6 +931,7 @@ router.get(
     req.params.CID = fileRecord.multihash
     req.params.streamable = true
     res.set('Content-Type', 'audio/mpeg')
+    res.set('Copy320-CID', fileRecord.multihash)
     next()
   },
   getCID

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
 const express = require('express')
 const path = require('path')
 const fs = require('fs-extra')


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This is used for the data backfill for simplicity in grabbing the cid associated with the copy320.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
No tests since it's just adding a header


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Hit `/tracks/stream/<encodedId>` and check the headers

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->