### PR TITLE
Display last block and indexed block in healthz

### DIFF
--- a/monitoring/healthz/src/DiscoveryTrending.tsx
+++ b/monitoring/healthz/src/DiscoveryTrending.tsx
@@ -10,7 +10,6 @@ export function DiscoveryTrending() {
   const responses = sps.map((sp) => {
     const endpoint = sp.endpoint
     const res = useSWR(sp.endpoint + '/v1/full/tracks/trending', fetcher)
-    console.log(endpoint)
     return { endpoint: endpoint, res: res}
   }).sort((a, b) => {
     if (!a.res.data) {

--- a/monitoring/healthz/src/DiscoveryTrending.tsx
+++ b/monitoring/healthz/src/DiscoveryTrending.tsx
@@ -22,7 +22,7 @@ export function DiscoveryTrending() {
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 function TrendingRow({ sp }: { sp: SP }) {
-  const { data, error } = useSWR(sp.endpoint + '/v1/tracks/trending', fetcher)
+  const { data, error } = useSWR(sp.endpoint + '/v1/full/tracks/trending', fetcher)
 
   if (!data)
     return (
@@ -32,12 +32,20 @@ function TrendingRow({ sp }: { sp: SP }) {
     )
 
   const tracks = data.data
+  const latestChainBlock = data.latest_chain_block
+  const latestIndexedBlock = data.latest_indexed_block
   return (
     <tr>
       <td>
         <a href={sp.endpoint + '/health_check'} target="_blank">
           {sp.endpoint.replace('https://', '')}
         </a>
+      </td>
+      <td>
+        Latest Chain Block: {latestChainBlock}
+      </td>
+      <td>
+        Latest Indexed Block: {latestIndexedBlock}
       </td>
       <td style={{ whiteSpace: 'nowrap' }}>
         {tracks.slice(0, 25).map((t: any) => (

--- a/monitoring/healthz/src/useServiceProviders.ts
+++ b/monitoring/healthz/src/useServiceProviders.ts
@@ -55,9 +55,9 @@ export function useServiceProviders(
 }
 
 export function useDiscoveryProviders() {
-  return useServiceProviders('prod', 'discovery-node')
+  return useServiceProviders('staging', 'discovery-node')
 }
 
 export function useContentProviders() {
-  return useServiceProviders('prod', 'content-node')
+  return useServiceProviders('staging', 'content-node')
 }


### PR DESCRIPTION
### Description
Adds two new fields to the healthz trending page that shows which block and last indexed block a discovery node has seen. This makes it pretty clear that the issues around trending seem to be that some nodes are behind others.

There also is an addition that the order of the nodes are displayed from largest indexed to lowest. In other words, the top nodes are the furthest along on indexing and they get more and more behind as the table reads. This should show patterns more naturally and you can logically see where some of the trends were moving simply by scrolling down.

Lastly, to do this I needed the `/full` trending endpoints so those were added.

![Screen Shot 2023-01-30 at 5 54 41 PM](https://user-images.githubusercontent.com/16739903/215631461-eb0222f8-c5b6-431f-aa29-f1f6fee63949.png)


### Tests
Just ran on my local machine against staging. 


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
I'm not too familiar with SWR but it seems anti-pattern-y to use it in a loop so this should be fixed in the future.
