### PR TITLE
Delete spl token indexer lock on startup

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -606,6 +606,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("index_user_listening_history_lock")
     redis_inst.delete("prune_plays_lock")
     redis_inst.delete("update_aggregate_table:aggregate_user_tips")
+    redis_inst.delete("spl_token_lock")
     redis_inst.delete("spl_token_backfill_lock")
     redis_inst.delete("profile_challenge_backfill_lock")
     redis_inst.delete("backfill_cid_data_lock")


### PR DESCRIPTION
### Description
Delete the lock on startup to avoid stalling the indexer.

### Tests
Tested on remote-dev


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
