### PR TITLE
Drop play signature index

### DIFF
--- a/discovery-provider/alembic/versions/5bd737667c70_drop_play_signature_index.py
+++ b/discovery-provider/alembic/versions/5bd737667c70_drop_play_signature_index.py
@@ -1,0 +1,33 @@
+"""Drop play signature index
+
+Revision ID: 5bd737667c70
+Revises: 988f095a1d43
+Create Date: 2023-02-13 17:45:15.082946
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5bd737667c70"
+down_revision = "988f095a1d43"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index(
+        op.f("ix_plays_sol_signature"),
+        table_name="plays",
+        info={"if_exists": True},
+    )
+
+
+def downgrade():
+    op.create_index(
+        op.f("ix_plays_sol_signature"),
+        "plays",
+        ["signature"],
+        unique=False,
+        info={"if_not_exists": True},
+    )


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Play signature is the largest index we have (17 GB). It doesn't seem to be used and is only exposed through an internal API that we don't even use.

Dropping this index will help reduce disk usage.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested locally.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->