### PR TITLE
[PLAT-538] Remove custom redis disk persistence, upgrade redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,7 +735,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: audius_identity_service_test
-      - image: redis:5.0.4
+      - image: redis:7.0
     steps:
       - checkout
       - diff-if-necessary:

--- a/discovery-provider/compose/docker-compose.redis.yml
+++ b/discovery-provider/compose/docker-compose.redis.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   redis-server:
     image: redis:3.0-alpine
-    command: redis-server --save ''
+    command: redis-server
     ports:
       - "${audius_redis_port}:6379"
     networks:

--- a/discovery-provider/src/eth_indexing/event_scanner.py
+++ b/discovery-provider/src/eth_indexing/event_scanner.py
@@ -8,7 +8,6 @@ from src.models.indexing.eth_block import EthBlock
 from src.models.users.associated_wallet import AssociatedWallet
 from src.models.users.user import User
 from src.queries.get_balances import enqueue_immediate_balance_refresh
-from src.utils.helpers import redis_set_and_dump
 from web3 import Web3
 from web3._utils.events import get_event_data
 
@@ -112,10 +111,8 @@ class EventScanner:
         logger.info(
             f"event_scanner.py | Saving last scanned block ({self.last_scanned_block}) to redis"
         )
-        redis_set_and_dump(
-            self.redis,
-            eth_indexing_last_scanned_block_key,
-            str(self.last_scanned_block),
+        self.redis.set(
+            eth_indexing_last_scanned_block_key, str(self.last_scanned_block)
         )
         with self.db.scoped_session() as session:
             record = session.query(EthBlock).first()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -559,7 +559,7 @@ def get_play_health_info(
             latest_db_play = float(latest_db_play.decode())
             latest_db_play = datetime.utcfromtimestamp(latest_db_play)
 
-        oldest_unarchived_play = redis.get(oldest_unarchived_play_key)
+        oldest_unarchived_play: str = redis.get(oldest_unarchived_play_key)
         if not oldest_unarchived_play:
             # Query and cache oldest unarchived play
             oldest_unarchived_play = get_oldest_unarchived_play()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -559,7 +559,7 @@ def get_play_health_info(
             latest_db_play = float(latest_db_play.decode())
             latest_db_play = datetime.utcfromtimestamp(latest_db_play)
 
-        oldest_unarchived_play: str = redis.get(oldest_unarchived_play_key)
+        oldest_unarchived_play = redis.get(oldest_unarchived_play_key)
         if not oldest_unarchived_play:
             # Query and cache oldest unarchived play
             oldest_unarchived_play = get_oldest_unarchived_play()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -570,7 +570,9 @@ def get_play_health_info(
                 )
         else:
             # Decode bytes into float for latest timestamp
-            oldest_unarchived_play = datetime.utcfromtimestamp(float(oldest_unarchived_play.decode()))
+            oldest_unarchived_play = datetime.utcfromtimestamp(
+                float(oldest_unarchived_play.decode())
+            )
 
         time_diff_general = (
             (current_time_utc - latest_db_play).total_seconds()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -559,7 +559,7 @@ def get_play_health_info(
             latest_db_play = float(latest_db_play.decode())
             latest_db_play = datetime.utcfromtimestamp(latest_db_play)
 
-        oldest_unarchived_play = redis.get(redis, oldest_unarchived_play_key)
+        oldest_unarchived_play = redis.get(oldest_unarchived_play_key)
         if not oldest_unarchived_play:
             # Query and cache oldest unarchived play
             oldest_unarchived_play = get_oldest_unarchived_play()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -566,12 +566,11 @@ def get_play_health_info(
             if oldest_unarchived_play:
                 redis.set(
                     oldest_unarchived_play_key,
-                    oldest_unarchived_play.timestamp(),
+                    oldest_unarchived_play,
                 )
         else:
             # Decode bytes into float for latest timestamp
-            oldest_unarchived_play = float(oldest_unarchived_play.decode())
-            oldest_unarchived_play = datetime.utcfromtimestamp(oldest_unarchived_play)
+            oldest_unarchived_play = datetime.utcfromtimestamp(float(oldest_unarchived_play.decode()))
 
         time_diff_general = (
             (current_time_utc - latest_db_play).total_seconds()
@@ -588,7 +587,7 @@ def get_play_health_info(
         "is_unhealthy": is_unhealthy_plays,
         "tx_info": sol_play_info,
         "time_diff_general": time_diff_general,
-        "oldest_unarchived_play_created_at": oldest_unarchived_play,
+        "oldest_unarchived_play_created_at": str(oldest_unarchived_play),
     }
 
 

--- a/discovery-provider/src/queries/get_oldest_unarchived_play.py
+++ b/discovery-provider/src/queries/get_oldest_unarchived_play.py
@@ -3,7 +3,7 @@ from src.models.social.play import Play
 from src.utils import db_session
 
 
-def get_oldest_unarchived_play():
+def get_oldest_unarchived_play() -> str:
     """
     Gets the oldest unarchived play in the database
     """

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1138,7 +1138,6 @@ def update_task(self):
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)
-        logger.info("raymont has " + have_lock)
         if have_lock:
             logger.info(
                 f"index.py | {self.request.id} | update_task | Acquired disc_prov_lock"

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -1138,6 +1138,7 @@ def update_task(self):
     try:
         # Attempt to acquire lock - do not block if unable to acquire
         have_lock = update_lock.acquire(blocking=False)
+        logger.info("raymont has " + have_lock)
         if have_lock:
             logger.info(
                 f"index.py | {self.request.id} | update_task | Acquired disc_prov_lock"

--- a/discovery-provider/src/utils/cache_solana_program.py
+++ b/discovery-provider/src/utils/cache_solana_program.py
@@ -33,7 +33,8 @@ def cache_latest_sol_db_tx(
 
 
 def get_latest_sol_db_tx(redis: Redis, cache_key: str):
-    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(redis.get(cache_key))
+    value = redis.get(cache_key)
+    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(value) if value else None
     return latest_sol_db
 
 
@@ -79,5 +80,6 @@ def cache_latest_sol_play_program_tx(
 
 
 def get_cache_latest_sol_program_tx(redis: Redis, cache_key: str):
-    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(redis.get(cache_key))
+    value = redis.get(cache_key)
+    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(value) if value else None
     return latest_sol_db

--- a/discovery-provider/src/utils/cache_solana_program.py
+++ b/discovery-provider/src/utils/cache_solana_program.py
@@ -1,13 +1,10 @@
+import json
 import logging
 from typing import Optional, TypedDict
 
 from redis import Redis
 from src.solana.solana_client_manager import SolanaClientManager
 from src.solana.solana_transaction_types import ConfirmedSignatureForAddressResult
-from src.utils.helpers import (
-    redis_get_json_cached_key_or_restore,
-    redis_set_json_and_dump,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +24,7 @@ def cache_latest_sol_db_tx(
     redis: Redis, cache_key: str, latest_tx: CachedProgramTxInfo
 ):
     try:
-        redis_set_json_and_dump(redis, cache_key, latest_tx)
+        redis.set(cache_key, json.dumps(latest_tx))
     except Exception as e:
         logger.error(
             f"cache_solana_program.py | Failed to cache key {cache_key} latest processed transaction {latest_tx}, {e}"
@@ -35,10 +32,8 @@ def cache_latest_sol_db_tx(
         raise e
 
 
-def get_latest_sol_db_tx(redis: Redis, cahce_key: str):
-    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(
-        redis, cahce_key
-    )
+def get_latest_sol_db_tx(redis: Redis, cache_key: str):
+    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(redis.get(cache_key))
     return latest_sol_db
 
 
@@ -72,8 +67,9 @@ def cache_latest_sol_play_program_tx(
         sig = tx["signature"]
         slot = tx["slot"]
         timestamp = tx["blockTime"]
-        redis_set_json_and_dump(
-            redis, cache_key, {"signature": sig, "slot": slot, "timestamp": timestamp}
+        redis.set(
+            cache_key,
+            json.dumps({"signature": sig, "slot": slot, "timestamp": timestamp}),
         )
     except Exception as e:
         logger.error(
@@ -83,7 +79,5 @@ def cache_latest_sol_play_program_tx(
 
 
 def get_cache_latest_sol_program_tx(redis: Redis, cache_key: str):
-    latest_sol_db: Optional[CachedProgramTxInfo] = redis_get_json_cached_key_or_restore(
-        redis, cache_key
-    )
+    latest_sol_db: Optional[CachedProgramTxInfo] = json.loads(redis.get(cache_key))
     return latest_sol_db

--- a/discovery-provider/src/utils/test_get_cached_metrics.py
+++ b/discovery-provider/src/utils/test_get_cached_metrics.py
@@ -1,7 +1,6 @@
 import json
 from datetime import datetime, timedelta
 
-from src.utils.helpers import redis_set_and_dump
 from src.utils.redis_metrics import (
     datetime_format_secondary,
     get_redis_metrics,
@@ -30,7 +29,7 @@ def test_get_cached_route_metrics(redis_mock):
             "another-ip": 3,
         },
     }
-    redis_set_and_dump(redis_mock, personal_route_metrics, json.dumps(metrics))
+    redis_mock.set(personal_route_metrics, json.dumps(metrics))
 
     result = get_redis_metrics(redis_mock, start_time_obj, personal_route_metrics)
 
@@ -54,7 +53,7 @@ def test_get_cached_app_metrics(redis_mock):
             "another-app": 3,
         },
     }
-    redis_set_and_dump(redis_mock, personal_app_metrics, json.dumps(metrics))
+    redis_mock.set(personal_app_metrics, json.dumps(metrics))
 
     result = get_redis_metrics(redis_mock, start_time_obj, personal_app_metrics)
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -153,11 +153,14 @@ services:
       mode: global
 
   discovery-provider-redis:
-    image: redis:5.0.5
+    image: redis:7.0
+    command: redis-server
     healthcheck:
       test: [ "CMD", "redis-cli", "PING" ]
       interval: 10s
       timeout: 5s
+    volumes:
+      - ./discovery-provider/
     logging: *default-logging
     deploy:
       mode: global
@@ -203,7 +206,8 @@ services:
       mode: global
 
   identity-service-redis:
-    image: redis:5.0.5
+    image: redis:7.0
+    command: redis-server
     healthcheck:
       test: [ "CMD", "redis-cli", "PING" ]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,7 +218,8 @@ services:
       mode: global
 
   identity-service-redis:
-    image: redis:5.0.5
+    image: redis:7.0
+    command: redis-server
     healthcheck:
       test: [ "CMD", "redis-cli", "PING" ]
       interval: 10s

--- a/identity-service/compose/docker-compose.full.yml
+++ b/identity-service/compose/docker-compose.full.yml
@@ -12,7 +12,8 @@ services:
     networks:
       - audius_dev
   identity-redis:
-    image: redis:5.0.4
+    image: redis:7.0
+    command: redis-server
     ports:
       - '7379:6379'
     networks:

--- a/identity-service/scripts/run-tests.sh
+++ b/identity-service/scripts/run-tests.sh
@@ -54,7 +54,7 @@ REDIS_CONTAINER='identity_test_redis'
 REDIS_EXISTS=$(docker ps -a -q -f status=running -f name=^/${REDIS_CONTAINER}$)
 if [ ! "${REDIS_EXISTS}" ]; then
   echo "Redis Container doesn't exist"
-  docker run -d --name $REDIS_CONTAINER -p 127.0.0.1:$redisPort:6379 redis:5.0.4
+  docker run -d --name $REDIS_CONTAINER -p 127.0.0.1:$redisPort:6379 redis:7.0
   sleep 1
 fi
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Remove custom `redis_set_and_dump` and `redis_get_and_restore`.
Instead of these, we can opt in for the build in redis persistence configurations https://redis.io/docs/management/persistence/

See docker-compose PR: https://github.com/AudiusProject/audius-docker-compose/pull/176

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

`audius-compose up` & verify health checks

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->