### PR TITLE
Reduce export batch size from 10k to 1000

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -591,7 +591,7 @@ const config = convict({
     doc: 'Maximum range of clock values to export at once to prevent process OOM',
     format: Number,
     env: 'maxExportClockValueRange',
-    default: 10000
+    default: 1000
   },
   nodeSyncFileSaveMaxConcurrency: {
     doc: 'Max concurrency of fetchFileFromNetworkAndSaveToFS calls inside nodesync',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
We see a few issues as a result of exports being 10k records including:
- statement connection timeout
- sql tx blocks and connections open for a while because CNodeUser is updated and the connection is held open while data is saved to disk
- sync wallet locks expiring and multiple sync operations running concurrently

The simplest way to alleviate this pressure is to lower the export batch size and do more requests with smaller amounts of data which means 
- transactions should commit quicker because it's less db operations at once
- tx's aren't held open as long because it's less data to fetch
- sync wallet locks should not expire (no way to guarantee this in either scenario though)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Mad dog and integration tests pass. Will also test on staging by updating a user replica set for a user with tens of thousands of records

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
Fully synced % should go up, particularly those with clock values in 10s to 100s of thousands


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->