### PR TITLE
[PAY-747] Handle solana-nft-gated premium content

### DIFF
--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -287,6 +287,13 @@ def _get_token_account_info(token_account):
     return token_account["account"]["data"]["parsed"]["info"]
 
 
+# - Fet and parse token accounts from given wallets to get the mint addresses
+# - Filter out token accounts with positive amounts and whose decimal places are not 0
+# - Find the metadata PDAs for the mint addresses
+# - Get the account infos for the PDAs if they exist
+# - Unpack the chain metadatas from the account infos
+# - Verify that the nft is from a verified collection whose mint address is the same as that passed into the function
+# - If so, then user owns nft from that collection
 def _does_user_own_sol_nft_collection(
     collection_mint_address: str, user_sol_wallets: List[str]
 ):

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -100,6 +100,7 @@ def _get_nft_gated_tracks(track_ids: List[int], session: Session):
     return list(
         filter(
             lambda track: track.is_premium  # type: ignore
+            and track.premium_conditions != None  # type: ignore
             and "nft_collection" in track.premium_conditions,  # type: ignore
             _get_tracks(track_ids, session),
         )

--- a/discovery-provider/src/queries/get_premium_track_signatures.py
+++ b/discovery-provider/src/queries/get_premium_track_signatures.py
@@ -6,7 +6,7 @@ import logging
 import pathlib
 import struct
 from collections import defaultdict
-from typing import Any, Dict, List, Set
+from typing import Dict, List, Set
 
 import base58
 from eth_typing import ChecksumAddress
@@ -243,7 +243,7 @@ def _get_eth_nft_gated_track_signatures(
 # Extended and simplified based on the reference links below
 # https://docs.metaplex.com/programs/token-metadata/accounts#metadata
 # https://github.com/metaplex-foundation/python-api/blob/441c2ba9be76962d234d7700405358c72ee1b35b/metaplex/metadata.py#L123
-def _unpack_metadata_account_for_metaplex_nft(data: Any):
+def _unpack_metadata_account_for_metaplex_nft(data):
     assert data[0] == 4
     i = 1  # key
     i += 32  # update authority

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -409,13 +409,13 @@
                     "type": "string",
                     "const": "sol"
                 },
-                "name": {
+                "address": {
                     "type": "string"
                 }
             },
             "required": [
                 "chain",
-                "name"
+                "address"
             ],
             "title": "PremiumConditionsSolNFTCollection"
         },

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -153,7 +153,7 @@ class SolanaClientManager:
 
     def get_token_accounts_by_owner(
         self, owner: PublicKey, retries=DEFAULT_MAX_RETRIES
-    ) -> Optional[int]:
+    ):
         def _get_token_accounts_by_owner(client: Client, index):
             endpoint = self.endpoints[index]
             num_retries = retries

--- a/discovery-provider/src/solana/solana_client_manager.py
+++ b/discovery-provider/src/solana/solana_client_manager.py
@@ -9,9 +9,8 @@ from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client, Commitment
 from solana.rpc.types import TokenAccountOpts
-from spl.token.constants import TOKEN_PROGRAM_ID
 from src.exceptions import UnsupportedVersionError
-from src.solana.solana_helpers import SPL_TOKEN_ID, SPL_TOKEN_ID_PK
+from src.solana.solana_helpers import SPL_TOKEN_ID_PK
 from src.solana.solana_transaction_types import (
     ConfirmedSignatureForAddressResponse,
     ConfirmedTransaction,

--- a/discovery-provider/src/solana/solana_helpers.py
+++ b/discovery-provider/src/solana/solana_helpers.py
@@ -30,3 +30,8 @@ SPL_TOKEN_ID_PK = PublicKey(SPL_TOKEN_ID)
 # NOTE: This is static and will not change
 ASSOCIATED_TOKEN_PROGRAM_ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 ASSOCIATED_TOKEN_PROGRAM_ID_PK = PublicKey(ASSOCIATED_TOKEN_PROGRAM_ID)
+
+# Static Metaplex Metadata Program ID
+# NOTE: This is static and will not change
+METADATA_PROGRAM_ID = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+METADATA_PROGRAM_ID_PK = PublicKey(METADATA_PROGRAM_ID)

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -322,11 +322,11 @@
           "type": "string",
           "const": "sol"
         },
-        "name": {
+        "address": {
           "type": "string"
         }
       },
-      "required": ["chain", "name"],
+      "required": ["chain", "address"],
       "title": "PremiumConditionsSolNFTCollection"
     },
     "PremiumConditionsFollowUserId": {

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -96,7 +96,7 @@ export type PremiumConditionsEthNFTCollection = {
 
 export type PremiumConditionsSolNFTCollection = {
   chain: 'sol'
-  name: string
+  address: string
 }
 
 export type PremiumConditions = {


### PR DESCRIPTION
### Description

Produce premium content signatures when user has access to solana-nft-gated premium tracks.

- Add `get_token_accounts_by_owner` and `get_account_info` methods to `SolanaClientManager`
- Add method that parses solana nft collection metadata
- Update track schema json

### Tests

Tested using solana mainnet RPCs, and tested with solana wallet address which owns an nft from a certain collection. It worked; the signature was generated.

Note: this method is sometimes a bit slow, taking between 5s to 10s, probably because of network conditions which forces retries happening at the `SolanaClientManager` level. Probably should keep an eye on this and make sure it's fast enough for our use case.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
n/a


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->