### PR TITLE
SDK: Retry once with new selections on failed requests

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.test.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.test.ts
@@ -428,12 +428,24 @@ describe('discoveryNodeSelector', () => {
         }
       }
 
-      await middleware.post!({
+      server.use(
+        rest.get(`${HEALTHY_NODE}/v1/full/tracks`, (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              data: {}
+            })
+          )
+        })
+      )
+
+      const actualResponse = await middleware.post!({
         fetch: fetch,
         url: '/v1/full/tracks',
         init: {},
         response: response as Response
       })
+      expect(actualResponse?.ok).toBe(true)
       expect(changeHandler).toBeCalledWith(HEALTHY_NODE)
     })
 
@@ -458,13 +470,24 @@ describe('discoveryNodeSelector', () => {
           return null
         }
       }
+      server.use(
+        rest.get(`${HEALTHY_NODE}/v1/full/tracks`, (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              data: {}
+            })
+          )
+        })
+      )
 
-      await middleware.post!({
+      const actualResponse = await middleware.post!({
         fetch: fetch,
         url: '/v1/full/tracks',
         init: {},
         response: response as Response
       })
+      expect(actualResponse?.ok).toBe(true)
       expect(changeHandler).toBeCalledWith(HEALTHY_NODE)
     })
 

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -198,7 +198,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
             endpoint,
             healthCheckThresholds: this.config.healthCheckThresholds
           })
-          await this.reselectIfNecessary({
+          const newEndpoint = await this.reselectIfNecessary({
             endpoint,
             health,
             reason,
@@ -207,6 +207,13 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
               version: data?.version ?? ''
             }
           })
+          if (newEndpoint && newEndpoint !== endpoint) {
+            // Retry once on new endpoint
+            return await context.fetch(
+              `${newEndpoint}${context.url}`,
+              context.init
+            )
+          }
         }
         return response
       }


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

If we reselect after failing a request, automatically retry the request (once!) with the new discovery node.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Added test to make sure we retry the request

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->