### PR TITLE
[PAY-123] Fix flaky rewards test

### DIFF
--- a/libs/tests/rewardsAttesterTest.js
+++ b/libs/tests/rewardsAttesterTest.js
@@ -120,10 +120,12 @@ describe('Delay calculator tests', () => {
     const solSlot = {
       last: 100
     }
-    // new slots every 250ms
+    // new slots every ~250ms for 4 slots/sec
+    // give it a little padding to make sure we produce
+    // a slot before the pollingInterval runs
     const i = setInterval(() => {
       solSlot.last += 1
-    }, 250)
+    }, 230)
 
     const libs = new MockLibs(
       () => solSlot.last,
@@ -138,13 +140,15 @@ describe('Delay calculator tests', () => {
     })
     calc.start()
     const slotThreshold1 = await calc.getSolanaSlotThreshold()
-    // Initially this should be 0.5sec/slot
+    // Initially this rate should be 0.5sec/slot
+    // 100 starting - 1s * 2slot/sec
     assert.strictEqual(slotThreshold1, 90)
 
-    // Wait for staleness interval
+    // Wait for staleness interval of 1s
     await new Promise((res) => setTimeout(res, 1100))
     const slotThreshold2 = await calc.getSolanaSlotThreshold()
-    // Current slot should be 104, and there should be 4 slots/sec,
+    // Current slot should be 104
+    // it should calculate 4 slot/sec
     // so 5 sec lag behind = 104 - 5 * 4 = 84
     assert.strictEqual(slotThreshold2, 84)
 


### PR DESCRIPTION
### Description
There's this old test that sometimes breaks in CI. I haven't been able to repro it, but I think this fixes the bug:
- Sometime we'd see 94 instead of 84 as the expected delay slot
- I think this is because the slots are produced on 250ms intervals and the solanaPollingInterval is 500ms, so occasionally it will poll and see a single slot created for 500ms and think the slot production rate is 2 per seconds instead of 4 per second, 104 - 5sec * 2slots/sec = 94

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->