### PR TITLE
CN should self-report as unhealthy if DB or redis connections are unhealthy

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -7,7 +7,7 @@ const utils = require('../../utils')
 const { getNumWorkers } = require('../../utils/cluster/clusterUtils')
 const { MONITORS } = require('../../monitors/monitors')
 
-const MIN_NUBMER_OF_CPUS = 8 // 8 cpu
+const MIN_NUMBER_OF_CPUS = 8 // 8 cpu
 const MIN_TOTAL_MEMORY = 15500000000 // 15.5 GB of RAM
 const MIN_FILESYSTEM_SIZE = 1950000000000 // 1950 GB of file system storage
 
@@ -238,7 +238,7 @@ const healthCheck = async (
 
   if (
     !response.numberOfCPUs ||
-    response.numberOfCPUs < MIN_NUBMER_OF_CPUS ||
+    response.numberOfCPUs < MIN_NUMBER_OF_CPUS ||
     !response.totalMemory ||
     response.totalMemory < MIN_TOTAL_MEMORY ||
     !response.storagePathSize ||

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -126,8 +126,20 @@ const healthCheckController = async (req) => {
     }
   }
 
+  /**
+   * Ensure DB and redis connections are healthy
+   * - If redis connection is down, all monitors will be null
+   * - If DB connection is down, databaseConnections value will be null
+   */
+  const DBAndRedisConnectionIsHealthy = !!response.databaseConnections
+
   if (config.get('isReadOnlyMode')) {
     return errorResponseServerError(response)
+  } else if (!DBAndRedisConnectionIsHealthy) {
+    return errorResponseServerError({
+      ...response,
+      healthy: false
+    })
   } else {
     return successResponse(response)
   }

--- a/creator-node/src/components/healthCheck/healthCheckController.js
+++ b/creator-node/src/components/healthCheck/healthCheckController.js
@@ -129,9 +129,10 @@ const healthCheckController = async (req) => {
   /**
    * Ensure DB and redis connections are healthy
    * - If redis connection is down, all monitors will be null
-   * - If DB connection is down, databaseConnections value will be null
+   * - If DB connection is down, databaseSize value will be null
+   * - It is safe to do this falsey comparison since databaseSize should always be non-zero if healthy
    */
-  const DBAndRedisConnectionIsHealthy = !!response.databaseConnections
+  const DBAndRedisConnectionIsHealthy = !!response.databaseSize
 
   if (config.get('isReadOnlyMode')) {
     return errorResponseServerError(response)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Per #flare-135 ([postmortem doc here](https://www.notion.so/audiusproject/Content-Node-Instability-1-7-23-flare-135-7a604ef3cc774e44ba9fcd59fdfc4920)), some prod nodes became unhealthy, presumably bc redis and/or DB connections were unhealthy. The observed behavior was that the values in `/health_check` that are populated by monitors (persisted in redis) were null. `/db_check` and `/disk_check` also returned all null values, which is consistent.

Not sure of root cause, but one downstream bug was that other nodes did not detect this unhealthiness and cycle users off those nodes. A simple fix is to have the nodes self-report as unhealthy, which this PR accomplishes. State machine will then detect this and cycle users off correctly

**NOTE**
local dev is not working for me currently, so am leaving this in draft mode since it's not tested

2 key points I can think of:
- cold-start related issue where the node reports unhealthy on initial startup before the first monitor job runs. this might be OK since it should report as unhealthy? unless docker tries to restart it or something
- would be good to repro this locally by taking down the DB or redis server to observe exact behavior. i think just checking this monitor value as truthy is safe (per code comment), but good to confirm

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

TODO

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->

TODO

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->