### PR TITLE
add is_repost_repost comment for clarification

### DIFF
--- a/discovery-provider/src/models/social/repost.py
+++ b/discovery-provider/src/models/social/repost.py
@@ -40,6 +40,10 @@ class Repost(Base, RepresentableMixin):
     )
     is_current = Column(Boolean, primary_key=True, nullable=False)
     is_delete = Column(Boolean, nullable=False)
+
+    # Column denotes whether the repost object is a repost of a repost,
+    # which is used to notify the initial reposter that a follower reposted
+    # their reposted content.
     is_repost_repost = Column(Boolean, nullable=False, server_default="false")
     created_at = Column(DateTime, nullable=False, index=True)
     txhash = Column(


### PR DESCRIPTION
### Description
Adding a note to the is_repost_repost column in the reposts table. Hopefully this clarifies the column - ik it isn't the best name but struggled to think of a better one. let me know if you have any suggestions for a different name or better clarification

