### PR TITLE
Removed unused arg user_id in get_playlists query

### DIFF
--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -31,7 +31,6 @@ class RouteArgs(TypedDict):
 class GetPlaylistArgs(TypedDict):
     current_user_id: int
     playlist_ids: List[int]
-    user_id: int
     with_users: bool
     routes: List[RouteArgs]
 
@@ -82,11 +81,6 @@ def _get_unpopulated_playlists(session, args):
             )
         except ValueError as e:
             raise exceptions.ArgumentError("Invalid value found in playlist id list", e)
-
-    if "user_id" in args:
-        user_id = args.get("user_id")
-        # user id filter if the optional query param is passed in
-        playlist_query = playlist_query.filter(Playlist.playlist_owner_id == user_id)
 
     # If no current_user_id, never show hidden playlists
     if not current_user_id:


### PR DESCRIPTION
### Description
It looks like this "user_id" arg has been replaced with "current_user_id" arg, so removing to avoid confusion. I checked calls to get_playlists() query and they all call with current_user_id.


### Tests
Tested hitting endpoints that call the get_playlist query (Playlist.get(), FullPlaylist.get(), FullPlaylistByPermalink.get())