### PR TITLE
Network Monitoring: fix query to fetch content nodes

### DIFF
--- a/discovery-provider/plugins/network-monitoring/package-lock.json
+++ b/discovery-provider/plugins/network-monitoring/package-lock.json
@@ -19,6 +19,7 @@
         "async-retry": "^1.3.3",
         "axios": "^0.27.2",
         "dotenv": "^16.0.1",
+        "lodash": "^4.17.21",
         "opentelemetry-instrumentation-sequelize": "0.29.0",
         "pg": "^8.7.3",
         "prom-client": "^14.0.1",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@tsconfig/node16-strictest": "^1.0.1",
         "@types/async-retry": "^1.4.4",
+        "@types/lodash": "^4.14.191",
         "@types/node": "17.0.31",
         "typescript": "4.6.4"
       }
@@ -2461,6 +2463,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -10432,6 +10440,12 @@
       "requires": {
         "@types/ms": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "@types/long": {
       "version": "4.0.2",

--- a/discovery-provider/plugins/network-monitoring/package.json
+++ b/discovery-provider/plugins/network-monitoring/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@tsconfig/node16-strictest": "^1.0.1",
     "@types/async-retry": "^1.4.4",
+    "@types/lodash": "^4.14.191",
     "@types/node": "17.0.31",
     "typescript": "4.6.4"
   },
@@ -27,6 +28,7 @@
     "async-retry": "^1.3.3",
     "axios": "^0.27.2",
     "dotenv": "^16.0.1",
+    "lodash": "^4.17.21",
     "opentelemetry-instrumentation-sequelize": "0.29.0",
     "pg": "^8.7.3",
     "prom-client": "^14.0.1",

--- a/discovery-provider/plugins/network-monitoring/src/content/index.ts
+++ b/discovery-provider/plugins/network-monitoring/src/content/index.ts
@@ -345,6 +345,11 @@ const _getUserClockValues = async (
 }> => {
 
     try {
+
+        if (endpoint === '') {
+            throw new Error('endpoint is an empty string')
+        }
+
         const axiosReqObj = {
             method: 'post',
             url: '/users/batch_clock_status',


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Fixes the network monitoring query to fetch all content nodes so that even deregistered content nodes get included.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Ran a network monitoring run locally

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->