### PR TITLE
Artist pick backfill: only update records last updated before the csvs were pulled

### DIFF
--- a/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
+++ b/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
@@ -31,7 +31,7 @@ def build_sql(up, env):
         for entry in f:
             handle, pinned_track_id = entry.split(",")
 
-            handles.append(handle)
+            handles.append(handle.lower())
             if up:
                 pinned_track_id = int(pinned_track_id.strip())
                 pinned_track_ids.append(pinned_track_id)
@@ -44,13 +44,13 @@ def build_sql(up, env):
     if up:
         inner_sql = """UPDATE users
         SET artist_pick_track_id = data_table.pinned_track_id
-        FROM (SELECT unnest(:handles) AS handle, unnest(:pinned_track_ids) AS pinned_track_id) AS data_table
-        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle = data_table.handle;"""
+        FROM (SELECT unnest(:handles) AS handle_lc, unnest(:pinned_track_ids) AS pinned_track_id) AS data_table
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle_lc = data_table.handle_lc;"""
     else:
         inner_sql = """UPDATE users
         SET artist_pick_track_id = null
-        FROM (SELECT unnest(:handles) AS handle) AS data_table
-        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle = data_table.handle;"""
+        FROM (SELECT unnest(:handles) AS handle_lc) AS data_table
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle_lc = data_table.handle_lc;"""
 
     sql = sa.text("begin; \n\n " + inner_sql + " \n\n commit;")
     sql = sql.bindparams(sa.bindparam("handles", ARRAY(String)))

--- a/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
+++ b/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
@@ -45,12 +45,12 @@ def build_sql(up, env):
         inner_sql = """UPDATE users
         SET artist_pick_track_id = data_table.pinned_track_id
         FROM (SELECT unnest(:handles) AS handle, unnest(:pinned_track_ids) AS pinned_track_id) AS data_table
-        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:15:00' AND users.handle = data_table.handle;"""
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle = data_table.handle;"""
     else:
         inner_sql = """UPDATE users
         SET artist_pick_track_id = null
         FROM (SELECT unnest(:handles) AS handle) AS data_table
-        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:15:00' AND users.handle = data_table.handle;"""
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle = data_table.handle;"""
 
     sql = sa.text("begin; \n\n " + inner_sql + " \n\n commit;")
     sql = sql.bindparams(sa.bindparam("handles", ARRAY(String)))

--- a/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
+++ b/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
@@ -40,10 +40,17 @@ def build_sql(up, env):
         'handles': handles,
         'pinned_track_ids': pinned_track_ids,
     }
+    # only backfill records last updated before the csvs were pulled
     if up:
-        inner_sql = "UPDATE users SET artist_pick_track_id = data_table.pinned_track_id FROM (SELECT unnest(:handles) AS handle, unnest(:pinned_track_ids) AS pinned_track_id) AS data_table WHERE users.is_current = True AND users.handle = data_table.handle;"
+        inner_sql = """UPDATE users
+        SET artist_pick_track_id = data_table.pinned_track_id
+        FROM (SELECT unnest(:handles) AS handle, unnest(:pinned_track_ids) AS pinned_track_id) AS data_table
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:15:00' AND users.handle = data_table.handle;"""
     else:
-        inner_sql = "UPDATE users SET artist_pick_track_id = null FROM (SELECT unnest(:handles) AS handle) AS data_table WHERE users.is_current = True AND users.handle = data_table.handle;"
+        inner_sql = """UPDATE users
+        SET artist_pick_track_id = null
+        FROM (SELECT unnest(:handles) AS handle) AS data_table
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:15:00' AND users.handle = data_table.handle;"""
 
     sql = sa.text("begin; \n\n " + inner_sql + " \n\n commit;")
     sql = sql.bindparams(sa.bindparam("handles", ARRAY(String)))

--- a/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
+++ b/discovery-provider/alembic/versions/2fad3671bf9f_backfill_artist_pick.py
@@ -1,7 +1,7 @@
 """backfill_artist_pick
 
 Revision ID: 2fad3671bf9f
-Revises: a8752810936c
+Revises: 4efaecad96fc
 Create Date: 2022-10-27 02:14:19.935610
 
 """


### PR DESCRIPTION
### Description
So as to not overwrite new data being written after the backfill csvs were generated, only update user records before 1/6/23 8:35 UTC (when the backfill data was pulled).


### Tests
Run up and down on prod clone. Verify no errors, verify that # of non-null artist picks in discprov == # of artist picks in the prod_identity CSV. Edit date, verify number of updated records change.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->