### PR TITLE
[PAY-875] Add content-type check on content+ipfs CID routes

### DIFF
--- a/creator-node/src/routes/files.js
+++ b/creator-node/src/routes/files.js
@@ -837,7 +837,18 @@ router.post(
  * @dev This route does not handle responses by design, so we can pipe the response to client.
  * TODO: It seems like handleResponse does work with piped responses, as seen from the track/stream endpoint.
  */
-router.get(['/ipfs/:CID', '/content/:CID'], getCID)
+router.get(
+  ['/ipfs/:CID', '/content/:CID'],
+  async (req, _res, next) => {
+    if (!req.is('image/png') && !req.is('image/jpeg')) {
+      return errorResponseBadRequest(
+        'invalid content type: only supported types are png and jpeg'
+      )
+    }
+    next()
+  },
+  getCID
+)
 
 /**
  * Serve images hosted by content node.


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds a content-type check on routes for requesting a CID. This is to gate tracks from being requested from these routes.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->