### PR TITLE
Fix top playlists with user_id

### DIFF
--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -16,7 +16,6 @@ from src.api.v1.helpers import (
     get_default_max,
     make_full_response,
     make_response,
-    pagination_parser,
     pagination_with_current_user_parser,
     search_parser,
     success_response,
@@ -223,7 +222,7 @@ class PlaylistSearchResult(Resource):
         return success_response(response["playlists"])
 
 
-top_parser = pagination_parser.copy()
+top_parser = pagination_with_current_user_parser.copy()
 top_parser.add_argument(
     "type",
     required=True,
@@ -253,6 +252,9 @@ class Top(Resource):
             args["offset"] = 0
         if args.get("type") not in ["album", "playlist"]:
             abort_bad_request_param("type", ns)
+        current_user_id = get_current_user_id(args)
+        if current_user_id:
+            args["current_user_id"] = current_user_id
 
         args["with_users"] = True
 

--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -21,6 +21,7 @@ from src.utils.db_session import get_db_read_replica
 
 
 class GetTopPlaylistsArgs(TypedDict):
+    current_user_id: Optional[int]
     limit: Optional[int]
     mood: Optional[str]
     filter: Optional[str]
@@ -33,7 +34,12 @@ class TopPlaylistKind(str, enum.Enum):
 
 
 def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
-    current_user_id = get_current_user_id(required=False)
+    current_user_id = args.get("current_user_id")
+
+    # NOTE: This is a temporary fix while migrating clients to pass 
+    # along an encoded user id via url param
+    if current_user_id is None:
+        current_user_id = get_current_user_id(required=False)
 
     # Argument parsing and checking
     if kind not in ("playlist", "album"):
@@ -44,7 +50,7 @@ def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
     limit = args.get("limit", 16)
     mood = args.get("mood", None)
 
-    if "filter" in args:
+    if args.get("filter") is not None:
         query_filter = args.get("filter")
         if query_filter != "followees":
             raise exceptions.ArgumentError(

--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -36,7 +36,7 @@ class TopPlaylistKind(str, enum.Enum):
 def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
     current_user_id = args.get("current_user_id")
 
-    # NOTE: This is a temporary fix while migrating clients to pass 
+    # NOTE: This is a temporary fix while migrating clients to pass
     # along an encoded user id via url param
     if current_user_id is None:
         current_user_id = get_current_user_id(required=False)

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -458,6 +458,10 @@ def get_top_playlists_route(type):
         args["mood"] = None
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
+
+    current_user_id = get_current_user_id(required=False)
+    args["current_user_id"] = current_user_id
+
     try:
         playlists = get_top_playlists(type, args)
         return api_helpers.success_response(playlists)

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -777,6 +777,7 @@ export class DiscoveryProvider {
     limit,
     mood,
     filter,
+    encodedUserId,
     withUsers = false
   }: Requests.GetTopFullPlaylistsParams) {
     const req = Requests.getTopFullPlaylists({
@@ -784,6 +785,7 @@ export class DiscoveryProvider {
       limit,
       mood,
       filter,
+      encodedUserId,
       withUsers
     })
     return await this._makeRequest(req)

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -505,6 +505,7 @@ export type GetTopFullPlaylistsParams = {
   mood?: string
   filter?: string
   withUsers?: boolean
+  encodedUserId?: string
 }
 
 export const getTopFullPlaylists = ({
@@ -512,6 +513,7 @@ export const getTopFullPlaylists = ({
   limit,
   mood,
   filter,
+  encodedUserId,
   withUsers = false
 }: GetTopFullPlaylistsParams) => {
   return {
@@ -521,7 +523,8 @@ export const getTopFullPlaylists = ({
       limit,
       mood,
       filter,
-      with_users: withUsers
+      with_users: withUsers,
+      user_id: encodedUserId
     }
   }
 }


### PR DESCRIPTION
### Description
Updates the discovery endpoint /v1/full/playlists/top to accept an encoded user_id
Update the get_top_playlists query to not break on a none filter arg
Update the get_top_playlists query to accept a user_id param in the arg - falling back to the legacy fetching of user_id from x-user-id as an interim backup to not break existing clients
Updates libs binding for this endpoint to allow the user_id param

### Tests
Ran libs linked locally and checked that the request was made with the correct parameter

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->