### PR TITLE
Add is_repost_repost column to reposts table

### DIFF
--- a/discovery-provider/alembic/versions/988f095a1d43_add_is_repost_repost_column.py
+++ b/discovery-provider/alembic/versions/988f095a1d43_add_is_repost_repost_column.py
@@ -1,0 +1,28 @@
+"""add_is_repost_repost_column
+
+Revision ID: 988f095a1d43
+Revises: a62b4e92b733
+Create Date: 2023-02-02 21:20:03.243055
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "988f095a1d43"
+down_revision = "a62b4e92b733"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "reposts",
+        sa.Column(
+            "is_repost_repost", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("reposts", "is_repost_repost")

--- a/discovery-provider/src/models/social/repost.py
+++ b/discovery-provider/src/models/social/repost.py
@@ -40,6 +40,7 @@ class Repost(Base, RepresentableMixin):
     )
     is_current = Column(Boolean, primary_key=True, nullable=False)
     is_delete = Column(Boolean, nullable=False)
+    is_repost_repost = Column(Boolean, nullable=False, server_default="false")
     created_at = Column(DateTime, nullable=False, index=True)
     txhash = Column(
         String,


### PR DESCRIPTION
### Description
Add is_repost_repost column to the reposts table. This will be used for generating is repost of a repost notifications.

one q - existing reposts get backfilled with false rather than null. i figure its better to avoid nulled values when possible but lmk if it's better leave existing reposts' is_repost_repost values with null.

### Tests
Ran the migration locally and on a prod clone to ensure it ran smoothly