### PR TITLE
Add is_current to query

### DIFF
--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -975,6 +975,7 @@ def get_karma(
             or_(User.cover_photo != None, User.cover_photo_sizes != None),
             or_(User.profile_picture != None, User.profile_picture_sizes != None),
             User.bio != None,
+            User.is_current == True
         )
         saves_and_reposts = saves_and_reposts.subquery()
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -975,7 +975,7 @@ def get_karma(
             or_(User.cover_photo != None, User.cover_photo_sizes != None),
             or_(User.profile_picture != None, User.profile_picture_sizes != None),
             User.bio != None,
-            User.is_current == True
+            User.is_current == True,
         )
         saves_and_reposts = saves_and_reposts.subquery()
 


### PR DESCRIPTION
### Description
Update get_karma query to filter users on is_current flag
Should speed up the query a good amount.
Ref query insights
<img width="1621" alt="Screenshot 2022-12-14 at 2 44 14 PM" src="https://user-images.githubusercontent.com/7064122/207699103-0ca7e280-7e9f-4387-9f96-3eb50fc7da4d.png">

### Tests
none

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->