### PR TITLE
Fix comms discovery tests and bump isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,6 @@ repos:
         stages: [push]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/comms/discovery/rpcz/main_test.go
+++ b/comms/discovery/rpcz/main_test.go
@@ -36,6 +36,16 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
+	// create streams
+	_, err = jsc.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:    config.RateLimitRulesBucketName,
+		Replicas:  config.NatsReplicaCount,
+		Placement: config.DiscoveryPlacement(),
+	})
+	if err != nil {
+		log.Fatalf("failed to create rate limit kv %v", err)
+	}
+
 	// setup test validator
 	limiter, err := NewRateLimiter(jsc)
 	if err != nil {


### PR DESCRIPTION
### Description
- Fixes failing `make test` in comms
- Bumps isort version to fix the following errors that prevented me from pushing this commit (more info [here](https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff)):
```
~/workspace/audius-protocol/comms   theo-fix-disc-tests *19 !1 ❯ git commit -S -m "Fix comms discovery tests"
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/theo/.cache/pre-commit/repo0z66_cah/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /Users/theo/.cache/pre-commit/repo0z66_cah
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'

stderr:
      error: subprocess-exited-with-error

      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [17 lines of output]
          Traceback (most recent call last):
            File "/Users/theo/.cache/pre-commit/repo0z66_cah/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/Users/theo/.cache/pre-commit/repo0z66_cah/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/Users/theo/.cache/pre-commit/repo0z66_cah/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/n4/hl0j5wyj0291_rvh5j8w0j7w0000gn/T/pip-build-env-fs0snlbp/overlay/lib/python3.11/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/n4/hl0j5wyj0291_rvh5j8w0j7w0000gn/T/pip-build-env-fs0snlbp/overlay/lib/python3.11/site-packages/poetry/core/factory.py", line 57, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'

          [end of output]

      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed

    × Encountered error while generating package metadata.
    ╰─> See above for output.

    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.

Check the log at /Users/theo/.cache/pre-commit/pre-commit.log
```


### Tests
`make reset && make test` now passes. Previous errors:
```
audius_discprov_env='standalone' test_host='com1' go test ./... -count=1
?   	comms.audius.co	[no test files]
?   	comms.audius.co/discovery	[no test files]
?   	comms.audius.co/discovery/config	[no test files]
?   	comms.audius.co/discovery/db	[no test files]
?   	comms.audius.co/discovery/db/queries	[no test files]
ok  	comms.audius.co/discovery/em	0.290s
?   	comms.audius.co/discovery/misc	[no test files]
ok  	comms.audius.co/discovery/pubkeystore	0.220s
WARN[02-15|15:33:14] audius_delegate_private_key not provided. Using randomly generated private key.
INFO[02-15|15:33:14] config                                   env=standalone wallet=0x22D3c8A377eeA8d7F7817107E78e9D09ab65de45 nkey=UBJGHVXK7URM5EEW2DYNPY6OZA46Y546SXDROG5A6YKWLPGRCVQIIJ4M ip=com1 nats_cluster=comms nu=comms np=c6eaba3a98da65e
INFO[02-15|15:33:14] database dialed                          host=localhost:5454 db=/comtest
2023/02/15 15:33:14 nats: bucket not found
FAIL	comms.audius.co/discovery/rpcz	0.230s
?   	comms.audius.co/discovery/schema	[no test files]
WARN[02-15|15:33:14] audius_delegate_private_key not provided. Using randomly generated private key.
INFO[02-15|15:33:14] config                                   env=standalone wallet=0x531251aBFb791940A4B98AcE3d8F6E7c17270d05 nkey=UBR5HP4OJ364UTIOVZSXXHVHHSVDFKNULK54JVCKMZKBZD24MP5I4JGH ip=com1 nats_cluster=comms nu=comms np=92258dbb1caabb2
INFO[02-15|15:33:14] database dialed                          host=localhost:5454 db=/comtest
2023/02/15 15:33:14 nats: bucket not found
FAIL	comms.audius.co/discovery/server	0.316s
ok  	comms.audius.co/natsd	0.104s
ok  	comms.audius.co/shared/peering	0.138s
?   	comms.audius.co/shared/utils	[no test files]
?   	comms.audius.co/storage	[no test files]
?   	comms.audius.co/storage/config	[no test files]
?   	comms.audius.co/storage/decider	[no test files]
?   	comms.audius.co/storage/monitor	[no test files]
ok  	comms.audius.co/storage/persistence	0.248s
ok  	comms.audius.co/storage/sharder	0.110s
ok  	comms.audius.co/storage/storageserver	0.285s
?   	comms.audius.co/storage/telemetry	[no test files]
ok  	comms.audius.co/storage/transcode	0.440s
FAIL
make: *** [test] Error 1
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A