### PR TITLE
Cache CN SPFactory calls

### DIFF
--- a/creator-node/src/apiSigning.js
+++ b/creator-node/src/apiSigning.js
@@ -3,6 +3,11 @@ const LibsUtils = libs.Utils
 const Web3 = require('web3')
 const web3 = new Web3()
 
+const {
+  getContentNodeInfoFromSpId
+} = require('./services/ContentNodeInfoManager')
+const { logger: genericLogger } = require('./logging')
+
 /**
  * Max age of signature in milliseconds
  * Set to 5 minutes
@@ -119,7 +124,6 @@ const generateTimestampAndSignatureForSPVerification = (spID, privateKey) => {
  * @param {string} data.reqSignature the signature from the request body
  */
 const verifyRequesterIsValidSP = async ({
-  audiusLibs,
   spID,
   reqTimestamp,
   reqSignature
@@ -132,17 +136,12 @@ const verifyRequesterIsValidSP = async ({
 
   spID = validateSPId(spID)
 
-  const spRecordFromSPFactory =
-    await audiusLibs.ethContracts.ServiceProviderFactoryClient.getServiceEndpointInfo(
-      'content-node',
-      spID
-    )
-
   let {
     owner: ownerWalletFromSPFactory,
     delegateOwnerWallet: delegateOwnerWalletFromSPFactory,
     endpoint: nodeEndpointFromSPFactory
-  } = spRecordFromSPFactory
+  } = await getContentNodeInfoFromSpId(spID, genericLogger)
+
   delegateOwnerWalletFromSPFactory =
     delegateOwnerWalletFromSPFactory.toLowerCase()
 

--- a/creator-node/src/apiSigning.ts
+++ b/creator-node/src/apiSigning.ts
@@ -1,11 +1,9 @@
+import { getContentNodeInfoFromSpId } from './services/ContentNodeInfoManager'
+
 const { libs } = require('@audius/sdk')
 const LibsUtils = libs.Utils
 const Web3 = require('web3')
 const web3 = new Web3()
-
-const {
-  getContentNodeInfoFromSpId
-} = require('./services/ContentNodeInfoManager')
 const { logger: genericLogger } = require('./logging')
 
 /**
@@ -14,7 +12,7 @@ const { logger: genericLogger } = require('./logging')
  */
 const MAX_SIGNATURE_AGE_MS = 300000
 
-const generateSignature = (data, privateKey) => {
+const generateSignature = (data: any, privateKey: string) => {
   // JSON stringify automatically removes white space given 1 param
   const toSignStr = JSON.stringify(sortKeys(data))
   const toSignHash = web3.utils.keccak256(toSignStr)
@@ -28,7 +26,10 @@ const generateSignature = (data, privateKey) => {
  * @param {object} data
  * @param {string} privateKey
  */
-const generateTimestampAndSignature = (data, privateKey) => {
+export const generateTimestampAndSignature = (
+  data: any,
+  privateKey: string
+) => {
   const timestamp = new Date().toISOString()
   const toSignObj = { ...data, timestamp }
   const signature = generateSignature(toSignObj, privateKey)
@@ -38,7 +39,7 @@ const generateTimestampAndSignature = (data, privateKey) => {
 
 // Keeps track of a cached listen signature
 // Two field object: { timestamp, signature }
-let cachedListenSignature = null
+let cachedListenSignature: { timestamp: string; signature: any } | null = null
 
 /**
  * Generates a signature for `data` if only the previous signature
@@ -46,7 +47,7 @@ let cachedListenSignature = null
  * @param {string} privateKey
  * @returns {object} {signature, timestamp} signature data
  */
-const generateListenTimestampAndSignature = (privateKey) => {
+export const generateListenTimestampAndSignature = (privateKey: any) => {
   if (cachedListenSignature) {
     const signatureTimestamp = cachedListenSignature.timestamp
     if (signatureHasExpired(signatureTimestamp)) {
@@ -72,7 +73,7 @@ const generateListenTimestampAndSignature = (privateKey) => {
  * @param {*} signature signature generated with signed data
  */
 // eslint-disable-next-line no-unused-vars
-const recoverWallet = (data, signature) => {
+export const recoverWallet = (data: any, signature: any) => {
   const structuredData = JSON.stringify(sortKeys(data))
   const hashedData = web3.utils.keccak256(structuredData)
   const recoveredWallet = web3.eth.accounts.recover(hashedData, signature)
@@ -84,13 +85,13 @@ const recoverWallet = (data, signature) => {
  * Returns boolean indicating if provided timestamp is older than maxTTL
  * @param {string | number} signatureTimestamp unix timestamp string when signature was generated
  */
-const signatureHasExpired = (
-  signatureTimestamp,
+export const signatureHasExpired = (
+  signatureTimestamp: string | number,
   maxTTL = MAX_SIGNATURE_AGE_MS
 ) => {
   const signatureTimestampDate = new Date(signatureTimestamp)
   const currentTimestampDate = new Date()
-  const signatureAge = currentTimestampDate - signatureTimestampDate
+  const signatureAge = +currentTimestampDate - +signatureTimestampDate
 
   return signatureAge >= maxTTL
 }
@@ -98,7 +99,7 @@ const signatureHasExpired = (
 /**
  * Recursively sorts keys of object or object array
  */
-const sortKeys = (x) => {
+const sortKeys = (x: any): any => {
   if (typeof x !== 'object' || !x) {
     return x
   }
@@ -110,7 +111,10 @@ const sortKeys = (x) => {
     .reduce((o, k) => ({ ...o, [k]: sortKeys(x[k]) }), {})
 }
 
-const generateTimestampAndSignatureForSPVerification = (spID, privateKey) => {
+export const generateTimestampAndSignatureForSPVerification = (
+  spID: number,
+  privateKey: string
+) => {
   return generateTimestampAndSignature({ spID }, privateKey)
 }
 
@@ -123,10 +127,14 @@ const generateTimestampAndSignatureForSPVerification = (spID, privateKey) => {
  * @param {string} data.reqTimestamp the timestamp from the request body
  * @param {string} data.reqSignature the signature from the request body
  */
-const verifyRequesterIsValidSP = async ({
+export const verifyRequesterIsValidSP = async ({
   spID,
   reqTimestamp,
   reqSignature
+}: {
+  spID: number | string
+  reqTimestamp: string
+  reqSignature: string
 }) => {
   if (!reqTimestamp || !reqSignature) {
     throw new Error(
@@ -140,10 +148,10 @@ const verifyRequesterIsValidSP = async ({
     owner: ownerWalletFromSPFactory,
     delegateOwnerWallet: delegateOwnerWalletFromSPFactory,
     endpoint: nodeEndpointFromSPFactory
-  } = await getContentNodeInfoFromSpId(spID, genericLogger)
+  } = (await getContentNodeInfoFromSpId(spID, genericLogger)) || {}
 
   delegateOwnerWalletFromSPFactory =
-    delegateOwnerWalletFromSPFactory.toLowerCase()
+    delegateOwnerWalletFromSPFactory?.toLowerCase()
 
   if (!ownerWalletFromSPFactory || !delegateOwnerWalletFromSPFactory) {
     throw new Error(
@@ -191,18 +199,18 @@ const verifyRequesterIsValidSP = async ({
  * @param {string} spID
  * @returns a parsed spID
  */
-function validateSPId(spID) {
+export function validateSPId(spID: string | number): number {
   if (!spID) {
     throw new Error('Must provide all required query parameters: spID')
   }
 
-  spID = parseInt(spID)
+  const spIDNum = parseInt(spID + '', 10)
 
-  if (isNaN(spID) || spID < 0) {
+  if (isNaN(spIDNum) || spIDNum < 0) {
     throw new Error(`Provided spID is not a valid id. spID=${spID}`)
   }
 
-  return spID
+  return spIDNum
 }
 
 module.exports = {

--- a/creator-node/src/apiSigning.ts
+++ b/creator-node/src/apiSigning.ts
@@ -12,7 +12,7 @@ const { logger: genericLogger } = require('./logging')
  */
 const MAX_SIGNATURE_AGE_MS = 300000
 
-const generateSignature = (data: any, privateKey: string) => {
+export const generateSignature = (data: any, privateKey: string) => {
   // JSON stringify automatically removes white space given 1 param
   const toSignStr = JSON.stringify(sortKeys(data))
   const toSignHash = web3.utils.keccak256(toSignStr)
@@ -99,7 +99,7 @@ export const signatureHasExpired = (
 /**
  * Recursively sorts keys of object or object array
  */
-const sortKeys = (x: any): any => {
+export const sortKeys = (x: any): any => {
   if (typeof x !== 'object' || !x) {
     return x
   }

--- a/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
+++ b/creator-node/src/components/replicaSet/URSMRegistrationComponentService.js
@@ -53,7 +53,6 @@ const respondToURSMRequestForSignature = async (
       nodeEndpointFromSPFactory,
       spID
     } = await verifyRequesterIsValidSP({
-      audiusLibs,
       spID,
       reqTimestamp,
       reqSignature

--- a/creator-node/src/middlewares.js
+++ b/creator-node/src/middlewares.js
@@ -465,7 +465,6 @@ async function ensureValidSPMiddleware(req, res, next) {
     }
 
     await verifyRequesterIsValidSP({
-      audiusLibs: req.app.get('audiusLibs'),
       spID,
       reqTimestamp: timestamp,
       reqSignature: signature

--- a/creator-node/src/reqLimiter.js
+++ b/creator-node/src/reqLimiter.js
@@ -4,7 +4,7 @@ const config = require('./config.js')
 const { logger } = require('./logging')
 const RedisStore = require('rate-limit-redis')
 const client = require('./redis.js')
-const { verifyRequesterIsValidSP } = require('./apiSigning.js')
+const { verifyRequesterIsValidSP } = require('./apiSigning')
 
 let endpointRateLimits = {}
 try {

--- a/creator-node/src/reqLimiter.js
+++ b/creator-node/src/reqLimiter.js
@@ -64,7 +64,6 @@ const userReqLimiter = rateLimit({
     ) {
       try {
         await verifyRequesterIsValidSP({
-          audiusLibs: libs,
           spID,
           reqTimestamp: timestamp,
           reqSignature: signature
@@ -159,7 +158,6 @@ const batchCidsExistReqLimiter = rateLimit({
     ) {
       try {
         await verifyRequesterIsValidSP({
-          audiusLibs: libs,
           spID,
           reqTimestamp: timestamp,
           reqSignature: signature

--- a/creator-node/test/transcodeAndSegment.test.js
+++ b/creator-node/test/transcodeAndSegment.test.js
@@ -19,7 +19,8 @@ describe('test transcode_and_segment route', function () {
       /* libsMock */ getLibsMock(),
       BlacklistManager,
       /* setMockFn */ null,
-      1 /* spId */
+      1 /* spId */,
+      true /* mockContentNodeInfoManager */
     )
 
     app = appInfo.app


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

every `verifyRequesterIsValidSP` function call was making a direct `SPFactory.getServiceEndpointInfo()` chain call - which is v bad. we already have a caching util built in for this, so just needed to swap the call over

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

fixed existing tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

ethRPC calls from foundation nodes should go down significantly...hopefully

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->