### PR TITLE
Use compose for dev in lieu of `make comms.storage`

### DIFF
--- a/comms/.air.toml
+++ b/comms/.air.toml
@@ -1,0 +1,42 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "/tmp/main"
+  cmd = "go build -o /tmp/main ."
+  delay = 0
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = true
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/comms/.dockerignore
+++ b/comms/.dockerignore
@@ -1,5 +1,6 @@
-Dockerfile
+Dockerfile*
 docker-compose*
 comms-linux
 wip
 .vscode
+*.md

--- a/comms/Dockerfile.v2
+++ b/comms/Dockerfile.v2
@@ -16,5 +16,6 @@ FROM alpine AS final
 RUN apk add ffmpeg
 COPY --from=builder /go/bin/* /bin
 COPY --from=builder /app/comms /bin/comms
-VOLUME ["/tmp/nats"]
+
+VOLUME ["/tmp"]
 ENTRYPOINT [ "comms" ]

--- a/comms/Dockerfile.v2.dev
+++ b/comms/Dockerfile.v2.dev
@@ -1,0 +1,16 @@
+FROM golang:alpine
+
+RUN apk add build-base make ffmpeg
+RUN export GO111MODULE=on && \
+    go install github.com/nats-io/nats-server/v2@latest && \
+    go install github.com/nats-io/natscli/nats@latest && \
+    go install github.com/nats-io/nkeys/nk@latest && \
+    go install github.com/nats-io/nsc/v2@latest && \
+    go install github.com/cosmtrek/air@latest
+
+WORKDIR /app
+COPY . .
+RUN make build.alpine
+
+VOLUME ["/tmp"]
+ENTRYPOINT [ "air" ]

--- a/comms/Makefile
+++ b/comms/Makefile
@@ -5,14 +5,6 @@ dev.discovery::
 		audius_db_url='postgresql://postgres:postgres@localhost:5454/audius_discovery?sslmode=disable' \
 		go run main.go discovery
 
-dev.storage::
-	@	audius_discprov_env='standalone' \
-		storage_v2="true" \
-		storage_v2_single_node="true" \
-		audius_delegate_owner_wallet="0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F" \
-		audius_delegate_private_key="293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" \
-		go run main.go storage
-
 reset::
 	docker compose down --volumes
 	docker compose up comdb comnats -d

--- a/comms/README.md
+++ b/comms/README.md
@@ -51,13 +51,6 @@ Currently docker build + push is done locally and some bash scripts are used to 
 * Authenticate on Dockerhub
 * `bash bash_scripts/deploy.sh`
 
-### Storage V2 Dev
+## Storage
 
-> Storage V2 is rapidly evolving within `comms` and as such uses split off infra for development
-> (keeping this as platform independent as possible)
-
-* run with `docker compose -f docker-compose.v2.yml up -d --build`
-* visit any storage node webui at `http://0.0.0.0:992[4|5|6|7]/storage` to test uploads
-* grep logs for success i.e. `docker compose logs storage1 | grep -i storing`
-* to check nats stream status `docker exec -ti com1 nats stream ls -a`
-* teardown `docker compose -f docker-compose.v2.yml down -v`
+See [storage/README.md](./storage/README.md)

--- a/comms/discovery/config/config.go
+++ b/comms/discovery/config/config.go
@@ -125,6 +125,14 @@ func Init() {
 		"np", NatsClusterPassword)
 }
 
+func GetEnvDefault(k, defaultV string) string {
+	v := os.Getenv(k)
+	if len(v) == 0 {
+		return defaultV
+	}
+	return v
+}
+
 func mgetenv(keys ...string) string {
 	for _, k := range keys {
 		v := os.Getenv(k)

--- a/comms/docker-compose.v2.base.yml
+++ b/comms/docker-compose.v2.base.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  comdb:
+    container_name: comdb
+    image: postgres
+    restart: unless-stopped
+    ports:
+      - 5454:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ./discovery/db/docker-initdb:/docker-entrypoint-initdb.d
+
+  nats:
+    build:
+      context: .
+      dockerfile: Dockerfile.v2
+    image: "comms:v2"
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    command:
+      - nats
+
+  storage:
+    build:
+      context: .
+      dockerfile: Dockerfile.v2
+    image: "comms:v2"
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    command:
+      - storage

--- a/comms/docker-compose.v2.dev.yml
+++ b/comms/docker-compose.v2.dev.yml
@@ -1,0 +1,45 @@
+version: '3'
+services:
+
+  comdb:
+    container_name: comdb
+    extends:
+      file: docker-compose.v2.base.yml
+      service: comdb
+
+  com1:
+    container_name: com1
+    extends:
+      file: docker-compose.v2.base.yml
+      service: nats
+    environment:
+      audius_discprov_env: standalone
+      audius_delegate_owner_wallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
+      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238"
+      test_host: "com1"
+    depends_on:
+      - comdb
+    ports:
+      - 8924:8924
+
+  storage1:
+    container_name: storage1
+    extends:
+      file: docker-compose.v2.base.yml
+      service: storage
+    build:
+      dockerfile: Dockerfile.v2.dev
+    image: "comms:v2-dev"
+    environment:
+      audius_discprov_env: standalone
+      test_host: "storage1"
+      audius_delegate_owner_wallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
+      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238"
+      NATS_SERVER_URL: "nats://com1:4222"
+      NAME: "storage1"
+    depends_on:
+      - com1
+    ports:
+      - 9924:8926
+    volumes:
+      - ./:/app

--- a/comms/docker-compose.v2.yml
+++ b/comms/docker-compose.v2.yml
@@ -1,202 +1,116 @@
 version: '3'
 services:
+
   comdb:
     container_name: comdb
-    image: postgres
-    restart: unless-stopped
-    ports:
-      - 5454:5432
-    environment:
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - ./discovery/db/docker-initdb:/docker-entrypoint-initdb.d
+    extends:
+      file: docker-compose.v2.base.yml
+      service: comdb
 
   com1:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: com1
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: nats
     environment:
-      audius_discprov_env: test
-      test_host: com1
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238"
-      audius_db_url: "postgresql://postgres:postgres@comdb:5432/com1?sslmode=disable"
-      audius_comms_cluster: "true"
-    command:
-      - nats
-    depends_on:
-      - comdb
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com1?sslmode=disable
+      test_host: "com1"
     ports:
       - 8924:8924
-    volumes:
-      - com1:/tmp/nats
 
   storage1:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: storage1
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: storage
     environment:
-      NAME: storage1
-      test_host: storage1
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238"
-    command:
-      - storage
-    depends_on:
-      - com1
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com1?sslmode=disable
+      test_host: "storage1"
+      NAME: "storage1"
     ports:
       - 9924:8926
 
   com2:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: com2
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: nats
     environment:
-      audius_discprov_env: test
-      test_host: com2
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
       audius_delegate_private_key: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc"
-      audius_db_url: "postgresql://postgres:postgres@comdb:5432/com2?sslmode=disable"
-      audius_comms_cluster: "true"
-    command:
-      - nats
-    depends_on:
-      - comdb
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com2?sslmode=disable
+      test_host: "com2"
     ports:
       - 8925:8924
-    volumes:
-      - com2:/tmp/nats
 
   storage2:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: storage2
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: storage
     environment:
-      NAME: storage2
-      test_host: storage2
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
       audius_delegate_private_key: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc"
-    command:
-      - storage
-    depends_on:
-      - com2
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com2?sslmode=disable
+      test_host: "storage2"
+      NAME: "storage2"
     ports:
       - 9925:8926
 
   com3:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: com3
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: nats
     environment:
-      audius_discprov_env: test
-      test_host: com3
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
       audius_delegate_private_key: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c"
-      audius_db_url: "postgresql://postgres:postgres@comdb:5432/com3?sslmode=disable"
-      audius_comms_cluster: "true"
-    command:
-      - nats
-    depends_on:
-      - comdb
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com3?sslmode=disable
+      test_host: "com3"
     ports:
       - 8926:8924
-    volumes:
-      - com3:/tmp/nats
 
   storage3:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: storage3
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: storage
     environment:
-      NAME: storage3
-      test_host: storage3
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
       audius_delegate_private_key: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c"
-    command:
-      - storage
-    depends_on:
-      - com3
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com3?sslmode=disable
+      test_host: "storage3"
+      NAME: "storage3"
     ports:
       - 9926:8926
 
   com4:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: com4
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: nats
     environment:
-      audius_discprov_env: test
-      test_host: com4
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
       audius_delegate_private_key: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb"
-      audius_db_url: "postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable"
-      audius_comms_cluster: "true"
-    command:
-      - nats
-    depends_on:
-      - comdb
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable
+      test_host: "com4"
     ports:
       - 8927:8924
-    volumes:
-      - com4:/tmp/nats
 
   storage4:
-    build:
-      context: .
-      dockerfile: Dockerfile.v2
-    image: "comms:v2"
     container_name: storage4
-    restart: unless-stopped
+    extends:
+      file: docker-compose.v2.base.yml
+      service: storage
     environment:
-      NAME: storage4
-      test_host: storage4
-      storage_v2: "true"
       audius_delegate_owner_wallet: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
       audius_delegate_private_key: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb"
-    command:
-      - storage
-    depends_on:
-      - com4
-    stop_signal: SIGKILL
+      audius_db_url: postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable
+      test_host: "storage4"
+      NAME: "storage4"
     ports:
       - 9927:8926
-
-volumes:
-  com1:
-  com2:
-  com3:
-  com4:

--- a/comms/shared/peering/nats_connection.go
+++ b/comms/shared/peering/nats_connection.go
@@ -9,9 +9,9 @@ import (
 )
 
 func DialJetstream(peerMap map[string]*Info) (nats.JetStreamContext, error) {
-	natsUrl := nats.DefaultURL
+	natsUrl := config.GetEnvDefault("NATS_SERVER_URL", nats.DefaultURL)
 
-	if peerMap != nil {
+	if len(peerMap) != 0 {
 		goodNatsUrls := []string{}
 		for _, peer := range peerMap {
 			if peer.NatsIsReachable {

--- a/comms/shared/peering/sps.go
+++ b/comms/shared/peering/sps.go
@@ -61,15 +61,18 @@ func PollRegisteredNodes() error {
 }
 
 func listNodes(typeFilter string) ([]ServiceNode, error) {
+	// TODO: yuk
+	// docker compose v2 dev single node
+	if os.Getenv("test_host") != "" && config.Env == "standalone" {
+		return testNodes[:1], nil
+	}
+	// docker compose v2 multi node
+	if os.Getenv("test_host") != "" {
+		return testNodes, nil
+	}
+	// make dev.discovery
 	if config.Env == "standalone" {
 		return []ServiceNode{}, nil
-	}
-	// TODO: config refactor
-	if os.Getenv("storage_v2") == "true" {
-		return v2DevNodes, nil
-	}
-	if os.Getenv("test_host") != "" {
-		return testDiscoveryNodes, nil
 	}
 
 	result := []ServiceNode{}
@@ -95,27 +98,7 @@ func GetContentNodes() ([]ServiceNode, error) {
 	return listNodes("content-node")
 }
 
-var testDiscoveryNodes = []ServiceNode{
-	{
-		Endpoint:            "http://com1:8925",
-		DelegateOwnerWallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F",
-	},
-	{
-		Endpoint:            "http://com2:8925",
-		DelegateOwnerWallet: "0x90b8d2655A7C268d0fA31758A714e583AE54489D",
-	},
-	{
-		Endpoint:            "http://com3:8925",
-		DelegateOwnerWallet: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B",
-	},
-	{
-		Endpoint:            "http://com4:8925",
-		DelegateOwnerWallet: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16",
-	},
-}
-
-// TODO: config refactor
-var v2DevNodes = []ServiceNode{
+var testNodes = []ServiceNode{
 	{
 		Endpoint:            "http://com1:8924",
 		DelegateOwnerWallet: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F",

--- a/comms/storage/README.md
+++ b/comms/storage/README.md
@@ -1,0 +1,20 @@
+# Storage V2
+
+> Storage V2 is rapidly evolving within `comms` and as such uses split off infra for development
+> (keeping this as platform independent as possible)
+
+## Quickstart
+
+Run a multi node cluster and test uploads.
+
+* run with `docker compose -f docker-compose.v2.yml up -d --build`
+* visit any storage node webui at `http://0.0.0.0:992[4|5|6|7]/storage` to test uploads
+* grep logs for success i.e. `docker compose logs storage1 | grep -i storing`
+* to check nats stream status `docker exec -ti com1 nats stream ls -a`
+* teardown `docker compose -f docker-compose.v2.yml down -v`
+
+## Development
+
+Run a single node cluster with hot reloading.
+
+* `docker compose -f docker-compose.v2.dev.yml up -d --build`

--- a/comms/storage/decider/RendezvousDecider.go
+++ b/comms/storage/decider/RendezvousDecider.go
@@ -4,6 +4,7 @@ package decider
 import (
 	"fmt"
 
+	"comms.audius.co/shared/peering"
 	"comms.audius.co/storage/sharder"
 	"github.com/nats-io/nats.go"
 	"github.com/tysonmote/rendezvous"
@@ -21,7 +22,13 @@ type RendezvousDecider struct {
 }
 
 // NewRendezvousDecider creates a storage decider that makes this node store content based on a rendezvous hash.
-func NewRendezvousDecider(namespace string, replicationFactor int, allStorageNodePubKeys []string, thisNodePubKey string, jsc nats.JetStreamContext) *RendezvousDecider {
+func NewRendezvousDecider(namespace string, replicationFactor int, thisNodePubKey string, jsc nats.JetStreamContext) *RendezvousDecider {
+	var allStorageNodePubKeys []string
+	allNodes, _ := peering.GetContentNodes()
+	for _, v := range allNodes {
+		allStorageNodePubKeys = append(allStorageNodePubKeys, v.DelegateOwnerWallet)
+	}
+
 	d := RendezvousDecider{
 		namespace:             namespace,
 		replicationFactor:     replicationFactor,


### PR DESCRIPTION
In a pre-requisite effort to get config under control. Move all dev to docker compose.
Remove need for hardcoded peer lists. We should rely on peering as much as possible, in dev or otherwise.

**TEST**

This PR adds two workflows for dev. Both should work and uploads should succeed.

See `comms/storage/README.md` Quickstart for test steps