### PR TITLE
Add trending notif

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_trending.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import redis
 from integration_tests.utils import populate_mock_db
 from src.tasks.index_trending import (
+    find_min_block_above_timestamp,
     floor_time,
     get_should_update_trending,
     set_last_trending_datetime,
@@ -13,12 +14,19 @@ from web3.types import BlockData
 
 REDIS_URL = shared_config["redis"]["url"]
 
+BASE_TIME = datetime(2012, 3, 16, 0, 0)
+
 
 class MockEth:
     def __init__(self, return_block: BlockData):
         self.return_block = return_block
 
     def get_block(self, *args):
+        if len(args) == 2:
+            hours_diff = args[0]
+            datetime_val = BASE_TIME + timedelta(minutes=hours_diff)
+            return {"timestamp": int(datetime_val.timestamp()), "number": hours_diff}
+
         return self.return_block
 
 
@@ -28,9 +36,7 @@ class MockWeb3:
 
 
 def test_floor_time_60():
-    assert floor_time(datetime(2012, 3, 16, 0, 0), 60 * 60) == datetime(
-        2012, 3, 16, 0, 0
-    )
+    assert floor_time(BASE_TIME, 60 * 60) == datetime(2012, 3, 16, 0, 0)
     assert floor_time(datetime(2012, 3, 16, 0, 1), 60 * 60) == datetime(
         2012, 3, 16, 0, 0
     )
@@ -40,9 +46,7 @@ def test_floor_time_60():
 
 
 def test_floor_time_15():
-    assert floor_time(datetime(2012, 3, 16, 0, 0), 60 * 15) == datetime(
-        2012, 3, 16, 0, 0
-    )
+    assert floor_time(BASE_TIME, 60 * 15) == datetime(2012, 3, 16, 0, 0)
     assert floor_time(datetime(2012, 3, 16, 0, 1), 60 * 15) == datetime(
         2012, 3, 16, 0, 0
     )
@@ -58,7 +62,7 @@ def test_floor_time_15():
 
 
 def test_get_should_update_trending_hour_updates(app):
-    last_trending_date = int(datetime(2012, 3, 16, 0, 0).timestamp())
+    last_trending_date = int(BASE_TIME.timestamp())
     last_block_date = int(datetime(2012, 3, 16, 1, 5).timestamp())
 
     redis_conn = redis.Redis.from_url(url=REDIS_URL)
@@ -69,18 +73,18 @@ def test_get_should_update_trending_hour_updates(app):
 
     # Add some users to the db so we have blocks
     entities = {
-        "users": [{}] * 3,
+        "users": [{}] * 80,
     }
     populate_mock_db(db, entities)
 
-    should_update = get_should_update_trending(db, web3, redis_conn, 60 * 60)
-    assert should_update != None
+    _, min_datetime = get_should_update_trending(db, web3, redis_conn, 60 * 60)
+    assert min_datetime != None
     # Result is rounded
-    assert datetime.fromtimestamp(should_update) == datetime(2012, 3, 16, 1, 0)
+    assert datetime.fromtimestamp(min_datetime) == datetime(2012, 3, 16, 1, 0)
 
 
 def test_get_should_update_trending_less_than_hour_no_update(app):
-    last_trending_date = int(datetime(2012, 3, 16, 0, 0).timestamp())
+    last_trending_date = int(BASE_TIME.timestamp())
     last_block_date = int(datetime(2012, 3, 16, 0, 1).timestamp())
 
     redis_conn = redis.Redis.from_url(url=REDIS_URL)
@@ -91,16 +95,17 @@ def test_get_should_update_trending_less_than_hour_no_update(app):
 
     # Add some users to the db so we have blocks
     entities = {
-        "users": [{}] * 3,
+        "users": [{}] * 20,
     }
     populate_mock_db(db, entities)
 
-    should_update = get_should_update_trending(db, web3, redis_conn, 60 * 60)
-    assert should_update == None
+    min_block, min_datetime = get_should_update_trending(db, web3, redis_conn, 60 * 60)
+    assert min_block == None
+    assert min_datetime == None
 
 
 def test_get_should_update_trending_fifteen_minutes(app):
-    last_trending_date = int(datetime(2012, 3, 16, 0, 0).timestamp())
+    last_trending_date = int(BASE_TIME.timestamp())
     last_block_date = int(datetime(2012, 3, 16, 0, 16).timestamp())
 
     redis_conn = redis.Redis.from_url(url=REDIS_URL)
@@ -111,18 +116,18 @@ def test_get_should_update_trending_fifteen_minutes(app):
 
     # Add some users to the db so we have blocks
     entities = {
-        "users": [{}] * 3,
+        "users": [{}] * 24,
     }
     populate_mock_db(db, entities)
 
-    should_update = get_should_update_trending(db, web3, redis_conn, 60 * 15)
-    assert should_update != None
+    _, min_datetime = get_should_update_trending(db, web3, redis_conn, 60 * 15)
+    assert min_datetime != None
     # Result is rounded
-    assert datetime.fromtimestamp(should_update) == datetime(2012, 3, 16, 0, 15)
+    assert datetime.fromtimestamp(min_datetime) == datetime(2012, 3, 16, 0, 15)
 
 
 def test_get_should_update_trending_less_fifteen_minutes_no_update(app):
-    last_trending_date = int(datetime(2012, 3, 16, 0, 0).timestamp())
+    last_trending_date = int(BASE_TIME.timestamp())
     last_block_date = int(datetime(2012, 3, 16, 0, 14).timestamp())
 
     redis_conn = redis.Redis.from_url(url=REDIS_URL)
@@ -133,9 +138,34 @@ def test_get_should_update_trending_less_fifteen_minutes_no_update(app):
 
     # Add some users to the db so we have blocks
     entities = {
-        "users": [{}] * 3,
+        "users": [{}] * 12,
     }
     populate_mock_db(db, entities)
 
-    should_update = get_should_update_trending(db, web3, redis_conn, 60 * 15)
-    assert should_update == None
+    min_block, min_datetime = get_should_update_trending(db, web3, redis_conn, 60 * 15)
+    assert min_block == None
+    assert min_datetime == None
+
+
+def test_find_min_block_above_timestamp(app):
+    """
+    Test that given a current blocknumber and min_timestamp,
+    the find_min_block_above_timestamp function should iterate
+    until it finds the min blocknumber at or above the timestamp
+    """
+
+    # Add some users to the db - wihch generates that number of blocks
+    entities = {
+        "users": [{}] * 180,
+    }
+    with app.app_context():
+        db = get_db()
+
+        populate_mock_db(db, entities)
+
+    block_number = 100
+    min_timestamp = BASE_TIME + timedelta(minutes=20)
+    web3 = MockWeb3({})
+
+    min_block = find_min_block_above_timestamp(block_number, min_timestamp, web3)
+    assert min_block["number"] == 20

--- a/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
@@ -1,0 +1,163 @@
+from datetime import datetime, timedelta
+
+from integration_tests.utils import populate_mock_db
+from sqlalchemy import asc
+from src.models.notifications.notification import Notification
+from src.queries.get_trending_tracks import make_trending_cache_key
+from src.tasks.index_trending import index_trending_notifications
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.utils.config import shared_config
+from src.utils.db_session import get_db
+from src.utils.redis_cache import set_json_cached_key
+from src.utils.redis_connection import get_redis
+
+REDIS_URL = shared_config["redis"]["url"]
+
+BASE_TIME = datetime(2023, 1, 1, 0, 0)
+
+
+def test_index_trending_notification(app):
+    """
+    Test that given when new trending values are calculated
+    the correct notifications are generated
+    """
+
+    with app.app_context():
+        db = get_db()
+        redis = get_redis()
+        trending_strategy_factory = TrendingStrategyFactory()
+        trending_strategy = trending_strategy_factory.get_strategy(TrendingType.TRACKS)
+        # Test that if there are no prev notifications, all trending in top are generated
+
+        trending_key = make_trending_cache_key("week", None, trending_strategy.version)
+        trending_tracks = [
+            {
+                "track_id": i,
+                "owner_id": i % 2 + 1,
+                "user": [{"user_id": i % 2 + 1, "wallet": "0x0"}],
+            }
+            for i in range(1, 21)
+        ]
+        track_ids = [track["track_id"] for track in trending_tracks]
+        trending_tracks = (trending_tracks, track_ids)
+        set_json_cached_key(redis, trending_key, trending_tracks)
+
+        # Add some users to the db so we have blocks
+        entities = {
+            "tracks": [{}] * 100,
+            "users": [{}] * 2,
+        }
+        populate_mock_db(db, entities)
+
+        index_trending_notifications(db, BASE_TIME)
+        with db.scoped_session() as session:
+            notifications = (
+                session.query(Notification).order_by(asc(Notification.specifier)).all()
+            )
+            assert len(notifications) == 5
+
+            notification_0 = notifications[0]
+            assert notification_0.specifier == "1"
+            assert (
+                notification_0.group_id
+                == "trending:time_range:week:genre:all:rank:1:track_id:1:timestamp:1672531200"
+            )
+            assert notification_0.type == "trending"
+            assert notification_0.data == {
+                "rank": 1,
+                "genre": "all",
+                "track_id": 1,
+                "time_range": "week",
+            }
+            assert notification_0.user_ids == [2]
+
+            notification_1 = notifications[1]
+            assert notification_1.specifier == "2"
+            assert (
+                notification_1.group_id
+                == "trending:time_range:week:genre:all:rank:2:track_id:2:timestamp:1672531200"
+            )
+            assert notification_1.type == "trending"
+            assert notification_1.data == {
+                "rank": 2,
+                "genre": "all",
+                "track_id": 2,
+                "time_range": "week",
+            }
+            assert notification_1.user_ids == [1]
+
+        # Test that on second iteration of trending, only new notifications appear
+        # Prev: 1, 2, 3, 4, 5
+        # New: 2, 4, 5, 1, 7
+        # new notifications for track_id: 2, 4, 5, 7
+        # no new notification for track_id: 1
+
+        trending_tracks = [
+            {
+                "track_id": i,
+                "owner_id": i % 2 + 1,
+                "user": [{"user_id": i % 2 + 1, "wallet": "0x0"}],
+            }
+            for i in [2, 4, 5, 1, 7, 8, 9, 10]
+        ]
+        track_ids = [track["track_id"] for track in trending_tracks]
+        trending_tracks = (trending_tracks, track_ids)
+        set_json_cached_key(redis, trending_key, trending_tracks)
+        updated_time = BASE_TIME + timedelta(hours=1)
+
+        index_trending_notifications(db, updated_time)
+        with db.scoped_session() as session:
+            all_notifications = session.query(Notification).all()
+            assert len(all_notifications) == 6
+
+            updated_notifications = (
+                session.query(Notification)
+                .filter(Notification.timestamp == updated_time)
+                .order_by(asc(Notification.specifier))
+                .all()
+            )
+            assert len(updated_notifications) == 1
+
+            assert updated_notifications[0].data == {
+                "rank": 5,
+                "genre": "all",
+                "track_id": 7,
+                "time_range": "week",
+            }
+
+        updated_time = BASE_TIME + timedelta(hours=24)
+
+        index_trending_notifications(db, updated_time)
+        with db.scoped_session() as session:
+            all_notifications = session.query(Notification).all()
+            assert len(all_notifications) == 9
+
+            updated_notifications = (
+                session.query(Notification)
+                .filter(Notification.timestamp == updated_time)
+                .order_by(asc(Notification.specifier))
+                .all()
+            )
+            assert len(updated_notifications) == 3
+
+            assert updated_notifications[0].data == {
+                "rank": 1,
+                "genre": "all",
+                "track_id": 2,
+                "time_range": "week",
+            }
+
+            assert updated_notifications[1].data == {
+                "rank": 2,
+                "genre": "all",
+                "track_id": 4,
+                "time_range": "week",
+            }
+
+            assert updated_notifications[2].data == {
+                "rank": 3,
+                "genre": "all",
+                "track_id": 5,
+                "time_range": "week",
+            }

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -43,7 +43,9 @@ def generate_unpopulated_trending(
     exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
     limit=TRENDING_LIMIT,
 ):
-    trending_tracks = generate_trending(session, time_range, genre, limit, 0, strategy)
+    trending_tracks = generate_trending(
+        session, time_range, genre, limit, 0, strategy.version
+    )
 
     track_scores = [
         strategy.get_track_score(time_range, track)

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -228,7 +228,7 @@ def index_trending_notifications(db: SessionManager, timestamp: datetime):
     with db.scoped_session() as session:
         trending_tracks = _get_trending_tracks_with_session(
             session,
-            {time: "week"},
+            {"time": "week", "exclude_premium": True},
             trending_strategy_factory.get_strategy(TrendingType.TRACKS),
         )
         top_trending = trending_tracks[:NOTIFICATIONS_TRACK_LIMIT]


### PR DESCRIPTION
### Description
Trending Notification created after each trending job run
Creates a new trending notification when a track is in the top 5 trending (weekly trending, across all genres)
If the track moves up, then create a new notification for the user. 
But do not notify the user within 24 hours of last notification. 

For the timestamps, the trending jobs was previously run every hour, but this has been updated to only run on the hours mark itself, triggered by finding the correct blocknumber/block timestamp corresponding to the point in time when the timestamp crosses over the hour mark

### Tests
Wrote test to validate it works as intended

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->