### PR TITLE
[PAY-757] Prevent premium tracks remixability

### DIFF
--- a/discovery-provider/src/queries/get_remix_track_parents.py
+++ b/discovery-provider/src/queries/get_remix_track_parents.py
@@ -47,6 +47,15 @@ def get_remix_track_parents(args):
     with db.scoped_session() as session:
 
         def get_unpopulated_remix_parents():
+            track = (
+                session.query(Track)
+                .filter(Track.track_id == track_id)
+                .filter(Track.is_current == True)
+                .filter(Track.is_premium == False)
+            ).one_or_none()
+            if not track:
+                return [], []
+
             base_query = (
                 session.query(Track)
                 .join(

--- a/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/discovery-provider/src/queries/get_remixable_tracks.py
@@ -30,6 +30,7 @@ def get_remixable_tracks(args):
                 Track.is_current == True,
                 Track.is_unlisted == False,
                 Track.is_delete == False,
+                Track.is_premium == False,
                 StemTrack.is_current == True,
                 StemTrack.is_unlisted == False,
                 StemTrack.is_delete == False,

--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -44,7 +44,7 @@ def get_remixes_of(args):
                 track_ids=[track_id],
                 filter_deleted=False,
                 filter_unlisted=False,
-                exclude_premium=False,
+                exclude_premium=True,
             )
 
             if not parent_track_res or parent_track_res[0] is None:


### PR DESCRIPTION
### Description

Prevent premium tracks remixability

related to https://github.com/AudiusProject/audius-client/pull/2422

### Tests

simply filters out premium tracks

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

none


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->