### PR TITLE
Write entity manager notifications in libs

### DIFF
--- a/libs/src/api/Notifications.ts
+++ b/libs/src/api/Notifications.ts
@@ -5,6 +5,8 @@ import {
 } from '../services/dataContracts/EntityManagerClient'
 import { Base, BaseConstructorArgs } from './base'
 
+type AnnouncementData = {}
+
 export class Notifications extends Base {
   constructor(...args: BaseConstructorArgs) {
     super(...args)
@@ -38,6 +40,70 @@ export class Notifications extends Base {
       const errorMessage = (e as Error).message
       logger.error(
         `Could not successfully submit view notification action to entity manager. Error: ${errorMessage}`
+      )
+      return { error: errorMessage }
+    }
+  }
+
+  /**
+   * Creates a new notification
+   * NOTE: currently only used for announcements and permissioned to a single wallet signer
+   */
+  async createNotification({
+    logger = console,
+    data
+  }: {
+    logger: any
+    data: AnnouncementData
+  }): Promise<{ txReceipt?: TransactionReceipt; error?: string }> {
+    try {
+      const { txReceipt } =
+        await this.contracts.EntityManagerClient!.manageEntity(
+          1, // NOTE: This field does not matter
+          EntityType.NOTIFICATION,
+          1, // NOTE: This field does not matter
+          Action.CREATE,
+          JSON.stringify(data)
+        )
+      return { txReceipt }
+    } catch (e) {
+      const errorMessage = (e as Error).message
+      logger.error(
+        `Could not successfully submit create notification action to entity manager. Error: ${errorMessage}`
+      )
+      return { error: errorMessage }
+    }
+  }
+
+  async viewPlaylist({
+    logger = console,
+    playlistId
+  }: {
+    logger: any
+    playlistId: number
+  }): Promise<{ txReceipt?: TransactionReceipt; error?: string }> {
+    try {
+      const userId: number | null = this.userStateManager.getCurrentUserId()
+      if (!userId) {
+        return { error: 'Missing current user ID' }
+      }
+      if (!playlistId) {
+        return { error: 'Missing playlist ID' }
+      }
+
+      const { txReceipt } =
+        await this.contracts.EntityManagerClient!.manageEntity(
+          userId,
+          EntityType.NOTIFICATION,
+          playlistId,
+          Action.VIEW_PLAYLIST,
+          ''
+        )
+      return { txReceipt }
+    } catch (e) {
+      const errorMessage = (e as Error).message
+      logger.error(
+        `Could not successfully submit view playlist action to entity manager. Error: ${errorMessage}`
       )
       return { error: errorMessage }
     }

--- a/libs/src/api/Notifications.ts
+++ b/libs/src/api/Notifications.ts
@@ -11,16 +11,20 @@ export class Notifications extends Base {
   constructor(...args: BaseConstructorArgs) {
     super(...args)
     this.viewNotification = this.viewNotification.bind(this)
+    this.createNotification = this.createNotification.bind(this)
+    this.viewPlaylist = this.viewPlaylist.bind(this)
   }
 
   /**
    * Submit a user's view of notification event
    */
-  async viewNotification({
-    logger = console
-  }: {
-    logger: any
-  }): Promise<{ txReceipt?: TransactionReceipt; error?: string }> {
+  async viewNotification(
+    {
+      logger = console
+    }: {
+      logger: any
+    } = { logger: console }
+  ): Promise<{ txReceipt?: TransactionReceipt; error?: string }> {
     try {
       const userId: number | null = this.userStateManager.getCurrentUserId()
       if (!userId) {

--- a/libs/src/services/dataContracts/EntityManagerClient.ts
+++ b/libs/src/services/dataContracts/EntityManagerClient.ts
@@ -19,7 +19,8 @@ export enum Action {
   UNREPOST = 'Unrepost',
   SUBSCRIBE = 'Subscribe',
   UNSUBSCRIBE = 'Unsubscribe',
-  VIEW = 'View'
+  VIEW = 'View',
+  VIEW_PLAYLIST = 'ViewPlaylist'
 }
 
 export enum EntityType {


### PR DESCRIPTION
### Description
Add methods to libs notifications to write actions:
Playlist View action to mark when a user views a playlist
Notifications View action to mark when a user views their notifications
Create Notification action to create announcement notifications

### Tests
Ran the system locally e2e and validated that the client could trigger the action and it was viewed and indexed on discovery

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->