### PR TITLE
Delete old plays instead of archiving

### DIFF
--- a/discovery-provider/alembic/versions/64e82a907294_delete_plays_archive_table.py
+++ b/discovery-provider/alembic/versions/64e82a907294_delete_plays_archive_table.py
@@ -1,0 +1,48 @@
+"""Delete plays_archive table
+
+Revision ID: 64e82a907294
+Revises: 988f095a1d43
+Create Date: 2023-02-13 19:13:34.023959
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "64e82a907294"
+down_revision = "988f095a1d43"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("plays_archive")
+
+
+def downgrade():
+    conn = op.get_bind()
+    query = """
+        DO
+        $do$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT
+                FROM
+                    information_schema.tables
+                WHERE
+                    table_name = 'plays_archive'
+            ) THEN -- update indexing checkpoints based on current plays
+            CREATE TABLE plays_archive (LIKE plays);
+
+            -- add column for archive date
+            ALTER TABLE
+                plays_archive
+            ADD
+                COLUMN archived_at timestamp;
+
+            END IF;
+
+        END
+        $do$
+        """
+    conn.execute(query)

--- a/discovery-provider/integration_tests/tasks/test_prune_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_prune_plays.py
@@ -45,7 +45,6 @@ def test_prune_plays_old_date(app):
     with db.scoped_session() as session:
         _prune_plays(
             session,
-            CURRENT_TIMESTAMP,
             cutoff_timestamp=datetime.now() - timedelta(weeks=6),
         )
         # verify plays
@@ -87,7 +86,6 @@ def test_prune_plays_max_batch(app):
     with db.scoped_session() as session:
         _prune_plays(
             session,
-            CURRENT_TIMESTAMP,
             cutoff_timestamp=CURRENT_TIMESTAMP - timedelta(weeks=140),
             max_batch=1,
         )
@@ -127,7 +125,7 @@ def test_prune_plays_skip_prune(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-        _prune_plays(session, CURRENT_TIMESTAMP)
+        _prune_plays(session)
         # verify plays
         plays_result: List[Play] = session.query(Play).order_by(Play.id).all()
         assert len(plays_result) == 1

--- a/discovery-provider/integration_tests/tasks/test_prune_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_prune_plays.py
@@ -4,7 +4,6 @@ from typing import List
 
 from integration_tests.utils import populate_mock_db
 from src.models.social.play import Play
-from src.models.social.plays_archive import PlaysArchive
 from src.tasks.prune_plays import _prune_plays
 from src.utils.config import shared_config
 from src.utils.db_session import get_db

--- a/discovery-provider/integration_tests/tasks/test_prune_plays.py
+++ b/discovery-provider/integration_tests/tasks/test_prune_plays.py
@@ -60,32 +60,6 @@ def test_prune_plays_old_date(app):
         assert plays_result[1].play_item_id == 3
         assert plays_result[1].created_at == CURRENT_TIMESTAMP
 
-        # verify archive
-        plays_archive_result: List[PlaysArchive] = (
-            session.query(PlaysArchive).order_by(PlaysArchive.id).all()
-        )
-
-        assert len(plays_archive_result) == 5
-        assert plays_archive_result[0].id == 1
-        assert plays_archive_result[0].play_item_id == 1
-        assert plays_archive_result[0].archived_at == CURRENT_TIMESTAMP
-
-        assert plays_archive_result[1].id == 2
-        assert plays_archive_result[1].play_item_id == 3
-        assert plays_archive_result[1].archived_at == CURRENT_TIMESTAMP
-
-        assert plays_archive_result[2].id == 3
-        assert plays_archive_result[2].play_item_id == 2
-        assert plays_archive_result[2].archived_at == CURRENT_TIMESTAMP
-
-        assert plays_archive_result[3].id == 4
-        assert plays_archive_result[3].play_item_id == 2
-        assert plays_archive_result[3].archived_at == CURRENT_TIMESTAMP
-
-        assert plays_archive_result[4].id == 5
-        assert plays_archive_result[4].play_item_id == 1
-        assert plays_archive_result[4].archived_at == CURRENT_TIMESTAMP
-
 
 def test_prune_plays_max_batch(app):
     """Test that we should archive plays in batches"""
@@ -133,16 +107,6 @@ def test_prune_plays_max_batch(app):
         assert plays_result[2].play_item_id == 3
         assert plays_result[2].created_at == CURRENT_TIMESTAMP
 
-        # verify archive
-        plays_archive_result: List[PlaysArchive] = (
-            session.query(PlaysArchive).order_by(PlaysArchive.id).all()
-        )
-
-        assert len(plays_archive_result) == 1
-        assert plays_archive_result[0].id == 1
-        assert plays_archive_result[0].play_item_id == 1
-        assert plays_archive_result[0].archived_at == CURRENT_TIMESTAMP
-
 
 def test_prune_plays_skip_prune(app):
     """Test that we should not prune if there are no plays before cutoff"""
@@ -168,10 +132,3 @@ def test_prune_plays_skip_prune(app):
         # verify plays
         plays_result: List[Play] = session.query(Play).order_by(Play.id).all()
         assert len(plays_result) == 1
-
-        # verify archive
-        plays_archive_result: List[PlaysArchive] = (
-            session.query(PlaysArchive).order_by(PlaysArchive.id).all()
-        )
-
-        assert len(plays_archive_result) == 0

--- a/discovery-provider/src/tasks/prune_plays.py
+++ b/discovery-provider/src/tasks/prune_plays.py
@@ -25,7 +25,7 @@ PRUNE_PLAYS_QUERY = """
 # start at all plays before 2020 (328751 total)
 # TODO move to a sliding window
 current_date = datetime.now()
-cutoff_timestamp = current_date - timedelta(days=365)
+cutoff_timestamp = current_date - timedelta(days=400)
 DEFAULT_CUTOFF_TIMESTAMP = datetime.fromisoformat(cutoff_timestamp.isoformat())
 
 # max number of plays to prune per run


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Remove plays archiving and just delete old plays instead. 

Before, we would archive old plays in a separate table. Now that we're confident these old plays are no longer needed, we should just delete these plays to save disk.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tests pass.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->