### PR TITLE
Async io fetch nodes

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -269,7 +269,7 @@ def test_index_valid_social_features(app, mocker):
         assert current_repost.repost_item_id == 1
 
         # ensure session is flushed, invalidating old records before bulk saving
-        aggregate_playlists: List[aggregate_playlists] = (
+        aggregate_playlists: List[AggregatePlaylist] = (
             session.query(AggregatePlaylist)
             .filter(AggregatePlaylist.playlist_id == 1)
             .all()

--- a/discovery-provider/src/utils/get_all_other_nodes.py
+++ b/discovery-provider/src/utils/get_all_other_nodes.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+import asyncio
 import logging
 from typing import List, Optional, Tuple
 
@@ -23,55 +23,21 @@ def fetch_discovery_node_info(sp_id, sp_factory_instance):
 
 def get_node_endpoint() -> Optional[str]:
     """
-    Get endpoint for this discovery node
-    At each node, get the service info which includes the endpoint
-    return node endpoint of node with matching delegate_owner_wallet
+    Get endpoint for this discovery node from the config
     """
-    eth_web3 = web3_provider.get_eth_web3()
+    node_url = shared_config["discprov"]["url"]
+    if not node_url or not is_fqdn(node_url):
+        return None
+    return node_url.rstrip("/")
 
-    eth_registry_address = eth_web3.toChecksumAddress(
-        shared_config["eth_contracts"]["registry"]
+
+async def get_async_discovery_node(sp_id, sp_factory_instance):
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(
+        None, fetch_discovery_node_info, sp_id, sp_factory_instance
     )
-    eth_registry_instance = eth_web3.eth.contract(
-        address=eth_registry_address, abi=eth_abi_values["Registry"]["abi"]
-    )
-    sp_factory_address = eth_registry_instance.functions.getContract(
-        SP_FACTORY_REGISTRY_KEY
-    ).call()
-    sp_factory_inst = eth_web3.eth.contract(
-        address=sp_factory_address, abi=eth_abi_values["ServiceProviderFactory"]["abi"]
-    )
-    num_discovery_nodes = sp_factory_inst.functions.getTotalServiceTypeProviders(
-        DISCOVERY_NODE_SERVICE_TYPE
-    ).call()
-    logger.info(f"number of discovery nodes: {num_discovery_nodes}")
 
-    ids_list = list(range(1, num_discovery_nodes + 1))
-
-    endpoint: Optional[str] = None
-
-    # fetch all discovery nodes info in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
-        discovery_node_futures = {
-            executor.submit(fetch_discovery_node_info, i, sp_factory_inst): i
-            for i in ids_list
-        }
-        for future in concurrent.futures.as_completed(discovery_node_futures):
-            node_op = discovery_node_futures[future]
-            try:
-                node_info = future.result()
-                wallet = node_info[3]
-                if wallet.lower() == shared_config["delegate"]["owner_wallet"].lower():
-                    endpoint = node_info[1]
-                    break
-            except Exception as e:
-                logger.error(
-                    f"get_all_other_nodes.py | ERROR in discovery_node_futures {node_op} generated {e}"
-                )
-
-    logger.info(f"this node's endpoint: {endpoint}")
-
-    return endpoint
+    return result
 
 
 def get_all_other_nodes() -> Tuple[List[str], List[str]]:
@@ -98,35 +64,35 @@ def get_all_other_nodes() -> Tuple[List[str], List[str]]:
     num_discovery_nodes = sp_factory_inst.functions.getTotalServiceTypeProviders(
         DISCOVERY_NODE_SERVICE_TYPE
     ).call()
-    logger.info(f"number of discovery nodes: {num_discovery_nodes}")
 
     ids_list = list(range(1, num_discovery_nodes + 1))
     all_other_nodes = []
     all_other_wallets = []
 
     # fetch all discovery nodes info in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
-        discovery_node_futures = {
-            executor.submit(fetch_discovery_node_info, i, sp_factory_inst): i
-            for i in ids_list
-        }
-        for future in concurrent.futures.as_completed(discovery_node_futures):
-            node_op = discovery_node_futures[future]
-            try:
-                node_info = future.result()
-                wallet = node_info[3]
-                if wallet != shared_config["delegate"]["owner_wallet"]:
-                    endpoint = node_info[1]
-                    all_other_wallets.append(wallet)
-                    if is_fqdn(endpoint):
-                        all_other_nodes.append(endpoint)
-            except Exception as e:
-                logger.error(
-                    f"index_metrics.py | ERROR in discovery_node_futures {node_op} generated {e}"
-                )
+    async def fetch_results():
+        result = await asyncio.gather(
+            *map(
+                lambda sp_id: get_async_discovery_node(sp_id, sp_factory_inst), ids_list
+            )
+        )
+        return result
 
-    logger.info(
-        f"this node's delegate owner wallet: {shared_config['delegate']['owner_wallet']}"
-    )
-    logger.info(f"all the other nodes: {all_other_nodes}")
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    resp = asyncio.run(fetch_results())
+
+    for node_info in resp:
+        try:
+            wallet = node_info[3]
+            if wallet != shared_config["delegate"]["owner_wallet"]:
+                endpoint = node_info[1]
+                all_other_wallets.append(wallet)
+                if is_fqdn(endpoint):
+                    all_other_nodes.append(endpoint)
+        except Exception as e:
+            logger.error(
+                f"get_all_other_nodes.py | ERROR in fetching node info {node_info} generated {e}"
+            )
+
     return all_other_nodes, all_other_wallets


### PR DESCRIPTION
### Description
Update fetching of nodes on chain to use async instead of mutithreading.
Hoping this fixes the error we're seeing on staging and prod of 
```
  File "/audius-discovery-provider/src/utils/get_all_other_nodes.py", line 54, in get_node_endpoint
    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
  File "/usr/lib/python3.9/concurrent/futures/__init__.py", line 49, in __getattr__
    from .thread import ThreadPoolExecutor as te
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 42, in <module>
    after_in_child=_global_shutdown_lock._at_fork_reinit,
AttributeError: 'Semaphore' object has no attribute '_at_fork_reinit'
```

Note, the `get_all_other_nodes` method is used by the following routes:
`/challenges/attest_sender`
`/redirect_weights`
`/sitemaps/<TYPE>/index.xml`

### Tests
Ran locally and was able to request all nodes

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->