### PR TITLE
Add metrics for total unmigrated files

### DIFF
--- a/creator-node/src/dbManager.js
+++ b/creator-node/src/dbManager.js
@@ -531,6 +531,20 @@ class DBManager {
     }
     return false
   }
+
+  static async getNumLegacyStoragePathsRecords() {
+    const query = `SELECT COUNT(*) FROM "Files" WHERE "storagePath" NOT LIKE '/file_storage/files/%' AND "storagePath" LIKE '/file_storage/%';`
+    // Returns [[{ count }]]
+    const queryResult = await sequelize.query(query)
+    return parseInt(queryResult[0][0].count, 10)
+  }
+
+  static async getNumCustomStoragePathsRecords() {
+    const query = `SELECT COUNT(*) FROM "Files" WHERE "storagePath" NOT LIKE '/file_storage/%';`
+    // Returns [[{ count }]]
+    const queryResult = await sequelize.query(query)
+    return parseInt(queryResult[0][0].count, 10)
+  }
 }
 
 /**

--- a/creator-node/src/diskManager.ts
+++ b/creator-node/src/diskManager.ts
@@ -1000,6 +1000,7 @@ export async function migrateFilesWithNonStandardStoragePaths(
 
     queryDelayMs = 5000
 
-    await timeout(queryDelayMs)
+    // Wait 10 minutes since the first queries for metrics can be heavy
+    await timeout(10 * 60 * 1000)
   }
 }

--- a/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
+++ b/creator-node/src/services/prometheusMonitoring/prometheus.constants.ts
@@ -62,7 +62,8 @@ const metricNames: Record<string, string> = {
   RECOVER_ORPHANED_DATA_SYNC_COUNTS_GAUGE: 'recover_orphaned_data_sync_counts',
   STORAGE_PATH_SIZE_BYTES: 'storage_path_size_bytes',
   FILES_MIGRATED_FROM_LEGACY_PATH_GAUGE: 'files_migrated_from_legacy_path',
-  FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE: 'files_migrated_from_custom_path'
+  FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE: 'files_migrated_from_custom_path',
+  TOTAL_UNMIGRATED_STORAGE_PATHS_GAUGE: 'total_unmigrated_storage_paths'
 }
 // Add a histogram for each job in the state machine queues.
 // Some have custom labels below, and all of them use the label: uncaughtError=true/false
@@ -231,6 +232,9 @@ export const METRIC_LABELS = Object.freeze({
   },
   [METRIC_NAMES.FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE]: {
     result: ['success', 'failure']
+  },
+  [METRIC_NAMES.TOTAL_UNMIGRATED_STORAGE_PATHS_GAUGE]: {
+    type: ['legacy', 'custom']
   }
 })
 
@@ -456,6 +460,16 @@ export const METRICS: Record<string, Metric> = Object.freeze({
       help: 'Number of total files migrated from a custom storage path to the standard storage path',
       labelNames:
         METRIC_LABEL_NAMES[METRIC_NAMES.FILES_MIGRATED_FROM_CUSTOM_PATH_GAUGE],
+      aggregator: 'sum' as AggregatorType // Only runs on primary process
+    }
+  },
+  [METRIC_NAMES.TOTAL_UNMIGRATED_STORAGE_PATHS_GAUGE]: {
+    metricType: METRIC_TYPES.GAUGE,
+    metricConfig: {
+      name: METRIC_NAMES.TOTAL_UNMIGRATED_STORAGE_PATHS_GAUGE,
+      help: 'Number of total entries in the Files table that have a legacy or custom storagePath column',
+      labelNames:
+        METRIC_LABEL_NAMES[METRIC_NAMES.TOTAL_UNMIGRATED_STORAGE_PATHS_GAUGE],
       aggregator: 'sum' as AggregatorType // Only runs on primary process
     }
   },


### PR DESCRIPTION
### Description
Adds metric to find total entries in the Files table that have a legacy or custom storagePath column.


### Tests
1. Create a user with a track: `A up; A seed clear; A seed create-user; A seed upload-track`
2. Manually change their files to have a legacy path: `UPDATE "Files" SET "storagePath" = CONCAT('/file_storage', SUBSTRING("storagePath" FROM 20));`
3. Hot reload and look verify that the metric was recorded:
<img width="1342" alt="Screen Shot 2022-12-20 at 1 04 58 PM" src="https://user-images.githubusercontent.com/4657956/208766306-c1780fdd-e890-4543-a247-07ebbfd20e7a.png">



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor the metric `audius_cn_total_unmigrated_storage_paths` - it's broken down by type="legacy" and type="custom"

For errors, watch out for:
- "Failed to record total count of unmigrated storagePaths"
- "Failed to reset counts of migrated storagePaths"