### PR TITLE
[CON-567] Add a simple load test

### DIFF
--- a/comms/Makefile
+++ b/comms/Makefile
@@ -30,6 +30,9 @@ test::
 	audius_discprov_env='standalone' go test ./... -count=1
 
 
+test.load::
+	hey -n 10000 -c 50 http://localhost:8926/storage/jobs
+
 
 build::
 	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build . -t audius/wip-comms:latest
@@ -55,6 +58,7 @@ tools::
 	go install github.com/kyleconroy/sqlc/cmd/sqlc@main
 	CGO_ENABLED=0 go install github.com/nats-io/natscli/nats@latest
 	CGO_ENABLED=0 go install github.com/amacneil/dbmate@latest
+	go install github.com/rakyll/hey@latest
 
 sqlc:: reset
 	sqlc generate


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds a simple load test using `hey` on the `/jobs` route. I image this won't become the idiomatic way of doing this in the future but perhaps this can become a seed for more tests.

Some other potential load testing tools
* ab (Apache Benchmark)
* Fortio (https://github.com/fortio/fortio)


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Run `make test.load`

Output should look something like

```
hey -n 10000 -c 50 http://localhost:8926/storage/jobs

Summary:
  Total:        0.1930 secs
  Slowest:      0.0094 secs
  Fastest:      0.0001 secs
  Average:      0.0009 secs
  Requests/sec: 51818.1588
  
  Total data:   30000 bytes
  Size/request: 3 bytes

Response time histogram:
  0.000 [1]     |
  0.001 [7261]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.002 [1664]  |■■■■■■■■■
  0.003 [829]   |■■■■■
  0.004 [156]   |■
  0.005 [25]    |
  0.006 [10]    |
  0.007 [16]    |
  0.008 [24]    |
  0.008 [11]    |
  0.009 [3]     |


Latency distribution:
  10% in 0.0003 secs
  25% in 0.0005 secs
  50% in 0.0007 secs
  75% in 0.0011 secs
  90% in 0.0020 secs
  95% in 0.0025 secs
  99% in 0.0036 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.0001 secs, 0.0094 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0026 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0038 secs
  resp wait:    0.0008 secs, 0.0001 secs, 0.0054 secs
  resp read:    0.0001 secs, 0.0000 secs, 0.0026 secs

Status code distribution:
  [200] 10000 responses
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->
 n/a

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->