### PR TITLE
Backfill null artist pick discrepancies in discprov

### DIFF
--- a/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
+++ b/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
@@ -1,7 +1,7 @@
 """backfill null artist pick discrepancies in discprov
 
 Revision ID: 36ed02ac38f7
-Revises: 2fad3671bf9f
+Revises: efafdb22df81
 Create Date: 2023-01-06 23:42:58.493746
 
 """
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '36ed02ac38f7'
-down_revision = '2fad3671bf9f'
+down_revision = 'efafdb22df81'
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
+++ b/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
@@ -6,9 +6,9 @@ Create Date: 2023-01-06 23:42:58.493746
 
 """
 import os
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '36ed02ac38f7'

--- a/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
+++ b/discovery-provider/alembic/versions/36ed02ac38f7_backfill_null_artist_pick_discrepancies_.py
@@ -1,0 +1,32 @@
+"""backfill null artist pick discrepancies in discprov
+
+Revision ID: 36ed02ac38f7
+Revises: 2fad3671bf9f
+Create Date: 2023-01-06 23:42:58.493746
+
+"""
+import os
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '36ed02ac38f7'
+down_revision = '2fad3671bf9f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    env = os.getenv("audius_discprov_env")
+    if env == "prod":
+        connection = op.get_bind()
+        sql = """UPDATE users
+        SET artist_pick_track_id = null
+        WHERE users.is_current = True AND users.updated_at < '2023-01-06 08:35:00' AND users.handle_lc = ANY(ARRAY['yyosu', 'amc_music', 'merawan', 'joshbay', 'ohrage']);
+        """
+        connection.execute(sql)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Description
For these 5 users, discprov has artist pick IDs saved while identity has null artist pick IDs. This means it successfully wrote when the users set an artist pick to both discprov and identity, but when they later unset their artist picks, the change wasn't indexed in discprov. I think this is because of optimizely gating weirdness bc of an adblocker, etc, like we were seeing with entity manager, in which case it defaulted to not writing to discprov.

I verified that unsetting an artist pick writes correctly to discprov normally. There are only 5 instances of this out of 12.5k records so it doesn't seem like a bug in the EM flow for artist pick. If it is optimizely, we shouldn't see anymore cases of this since the EM users flag, which the discprov write was gated by, is deleted now.

There were also a couple users with different artist pick track IDs in discprov vs identity, I think because of the same issue + the validation issues we saw and fixed [here](https://github.com/AudiusProject/audius-protocol/pull/4548). Those are taken care of by the main [backfill](https://github.com/AudiusProject/audius-protocol/pull/4197/).

How I got these users:
1. Pulled all (`handle`, `artist_pick_track_id`) from `SocialHandles` in prod identity and `users` in prod discprov
2. Wrote a script to compare entries. Discprov had 5 handles with artist picks that didn't exist in identity and there were 20 mismatched track IDs
3. Also, when testing the backfills on a 1/6/23 prod clone that was created shortly after pulling the backfill data, after backfilling all 12,554 artist pick IDs from identity, the number of current users with artist pick IDs last updated before the backfill data was pulled should have been 12,554 (excluding any cases where a user changed their previously set artist pick after the data pull timestamp, which there were none). The actual count was 5 more than expected, the 5 being these users.

### Tests
Ran on remote box after running main backfill.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->