### PR TITLE
SDK: Allow updating DN selector config after initializing

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.test.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.test.ts
@@ -234,6 +234,14 @@ describe('discoveryNodeSelector', () => {
     const selected = await selector.getSelectedEndpoint()
     expect(selected).toBe(BEHIND_BLOCKDIFF_NODE)
     expect(selector.isBehind).toBe(true)
+
+    // Update config and trigger reselection
+    selector.updateConfig({
+      allowlist: new Set([HEALTHY_NODE])
+    })
+    const selected2 = await selector.getSelectedEndpoint()
+    expect(selected2).toBe(HEALTHY_NODE)
+    expect(selector.isBehind).toBe(false)
   })
 
   test('respects blocklist', async () => {
@@ -248,6 +256,14 @@ describe('discoveryNodeSelector', () => {
     const selected = await selector.getSelectedEndpoint()
     expect(selected).toBe(BEHIND_BLOCKDIFF_NODE)
     expect(selector.isBehind).toBe(true)
+
+    // Update config and trigger reselection
+    selector.updateConfig({
+      blocklist: new Set([BEHIND_BLOCKDIFF_NODE])
+    })
+    const selected2 = await selector.getSelectedEndpoint()
+    expect(selected2).toBe(HEALTHY_NODE)
+    expect(selector.isBehind).toBe(false)
   })
 
   test('uses configured default', async () => {

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -41,7 +41,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   /**
    * Configuration passed in by consumer (with defaults)
    */
-  private readonly config: DiscoveryNodeSelectorServiceConfigInternal
+  private config: DiscoveryNodeSelectorServiceConfigInternal
 
   /**
    * Whether or not we are using a backup, meaning we were
@@ -113,6 +113,8 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
     this.backupServices = {}
     this.selectedNode =
       this.config.initialSelectedNode &&
+      (!this.config.allowlist ||
+        this.config.allowlist?.has(this.config.initialSelectedNode)) &&
       !this.config.blocklist?.has(this.config.initialSelectedNode)
         ? this.config.initialSelectedNode
         : null
@@ -127,6 +129,30 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
     this.removeAllEventListeners = this.eventEmitter.removeAllListeners.bind(
       this.eventEmitter
     )
+  }
+
+  /**
+   * Updates the config.
+   * Note that setting the initial node or bootstrap nodes here does nothing as the service is already initialized.
+   * Will force reselections if health check thresholds change (as that might cause the current node to be considered unhealthy)
+   * or if the selected node is excluded per allow/blocklists
+   */
+  public updateConfig(
+    config: Exclude<
+      DiscoveryNodeSelectorServiceConfig,
+      'initialSelectedNode' | 'bootstrapServices'
+    >
+  ) {
+    this.config = mergeConfigWithDefaults(config, this.config)
+    if (this.selectedNode) {
+      if (config.healthCheckThresholds) {
+        this.selectedNode = null
+      } else if (!config.allowlist?.has(this.selectedNode)) {
+        this.selectedNode = null
+      } else if (config.blocklist?.has(this.selectedNode)) {
+        this.selectedNode = null
+      }
+    }
   }
 
   /**
@@ -328,6 +354,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
     this.info(`Selected discprov ${selectedService}`, decisionTree, {
       attemptedServicesCount
     })
+    this.isBehind = false
     return selectedService
   }
 

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -147,7 +147,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
     if (this.selectedNode) {
       if (config.healthCheckThresholds) {
         this.selectedNode = null
-      } else if (!config.allowlist?.has(this.selectedNode)) {
+      } else if (config.allowlist && !config.allowlist.has(this.selectedNode)) {
         this.selectedNode = null
       } else if (config.blocklist?.has(this.selectedNode)) {
         this.selectedNode = null

--- a/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
@@ -15,7 +15,6 @@ export const defaultDiscoveryNodeSelectorConfig: DiscoveryNodeSelectorServiceCon
     requestTimeout: 30000, // 30s
     unhealthyTTL: 3600000, // 1 hour
     backupsTTL: 120000, // 2 min
-    cacheTTL: 600000, //  10 min
     healthCheckThresholds: {
       minVersion: bootstrap.version,
       maxSlotDiffPlays: null,

--- a/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
@@ -65,12 +65,6 @@ export type DiscoveryNodeSelectorServiceConfigInternal = {
    */
   backupsTTL: number
   /**
-   * How long the cache should live for selected nodes, in ms.
-   * If unset, never expires.
-   * @default 600000 ten minutes
-   */
-  cacheTTL: number | null
-  /**
    * Configuration for determining healthy status
    */
   healthCheckThresholds: HealthCheckThresholds

--- a/libs/src/sdk/utils/deepPartial.ts
+++ b/libs/src/sdk/utils/deepPartial.ts
@@ -1,6 +1,8 @@
 // Adjusted from Terry: https://stackoverflow.com/questions/61132262/typescript-deep-partial
 export type DeepPartial<T> = T extends any[]
   ? T
+  : T extends Set<any>
+  ? T
   : T extends object
   ? {
       [P in keyof T]?: DeepPartial<T[P]>


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Allows the SDK to have its configuration changed after initialization for a subset of the configuration properties. Useful for eg. setting the allow/blocklists via Optimizely asynchronously, allowing SDK to initialize synchronously with some async config later.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->