### PR TITLE
Add libs is playlist upload to metadata

### DIFF
--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -134,6 +134,10 @@
                             }
                         ]
                     }
+                },
+                "is_playlist_upload": {
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "required": [
@@ -159,7 +163,8 @@
                 "title",
                 "track_segments",
                 "is_premium",
-                "premium_conditions"
+                "premium_conditions",
+                "is_playlist_upload"
             ],
             "title": "Track"
         },

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -155,6 +155,8 @@ export type TrackMetadata = {
   // Added fields
   dateListened?: string
   duration: number
+
+  is_playlist_upload?: boolean
 }
 
 export type CollectionMetadata = {


### PR DESCRIPTION
### Description
Libs changes to add extra field to track upload metadata used for notifications
NOTE: There is a corresponding client change to utilize these changes

Fixes PLAT-526

### Tests
Ran locally and validated that it wrote with the extra field

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->