### PR TITLE
Fix err logs

### DIFF
--- a/discovery-provider/src/eth_indexing/event_scanner.py
+++ b/discovery-provider/src/eth_indexing/event_scanner.py
@@ -8,6 +8,7 @@ from src.models.indexing.eth_block import EthBlock
 from src.models.users.associated_wallet import AssociatedWallet
 from src.models.users.user import User
 from src.queries.get_balances import enqueue_immediate_balance_refresh
+from src.utils.helpers import redis_set_and_dump
 from web3 import Web3
 from web3._utils.events import get_event_data
 
@@ -111,7 +112,8 @@ class EventScanner:
         logger.info(
             f"event_scanner.py | Saving last scanned block ({self.last_scanned_block}) to redis"
         )
-        self.redis.set(
+        redis_set_and_dump(
+            self.redis,
             eth_indexing_last_scanned_block_key,
             str(self.last_scanned_block),
         )

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -55,12 +55,12 @@ def redis_restore(redis, key):
             logger.debug(f"successfully restored redis value for key: {key}")
             return redis.get(key)
     except FileNotFoundError as not_found:
-        logger.error(f"could not read redis dump file: {filename}")
-        logger.error(not_found)
+        logger.error(
+            f"could not read redis dump file: {filename} with error {not_found}"
+        )
         return None
     except Exception as e:
-        logger.error(f"could not perform redis restore for key: {key}")
-        logger.error(e)
+        logger.error(f"could not perform redis restore for key: {key} with error {e}")
         return None
 
 
@@ -97,8 +97,7 @@ def redis_dump(redis, key):
             f.write(dumped)
             logger.debug(f"successfully performed redis dump for key: {key}")
     except Exception as e:
-        logger.error(f"could not perform redis dump for key: {key}")
-        logger.error(e)
+        logger.error(f"could not perform redis dump for key: {key} with error {e}")
 
 
 def redis_set_json_and_dump(redis, key, value):


### PR DESCRIPTION
### Description
1.) Removes an error log in the redis helper
2.) Seeing lots of error logs for `could not read redis dump file: eth_indexing_last_scanned_block_2_dump`
This is because the event scanner does not store the redis value on disk - This change adds it to be saved on disk

### Tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->