### PR TITLE
Index 1 block behind to avoid reverting

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -112,6 +112,9 @@ def get_latest_block(db: SessionManager):
         target_latest_block_number = current_block_number + block_processing_window
 
         latest_block_from_chain = update_task.web3.eth.get_block("latest", True)
+        latest_block_from_chain = update_task.web3.eth.get_block(
+            latest_block_from_chain.number, True
+        )
         latest_block_number_from_chain = latest_block_from_chain.number
 
         target_latest_block_number = min(

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -3,6 +3,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import os
 import time
 from datetime import datetime
 from operator import itemgetter, or_
@@ -112,9 +113,14 @@ def get_latest_block(db: SessionManager):
         target_latest_block_number = current_block_number + block_processing_window
 
         latest_block_from_chain = update_task.web3.eth.get_block("latest", True)
-        latest_block_from_chain = update_task.web3.eth.get_block(
-            latest_block_from_chain.number, True
-        )
+
+        if os.getenv("audius_discprov_env") != "dev":
+            # index 1 block behind to avoid reverting
+            # TODO make reverting 1 block fast and remove this workaround
+            latest_block_from_chain = update_task.web3.eth.get_block(
+                latest_block_from_chain.number - 1, True
+            )
+
         latest_block_number_from_chain = latest_block_from_chain.number
 
         target_latest_block_number = min(

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -3,7 +3,6 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-import os
 import time
 from datetime import datetime
 from operator import itemgetter, or_
@@ -113,14 +112,6 @@ def get_latest_block(db: SessionManager):
         target_latest_block_number = current_block_number + block_processing_window
 
         latest_block_from_chain = update_task.web3.eth.get_block("latest", True)
-
-        if os.getenv("audius_discprov_env") != "dev":
-            # index 1 block behind to avoid reverting
-            # TODO make reverting 1 block fast and remove this workaround
-            latest_block_from_chain = update_task.web3.eth.get_block(
-                latest_block_from_chain.number - 1, True
-            )
-
         latest_block_number_from_chain = latest_block_from_chain.number
 
         target_latest_block_number = min(

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -106,6 +106,12 @@ def get_latest_block(db: SessionManager, final_poa_block: int):
         )
 
         latest_block_from_chain = web3.eth.get_block("latest", True)
+        if os.getenv("audius_discprov_env") != "dev":
+            # index 1 block behind to avoid reverting
+            # TODO make reverting 1 block fast and remove this workaround
+            latest_block_from_chain = web3.eth.get_block(
+                latest_block_from_chain.number - 1, True
+            )
         latest_block_number_from_chain = latest_block_from_chain.number
 
         target_latest_block_number = min(


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Reverting 1 block is now more common with 1 second block time. Reverting can take a while and block indexing for a minute so this change makes indexing trail 1 block behind latest to avoid reversions.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->