### PR TITLE
Backfill missing spl-token transactions

### DIFF
--- a/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
+++ b/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
@@ -6,6 +6,7 @@ Create Date: 2022-12-05 20:30:57.288526
 
 """
 import os
+import shutil
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -41,14 +42,17 @@ def upgrade():
     connection.execute(query)
 
     path_zip = Path(__file__).parent.joinpath(
-        "../tmp/audio_transactions_history.csv.zip"
+        "../audio_transactions_csv/audio_transactions_history.csv.zip"
     )
-    path_csv = Path(__file__).parent.joinpath("../tmp/audio_transactions_history.csv")
-    path_tmp = Path(__file__).parent.joinpath("../tmp")
-    if os.path.isfile(path_zip):
-        os.rmdir(path_tmp)
-
+    path_csv = Path(__file__).parent.joinpath(
+        "../audio_transactions_csv/audio_transactions_history.csv"
+    )
+    path_tmp = Path(__file__).parent.joinpath("../audio_transactions_csv")
+    if os.path.isdir(path_tmp):
+        shutil.rmtree(path_tmp)
     os.mkdir(path_tmp)
+
+    print(path_tmp)
     aws_url = "https://s3.us-west-1.amazonaws.com/download.audius.co/audio_transactions_history.csv.zip"
     print(f"Migration - downloading {aws_url}")
     urllib.request.urlretrieve(aws_url, path_zip)
@@ -59,9 +63,8 @@ def upgrade():
     cursor = connection.connection.cursor()
     with open(path_csv, "r") as f:
         cursor.copy_from(f, "audio_transactions_history", sep=",")
-    os.remove(path_zip)
-    os.remove(path_csv)
-    os.rmdir(path_tmp)
+    if os.path.isdir(path_tmp):
+        shutil.rmtree(path_tmp)
 
 
 def downgrade():

--- a/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
+++ b/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
@@ -52,7 +52,6 @@ def upgrade():
         shutil.rmtree(path_tmp)
     os.mkdir(path_tmp)
 
-    print(path_tmp)
     aws_url = "https://s3.us-west-1.amazonaws.com/download.audius.co/audio_transactions_history.csv.zip"
     print(f"Migration - downloading {aws_url}")
     urllib.request.urlretrieve(aws_url, path_zip)

--- a/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
+++ b/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
@@ -45,6 +45,9 @@ def upgrade():
     )
     path_csv = Path(__file__).parent.joinpath("../tmp/audio_transactions_history.csv")
     path_tmp = Path(__file__).parent.joinpath("../tmp")
+    if os.path.isfile(path_zip):
+        os.rmdir(path_tmp)
+
     os.mkdir(path_tmp)
     aws_url = "https://s3.us-west-1.amazonaws.com/download.audius.co/audio_transactions_history.csv.zip"
     print(f"Migration - downloading {aws_url}")

--- a/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
+++ b/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
@@ -26,11 +26,17 @@ def upgrade():
         return
 
     connection = op.get_bind()
-    query = """
-        delete from audio_transactions_history where slot < 164000000;
+    # Highest slot for user_bank and rewards_manager txs in audio_transactions_history table
+    max_backfill_slot = 164000000
+    # Highest slot for spl_token txs in audio_transactions_history table
+    latest_spl_token_slot = 1
+    latest_spl_token_sig = "adsf"
+    query = f"""
+        delete from audio_transactions_history where slot < {max_backfill_slot};
         delete from audio_transactions_history where
         ((transaction_type in ('purchase_stripe', 'purchase_unknown', 'purchase_coinbase'))
-        or (transaction_type = 'transfer' and method = 'receive')) and slot > 164000000;
+        or (transaction_type = 'transfer' and method = 'receive')) and slot > {max_backfill_slot};
+        update spl_token_tx set last_scanned_slot = {latest_spl_token_slot}, signature = '{latest_spl_token_sig}';
     """
     connection.execute(query)
 

--- a/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
+++ b/discovery-provider/alembic/versions/7b843f2d3a0d_load_audio_transactions_csv.py
@@ -29,8 +29,8 @@ def upgrade():
     # Highest slot for user_bank and rewards_manager txs in audio_transactions_history table
     max_backfill_slot = 164000000
     # Highest slot for spl_token txs in audio_transactions_history table
-    latest_spl_token_slot = 1
-    latest_spl_token_sig = "adsf"
+    latest_spl_token_slot = 165961521
+    latest_spl_token_sig = "8iwjvTmHn8Q7ssB35SGnnayLj5UyYZNxvqMyAqUCy9sZ"
     query = f"""
         delete from audio_transactions_history where slot < {max_backfill_slot};
         delete from audio_transactions_history where


### PR DESCRIPTION
### Description
Deletes all spl-token transactions in `audio_transactions_history` table and backfills them with data from a csv file.

Since v1 of this migration hasn't made it out to foundation nodes or SPs yet, I figured it would be easier to backfill all the data at once, instead of adding a separate migration for just the missing spl token transactions.

### Tests
Tested v1 of the migration on prod DN 4, so we know downloading, unzipping, and copying the csv data works. Tested the query manually in navicat. Tested e2e on prod DN 4.
