### PR TITLE
Update discovery api to return permalink with playlist objects

### DIFF
--- a/discovery-provider/src/api/v1/models/playlists.py
+++ b/discovery-provider/src/api/v1/models/playlists.py
@@ -27,6 +27,7 @@ playlist_model = ns.model(
     {
         "artwork": fields.Nested(playlist_artwork, allow_null=True),
         "description": fields.String,
+        "permalink": fields.String,
         "id": fields.String(required=True),
         "is_album": fields.Boolean(required=True),
         "playlist_name": fields.String(required=True),

--- a/discovery-provider/src/models/playlists/playlist.py
+++ b/discovery-provider/src/models/playlists/playlist.py
@@ -5,6 +5,7 @@ from src.model_validator import ModelValidator
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin, validate_field_helper
 from src.models.playlists.playlist_route import PlaylistRoute
+from src.models.users.user import User
 
 
 class Playlist(Base, RepresentableMixin):
@@ -48,6 +49,15 @@ class Playlist(Base, RepresentableMixin):
         primaryjoin="and_(\
             remote(Playlist.playlist_id) == foreign(PlaylistRoute.playlist_id),\
             PlaylistRoute.is_current)",
+        lazy="joined",
+        viewonly=True,
+    )
+
+    user = relationship(  # type: ignore
+        User,
+        primaryjoin="and_(\
+            remote(Playlist.playlist_owner_id) == foreign(User.user_id),\
+            User.is_current)",
         lazy="joined",
         viewonly=True,
     )

--- a/discovery-provider/src/models/playlists/playlist.py
+++ b/discovery-provider/src/models/playlists/playlist.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import relationship, validates
 from src.model_validator import ModelValidator
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin, validate_field_helper
+from src.models.playlists.playlist_route import PlaylistRoute
 
 
 class Playlist(Base, RepresentableMixin):
@@ -42,8 +43,27 @@ class Playlist(Base, RepresentableMixin):
         "Block", primaryjoin="Playlist.blocknumber == Block.number"
     )
 
+    _routes = relationship(  # type: ignore
+        PlaylistRoute,
+        primaryjoin="and_(\
+            remote(Playlist.playlist_id) == foreign(PlaylistRoute.playlist_id),\
+            PlaylistRoute.is_current)",
+        lazy="joined",
+        viewonly=True,
+    )
+
     ModelValidator.init_model_schemas("Playlist")
     fields = ["playlist_name", "description"]
+
+    @property
+    def _slug(self):
+        return self._routes[0].slug if self._routes else ""
+
+    @property
+    def permalink(self):
+        if self.user and self.user[0].handle and self._slug:
+            return f"/{self.user[0].handle}/playlist/{self._slug}"
+        return ""
 
     # unpacking args into @validates
     @validates(*fields)

--- a/libs/src/sdk/api/generated/default/models/Playlist.ts
+++ b/libs/src/sdk/api/generated/default/models/Playlist.ts
@@ -50,6 +50,12 @@ export interface Playlist
         * @type {string}
         * @memberof Playlist
         */
+        permalink?: string;
+        /**
+        * 
+        * @type {string}
+        * @memberof Playlist
+        */
         id: string;
         /**
         * 

--- a/libs/src/sdk/api/generated/full/models/PlaylistFull.ts
+++ b/libs/src/sdk/api/generated/full/models/PlaylistFull.ts
@@ -74,6 +74,12 @@ export interface PlaylistFull
         * @type {string}
         * @memberof PlaylistFull
         */
+        permalink?: string;
+        /**
+        * 
+        * @type {string}
+        * @memberof PlaylistFull
+        */
         id: string;
         /**
         * 


### PR DESCRIPTION
### Description
Add permalinks to the playlist model to get returned to the front end when fetching a playlist

### Tests
ran the /playlists/<playlist_id> endpoint on my remote machine and confirmed permalink is getting returned

