### PR TITLE
Fix & consolidate CN envvars for local dev for audius-compose

### DIFF
--- a/dev-tools/startup/creator-node.sh
+++ b/dev-tools/startup/creator-node.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+### Environment Variables
+
+# Unique to each node
+
 export delegateOwnerWallet=$(printenv "CN${replica}_SP_OWNER_ADDRESS")
 export delegatePrivateKey=$(printenv "CN${replica}_SP_OWNER_PRIVATE_KEY")
 
@@ -7,6 +11,77 @@ export spOwnerWallet=$(printenv "CN${replica}_SP_OWNER_ADDRESS")
 export spID=$replica
 
 export creatorNodeEndpoint="http://audius-protocol-creator-node-${replica}:4000"
+
+# Constants
+
+export logLevel="debug"
+export devMode="true"
+export creatorNodeIsDebug="true"
+export debuggerPort=10000
+export expressAppConcurrency=2
+
+export identityService="http://identity-service:7000"
+
+export rateLimitingAudiusUserReqLimit=3000
+export rateLimitingUserReqLimit=3000
+export rateLimitingMetadataReqLimit=3000
+export rateLimitingImageReqLimit=6000
+export rateLimitingTrackReqLimit=6000
+export rateLimitingBatchCidsExistLimit=1
+export maxAudioFileSizeBytes=250000000
+export maxMemoryFileSizeBytes=50000000
+
+export ethProviderUrl="http://eth-ganache:8545"
+export ethTokenAddress="${ETH_TOKEN_ADDRESS}"
+export ethRegistryAddress="${ETH_REGISTRY_ADDRESS}"
+export ethOwnerWallet="${ETH_OWNER_WALLET}"
+export dataProviderUrl="http://poa-ganache:8545"
+export dataRegistryAddress="${POA_REGISTRY_ADDRESS}"
+
+export storagePath=/file_storage
+export port=4000
+export redisPort=6379
+
+# Sync / SnapbackSM configs
+export stateMonitoringQueueRateLimitInterval=60000
+export stateMonitoringQueueRateLimitJobsPerInterval=1
+export snapbackModuloBase=3
+export minimumDailySyncCount=5
+export minimumRollingSyncCount=10
+export minimumSuccessfulSyncCountPercentage=50
+export snapbackHighestReconfigMode=PRIMARY_AND_OR_SECONDARIES
+export secondaryUserSyncDailyFailureCountThreshold=100
+export maxSyncMonitoringDurationInMs=10000 # 10sec
+export skippedCIDsRetryQueueJobIntervalMs=30000 # 30sec in ms
+export monitorStateJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+export findSyncRequestsJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+export findReplicaSetUpdatesJobLastSuccessfulRunDelayMs=600000 # 10min in ms
+export fetchCNodeEndpointToSpIdMapIntervalMs=10000 #10sec in ms
+export enforceWriteQuorum=true
+export recoverOrphanedDataQueueRateLimitInterval=60000 #1min in ms
+export recoverOrphanedDataQueueRateLimitJobsPerInterval=1
+export mergePrimaryAndSecondaryEnabled=true
+export maxNumberSecondsPrimaryRemainsUnhealthy=30
+export maxNumberSecondsSecondaryRemainsUnhealthy=10
+
+# peerSetManager
+export peerHealthCheckRequestTimeout=2000 # ms
+export minimumMemoryAvailable=2000000000 # bytes; 2gb
+export maxFileDescriptorsAllocatedPercentage=95
+export maxNumberSecondsPrimaryRemainsUnhealthy=5
+export maxNumberSecondsSecondaryRemainsUnhealthy=5
+
+# Number of missed blocks after which we would consider a discovery node unhealthy
+export discoveryNodeUnhealthyBlockDiff=10
+
+# Maximum number of wallets the /users/batch_clock_status route will accept at one time
+export maxBatchClockStatusBatchSize=5
+
+export entityManagerAddress="0x5b9b42d6e4B2e4Bf8d42Eba32D46918e10899B66"
+export entityManagerReplicaSetEnabled="true"
+
+# Premium content
+export premiumContentEnabled="true"
 
 cd ../audius-libs
 npm link

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -377,31 +377,6 @@ services:
     build: creator-node
     command: sh -c ". /tmp/dev-tools/startup/startup.sh && scripts/start.sh"
     env_file: .env # used by the startup script
-    environment:
-      logLevel: "debug"
-      devMode: "true"
-      creatorNodeIsDebug: "true"
-      debuggerPort: 10000
-
-      rateLimitingAudiusUserReqLimit: 3000
-      rateLimitingUserReqLimit: 3000
-      rateLimitingMetadataReqLimit: 3000
-      rateLimitingImageReqLimit: 6000
-      rateLimitingTrackReqLimit: 6000
-      rateLimitingBatchCidsExistLimit: 1
-      maxAudioFileSizeBytes: 250000000
-      maxMemoryFileSizeBytes: 50000000
-      expressAppConcurrency: 2
-
-      identityService: "http://identity-service:7000"
-
-      ethProviderUrl: "http://eth-ganache:8545"
-      ethTokenAddress: "${ETH_TOKEN_ADDRESS}"
-      ethRegistryAddress: "${ETH_REGISTRY_ADDRESS}"
-      ethOwnerWallet: "${ETH_OWNER_WALLET}"
-
-      dataProviderUrl: "http://poa-ganache:8545"
-      dataRegistryAddress: "${POA_REGISTRY_ADDRESS}"
     volumes:
       - ./creator-node/src:/usr/src/app/src
       - audius-libs:/usr/src/audius-libs


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

For local dev, we define CN envvars in 3 places:
1. `./creator-node/compose/base.env` -> this is for legacy `A` and is deprecated in `audius-compose` stack
2. `./docker-compose.yml`
3. `./dev-tools/startup/creator-node.sh`

#2 and #3 are redundant so I moved all envs from `./docker-compose.yml` into `./dev-tools/startup/creator-node.sh`

Also many of the envvars from `base.env` were not copied over into the new `audius-compose` stack, so I also copied those over

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Confirmed below works as expected
```
audius-compose build
audius-compose up
audius-cmd create-user
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->