### PR TITLE
Update Replica set endpoint

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_user_replica_set.py
+++ b/discovery-provider/integration_tests/queries/test_get_user_replica_set.py
@@ -1,0 +1,77 @@
+from integration_tests.utils import populate_mock_db
+from src.queries.get_user_replica_set import get_user_replica_set
+from src.utils.db_session import get_db
+
+
+def test_get_user_replica_set(app):
+    """Tests that genre metrics can be queried"""
+    with app.app_context():
+        db = get_db()
+
+        entities = {
+            "users": [
+                {
+                    "user_id": 1,
+                    "wallet": "0x1",
+                    "creator_node_endpoint": "https://cn1.io,https://cn2.io,https://cn3.io",
+                    "primary_id": 1,
+                    "secondary_ids": [2, 3],
+                },
+                {
+                    "user_id": 2,
+                    "wallet": "0x2",
+                    "creator_node_endpoint": "https://cn1.io,https://cn2.io,https://cn3.io",
+                },
+                {"user_id": 3, "wallet": "0x3"},
+            ],
+        }
+
+        populate_mock_db(db, entities)
+
+        # User 1 is ideal case where user has all field
+        args_1 = {"user_id": 1}
+        replica_set_1 = get_user_replica_set(args_1)
+
+        assert replica_set_1 == {
+            "user_id": 1,
+            "wallet": "0x01",
+            "primary": "https://cn1.io",
+            "secondary1": "https://cn2.io",
+            "secondary2": "https://cn3.io",
+            "primarySpID": 1,
+            "secondary1SpID": 2,
+            "secondary2SpID": 3,
+        }
+
+        # User 2 is next case where user has creator_node_endpoint but not primary and secondary
+        args_2 = {"user_id": 2}
+        replica_set_2 = get_user_replica_set(args_2)
+        assert replica_set_2 == {
+            "user_id": 2,
+            "wallet": "0x02",
+            "primary": "https://cn1.io",
+            "secondary1": "https://cn2.io",
+            "secondary2": "https://cn3.io",
+            "primarySpID": None,
+            "secondary1SpID": None,
+            "secondary2SpID": None,
+        }
+
+        # User 3 is next case where user does not have creator node endpoint or primary/secondary
+        args_3 = {"user_id": 3}
+        replica_set_3 = get_user_replica_set(args_3)
+        assert replica_set_3 == {
+            "user_id": 3,
+            "wallet": "0x03",
+            "primary": None,
+            "secondary1": None,
+            "secondary2": None,
+            "primarySpID": None,
+            "secondary1SpID": None,
+            "secondary2SpID": None,
+        }
+
+        # User 4 is next case where user does not exist
+        args_4 = {"user_id": 4}
+        replica_set_4 = get_user_replica_set(args_4)
+        assert replica_set_4 == {}

--- a/discovery-provider/integration_tests/queries/test_get_user_replica_set.py
+++ b/discovery-provider/integration_tests/queries/test_get_user_replica_set.py
@@ -12,17 +12,17 @@ def test_get_user_replica_set(app):
             "users": [
                 {
                     "user_id": 1,
-                    "wallet": "0x1",
+                    "wallet": "0x01",
                     "creator_node_endpoint": "https://cn1.io,https://cn2.io,https://cn3.io",
                     "primary_id": 1,
                     "secondary_ids": [2, 3],
                 },
                 {
                     "user_id": 2,
-                    "wallet": "0x2",
+                    "wallet": "0x02",
                     "creator_node_endpoint": "https://cn1.io,https://cn2.io,https://cn3.io",
                 },
-                {"user_id": 3, "wallet": "0x3"},
+                {"user_id": 3, "wallet": "0x03", "creator_node_endpoint": None},
             ],
         }
 
@@ -63,7 +63,7 @@ def test_get_user_replica_set(app):
         assert replica_set_3 == {
             "user_id": 3,
             "wallet": "0x03",
-            "primary": None,
+            "primary": "",
             "secondary1": None,
             "secondary2": None,
             "primarySpID": None,

--- a/discovery-provider/src/queries/get_user_replica_set.py
+++ b/discovery-provider/src/queries/get_user_replica_set.py
@@ -25,14 +25,19 @@ def get_user_replica_set(args):
             return {}
 
         user = users[0]
-        endpoints = user.creator_node_endpoint.split(",")
+        cnode_endpoints = (
+            user.creator_node_endpoint if user.creator_node_endpoint is not None else ""
+        )
+        endpoints = cnode_endpoints.split(",")
+        secondary_ids = user.secondary_ids if user.secondary_ids is not None else ""
+
         return {
             "user_id": user.user_id,
             "wallet": user.wallet,
-            "primary": endpoints[0],
-            "secondary1": endpoints[1],
-            "secondary2": endpoints[2],
+            "primary": endpoints[0] if len(endpoints) >= 1 else None,
+            "secondary1": endpoints[1] if len(endpoints) >= 2 else None,
+            "secondary2": endpoints[2] if len(endpoints) >= 3 else None,
             "primarySpID": user.primary_id,
-            "secondary1SpID": user.secondary_ids[0],
-            "secondary2SpID": user.secondary_ids[1],
+            "secondary1SpID": secondary_ids[0] if len(secondary_ids) >= 1 else None,
+            "secondary2SpID": secondary_ids[1] if len(secondary_ids) >= 2 else None,
         }


### PR DESCRIPTION
### Description
The endpoint currently 500 errors if the user does not have a primary/secondary id set
The method has been updated to return with None in fields that are not set in the db

### Tests
Added a test for this

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->