### PR TITLE
Use track cid streaming and fallback track id streaming

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -461,15 +461,15 @@ class TrackStream(Resource):
         primary_node = creator_nodes[0]
         signature_param = urllib.parse.quote(json.dumps(signature))
         track_cid = track["track_cid"]
-        if CID_STREAM_ENABLED:
-            if not track_cid:
-                logger.info(
-                    f"We should not reach here! If you see this, it's because the track with id {track_id} has no track_cid. Please investigate."
-                )
-                abort_not_found(track_id, ns)
-            path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
-        else:
+        if not track_cid:
+            logger.info(
+                f"We should not reach here! If you see this, it's because the track with id {track_id} has no track_cid. Please investigate."
+            )
             path = f"tracks/stream/{track_id}"
+        elif not CID_STREAM_ENABLED:
+            path = f"tracks/stream/{track_id}"
+        else:
+            path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
         stream_url = urljoin(primary_node, path)
 
         return stream_url

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -462,8 +462,8 @@ class TrackStream(Resource):
         signature_param = urllib.parse.quote(json.dumps(signature))
         track_cid = track["track_cid"]
         if not track_cid:
-            logger.info(
-                f"We should not reach here! If you see this, it's because the track with id {track_id} has no track_cid. Please investigate."
+            logger.warning(
+                f"tracks.py | stream | We should not reach here! If you see this, it's because the track with id {track_id} has no track_cid. Please investigate."
             )
             path = f"tracks/stream/{track_id}"
         elif not CID_STREAM_ENABLED:

--- a/discovery-provider/src/queries/get_track_stream_signature.py
+++ b/discovery-provider/src/queries/get_track_stream_signature.py
@@ -9,7 +9,7 @@ from src.premium_content.premium_content_access_checker import (
 from src.premium_content.signature import get_premium_content_signature
 from src.queries.get_authed_user import get_authed_user
 
-CID_STREAM_ENABLED = False
+CID_STREAM_ENABLED = True
 
 
 class GetTrackStreamSignature(TypedDict):


### PR DESCRIPTION
### Description

Turn on track cid streaming. If track has no cid, use track id streaming.

### Tests

Was already tested prior. Does need some CN counterpart changes; PR for this should be coming soon.
Should definitely test the combo of this and that PRs though.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

None here. There should be existing monitoring on CN side.

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->