### PR TITLE
Fix redis timestamp in health check

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -566,7 +566,7 @@ def get_play_health_info(
             if oldest_unarchived_play:
                 redis.set(
                     oldest_unarchived_play_key,
-                    oldest_unarchived_play,
+                    oldest_unarchived_play.timestamp(),
                 )
         else:
             # Decode bytes into float for latest timestamp

--- a/discovery-provider/src/queries/get_latest_play.py
+++ b/discovery-provider/src/queries/get_latest_play.py
@@ -1,8 +1,10 @@
+from datetime import datetime
+
 from src.models.social.play import Play
 from src.utils import db_session
 
 
-def get_latest_play():
+def get_latest_play() -> datetime:
     """
     Gets the latest play in the database
     """

--- a/discovery-provider/src/queries/get_oldest_unarchived_play.py
+++ b/discovery-provider/src/queries/get_oldest_unarchived_play.py
@@ -1,9 +1,11 @@
+from datetime import datetime
+
 from sqlalchemy import func
 from src.models.social.play import Play
 from src.utils import db_session
 
 
-def get_oldest_unarchived_play() -> str:
+def get_oldest_unarchived_play() -> datetime:
     """
     Gets the oldest unarchived play in the database
     """


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
timestamp was in datetime format rather than POSIX float so redis could not set it

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
tested on stage

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->