### PR TITLE
Del trending task redis lock key on restart

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -610,6 +610,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("spl_token_backfill_lock")
     redis_inst.delete("profile_challenge_backfill_lock")
     redis_inst.delete("backfill_cid_data_lock")
+    redis_inst.delete("index_trending_lock")
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_TRACK_IS_AVAILABLE_LOCK)
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -286,7 +286,8 @@ def index_trending_task(self):
     redis = index_trending_task.redis
     web3 = index_trending_task.web3
     have_lock = False
-    update_lock = redis.lock("index_trending_lock", timeout=86400)
+    timeout = 60 * 60 * 2
+    update_lock = redis.lock("index_trending_lock", timeout=timeout)
     try:
         should_update_timestamp = get_should_update_trending(
             db, web3, redis, UPDATE_TRENDING_DURATION_DIFF_SEC


### PR DESCRIPTION
### Description
Delete the trending task key in app.py - noticed that when discovery restarted, the trending task did not restart
The lock was also for 24 hours - reduced to 2 hrs

### Tests
none

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->