### PR TITLE
Add tier change notification via triggers

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
@@ -1,0 +1,60 @@
+create or replace function handle_user_balance_change() returns trigger as $$
+declare
+  new_val int;
+  new_tier text;
+  new_tier_value int;
+  previous_tier text;
+  previous_tier_value int;
+begin
+  SELECT label, val into new_tier, new_tier_value
+  FROM (
+    VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
+  ) as tier (label, val)
+  WHERE
+    new.current_balance::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  SELECT label, val into previous_tier, previous_tier_value
+  FROM (
+    VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
+  ) as tier (label, val)
+  WHERE
+    new.previous_balance::bigint >= tier.val
+  ORDER BY 
+    tier.val DESC
+  limit 1;
+
+  -- create a notification if the tier changes
+  if new_tier_value > previous_tier_value or (new_tier_value is not NULL and previous_tier_value is NULL) then
+    insert into notification
+      (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      ( 
+        new.blocknumber,
+        ARRAY [new.user_id], 
+        new.updated_at, 
+        'tier_change',
+        new.user_id,
+        'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
+        json_build_object('new_tier', new_tier, 'new_tier_value', new_tier_value, 'current_value', new.current_balance)
+      )
+    on conflict do nothing;
+    return null;
+  end if;
+
+  return null;
+exception
+  when others then return null;
+end;
+$$ language plpgsql;
+
+
+do $$ begin
+  create trigger on_user_balance_changes
+    after insert or update on user_balance_changes
+    for each row execute procedure handle_user_balance_change();
+exception
+  when others then null;
+end $$;

--- a/discovery-provider/alembic/versions/6a9f01e775d5_update_triggers.py
+++ b/discovery-provider/alembic/versions/6a9f01e775d5_update_triggers.py
@@ -5,28 +5,15 @@ Revises: efafdb22df81
 Create Date: 2023-01-17 18:39:06.300212
 
 """
-from pathlib import Path
 
-import sqlalchemy
 from alembic import op
+from src.utils.alembic_helpers import build_sql
 
 # revision identifiers, used by Alembic.
 revision = "6a9f01e775d5"
 down_revision = "efafdb22df81"
 branch_labels = None
 depends_on = None
-
-
-def load_sql(name):
-    path = Path(__file__).parent.joinpath(f"../trigger_sql/{name}")
-    with open(path) as f:
-        return f.read()
-
-
-def build_sql(file_names):
-    files = [load_sql(f) for f in file_names]
-    inner_sql = "\n;\n".join(files)
-    return sqlalchemy.text("begin; \n\n " + inner_sql + " \n\n commit;")
 
 
 up_files = [

--- a/discovery-provider/alembic/versions/6a9f01e775d5_update_triggers.py
+++ b/discovery-provider/alembic/versions/6a9f01e775d5_update_triggers.py
@@ -1,8 +1,8 @@
-"""migrate triggers for notifications
+"""update  triggers
 
-Revision ID: 58b26285cdcf
-Revises: b0623220e904
-Create Date: 2022-07-13 16:02:12.264201
+Revision ID: 6a9f01e775d5
+Revises: efafdb22df81
+Create Date: 2023-01-17 18:39:06.300212
 
 """
 from pathlib import Path
@@ -11,8 +11,8 @@ import sqlalchemy
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "58b26285cdcf"
-down_revision = "b0623220e904"
+revision = "6a9f01e775d5"
+down_revision = "efafdb22df81"
 branch_labels = None
 depends_on = None
 
@@ -31,17 +31,7 @@ def build_sql(file_names):
 
 up_files = [
     # New triggers
-    "handle_challenge_disbursements.sql",
-    "handle_supporter_rank_ups.sql",
-    "handle_reaction.sql",
-    "handle_user_tip.sql",
-    # Updates to old triggers
-    "handle_reaction.sql",
-    "handle_play.sql",
-    "handle_repost.sql",
-    "handle_save.sql",
-    "handle_track.sql",
-    "handle_follow.sql",
+    "handle_user_balance_changes.sql",
 ]
 
 

--- a/discovery-provider/integration_tests/notifications/test_tier_change.py
+++ b/discovery-provider/integration_tests/notifications/test_tier_change.py
@@ -1,0 +1,145 @@
+import logging
+from typing import List
+
+from integration_tests.utils import populate_mock_db
+from sqlalchemy import asc
+from src.models.notifications.notification import Notification
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+# ========================================== Start Tests ==========================================
+def test_tier_change(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "user_balance_changes": [
+            {
+                "user_id": 1,
+                "blocknumber": 10,
+                # No tier change, none -> none
+                "previous_balance": 0,
+                "current_balance": 6,
+            },
+            {
+                "user_id": 2,
+                "blocknumber": 11,
+                # Tier change, none -> bronze
+                "previous_balance": 0,
+                "current_balance": 10,
+            },
+            {
+                "user_id": 3,
+                "blocknumber": 12,
+                # Tier change, none -> bronze
+                "previous_balance": 0,
+                "current_balance": 15,
+            },
+            {
+                "user_id": 4,
+                "blocknumber": 13,
+                # Tier change, none -> platinum
+                "previous_balance": 0,
+                "current_balance": 200000,
+            },
+            {
+                "user_id": 5,
+                "blocknumber": 14,
+                # No tier change, gold -> gold
+                "previous_balance": 12000,
+                "current_balance": 90000,
+            },
+        ],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        notifications: List[Notification] = (
+            session.query(Notification).order_by(asc(Notification.blocknumber)).all()
+        )
+        assert len(notifications) == 3
+        assert notifications[0].user_ids == [2]
+        assert notifications[0].specifier == "2"
+        assert (
+            notifications[0].group_id
+            == "tier_change:user_id:2:tier:bronze:blocknumber:11"
+        )
+        assert notifications[0].data == {
+            "new_tier": "bronze",
+            "new_tier_value": 10,
+            "current_value": "10",
+        }
+
+        assert notifications[1].user_ids == [3]
+        assert (
+            notifications[1].group_id
+            == "tier_change:user_id:3:tier:bronze:blocknumber:12"
+        )
+        assert notifications[1].data == {
+            "new_tier": "bronze",
+            "new_tier_value": 10,
+            "current_value": "15",
+        }
+
+        assert notifications[2].user_ids == [4]
+        assert notifications[2].specifier == "4"
+        assert (
+            notifications[2].group_id
+            == "tier_change:user_id:4:tier:platinum:blocknumber:13"
+        )
+        assert notifications[2].data == {
+            "new_tier": "platinum",
+            "new_tier_value": 100000,
+            "current_value": "200000",
+        }
+
+        session.execute(
+            """
+            update user_balance_changes
+            set 
+              previous_balance = 10,
+              current_balance = 9999999,
+              blocknumber=20
+            where user_id = 2;
+            """
+        )
+
+        notifications: List[Notification] = (
+            session.query(Notification)
+            .filter(Notification.blocknumber > 19)
+            .order_by(asc(Notification.blocknumber))
+            .all()
+        )
+        assert len(notifications) == 1
+        assert notifications[0].user_ids == [2]
+        assert notifications[0].specifier == "2"
+        assert (
+            notifications[0].group_id
+            == "tier_change:user_id:2:tier:platinum:blocknumber:20"
+        )
+        assert notifications[0].data == {
+            "new_tier": "platinum",
+            "new_tier_value": 100000,
+            "current_value": "9999999",
+        }
+
+        session.execute(
+            """
+            update user_balance_changes
+            set 
+              previous_balance = 9999999,
+              current_balance = 10000,
+              blocknumber=22
+            where user_id = 2;
+            """
+        )
+
+        notifications: List[Notification] = (
+            session.query(Notification)
+            .filter(Notification.blocknumber > 20)
+            .order_by(asc(Notification.blocknumber))
+            .all()
+        )
+        assert len(notifications) == 0

--- a/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
@@ -34,7 +34,7 @@ def test_get_save_notifications(app):
             assert len(u1_notifiations) == 1
             assert (
                 u1_notifiations[0]["group_id"]
-                == "tier_change:user_id:2:tier:bronze:blocknumber:10"
+                == "tier_change:user_id:1:tier:bronze:blocknumber:10"
             )
             assert u1_notifiations[0]["is_seen"] == False
             assert len(u1_notifiations[0]["actions"]) == 1

--- a/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timedelta
+
+from integration_tests.utils import populate_mock_db
+from src.queries.get_notifications import get_notifications
+from src.utils.db_session import get_db
+
+t1 = datetime(2020, 10, 10, 10, 35, 0)
+t2 = t1 - timedelta(hours=1)
+t3 = t1 - timedelta(hours=2)
+t4 = t1 - timedelta(hours=3)
+
+
+def test_get_save_notifications(app):
+    with app.app_context():
+        db_mock = get_db()
+
+        test_entities = {
+            "user_balance_changes": [
+                {
+                    "user_id": 1,
+                    "blocknumber": 10,
+                    # No tier change, none -> none
+                    "previous_balance": 0,
+                    "current_balance": 20,
+                },
+            ],
+            "users": [{"user_id": i + 1} for i in range(2)],
+        }
+        populate_mock_db(db_mock, test_entities)
+
+        with db_mock.scoped_session() as session:
+            args = {"limit": 10, "user_id": 1}
+            u1_notifiations = get_notifications(session, args)
+            assert len(u1_notifiations) == 1
+            assert (
+                u1_notifiations[0]["group_id"]
+                == "tier_change:user_id:2:tier:bronze:blocknumber:10"
+            )
+            assert u1_notifiations[0]["is_seen"] == False
+            assert len(u1_notifiations[0]["actions"]) == 1
+            u1_notifiations[0]["actions"][0]["data"] = {
+                "new_tier": "bronze",
+                "new_tier_value": 10,
+                "current_value": "20",
+            }

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -27,6 +27,7 @@ from src.models.users.aggregate_user import AggregateUser
 from src.models.users.associated_wallet import AssociatedWallet, WalletChain
 from src.models.users.supporter_rank_up import SupporterRankUp
 from src.models.users.user import User
+from src.models.users.user_balance_change import UserBalanceChange
 from src.models.users.user_bank import UserBankAccount, UserBankTx
 from src.models.users.user_listening_history import UserListeningHistory
 from src.models.users.user_tip import UserTip
@@ -131,6 +132,7 @@ def populate_mock_db(db, entities, block_offset=None):
         challenge_disbursements = entities.get("challenge_disbursements", [])
         notification_seens = entities.get("notification_seens", [])
         playlist_seens = entities.get("playlist_seens", [])
+        user_balance_changes = entities.get("user_balance_changes", [])
 
         num_blocks = max(
             len(tracks),
@@ -550,4 +552,15 @@ def populate_mock_db(db, entities, block_offset=None):
                 seen_at=notification_seen.get("seen_at", datetime.now()),
             )
             session.add(ns)
+        for i, balance_change in enumerate(user_balance_changes):
+            ns = UserBalanceChange(
+                user_id=balance_change.get("user_id", i),
+                blocknumber=balance_change.get("blocknumber", i),
+                current_balance=balance_change.get("current_balance", 0),
+                previous_balance=balance_change.get("previous_balance", 0),
+                created_at=balance_change.get("created_at", datetime.now()),
+                updated_at=balance_change.get("updated_at", datetime.now()),
+            )
+            session.add(ns)
+
         session.commit()

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -19,6 +19,7 @@ from src.queries.get_notifications import (
     SaveNotification,
     SupporterRankUpNotification,
     SupportingRankUpNotification,
+    TierChangeNotification,
     TipReceiveNotification,
     TipSendNotification,
     TrackMilestoneNotification,
@@ -253,6 +254,19 @@ def extend_milestone(action: NotificationAction):
     return notification
 
 
+def extend_tier_change(action: NotificationAction):
+    data: TierChangeNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": data,
+    }
+    return notification
+
+
 notification_action_handler = {
     "follow": extend_follow,
     "repost": extend_repost,
@@ -267,4 +281,5 @@ notification_action_handler = {
     "supporter_rank_up": extend_support_rank_up,
     "challenge_reward": extend_challenge_reward,
     "reaction": extend_reaction,
+    "tier_change": extend_tier_change,
 }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -209,6 +209,12 @@ class PlaylistMilestoneNotification(TypedDict):
     threshold: int
 
 
+class TierChangeNotification(TypedDict):
+    new_tier: str
+    new_tier_value: int
+    current_value: str
+
+
 NotificationData = Union[
     FollowNotification,
     RepostNotification,
@@ -226,6 +232,7 @@ NotificationData = Union[
     FollowerMilestoneNotification,
     TrackMilestoneNotification,
     PlaylistMilestoneNotification,
+    TierChangeNotification,
 ]
 
 


### PR DESCRIPTION
### Description
Adds tier change notification for triggers

### Tests
Wrote tests to verify that the notification was created on tier change update or insert

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->