### PR TITLE
Fix discovery playlist seen indexing

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -190,8 +190,10 @@ class ManageEntityParameters:
         key: Tuple[int, int],
         record: PlaylistSeen,
     ):
-        self.new_records[EntityType.PLAYLIST_SEEN][key].append(record)  # type: ignore
-        self.existing_records[EntityType.PLAYLIST_SEEN][key] = record  # type: ignore
+        if key not in self.new_records[EntityType.PLAYLIST_SEEN]:  # type: ignore
+            self.new_records[EntityType.PLAYLIST_SEEN][key].append(record)  # type: ignore
+            self.existing_records[EntityType.PLAYLIST_SEEN][key] = record  # type: ignore
+        # If key exists, do nothing
 
 
 def get_record_key(user_id: int, entity_type: str, entity_id: int):


### PR DESCRIPTION
### Description
The reason it’s broken is because the playlist seen primary key constrain is being broken.
Here’s a snapshot of the tbl in stage
```
                                            Table "public.playlist_seen"
   Column    |            Type             | Collation | Nullable | Default | Storage  | Stats target | Description
-------------+-----------------------------+-----------+----------+---------+----------+--------------+-------------
 user_id     | integer                     |           | not null |         | plain    |              |
 playlist_id | integer                     |           | not null |         | plain    |              |
 seen_at     | timestamp without time zone |           | not null |         | plain    |              |
 is_current  | boolean                     |           | not null |         | plain    |              |
 blocknumber | integer                     |           |          |         | plain    |              |
 blockhash   | character varying           |           |          |         | extended |              |
 txhash      | character varying           |           |          |         | extended |              |
Indexes:
    "playlist_seen_pkey" PRIMARY KEY, btree (is_current, user_id, playlist_id, seen_at)

audius_discovery=> select * from playlist_seen where user_id='381066790' order by seen_at desc;
  user_id  | playlist_id |       seen_at       | is_current | blocknumber |                             blockhash                              |                               txhash
-----------+-------------+---------------------+------------+-------------+--------------------------------------------------------------------+--------------------------------------------------------------------
 381066790 |        1463 | 2023-01-24 18:15:18 | f          |    31819856 | 0xaad74d7dfff01f5d0e0965174d74399c31a6fe913c6b34d2cbc2353870b96648 | 0xb065efec7c992728126b7d1f8c51ecc37250a66d6209e97df79142bc3bda7773
 381066790 |        1463 | 2023-01-24 18:15:18 | t          |    31819856 | 0xaad74d7dfff01f5d0e0965174d74399c31a6fe913c6b34d2cbc2353870b96648 | 0xde992d7566a787f665c15b5727b2b7293cf254ce44803b8a8e1269200f3d1033
 ```
As you can see there are two records for the same user_id, playlist_id, seen_at combination because the two records were created in the same block.
When a record with the same user_id, playlist_id is created, it will make both the above records have is_current false and break the constraint and thus indexing
Resolution: Update the utils in entity manager to not allow multiple changes to the same key in the same block - similar to the notification change above it
[https://github.com/AudiusProject/audius-protocol/blob/6ac082434fcde9a9af73edfb0df7[…]849563adae/discovery-provider/src/tasks/entity_manager/utils.py](https://github.com/AudiusProject/audius-protocol/blob/6ac082434fcde9a9af73edfb0df750849563adae/discovery-provider/src/tasks/entity_manager/utils.py#L179-L194)
Post deploy, remove a row in the playlist_seen tbl for that user and staging should be fixed
Working on this now, should take ~20 min to complete

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->