### PR TITLE
Handle nil body data in nethermind rpc request

### DIFF
--- a/discovery-provider/nginx_conf/main.lua
+++ b/discovery-provider/nginx_conf/main.lua
@@ -262,7 +262,9 @@ function _M.validate_nethermind_rpc_request ()
         return
     end
     ngx.req.read_body()
-    ngx.log(ngx.INFO, "asdf ngx.req.get_body_data() ", ngx.req.get_body_data())
+    ngx.log(ngx.ERR, "asdf ngx.req.get_headers() ", ngx.req.get_headers())
+
+    ngx.log(ngx.ERR, "asdf ngx.req.get_body_data() ", ngx.req.get_body_data())
 
     local body = cjson.decode(ngx.req.get_body_data())
     is_bad = utils.starts_with(body.method, "clique_")

--- a/discovery-provider/nginx_conf/main.lua
+++ b/discovery-provider/nginx_conf/main.lua
@@ -262,6 +262,8 @@ function _M.validate_nethermind_rpc_request ()
         return
     end
     ngx.req.read_body()
+    ngx.log(ngx.INFO, "asdf ngx.req.get_body_data() ", ngx.req.get_body_data())
+
     local body = cjson.decode(ngx.req.get_body_data())
     is_bad = utils.starts_with(body.method, "clique_")
     if is_bad then

--- a/discovery-provider/nginx_conf/main.lua
+++ b/discovery-provider/nginx_conf/main.lua
@@ -262,14 +262,14 @@ function _M.validate_nethermind_rpc_request ()
         return
     end
     ngx.req.read_body()
-    ngx.log(ngx.ERR, "asdf ngx.req.get_headers() ", ngx.req.get_headers())
 
-    ngx.log(ngx.ERR, "asdf ngx.req.get_body_data() ", ngx.req.get_body_data())
-
-    local body = cjson.decode(ngx.req.get_body_data())
-    is_bad = utils.starts_with(body.method, "clique_")
-    if is_bad then
-        ngx.exit(405)
+    local data = ngx.req.get_body_data()
+    if data then
+        local body = cjson.decode(data)
+        is_bad = utils.starts_with(body.method, "clique_")
+        if is_bad then
+            ngx.exit(405)
+        end
     end
 end
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Seeing a bunch of these errors
```
{"level": "ERROR", "type": "openresty", "log": "{\"level\": \"ERROR\", \"type\": \"openresty\", \"message\": \"2023/01/18 01:26:06 [error] 22#22: *766 lua entry thread aborted: runtime error: /usr/local/openresty/conf/main.lua:265: bad argument #1 to 'decode' (string expected, got nil)\"}"}
{"level": "ERROR", "type": "openresty", "log": "{\"level\": \"ERROR\", \"type\": \"openresty\", \"message\": \"stack traceback:\"}"}
{"level": "ERROR", "type": "openresty", "log": "{\"level\": \"ERROR\", \"type\": \"openresty\", \"message\": \"coroutine 0:\"}"}
{"level": "ERROR", "type": "openresty", "log": "{\"level\": \"ERROR\", \"type\": \"openresty\", \"message\": \"[C]: in function 'decode'\"}"}
{"level": "ERROR", "type": "openresty", "log": "{\"level\": \"ERROR\", \"type\": \"openresty\", \"message\": \"/usr/local/openresty/conf/main.lua:265: in function </usr/local/openresty/conf/main.lua:260>, client: 172.31.36.20, server: , request: \\\"HEAD /nethermind HTTP/1.1\\\", host: \\\"discoveryprovider.staging.audius.co\\\", referrer: \\\"https://poa-gateway.staging.audius.co\\\"\"}"}
```

Maybe we need get_body_file too like here?
https://github.com/openresty/lua-nginx-module#synopsis


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage DN1

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->