### PR TITLE
[CON-561] Add launch config to debug storage node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,15 @@
             "name": "(Content Node) Test",
             "request": "launch",
             "type": "node-terminal"
+        },
+        {
+            "name": "(Storage Node) Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/comms",
+            "env": { "audius_discprov_env": "standalone" },
+            "args": ["storage"]
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds VSCode launch config to run storage node with a debugger.


### Tests
N/A


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A