### PR TITLE
Clear beatfile

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -115,7 +115,7 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        rm /var/celerybeat*
+        rm /var/celerybeat* 2> /dev/null
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
@@ -126,7 +126,7 @@ else
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        rm /var/celerybeat*
+        rm /var/celerybeat* 2> /dev/null
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -114,6 +114,8 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
     fi
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
+        # Clear the celerybeat artifacts
+        rm /var/celerybeat*
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
@@ -123,6 +125,8 @@ else
     fi
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
+        # Clear the celerybeat artifacts
+        rm /var/celerybeat*
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -115,8 +115,8 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        [ -e /var/celerybeat-schedule ] && rm celerybeat-schedule
-        [ -e /var/celerybeat.pid ] && rm celerybeat.pid
+        [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
+        [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
@@ -127,8 +127,8 @@ else
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        [ -e /var/celerybeat-schedule ] && rm celerybeat-schedule
-        [ -e /var/celerybeat.pid ] && rm celerybeat.pid
+        [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
+        [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -115,7 +115,8 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        rm /var/celerybeat* 2> /dev/null
+        [ -e /var/celerybeat-schedule ] && rm celerybeat-schedule
+        [ -e /var/celerybeat.pid ] && rm celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
@@ -126,7 +127,8 @@ else
 
     if [[ "$audius_no_workers" != "true" ]] && [[ "$audius_no_workers" != "1" ]]; then
         # Clear the celerybeat artifacts
-        rm /var/celerybeat* 2> /dev/null
+        [ -e /var/celerybeat-schedule ] && rm celerybeat-schedule
+        [ -e /var/celerybeat.pid ] && rm celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Lots of nodes behind today (healthz.audius.co)

I believe what happens is that the auto restart policy on the indexer docker container can in some cases (maybe OOM) bring it back from the dead by just bringing back the container and not clearing the volume. https://github.com/AudiusProject/audius-docker-compose/blob/main/discovery-provider/docker-compose.yml#L132

This can cause the /var/celerybeat.pid to exist between celery invocations, which will cause the celery tasks to never start. 
One SP for example dn1.materlightblooming.xyz has no logs for `index.py` (our main indexer job) https://audius.loggly.com/search#terms=%22index.py%22&from=2023-01-24T20:49:38.302Z&until=2023-01-24T21:19:38.302Z&source_group=&filter=tag;matterlightblooming

I was able to repro this state by running `docker kill indexer` and `audius-cli launch discovery-provider` on one of our staging boxes. Doing `docker kill indexer && docker rm indexer` clears the volume and doesn't exhibit this behavior.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested this on stage discovery 5 -- can confirm that this fixes the issue!


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->