### PR TITLE
Tracks stream optimizations pt 2

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -877,12 +877,11 @@ router.get(
         const findSourceFileForSegmentsStart = Date.now()
         // return unique sourceFile entries for the list of segments
         const fileSegmentRecords = await models.File.findAll({
-          attributes: ['sourceFile'],
+          attributes: [sequelize.fn('DISTINCT', sequelize.col('sourceFile'))],
           where: {
             multihash: segments,
             cnodeUserUUID: file.cnodeUserUUID
           },
-          group: 'sourceFile',
           raw: true
         })
         debugTimings.findSourceFileForSegments =
@@ -894,7 +893,7 @@ router.get(
           attributes: ['multihash'],
           where: {
             type: 'copy320',
-            sourceFile: fileSegmentRecords[0]
+            sourceFile: fileSegmentRecords[0].sourceFile
           },
           raw: true
         })

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -877,7 +877,7 @@ router.get(
         const findSourceFileForSegmentsStart = Date.now()
         // return unique sourceFile entries for the list of segments
         const fileSegmentRecords = await models.File.findAll({
-          attributes: [sequelize.fn('DISTINCT', sequelize.col('sourceFile'))],
+          attributes: [models.sequelize.fn('DISTINCT', models.sequelize.col('sourceFile'))],
           where: {
             multihash: segments,
             cnodeUserUUID: file.cnodeUserUUID

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -877,7 +877,9 @@ router.get(
         const findSourceFileForSegmentsStart = Date.now()
         // return unique sourceFile entries for the list of segments
         const fileSegmentRecords = await models.File.findAll({
-          attributes: [models.sequelize.fn('DISTINCT', models.sequelize.col('sourceFile'))],
+          attributes: [
+            models.sequelize.fn('DISTINCT', models.sequelize.col('sourceFile'))
+          ],
           where: {
             multihash: segments,
             cnodeUserUUID: file.cnodeUserUUID

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -875,8 +875,8 @@ router.get(
         )
 
         const findSourceFileForSegmentsStart = Date.now()
-        // return unique sourceFile entries for the list of segments
-        const fileSegmentRecords = await models.File.findAll({
+        // return a sourceFile which contains segments
+        const sourceFileRecord = await models.File.findOne({
           attributes: [
             models.sequelize.fn('DISTINCT', models.sequelize.col('sourceFile'))
           ],
@@ -895,7 +895,7 @@ router.get(
           attributes: ['multihash'],
           where: {
             type: 'copy320',
-            sourceFile: fileSegmentRecords[0].sourceFile
+            sourceFile: sourceFileRecord.sourceFile
           },
           raw: true
         })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Optimize /tracks/stream/:encodedId route. The issue here is if a single user has uploaded the same track multiple times (eg probers) the query for all sourceFiles can return a lot of records, on staging it was 382k records non-distinct and 8900 records distinct. In addition we had some checks in JS which were blocking the event loop, the biggest offender was  

```
const uniqSourceFiles = fileSegmentRecords
          .map((record) => record.sourceFile)
          .filter((v, i, a) => a.indexOf(v) === i)
```

This does a filter and an indexOf which is an O(n^2) operation on a list of 328k items. I removed these checks and had Postgres return the list of distinct items which saves us all the JS processing.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Hotfix onto stage and tested to make sure stream routes that were previously unplayable now play correctly.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
There's logs in the /tracks/stream route for debug timings and the times should be very quick to resolve tracks.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->