### PR TITLE
(WIP) PLAT-339: add filter arg to top parser

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -277,7 +277,12 @@ top_parser.add_argument(
 top_parser.add_argument(
     "mood",
     required=False,
-    description="Filer to a mood",
+    description="Filter to a mood",
+)
+top_parser.add_argument(
+    "filter",
+    required=False,
+    description="Filter for the playlist query",
 )
 
 


### PR DESCRIPTION
### Description
When anyone goes to the "Let Them DJ" page the same results are given for any user. The correct behavior is that this list is made up of playlists from the followees of the user requesting the page. If you unfollow any of the accounts on the page itself you will see they still show up after a refresh.

This fix makes the filter param available in the downstream query. Previously this was non-existent and falling into the "None" case every time.


### Tests
I still need to learn how to write API level tests, stay tuned for tomorrow 🙃 


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I don't think so. People will see that their "Let Them DJ" page change to reflect who they follow.


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->