### PR TITLE
NO-TICKET: fix link for template generation in SDK

### DIFF
--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -79,7 +79,7 @@ program
       '-g',
       generator,
       '-o',
-      `templates/${generator}`
+      `/local/templates/${generator}`
     ])
   })
 


### PR DESCRIPTION
### Description
Docker didn't have the correct location for the output of template generation. This fixes that.


### Tests
Delete the `typescript-fetch` in the templates folder, run `node gen.js template typescript-fetch` and it should regenerate correctly now.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
None.