### PR TITLE
Update full getPlaylists endpoint in libs to accept slug

### DIFF
--- a/libs/src/sdk/api/generated/full/apis/PlaylistsApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/PlaylistsApi.ts
@@ -32,13 +32,17 @@ import {
 
 export interface GetPlaylistRequest {
     /**
-     * A Playlist ID
-     */
-    playlistId: string;
-    /**
      * The user ID of the user making the request
      */
     userId?: string;
+    /**
+     * The permalink of the playlist
+     */
+    permalink?: Array<string>;
+    /**
+     * The ID of the desired playlist
+     */
+    playlistId?: Array<string>;
 }
 
 export interface GetPlaylistTracksRequest {
@@ -136,21 +140,25 @@ export class PlaylistsApi extends runtime.BaseAPI {
     /**
      * Get a playlist by ID
      */
-    async getPlaylist(requestParameters: GetPlaylistRequest): Promise<NonNullable<FullPlaylistResponse["data"]>> {
-        if (requestParameters.playlistId === null || requestParameters.playlistId === undefined) {
-            throw new runtime.RequiredError('playlistId','Required parameter requestParameters.playlistId was null or undefined when calling getPlaylist.');
-        }
-
+    async getPlaylist(requestParameters: GetPlaylistRequest = {}): Promise<NonNullable<FullPlaylistResponse["data"]>> {
         const queryParameters: any = {};
 
         if (requestParameters.userId !== undefined) {
             queryParameters['user_id'] = requestParameters.userId;
         }
 
+        if (requestParameters.permalink) {
+            queryParameters['permalink'] = requestParameters.permalink;
+        }
+
+        if (requestParameters.playlistId) {
+            queryParameters['playlist_id'] = requestParameters.playlistId;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         return this.request({
-            path: `/playlists/{playlist_id}`.replace(`{${"playlist_id"}}`, encodeURIComponent(String(requestParameters.playlistId))),
+            path: `/playlists`,
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -442,8 +442,16 @@ export class DiscoveryProvider {
     return await this._makeRequest<CollectionMetadata[]>(req)
   }
 
-  async getFullPlaylist(encodedPlaylistId: string = '', encodedUserId: string, permalink: string = '') {
-    const req = Requests.getFullPlaylist(encodedPlaylistId, encodedUserId, permalink)
+  async getFullPlaylist(
+    encodedPlaylistId: string = '',
+    encodedUserId: string,
+    permalink: string = ''
+  ) {
+    const req = Requests.getFullPlaylist(
+      encodedPlaylistId,
+      encodedUserId,
+      permalink
+    )
     return await this._makeRequest(req)
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -442,8 +442,8 @@ export class DiscoveryProvider {
     return await this._makeRequest<CollectionMetadata[]>(req)
   }
 
-  async getFullPlaylist(encodedPlaylistId: string, encodedUserId: string) {
-    const req = Requests.getFullPlaylist(encodedPlaylistId, encodedUserId)
+  async getFullPlaylist(encodedPlaylistId: string = '', encodedUserId: string, permalink: string = '') {
+    const req = Requests.getFullPlaylist(encodedPlaylistId, encodedUserId, permalink)
     return await this._makeRequest(req)
   }
 

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -244,7 +244,7 @@ export const getPlaylists = (
 export const getFullPlaylist = (
   encodedPlaylistId: string,
   encodedUserId: string,
-  permalink: string,
+  permalink: string
 ) => {
   return {
     endpoint: 'v1/full/playlists',

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -243,13 +243,15 @@ export const getPlaylists = (
 
 export const getFullPlaylist = (
   encodedPlaylistId: string,
-  encodedUserId: string
+  encodedUserId: string,
+  permalink: string,
 ) => {
   return {
     endpoint: 'v1/full/playlists',
-    urlParams: '/' + encodedPlaylistId,
     queryParams: {
-      user_id: encodedUserId
+      user_id: encodedUserId,
+      playlist_id: [encodedPlaylistId],
+      permalink: [permalink]
     }
   }
 }


### PR DESCRIPTION
### Description
This diff updates libs both manually and using the autogenerated sdk to accommodate a change to the getPlaylist endpoint which will now be able to retrieve data by permalink as well as playlist id. 

Note it accompanies this diff: https://github.com/AudiusProject/audius-protocol/pull/4400

### Tests
n/a


