### PR TITLE
Use dummy container for solana tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -44,7 +44,7 @@ services:
       mode: global
 
   # NOTE: We don't need solana but services have depend_on solana-test-validator
-  # so we use a dummpy container
+  # so we use a dummy container
   solana-test-validator:
     image: alpine:3.14
     command: sleep inf

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -43,11 +43,18 @@ services:
     deploy:
       mode: global
 
+  # NOTE: We don't need solana but services have depend_on solana-test-validator
+  # so we use a dummpy container
   solana-test-validator:
-    extends:
-      file: docker-compose.yml
-      service: solana-test-validator
+    image: alpine:3.14
+    command: sleep inf
+    healthcheck:
+      test: [ "CMD", "true" ]
+      interval: 10s
+      timeout: 5s
     logging: *default-logging
+    deploy:
+      mode: global
 
   build-audius-libs:
     extends:
@@ -78,7 +85,7 @@ services:
     logging: *default-logging
     deploy:
       mode: global
-      replicas: 1  # Override default replicas
+      replicas: 1 # Override default replicas
 
   test-creator-node:
     extends:
@@ -117,7 +124,7 @@ services:
       service: discovery-provider-elasticsearch
     deploy:
       mode: global
-      replicas: 1  # Override default replicas
+      replicas: 1 # Override default replicas
 
   discovery-provider-db:
     image: postgres:11.4
@@ -167,7 +174,7 @@ services:
     logging: *default-logging
     deploy:
       mode: global
-      replicas: 1  # Override default replicas
+      replicas: 1 # Override default replicas
     profiles:
       - tests
       - elasticsearch


### PR DESCRIPTION
### Description
Uses a dummy container for solana tests so that up and test can be run simultaneously.


### Tests
Below commands need to be tested again on MacOS and Linux

```
audius-compose up
audius-compose test discovery-provider
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA