### PR TITLE
Rate limit EM replica set updates

### DIFF
--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -230,13 +230,10 @@ const filterReplicaSetUpdates = (decodedABI, senderAddress) => {
 
   if (decodedABI.name === 'updateReplicaSet') {
     // TODO remove legacy replica set updates
-    isReplicaSetTransaction = true
-    if (isReplicaSetTransaction) {
-      isFirstReplicaSetConfig = decodedABI.params.find(
-        (param) => param.name === '_oldPrimaryId' && param.value === '0'
-      )
-    }
-  } else if (decodedABI.name === 'EntityManager') {
+    isFirstReplicaSetConfig = decodedABI.params.find(
+      (param) => param.name === '_oldPrimaryId' && param.value === '0'
+    )
+  } else if (decodedABI.name === 'manageEntity') {
     isReplicaSetTransaction = decodedABI.params.find(
       (param) =>
         param.name === '_entityType' && param.value === 'UserReplicaSet'

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -216,17 +216,21 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
   return txReceipt
 }
 
-const filterReplicaSetUpdates = (decodedABI, senderAddress) => {
-  // Rate limit replica set reconfiguration transactions
-  // A reconfiguration (as opposed to a first time selection) will have an
-  // _oldPrimaryId value of "0"
+/**
+ * Rate limit replica set reconfiguration transactions
+ * the available wallets using mod
+ *
+ * A reconfiguration (as opposed to a first time selection) will have an
+ * _oldPrimaryId value of "0"
+ */
 
+const filterReplicaSetUpdates = (decodedABI, senderAddress) => {
   let isReplicaSetTransaction = false
   let isFirstReplicaSetConfig = false
 
   if (decodedABI.name === 'updateReplicaSet') {
     // TODO remove legacy replica set updates
-    isReplicaSetTransaction = decodedABI.name === 'updateReplicaSet'
+    isReplicaSetTransaction = true
     if (isReplicaSetTransaction) {
       isFirstReplicaSetConfig = decodedABI.params.find(
         (param) => param.name === '_oldPrimaryId' && param.value === '0'
@@ -241,7 +245,7 @@ const filterReplicaSetUpdates = (decodedABI, senderAddress) => {
     // EntityManager create user actions include the initial replica set
   }
 
-  if (!isFirstReplicaSetConfig) {
+  if (isReplicaSetTransaction && !isFirstReplicaSetConfig) {
     transactionRateLimiter.updateReplicaSetReconfiguration += 1
     if (
       transactionRateLimiter.updateReplicaSetReconfiguration >

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -120,33 +120,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     contractRegistryKey.charAt(0).toUpperCase() + contractRegistryKey.slice(1) // uppercase the first letter
   const decodedABI = AudiusABIDecoder.decodeMethod(contractName, encodedABI)
 
-  // Rate limit replica set reconfiguration transactions
-  // A reconfiguration (as opposed to a first time selection) will have an
-  // _oldPrimaryId value of "0"
-  const isReplicaSetTransaction = decodedABI.name === 'updateReplicaSet'
-  if (isReplicaSetTransaction) {
-    const isFirstReplicaSetConfig = decodedABI.params.find(
-      (param) => param.name === '_oldPrimaryId' && param.value === '0'
-    )
-    if (!isFirstReplicaSetConfig) {
-      transactionRateLimiter.updateReplicaSetReconfiguration += 1
-      if (
-        transactionRateLimiter.updateReplicaSetReconfiguration >
-        UPDATE_REPLICA_SET_RECONFIGURATION_LIMIT
-      ) {
-        throw new Error('updateReplicaSet rate limit reached')
-      }
-
-      if (
-        UPDATE_REPLICA_SET_WALLET_WHITELIST.length > 0 &&
-        !UPDATE_REPLICA_SET_WALLET_WHITELIST.includes(senderAddress)
-      ) {
-        throw new Error(
-          `Sender ${senderAddress} not allowed to make updateReplicaSet calls`
-        )
-      }
-    }
-  }
+  filterReplicaSetUpdates(decodedABI)
 
   // will be set later. necessary for code outside scope of try block
   let txReceipt
@@ -240,6 +214,48 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
   })
 
   return txReceipt
+}
+
+const filterReplicaSetUpdates = (decodedABI) => {
+  // Rate limit replica set reconfiguration transactions
+  // A reconfiguration (as opposed to a first time selection) will have an
+  // _oldPrimaryId value of "0"
+
+  let isReplicaSetTransaction = false
+  let isFirstReplicaSetConfig = false
+
+
+  if (decodedABI.name === 'updateReplicaSet') {  // TODO remove legacy replica set updates
+    isReplicaSetTransaction = decodedABI.name === 'updateReplicaSet'
+    if (isReplicaSetTransaction) {
+      isFirstReplicaSetConfig = decodedABI.params.find(
+        (param) => param.name === '_oldPrimaryId' && param.value === '0'
+      )
+    }
+  } else if (decodedABI.name === 'EntityManager') {
+    isReplicaSetTransaction = decodedABI.params.find(param => param.name === '_entityType' && param.value === 'UserReplicaSet')
+    // isFirstReplicaSetConfig must be false
+    // EntityManager create user actions include the initial replica set
+  }
+  
+  if (!isFirstReplicaSetConfig) {
+    transactionRateLimiter.updateReplicaSetReconfiguration += 1
+    if (
+      transactionRateLimiter.updateReplicaSetReconfiguration >
+      UPDATE_REPLICA_SET_RECONFIGURATION_LIMIT
+    ) {
+      throw new Error('updateReplicaSet rate limit reached')
+    }
+
+    if (
+      UPDATE_REPLICA_SET_WALLET_WHITELIST.length > 0 &&
+      !UPDATE_REPLICA_SET_WALLET_WHITELIST.includes(senderAddress)
+    ) {
+      throw new Error(
+        `Sender ${senderAddress} not allowed to make updateReplicaSet calls`
+      )
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Add rate limit for replica set updates in EntityManager too. Shares logic with legacy replica set updates.

Initial replica set on creation looks like this: 

https://github.com/AudiusProject/audius-protocol/blob/f9487634378cddd7420ad02df11e571c33867ac4/libs/src/api/Users.ts#L501-L507

EM replica set updates look like this: 

https://github.com/AudiusProject/audius-protocol/blob/f9487634378cddd7420ad02df11e571c33867ac4/libs/src/api/Users.ts#L624-L630

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Did not test.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->