### PR TITLE
Add permalink to user collections in users/account

### DIFF
--- a/discovery-provider/src/queries/get_users_account.py
+++ b/discovery-provider/src/queries/get_users_account.py
@@ -94,6 +94,7 @@ def get_users_account(args):
                 "id": playlist["playlist_id"],
                 "name": playlist["playlist_name"],
                 "is_album": playlist["is_album"],
+                "permalink": playlist["permalink"],
                 "user": {
                     "id": playlist_owner["user_id"],
                     "handle": playlist_owner["handle"],


### PR DESCRIPTION
### Description
Realized user collections get loaded through a different route where playlists get skimmed down to fewer attributes, so made sure to add permalink here as well

### Tests
Tested against my machine hitting my wallet address
http://34.132.236.109:5000/users/account?wallet=<wallet address>