### PR TITLE
Use username instead of display_name for tiktok

### DIFF
--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -77,6 +77,7 @@ module.exports = function (app) {
           {
             fields: [
               'open_id',
+              'username',
               'display_name',
               'profile_deep_link',
               'is_verified'
@@ -101,7 +102,7 @@ module.exports = function (app) {
 
         if (existingTikTokUser) {
           return errorResponseBadRequest(
-            `Another Audius profile has already been authenticated with TikTok user @${tikTokUser.display_name}!`
+            `Another Audius profile has already been authenticated with TikTok user @${tikTokUser.username}!`
           )
         } else {
           // Store the user id, and current profile for user in db
@@ -141,8 +142,7 @@ module.exports = function (app) {
         const isUnassociated = tikTokObj && !tikTokObj.blockchainUserId
         const handlesMatch =
           tikTokObj &&
-          tikTokObj.profile.display_name.toLowerCase() ===
-            user.handle.toLowerCase()
+          tikTokObj.profile.username.toLowerCase() === user.handle.toLowerCase()
 
         // only set blockchainUserId if not already set
         if (isUnassociated && handlesMatch) {
@@ -187,12 +187,12 @@ module.exports = function (app) {
             where: { handle }
           })
           if (socialHandle) {
-            socialHandle.tikTokHandle = tikTokObj.profile.display_name
+            socialHandle.tikTokHandle = tikTokObj.profile.username
             await socialHandle.save()
-          } else if (tikTokObj.profile && tikTokObj.profile.display_name) {
+          } else if (tikTokObj.profile && tikTokObj.profile.username) {
             await models.SocialHandles.create({
               handle,
-              tikTokHandle: tikTokObj.profile.display_name
+              tikTokHandle: tikTokObj.profile.username
             })
           }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Obvious bug is obvious, fixed by using `username` instead of `display_name`. The TikTok api docs do not surface that `username` is an available field. While testing I was using a tiktok account that did not have a display name and defaulted to the username


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->