### PR TITLE
Fix CN stack too deep error & probably CPU maxing out

### DIFF
--- a/creator-node/package-lock.json
+++ b/creator-node/package-lock.json
@@ -3549,7 +3549,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -425,8 +425,10 @@ export async function sweepSubdirectoriesInFiles(
 
   // keep calling this function recursively without an await so the original function scope can close
   // Only call again if backgroundDiskCleanupDeleteEnabled = true, to prevent re-processing infinitely
-  if (redoJob && config.get('backgroundDiskCleanupDeleteEnabled'))
+  if (redoJob && config.get('backgroundDiskCleanupDeleteEnabled')) {
+    await timeout(1000)
     return sweepSubdirectoriesInFiles()
+  }
 }
 
 /**

--- a/creator-node/src/index.ts
+++ b/creator-node/src/index.ts
@@ -131,12 +131,18 @@ const runAsyncBackgroundTasks = async () => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     sweepSubdirectoriesInFiles()
   }
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  migrateFilesWithNonStandardStoragePaths(
-    500,
-    serviceRegistry.prometheusRegistry,
-    logger
-  )
+
+  if (
+    config.get('migrateFilesWithLegacyStoragePath') ||
+    config.get('migrateFilesWithCustomStoragePath')
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    migrateFilesWithNonStandardStoragePaths(
+      500,
+      serviceRegistry.prometheusRegistry,
+      logger
+    )
+  }
 }
 
 // The primary process performs one-time validation and spawns worker processes that each run the Express app

--- a/creator-node/src/utils/cluster/clusterUtilsForPrimary.ts
+++ b/creator-node/src/utils/cluster/clusterUtilsForPrimary.ts
@@ -50,11 +50,6 @@ class ClusterUtilsForPrimary {
     prometheusRegistry: any,
     logger: Logger
   ) {
-    logger.debug(
-      `Creating msgToRecordMetric to all workers from ${JSON.stringify(
-        metricToRecord
-      )}`
-    )
     const validatedMetricToRecord =
       promUtils().validateMetricToRecord(metricToRecord)
     // Non-cluster mode can just record the metric now
@@ -69,11 +64,6 @@ class ClusterUtilsForPrimary {
       cmd: 'recordMetric',
       val: validatedMetricToRecord
     }
-    logger.debug(
-      `Sending msgToRecordMetric to all workers: ${JSON.stringify(
-        msgToRecordMetric
-      )}`
-    )
     // Send out to all workers. Only the special worker will end up recording it
     for (const id in cluster.workers) {
       const worker = cluster.workers?.[id]

--- a/creator-node/src/utils/cluster/clusterUtilsForPrimary.ts
+++ b/creator-node/src/utils/cluster/clusterUtilsForPrimary.ts
@@ -50,6 +50,11 @@ class ClusterUtilsForPrimary {
     prometheusRegistry: any,
     logger: Logger
   ) {
+    logger.debug(
+      `Creating msgToRecordMetric to all workers from ${JSON.stringify(
+        metricToRecord
+      )}`
+    )
     const validatedMetricToRecord =
       promUtils().validateMetricToRecord(metricToRecord)
     // Non-cluster mode can just record the metric now
@@ -64,6 +69,11 @@ class ClusterUtilsForPrimary {
       cmd: 'recordMetric',
       val: validatedMetricToRecord
     }
+    logger.debug(
+      `Sending msgToRecordMetric to all workers: ${JSON.stringify(
+        msgToRecordMetric
+      )}`
+    )
     // Send out to all workers. Only the special worker will end up recording it
     for (const id in cluster.workers) {
       const worker = cluster.workers?.[id]


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Infinite recursion causes stack too deep, blocks event loop (thsi is why requests never go through), and maxes out CPU usage on all node server processes
Solution:
- replace recursive call with infinite while loop
- add delay btwn while loop iterations
- add short circuit for while loop

[Loggly link of errors](https://audius.loggly.com/search#terms=tag:audius-stage-creator-*%20%22RangeError:%20Maximum%20call%20stack%20size%20exceeded%22&from=2022-12-12T22:22:13.424Z&until=2022-12-19T22:22:13.424Z&source_group=)
```
{"name":"audius_creator_node","clusterWorker":"Worker 2","hostname":"8ef9f0e7d117","pid":116,"requestID":"APF-Z4GMb","requestMethod":"GET","requestHostname":"127.0.0.1","requestUrl":"/prometheus/linux","level":20,"msg":"Begin processing request","time":"2022-12-19T22:06:20.327Z","v":0,"trace_id":"08f5b446fbc3e82968057536535bab81","span_id":"cc279508e7fd5372","trace_flags":"01","resource.span.name":"HTTP GET","resource.span.links":[],"resource.span.attributed":{"http.url":"http://127.0.0.1:3000/prometheus/linux","http.host":"127.0.0.1:3000","net.host.name":"127.0.0.1","http.method":"GET","http.client_ip":"34.132.7.228","http.target":"/prometheus/linux","http.user_agent":"Prometheus/2.33.4","http.flavor":"1.0","net.transport":"ip_tcp"},"resource.service.name":"content-node","resource.service.spid":0,"resource.service.endpoint":"https://creatornode6.staging.audius.co/","logLevel":"debug"}
Exception in PromiseRejectCallback:
/usr/src/app/build/src/diskManager.js:668
    return migrateFilesWithNonStandardStoragePaths(5000, prometheusRegistry, logger);

RangeError: Maximum call stack size exceeded
(node:19) UnhandledPromiseRejectionWarning: RangeError: Maximum call stack size exceeded
    at stringify (<anonymous>)
    at writeChannelMessage (internal/child_process/serialization.js:127:20)
    at ChildProcess.target._send (internal/child_process.js:836:17)
    at ChildProcess.target.send (internal/child_process.js:734:19)
    at Worker.send (internal/cluster/worker.js:46:10)
    at ClusterUtilsForPrimary.sendMetricToWorker (/usr/src/app/build/src/utils/cluster/clusterUtilsForPrimary.js:54:24)
    at _resetStoragePathMetrics (/usr/src/app/build/src/diskManager.js:602:36)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:646:5)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
    at migrateFilesWithNonStandardStoragePaths (/usr/src/app/build/src/diskManager.js:668:12)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:19) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:19) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Live on staging CN6 and 10 - works

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

Ensure that disk deletion & storagePath migration jobs still work, and CPU no longer maxes out

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->