### PR TITLE
Fix spl token indexer parsing

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_spl_token.py
+++ b/discovery-provider/integration_tests/tasks/test_index_spl_token.py
@@ -52,6 +52,25 @@ mock_create_account_meta = {
             }
         ],
         "preTokenBalances": [],
+        "logMessages": [
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+            "Program log: Transfer 2039280 lamports to the associated token account",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Allocate space for the associated token account",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Assign the associated token account to the SPL Token program",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Initialize the associated token account",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: InitializeAccount",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3272 of 176939 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 27014 of 200000 compute units",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+        ],
     },
     "transaction": {
         "message": {
@@ -214,14 +233,14 @@ def test_parse_spl_token_transaction():
     tx_info = parse_spl_token_transaction(
         solana_client_manager_mock, mock_confirmed_signature_for_address
     )
-    assert tx_info["user_bank"] == "9f79QvW5XQ1XCXGLeCCHjBZkPet51yAPxtU7fcaY6UxD"
+    assert tx_info["user_bank"] == "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9"
     assert tx_info["root_accounts"] == [
-        "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
         "iVsXfN4oZnARo6AYwm8FFXBnDQYnwhkPxJiuPHDzfJ4",
+        "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
     ]
     assert tx_info["token_accounts"] == [
-        "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9",
         "9f79QvW5XQ1XCXGLeCCHjBZkPet51yAPxtU7fcaY6UxD",
+        "7CyoHxibpPrTVc2AsmoSq7gRoDwnwN7LRnHDcR4yWVf9",
     ]
 
 
@@ -341,9 +360,125 @@ mock_purchase_meta = {
     },
 }
 
-mock_purchase_tx_info = {
+mock_purchase_meta_different_ordering = {
+    "blockTime": 1667410823,
+    "meta": {
+        "err": None,
+        "fee": 5000,
+        "innerInstructions": [],
+        "loadedAddresses": {"readonly": [], "writable": []},
+        "logMessages": [
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo invoke [1]",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo consumed 588 of 400000 compute units",
+            "Program Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6172 of 399412 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+        ],
+        "postBalances": [2930160, 2039280, 2039280, 260042654, 121159680, 934087680],
+        "postTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "AEty8wg5HqCJz7a8U8FS9sYXtCudYH93JLZgMfjCAR6u",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "0",
+                    "decimals": 8,
+                    "uiAmount": None,
+                    "uiAmountString": "0",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "12780604010",
+                    "decimals": 8,
+                    "uiAmount": 127.8060401,
+                    "uiAmountString": "127.8060401",
+                },
+            },
+        ],
+        "preBalances": [2935160, 2039280, 2039280, 260042654, 121159680, 934087680],
+        "preTokenBalances": [
+            {
+                "accountIndex": 1,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "AEty8wg5HqCJz7a8U8FS9sYXtCudYH93JLZgMfjCAR6u",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "1025896376",
+                    "decimals": 8,
+                    "uiAmount": 10.25896376,
+                    "uiAmountString": "10.25896376",
+                },
+            },
+            {
+                "accountIndex": 2,
+                "mint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "owner": "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+                "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "uiTokenAmount": {
+                    "amount": "11754707634",
+                    "decimals": 8,
+                    "uiAmount": 117.54707634,
+                    "uiAmountString": "117.54707634",
+                },
+            },
+        ],
+        "rewards": [],
+        "status": {"Ok": None},
+    },
+    "slot": 158882288,
+    "transaction": {
+        "message": {
+            "header": {
+                "numReadonlySignedAccounts": 0,
+                "numReadonlyUnsignedAccounts": 3,
+                "numRequiredSignatures": 1,
+            },
+            "accountKeys": [
+                "AEty8wg5HqCJz7a8U8FS9sYXtCudYH93JLZgMfjCAR6u",
+                "8aEJ32LCGaGbNbidd1Gg33yqvZ11AXfAzzEAXxAJEzA8",
+                "HTmKqU5T3uhzz6heG47awyVuzcbWu9o4rE1HtrXv5ACg",
+                "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+                "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo",
+                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            ],
+            "recentBlockhash": "23SZfDKbmSqtHaR9F2UMkRzTvvoTo8NT7oRH5VB3D5xh",
+            "instructions": [
+                {
+                    "accounts": [0],
+                    "data": "Bs2CZBUGWJZV5kqF3ecfJisidP9WQtCpeeWCzk6AUyYLQWgLdHPz",
+                    "programIdIndex": 4,
+                },
+                {
+                    "accounts": [1, 3, 2, 0],
+                    "data": "iTUiLjKABVyv7",
+                    "programIdIndex": 5,
+                },
+            ],
+            "indexToProgramIds": {},
+        },
+        "signatures": [
+            "iBTtH8W1ViHdnAzQYNKovYsBszHvikwUAG4V8Qk5HNWQRCYc468ugKnoYSqL6f7LLmbKa5ZYFSLaEbZuH42fbBM"
+        ],
+    },
+}
+
+mock_purchase_tx_info_1 = {
     "jsonrpc": "2.0",
     "result": mock_purchase_meta,
+    "id": 4,
+}
+
+mock_purchase_tx_info_2 = {
+    "jsonrpc": "2.0",
+    "result": mock_purchase_meta_different_ordering,
     "id": 4,
 }
 
@@ -355,6 +490,36 @@ def test_parse_memo_instruction():
     assert memo == "Bs2CZBUGWJZV5kqF3ecfJisidP9WQtCpeeWCzk6AUyYLQWgLdHPz"
     vendor = decode_memo_and_extract_vendor(memo)
     assert vendor == "Link by Stripe"
+
+
+def test_parse_spl_token_purchase_transactions():
+    solana_client_manager_mock = create_autospec(SolanaClientManager)
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_purchase_tx_info_1
+    tx_info = parse_spl_token_transaction(
+        solana_client_manager_mock, mock_confirmed_signature_for_address
+    )
+    assert tx_info["user_bank"] == "7dw7W4Yv7F1uWb9dVH1CFPm39mePyypuCji2zxcFA556"
+    assert tx_info["root_accounts"] == [
+        "GNkt1SGkdzvfaCYVpSKs7yjLxeyLJFKZv32cVYJ3GyHX",
+        "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+    ]
+    assert tx_info["token_accounts"] == [
+        "C4qrWm6kkLwUNExA2Ldt6uXLroRfcTGXJLx1zGvEt5DB",
+        "7dw7W4Yv7F1uWb9dVH1CFPm39mePyypuCji2zxcFA556",
+    ]
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_purchase_tx_info_2
+    tx_info = parse_spl_token_transaction(
+        solana_client_manager_mock, mock_confirmed_signature_for_address
+    )
+    assert tx_info["user_bank"] == "HTmKqU5T3uhzz6heG47awyVuzcbWu9o4rE1HtrXv5ACg"
+    assert tx_info["root_accounts"] == [
+        "AEty8wg5HqCJz7a8U8FS9sYXtCudYH93JLZgMfjCAR6u",
+        "5ZiE3vAkrdXBgyFL7KqG3RoEGBws4CjRcXVbABDLZTgx",
+    ]
+    assert tx_info["token_accounts"] == [
+        "8aEJ32LCGaGbNbidd1Gg33yqvZ11AXfAzzEAXxAJEzA8",
+        "HTmKqU5T3uhzz6heG47awyVuzcbWu9o4rE1HtrXv5ACg",
+    ]
 
 
 def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disable=W0621
@@ -442,7 +607,7 @@ def test_fetch_and_parse_sol_rewards_transfer_instruction(app):  # pylint: disab
         "blockTime": 1665685554,
         "confirmationStatus": "finalized",
     }
-    solana_client_manager_mock.get_sol_tx_info.return_value = mock_purchase_tx_info
+    solana_client_manager_mock.get_sol_tx_info.return_value = mock_purchase_tx_info_1
     parse_sol_tx_batch(
         db,
         solana_client_manager_mock,

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -43,7 +43,7 @@ from src.utils.helpers import (
     get_solana_tx_owner,
     get_solana_tx_token_balances,
     get_valid_instruction,
-    has_instruction,
+    has_log,
 )
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
@@ -155,9 +155,7 @@ def parse_spl_token_transaction(
         if error:
             return None
 
-        has_transfer_checked_instruction = has_instruction(
-            meta, TRANSFER_CHECKED_INSTRUCTION
-        )
+        has_transfer_checked_instruction = has_log(meta, TRANSFER_CHECKED_INSTRUCTION)
         if not has_transfer_checked_instruction:
             logger.info(
                 f"index_spl_token.py | {tx_sig} No transfer checked instruction found"
@@ -185,7 +183,9 @@ def parse_spl_token_transaction(
 
         # Balance is expected to change if there is a transfer instruction.
         if postbalance == -1 or prebalance == -1:
-            logger.error(f"index_spl_token.py | {tx_sig} error while parsing pre and post balances")
+            logger.error(
+                f"index_spl_token.py | {tx_sig} error while parsing pre and post balances"
+            )
             return None
         if postbalance - prebalance == 0:
             logger.error(f"index_spl_token.py | {tx_sig} no balance change found")

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -157,7 +157,7 @@ def parse_spl_token_transaction(
 
         has_transfer_checked_instruction = has_log(meta, TRANSFER_CHECKED_INSTRUCTION)
         if not has_transfer_checked_instruction:
-            logger.info(
+            logger.error(
                 f"index_spl_token.py | {tx_sig} No transfer checked instruction found"
             )
             return None

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -481,9 +481,6 @@ def process_spl_token_tx(
             limit=FETCH_TX_SIGNATURES_BATCH_SIZE,
         )
         solana_logger.add_log(f"Retrieved transactions before {last_tx_signature}")
-        logger.info(
-            f"index_spl_token.py | Retrieved transactions before {last_tx_signature}"
-        )
         transactions_array = transactions_history["result"]
         if not transactions_array:
             # This is considered an 'intersection' since there are no further transactions to process but

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -181,13 +181,11 @@ def process_transfer_instruction(
         )
         return
 
-    sender_index = instruction["accounts"][TRANSFER_SENDER_ACCOUNT_INDEX]
-    receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
     pre_sender_balance, post_sender_balance = get_solana_tx_token_balances(
-        meta, sender_index
+        meta, sender_idx
     )
     pre_receiver_balance, post_receiver_balance = get_solana_tx_token_balances(
-        meta, receiver_index
+        meta, receiver_idx
     )
     if (
         pre_sender_balance is None

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -38,7 +38,6 @@ from src.solana.solana_transaction_types import (
     ConfirmedTransaction,
     ResultMeta,
     TransactionInfoResult,
-    TransactionMessage,
     TransactionMessageInstruction,
 )
 from src.tasks.celery_app import celery
@@ -47,7 +46,12 @@ from src.utils.cache_solana_program import (
     fetch_and_cache_latest_program_tx_redis,
 )
 from src.utils.config import shared_config
-from src.utils.helpers import get_solana_tx_token_balances
+from src.utils.helpers import (
+    get_account_index,
+    get_solana_tx_token_balances,
+    get_valid_instruction,
+    has_instruction,
+)
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
     latest_sol_user_bank_db_tx_key,
@@ -148,12 +152,11 @@ def process_transfer_instruction(
     challenge_event_bus: ChallengeEventBus,
     timestamp: datetime.datetime,
 ):
-    # The transaction might list sender/receiver in a different order in the pubKeys.
-    # The "accounts" field of the instruction has the mapping of accounts to pubKey index
-    sender_index = instruction["accounts"][TRANSFER_SENDER_ACCOUNT_INDEX]
-    receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
-    sender_account = account_keys[sender_index]
-    receiver_account = account_keys[receiver_index]
+    sender_idx = get_account_index(instruction, TRANSFER_SENDER_ACCOUNT_INDEX)
+    receiver_idx = get_account_index(instruction, TRANSFER_RECEIVER_ACCOUNT_INDEX)
+    sender_account = account_keys[sender_idx]
+    receiver_account = account_keys[receiver_idx]
+
     # Accounts to refresh balance
     logger.info(
         f"index_user_bank.py | Balance refresh accounts: {sender_account}, {receiver_account}"
@@ -178,6 +181,8 @@ def process_transfer_instruction(
         )
         return
 
+    sender_index = instruction["accounts"][TRANSFER_SENDER_ACCOUNT_INDEX]
+    receiver_index = instruction["accounts"][TRANSFER_RECEIVER_ACCOUNT_INDEX]
     pre_sender_balance, post_sender_balance = get_solana_tx_token_balances(
         meta, sender_index
     )
@@ -290,30 +295,6 @@ def parse_create_token_data(data: str) -> CreateTokenAccount:
     return parse_instruction_data(data, create_token_account_instr)
 
 
-def get_valid_instruction(
-    tx_message: TransactionMessage, meta: ResultMeta
-) -> Optional[TransactionMessageInstruction]:
-    """Checks that the tx is valid
-    checks for the transaction message for correct instruction log
-    checks accounts keys for claimable token program
-    """
-    try:
-        account_keys = tx_message["accountKeys"]
-        instructions = tx_message["instructions"]
-        user_bank_program_index = account_keys.index(USER_BANK_ADDRESS)
-        for instruction in instructions:
-            if instruction["programIdIndex"] == user_bank_program_index:
-                return instruction
-
-        return None
-    except Exception as e:
-        logger.error(
-            f"index_user_bank.py | Error processing instruction valid, {e}",
-            exc_info=True,
-        )
-        return None
-
-
 def process_user_bank_tx_details(
     session: Session,
     redis: Redis,
@@ -334,18 +315,17 @@ def process_user_bank_tx_details(
     tx_message = result["transaction"]["message"]
 
     # Check for valid instruction
-    has_create_token_instruction = any(
-        log == "Program log: Instruction: CreateTokenAccount"
-        for log in meta["logMessages"]
+    has_create_token_instruction = has_instruction(
+        meta, "Program log: Instruction: CreateTokenAccount"
     )
-    has_transfer_instruction = any(
-        log == "Program log: Instruction: Transfer" for log in meta["logMessages"]
+    has_transfer_instruction = has_instruction(
+        meta, "Program log: Instruction: Transfer"
     )
 
     if not has_create_token_instruction and not has_transfer_instruction:
         return
 
-    instruction = get_valid_instruction(tx_message, meta)
+    instruction = get_valid_instruction(tx_message, meta, USER_BANK_ADDRESS)
     if instruction is None:
         logger.error(f"index_user_bank.py | {tx_sig} No Valid instruction found")
         return

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -50,7 +50,7 @@ from src.utils.helpers import (
     get_account_index,
     get_solana_tx_token_balances,
     get_valid_instruction,
-    has_instruction,
+    has_log,
 )
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
@@ -315,12 +315,10 @@ def process_user_bank_tx_details(
     tx_message = result["transaction"]["message"]
 
     # Check for valid instruction
-    has_create_token_instruction = has_instruction(
+    has_create_token_instruction = has_log(
         meta, "Program log: Instruction: CreateTokenAccount"
     )
-    has_transfer_instruction = has_instruction(
-        meta, "Program log: Instruction: Transfer"
-    )
+    has_transfer_instruction = has_log(meta, "Program log: Instruction: Transfer")
 
     if not has_create_token_instruction and not has_transfer_instruction:
         return

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -548,12 +548,52 @@ def get_valid_instruction(
     return None
 
 
-def has_instruction(meta: ResultMeta, instruction: str):
+def has_log(meta: ResultMeta, instruction: str):
     return any(log == instruction for log in meta["logMessages"])
 
 
 # The transaction might list sender/receiver in a different order in the pubKeys.
 # The "accounts" field of the instruction has the mapping of accounts to pubKey index
+# Example of transaction JSON returned from solana getTransaction():
+# Eg: accounts[0] = 1, so to look up pre and post balances for
+# 3Y7gfpxeniGVyVC93CrK42tD4GFSt6gxTW2xfFzKqxVt, look for accountIndex: 1
+# "transaction": {
+#     "message": {
+#         "header": {
+#             "numReadonlySignedAccounts": 0,
+#             "numReadonlyUnsignedAccounts": 3,
+#             "numRequiredSignatures": 1
+#         },
+#         "accountKeys": [
+#             "FFQB4iQRXWqQHDRbpixXyGoufw8qdVt8SDLuFzZSZZka",
+#             "3Y7gfpxeniGVyVC93CrK42tD4GFSt6gxTW2xfFzKqxVt",
+#             "E2LCbKdo2L3ikt1gK6pwp1pDLuhAfHBNf6fEQXpAqrf9",
+#             "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+#             "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo",
+#             "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+#         ],
+#         "recentBlockhash": "22F56uRSayJV1AKMN5jiim5xyGCxvShamW4VrZyfgM9U",
+#         "instructions": [
+#             {
+#             "accounts": [
+#                 0
+#             ],
+#             "data": "Bs2CZBUGWJZV5kqF3ecfJisidP9WQtCpeeWCzk6AUyYLQWgLdHPz",
+#             "programIdIndex": 4
+#             },
+#             {
+#             "accounts": [
+#                 1,
+#                 3,
+#                 2,
+#                 0
+#             ],
+#             "data": "ixUKHa1t4JYGF",
+#             "programIdIndex": 5
+#             }
+#       ],
+#       "indexToProgramIds": {}
+#     },
 def get_account_index(instruction: TransactionMessageInstruction, index: int):
     return instruction["accounts"][index]
 

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -16,6 +16,11 @@ from hashids import Hashids
 from jsonformatter import JsonFormatter
 from sqlalchemy import inspect
 from src import exceptions
+from src.solana.solana_transaction_types import (
+    ResultMeta,
+    TransactionMessage,
+    TransactionMessageInstruction,
+)
 from src.utils import redis_connection
 from src.utils.redis_constants import final_poa_block_redis_key
 
@@ -524,6 +529,33 @@ def get_solana_tx_owner(meta, idx) -> str:
         ),
         "",
     )
+
+
+def get_valid_instruction(
+    tx_message: TransactionMessage, meta: ResultMeta, program_address: str
+) -> Optional[TransactionMessageInstruction]:
+    """Checks that the tx is valid
+    checks for the transaction message for correct instruction log
+    checks accounts keys for claimable token program
+    """
+    account_keys = tx_message["accountKeys"]
+    instructions = tx_message["instructions"]
+    program_index = account_keys.index(program_address)
+    for instruction in instructions:
+        if instruction["programIdIndex"] == program_index:
+            return instruction
+
+    return None
+
+
+def has_instruction(meta: ResultMeta, instruction: str):
+    return any(log == instruction for log in meta["logMessages"])
+
+
+# The transaction might list sender/receiver in a different order in the pubKeys.
+# The "accounts" field of the instruction has the mapping of accounts to pubKey index
+def get_account_index(instruction: TransactionMessageInstruction, index: int):
+    return instruction["accounts"][index]
 
 
 def get_final_poa_block(shared_config) -> Optional[int]:


### PR DESCRIPTION
### Description
Fix the parsing function in spl token indexer to lookup account indices correctly (same way as we do in `index_user_bank.py`). This was the bug that was causing us to skip certain transactions if `accountKeys` were not in a specific order.


### Tests
Updated spl token indexer unit test to include 2 purchase transactions with different `accountKeys` ordering.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->