### PR TITLE
Exclude @audius/anchor-audius-data from react-native builds

### DIFF
--- a/libs/rollup.config.ts
+++ b/libs/rollup.config.ts
@@ -7,6 +7,7 @@ import { terser } from 'rollup-plugin-terser'
 import nodePolyfills from 'rollup-plugin-polyfill-node'
 import alias from '@rollup/plugin-alias'
 import ignore from 'rollup-plugin-ignore'
+import path from 'path'
 
 import pkg from './package.json'
 
@@ -249,16 +250,24 @@ export const outputConfigs = {
     output: [{ file: 'dist/native-libs.js', format: 'es', sourcemap: true }],
     plugins: [
       ignore(['web3', 'graceful-fs', 'node-localstorage']),
+      alias({
+        entries: [
+          { find: 'stream', replacement: 'stream-browserify' },
+          {
+            // Need to exclude @audius/anchor-audius-data,
+            // but it has a named import so the default ignore plugin won't work
+            find: '@audius/anchor-audius-data',
+            replacement: path.resolve(__dirname, 'src/NativeAudiusAnchorData')
+          }
+        ]
+      }),
       resolve({ extensions, preferBuiltins: true }),
       commonjs({ extensions }),
-      alias({
-        entries: [{ find: 'stream', replacement: 'stream-browserify' }]
-      }),
       babel({ babelHelpers: 'bundled', extensions }),
       json(),
       pluginTypescript
     ],
-    external
+    external: external.filter((dep) => dep !== '@audius/anchor-audius-data')
   },
 
   /**

--- a/libs/src/NativeAudiusAnchorData.ts
+++ b/libs/src/NativeAudiusAnchorData.ts
@@ -1,0 +1,3 @@
+// Empty module but with a named idl export, to bypass importing all of @audius/anchor-audius-data for react-native
+export const idl = undefined
+export default undefined


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

- Moves the aliases before the resolve plugin, so that the aliases can get used instead
- Replaces @audius/anchor-audius-data with an empty mock for react-native

We should be able to remove the patch for @audius/sdk from our react-native client once we update to this.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->