### PR TITLE
Fix CN isReadOnlyMode health check

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -17,7 +17,6 @@ const MIN_FILESYSTEM_SIZE = 1950000000000 // 1950 GB of file system storage
  * the current git SHA, service version info, location info, and system info.
  * @param {*} ServiceRegistry
  * @param {*} logger
- * @param {*} sequelize
  * @param {*} getMonitors
  * @param {*} getTranscodeQueueJobs
  * @param {*} getAsyncProcessingQueueJobs
@@ -28,7 +27,6 @@ const MIN_FILESYSTEM_SIZE = 1950000000000 // 1950 GB of file system storage
 const healthCheck = async (
   { libs, snapbackSM, trustedNotifierManager } = {},
   logger,
-  sequelize,
   getMonitors,
   getTranscodeQueueJobs,
   transcodingQueueIsAvailable,
@@ -51,6 +49,8 @@ const healthCheck = async (
 
   // expose audiusInfraStack to see how node is being run
   const audiusContentInfraSetup = config.get('audiusContentInfraSetup')
+
+  const isReadOnlyMode = config.get('isReadOnlyMode')
 
   // System information
   const [
@@ -142,6 +142,7 @@ const healthCheck = async (
   const response = {
     ...versionInfo,
     healthy,
+    isReadOnlyMode,
     git: process.env.GIT_SHA,
     audiusDockerCompose: process.env.AUDIUS_DOCKER_COMPOSE_GIT_SHA,
     selectedDiscoveryProvider: 'none',
@@ -259,7 +260,6 @@ const parseDateOrNull = (date) => {
 const healthCheckVerbose = async (
   { libs, snapbackSM, trustedNotifierManager } = {},
   logger,
-  sequelize,
   getMonitors,
   numberOfCPUs,
   getTranscodeQueueJobs,
@@ -269,7 +269,6 @@ const healthCheckVerbose = async (
   return healthCheck(
     { libs, snapbackSM, trustedNotifierManager },
     logger,
-    sequelize,
     getMonitors,
     getTranscodeQueueJobs,
     transcodingQueueIsAvailable,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Ensure health check still returns full response object if `isReadOnlyMode = true`

Also:
- remove unused `sequelize` param for `healthCheck` func

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Updated unit tests
Confirmed route returns 500 and `isReadOnlyMode: true` when set:
<img width="1650" alt="Screenshot 2023-01-17 at 4 12 39 PM" src="https://user-images.githubusercontent.com/3323835/213013614-a374d6a7-ad54-46cb-a723-9c47a417db7d.png">


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

`<endpoint>/health_check` should return identical response whether `isReadOnlyMode` is true or false, with only exception being http response code of 500 vs 200

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->