### PR TITLE
[C-2005] Remove filter deleted on individual discovery node tracks

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -106,7 +106,7 @@ def get_single_track(track_id, current_user_id, endpoint_ns, exclude_premium=Tru
     args = {
         "id": [track_id],
         "with_users": True,
-        "filter_deleted": True,
+        "filter_deleted": False,
         "exclude_premium": exclude_premium,
         "current_user_id": current_user_id,
     }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This is kind of wild! We don't actually call this api from *anywhere* in the client except for offline mode.
<img width="350" alt="Screenshot 2023-02-01 at 4 55 51 PM" src="https://user-images.githubusercontent.com/2731362/216204633-437359f2-09ff-4d67-bba0-f3e201efc712.png">
The client fetches single tracks by handle & slug most of the time and that does not filter out deleted tracks.

This however makes it so that trying to download deleted favorites don't work so well (we try a few times because of a 404 and don't actually realize that the track is juts deleted).

I believe this change is safe to make! But it's obviously a big deal.

The other change I would like to make would be to revert https://github.com/AudiusProject/audius-protocol/pull/2220
But I think it's still possible there is missing data somewhere and that warrants a larger convo.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->