### PR TITLE
Fall back to network fetch when storagePath doesn't exist

### DIFF
--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -434,9 +434,9 @@ class DBManager {
     )?.length
   }
 
-  static async _getLegacyStoragePathsAndCids(minCid, maxCid, batchSize, dir) {
+  static async _getLegacyStoragePathRecords(minCid, maxCid, batchSize, dir) {
     const dirQuery = `
-      SELECT "storagePath", "multihash", "skipped" FROM
+      SELECT "storagePath", "multihash", "dirMultihash", "fileName", "trackBlockchainId", "fileUUID", "skipped" FROM
         (SELECT * FROM "Files" AS "Page"
           WHERE "multihash" BETWEEN :minCid AND :maxCid AND "type" = 'dir'
           ORDER BY "multihash" DESC)
@@ -445,7 +445,7 @@ class DBManager {
       LIMIT :batchSize
       `
     const nonDirQuery = `
-      SELECT "storagePath", "multihash", "skipped" FROM
+      SELECT "storagePath", "multihash", "dirMultihash", "fileName", "trackBlockchainId", "fileUUID", "skipped" FROM
         (SELECT * FROM "Files" AS "Page"
           WHERE "multihash" BETWEEN :minCid AND :maxCid AND "type" != 'dir'
           ORDER BY "multihash" DESC)
@@ -463,17 +463,11 @@ class DBManager {
         fileRecords
       )}`
     )
-    return fileRecords.map((result) => {
-      return {
-        storagePath: result.storagePath,
-        cid: result.multihash,
-        skipped: result.skipped
-      }
-    })
+    return fileRecords
   }
 
-  static async getNonDirLegacyStoragePathsAndCids(minCid, maxCid, batchSize) {
-    return DBManager._getLegacyStoragePathsAndCids(
+  static async getNonDirLegacyStoragePathRecords(minCid, maxCid, batchSize) {
+    return DBManager._getLegacyStoragePathRecords(
       minCid,
       maxCid,
       batchSize,
@@ -481,8 +475,8 @@ class DBManager {
     )
   }
 
-  static async getDirLegacyStoragePathsAndCids(minCid, maxCid, batchSize) {
-    return DBManager._getLegacyStoragePathsAndCids(
+  static async getDirLegacyStoragePathRecords(minCid, maxCid, batchSize) {
+    return DBManager._getLegacyStoragePathRecords(
       minCid,
       maxCid,
       batchSize,

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -443,8 +443,18 @@ async function _touch(path: string) {
   }
 }
 
+type FileRecord = {
+  storagePath: string
+  multihash: string
+  fileUUID: string
+  skipped: boolean
+  dirMultihash?: string
+  fileName?: string
+  trackBlockchainId?: number
+}
+
 async function _copyLegacyFiles(
-  legacyPathsAndCids: { storagePath: string; cid: string; skipped: boolean }[],
+  fileRecords: FileRecord[],
   prometheusRegistry: any,
   logger: Logger
 ): Promise<
@@ -458,7 +468,8 @@ async function _copyLegacyFiles(
     legacyPath: string
     nonLegacyPath: string
   }[] = []
-  for (const { storagePath: legacyPath, cid, skipped } of legacyPathsAndCids) {
+  for (const fileRecord of fileRecords) {
+    const legacyPath = fileRecord.storagePath
     let nonLegacyPath = ''
     try {
       // Compute new path
@@ -484,20 +495,44 @@ async function _copyLegacyFiles(
         // Update mtime again just in case copyFile changed it
         const now = new Date()
         await fs.utimes(nonLegacyPath, now, now)
-      } catch (e: any) {
-        // If we see a ENOSPC error, log out the disk space and inode details from the system
-        if (e.message.includes('ENOSPC')) {
+      } catch (copyError: any) {
+        if (copyError.message.includes('ENOSPC')) {
+          // If we see a ENOSPC error, log out the disk space and inode details from the system
           await Promise.all([
             runShellCommand(`df`, ['-h'], logger),
             runShellCommand(`df`, ['-ih'], logger)
           ])
-        }
-        throw e
+          throw copyError
+        } else if (copyError.message.includes('ENOENT')) {
+          // If we see an ENOENT error ("no such file"), try fetching the file from network
+          let success, error
+          try {
+            ;({ success, error } = await _migrateFileByFetchingFromNetwork(
+              fileRecord,
+              logger
+            ))
+          } catch (fetchFallbackError: any) {
+            success = false
+            error = fetchFallbackError
+          }
+
+          // Add delay between calls since each call will make an internal request to every node
+          await timeout(1000)
+
+          if (!success) {
+            logger.error(
+              `Error fixing fileRecord (legacy fetch from network fallback) ${JSON.stringify(
+                fileRecord
+              )}: ${error}`
+            )
+            throw copyError
+          }
+        } else throw copyError
       }
 
       // Verify that the correct contents were copied
       const cidMatchesExpected = await verifyCIDMatchesExpected({
-        cid,
+        cid: fileRecord.multihash,
         path: nonLegacyPath,
         logger
       })
@@ -515,7 +550,7 @@ async function _copyLegacyFiles(
       }
     } catch (e: any) {
       // If the file is skipped (blacklisted) then we don't care if it failed to copy
-      if (skipped && nonLegacyPath?.length) {
+      if (fileRecord.skipped && nonLegacyPath?.length) {
         copiedPaths.push({ legacyPath, nonLegacyPath })
       } else {
         erroredPaths[legacyPath] = e.toString()
@@ -524,32 +559,12 @@ async function _copyLegacyFiles(
   }
 
   // Record results in Prometheus metric and log errors
-  if (copiedPaths.length > 0) {
-    clusterUtilsForPrimary.sendMetricToWorker(
-      {
-        metricType: 'GAUGE_INC',
-        metricName:
-          prometheusRegistry.metricNames.FILES_MIGRATED_FROM_LEGACY_PATH_GAUGE,
-        metricValue: copiedPaths.length,
-        metricLabels: { result: 'success' }
-      },
-      prometheusRegistry,
-      logger
-    )
-  }
-  if (Object.keys(erroredPaths).length > 0) {
-    clusterUtilsForPrimary.sendMetricToWorker(
-      {
-        metricType: 'GAUGE_INC',
-        metricName:
-          prometheusRegistry.metricNames.FILES_MIGRATED_FROM_LEGACY_PATH_GAUGE,
-        metricValue: Object.keys(erroredPaths).length,
-        metricLabels: { result: 'failure' }
-      },
-      prometheusRegistry,
-      logger
-    )
-  }
+  _recordLegacyMigrationMetrics(
+    copiedPaths.length,
+    Object.keys(erroredPaths).length,
+    prometheusRegistry,
+    logger
+  )
   if (!isEmpty(erroredPaths)) {
     logger.warn(
       `Failed to copy some legacy files: ${JSON.stringify(erroredPaths)}`
@@ -594,10 +609,10 @@ const _migrateNonDirFilesWithLegacyStoragePaths = async (
   _callFuncOnAllCidsPaginated(async (minCid, maxCid) => {
     // Query for legacy storagePaths in the pagination range until no new results are returned
     let newResultsFound = true
-    let results: { storagePath: string; cid: string; skipped: boolean }[] = []
+    let results: FileRecord[] = []
     while (newResultsFound) {
       const prevResults = results
-      results = await DbManager.getNonDirLegacyStoragePathsAndCids(
+      results = await DbManager.getNonDirLegacyStoragePathRecords(
         minCid,
         maxCid,
         batchSize
@@ -625,20 +640,20 @@ const _migrateDirsWithLegacyStoragePaths = async (
   _callFuncOnAllCidsPaginated(async (minCid, maxCid) => {
     // Query for legacy storagePaths in the pagination range until no new results are returned
     let newResultsFound = true
-    let results: { storagePath: string; cid: string; skipped: boolean }[] = []
+    let results: FileRecord[] = []
     while (newResultsFound) {
       const prevResults = results
-      results = await DbManager.getDirLegacyStoragePathsAndCids(
+      results = await DbManager.getDirLegacyStoragePathRecords(
         minCid,
         maxCid,
         batchSize
       )
       if (results.length) {
         newResultsFound = !isEqual(prevResults, results)
-        const legacyAndNonLegacyPaths = results.map((storagePathAndCid) => {
+        const legacyAndNonLegacyPaths = results.map((fileRecord) => {
           return {
-            legacyPath: storagePathAndCid.storagePath,
-            nonLegacyPath: computeFilePath(storagePathAndCid.cid)
+            legacyPath: fileRecord.storagePath,
+            nonLegacyPath: computeFilePath(fileRecord.multihash)
           }
         })
         await DbManager.updateLegacyPathDbRows(legacyAndNonLegacyPaths, logger)
@@ -649,16 +664,8 @@ const _migrateDirsWithLegacyStoragePaths = async (
     }
   })
 
-async function _migrateFileWithCustomStoragePath(
-  fileRecord: {
-    storagePath: string
-    multihash: string
-    fileUUID: string
-    skipped: boolean
-    dirMultihash?: string
-    fileName?: string
-    trackBlockchainId?: number
-  },
+async function _migrateFileByFetchingFromNetwork(
+  fileRecord: FileRecord,
   logger: Logger
 ): Promise<{ success: boolean; error: any }> {
   const fetchStartTime = getStartTime()
@@ -712,15 +719,7 @@ const _migrateFilesWithCustomStoragePaths = async (
   _callFuncOnAllCidsPaginated(async (minCid, maxCid) => {
     // Query for custom storagePaths in the pagination range until no new results are returned
     let newResultsFound
-    let results: {
-      storagePath: string
-      multihash: string
-      fileUUID: string
-      skipped: boolean
-      dirMultihash?: string
-      fileName?: string
-      trackBlockchainId?: number
-    }[] = []
+    let results: FileRecord[] = []
     while (newResultsFound) {
       const prevResults = results
       results = await DbManager.getCustomStoragePathsRecords(
@@ -736,7 +735,7 @@ const _migrateFilesWithCustomStoragePaths = async (
         for (const fileRecord of results) {
           let success, error
           try {
-            ;({ success, error } = await _migrateFileWithCustomStoragePath(
+            ;({ success, error } = await _migrateFileByFetchingFromNetwork(
               fileRecord,
               logger
             ))
@@ -749,48 +748,94 @@ const _migrateFilesWithCustomStoragePaths = async (
           } else {
             numFilesFailedToMigrate++
             logger.error(
-              `Error fixing fileRecord ${JSON.stringify(fileRecord)}: ${error}`
+              `Error fixing fileRecord (custom) ${JSON.stringify(
+                fileRecord
+              )}: ${error}`
             )
           }
 
           // Add delay between calls since each call will make an internal request to every node
           await timeout(1000)
         }
-        // Record results in Prometheus metric
-        if (numFilesMigratedSuccessfully > 0) {
-          clusterUtilsForPrimary.sendMetricToWorker(
-            {
-              metricType: 'GAUGE_INC',
-              metricName:
-                prometheusRegistry.metricNames
-                  .FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE,
-              metricValue: numFilesMigratedSuccessfully,
-              metricLabels: { result: 'success' }
-            },
-            prometheusRegistry,
-            logger
-          )
-        }
-        if (numFilesFailedToMigrate > 0) {
-          clusterUtilsForPrimary.sendMetricToWorker(
-            {
-              metricType: 'GAUGE_INC',
-              metricName:
-                prometheusRegistry.metricNames
-                  .FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE,
-              metricValue: numFilesFailedToMigrate,
-              metricLabels: { result: 'failure' }
-            },
-            prometheusRegistry,
-            logger
-          )
-        }
+
+        _recordCustomMigrationMetrics(
+          numFilesMigratedSuccessfully,
+          numFilesFailedToMigrate,
+          prometheusRegistry,
+          logger
+        )
       } else {
         newResultsFound = false
       }
       await timeout(queryDelayMs) // Avoid spamming fast queries
     }
   })
+
+function _recordLegacyMigrationMetrics(
+  numSuccess: number,
+  numFailure: number,
+  prometheusRegistry: any,
+  logger: Logger
+) {
+  _recordMigrationMetrics(
+    true,
+    numSuccess,
+    numFailure,
+    prometheusRegistry,
+    logger
+  )
+}
+
+function _recordCustomMigrationMetrics(
+  numSuccess: number,
+  numFailure: number,
+  prometheusRegistry: any,
+  logger: Logger
+) {
+  _recordMigrationMetrics(
+    false,
+    numSuccess,
+    numFailure,
+    prometheusRegistry,
+    logger
+  )
+}
+
+function _recordMigrationMetrics(
+  legacy: boolean,
+  numSuccess: number,
+  numFailure: number,
+  prometheusRegistry: any,
+  logger: Logger
+) {
+  const metricName = legacy
+    ? prometheusRegistry.metricNames.FILES_MIGRATED_FROM_LEGACY_PATH_GAUGE
+    : prometheusRegistry.metricNames.FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE
+  if (numSuccess > 0) {
+    clusterUtilsForPrimary.sendMetricToWorker(
+      {
+        metricType: 'GAUGE_INC',
+        metricName,
+        metricValue: numSuccess,
+        metricLabels: { result: 'success' }
+      },
+      prometheusRegistry,
+      logger
+    )
+  }
+  if (numFailure > 0) {
+    clusterUtilsForPrimary.sendMetricToWorker(
+      {
+        metricType: 'GAUGE_INC',
+        metricName,
+        metricValue: numFailure,
+        metricLabels: { result: 'failure' }
+      },
+      prometheusRegistry,
+      logger
+    )
+  }
+}
 
 function _resetStoragePathMetrics(prometheusRegistry: any, logger: Logger) {
   // Reset metric for legacy migrations

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -545,13 +545,12 @@ async function _copyLegacyFiles(
           // Add delay between calls since each call will make an internal request to every node
           await timeout(1000)
 
-          if (!success) {
-            logger.error(
-              `Error fixing fileRecord (legacy fetch from network fallback) ${JSON.stringify(
-                fileRecord
-              )}: ${error}`
+          if (success) {
+            copiedPaths.push({ legacyPath, nonLegacyPath })
+          } else {
+            throw new Error(
+              `Legacy fetch from network fallback error: ${error}. Copy error: ${copyError}`
             )
-            throw copyError
           }
         } else throw copyError
       }

--- a/creator-node/src/fileManager.js
+++ b/creator-node/src/fileManager.js
@@ -497,7 +497,7 @@ async function fetchFileFromNetworkAndSaveToFS(
      * Attempts to fetch CID:
      *  - If file already stored on disk, return immediately
      *  - If file not already stored, request from user's replica set gateways in parallel and write to disk if file exists
-     *  - If file does not exist on user's replca set, try the network and write to disk if file exists
+     *  - If file does not exist on user's replica set, try the network and write to disk if file exists
      */
 
     if (await fs.pathExists(storageLocation)) {


### PR DESCRIPTION
### Description
Makes legacy non-dir storagePaths fall back to fetching from network when they fail to copy from the legacy file path. So far all spot checks have been available in network (find failed CID and query it via /ipfs on any node), so this should resolve the vast majority of legacy storagePaths that are failing to migrate.



### Tests
I tested on stage UM and verified that it's now showing a nonzero number of successful legacy files being migrated - previously they were all failing.

<img width="1327" alt="Screen Shot 2022-12-13 at 2 29 36 PM" src="https://user-images.githubusercontent.com/4657956/207458647-c4dedebe-31a3-4376-ac0c-e23ea1840d86.png">


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor for logs of "Legacy fetch from network fallback error" and "Error fixing fileRecord," and spot check failed files. The nodes that had only failed files should now start seeing some succeeding (verify by making sure the `audius_cn_files_migrated_from_legacy_path{result="success"}` metric is nonzero).