### PR TITLE
[CON-534] add new required field to accessChecker `trackId`

### DIFF
--- a/creator-node/src/contentAccess/types.ts
+++ b/creator-node/src/contentAccess/types.ts
@@ -24,7 +24,7 @@ export type SignedData = {
   cid: string
   timestamp: number
   shouldCache: boolean
-  trackId: string
+  trackId: number
 }
 
 export type CheckAccessResponse =

--- a/creator-node/src/contentAccess/types.ts
+++ b/creator-node/src/contentAccess/types.ts
@@ -24,6 +24,7 @@ export type SignedData = {
   cid: string
   timestamp: number
   shouldCache: boolean
+  trackId: string
 }
 
 export type CheckAccessResponse =

--- a/creator-node/test/contentAccessChecker.test.ts
+++ b/creator-node/test/contentAccessChecker.test.ts
@@ -19,7 +19,7 @@ describe('Test content access', function () {
     '0x1D9c77BcfBfa66D37390BF2335f0140979a6122B'
 
   const cid = 'QmcbnrugPPDrRXb5NeYKwPb7HWUj7aN2tXmhgwRfw2pRXo'
-  const trackId = '12345'
+  const trackId = 12345
   const data = {
     cid,
     shouldCache: true,

--- a/creator-node/test/contentAccessChecker.test.ts
+++ b/creator-node/test/contentAccessChecker.test.ts
@@ -19,10 +19,12 @@ describe('Test content access', function () {
     '0x1D9c77BcfBfa66D37390BF2335f0140979a6122B'
 
   const cid = 'QmcbnrugPPDrRXb5NeYKwPb7HWUj7aN2tXmhgwRfw2pRXo'
+  const trackId = '12345'
   const data = {
     cid,
     shouldCache: true,
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    trackId
   }
 
   before(async () => {
@@ -51,10 +53,7 @@ describe('Test content access', function () {
 
   describe('content access', () => {
     it('fails when recovered DN wallet is not from registered DN', async () => {
-      const signature = generateSignature(
-        data,
-        badDNPrivateKey
-      )
+      const signature = generateSignature(data, badDNPrivateKey)
 
       const access = await checkCIDAccess({
         cid,
@@ -72,10 +71,7 @@ describe('Test content access', function () {
     })
 
     it('failed when the cid does not match what is signed', async () => {
-      const signature = generateSignature(
-        data,
-        dummyDNPrivateKey
-      )
+      const signature = generateSignature(data, dummyDNPrivateKey)
       const access = await checkCIDAccess({
         cid: 'incorrectCID',
         data,
@@ -95,6 +91,7 @@ describe('Test content access', function () {
       const tenDays = 1_000 * 60 * 60 * 24 * 10
       const expiredTimestampData = {
         cid: cid,
+        trackId,
         shouldCache: true,
         timestamp: Date.now() - tenDays // ten days old
       }
@@ -119,10 +116,7 @@ describe('Test content access', function () {
     })
 
     it('passes when everything matches', async () => {
-      const signature = generateSignature(
-        data,
-        dummyDNPrivateKey
-      )
+      const signature = generateSignature(data, dummyDNPrivateKey)
       const access = await checkCIDAccess({
         cid,
         signature,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Add `trackId` to one of the required fields for streaming a track. This is part of the work to make TNS and Blacklist Manager work for the new streaming setup.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Updated the unit tests for the accessChecker service to accommodate the new field. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

No major monitoring changes

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->