### PR TITLE
Add dynamic nethermind gas limit

### DIFF
--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -178,7 +178,11 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
         nethermindEncodedABI = encodedABI
       }
       relayPromises.push(
-        relayToNethermind(nethermindEncodedABI, nethermindContractAddress, gasLimit)
+        relayToNethermind(
+          nethermindEncodedABI,
+          nethermindContractAddress,
+          gasLimit
+        )
       )
     }
     const relayTxs = await Promise.allSettled(relayPromises)

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -178,7 +178,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
         nethermindEncodedABI = encodedABI
       }
       relayPromises.push(
-        relayToNethermind(nethermindEncodedABI, nethermindContractAddress)
+        relayToNethermind(nethermindEncodedABI, nethermindContractAddress, gasLimit)
       )
     }
     const relayTxs = await Promise.allSettled(relayPromises)
@@ -444,7 +444,7 @@ const createAndSendTransaction = async (
 
 let inFlight = 0
 
-async function relayToNethermind(encodedABI, contractAddress) {
+async function relayToNethermind(encodedABI, contractAddress, gasLimit) {
   // generate a new private key per transaction (gas is free)
   const accounts = new Accounts(config.get('nethermindWeb3Provider'))
 
@@ -456,7 +456,7 @@ async function relayToNethermind(encodedABI, contractAddress) {
     const transaction = {
       to: contractAddress,
       value: 0,
-      gas: '100880',
+      gas: gasLimit,
       gasPrice: 0,
       data: encodedABI
     }


### PR DESCRIPTION
### Description
Pass gas value to nethermind to allow for larger transaction sized
NOTE: This is untested, was planning on testing on stage
NOTE: Ran into this limit while testing announcement notifications

### Tests
none

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->