### PR TITLE
Prepend https:// to creatorNodeEndpoint

### DIFF
--- a/creator-node/src/serviceRegistry.js
+++ b/creator-node/src/serviceRegistry.js
@@ -409,6 +409,12 @@ class ServiceRegistry {
    * Poll L1 SPFactory for spID & set spID config once recovered.
    */
   async _recoverNodeL1Identity() {
+    if (!config.get('creatorNodeEndpoint')?.startsWith('http')) {
+      config.set(
+        'creatorNodeEndpoint',
+        'https://' + config.get('creatorNodeEndpoint')
+      )
+    }
     const endpoint = config.get('creatorNodeEndpoint')
 
     const retryTimeoutMs = 5000 // 5sec


### PR DESCRIPTION
### Description
Prepend https:// to creatorNodeEndpoint env var in case it's missing.


### Tests
CI passes.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Monitor for `RecoverNodeL1Identity Error` logs.