### PR TITLE
Only process messages once per seq num

### DIFF
--- a/comms/db/migrations/20221222050259_add_rpc_log_pk.sql
+++ b/comms/db/migrations/20221222050259_add_rpc_log_pk.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter table rpc_log add primary key (jetstream_sequence);
+
+-- migrate:down
+alter table rpc_log drop constraint rpc_log_pkey;

--- a/comms/server/server_test.go
+++ b/comms/server/server_test.go
@@ -214,20 +214,10 @@ func TestGetChats(t *testing.T) {
 		defer res.Body.Close()
 
 		// Assertions
-		expectedData := schema.UserChat{
-			ChatID:             chatId1,
-			LastMessageAt:      chat1CreatedAt.Format(time.RFC3339Nano),
-			InviteCode:         chatId1,
-			UnreadMessageCount: float64(0),
-			ChatMembers: []schema.ChatMember{
-				expectedMember1,
-				expectedMember2,
-			},
-		}
 		expectedResponse, err := json.Marshal(
 			schema.CommsResponse{
 				Health: expectedHealth,
-				Data:   expectedData,
+				Data:   expectedChat1Data,
 			},
 		)
 		assert.NoError(t, err)


### PR DESCRIPTION
### Description
Check for seq num in `rpc_log`, do not process message if already in the log. This keeps `Apply` idempotent in case messages get redelivered.

Thoughts on making `jetstream_sequence` the PK in `rpc_log`?

Also threw a small unrelated cleanup change to `server_test` in here.

### Tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
