### PR TITLE
Check clock values, not blocknumbers, when replacing primary in sanity check

### DIFF
--- a/libs/src/sanityChecks/rolloverNodes.ts
+++ b/libs/src/sanityChecks/rolloverNodes.ts
@@ -1,7 +1,7 @@
 import { Nullable, Utils } from '../utils'
 import { CreatorNode } from '../services/creatorNode'
 import type { AudiusLibs } from '../AudiusLibs'
-import _ from 'lodash'
+import maxBy from 'lodash/maxBy'
 
 const THREE_SECONDS = 3000
 const MAX_TRIES = 3
@@ -39,7 +39,7 @@ const getNewPrimary = async (secondaries: string[], wallet: string) => {
       })
     )
   ).filter(Boolean)
-  const max = _.maxBy(secondaryStatuses, (s) => s?.clockValue)?.secondary
+  const max = maxBy(secondaryStatuses, (s) => s?.clockValue)?.secondary
   if (!max) {
     throw new Error(`Could not find valid secondaries for user ${secondaries}`)
   }

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -115,7 +115,7 @@ export class CreatorNode {
   static async getClockValue(
     endpoint: string,
     wallet: string,
-    timeout: number,
+    timeout?: number,
     params: Record<string, string> = {}
   ) {
     const baseReq: AxiosRequestConfig = {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Gets the secondary with the max clockValue in the primary replacement. Since the secondaries are all we have if the primary is down, we just want to pick the best one


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->