### PR TITLE
Subscribe/unsubscribe on follow/unfollow in EM

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -220,7 +220,7 @@ def test_index_valid_social_features(app, mocker):
 
         # Verify subscriptions
         all_subscriptions: List[Subscription] = session.query(Subscription).all()
-        assert len(all_subscriptions) == 3
+        assert len(all_subscriptions) == 5
 
         user_1_subscribers: List[Subscription] = (
             session.query(Subscription)
@@ -237,10 +237,34 @@ def test_index_valid_social_features(app, mocker):
             .filter(Subscription.is_current == True, Subscription.user_id == 2)
             .all()
         )
-        assert len(user_2_subscribers) == 1
-        user_2_subscriber = user_2_subscribers[0]
-        assert user_2_subscriber.subscriber_id == 3
-        assert user_2_subscriber.is_delete == True
+        assert len(user_2_subscribers) == 2
+        subscriber_ids = map(
+            lambda subscription: subscription.subscriber_id, user_2_subscribers
+        )
+        # Automatic subscribe on follow
+        assert 1 in subscriber_ids
+        assert 3 in subscriber_ids
+        user_2_subscriber_1 = filter(
+            lambda subscription: subscription.subscriber_id == 1, user_2_subscribers
+        )[0]
+        assert user_2_subscriber_1.subscriber_id == 1
+        assert user_2_subscriber_1.is_delete == False
+        user_2_subscriber_3 = filter(
+            lambda subscription: subscription.subscriber_id == 3, user_2_subscribers
+        )[0]
+        assert user_2_subscriber_3.subscriber_id == 3
+        assert user_2_subscriber_3.is_delete == True
+
+        user_3_subscribers: List[Subscription] = (
+            session.query(Subscription)
+            .filter(Subscription.is_current == True, Subscription.user_id == 3)
+            .all()
+        )
+        assert len(user_3_subscribers) == 1
+        # Automatic unsubscribe on unfollow
+        user_3_subscriber = user_3_subscribers[0]
+        assert user_3_subscriber.subscriber_id == 1
+        assert user_3_subscriber.is_delete == True
 
         # Verify saves
         all_saves: List[Save] = session.query(Save).all()

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -244,14 +244,14 @@ def test_index_valid_social_features(app, mocker):
         # Automatic subscribe on follow
         assert 1 in subscriber_ids
         assert 3 in subscriber_ids
-        user_2_subscriber_1 = filter(
+        user_2_subscriber_1 = list(filter(
             lambda subscription: subscription.subscriber_id == 1, user_2_subscribers
-        )[0]
+        ))[0]
         assert user_2_subscriber_1.subscriber_id == 1
         assert user_2_subscriber_1.is_delete == False
-        user_2_subscriber_3 = filter(
+        user_2_subscriber_3 = list(filter(
             lambda subscription: subscription.subscriber_id == 3, user_2_subscribers
-        )[0]
+        ))[0]
         assert user_2_subscriber_3.subscriber_id == 3
         assert user_2_subscriber_3.is_delete == True
 

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -244,14 +244,18 @@ def test_index_valid_social_features(app, mocker):
         # Automatic subscribe on follow
         assert 1 in subscriber_ids
         assert 3 in subscriber_ids
-        user_2_subscriber_1 = list(filter(
-            lambda subscription: subscription.subscriber_id == 1, user_2_subscribers
-        ))[0]
+        user_2_subscriber_1 = list(
+            filter(
+                lambda subscription: subscription.subscriber_id == 1, user_2_subscribers
+            )
+        )[0]
         assert user_2_subscriber_1.subscriber_id == 1
         assert user_2_subscriber_1.is_delete == False
-        user_2_subscriber_3 = list(filter(
-            lambda subscription: subscription.subscriber_id == 3, user_2_subscribers
-        ))[0]
+        user_2_subscriber_3 = list(
+            filter(
+                lambda subscription: subscription.subscriber_id == 3, user_2_subscribers
+            )
+        )[0]
         assert user_2_subscriber_3.subscriber_id == 3
         assert user_2_subscriber_3.is_delete == True
 

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -28,7 +28,7 @@ from src.tasks.entity_manager.playlist import (
     update_playlist,
 )
 from src.tasks.entity_manager.social_features import (
-    action_to_record_type,
+    action_to_record_types,
     create_social_action_types,
     create_social_record,
     delete_social_action_types,
@@ -311,10 +311,11 @@ def collect_entities_to_fetch(update_task, entity_manager_txs, metadata):
             action = helpers.get_tx_arg(event, "_action")
 
             # Query social operations as needed
-            if action in action_to_record_type.keys():
-                record_type = action_to_record_type[action]
-                entity_key = get_record_key(user_id, entity_type, entity_id)
-                entities_to_fetch[record_type].add(entity_key)
+            if action in action_to_record_types.keys():
+                record_types = action_to_record_types[action]
+                for record_type in record_types:
+                    entity_key = get_record_key(user_id, entity_type, entity_id)
+                    entities_to_fetch[record_type].add(entity_key)
 
             # Add playlist track ids in entities to fetch
             # to prevent playlists from including premium tracks

--- a/discovery-provider/src/tasks/entity_manager/notification.py
+++ b/discovery-provider/src/tasks/entity_manager/notification.py
@@ -26,7 +26,7 @@ def validate_notification_tx(params: ManageEntityParameters):
     if params.action == Action.VIEW:
         user_id = params.user_id
         if user_id not in params.existing_records[EntityType.USER]:
-            raise Exception(f"User {user_id} does not exists")
+            raise Exception(f"User {user_id} does not exist")
 
         wallet = params.existing_records[EntityType.USER][user_id].wallet
         if wallet and wallet.lower() != params.signer.lower():
@@ -107,7 +107,7 @@ def create_notification(params: ManageEntityParameters):
 def validate_view_playlist_tx(params: ManageEntityParameters):
     user_id = params.user_id
     if user_id not in params.existing_records[EntityType.USER]:
-        raise Exception(f"User {user_id} does not exists")
+        raise Exception(f"User {user_id} does not exist")
 
     wallet = params.existing_records[EntityType.USER][user_id].wallet
     if wallet and wallet.lower() != params.signer.lower():

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -42,7 +42,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
 
     if params.action == Action.CREATE:
         if playlist_id in params.existing_records[EntityType.PLAYLIST]:
-            raise Exception(f"Cannot create playlist {playlist_id} that already exist")
+            raise Exception(f"Cannot create playlist {playlist_id} that already exists")
         if playlist_id < PLAYLIST_ID_OFFSET:
             raise Exception(f"Cannot create playlist {playlist_id} below the offset")
     else:

--- a/discovery-provider/src/tasks/entity_manager/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/playlist.py
@@ -22,7 +22,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
     user_id = params.user_id
     playlist_id = params.entity_id
     if user_id not in params.existing_records[EntityType.USER]:
-        raise Exception(f"User {user_id} does not exists")
+        raise Exception(f"User {user_id} does not exist")
 
     wallet = params.existing_records[EntityType.USER][user_id].wallet
     if wallet and wallet.lower() != params.signer.lower():
@@ -42,7 +42,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
 
     if params.action == Action.CREATE:
         if playlist_id in params.existing_records[EntityType.PLAYLIST]:
-            raise Exception(f"Cannot create playlist {playlist_id} that already exists")
+            raise Exception(f"Cannot create playlist {playlist_id} that already exist")
         if playlist_id < PLAYLIST_ID_OFFSET:
             raise Exception(f"Cannot create playlist {playlist_id} below the offset")
     else:

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -10,15 +10,15 @@ from src.premium_content.premium_content_access_checker import (
 )
 from src.tasks.entity_manager.utils import Action, EntityType, ManageEntityParameters
 
-action_to_record_type = {
-    Action.FOLLOW: EntityType.FOLLOW,
-    Action.UNFOLLOW: EntityType.FOLLOW,
-    Action.SAVE: EntityType.SAVE,
-    Action.UNSAVE: EntityType.SAVE,
-    Action.REPOST: EntityType.REPOST,
-    Action.UNREPOST: EntityType.REPOST,
-    Action.SUBSCRIBE: EntityType.SUBSCRIPTION,
-    Action.UNSUBSCRIBE: EntityType.SUBSCRIPTION,
+action_to_record_types = {
+    Action.FOLLOW: [EntityType.FOLLOW, EntityType.SUBSCRIPTION],
+    Action.UNFOLLOW: [EntityType.FOLLOW, EntityType.SUBSCRIPTION],
+    Action.SAVE: [EntityType.SAVE],
+    Action.UNSAVE: [EntityType.SAVE],
+    Action.REPOST: [EntityType.REPOST],
+    Action.UNREPOST: [EntityType.REPOST],
+    Action.SUBSCRIBE: [EntityType.SUBSCRIPTION],
+    Action.UNSUBSCRIBE: [EntityType.SUBSCRIPTION],
 }
 
 action_to_challenge_event = {
@@ -56,144 +56,147 @@ def create_social_record(params: ManageEntityParameters):
 
     validate_social_feature(params)
 
+    record_types = action_to_record_types[params.action]
     create_record: Union[Save, Follow, Repost, Subscription, None] = None
-    if params.action == Action.FOLLOW:
-        create_record = Follow(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            follower_user_id=params.user_id,
-            followee_user_id=params.entity_id,
-            is_current=True,
-            is_delete=False,
-        )
-    if params.action == Action.SAVE:
-        create_record = Save(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.user_id,
-            save_item_id=params.entity_id,
-            save_type=params.entity_type.lower(),
-            is_current=True,
-            is_delete=False,
-        )
-    if params.action == Action.REPOST:
-        create_record = Repost(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.user_id,
-            repost_item_id=params.entity_id,
-            repost_type=params.entity_type.lower(),
-            is_current=True,
-            is_delete=False,
-        )
-    if params.action == Action.SUBSCRIBE:
-        create_record = Subscription(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.entity_id,
-            subscriber_id=params.user_id,
-            is_current=True,
-            is_delete=False,
-        )
-
-    if create_record:
-        params.add_social_feature_record(
-            params.user_id,
-            params.entity_type,
-            params.entity_id,
-            action_to_record_type[params.action],
-            create_record,
-        )
-
-        # dispatch repost, favorite, follow challenges
-        if params.action in action_to_challenge_event:
-            challenge_event = action_to_challenge_event[params.action]
-            params.challenge_bus.dispatch(
-                challenge_event, params.block_number, params.user_id
+    for record_type in record_types:
+        if record_type == EntityType.FOLLOW:
+            create_record = Follow(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                follower_user_id=params.user_id,
+                followee_user_id=params.entity_id,
+                is_current=True,
+                is_delete=False,
             )
+        elif record_type == EntityType.SAVE:
+            create_record = Save(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.user_id,
+                save_item_id=params.entity_id,
+                save_type=params.entity_type.lower(),
+                is_current=True,
+                is_delete=False,
+            )
+        elif record_type == EntityType.REPOST:
+            create_record = Repost(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.user_id,
+                repost_item_id=params.entity_id,
+                repost_type=params.entity_type.lower(),
+                is_current=True,
+                is_delete=False,
+            )
+        elif record_type == EntityType.SUBSCRIPTION:
+            create_record = Subscription(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.entity_id,
+                subscriber_id=params.user_id,
+                is_current=True,
+                is_delete=False,
+            )
+
+        if create_record:
+            params.add_social_feature_record(
+                params.user_id,
+                params.entity_type,
+                params.entity_id,
+                record_type,
+                create_record,
+            )
+
+    # dispatch repost, favorite, follow challenges
+    if create_record and params.action in action_to_challenge_event:
+        challenge_event = action_to_challenge_event[params.action]
+        params.challenge_bus.dispatch(
+            challenge_event, params.block_number, params.user_id
+        )
 
 
 def delete_social_record(params):
 
     validate_social_feature(params)
 
+    record_types = action_to_record_types[params.action]
     deleted_record = None
-    if params.action == Action.UNFOLLOW:
-        deleted_record = Follow(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            follower_user_id=params.user_id,
-            followee_user_id=params.entity_id,
-            is_current=True,
-            is_delete=True,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-        )
-    elif params.action == Action.UNSAVE:
-        deleted_record = Save(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.user_id,
-            save_item_id=params.entity_id,
-            save_type=params.entity_type.lower(),
-            is_current=True,
-            is_delete=True,
-        )
-    elif params.action == Action.UNREPOST:
-        deleted_record = Repost(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.user_id,
-            repost_item_id=params.entity_id,
-            repost_type=params.entity_type.lower(),
-            is_current=True,
-            is_delete=True,
-        )
-    elif params.action == Action.UNSUBSCRIBE:
-        deleted_record = Subscription(
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            txhash=params.txhash,
-            user_id=params.entity_id,
-            subscriber_id=params.user_id,
-            is_current=True,
-            is_delete=True,
-        )
-
-    if deleted_record:
-        record_type = action_to_record_type[params.action]
-        params.add_social_feature_record(
-            params.user_id,
-            params.entity_type,
-            params.entity_id,
-            record_type,
-            deleted_record,
-        )
-
-        # dispatch repost, favorite, follow challenges
-        if params.action in action_to_challenge_event:
-            challenge_event = action_to_challenge_event[params.action]
-            params.challenge_bus.dispatch(
-                challenge_event, params.block_number, params.user_id
+    for record_type in record_types:
+        if record_type == EntityType.FOLLOW:
+            deleted_record = Follow(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                follower_user_id=params.user_id,
+                followee_user_id=params.entity_id,
+                is_current=True,
+                is_delete=True,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
             )
+        elif record_type == EntityType.SAVE:
+            deleted_record = Save(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.user_id,
+                save_item_id=params.entity_id,
+                save_type=params.entity_type.lower(),
+                is_current=True,
+                is_delete=True,
+            )
+        elif record_type == EntityType.REPOST:
+            deleted_record = Repost(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.user_id,
+                repost_item_id=params.entity_id,
+                repost_type=params.entity_type.lower(),
+                is_current=True,
+                is_delete=True,
+            )
+        elif record_type == EntityType.SUBSCRIPTION:
+            deleted_record = Subscription(
+                blockhash=params.event_blockhash,
+                blocknumber=params.block_number,
+                created_at=params.block_datetime,
+                txhash=params.txhash,
+                user_id=params.entity_id,
+                subscriber_id=params.user_id,
+                is_current=True,
+                is_delete=True,
+            )
+
+        if deleted_record:
+            params.add_social_feature_record(
+                params.user_id,
+                params.entity_type,
+                params.entity_id,
+                record_type,
+                deleted_record,
+            )
+
+    # dispatch repost, favorite, follow challenges
+    if deleted_record and params.action in action_to_challenge_event:
+        challenge_event = action_to_challenge_event[params.action]
+        params.challenge_bus.dispatch(
+            challenge_event, params.block_number, params.user_id
+        )
 
 
 def validate_social_feature(params: ManageEntityParameters):
     if params.user_id not in params.existing_records[EntityType.USER]:
-        raise Exception(f"User {params.user_id} does not exists")
+        raise Exception(f"User {params.user_id} does not exist")
 
     wallet = params.existing_records[EntityType.USER][params.user_id].wallet
     if wallet and wallet.lower() != params.signer.lower():


### PR DESCRIPTION
### Description
Subscribe on follow in discovery indexer rather than in the client. This will reduce the time required waiting for relay to complete when following a user (and then auto-subscribing) since the EM events are processed at the same time rather than sequentially. The time delay from doing sequential FOLLOW then SUBSCRIBE events was causing some writes to not be successfully persisted to the subscriptions table in discovery if the user exited the app shortly afterward, since we don't fire and forget relays.

### Tests
integration + test with local client


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->