### PR TITLE
Include imageUrl for nft collection premium conditions for track

### DIFF
--- a/discovery-provider/integration_tests/premium_content/test_access.py
+++ b/discovery-provider/integration_tests/premium_content/test_access.py
@@ -26,6 +26,7 @@ def test_access(app):
                     "address": "some-nft-collection-address",
                     "name": "some nft collection name",
                     "slug": "some-nft-collection",
+                    "imageUrl": "some-nft-collection-image-url",
                     "externalLink": "some-nft-collection-external-link",
                 }
             },
@@ -41,6 +42,7 @@ def test_access(app):
                     "address": "some-nft-collection-address",
                     "name": "some nft collection name",
                     "slug": "some-nft-collection",
+                    "imageUrl": "some-nft-collection-image-url",
                     "externalLink": "some-nft-collection-external-link",
                 }
             },
@@ -142,6 +144,7 @@ def test_batch_access(app):
                     "address": "some-nft-collection-address",
                     "name": "some nft collection name",
                     "slug": "some-nft-collection",
+                    "imageUrl": "some-nft-collection-image-url",
                     "externalLink": "some-nft-collection-external-link",
                 }
             },
@@ -157,6 +160,7 @@ def test_batch_access(app):
                     "address": "some-nft-collection-address",
                     "name": "some nft collection name",
                     "slug": "some-nft-collection",
+                    "imageUrl": "some-nft-collection-image-url",
                     "externalLink": "some-nft-collection-external-link",
                 }
             },

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -402,6 +402,9 @@
                 "slug": {
                     "type": "string"
                 },
+                "imageUrl": {
+                    "type": "string"
+                },
                 "externalLink": {
                     "type": [
                         "string",
@@ -431,6 +434,9 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "imageUrl": {
                     "type": "string"
                 },
                 "externalLink": {

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -403,7 +403,11 @@
                     "type": "string"
                 },
                 "imageUrl": {
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
                 },
                 "externalLink": {
                     "type": [
@@ -437,7 +441,11 @@
                     "type": "string"
                 },
                 "imageUrl": {
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
                 },
                 "externalLink": {
                     "type": [

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -319,6 +319,9 @@
         "slug": {
             "type": "string"
         },
+        "imageUrl":  {
+            "type": "string"
+        },
         "externalLink": {
             "type": ["string", "null"],
             "default": null
@@ -339,6 +342,9 @@
           "type": "string"
         },
         "name": {
+            "type": "string"
+        },
+        "imageUrl":  {
             "type": "string"
         },
         "externalLink": {

--- a/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -320,7 +320,8 @@
             "type": "string"
         },
         "imageUrl":  {
-            "type": "string"
+            "type": ["string", "null"],
+            "default": null
         },
         "externalLink": {
             "type": ["string", "null"],
@@ -345,7 +346,8 @@
             "type": "string"
         },
         "imageUrl":  {
-            "type": "string"
+            "type": ["string", "null"],
+            "default": null
         },
         "externalLink": {
             "type": ["string", "null"],

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -94,6 +94,7 @@ export type PremiumConditionsEthNFTCollection = {
   address: string
   name: string
   slug: string
+  imageUrl: string
   externalLink: Nullable<string>
 }
 
@@ -101,6 +102,7 @@ export type PremiumConditionsSolNFTCollection = {
   chain: 'sol'
   address: string
   name: string
+  imageUrl: string
   externalLink: Nullable<string>
 }
 

--- a/libs/src/utils/types.ts
+++ b/libs/src/utils/types.ts
@@ -94,7 +94,7 @@ export type PremiumConditionsEthNFTCollection = {
   address: string
   name: string
   slug: string
-  imageUrl: string
+  imageUrl: Nullable<string>
   externalLink: Nullable<string>
 }
 
@@ -102,7 +102,7 @@ export type PremiumConditionsSolNFTCollection = {
   chain: 'sol'
   address: string
   name: string
-  imageUrl: string
+  imageUrl: Nullable<string>
   externalLink: Nullable<string>
 }
 


### PR DESCRIPTION
### Description

So that the client may later know where the nft collection image lives and can fetch it.
Will need to upgrade sdk and client to consume.

### Tests

None

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

N/A

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->