### PR TITLE
Stop error log on no account existing

### DIFF
--- a/discovery-provider/src/tasks/cache_user_balance.py
+++ b/discovery-provider/src/tasks/cache_user_balance.py
@@ -254,6 +254,14 @@ def refresh_user_ids(
                                 )
 
                                 bal_info = waudio_token.get_balance(derived_account)
+                                if (
+                                    "error" in bal_info
+                                    and "code" in bal_info["error"]
+                                    and bal_info["error"]["code"] == -32602
+                                ):
+                                    # Error is 'Invalid param: could not find account'
+                                    # meaning that the token account does not exist
+                                    continue
                                 associated_waudio_balance: str = bal_info["result"][
                                     "value"
                                 ]["amount"]


### PR DESCRIPTION
### Description
Seeings log of error logs:
```
cache_user_balance.py | Error fetching associated  wallet balance for user 190321, wallet <WALLET>: 'result'
```
Because users are associating solana wallets that do not have a token account - which should not log an error.
This change adds an extra check for that and continues instead of logging the err


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->