### PR TITLE
Custom DM email notification frequency

### DIFF
--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -81,11 +81,10 @@ WITH latest_user_seen AS (
 )
 SELECT
   n.*,
-  latest_user_seen.user_id AS receiver_user_id
+  unnest(n.user_ids) AS receiver_user_id
 FROM (
   SELECT *
-  FROM
-      notification
+  FROM notification
   WHERE
     notification.timestamp > :start_offset AND
     notification.user_ids && (:user_ids)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,7 @@ services:
     build: discovery-provider/plugins/notifications
     environment:
       AUDIUS_REDIS_URL: "redis://identity-service-redis:6379/00"
-      DN_DB_URL: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius-discovery"
+      DN_DB_URL: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius_discovery"
       IDENTITY_DB_URL: "postgresql://postgres:postgres@identity-service-db:5432/postgres"
     volumes:
       - ./discovery-provider/plugins/notifications:/notifications
@@ -336,7 +336,7 @@ services:
     container_name: comms
     command: /comms-linux discovery
     environment:
-      audius_db_url: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius-discovery?sslmode=disable"
+      audius_db_url: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius_discovery?sslmode=disable"
     depends_on:
       - nats
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,7 @@ services:
     build: discovery-provider/plugins/notifications
     environment:
       AUDIUS_REDIS_URL: "redis://identity-service-redis:6379/00"
-      DN_DB_URL: "postgresql://postgres:postgres@discovery-provider-db:5432/postgres"
+      DN_DB_URL: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius-discovery"
       IDENTITY_DB_URL: "postgresql://postgres:postgres@identity-service-db:5432/postgres"
     volumes:
       - ./discovery-provider/plugins/notifications:/notifications
@@ -336,7 +336,7 @@ services:
     container_name: comms
     command: /comms-linux discovery
     environment:
-      audius_db_url: "postgres://postgres:postgres@discovery-provider-db:5432/postgres?sslmode=disable"
+      audius_db_url: "postgresql://postgres:postgres@audius-protocol-discovery-provider-1:5432/audius-discovery?sslmode=disable"
     depends_on:
       - nats
     restart: unless-stopped
@@ -378,7 +378,6 @@ services:
     command: sh -c ". /tmp/dev-tools/startup/startup.sh && scripts/start.sh"
     env_file: .env # used by the startup script
     environment:
-      audius_db_url: "postgres://postgres:postgres@discovery-provider-db:5432/postgres"
       PYTHONPYCACHEPREFIX: /tmp/pycache
 
       audius_web3_host: "poa-ganache"
@@ -411,8 +410,6 @@ services:
     expose:
       - "5432"
     depends_on:
-      discovery-provider-db:
-        condition: service_healthy
       poa-ganache:
         condition: service_healthy
       eth-ganache:
@@ -425,17 +422,6 @@ services:
     deploy:
       mode: replicated
       replicas: "${DISCOVERY_PROVIDER_REPLICAS}"
-
-  discovery-provider-db:
-    image: postgres:11.4
-    user: postgres
-    healthcheck:
-      test: [ "CMD", "pg_isready" ]
-      interval: 10s
-      timeout: 5s
-    logging: *default-logging
-    deploy:
-      mode: global
 
   # creator-node
 


### PR DESCRIPTION
### Description
For live frequency users:
- New DMs don’t trigger a live email, but get included in any other emails that would be scheduled to go out.
- If nothing scheduled to go out, send in daily email.

Also added test coverage for emailed app notifications.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->