### PR TITLE
Discovery notification on track/playlist creation

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_playlist.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_playlist.sql
@@ -2,6 +2,7 @@ create or replace function handle_playlist() returns trigger as $$
 declare
   track_owner_id int := 0;
   track_item json;
+  subscriber_user_ids integer[];
 begin
 
   insert into aggregate_user (user_id) values (new.playlist_owner_id) on conflict do nothing;
@@ -32,6 +33,38 @@ begin
     )
     where user_id = new.playlist_owner_id;
   end if;
+
+  -- Create playlist notification
+  begin
+    if new.created_at = new.updated_at AND 
+    new.is_private = FALSE AND 
+    new.is_delete = FALSE then
+      select array(
+        select subscriber_id 
+          from subscriptions 
+          where is_current and 
+          not is_delete and 
+          user_id=new.playlist_owner_id
+      ) into subscriber_user_ids;
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.playlist_owner_id,
+          'create:playlist_id:' || new.playlist_id,
+          json_build_object('playlist_id', new.playlist_id, 'is_album', new.is_album)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+		when others then raise;
+	end;
 
   begin
     if new.is_delete IS FALSE and new.is_private IS FALSE then

--- a/discovery-provider/alembic/trigger_sql/handle_playlist.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_playlist.sql
@@ -63,7 +63,7 @@ begin
       end if;
     end if;
 	exception
-		when others then raise;
+		when others then null;
 	end;
 
   begin

--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -38,7 +38,6 @@ begin
           user_id=new.owner_id
       ) into subscriber_user_ids;
 
-
       if array_length(subscriber_user_ids, 1)	> 0 then
         insert into notification
           (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
@@ -56,7 +55,7 @@ begin
       end if;
     end if;
 	exception
-		when others then RAISE;
+		when others then null;
 	end;
 
   -- If remix, create notification
@@ -84,7 +83,7 @@ begin
       end if;
     end if;
 	exception
-		when others then RAISE WARNING 'failed in create remix notif';
+		when others then null;
 	end;
 
   return null;

--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -4,6 +4,7 @@ declare
   new_val int;
   delta int := 0;
   parent_track_owner_id int;
+  subscriber_user_ids int[];
 begin
   insert into aggregate_track (track_id) values (new.track_id) on conflict do nothing;
   insert into aggregate_user (user_id) values (new.owner_id) on conflict do nothing;
@@ -22,9 +23,49 @@ begin
   where user_id = new.owner_id
   ;
 
+  -- If new track, create notification
+  begin
+    if new.is_unlisted = FALSE AND 
+    new.is_available = True AND 
+    new.is_delete = FALSE AND 
+    new.is_playlist_upload = FALSE AND
+    new.stem_of IS NULL THEN
+      select array(
+        select subscriber_id 
+          from subscriptions 
+          where is_current and 
+          not is_delete and 
+          user_id=new.owner_id
+      ) into subscriber_user_ids;
+
+
+      if array_length(subscriber_user_ids, 1)	> 0 then
+        insert into notification
+          (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        values
+        (
+          new.blocknumber,
+          subscriber_user_ids,
+          new.updated_at,
+          'create',
+          new.owner_id,
+          'create:track:' || new.track_id,
+          json_build_object('track_id', new.track_id)
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+	exception
+		when others then RAISE;
+	end;
+
   -- If remix, create notification
   begin
-    if new.remix_of is not null AND new.is_unlisted = FALSE and new.is_available = true AND new.is_delete = FALSE AND new.stem_of IS NULL then
+    if new.remix_of is not null AND
+    new.is_unlisted = FALSE AND
+    new.is_available = true AND
+    new.is_delete = FALSE AND
+    new.stem_of IS NULL then
       select owner_id into parent_track_owner_id from tracks where is_current and track_id = (new.remix_of->'tracks'->0->>'parent_track_id')::int limit 1;
       if parent_track_owner_id is not null then
         insert into notification
@@ -43,7 +84,7 @@ begin
       end if;
     end if;
 	exception
-		when others then null;
+		when others then RAISE WARNING 'failed in create remix notif';
 	end;
 
   return null;

--- a/discovery-provider/alembic/versions/f6f009132212_add_track_is_playlist_upload.py
+++ b/discovery-provider/alembic/versions/f6f009132212_add_track_is_playlist_upload.py
@@ -1,0 +1,41 @@
+
+"""add track is playlist upload
+
+Revision ID: f6f009132212
+Revises: 7b843f2d3a0d
+Create Date: 2022-12-13 16:54:11.916053
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from src.utils.alembic_helpers import build_sql
+
+# revision identifiers, used by Alembic.
+revision = 'f6f009132212'
+down_revision = '7b843f2d3a0d'
+branch_labels = None
+depends_on = None
+
+up_files = [
+    "handle_playlist.sql",
+    "handle_track.sql",
+]
+
+
+def upgrade():
+    op.add_column(
+        "tracks",
+        sa.Column("is_playlist_upload", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    connection = op.get_bind()
+    connection.execute(build_sql(up_files))
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    op.drop_column("tracks", "premium_conditions")
+    sql = build_sql(up_files)
+    connection = op.get_bind()
+    connection.execute(sql)

--- a/discovery-provider/integration_tests/notifications/test_playlist.py
+++ b/discovery-provider/integration_tests/notifications/test_playlist.py
@@ -74,6 +74,7 @@ def test_playlist_track_added_notification(app):
         assert notifications[1].data == {"track_id": 30, "playlist_id": 0}
         assert notifications[1].user_ids == [15]
 
+
 # ========================================== Start Tests ==========================================
 def test_playlist_create_notification(app):
     with app.app_context():
@@ -82,8 +83,8 @@ def test_playlist_create_notification(app):
     # Insert Playlist with two new tracks and check that a notificaiton is created for the track owners
     now = datetime.now()
     entities = {
-        "users": [{"user_id": i+1} for i in range(5)],
-        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)]
+        "users": [{"user_id": i + 1} for i in range(5)],
+        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)],
     }
     populate_mock_db(db, entities)
 
@@ -110,17 +111,12 @@ def test_playlist_create_notification(app):
     with db.scoped_session() as session:
 
         notifications: List[Notification] = (
-            session.query(Notification)
-            .filter(Notification.type == 'create')
-            .all()
+            session.query(Notification).filter(Notification.type == "create").all()
         )
         assert len(notifications) == 1
-        assert (
-            notifications[0].group_id
-            == "create:playlist_id:1"
-        )
+        assert notifications[0].group_id == "create:playlist_id:1"
         assert notifications[0].specifier == "1"
         assert notifications[0].type == "create"
         assert notifications[0].slot == None
-        assert notifications[0].data == { "playlist_id": 1, "is_album": False}
+        assert notifications[0].data == {"playlist_id": 1, "is_album": False}
         assert notifications[0].user_ids == list(range(1, 5))

--- a/discovery-provider/integration_tests/notifications/test_track.py
+++ b/discovery-provider/integration_tests/notifications/test_track.py
@@ -44,3 +44,40 @@ def test_track_remix_notification(app):
             "track_id": 100,
         }
         assert notification.user_ids == [1]
+
+
+def test_track_create_notification(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "users": [{"user_id": i+1} for i in range(5)],
+        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)]
+    }
+    populate_mock_db(db, entities)
+    entities = {
+        "tracks": [
+            {"track_id": 20, "owner_id": 1},
+            {"track_id": 21, "owner_id": 1, "is_playlist_upload": True},
+            {"track_id": 2, "owner_id": 2}
+        ],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+
+        notifications: List[Notification] = (
+            session.query(Notification)
+            .filter(Notification.type == "create")
+            .all()
+        )
+        assert len(notifications) == 1
+        notification = notifications[0]
+        assert notification.specifier == "1"
+        assert notification.group_id == "create:track:20"
+        assert notification.type == "create"
+        assert notification.slot == None
+        assert notification.data == {
+            "track_id": 20,
+        }
+        assert notification.user_ids == list(range(1, 5))

--- a/discovery-provider/integration_tests/notifications/test_track.py
+++ b/discovery-provider/integration_tests/notifications/test_track.py
@@ -51,15 +51,15 @@ def test_track_create_notification(app):
         db = get_db()
 
     entities = {
-        "users": [{"user_id": i+1} for i in range(5)],
-        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)]
+        "users": [{"user_id": i + 1} for i in range(5)],
+        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)],
     }
     populate_mock_db(db, entities)
     entities = {
         "tracks": [
             {"track_id": 20, "owner_id": 1},
             {"track_id": 21, "owner_id": 1, "is_playlist_upload": True},
-            {"track_id": 2, "owner_id": 2}
+            {"track_id": 2, "owner_id": 2},
         ],
     }
     populate_mock_db(db, entities)
@@ -67,9 +67,7 @@ def test_track_create_notification(app):
     with db.scoped_session() as session:
 
         notifications: List[Notification] = (
-            session.query(Notification)
-            .filter(Notification.type == "create")
-            .all()
+            session.query(Notification).filter(Notification.type == "create").all()
         )
         assert len(notifications) == 1
         notification = notifications[0]

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -121,6 +121,7 @@ def test_index_valid_track(app, mocker):
             "updated_at": "2020-07-11 08:22:15",
             "release_date": "Sat Jul 11 2020 01:19:58 GMT-0700",
             "file_type": None,
+            "is_playlist_upload": True,
             "track_segments": [
                 {
                     "duration": 6.016,

--- a/discovery-provider/integration_tests/tasks/test_index_tracks.py
+++ b/discovery-provider/integration_tests/tasks/test_index_tracks.py
@@ -117,6 +117,7 @@ cid_metadata_client = CIDMetadataClient(
             "has_current_user_reposted": False,
             "is_current": True,
             "is_unlisted": False,
+            "is_playlist_upload": False,
             "field_visibility": {
                 "mood": True,
                 "tags": True,
@@ -148,6 +149,7 @@ cid_metadata_client = CIDMetadataClient(
             "title": "real magic bassy flip 2",
             "length": None,
             "cover_art": None,
+            "is_playlist_upload": False,
             "cover_art_sizes": "QmdxhDiRUC3zQEKqwnqksaSsSSeHiRghjwKzwoRvm77yaZ",
             "tags": "realmagic,rickyreed,theroom",
             "genre": "R&B/Soul",
@@ -304,6 +306,7 @@ def test_index_tracks(mock_index_task, app):
         assert track_record.track_segments == track_metadata["track_segments"]
         assert track_record.is_unlisted == track_metadata["is_unlisted"]
         assert track_record.field_visibility == track_metadata["field_visibility"]
+        assert track_record.is_playlist_upload == track_metadata["is_playlist_upload"]
         assert track_record.remix_of == track_metadata["remix_of"]
         assert track_record.download == {
             "is_downloadable": track_metadata["download"].get("is_downloadable")

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -180,6 +180,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 is_unlisted=track_meta.get("is_unlisted", False),
                 is_premium=track_meta.get("is_premium", False),
                 premium_conditions=track_meta.get("premium_conditions", None),
+                is_playlist_upload=track_meta.get("is_playlist_upload", False),
             )
             session.add(track)
         for i, playlist_meta in enumerate(playlists):

--- a/discovery-provider/src/models/tracks/track.py
+++ b/discovery-provider/src/models/tracks/track.py
@@ -69,6 +69,7 @@ class Track(Base, RepresentableMixin):
     is_available = Column(Boolean, nullable=False, server_default=text("true"))
     is_premium = Column(Boolean, nullable=False, server_default=text("false"))
     premium_conditions = Column(JSONB())
+    is_playlist_upload = Column(Boolean, nullable=False, server_default=text("false"))
 
     block = relationship(  # type: ignore
         "Block", primaryjoin="Track.blockhash == Block.blockhash"

--- a/discovery-provider/src/tasks/metadata.py
+++ b/discovery-provider/src/tasks/metadata.py
@@ -92,6 +92,7 @@ track_metadata_format: TrackMetadata = {
     "stem_of": None,
     "is_premium": False,
     "premium_conditions": None,
+    "is_playlist_upload": False,
 }
 
 # Required format for user metadata retrieved from the content system

--- a/discovery-provider/src/tasks/metadata.py
+++ b/discovery-provider/src/tasks/metadata.py
@@ -63,6 +63,7 @@ class TrackMetadata(TypedDict):
     stem_of: Optional[TrackStem]
     is_premium: Optional[bool]
     premium_conditions: Optional[Any]
+    is_playlist_upload: Optional[bool]
 
 
 track_metadata_format: TrackMetadata = {

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -493,6 +493,7 @@ def populate_track_record_metadata(track_record, track_metadata, handle):
     track_record.field_visibility = track_metadata["field_visibility"]
 
     track_record.is_premium = track_metadata["is_premium"]
+    track_record.is_playlist_upload = track_metadata["is_playlist_upload"] if "is_playlist_upload" in track_metadata else False
     if is_valid_json_field(track_metadata, "premium_conditions"):
         track_record.premium_conditions = track_metadata["premium_conditions"]
     else:

--- a/discovery-provider/src/tasks/tracks.py
+++ b/discovery-provider/src/tasks/tracks.py
@@ -493,7 +493,11 @@ def populate_track_record_metadata(track_record, track_metadata, handle):
     track_record.field_visibility = track_metadata["field_visibility"]
 
     track_record.is_premium = track_metadata["is_premium"]
-    track_record.is_playlist_upload = track_metadata["is_playlist_upload"] if "is_playlist_upload" in track_metadata else False
+    track_record.is_playlist_upload = (
+        track_metadata["is_playlist_upload"]
+        if "is_playlist_upload" in track_metadata
+        else False
+    )
     if is_valid_json_field(track_metadata, "premium_conditions"):
         track_record.premium_conditions = track_metadata["premium_conditions"]
     else:

--- a/identity-service/src/notifications/notificationQueue.js
+++ b/identity-service/src/notifications/notificationQueue.js
@@ -141,7 +141,9 @@ async function promiseAllInBatches(task, logger, items, batchSize) {
     const itemsForBatch = items.slice(position, position + batchSize)
     results = [
       ...results,
-      ...(await Promise.allSettled(itemsForBatch.map((item) => task(logger, item))))
+      ...(await Promise.allSettled(
+        itemsForBatch.map((item) => task(logger, item))
+      ))
     ]
     position += batchSize
   }


### PR DESCRIPTION
### Description
Create notifications for new track and playlist uploads
Changes:
* Additional field indexed out of track metadata `is_playlist_upload` indicating if the track is a part of a playlist upload
* Adds that field to the tracks table as a bool column
* In the track/playlist trigger, if new, create a new notification for all the user's subscribers

Fixes PLAT-526

### Tests
Wrote some tests for the indexing and the notification creation

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->