### PR TITLE
SDK: Update template to allow raw string body

### DIFF
--- a/libs/src/sdk/api/generated/default/models/User.ts
+++ b/libs/src/sdk/api/generated/default/models/User.ts
@@ -41,10 +41,10 @@ export interface User {
     albumCount: number;
     /**
      * 
-     * @type {number}
+     * @type {string}
      * @memberof User
      */
-    artistPickTrackId?: number;
+    artistPickTrackId?: string;
     /**
      * 
      * @type {string}

--- a/libs/src/sdk/api/generated/default/runtime.ts
+++ b/libs/src/sdk/api/generated/default/runtime.ts
@@ -159,7 +159,7 @@ export class BaseAPI {
             body:
                 isFormData(overriddenInit.body) ||
                 overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
+                isBlob(overriddenInit.body) || isString(overriddenInit.body)
                     ? overriddenInit.body
                     : JSON.stringify(overriddenInit.body),
         };
@@ -231,6 +231,10 @@ function isBlob(value: any): value is Blob {
 
 function isFormData(value: any): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
+}
+
+function isString(value: any): value is string {
+    return typeof value === 'string'
 }
 
 export class ResponseError extends Error {

--- a/libs/src/sdk/api/generated/full/models/UserFull.ts
+++ b/libs/src/sdk/api/generated/full/models/UserFull.ts
@@ -47,10 +47,10 @@ export interface UserFull {
     albumCount: number;
     /**
      * 
-     * @type {number}
+     * @type {string}
      * @memberof UserFull
      */
-    artistPickTrackId?: number;
+    artistPickTrackId?: string;
     /**
      * 
      * @type {string}

--- a/libs/src/sdk/api/generated/full/runtime.ts
+++ b/libs/src/sdk/api/generated/full/runtime.ts
@@ -159,7 +159,7 @@ export class BaseAPI {
             body:
                 isFormData(overriddenInit.body) ||
                 overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
+                isBlob(overriddenInit.body) || isString(overriddenInit.body)
                     ? overriddenInit.body
                     : JSON.stringify(overriddenInit.body),
         };
@@ -231,6 +231,10 @@ function isBlob(value: any): value is Blob {
 
 function isFormData(value: any): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
+}
+
+function isString(value: any): value is string {
+    return typeof value === 'string'
 }
 
 export class ResponseError extends Error {

--- a/libs/src/sdk/api/generator/templates/typescript-fetch/runtime.mustache
+++ b/libs/src/sdk/api/generator/templates/typescript-fetch/runtime.mustache
@@ -148,7 +148,7 @@ export class BaseAPI {
             body:
                 isFormData(overriddenInit.body) ||
                 overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
+                isBlob(overriddenInit.body) || isString(overriddenInit.body)
                     ? overriddenInit.body
                     : JSON.stringify(overriddenInit.body),
         };
@@ -220,6 +220,10 @@ function isBlob(value: any): value is Blob {
 
 function isFormData(value: any): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
+}
+
+function isString(value: any): value is string {
+    return typeof value === 'string'
 }
 
 export class ResponseError extends Error {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Updates SDK to not `JSON.stringify` strings. Needed for `ChatsApi` to be able to `JSON.stringify` ahead of time and sign the exact payload.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->