### PR TITLE
Append in_eu field to location response

### DIFF
--- a/identity-service/src/routes/location.js
+++ b/identity-service/src/routes/location.js
@@ -31,7 +31,7 @@ module.exports = function (app) {
             'api-key': IP_API_KEY
           }
         })
-        return successResponse(res.data)
+        return successResponse({ ...res.data, in_eu: res.data.is_eu })
       } catch (e) {
         logger.error(`Got error in location: ${e.response?.data}`)
         return errorResponse(e.response?.status, e.response?.data)


### PR DESCRIPTION
### Description
We're switching to ipdata from ipapi for location data for `/location` in identity. Unfortunately ipdata uses a different name for one of the fields we depend on - `is_eu` instead of `in_eu`, so this commit appends an `in_eu` field with the same value so client can stay the same.


### Tests
Checked response using insomnia.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->