### PR TITLE
SDK: Don't fail healthcheck on 0 blockdiff

### DIFF
--- a/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
+++ b/libs/src/sdk/middleware/discoveryNodeSelectorMiddleware.ts
@@ -129,7 +129,11 @@ const isDiscoveryNodeHealthy = async ({
     })
     return false
   }
-  if (!data.block_difference || data.block_difference > unhealthyBlockDiff) {
+  if (
+    data.block_difference === null ||
+    data.block_difference === undefined ||
+    data.block_difference > unhealthyBlockDiff
+  ) {
     console.warn('Audius SDK discovery provider POA indexing unhealthy', {
       endpoint
     })


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Previously, the SDK would fail on healthchecks for services with a blockdiff of 0 due to a falsey check rather than a null/undefined check

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->