### PR TITLE
PLAT-618: fix cache decorator

### DIFF
--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -135,7 +135,6 @@ def cache(**kwargs):
     def outer_wrap(func):
         @functools.wraps(func)
         def inner_wrap(*args, **kwargs):
-            # .get() returns None if value not found
             has_user_id = (
                 "user_id" in request.args and request.args["user_id"] is not None
             )

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -136,8 +136,8 @@ def cache(**kwargs):
         @functools.wraps(func)
         def inner_wrap(*args, **kwargs):
             # .get() returns None if value not found
-            has_user_id = request.args.get("user_id") or request.headers.get(
-                "x-user-id"
+            has_user_id = (
+                "user_id" in request.args and request.args["user_id"] is not None
             )
             key = extract_key(request.path, request.args.items(), cache_prefix_override)
             # only read cache responses w/o user id because only those are inserted

--- a/discovery-provider/src/utils/redis_cache.py
+++ b/discovery-provider/src/utils/redis_cache.py
@@ -136,7 +136,9 @@ def cache(**kwargs):
         @functools.wraps(func)
         def inner_wrap(*args, **kwargs):
             # .get() returns None if value not found
-            has_user_id = request.args.get("user_id") or request.args.get("X-User-ID")
+            has_user_id = request.args.get("user_id") or request.headers.get(
+                "x-user-id"
+            )
             key = extract_key(request.path, request.args.items(), cache_prefix_override)
             # only read cache responses w/o user id because only those are inserted
             if not has_user_id:


### PR DESCRIPTION
### Description
X-User-ID is not handled correctly in the cache decorator. This PR adds that to the qualifying criteria of `has_user_id`. There is also checks added so we don't write to the cache when a user id is provided because those will never be read.


### Tests
Still getting my local env to correctly run tests, tune in later.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
No logs or alerts. Cache should have less stored now because there was unnecessary records being put in there. 