### PR TITLE
Rt sdk fix

### DIFF
--- a/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
+++ b/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
@@ -85,10 +85,12 @@ const isApiResponseHealthy = ({
 
 const isDiscoveryNodeHealthy = async ({
   endpoint,
+  currentVersion,
   unhealthyBlockDiff,
   unhealthySlotDiffPlays
 }: {
   endpoint: string
+  currentVersion: string
   unhealthyBlockDiff: number
   unhealthySlotDiffPlays: number | null
 }) => {
@@ -113,6 +115,15 @@ const isDiscoveryNodeHealthy = async ({
   }
   if (data.service !== DISCOVERY_SERVICE_NAME) {
     console.warn('Audius SDK discovery provider service name unhealthy', {
+      endpoint
+    })
+    return false
+  }
+  if (
+    currentVersion &&
+    (!data.version || semver.lt(data.version, currentVersion))
+  ) {
+    console.warn('Audius SDK discovery provider version unhealthy', {
       endpoint
     })
     return false
@@ -229,6 +240,7 @@ export const discoveryNodeSelectorMiddleware = ({
         console.warn('Audius SDK request failed:', context)
         const isHealthy = await isDiscoveryNodeHealthy({
           endpoint,
+          currentVersion,
           unhealthyBlockDiff,
           unhealthySlotDiffPlays
         })

--- a/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
+++ b/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
@@ -85,12 +85,10 @@ const isApiResponseHealthy = ({
 
 const isDiscoveryNodeHealthy = async ({
   endpoint,
-  currentVersion,
   unhealthyBlockDiff,
   unhealthySlotDiffPlays
 }: {
   endpoint: string
-  currentVersion: string
   unhealthyBlockDiff: number
   unhealthySlotDiffPlays: number | null
 }) => {
@@ -119,12 +117,6 @@ const isDiscoveryNodeHealthy = async ({
     })
     return false
   }
-  // if (!data.version || semver.lt(data.version, currentVersion)) {
-  //   console.warn('Audius SDK discovery provider version unhealthy', {
-  //     endpoint
-  //   })
-  //   return false
-  // }
   if (!data.block_difference || data.block_difference > unhealthyBlockDiff) {
     console.warn('Audius SDK discovery provider POA indexing unhealthy', {
       endpoint
@@ -237,7 +229,6 @@ export const discoveryNodeSelectorMiddleware = ({
         console.warn('Audius SDK request failed:', context)
         const isHealthy = await isDiscoveryNodeHealthy({
           endpoint,
-          currentVersion,
           unhealthyBlockDiff,
           unhealthySlotDiffPlays
         })

--- a/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
+++ b/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
@@ -119,12 +119,12 @@ const isDiscoveryNodeHealthy = async ({
     })
     return false
   }
-  if (!data.version || semver.lt(data.version, currentVersion)) {
-    console.warn('Audius SDK discovery provider version unhealthy', {
-      endpoint
-    })
-    return false
-  }
+  // if (!data.version || semver.lt(data.version, currentVersion)) {
+  //   console.warn('Audius SDK discovery provider version unhealthy', {
+  //     endpoint
+  //   })
+  //   return false
+  // }
   if (!data.block_difference || data.block_difference > unhealthyBlockDiff) {
     console.warn('Audius SDK discovery provider POA indexing unhealthy', {
       endpoint


### PR DESCRIPTION
### Description
Temp fix for bug that is breaking audio transactions page on prod.
`currentVersion` is an empty string in this code path because libs performs services selection, caches result in local storage, which causes SDK to shortcircuit and not perform services selection.

### Tests
Tested locally by linking libs to local client.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
