### PR TITLE
Serve top playlists from ElasticSearch

### DIFF
--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,5 +1,5 @@
 export const indexNames = {
-  playlists: 'playlists11',
+  playlists: 'playlists12',
   reposts: 'reposts9',
   saves: 'saves9',
   tracks: 'tracks9',

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -31,9 +31,9 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
         updated_at: { type: 'date' },
         is_album: { type: 'boolean' },
         is_private: { type: 'boolean' },
-        permalink: { type: 'keyword' },
+        permalink: lowerKeyword,
         is_delete: { type: 'boolean' },
-        routes: { type: 'keyword' },
+        routes: lowerKeyword,
         suggest: standardSuggest,
         playlist_name: {
           ...lowerKeyword,
@@ -74,8 +74,8 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
 
         tracks: {
           properties: {
-            mood: { type: 'keyword' },
-            genre: { type: 'keyword' },
+            mood: lowerKeyword,
+            genre: lowerKeyword,
             tags: lowerKeyword,
             play_count: { type: 'integer' },
             repost_count: { type: 'integer' },

--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -299,7 +299,7 @@ class Top(Resource):
     @record_metrics
     @ns.doc(id="""Top Playlists""", description="""Gets top playlists.""")
     @ns.marshal_with(full_playlists_with_score_response)
-    # @cache(ttl_sec=30 * 60)
+    @cache(ttl_sec=30 * 60)
     def get(self):
         args = top_parser.parse_args()
         if args.get("limit") is None:

--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -299,7 +299,7 @@ class Top(Resource):
     @record_metrics
     @ns.doc(id="""Top Playlists""", description="""Gets top playlists.""")
     @ns.marshal_with(full_playlists_with_score_response)
-    @cache(ttl_sec=30 * 60)
+    # @cache(ttl_sec=30 * 60)
     def get(self):
         args = top_parser.parse_args()
         if args.get("limit") is None:

--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -7,6 +7,7 @@ from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.playlists.playlist import Playlist
 from src.models.social.repost import RepostType
 from src.models.social.save import SaveType
+from src.queries.get_top_playlists_es import get_top_playlists_es
 from src.queries.query_helpers import (
     create_followee_playlists_subquery,
     decayed_score,
@@ -40,6 +41,9 @@ def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
     # along an encoded user id via url param
     if current_user_id is None:
         current_user_id = get_current_user_id(required=False)
+
+    # todo: wrap in try / catch
+    return get_top_playlists_es(kind, args)
 
     # Argument parsing and checking
     if kind not in ("playlist", "album"):

--- a/discovery-provider/src/queries/get_top_playlists.py
+++ b/discovery-provider/src/queries/get_top_playlists.py
@@ -1,6 +1,8 @@
 import enum
+import logging
 from typing import Optional, TypedDict
 
+from flask import request
 from sqlalchemy import desc
 from src import exceptions
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
@@ -19,6 +21,9 @@ from src.queries.query_helpers import (
 )
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
+from src.utils.elasticdsl import esclient
+
+logger = logging.getLogger(__name__)
 
 
 class GetTopPlaylistsArgs(TypedDict):
@@ -35,15 +40,24 @@ class TopPlaylistKind(str, enum.Enum):
 
 
 def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
+    skip_es = request.args.get("es") == "0"
+    use_es = esclient and not skip_es
+    if use_es:
+        try:
+            return get_top_playlists_es(kind, args)
+        except Exception as e:
+            logger.error(f"elasticsearch get_top_playlists_es failed: {e}")
+
+    return get_top_playlists_sql(kind, args)
+
+
+def get_top_playlists_sql(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
     current_user_id = args.get("current_user_id")
 
     # NOTE: This is a temporary fix while migrating clients to pass
     # along an encoded user id via url param
     if current_user_id is None:
         current_user_id = get_current_user_id(required=False)
-
-    # todo: wrap in try / catch
-    return get_top_playlists_es(kind, args)
 
     # Argument parsing and checking
     if kind not in ("playlist", "album"):
@@ -70,7 +84,6 @@ def get_top_playlists(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
-
         # If filtering by followees, set the playlist view to be only playlists from
         # users that the current user follows.
         if query_filter == "followees":

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -56,10 +56,13 @@ def get_top_playlists_es(kind, args):
         }
     }
 
-    # omit unused fields from result
-    dsl["_source"] = {"exclude": ["saved_by", "reposted_by", "tracks"]}
-
-    found = esclient.search(index=ES_PLAYLISTS, query=dsl["query"], size=limit)
+    found = esclient.search(
+        index=ES_PLAYLISTS,
+        query=dsl["query"],
+        size=limit,
+        # omit unused fields from result
+        _source_excludes=["saved_by", "reposted_by", "tracks"],
+    )
 
     playlists = []
     for hit in found["hits"]["hits"]:

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -2,7 +2,12 @@ import time
 
 from src.api.v1.helpers import extend_playlist
 from src.queries.query_helpers import get_current_user_id
-from src.utils.elasticdsl import ES_PLAYLISTS, ES_USERS, esclient
+from src.utils.elasticdsl import (
+    ES_PLAYLISTS,
+    ES_USERS,
+    esclient,
+    populate_user_metadata_es,
+)
 
 
 def get_top_playlists_es(kind, args):
@@ -76,7 +81,9 @@ def get_top_playlists_es(kind, args):
     user_by_id = {d["_id"]: d["_source"] for d in user_list["docs"] if d["found"]}
 
     for p in playlists:
-        p["user"] = user_by_id[str(p["playlist_owner_id"])]
+        u = user_by_id[str(p["playlist_owner_id"])]
+        # omit current_user because top playlists are cached across users
+        p["user"] = populate_user_metadata_es(u, None)
         extend_playlist(p)
 
     return playlists

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -2,17 +2,13 @@ import time
 
 from src.api.v1.helpers import extend_playlist
 from src.queries.query_helpers import get_current_user_id
-from src.utils.elasticdsl import (
-    esclient,
-    ES_PLAYLISTS,
-    ES_USERS,
-)
+from src.utils.elasticdsl import ES_PLAYLISTS, ES_USERS, esclient
 
 
 def get_top_playlists_es(kind, args):
     current_user_id = get_current_user_id(required=False)
     limit = args.get("limit", 16)
-    is_album = kind == 'album'
+    is_album = kind == "album"
 
     dsl = {
         "must": [
@@ -21,27 +17,25 @@ def get_top_playlists_es(kind, args):
             {"term": {"is_album": {"value": is_album}}},
         ],
         "must_not": [],
-        "should": []
+        "should": [],
     }
 
-    mood = args.get('mood')
+    mood = args.get("mood")
     if mood:
-        dsl['must'].append({
-            "term": {
-                "tracks.mood": mood
-            }
-        })
+        dsl["must"].append({"term": {"tracks.mood": mood}})
 
-    if args.get("filter") == 'followees':
-        dsl['must'].append({
-            "terms": {
-                'playlist_owner_id': {
-                    "index": ES_USERS,
-                    "id": str(current_user_id),
-                    "path": "following_ids",
-                },
+    if args.get("filter") == "followees":
+        dsl["must"].append(
+            {
+                "terms": {
+                    "playlist_owner_id": {
+                        "index": ES_USERS,
+                        "id": str(current_user_id),
+                        "path": "following_ids",
+                    },
+                }
             }
-        })
+        )
 
     # decay score
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html#decay-functions-date-fields
@@ -52,48 +46,34 @@ def get_top_playlists_es(kind, args):
                 "script": {
                     "source": "_score * doc['repost_count'].value * decayDateGauss(params.origin, params.scale, params.offset, params.decay, doc['created_at'].value)",
                     "params": {
-                        "origin": str(round(time.time()*1000)),
+                        "origin": str(round(time.time() * 1000)),
                         "scale": "30d",
                         "offset": "0",
                         "decay": 0.5,
-                    }
+                    },
                 },
             }
         }
     }
 
-    # top playlists have large saved_by and reposted_by
-    # exclude them from the result
-    dsl['_source'] = {
-        'exclude': ['saved_by', 'reposted_by']
-    }
+    # omit unused fields from result
+    dsl["_source"] = {"exclude": ["saved_by", "reposted_by", "tracks"]}
 
-    found = esclient.search(index=ES_PLAYLISTS, query=dsl['query'], size=limit)
+    found = esclient.search(index=ES_PLAYLISTS, query=dsl["query"], size=limit)
 
     playlists = []
     for hit in found["hits"]["hits"]:
         p = hit["_source"]
-        p['score'] = hit['_score']
+        p["score"] = hit["_score"]
         playlists.append(p)
 
     # with users behavior
-    user_id_set = set([str(p['playlist_owner_id']) for p in playlists])
-    user_id_set.add(str(current_user_id))
+    user_id_set = set([str(p["playlist_owner_id"]) for p in playlists])
     user_list = esclient.mget(index=ES_USERS, ids=list(user_id_set))
     user_by_id = {d["_id"]: d["_source"] for d in user_list["docs"] if d["found"]}
 
-    # current_user = user_by_id.get(str(current_user_id))
     for p in playlists:
-        p['user'] = user_by_id[str(p['playlist_owner_id'])]
+        p["user"] = user_by_id[str(p["playlist_owner_id"])]
         extend_playlist(p)
-
-        # elsewhere we call:
-        #   populate_track_or_playlist_metadata_es(p, current_user)
-        # but we want to cache top playlists... 
-        # and we source excluded saved_by and reposted_by
-        # so we don't tailor to current_user here
-
-        # also null out tracks
-        p['tracks'] = None
 
     return playlists

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -74,5 +74,8 @@ def get_top_playlists_es(kind, args):
         # and we source excluded saved_by and reposted_by
         # so we don't tailor to current_user here
 
+        # also null out tracks
+        p['tracks'] = None
+
     return playlists
 

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -66,7 +66,7 @@ def get_top_playlists_es(kind, args):
         query=dsl["query"],
         size=limit,
         # omit unused fields from result
-        _source_excludes=["saved_by", "reposted_by", "tracks"],
+        source_excludes=["saved_by", "reposted_by", "tracks"],
     )
 
     playlists = []

--- a/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/discovery-provider/src/queries/get_top_playlists_es.py
@@ -1,0 +1,70 @@
+
+
+from src.utils.elasticdsl import populate_track_or_playlist_metadata_es
+from src.api.v1.helpers import extend_playlist
+from src.queries.query_helpers import get_current_user_id
+from src.queries.search_es import default_function_score
+from src.utils.elasticdsl import (
+    esclient,
+    ES_PLAYLISTS,
+    ES_USERS,
+)
+
+
+def get_top_playlists_es(kind, args):
+    current_user_id = get_current_user_id(required=False)
+    limit = args.get("limit", 16)
+    is_album = kind == 'album'
+
+    dsl = {
+        "must": [
+            {"term": {"is_private": {"value": False}}},
+            {"term": {"is_delete": False}},
+            {"term": {"is_album": {"value": is_album}}},
+        ],
+        "must_not": [],
+        "should": []
+    }
+
+    mood = args.get('mood')
+    if mood:
+        dsl['must'].append({
+            "term": {
+                "tracks.mood": mood
+            }
+        })
+
+    if args.get("filter") == 'followees':
+        dsl['must'].append({
+            "terms": {
+                'playlist_owner_id': {
+                    "index": ES_USERS,
+                    "id": str(current_user_id),
+                    "path": "following_ids",
+                },
+            }
+        })
+
+    dsl = default_function_score(dsl, "repost_count")
+
+    found = esclient.search(index=ES_PLAYLISTS, query=dsl['query'], size=limit)
+
+    playlists = [h["_source"] for h in found["hits"]["hits"]]
+
+    # with users behavior
+    user_id_set = set([str(p['playlist_owner_id']) for p in playlists])
+    user_id_set.add(str(current_user_id))
+    user_list = esclient.mget(index=ES_USERS, ids=list(user_id_set))
+    user_by_id = {d["_id"]: d["_source"] for d in user_list["docs"] if d["found"]}
+
+    current_user = user_by_id.get(str(current_user_id))
+    for p in playlists:
+        p['user'] = user_by_id[str(p['playlist_owner_id'])]
+        extend_playlist(p)
+
+        # sets has_current_user_reposted
+        # but not: followee_reposts, followee_favorites
+        # populate_track_or_playlist_metadata_es(p, current_user)
+
+    return playlists
+


### PR DESCRIPTION
### Description

Queries elasticsearch for top "mood" playlists and also "let them dj".

* `/v1/full/playlists/top?limit=16&mood=upbeat&type=playlist&with_users=true`


Function score might could use some tweaking.


### Debugging

To print out DSL:

```
print("playlist dsl", json.dumps(dsl))
```

