### PR TITLE
Trending fix web3

### DIFF
--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -32,6 +32,7 @@ from src.utils.prometheus_metric import (
 from src.utils.redis_cache import set_json_cached_key
 from src.utils.redis_constants import trending_tracks_last_completion_redis_key
 from src.utils.session_manager import SessionManager
+from src.utils.web3_provider import get_web3
 from web3 import Web3
 
 logger = logging.getLogger(__name__)
@@ -370,8 +371,8 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
 def get_block(web3, block_number: int):
     final_poa_block = helpers.get_final_poa_block(shared_config)
     if final_poa_block:
-        nethermin_block_number = block_number - final_poa_block
-        return web3.eth.get_block(nethermin_block_number, True)
+        nethermind_block_number = block_number - final_poa_block
+        return web3.eth.get_block(nethermind_block_number, True)
     else:
         return web3.eth.get_block(block_number, True)
 
@@ -423,7 +424,7 @@ def index_trending_task(self):
     """Caches all trending combination of time-range and genre (including no genre)."""
     db = index_trending_task.db
     redis = index_trending_task.redis
-    web3 = index_trending_task.web3
+    web3 = get_web3()
     have_lock = False
     timeout = 60 * 60 * 2
     update_lock = redis.lock("index_trending_lock", timeout=timeout)

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -366,9 +366,18 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
             block = prev_block
             curr_block_number -= 1
         logger.info(
+            "index_trending.py | find min block above timestamp start",
+        )
+        logger.info(
+            f"index_trending.py | find min block above timestamp start num {curr_block_number}",
+        )
+        logger.info(
+            f"index_trending.py | find min block above timestamp start {min_timestamp} prev {prev_timestamp}",
+        )
+
+        logger.info(
             "index_trending.py | find min block above timestamp",
             extra={
-                "block_timestamp": block["timestamp"],
                 "curr_block_number": curr_block_number,
                 "min_timestamp": min_timestamp,
                 "prev_timestamp": prev_timestamp,

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -292,11 +292,11 @@ def index_trending_notifications(db: SessionManager, timestamp: datetime):
                 prev_rank = previous_track_notification["rank"]
                 if prev_rank <= rank:
                     continue
-
+            notif_timestamp = int(round(timestamp.timestamp()))
             notifications.append(
                 {
                     "owner_id": track["owner_id"],
-                    "group_id": f"trending:time_range:week:genre:all:rank:{rank}:track_id:{track_id}:timestamp:{int(timestamp.timestamp())}",
+                    "group_id": f"trending:time_range:week:genre:all:rank:{rank}:track_id:{track_id}:timestamp:{notif_timestamp}",
                     "track_id": track_id,
                     "rank": rank,
                 }

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -269,7 +269,6 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
         previous_trending = {
             n[0]: {"timestamp": n[1], **n[2]} for n in previous_trending_notifications
         }
-        logger.info(previous_trending)
 
         notifications = []
 
@@ -280,7 +279,6 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
             track_id = track["track_id"]
             rank = index + 1
             previous_track_notification = previous_trending.get(str(track["track_id"]))
-            logger.info(previous_track_notification)
             if previous_track_notification is not None:
                 current_datetime = datetime.fromtimestamp(timestamp)
                 prev_notification_datetime = datetime.fromtimestamp(

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -365,6 +365,16 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
         if prev_timestamp >= min_timestamp:
             block = prev_block
             curr_block_number -= 1
+        logger.info(
+            "index_trending.py | find min block above timestamp",
+            extra={
+                "block_timestamp": block["timestamp"],
+                "curr_block_number": curr_block_number,
+                "min_timestamp": min_timestamp,
+                "prev_timestamp": prev_timestamp,
+            },
+        )
+
     return block
 
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -306,7 +306,7 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
             [
                 Notification(
                     user_ids=[n["owner_id"]],
-                    timestamp=timestamp,
+                    timestamp=datetime.fromtimestamp(timestamp),
                     type="trending",
                     group_id=n["group_id"],
                     specifier=n["track_id"],

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -365,24 +365,8 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
         if prev_timestamp >= min_timestamp:
             block = prev_block
             curr_block_number -= 1
-        logger.info(
-            "index_trending.py | find min block above timestamp start",
-        )
-        logger.info(
-            f"index_trending.py | find min block above timestamp start num {curr_block_number}",
-        )
-        logger.info(
-            f"index_trending.py | find min block above timestamp start {min_timestamp} prev {prev_timestamp}",
-        )
-
-        logger.info(
-            "index_trending.py | find min block above timestamp",
-            extra={
-                "curr_block_number": curr_block_number,
-                "min_timestamp": min_timestamp,
-                "prev_timestamp": prev_timestamp,
-            },
-        )
+        else:
+            return block
 
     return block
 


### PR DESCRIPTION
### Description
Fix index trending web3 blocknumber error
It was using the web3 instance from the database task instead of the nethermind web3
Also fixed error with int vs timestamp


### Tests
Ran on staging

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->