### PR TITLE
PLAT-623: death to the jdk

### DIFF
--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -12,8 +12,12 @@ const spawnOpenAPIGenerator = (openApiGeneratorArgs) => {
       console.error(`exec error: ${error}`)
       return
     }
-    console.log(`stdout: ${stdout}`)
-    console.error(`stderr: ${stderr}`)
+    if (stdout) {
+      console.log(`stdout: ${stdout}`)
+    }
+    if (stderr) {
+      console.error(`stderr: ${stderr}`)
+    }
   })
   return openApiGeneratorCLI
 }

--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -7,22 +7,13 @@ const spawnOpenAPIGenerator = (openApiGeneratorArgs) => {
   console.log('Running OpenAPI Generator:')
   const fullCmd = `docker run --rm -v "${process.env.PWD}:/local" openapitools/openapi-generator-cli ${openApiGeneratorArgs.join(' ')}`
   console.log(fullCmd)
-  const openApiGeneratorCLI = exec(fullCmd)
-
-  openApiGeneratorCLI.stdout.on('data', (data) => {
-    console.log(`${data}`)
-  })
-
-  openApiGeneratorCLI.stderr.on('data', (data) => {
-    console.log(`${data}`)
-  })
-
-  openApiGeneratorCLI.on('error', (error) => {
-    console.log(`error: ${error.message}`)
-  })
-
-  openApiGeneratorCLI.on('close', (code) => {
-    console.log(`child process exited with code ${code}`)
+  const openApiGeneratorCLI = exec(fullCmd, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(`stdout: ${stdout}`);
+    console.error(`stderr: ${stderr}`);
   })
   return openApiGeneratorCLI
 }

--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -1,15 +1,13 @@
-const { spawn } = require('child_process')
+const { exec } = require('child_process')
 const commander = require('commander')
 
 const program = new commander.Command()
 
 const spawnOpenAPIGenerator = (openApiGeneratorArgs) => {
   console.log('Running OpenAPI Generator:')
-  console.log(`openapi-generator-cli ${openApiGeneratorArgs.join(' ')}`)
-  const openApiGeneratorCLI = spawn(
-    'openapi-generator-cli',
-    openApiGeneratorArgs
-  )
+  const fullCmd = `docker run --rm -v "${process.env.PWD}:/local" openapitools/openapi-generator-cli ${openApiGeneratorArgs.join(' ')}`
+  console.log(fullCmd)
+  const openApiGeneratorCLI = exec(fullCmd)
 
   openApiGeneratorCLI.stdout.on('data', (data) => {
     console.log(`${data}`)
@@ -51,11 +49,11 @@ const generate = ({ env, apiVersion, apiFlavor, generator }) => {
     '-i',
     `${baseURL}/${apiPath}/swagger.json`,
     '-o',
-    `src/sdk/api/generated/${outputFolderName}`,
+    `/local/src/sdk/api/generated/${outputFolderName}`,
     '--skip-validate-spec',
     '--additional-properties=modelPropertyNaming=original,useSingleRequestParameter=true,withSeparateModelsAndApi=true,apiPackage=api,modelPackage=model',
     '-t',
-    `src/sdk/api/generator/templates/${generator}`
+    `/local/src/sdk/api/generator/templates/${generator}`
   ]
   spawnOpenAPIGenerator(openApiGeneratorArgs)
 }

--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -9,11 +9,11 @@ const spawnOpenAPIGenerator = (openApiGeneratorArgs) => {
   console.log(fullCmd)
   const openApiGeneratorCLI = exec(fullCmd, (error, stdout, stderr) => {
     if (error) {
-      console.error(`exec error: ${error}`);
-      return;
+      console.error(`exec error: ${error}`)
+      return
     }
-    console.log(`stdout: ${stdout}`);
-    console.error(`stderr: ${stderr}`);
+    console.log(`stdout: ${stdout}`)
+    console.error(`stderr: ${stderr}`)
   })
   return openApiGeneratorCLI
 }


### PR DESCRIPTION
### Description
To remove the JDK dependency when generating SDK code.


### Tests
From the `libs` directory run the sequence of codegen commands via NPM and you should see that the script uses docker to pull the openapi image instead of building with java. You can also remove the jdk from your system to prove it's no longer needed. I never installed the JDK on this machine that I tested on.

The first time you run this you'll need to pull the docker image, afterwards it should be pretty quick.

You can find the full list in the readme next to gen.js.

```
#### DEVELOPMENT ####
npm run gen:dev
npm run gen:dev:default
npm run gen:dev:full

#### STAGING ####
npm run gen:stage
npm run gen:stage:default
npm run gen:stage:full

#### PROD ####
npm run gen:prod
npm run gen:prod:default
npm run gen:prod:full
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I don't think so.

================ REMINDER: ================
Some workflows may still use the JDK and install it. I'll do a followup to clean those.