### PR TITLE
SDK: Update CI to allow version, preid to be specified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ parameters:
     default: false
   sdk_version:
     type: string
-    default: ""
+    default: "patch"
   sdk_preid:
     type: string
     default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,12 @@ parameters:
   full_ci:
     type: boolean
     default: false
+  sdk_version:
+    type: string
+    default: ""
+  sdk_preid:
+    type: string
+    default: ""
 
 jobs:
   noop:
@@ -1789,6 +1795,8 @@ workflows:
           name: publish-sdk (<< pipeline.parameters.sdk_release_commit >>)
           sdk_release_commit: << pipeline.parameters.sdk_release_commit >>
           slack_mentions_user: << pipeline.parameters.slack_mentions_user >>
+          preid: << pipeline.parameters.sdk_preid >>
+          version: << pipeline.parameters.sdk_version >>
           context:
             - Audius Client
             - slack-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,14 @@ jobs:
         description: The git commit to build and release
         type: string
         default: ""
+      version:
+        description: The version to publish
+        type: string
+        default: ""
+      preid:
+        description: See npm version preid
+        type: string
+        default: ""
       slack_mentions_user:
         description: Used for CircleCI @mentions
         type: string
@@ -388,7 +396,7 @@ jobs:
           name: Bump and Publish Libs
           command: |
             export PROTOCOL_DIR=/home/circleci/project
-            libs/scripts/release.sh << parameters.sdk_release_commit >>
+            libs/scripts/release.sh << parameters.sdk_release_commit >> << parameters.version >> << parameters.preid >>
       - slack-fail:
           branch_pattern: main
           slack_mentions_user: << parameters.slack_mentions_user >>

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -59,11 +59,11 @@ function git-reset () {
         fi
 
         # only allow commits found on main or release branches to be deployed
-        echo "commit has to be on main or a release branch"
-        git branch -a --contains ${GIT_COMMIT} \
-            | tee /dev/tty \
-            | grep -Eq 'remotes/origin/main|remotes/origin/release' \
-            || exit 1
+        # echo "commit has to be on main or a release branch"
+        # git branch -a --contains ${GIT_COMMIT} \
+        #     | tee /dev/tty \
+        #     | grep -Eq 'remotes/origin/main|remotes/origin/release' \
+        #     || exit 1
 
         # Ensure working directory clean
         git reset --hard ${GIT_COMMIT}
@@ -120,7 +120,8 @@ function merge-bump () {
 
 # publish to npm
 function publish () {
-    npm publish . --access public
+    echo "not actually publishing!"
+    # npm publish . --access public
 }
 
 # informative links

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -59,11 +59,11 @@ function git-reset () {
         fi
 
         # only allow commits found on main or release branches to be deployed
-        # echo "commit has to be on main or a release branch"
-        # git branch -a --contains ${GIT_COMMIT} \
-        #     | tee /dev/tty \
-        #     | grep -Eq 'remotes/origin/main|remotes/origin/release' \
-        #     || exit 1
+        echo "commit has to be on main or a release branch"
+        git branch -a --contains ${GIT_COMMIT} \
+            | tee /dev/tty \
+            | grep -Eq 'remotes/origin/main|remotes/origin/release' \
+            || exit 1
 
         # Ensure working directory clean
         git reset --hard ${GIT_COMMIT}
@@ -120,8 +120,7 @@ function merge-bump () {
 
 # publish to npm
 function publish () {
-    echo "not actually publishing!"
-    # npm publish . --access public
+    npm publish . --access public
 }
 
 # informative links

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -14,6 +14,8 @@ else
     RELEASE_VERSION=${2}
 fi
 
+PREID=${3}
+
 if [[ $(whoami) != "circleci" ]]; then
     echo "This script is intended to be run through CI."
     echo "Please see:"
@@ -73,7 +75,7 @@ function git-reset () {
 function bump-version () {
     (
         # Patch the version
-        VERSION=$(npm version ${RELEASE_VERSION})
+        VERSION=$(npm version ${RELEASE_VERSION} --preid=${PREID})
         tmp=$(mktemp)
         jq ". += {audius: {releaseSHA: \"${GIT_COMMIT}\"}}" package.json > "$tmp" \
             && mv "$tmp" package.json

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -59,11 +59,11 @@ function git-reset () {
         fi
 
         # only allow commits found on main or release branches to be deployed
-        echo "commit has to be on main or a release branch"
-        git branch -a --contains ${GIT_COMMIT} \
-            | tee /dev/tty \
-            | grep -Eq 'remotes/origin/main|remotes/origin/release' \
-            || exit 1
+        # echo "commit has to be on main or a release branch"
+        # git branch -a --contains ${GIT_COMMIT} \
+        #     | tee /dev/tty \
+        #     | grep -Eq 'remotes/origin/main|remotes/origin/release' \
+        #     || exit 1
 
         # Ensure working directory clean
         git reset --hard ${GIT_COMMIT}

--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -7,6 +7,13 @@ else
     GIT_COMMIT=${1}
 fi
 
+if [[ -z ${2} ]]; then
+    echo "A version must be supplied as the second parameter (See `npm version` for valid values)."
+    exit 2
+else
+    RELEASE_VERSION=${2}
+fi
+
 if [[ $(whoami) != "circleci" ]]; then
     echo "This script is intended to be run through CI."
     echo "Please see:"
@@ -66,7 +73,7 @@ function git-reset () {
 function bump-version () {
     (
         # Patch the version
-        VERSION=$(npm version patch)
+        VERSION=$(npm version ${RELEASE_VERSION})
         tmp=$(mktemp)
         jq ". += {audius: {releaseSHA: \"${GIT_COMMIT}\"}}" package.json > "$tmp" \
             && mv "$tmp" package.json
@@ -111,7 +118,8 @@ function merge-bump () {
 
 # publish to npm
 function publish () {
-    npm publish . --access public
+    echo "not actually publishing!"
+    # npm publish . --access public
 }
 
 # informative links


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Updates the CI job to allow the `npm version` parameters to be specified, namely the version and the `--preid` fields, so that we can publish betas etc.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->