### PR TITLE
Skip txs with unsupported versions in spl token indexer

### DIFF
--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -14,6 +14,12 @@ class NotFoundError(Base):
     pass  # pylint: disable=W0107
 
 
+class UnsupportedVersionError(Base):
+    """Invalid arguments passed to request"""
+
+    pass  # pylint: disable=W0107
+
+
 class MissingEthRecipientError(Base):
     """Exception raised for missing eth recipient error while indexing
     Attributes:

--- a/discovery-provider/src/exceptions.py
+++ b/discovery-provider/src/exceptions.py
@@ -15,7 +15,7 @@ class NotFoundError(Base):
 
 
 class UnsupportedVersionError(Base):
-    """Invalid arguments passed to request"""
+    """Unsupported Solana transaction version"""
 
     pass  # pylint: disable=W0107
 

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -54,6 +54,8 @@ class SolanaClientManager:
                     _check_unsupported_version(tx_info, tx_sig)
                     if tx_info["result"] is not None:
                         return tx_info
+                # We currently only support "legacy" solana transactions. If we encounter
+                # a newer version, raise this specific error so that it can be handled upstream.
                 except UnsupportedVersionError as e:
                     raise e
                 except Exception as e:

--- a/discovery-provider/src/tasks/index_spl_token.py
+++ b/discovery-provider/src/tasks/index_spl_token.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional, Set, TypedDict
 import base58
 from redis import Redis
 from solana.publickey import PublicKey
+from src.exceptions import UnsupportedVersionError
 from src.models.indexing.spl_token_transaction import SPLTokenTransaction
 from src.models.users.associated_wallet import AssociatedWallet, WalletChain
 from src.models.users.audio_transactions_history import (
@@ -175,6 +176,8 @@ def parse_spl_token_transaction(
         }
         return receiver_spl_tx_info
 
+    except UnsupportedVersionError:
+        return None
     except Exception as e:
         signature = tx_sig["signature"]
         logger.error(

--- a/discovery-provider/src/tasks/index_spl_token_backfill.py
+++ b/discovery-provider/src/tasks/index_spl_token_backfill.py
@@ -10,6 +10,7 @@ from redis import Redis
 from solana.publickey import PublicKey
 from sqlalchemy import and_, asc, desc, or_
 from sqlalchemy.orm.session import Session
+from src.exceptions import UnsupportedVersionError
 from src.models.indexing.indexing_checkpoints import IndexingCheckpoint
 from src.models.indexing.spl_token_backfill_transaction import (
     SPLTokenBackfillTransaction,
@@ -177,6 +178,8 @@ def parse_spl_token_transaction(
         }
         return receiver_spl_tx_info
 
+    except UnsupportedVersionError:
+        return None
     except Exception as e:
         signature = tx_sig["signature"]
         logger.error(


### PR DESCRIPTION
### Description
Adds an exception for when an indexer encounters a solana transaction with an unsupported version. Example: https://solscan.io/tx/22sVpjeQ4tm13kSwA8QoiQ5b7q1V3JBqSFbkRoDR87fu834zCzxeCmX894vtPG6ypQLnxxvmZ3KpxwntcL8wyqxL


### Tests
Tested on remote-dev


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Outputs a log line when encountered.