### PR TITLE
Remove mismatched CID check from storagePath migrations

### DIFF
--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -502,18 +502,12 @@ async function _copyLegacyFiles(
           path: nonLegacyPath,
           logger
         })
-        if (cidMatchesExpected) {
-          copiedPaths.push({ legacyPath, nonLegacyPath })
-        } else {
-          try {
-            await fs.unlink(nonLegacyPath)
-          } catch (e) {
-            logger.error(
-              `_copyLegacyFiles() could not remove mismatched CID file at storageLocation=${nonLegacyPath}`
-            )
-          }
-          throw new Error('CID does not match what is expected to be')
+        if (!cidMatchesExpected) {
+          logger.warn(
+            'CID does not match what is expected to be based on contents hash, but contents were copied anyway'
+          )
         }
+        copiedPaths.push({ legacyPath, nonLegacyPath })
       } catch (copyError: any) {
         if (copyError.message.includes('ENOSPC')) {
           // If we see a ENOSPC error, log out the disk space and inode details from the system


### PR DESCRIPTION
### Description
Allows files with legacy or custom storagePaths to be migrated even if their recomputed hash of the file doesn't match the CID.


### Tests
CI passing is sufficient. We still log a warning.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor for the following log to make sure previously blocked files are now migrated successfully: "CID does not match what is expected to be based on contents hash, but contents were copied anyway"