### PR TITLE
Fix notifications endpoint

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_reaction.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_reaction.sql
@@ -8,7 +8,7 @@ begin
   
   if new.reaction_type = 'tip' then
 
-    select into amount, sender_user_id, receiver_user_id into tip_amount, sender_user_id, receiver_user_id from user_tips ut where ut.signature == new.reacted_to;
+    select amount, sender_user_id, receiver_user_id into tip_amount, sender_user_id, receiver_user_id from user_tips ut where ut.signature == new.reacted_to;
 
     if sender_user_id is not null and receiver_user_id is not null then
 

--- a/discovery-provider/alembic/trigger_sql/handle_reaction.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_reaction.sql
@@ -1,25 +1,53 @@
 create or replace function handle_reaction() returns trigger as $$
 declare
+  tip_row notification%ROWTYPE;
   sender_user_id int;
+  receiver_user_id int;
+  tip_amount bigint;
 begin
-
-  select user_id into sender_user_id from users where users.wallet=new.sender_wallet and is_current limit 1;
   
-  if sender_user_id is not null then
-    insert into notification
-      (slot, user_ids, timestamp, type, specifier, group_id, data)
-    values
-      (
-      new.slot,
-      ARRAY [sender_user_id],
-      new.timestamp,
-      'reaction',
-      sender_user_id,
-      'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value || ':timestamp:' || new.timestamp,
-      json_build_object('sender_wallet', new.sender_wallet, 'reaction_type', new.reaction_type, 'reacted_to', new.reacted_to, 'reaction_value', new.reaction_value)
-    )
-    on conflict do nothing;
+  if new.reaction_type = 'tip' then
+
+    select into amount, sender_user_id, receiver_user_id into tip_amount, sender_user_id, receiver_user_id from user_tips ut where ut.signature == new.reacted_to;
+
+    if sender_user_id is not null and receiver_user_id is not null then
+
+      insert into notification
+        (slot, user_ids, timestamp, type, specifier, group_id, data)
+      values
+        (
+        new.slot,
+        ARRAY [sender_user_id],
+        new.timestamp,
+        'reaction',
+        receiver_user_id,
+        'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value || ':timestamp:' || new.timestamp,
+        json_build_object(
+          'sender_wallet', new.sender_wallet,
+          'reaction_type', new.reaction_type,
+          'reacted_to', new.reacted_to,
+          'reaction_value', new.reaction_value,
+          'receiver_user_id', receiver_user_id,
+          'sender_user_id', sender_user_id,
+          'tip_amount', tip_amount::varchar(255)
+        )
+      )
+      on conflict do nothing;
+
+      -- find the notification for tip send - update the data to include reaction value
+      select * into tip_row from user_tips where user_tips.signature = new.reacted_to limit 1;
+      if tip_row is not null then
+        UPDATE notification
+        SET data = jsonb_set(
+          notification.data,
+          'reaction_value',
+          tip_row.reaction_value
+        )
+        WHERE notification.group_id = 'tip_receive:user_id:' || receiver_user_id || ':signature:' || new.reacted_to;
+      end if;
+    end if;
   end if;
+
   return null;
 
 exception

--- a/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
@@ -31,7 +31,7 @@ begin
     on conflict do nothing;
 
     if new.rank = 1 then 
-      select sender_user_id into dethroned_user_id from supporter_rank_ups where rank=1 and receiver_user_id=1026 order by slot desc limit 1;
+      select sender_user_id into dethroned_user_id from supporter_rank_ups where rank=1 order by slot desc limit 1;
       if dethroned_user_id is not NULL then
         -- create a notification for the sender and receiver
         insert into notification

--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -48,7 +48,7 @@ begin
           new.updated_at,
           'create',
           new.owner_id,
-          'create:track:' || new.track_id,
+          'create:track:user_id' || new.owner_id,
           json_build_object('track_id', new.track_id)
         )
         on conflict do nothing;

--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -48,7 +48,7 @@ begin
           new.updated_at,
           'create',
           new.owner_id,
-          'create:track:user_id' || new.owner_id,
+          'create:track:user_id:' || new.owner_id,
           json_build_object('track_id', new.track_id)
         )
         on conflict do nothing;

--- a/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
@@ -11,7 +11,7 @@ begin
     VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
   ) as tier (label, val)
   WHERE
-    new.current_balance::bigint >= tier.val
+    substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18)) >= tier.val
   ORDER BY 
     tier.val DESC
   limit 1;
@@ -21,7 +21,7 @@ begin
     VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
   ) as tier (label, val)
   WHERE
-    new.previous_balance::bigint >= tier.val
+    substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18)) >= tier.val
   ORDER BY 
     tier.val DESC
   limit 1;

--- a/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_user_balance_changes.sql
@@ -8,20 +8,20 @@ declare
 begin
   SELECT label, val into new_tier, new_tier_value
   FROM (
-    VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 10000::bigint), ('platinum', 100000::bigint)
   ) as tier (label, val)
   WHERE
-    substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18)) >= tier.val
+    substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
   ORDER BY 
     tier.val DESC
   limit 1;
 
   SELECT label, val into previous_tier, previous_tier_value
   FROM (
-    VALUES ('bronze', 10), ('silver', 100), ('gold', 10000), ('platinum', 100000)
+    VALUES ('bronze', 10::bigint), ('silver', 100::bigint), ('gold', 10000::bigint), ('platinum', 100000::bigint)
   ) as tier (label, val)
   WHERE
-    substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18)) >= tier.val
+    substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
   ORDER BY 
     tier.val DESC
   limit 1;
@@ -38,7 +38,11 @@ begin
         'tier_change',
         new.user_id,
         'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
-        json_build_object('new_tier', new_tier, 'new_tier_value', new_tier_value, 'current_value', new.current_balance)
+        json_build_object(
+          'new_tier', new_tier,
+          'new_tier_value', new_tier_value,
+          'current_value', new.current_balance
+        )
       )
     on conflict do nothing;
     return null;

--- a/discovery-provider/alembic/trigger_sql/handle_user_tip.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_user_tip.sql
@@ -37,6 +37,7 @@ begin
   return null;
 exception
   when others then return null;
+return null;
 end;
 $$ language plpgsql;
 

--- a/discovery-provider/alembic/trigger_sql/handle_user_tip.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_user_tip.sql
@@ -11,8 +11,13 @@ begin
       new.created_at, 
       'tip_receive',
       new.receiver_user_id,
-      'tip_receive:user_id:' || new.receiver_user_id || ':slot:' || new.slot,
-      json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'amount', new.amount)
+      'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
     ),
     ( 
       new.slot,
@@ -20,8 +25,13 @@ begin
       new.created_at, 
       'tip_send',
       new.sender_user_id,
-      'tip_send:user_id:' || new.sender_user_id || ':slot:' || new.slot,
-      json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'amount', new.amount)
+      'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
+      json_build_object(
+        'sender_user_id', new.sender_user_id,
+        'receiver_user_id', new.receiver_user_id,
+        'amount', new.amount,
+        'tx_signature', new.signature
+      )
     )
     on conflict do nothing;
   return null;

--- a/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
+++ b/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
@@ -1,7 +1,7 @@
 """update triggers for notifications
 
 Revision ID: 0f75bcb73b0a
-Revises: 988f095a1d43
+Revises: 64e82a907294
 Create Date: 2023-02-14 15:22:13.771266
 
 """
@@ -9,8 +9,8 @@ from alembic import op
 from src.utils.alembic_helpers import build_sql
 
 # revision identifiers, used by Alembic.
-revision = '0f75bcb73b0a'
-down_revision = '988f095a1d43'
+revision = "0f75bcb73b0a"
+down_revision = "64e82a907294"
 branch_labels = None
 depends_on = None
 
@@ -20,19 +20,19 @@ up_files = [
     "handle_track.sql",
     "handle_user_tip.sql",
     "handle_user_balance_changes.sql",
-    "handle_supporter_rank_ups.sql"
+    "handle_supporter_rank_ups.sql",
 ]
+
 
 def upgrade():
     sql = build_sql(up_files)
     connection = op.get_bind()
     connection.execute(sql)
     connection.execute(
-      """
+        """
       DELETE FROM notification where type in ('reaction', 'tip_send', 'tip_receive', 'create', 'tier_change');
       """
     )
-
 
 
 def downgrade():

--- a/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
+++ b/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
@@ -1,7 +1,7 @@
 """update triggers for notifications
 
 Revision ID: 0f75bcb73b0a
-Revises: a62b4e92b733
+Revises: 988f095a1d43
 Create Date: 2023-02-14 15:22:13.771266
 
 """
@@ -10,7 +10,7 @@ from src.utils.alembic_helpers import build_sql
 
 # revision identifiers, used by Alembic.
 revision = '0f75bcb73b0a'
-down_revision = 'a62b4e92b733'
+down_revision = '988f095a1d43'
 branch_labels = None
 depends_on = None
 

--- a/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
+++ b/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
@@ -1,0 +1,41 @@
+"""update triggers for notifications
+
+Revision ID: 0f75bcb73b0a
+Revises: a62b4e92b733
+Create Date: 2023-02-14 15:22:13.771266
+
+"""
+from alembic import op
+from src.utils.alembic_helpers import build_sql
+
+# revision identifiers, used by Alembic.
+revision = '0f75bcb73b0a'
+down_revision = 'a62b4e92b733'
+branch_labels = None
+depends_on = None
+
+up_files = [
+    "handle_repost.sql",
+    "handle_reaction.sql",
+    "handle_track.sql",
+    "handle_user_tip.sql",
+    "handle_user_balance_change.sql",
+    "handle_supporter_rank_ups.sql"
+]
+
+def upgrade():
+    sql = build_sql(up_files)
+    connection = op.get_bind()
+    connection.execute(sql)
+    conn.execute(
+      """
+      DELETE FROM notification where type in ('reaction', 'tip_send', 'tip_receive', 'create', 'tier_change');
+      """
+    )
+
+
+
+def downgrade():
+    sql = build_sql(up_files)
+    connection = op.get_bind()
+    connection.execute(sql)

--- a/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
+++ b/discovery-provider/alembic/versions/0f75bcb73b0a_update_triggers_for_notifications.py
@@ -19,7 +19,7 @@ up_files = [
     "handle_reaction.sql",
     "handle_track.sql",
     "handle_user_tip.sql",
-    "handle_user_balance_change.sql",
+    "handle_user_balance_changes.sql",
     "handle_supporter_rank_ups.sql"
 ]
 
@@ -27,7 +27,7 @@ def upgrade():
     sql = build_sql(up_files)
     connection = op.get_bind()
     connection.execute(sql)
-    conn.execute(
+    connection.execute(
       """
       DELETE FROM notification where type in ('reaction', 'tip_send', 'tip_receive', 'create', 'tier_change');
       """

--- a/discovery-provider/integration_tests/notifications/test_reaction.py
+++ b/discovery-provider/integration_tests/notifications/test_reaction.py
@@ -18,16 +18,32 @@ def test_reaction_notification(app):
     now = datetime.now()
     # Insert a reaction and check that a notificaiton is created
     entities = {
-        "users": [{"user_id": i + 1, "wallet": "0x" + str(i)} for i in range(3)],
+        "users": [{"user_id": i + 1, "wallet": "0x" + str(i)} for i in range(4)],
     }
     populate_mock_db(db, entities)
+
+    entities = {
+        "user_tips": [
+            {
+                "sender_user_id": i+1,
+                "receiver_user_id": i+2,
+                "signature": f'sig_{i}',
+                "amount": (i+1) * 100000000,
+            } for i in range(3)
+        ],
+    }
+    populate_mock_db(db, entities)
+
     entities = {
         "reactions": [
             {
                 "id": i + 1,
-                "sender_wallet": "0x" + str(i),
-                "reacted_to": "react_" + str(i),
+                "sender_wallet": f'0x{i}',
+                "reacted_to": f'sig_{i}',
                 "timestamp": now,
+                "reaction_type": 'tip',
+                "reaction_value": i,
+                "tx_signature": f'tx_sig_{i}'
             }
             for i in range(3)
         ],
@@ -37,29 +53,29 @@ def test_reaction_notification(app):
     with db.scoped_session() as session:
 
         notifications: List[Notification] = (
-            session.query(Notification).order_by(asc(Notification.slot)).all()
+            session.query(Notification).filter(Notification.type == 'reaction').order_by(asc(Notification.slot)).all()
         )
         assert len(notifications) == 3
-        assert notifications[0].specifier == "1"
+        assert notifications[0].specifier == "2"
         assert notifications[
             0
-        ].group_id == "reaction:reaction_to:react_0:reaction_type:type:reaction_value:1:timestamp:" + now.strftime(
+        ].group_id == "reaction:reaction_to:sig_0:reaction_type:tip:reaction_value:0:timestamp:" + now.strftime(
             "%Y-%m-%d %H:%M:%S.%f"
         ).rstrip(
             "0"
         )
-        assert notifications[1].specifier == "2"
+        assert notifications[1].specifier == "3"
         assert notifications[
             1
-        ].group_id == "reaction:reaction_to:react_1:reaction_type:type:reaction_value:1:timestamp:" + now.strftime(
+        ].group_id == "reaction:reaction_to:sig_1:reaction_type:tip:reaction_value:1:timestamp:" + now.strftime(
             "%Y-%m-%d %H:%M:%S.%f"
         ).rstrip(
             "0"
         )
-        assert notifications[2].specifier == "3"
+        assert notifications[2].specifier == "4"
         assert notifications[
             2
-        ].group_id == "reaction:reaction_to:react_2:reaction_type:type:reaction_value:1:timestamp:" + now.strftime(
+        ].group_id == "reaction:reaction_to:sig_2:reaction_type:tip:reaction_value:2:timestamp:" + now.strftime(
             "%Y-%m-%d %H:%M:%S.%f"
         ).rstrip(
             "0"
@@ -68,9 +84,25 @@ def test_reaction_notification(app):
         assert notifications[0].slot == 0
         assert notifications[0].blocknumber == None
         assert notifications[0].data == {
-            "reacted_to": "react_0",
-            "reaction_type": "type",
+            "reacted_to": "sig_0",
+            "reaction_type": "tip",
             "sender_wallet": "0x0",
-            "reaction_value": 1,
+            "reaction_value": 0,
+            "receiver_user_id": 2,
+            "sender_user_id": 1,
+            "tip_amount": '100000000'
+
         }
         assert notifications[0].user_ids == [1]
+
+        notifications: List[Notification] = (
+            session.query(Notification).filter(Notification.type == 'tip_receive').order_by(asc(Notification.slot)).all()
+        )
+        assert len(notifications) == 3
+        assert notifications[0].data == {
+          "reaction_value": 0,
+          "receiver_user_id": 2,
+          "sender_user_id": 1,
+          "amount": 100000000,
+          'tx_signature': 'sig_0'
+        }

--- a/discovery-provider/integration_tests/notifications/test_reaction.py
+++ b/discovery-provider/integration_tests/notifications/test_reaction.py
@@ -25,11 +25,12 @@ def test_reaction_notification(app):
     entities = {
         "user_tips": [
             {
-                "sender_user_id": i+1,
-                "receiver_user_id": i+2,
-                "signature": f'sig_{i}',
-                "amount": (i+1) * 100000000,
-            } for i in range(3)
+                "sender_user_id": i + 1,
+                "receiver_user_id": i + 2,
+                "signature": f"sig_{i}",
+                "amount": (i + 1) * 100000000,
+            }
+            for i in range(3)
         ],
     }
     populate_mock_db(db, entities)
@@ -38,12 +39,12 @@ def test_reaction_notification(app):
         "reactions": [
             {
                 "id": i + 1,
-                "sender_wallet": f'0x{i}',
-                "reacted_to": f'sig_{i}',
+                "sender_wallet": f"0x{i}",
+                "reacted_to": f"sig_{i}",
                 "timestamp": now,
-                "reaction_type": 'tip',
+                "reaction_type": "tip",
                 "reaction_value": i,
-                "tx_signature": f'tx_sig_{i}'
+                "tx_signature": f"tx_sig_{i}",
             }
             for i in range(3)
         ],
@@ -53,7 +54,10 @@ def test_reaction_notification(app):
     with db.scoped_session() as session:
 
         notifications: List[Notification] = (
-            session.query(Notification).filter(Notification.type == 'reaction').order_by(asc(Notification.slot)).all()
+            session.query(Notification)
+            .filter(Notification.type == "reaction")
+            .order_by(asc(Notification.slot))
+            .all()
         )
         assert len(notifications) == 3
         assert notifications[0].specifier == "2"
@@ -90,19 +94,21 @@ def test_reaction_notification(app):
             "reaction_value": 0,
             "receiver_user_id": 2,
             "sender_user_id": 1,
-            "tip_amount": '100000000'
-
+            "tip_amount": "100000000",
         }
         assert notifications[0].user_ids == [1]
 
         notifications: List[Notification] = (
-            session.query(Notification).filter(Notification.type == 'tip_receive').order_by(asc(Notification.slot)).all()
+            session.query(Notification)
+            .filter(Notification.type == "tip_receive")
+            .order_by(asc(Notification.slot))
+            .all()
         )
         assert len(notifications) == 3
         assert notifications[0].data == {
-          "reaction_value": 0,
-          "receiver_user_id": 2,
-          "sender_user_id": 1,
-          "amount": 100000000,
-          'tx_signature': 'sig_0'
+            "reaction_value": 0,
+            "receiver_user_id": 2,
+            "sender_user_id": 1,
+            "amount": 100000000,
+            "tx_signature": "sig_0",
         }

--- a/discovery-provider/integration_tests/notifications/test_tier_change.py
+++ b/discovery-provider/integration_tests/notifications/test_tier_change.py
@@ -21,35 +21,35 @@ def test_tier_change(app):
                 "blocknumber": 10,
                 # No tier change, none -> none
                 "previous_balance": 0,
-                "current_balance": 6,
+                "current_balance": 6 * 1000000000000000000,
             },
             {
                 "user_id": 2,
                 "blocknumber": 11,
                 # Tier change, none -> bronze
                 "previous_balance": 0,
-                "current_balance": 10,
+                "current_balance": 10 * 1000000000000000000,
             },
             {
                 "user_id": 3,
                 "blocknumber": 12,
                 # Tier change, none -> bronze
                 "previous_balance": 0,
-                "current_balance": 15,
+                "current_balance": 15 * 1000000000000000000,
             },
             {
                 "user_id": 4,
                 "blocknumber": 13,
                 # Tier change, none -> platinum
                 "previous_balance": 0,
-                "current_balance": 200000,
+                "current_balance": 200000 * 1000000000000000000,
             },
             {
                 "user_id": 5,
                 "blocknumber": 14,
                 # No tier change, gold -> gold
-                "previous_balance": 12000,
-                "current_balance": 90000,
+                "previous_balance": 12000 * 1000000000000000000,
+                "current_balance": 90000 * 1000000000000000000,
             },
         ],
     }
@@ -69,7 +69,7 @@ def test_tier_change(app):
         assert notifications[0].data == {
             "new_tier": "bronze",
             "new_tier_value": 10,
-            "current_value": "10",
+            "current_value": "10000000000000000000",
         }
 
         assert notifications[1].user_ids == [3]
@@ -80,7 +80,7 @@ def test_tier_change(app):
         assert notifications[1].data == {
             "new_tier": "bronze",
             "new_tier_value": 10,
-            "current_value": "15",
+            "current_value": "15000000000000000000",
         }
 
         assert notifications[2].user_ids == [4]
@@ -92,15 +92,15 @@ def test_tier_change(app):
         assert notifications[2].data == {
             "new_tier": "platinum",
             "new_tier_value": 100000,
-            "current_value": "200000",
+            "current_value": "200000000000000000000000",
         }
 
         session.execute(
             """
             update user_balance_changes
             set 
-              previous_balance = 10,
-              current_balance = 9999999,
+              previous_balance = 10000000000000000000,
+              current_balance = 9999999000000000000000000,
               blocknumber=20
             where user_id = 2;
             """
@@ -122,15 +122,15 @@ def test_tier_change(app):
         assert notifications[0].data == {
             "new_tier": "platinum",
             "new_tier_value": 100000,
-            "current_value": "9999999",
+            "current_value": "9999999000000000000000000",
         }
 
         session.execute(
             """
             update user_balance_changes
             set 
-              previous_balance = 9999999,
-              current_balance = 10000,
+              previous_balance = 9999999000000000000000000,
+              current_balance = 10000000000000000000000,
               blocknumber=22
             where user_id = 2;
             """

--- a/discovery-provider/integration_tests/notifications/test_track.py
+++ b/discovery-provider/integration_tests/notifications/test_track.py
@@ -72,7 +72,7 @@ def test_track_create_notification(app):
         assert len(notifications) == 1
         notification = notifications[0]
         assert notification.specifier == "1"
-        assert notification.group_id == "create:track:20"
+        assert notification.group_id == "create:track:user_id:1"
         assert notification.type == "create"
         assert notification.slot == None
         assert notification.data == {

--- a/discovery-provider/integration_tests/notifications/test_user_tip.py
+++ b/discovery-provider/integration_tests/notifications/test_user_tip.py
@@ -52,7 +52,7 @@ def test_supporter_rank_up_notification(app):
             "amount": 300000000,
             "sender_user_id": 1,
             "receiver_user_id": 3,
-            'tx_signature': '2'
+            "tx_signature": "2",
         }
         assert send_notifications[0].user_ids == [1]
 
@@ -65,6 +65,6 @@ def test_supporter_rank_up_notification(app):
             "amount": 300000000,
             "sender_user_id": 1,
             "receiver_user_id": 3,
-            'tx_signature': '2'
+            "tx_signature": "2",
         }
         assert receive_notifications[0].user_ids == [3]

--- a/discovery-provider/integration_tests/notifications/test_user_tip.py
+++ b/discovery-provider/integration_tests/notifications/test_user_tip.py
@@ -44,7 +44,7 @@ def test_supporter_rank_up_notification(app):
         assert len(receive_notifications) == 3
 
         assert send_notifications[0].specifier == "1"
-        assert send_notifications[0].group_id == "tip_send:user_id:1:slot:2"
+        assert send_notifications[0].group_id == "tip_send:user_id:1:signature:2"
         assert send_notifications[0].type == "tip_send"
         assert send_notifications[0].slot == 2
         assert send_notifications[0].blocknumber == None
@@ -52,11 +52,12 @@ def test_supporter_rank_up_notification(app):
             "amount": 300000000,
             "sender_user_id": 1,
             "receiver_user_id": 3,
+            'tx_signature': '2'
         }
         assert send_notifications[0].user_ids == [1]
 
         assert receive_notifications[0].specifier == "3"
-        assert receive_notifications[0].group_id == "tip_receive:user_id:3:slot:2"
+        assert receive_notifications[0].group_id == "tip_receive:user_id:3:signature:2"
         assert receive_notifications[0].type == "tip_receive"
         assert receive_notifications[0].slot == 2
         assert receive_notifications[0].blocknumber == None
@@ -64,5 +65,6 @@ def test_supporter_rank_up_notification(app):
             "amount": 300000000,
             "sender_user_id": 1,
             "receiver_user_id": 3,
+            'tx_signature': '2'
         }
         assert receive_notifications[0].user_ids == [3]

--- a/discovery-provider/integration_tests/queries/test_notifications/test_follow_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_follow_notification.py
@@ -48,6 +48,7 @@ def test_get_notifications(app):
                 {
                     "specifier": "2",
                     "type": "follow",
+                    "group_id": "follow:1",
                     "timestamp": t2,
                     "data": {"follower_user_id": 2, "followee_user_id": 1},
                 }
@@ -73,6 +74,7 @@ def test_get_notifications(app):
                     "specifier": "4",
                     "timestamp": t2,
                     "type": "follow",
+                    "group_id": "follow:3",
                     "data": {"follower_user_id": 4, "followee_user_id": 3},
                 }
             ]

--- a/discovery-provider/integration_tests/queries/test_notifications/test_paginate_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_paginate_notification.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 
 from integration_tests.utils import populate_mock_db
@@ -6,6 +7,8 @@ from src.utils.db_session import get_db
 
 t1 = datetime(2020, 10, 10, 10, 35, 0)
 times = [t1 - timedelta(hours=i) for i in range(200)]
+
+logger = logging.getLogger(__name__)
 
 
 def test_get_notifications(app):
@@ -56,5 +59,7 @@ def test_get_notifications(app):
                 "timestamp": timestamp,
             }
             u1_notification_2 = get_notifications(session, args_2)
+            logger.info(u1_notification_2)
+            logger.info(u1_notification_1)
             assert len(u1_notification_2) == 4
             assert u1_notification_2[0] == u1_notification_1[9]

--- a/discovery-provider/integration_tests/queries/test_notifications/test_remix_track_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_remix_track_notification.py
@@ -67,6 +67,7 @@ def test_remix_track_notifications(app):
                     "specifier": "2",
                     "type": "remix",
                     "timestamp": t1,
+                    "group_id": "remix:track:2:parent_track:1:blocknumber:4",
                     "data": {"parent_track_id": 1, "track_id": 2},
                 }
             ]
@@ -83,6 +84,7 @@ def test_remix_track_notifications(app):
                     "specifier": "1",
                     "type": "cosign",
                     "timestamp": t1,
+                    "group_id": "cosign:parent_track1:original_track:2",
                     "data": {"track_id": 2, "track_owner_id": 2, "parent_track_id": 1},
                 }
             ]

--- a/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_user_tier_change_notification.py
@@ -21,7 +21,7 @@ def test_get_save_notifications(app):
                     "blocknumber": 10,
                     # No tier change, none -> none
                     "previous_balance": 0,
-                    "current_balance": 20,
+                    "current_balance": 20000000000000000000,
                 },
             ],
             "users": [{"user_id": i + 1} for i in range(2)],
@@ -41,5 +41,5 @@ def test_get_save_notifications(app):
             u1_notifiations[0]["actions"][0]["data"] = {
                 "new_tier": "bronze",
                 "new_tier_value": 10,
-                "current_value": "20",
+                "current_value": "20000000000000000000",
             }

--- a/discovery-provider/src/api/v1/models/notifications.py
+++ b/discovery-provider/src/api/v1/models/notifications.py
@@ -12,7 +12,6 @@ notification_action = ns.model(
     "notification_action",
     {
         "specifier": fields.String(required=True),
-        "type": fields.String(required=True),
         "timestamp": fields.Integer(required=True),
         "data": Any,
     },
@@ -21,16 +20,7 @@ notification_action = ns.model(
 notification = ns.model(
     "notification",
     {
-        "group_id": fields.String(required=True),
-        "is_seen": fields.Boolean(required=True),
-        "seen_at": fields.Integer(required=False),
-        "actions": fields.List(fields.Nested(notification_action)),
-    },
-)
-
-notification = ns.model(
-    "notification",
-    {
+        "type": fields.String(required=True),
         "group_id": fields.String(required=True),
         "is_seen": fields.Boolean(required=True),
         "seen_at": fields.Integer(required=False),

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -178,9 +178,10 @@ def extend_send_tip(action: NotificationAction):
             "amount": to_wei_string(data["amount"]),
             "sender_user_id": encode_int_id(data["sender_user_id"]),
             "receiver_user_id": encode_int_id(data["receiver_user_id"]),
-            "tip_tx_signature": data["tx_signature"]
+            "tip_tx_signature": data["tx_signature"],
         },
     }
+
 
 def extend_receive_tip(action: NotificationAction):
     data: Union[TipReceiveNotification, TipSendNotification] = action["data"]  # type: ignore
@@ -195,7 +196,9 @@ def extend_receive_tip(action: NotificationAction):
             "sender_user_id": encode_int_id(data["sender_user_id"]),
             "receiver_user_id": encode_int_id(data["receiver_user_id"]),
             "tip_tx_signature": data["tx_signature"],
-            "reaction_value": data["reaction_value"] if "reaction_value" in data else None
+            "reaction_value": data["reaction_value"]
+            if "reaction_value" in data
+            else None,
         },
     }
 
@@ -263,7 +266,7 @@ def extend_reaction(action: NotificationAction):
             "reaction_value": data["reaction_value"],
             "receiver_user_id": encode_int_id(data["receiver_user_id"]),
             "sender_user_id": encode_int_id(data["sender_user_id"]),
-            "tip_amount": to_wei_string(data["tip_amount"])
+            "tip_amount": to_wei_string(data["tip_amount"]),
         },
     }
 

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List, Union
 
 from src.queries.get_notifications import (
+    AnnouncementNotification,
     ChallengeRewardNotification,
     CosignRemixNotification,
     CreatePlaylistNotification,
@@ -17,20 +18,24 @@ from src.queries.get_notifications import (
     RemixNotification,
     RepostNotification,
     SaveNotification,
+    SupporterDethronedNotification,
     SupporterRankUpNotification,
     SupportingRankUpNotification,
     TierChangeNotification,
     TipReceiveNotification,
     TipSendNotification,
     TrackMilestoneNotification,
+    TrendingNotification,
 )
 from src.utils.helpers import encode_int_id
+from src.utils.spl_audio import to_wei_string
 
 logger = logging.getLogger(__name__)
 
 
 def extend_notification(notification: Notification):
     formatted = {
+        "type": notification["type"],
         "group_id": notification["group_id"],
         "is_seen": notification["is_seen"],
     }
@@ -118,6 +123,7 @@ def extend_remix(action: NotificationAction):
         "data": {
             "parent_track_id": encode_int_id(data["parent_track_id"]),
             "track_id": encode_int_id(data["track_id"]),
+            "track_owner_id": encode_int_id(int(action["specifier"])),
         },
     }
 
@@ -132,6 +138,7 @@ def extend_cosign(action: NotificationAction):
         else action["timestamp"],
         "data": {
             "track_owner_id": encode_int_id(data["track_owner_id"]),
+            "parent_track_owner_id": encode_int_id(int(action["specifier"])),
             "parent_track_id": encode_int_id(data["parent_track_id"]),
             "track_id": encode_int_id(data["track_id"]),
         },
@@ -149,15 +156,17 @@ def extend_create(action: NotificationAction):
     }
     if "track_id" in action["data"]:
         track_data: CreateTrackNotification = action["data"]  # type: ignore
-        notification["track_id"] = encode_int_id(track_data["track_id"])
+        notification["data"]["track_id"] = encode_int_id(track_data["track_id"])
     else:
         playlist_data: CreatePlaylistNotification = action["data"]  # type: ignore
-        notification["is_album"] = playlist_data["is_album"]
-        notification["playlist_id"] = (encode_int_id(playlist_data["playlist_id"]),)
+        notification["data"]["is_album"] = playlist_data["is_album"]
+        notification["data"]["playlist_id"] = (
+            encode_int_id(playlist_data["playlist_id"]),
+        )
     return notification
 
 
-def extend_tip(action: NotificationAction):
+def extend_send_tip(action: NotificationAction):
     data: Union[TipReceiveNotification, TipSendNotification] = action["data"]  # type: ignore
     return {
         "specifier": encode_int_id(int(action["specifier"])),
@@ -166,14 +175,32 @@ def extend_tip(action: NotificationAction):
         if action["timestamp"]
         else action["timestamp"],
         "data": {
-            "amount": data["amount"],
+            "amount": to_wei_string(data["amount"]),
             "sender_user_id": encode_int_id(data["sender_user_id"]),
             "receiver_user_id": encode_int_id(data["receiver_user_id"]),
+            "tip_tx_signature": data["tx_signature"]
+        },
+    }
+
+def extend_receive_tip(action: NotificationAction):
+    data: Union[TipReceiveNotification, TipSendNotification] = action["data"]  # type: ignore
+    return {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "amount": to_wei_string(data["amount"]),
+            "sender_user_id": encode_int_id(data["sender_user_id"]),
+            "receiver_user_id": encode_int_id(data["receiver_user_id"]),
+            "tip_tx_signature": data["tx_signature"],
+            "reaction_value": data["reaction_value"] if "reaction_value" in data else None
         },
     }
 
 
-def extend_support_rank_up(action: NotificationAction):
+def extend_supporter_rank_up(action: NotificationAction):
     data: Union[SupporterRankUpNotification, SupportingRankUpNotification] = action["data"]  # type: ignore
     return {
         "specifier": encode_int_id(int(action["specifier"])),
@@ -189,6 +216,22 @@ def extend_support_rank_up(action: NotificationAction):
     }
 
 
+def extend_supporter_dethroned(action: Notification):
+    data: Union[SupporterDethronedNotification] = action["data"]  # type: ignore
+    return {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "dethroned_user_id": encode_int_id(data["dethroned_user_id"]),
+            "sender_user_id": encode_int_id(data["sender_user_id"]),
+            "receiver_user_id": encode_int_id(data["receiver_user_id"]),
+        },
+    }
+
+
 def extend_challenge_reward(action: NotificationAction):
     data: ChallengeRewardNotification = action["data"]  # type: ignore
     return {
@@ -198,7 +241,7 @@ def extend_challenge_reward(action: NotificationAction):
         if action["timestamp"]
         else action["timestamp"],
         "data": {
-            "amount": data["amount"],
+            "amount": to_wei_string(data["amount"]),
             "specifier": data["specifier"],
             "challenge_id": data["challenge_id"],
         },
@@ -218,36 +261,59 @@ def extend_reaction(action: NotificationAction):
             "reaction_type": data["reaction_type"],
             "sender_wallet": data["sender_wallet"],
             "reaction_value": data["reaction_value"],
+            "receiver_user_id": encode_int_id(data["receiver_user_id"]),
+            "sender_user_id": encode_int_id(data["sender_user_id"]),
+            "tip_amount": to_wei_string(data["tip_amount"])
         },
     }
 
 
 def extend_milestone(action: NotificationAction):
+    type = action["type"].lower()
+    logger.info("notification mapping")
     notification = {
         "specifier": encode_int_id(int(action["specifier"])),
-        "type": action["type"],
+        "type": type,
         "timestamp": datetime.timestamp(action["timestamp"])
         if action["timestamp"]
         else action["timestamp"],
     }
-    if "track_id" in action["data"]:
+
+    if action["group_id"].startswith("milestone:PLAYLIST_REPOST_COUNT") or action[
+        "group_id"
+    ].startswith("milestone:PLAYLIST_SAVE_COUNT"):
+        group_id_parts = action["group_id"].split(":")
+        id = int(group_id_parts[3])
+        playlist_data: PlaylistMilestoneNotification = action["data"]  # type: ignore
+        notification["data"] = {
+            "type": playlist_data["type"].lower(),
+            "threshold": playlist_data["threshold"],
+            "playlist_id": encode_int_id(id),
+        }
+    elif action["group_id"].startswith("milestone:TRACK_SAVE_COUNT") or action[
+        "group_id"
+    ].startswith("milestone:TRACK_REPOST_COUNT"):
+        group_id_parts = action["group_id"].split(":")
+        id = int(group_id_parts[3])
+        playlist_data: PlaylistMilestoneNotification = action["data"]  # type: ignore
+        notification["data"] = {
+            "type": playlist_data["type"].lower(),
+            "threshold": playlist_data["threshold"],
+            "track_id": encode_int_id(id),
+        }
+
+    elif action["group_id"].startswith("milestone:LISTEN_COUNT"):
         track_data: TrackMilestoneNotification = action["data"]  # type: ignore
         notification["data"] = {
-            "type": track_data["type"],
+            "type": track_data["type"].lower(),
             "threshold": track_data["threshold"],
             "track_id": encode_int_id(track_data["track_id"]),
         }
-    if "playlist_id" in action["data"]:
-        playlist_data: PlaylistMilestoneNotification = action["data"]  # type: ignore
-        notification["data"] = {
-            "type": playlist_data["type"],
-            "threshold": playlist_data["threshold"],
-            "playlist_id": encode_int_id(playlist_data["playlist_id"]),
-        }
-    if "user_id" in action["data"]:
+    elif action["group_id"].startswith("milestone:FOLLOWER_COUNT"):
+        logger.info("notification mapping found follower ")
         user_data: FollowerMilestoneNotification = action["data"]  # type: ignore
         notification["data"] = {
-            "type": user_data["type"],
+            "type": user_data["type"].lower(),
             "threshold": user_data["threshold"],
             "user_id": encode_int_id(user_data["user_id"]),
         }
@@ -267,19 +333,53 @@ def extend_tier_change(action: NotificationAction):
     return notification
 
 
+def extend_trending(action: NotificationAction):
+    data: TrendingNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "rank": data["rank"],
+            "genre": data["genre"],
+            "track_id": encode_int_id(data["track_id"]),
+            "time_range": data["time_range"],
+        },
+    }
+    return notification
+
+
+def extend_announcement(action: NotificationAction):
+    data: AnnouncementNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": data,
+    }
+    return notification
+
+
 notification_action_handler = {
     "follow": extend_follow,
     "repost": extend_repost,
     "save": extend_save,
-    "milstone": extend_milestone,
+    "milestone": extend_milestone,
     "remix": extend_remix,
     "cosign": extend_cosign,
     "create": extend_create,
-    "tip_receive": extend_tip,
-    "tip_send": extend_tip,
-    "supporting_rank_up": extend_support_rank_up,
-    "supporter_rank_up": extend_support_rank_up,
+    "tip_receive": extend_receive_tip,
+    "tip_send": extend_send_tip,
+    "supporting_rank_up": extend_supporter_rank_up,
+    "supporter_rank_up": extend_supporter_rank_up,
+    "supporter_dethroned": extend_supporter_dethroned,
     "challenge_reward": extend_challenge_reward,
     "reaction": extend_reaction,
     "tier_change": extend_tier_change,
+    "trending": extend_trending,
+    "announcement": extend_announcement,
 }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -72,7 +72,7 @@ GROUP BY
   n.type, n.group_id, user_seen.seen_at, user_seen.prev_seen_at
 ORDER BY
   user_seen.seen_at desc NULLS LAST,
-  n.group_id asc
+  n.group_id desc
 limit :limit;
 """
 )
@@ -147,6 +147,9 @@ def get_notification_groups(session: Session, args: GetNotificationArgs):
     """
     limit = args.get("limit") or DEFAULT_LIMIT
     limit = min(limit, MAX_LIMIT)  # type: ignore
+
+    # Set valid types
+    args["valid_types"] = args.get("valid_type", []) + default_valid_types
 
     rows = session.execute(
         notification_groups_sql,
@@ -353,8 +356,6 @@ notifications_sql = notifications_sql.bindparams(
 
 
 def get_notifications(session: Session, args: GetNotificationArgs):
-    # Set valid types
-    args["valid_types"] = args.get("valid_type", []) + default_valid_types
     notifications = get_notification_groups(session, args)
     notification_ids = []
     for notification in notifications:

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -60,7 +60,7 @@ WHERE
   (:valid_types is NOT NULL AND n.type in :valid_types) AND
   (
     (:timestamp_offset is NULL AND :group_id_offset is NULL) OR
-    (:timestamp_offset is NOT NULL AND :group_id_offset is NOT NULL AND n.group_id < :group_id_offset) OR
+    (:timestamp_offset is NULL AND :group_id_offset is NOT NULL AND n.group_id < :group_id_offset) OR
     (:timestamp_offset is NOT NULL AND user_seen.seen_at is NULL AND n.timestamp < :timestamp_offset) OR
     (:timestamp_offset is NOT NULL AND user_seen.seen_at is NOT NULL AND user_seen.seen_at < :timestamp_offset) OR
     (

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -247,7 +247,7 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
         latest_notification_query = text(
             """
                 SELECT 
-                    DISTINCT specifier,
+                    DISTINCT ON (specifier) specifier,
                     timestamp,
                     data
                 FROM notification
@@ -255,6 +255,7 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
                     type=:type AND
                     specifier in :track_ids
                 ORDER BY
+                    specifier desc,
                     timestamp desc
             """
         )

--- a/libs/src/api/Notifications.ts
+++ b/libs/src/api/Notifications.ts
@@ -1,9 +1,9 @@
 import type { TransactionReceipt } from 'web3-core'
+import { Base, BaseConstructorArgs, Services } from './base'
 import {
   Action,
   EntityType
 } from '../services/dataContracts/EntityManagerClient'
-import { Base, BaseConstructorArgs } from './base'
 
 type AnnouncementData = {}
 
@@ -111,5 +111,26 @@ export class Notifications extends Base {
       )
       return { error: errorMessage }
     }
+  }
+
+
+  async getNotifications({
+    encodedUserId,
+    timestamp,
+    groupId,
+    limit
+  }: {
+    encodedUserId: string,
+    timestamp: number,
+    groupId?: string,
+    limit?: number
+  }): Promise<any> {
+    this.REQUIRES(Services.DISCOVERY_PROVIDER)
+    return await this.discoveryProvider.getUserNotifications({
+      encodedUserId,
+      timestamp,
+      groupId,
+      limit,
+    })
   }
 }

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -63,9 +63,9 @@ export type UserProfile = {
   handle: string
   verified: boolean
   profilePicture:
-    | { '150x150': string; '480x480': string; '1000x1000': string }
-    | null
-    | undefined
+  | { '150x150': string; '480x480': string; '1000x1000': string }
+  | null
+  | undefined
   sub: number
   iat: string
 }
@@ -865,6 +865,27 @@ export class DiscoveryProvider {
     return await this._makeRequest(req)
   }
 
+  async getUserNotifications({
+    encodedUserId,
+    timestamp,
+    groupId,
+    limit,
+  }: {
+    encodedUserId: string,
+    timestamp: number,
+    groupId?: string,
+    limit?: number
+  }) {
+
+    const req = Requests.getUserNotifications({
+      encodedUserId,
+      timestamp,
+      groupId,
+      limit
+    })
+    return await this._makeRequest(req)
+  }
+
   async getURSMContentNodes(ownerWallet: string | null = null) {
     const req = Requests.getURSMContentNodes(ownerWallet)
     return await this._makeRequest(req)
@@ -1217,12 +1238,12 @@ export class DiscoveryProvider {
     blockNumber?: number
   ): Promise<
     | {
-        latest_indexed_block: number
-        latest_chain_block: number
-        latest_indexed_slot_plays: number
-        latest_chain_slot_plays: number
-        data: Response
-      }
+      latest_indexed_block: number
+      latest_chain_block: number
+      latest_indexed_slot_plays: number
+      latest_chain_slot_plays: number
+      data: Response
+    }
     | undefined
     | null
   > {

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -651,6 +651,27 @@ export const getNotifications = (
   }
 }
 
+export const getUserNotifications = ({
+  encodedUserId,
+  timestamp,
+  groupId,
+  limit,
+}: {
+  encodedUserId: string,
+  timestamp: number,
+  groupId?: string,
+  limit?: number
+}) => {
+  return {
+    endpoint: `v1/full/notifications/${encodedUserId}`,
+    queryParams: {
+      timestamp,
+      group_id: groupId,
+      limit
+    }
+  }
+}
+
 export const getUserSubscribers = (encodedUserId: string, timeout: number) => {
   return {
     endpoint: `v1/full/users/${encodedUserId}/subscribers`,


### PR DESCRIPTION
### Description
Fix the discover notifications endpoint
Adds mappings for all notifications to be formatted correctly
Reformats the base notification to add type
Fixes triggers:
* Create track group id is changes so that notifications rollup
* Added dethroned trigger
* fix user balance change notification for correct wei units
* Add extra metadata to tip notification
Added a migration to update these notification and delete all past notifications for these types

Adds libs binding to fetch notifications and add type per each notification


### Tests
Ran against prod db snapshot and validated each one was sent correctly

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->