### PR TITLE
SDK: Decrypt the last message in the getChats response

### DIFF
--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -47,7 +47,12 @@ export class ChatsApi extends BaseAPI {
   // #region QUERY
 
   public async get(requestParameters: ChatGetRequest) {
-    const response = await this.getRaw(requestParameters)
+    this.assertNotNullOrUndefined(
+      requestParameters.chatId,
+      'requestParameters.chatId',
+      'getChat'
+    )
+    const response = await this.getRaw(requestParameters.chatId)
     return {
       ...response,
       data: await this.decryptLastChatMessage(response.data)
@@ -412,13 +417,8 @@ export class ChatsApi extends BaseAPI {
     }
   }
 
-  private async getRaw(requestParameters: ChatGetRequest) {
-    this.assertNotNullOrUndefined(
-      requestParameters.chatId,
-      'requestParameters.chatId',
-      'getChat'
-    )
-    const path = `/comms/chats/${requestParameters.chatId}`
+  private async getRaw(chatId: string) {
+    const path = `/comms/chats/${chatId}`
     return (await this.request({
       method: 'GET',
       path,
@@ -429,7 +429,7 @@ export class ChatsApi extends BaseAPI {
   private async getChatSecret(chatId: string) {
     const existingChatSecret = this.chatSecrets[chatId]
     if (!existingChatSecret) {
-      const response = await this.getRaw({ chatId })
+      const response = await this.getRaw(chatId)
       const chatSecret = await this.readInviteCode(
         base64.decode(response.data.invite_code)
       )

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -55,7 +55,9 @@ export class ChatsApi extends BaseAPI {
     const response = await this.getRaw(requestParameters.chatId)
     return {
       ...response,
-      data: await this.decryptLastChatMessage(response.data)
+      data: response.data
+        ? await this.decryptLastChatMessage(response.data)
+        : response.data
     }
   }
 

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -77,12 +77,12 @@ export class ChatsApi extends BaseAPI {
       query: queryParameters
     })) as TypedCommsResponse<UserChat[]>
 
-    const unencrypted = await Promise.all(
-      response.data.map(async (c) => await this.decryptLastChatMessage(c))
+    const decrypted = await Promise.all(
+      response.data.map(this.decryptLastChatMessage)
     )
     return {
       ...response,
-      data: unencrypted
+      data: decrypted
     }
   }
 
@@ -113,7 +113,7 @@ export class ChatsApi extends BaseAPI {
       headers: await this.getSignatureHeader(path),
       query: queryParameters
     })) as TypedCommsResponse<ChatMessage[]>
-    const unencrypted = await Promise.all(
+    const decrypted = await Promise.all(
       response.data.map(async (m) => ({
         ...m,
         message: await this.decryptString(
@@ -124,7 +124,7 @@ export class ChatsApi extends BaseAPI {
     )
     return {
       ...response,
-      data: unencrypted
+      data: decrypted
     }
   }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Ensures the `last_message` in the chats responses are decrypted before being returned by the SDK.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally with client by linking libs

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->