### PR TITLE
Eventlet py version

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -34,7 +34,7 @@ hashids==1.2.0
 fakeredis==1.4.2
 jsonformatter==0.3.0
 pytest-postgresql==2.4.1
-eventlet==0.28.0
+eventlet==0.33.0
 psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1

--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -34,7 +34,7 @@ hashids==1.2.0
 fakeredis==1.4.2
 jsonformatter==0.3.0
 pytest-postgresql==2.4.1
-eventlet==0.33.0
+eventlet==0.30.2
 psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1


### PR DESCRIPTION
### Description
Update version of eventlet
Note current version on stage/prod is broken when used in api request handler
```
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 42, in <module>
    after_in_child=_global_shutdown_lock._at_fork_reinit,
AttributeError: 'Semaphore' object has no attribute '_at_fork_reinit'
```
Leads to an error fixed in version 0.30.0 ref: https://eventlet.net/doc/changelog.html#id8
But, we cannot update to latest because of breaking change in 0.30.3 https://eventlet.net/doc/changelog.html#id8 and gunicorn depends on it. (Unless we also update gunicorn)


### Tests
Ran on staging and validated the get_all_other_nodes works

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->