### PR TITLE
Playlist es indexer fix

### DIFF
--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,5 +1,5 @@
 export const indexNames = {
-  playlists: 'playlists10',
+  playlists: 'playlists11',
   reposts: 'reposts9',
   saves: 'saves9',
   tracks: 'tracks9',

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -116,7 +116,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
           where
             is_current = true
             and is_delete = false
-            and repost_type = (case when is_album then 'album' else 'playlist' end)::reposttype
+            and repost_type != 'track'::reposttype
             and repost_item_id = playlist_id
             order by created_at desc
         ) as reposted_by,
@@ -127,7 +127,7 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
           where
             is_current = true
             and is_delete = false
-            and save_type = (case when is_album then 'album' else 'playlist' end)::savetype
+            and save_type != 'track'::savetype
             and save_item_id = playlist_id
             order by created_at desc
         ) as saved_by


### PR DESCRIPTION
### Description
Bug in feed endpoint using es where playlist save and repost counts are incorrect. 
The root cause is because entity manger events for save and repost store save_type and repost type as playlist instead of the legacy album field. 

This change allows es to update on either field

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->