### PR TITLE
[CON-595] Improve comms/storage config (pt3)

### DIFF
--- a/comms/Makefile
+++ b/comms/Makefile
@@ -1,7 +1,7 @@
 
 dev.discovery::
 	@	audius_discprov_env='standalone' \
-		audius_delegate_private_key='293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238' \
+		AUDIUS_DELEGATE_PRIVATE_KEY='293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238' \
 		audius_db_url='postgresql://postgres:postgres@localhost:5454/audius_discovery?sslmode=disable' \
 		go run main.go discovery
 

--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -18,7 +18,8 @@ import (
 )
 
 func DiscoveryMain() {
-	config.Init()
+	discoveryConfig := config.GetDiscoveryConfig()
+	config.Init(discoveryConfig.Keys)
 
 	// dial datasources in parallel
 	g := errgroup.Group{}
@@ -27,6 +28,7 @@ func DiscoveryMain() {
 	var proc *rpcz.RPCProcessor
 
 	g.Go(func() error {
+		peering := peering.New(nil)
 		err := peering.PollRegisteredNodes()
 		if err != nil {
 			return err

--- a/comms/discovery/em/cid.go
+++ b/comms/discovery/em/cid.go
@@ -6,14 +6,16 @@ import (
 	"net/http"
 
 	"comms.audius.co/discovery/config"
+	sharedConfig "comms.audius.co/shared/config"
 	"comms.audius.co/shared/peering"
 )
 
 type CidFetcher struct {
-	sps []peering.ServiceNode
+	sps []sharedConfig.ServiceNode
 }
 
 func NewCidFetcher() (*CidFetcher, error) {
+	peering := peering.New(nil)
 	sps, err := peering.GetContentNodes()
 	if err != nil {
 		return nil, err

--- a/comms/discovery/rpcz/main_test.go
+++ b/comms/discovery/rpcz/main_test.go
@@ -17,7 +17,8 @@ var (
 
 // this runs before all tests (not a per-test setup / teardown)
 func TestMain(m *testing.M) {
-	config.Init()
+	discoveryConfig := config.GetDiscoveryConfig()
+	config.Init(discoveryConfig.Keys)
 
 	// setup
 	os.Setenv("audius_db_url", "postgresql://postgres:postgres@localhost:5454/comtest?sslmode=disable")

--- a/comms/discovery/server/main_test.go
+++ b/comms/discovery/server/main_test.go
@@ -18,7 +18,8 @@ var (
 
 // this runs before all tests (not a per-test setup / teardown)
 func TestMain(m *testing.M) {
-	config.Init()
+	discoveryConfig := config.GetDiscoveryConfig()
+	config.Init(discoveryConfig.Keys)
 
 	// setup
 	os.Setenv("audius_db_url", "postgresql://postgres:postgres@localhost:5454/comtest?sslmode=disable")

--- a/comms/docker-compose.v2.base.yml
+++ b/comms/docker-compose.v2.base.yml
@@ -1,4 +1,45 @@
 version: '3'
+
+x-common-env: &common-env
+  AUDIUS_DEV_ONLY_REGISTERED_NODES: '
+        [
+          {
+            "id": "content-node::1",
+            "spId": "1",
+            "endpoint": "http://node1",
+            "delegateOwnerWallet": "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F",
+            "type": { "id": "content-node" }
+          },
+          {
+            "id": "content-node::2",
+            "spId": "2",
+            "endpoint": "http://node2",
+            "delegateOwnerWallet": "0x90b8d2655A7C268d0fA31758A714e583AE54489D",
+            "type": { "id": "content-node" }
+          },
+          {
+            "id": "content-node::3",
+            "spId": "3",
+            "endpoint": "http://node3",
+            "delegateOwnerWallet": "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B",
+            "type": { "id": "content-node" }
+          },
+          {
+            "id": "content-node::4",
+            "spId": "4",
+            "endpoint": "http://node4",
+            "delegateOwnerWallet": "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16",
+            "type": { "id": "content-node" }
+          }
+        ]'
+
+x-extra-hosts: &extra-hosts
+  extra_hosts:
+    - "node1:host-gateway"
+    - "node2:host-gateway"
+    - "node3:host-gateway"
+    - "node4:host-gateway"
+
 services:
   comdb:
     container_name: comdb
@@ -10,8 +51,6 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ./discovery/db/docker-initdb:/docker-entrypoint-initdb.d
-    deploy:
-      mode: global
 
   nats:
     build:
@@ -23,6 +62,21 @@ services:
     command:
       - nats
 
+  nats-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.v2
+    image: "comms:v2"
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    command:
+      - nats
+    depends_on:
+      - comdb
+    environment:
+      <<: *common-env
+    <<: *extra-hosts
+
   storage:
     build:
       context: .
@@ -32,6 +86,19 @@ services:
     stop_signal: SIGKILL
     command:
       - storage
+
+  storage-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.v2.dev
+    image: "comms:v2-dev"
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    command:
+      - storage
+    environment:
+      <<: *common-env
+    <<: *extra-hosts
   
   nginx:
     image: openresty/openresty:1.21.4.1-alpine-fat

--- a/comms/docker-compose.v2.dev.yml
+++ b/comms/docker-compose.v2.dev.yml
@@ -1,17 +1,5 @@
 version: '3'
 
-x-common-variables: &shared-vars
-   AUDIUS_DEV_ONLY_REGISTERED_NODES: '
-        [
-          {
-            "id": "content-node::1",
-            "spId": "1",
-            "endpoint": "http://node1",
-            "delegateOwnerWallet": "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F",
-            "type": { "id": "content-node" }
-          }
-        ]'
-
 services:
 
   ingress:
@@ -34,30 +22,20 @@ services:
     container_name: com1
     extends:
       file: docker-compose.v2.base.yml
-      service: nats
+      service: nats-dev
     environment:
       audius_discprov_env: standalone # TODO: remove (keeping for now to make sure the standalone code path is still working)
-      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
+      AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       test_host: "com1"
-      <<: *shared-vars
-    depends_on:
-      - comdb
-    extra_hosts:
-      - "node1:host-gateway"
 
   storage1:
     container_name: storage1
     extends:
       file: docker-compose.v2.base.yml
-      service: storage
-    build:
-      dockerfile: Dockerfile.v2.dev
-    image: "comms:v2-dev"
+      service: storage-dev
     environment:
       audius_discprov_env: standalone # TODO: remove (keeping for now to make sure the standalone code path is still working)
-      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Remove after shared/peering/ config is in place
       AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
-      <<: *shared-vars
       NATS_SERVER_URL: "nats://com1:4222" # TODO: remove when 'standalone' goes away
       NAME: "storage1"
       test_host: "com1"
@@ -65,5 +43,3 @@ services:
       - com1
     volumes:
       - ./:/app
-    extra_hosts:
-      - "node1:host-gateway"

--- a/comms/docker-compose.v2.multi.yml
+++ b/comms/docker-compose.v2.multi.yml
@@ -1,45 +1,4 @@
-version: '3.4'
-
-x-common-variables: &shared-vars
-  AUDIUS_DEV_ONLY_REGISTERED_NODES: '
-        [
-          {
-            "id": "content-node::1",
-            "spId": "1",
-            "endpoint": "http://node1",
-            "delegateOwnerWallet": "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F",
-            "type": { "id": "content-node" }
-          },
-          {
-            "id": "content-node::2",
-            "spId": "2",
-            "endpoint": "http://node2",
-            "delegateOwnerWallet": "0x90b8d2655A7C268d0fA31758A714e583AE54489D",
-            "type": { "id": "content-node" }
-          },
-          {
-            "id": "content-node::3",
-            "spId": "3",
-            "endpoint": "http://node3",
-            "delegateOwnerWallet": "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B",
-            "type": { "id": "content-node" }
-          },
-          {
-            "id": "content-node::4",
-            "spId": "4",
-            "endpoint": "http://node4",
-            "delegateOwnerWallet": "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16",
-            "type": { "id": "content-node" }
-          }
-        ]'
-  audius_db_url: postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable
-
-x-common-variables: &extra-hosts
-  extra_hosts:
-    - "node1:host-gateway"
-    - "node2:host-gateway"
-    - "node3:host-gateway"
-    - "node4:host-gateway"
+version: '3'
 
 services:
 
@@ -63,98 +22,82 @@ services:
     container_name: com1
     extends:
       file: docker-compose.v2.base.yml
-      service: nats
+      service: nats-dev
     environment:
-      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
-      audius_db_url: postgresql://postgres:postgres@comdb:5432/com1?sslmode=disable
+      AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       test_host: "com1"
-      <<: *shared-vars
-    <<: *extra-hosts
 
   storage1:
     container_name: storage1
     extends:
       file: docker-compose.v2.base.yml
-      service: storage
+      service: storage-dev
     environment:
-      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Remove after shared/peering/ config is in place
       AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
-      <<: *shared-vars
       test_host: "com1"
       NAME: "storage1"
-    <<: *extra-hosts
+    depends_on:
+      - com1
 
   com2:
     container_name: com2
     extends:
       file: docker-compose.v2.base.yml
-      service: nats
+      service: nats-dev
     environment:
-      audius_delegate_private_key: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc" # Public key: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
-      audius_db_url: postgresql://postgres:postgres@comdb:5432/com2?sslmode=disable
+      AUDIUS_DELEGATE_PRIVATE_KEY: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc" # Public key: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
       test_host: "com2"
-      <<: *shared-vars
-    <<: *extra-hosts
 
   storage2:
     container_name: storage2
     extends:
       file: docker-compose.v2.base.yml
-      service: storage
+      service: storage-dev
     environment:
-      audius_delegate_private_key: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc" # Remove after shared/peering/ config is in place
       AUDIUS_DELEGATE_PRIVATE_KEY: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc" # Public key: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
-      <<: *shared-vars
       test_host: "com2"
       NAME: "storage2"
-    <<: *extra-hosts
+    depends_on:
+      - com2
 
   com3:
     container_name: com3
     extends:
       file: docker-compose.v2.base.yml
-      service: nats
+      service: nats-dev
     environment:
-      audius_delegate_private_key: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c" # Public key: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
-      audius_db_url: postgresql://postgres:postgres@comdb:5432/com3?sslmode=disable
+      AUDIUS_DELEGATE_PRIVATE_KEY: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c" # Public key: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
       test_host: "com3"
-      <<: *shared-vars
-    <<: *extra-hosts
 
   storage3:
     container_name: storage3
     extends:
       file: docker-compose.v2.base.yml
-      service: storage
+      service: storage-dev
     environment:
-      audius_delegate_private_key: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c" # Remove after shared/peering config is in place
       AUDIUS_DELEGATE_PRIVATE_KEY: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c" # Public key: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
-      <<: *shared-vars
       test_host: "com3"
       NAME: "storage3"
-    <<: *extra-hosts
+    depends_on:
+      - com3
 
   com4:
     container_name: com4
     extends:
       file: docker-compose.v2.base.yml
-      service: nats
+      service: nats-dev
     environment:
-      audius_delegate_private_key: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb" # Public key: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
-      audius_db_url: postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable
+      AUDIUS_DELEGATE_PRIVATE_KEY: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb" # Public key: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
       test_host: "com4"
-      <<: *shared-vars
-    <<: *extra-hosts
 
   storage4:
     container_name: storage4
     extends:
       file: docker-compose.v2.base.yml
-      service: storage
+      service: storage-dev
     environment:
-      audius_delegate_private_key: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb" # Remove after shared/peering config is in place
       AUDIUS_DELEGATE_PRIVATE_KEY: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb" # Public key: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
-      <<: *shared-vars
       test_host: "com4"
       NAME: "storage4"
-    <<: *extra-hosts
+    depends_on:
+      - com4

--- a/comms/docker-compose.yml
+++ b/comms/docker-compose.yml
@@ -22,8 +22,7 @@ services:
     environment:
       audius_discprov_env: test
       test_host: com1
-      # audius_delegate_owner_wallet: '0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F'
-      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238"
+      AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       audius_db_url: "postgresql://postgres:postgres@comdb:5432/com1?sslmode=disable"
       audius_comms_cluster: "true"
       # audius_comms_replica_count: 3 # could be a future dynamic replica config count thing
@@ -45,8 +44,7 @@ services:
     environment:
       audius_discprov_env: test
       test_host: com2
-      # audius_delegate_owner_wallet: '0x90b8d2655A7C268d0fA31758A714e583AE54489D'
-      audius_delegate_private_key: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc"
+      AUDIUS_DELEGATE_PRIVATE_KEY: "1ca1082d2304d96c2e6a3e551226e72e2cb54fddfe69b946b0efc2d9b43c19fc" # Public key: "0x90b8d2655A7C268d0fA31758A714e583AE54489D"
       audius_db_url: "postgresql://postgres:postgres@comdb:5432/com2?sslmode=disable"
       audius_comms_cluster: "true"
     depends_on:
@@ -62,8 +60,7 @@ services:
     environment:
       audius_discprov_env: test
       test_host: com3
-      # audius_delegate_owner_wallet: '0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B'
-      audius_delegate_private_key: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c"
+      AUDIUS_DELEGATE_PRIVATE_KEY: "12712efcf90774399e272f8fc89ef264058b4cdd7f7f86956052050cbfb4350c" # Public key: "0xb7b9599EeB2FD9237C94cFf02d74368Bb2df959B"
       audius_db_url: "postgresql://postgres:postgres@comdb:5432/com3?sslmode=disable"
       audius_comms_cluster: "true"
     depends_on:
@@ -79,7 +76,7 @@ services:
     environment:
       audius_discprov_env: test
       test_host: com4
-      audius_delegate_private_key: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb"
+      AUDIUS_DELEGATE_PRIVATE_KEY: "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb" # Public key: "0xfa4f42633Cb0c72Aa35D3D1A3566abb7142c7b16"
       audius_db_url: "postgresql://postgres:postgres@comdb:5432/com4?sslmode=disable"
       audius_comms_cluster: "true"
     depends_on:

--- a/comms/natsd/config/config.go
+++ b/comms/natsd/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	sharedConfig "comms.audius.co/shared/config"
+)
+
+type NatsConfig struct {
+	Keys sharedConfig.KeysConfigDecoder `envconfig:"DELEGATE_PRIVATE_KEY" required:"true" json:"Keys"`
+}
+
+var natsConfig *NatsConfig
+
+// GetDiscoveryConfig returns the discovery config by parsing env vars.
+func GetNatsConfig() *NatsConfig {
+	if natsConfig == nil {
+		natsConfig = &NatsConfig{}
+		sharedConfig.EnsurePrivKeyAndLoadConf(natsConfig)
+	}
+	return natsConfig
+}

--- a/comms/shared/config/config.go
+++ b/comms/shared/config/config.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/nats-io/nkeys"
+)
+
+const Prefix = "AUDIUS"
+
+// TODO: Doesn't really belong in config, but it can't be in peering because of import cycles
+type ServiceNode struct {
+	ID                  string `json:"id"`
+	SPID                string `json:"spID"`
+	Endpoint            string `json:"endpoint"`
+	DelegateOwnerWallet string `json:"delegateOwnerWallet"`
+	Type                struct {
+		ID string `json:"id"`
+	} `json:"type"`
+}
+
+type ServiceNodesDecoder []ServiceNode
+
+type KeysConfig struct {
+	DelegatePrivateKey *ecdsa.PrivateKey `envconfig:"DELEGATE_PRIVATE_KEY" required:"true" json:"-"`
+
+	// Fields derived from DelegatePrivateKey
+	DelegatePublicKey string        `envconfig:"DELEGATE_PRIVATE_KEY" json:"DelegatePublicKey"`
+	NkeyPair          nkeys.KeyPair `envconfig:"DELEGATE_PRIVATE_KEY" json:"-"`
+	NkeyPublic        string        `envconfig:"DELEGATE_PRIVATE_KEY" json:"NkeyPublic"`
+}
+type KeysConfigDecoder KeysConfig
+
+// EnsurePrivKeyAndLoadConf ensures the private key env var is set and loads a config struct from env vars.
+func EnsurePrivKeyAndLoadConf[T any](config *T) {
+	EnsurePrivateKeyIsSet()
+	if err := envconfig.Process(Prefix, config); err != nil {
+		log.Fatalf("failed to load %T: %v", *config, err.Error())
+	}
+	configBytes, _ := json.MarshalIndent(config, "", "\t")
+	log.Printf("Parsed %T: %s", *config, string(configBytes))
+}
+
+// EnsurePrivateKeyIsSet ensures there's a value for the env var `AUDIUS_DELEGATE_PRIVATE_KEY` by first falling back to `delegatePrivateKey` and then generating a random private key if neither is set.
+func EnsurePrivateKeyIsSet() {
+	// Ensure private key env var is set by checking deprecated env var or generating random private key
+	if os.Getenv("AUDIUS_DELEGATE_PRIVATE_KEY") == "" {
+		if os.Getenv("delegatePrivateKey") == "" {
+			log.Print("WARN: Missing 'AUDIUS_DELEGATE_PRIVATE_KEY' and deprecated fallback delegatePrivateKey env vars. Generating random private key.")
+			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", generatePrivateKeyHex())
+		} else {
+			log.Print("WARN: Using DEPRECATED 'delegatePrivateKey' env var. Please set 'AUDIUS_DELEGATE_PRIVATE_KEY' env var to the same value.")
+			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", os.Getenv("delegatePrivateKey"))
+		}
+	}
+}
+
+func generatePrivateKeyHex() string {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+	privateKeyBytes := crypto.FromECDSA(privateKey)
+	return hex.EncodeToString(privateKeyBytes)
+}
+
+func (snd *ServiceNodesDecoder) Decode(value string) error {
+	var nodes []ServiceNode
+	err := json.Unmarshal([]byte(value), &nodes)
+	if err != nil {
+		return fmt.Errorf("failed to decode service nodes: %v", err)
+	}
+	*snd = ServiceNodesDecoder(nodes)
+	return nil
+}
+
+func (kcd *KeysConfigDecoder) Decode(value string) error {
+	privateBytes, err := hex.DecodeString(value)
+	if err != nil {
+		return fmt.Errorf("AUDIUS_DELEGATE_PRIVATE_KEY: failed to decode: %v", err)
+	}
+
+	privateKey, err := crypto.ToECDSA(privateBytes)
+	if err != nil {
+		return fmt.Errorf("fAUDIUS_DELEGATE_PRIVATE_KEY: failed to convert private key to ecdsa: %v", err)
+	}
+
+	nKeyPair, err := nkeys.FromRawSeed(nkeys.PrefixByteUser, privateBytes)
+	if err != nil {
+		return fmt.Errorf("AUDIUS_DELEGATE_PRIVATE_KEY: invalid nkey: %v", err)
+	}
+
+	nKeyPublic, err := nKeyPair.PublicKey()
+	if err != nil {
+		return fmt.Errorf("AUDIUS_DELEGATE_PRIVATE_KEY: invalid nkey: %v", err)
+	}
+
+	*kcd = KeysConfigDecoder(KeysConfig{
+		DelegatePrivateKey: privateKey,
+		DelegatePublicKey:  crypto.PubkeyToAddress(privateKey.PublicKey).Hex(),
+		NkeyPair:           nKeyPair,
+		NkeyPublic:         nKeyPublic,
+	})
+	return nil
+}

--- a/comms/shared/peering/exchange_endpoint.go
+++ b/comms/shared/peering/exchange_endpoint.go
@@ -11,8 +11,8 @@ import (
 // that's not "on chain"
 // after validating request came from a registered peer
 // this server should respond with connection info
-func ExchangeEndpoint(c echo.Context) error {
-	registeredNodes, err := AllNodes()
+func (p *Peering) ExchangeEndpoint(c echo.Context) error {
+	registeredNodes, err := p.AllNodes()
 	if err != nil {
 		return err
 	}

--- a/comms/shared/peering/info_test.go
+++ b/comms/shared/peering/info_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestInfo(t *testing.T) {
 	os.Setenv("test_host", "1.2.3.4")
-	os.Setenv("audius_delegate_private_key", "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238")
+	os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238")
 
-	config.Init()
+	discoveryConfig := config.GetDiscoveryConfig()
+	config.Init(discoveryConfig.Keys)
 	info, err := MyInfo()
 	assert.NoError(t, err)
 	assert.Equal(t, "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F", info.Address)

--- a/comms/shared/peering/nats_connection.go
+++ b/comms/shared/peering/nats_connection.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-func DialJetstream(peerMap map[string]*Info) (nats.JetStreamContext, error) {
+func (p *Peering) DialJetstream(peerMap map[string]*Info) (nats.JetStreamContext, error) {
 	natsUrl := config.GetEnvDefault("NATS_SERVER_URL", nats.DefaultURL)
 
 	if len(peerMap) != 0 {

--- a/comms/shared/peering/peering.go
+++ b/comms/shared/peering/peering.go
@@ -1,7 +1,13 @@
 package peering
 
-var registeredNodesOverride []ServiceNode
+import sharedConfig "comms.audius.co/shared/config"
 
-func New(registeredNodes []ServiceNode) {
-	registeredNodesOverride = registeredNodes
+type Peering struct {
+	registeredNodesOverride []sharedConfig.ServiceNode
+}
+
+func New(registeredNodes []sharedConfig.ServiceNode) *Peering {
+	return &Peering{
+		registeredNodesOverride: registeredNodes,
+	}
 }

--- a/comms/shared/peering/solicit.go
+++ b/comms/shared/peering/solicit.go
@@ -21,11 +21,11 @@ var (
 	peerMap = map[string]*Info{}
 )
 
-func Solicit() map[string]*Info {
+func (p *Peering) Solicit() map[string]*Info {
 
 	config.Logger.Info("solicit begin")
 
-	sps, err := AllNodes()
+	sps, err := p.AllNodes()
 	if err != nil {
 		config.Logger.Error("solicit failed: " + err.Error())
 		return peerMap
@@ -38,7 +38,7 @@ func Solicit() map[string]*Info {
 		wg.Add(1)
 		go func() {
 			u := sp.Endpoint + "/nats/exchange"
-			info, err := solicitServer(u)
+			info, err := p.solicitServer(u)
 			if err != nil {
 				// config.Logger.Debug("get info failed", "endpoint", u, "err", err)
 			} else {
@@ -71,7 +71,7 @@ func addPeer(info *Info) {
 	}
 }
 
-func ListPeers() []Info {
+func (p *Peering) ListPeers() []Info {
 	mu.Lock()
 	defer mu.Unlock()
 	peers := make([]Info, 0, len(peerMap))
@@ -84,7 +84,7 @@ func ListPeers() []Info {
 	return peers
 }
 
-func solicitServer(endpoint string) (*Info, error) {
+func (p *Peering) solicitServer(endpoint string) (*Info, error) {
 
 	// sign request
 	myInfo, err := MyInfo()
@@ -92,7 +92,7 @@ func solicitServer(endpoint string) (*Info, error) {
 		return nil, err
 	}
 
-	resp, err := PostSignedJSON(endpoint, myInfo)
+	resp, err := p.PostSignedJSON(endpoint, myInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func solicitServer(endpoint string) (*Info, error) {
 	return info, nil
 }
 
-func PostSignedJSON(endpoint string, obj interface{}) (*http.Response, error) {
+func (p *Peering) PostSignedJSON(endpoint string, obj interface{}) (*http.Response, error) {
 	payload, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err

--- a/comms/shared/peering/sps_test.go
+++ b/comms/shared/peering/sps_test.go
@@ -3,6 +3,8 @@ package peering
 import (
 	"fmt"
 	"testing"
+
+	sharedConfig "comms.audius.co/shared/config"
 )
 
 func TestPeers(t *testing.T) {
@@ -17,7 +19,7 @@ func TestPeers(t *testing.T) {
 
 	output := struct {
 		Data struct {
-			ServiceNodes []ServiceNode
+			ServiceNodes []sharedConfig.ServiceNode
 		}
 	}{}
 

--- a/comms/storage/config/config.go
+++ b/comms/storage/config/config.go
@@ -2,30 +2,13 @@
 package config
 
 import (
-	"crypto/ecdsa"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"log"
-	"os"
-
-	"comms.audius.co/shared/peering"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/kelseyhightower/envconfig"
+	shared "comms.audius.co/shared/config"
 )
 
-type PrivateKeyDecoder ecdsa.PrivateKey
-type PublicKeyDecoder PublicKey
-type PublicKey struct {
-	Hex string
-}
-type ServiceNodesDecoder []peering.ServiceNode
-
 type StorageConfig struct {
-	DelegatePrivateKey     PrivateKeyDecoder   `envconfig:"delegate_private_key" required:"true"`
-	DelegatePublicKey      PublicKeyDecoder    `envconfig:"delegate_private_key"` // Derives public key from private key
-	StorageDriverUrl       string              `envconfig:"storage_driver_url" default:"file:///tmp/audius_storage"`
-	DevOnlyRegisteredNodes ServiceNodesDecoder `envconfig:"dev_only_registered_nodes"`
+	Keys                   shared.KeysConfigDecoder   `envconfig:"DELEGATE_PRIVATE_KEY" required:"true" json:"Keys"`
+	StorageDriverUrl       string                     `envconfig:"STORAGE_DRIVER_URL" default:"file:///tmp/audius_storage" json:"StorageDriverUrl"`
+	DevOnlyRegisteredNodes shared.ServiceNodesDecoder `envconfig:"DEV_ONLY_REGISTERED_NODES" json:"DevOnlyRegisteredNodes"`
 }
 
 var storageConfig *StorageConfig
@@ -33,76 +16,8 @@ var storageConfig *StorageConfig
 // GetStorageConfig returns the storage config by parsing env vars.
 func GetStorageConfig() *StorageConfig {
 	if storageConfig == nil {
-		convertLegacyEnvVars()
-		var newStorageConfig StorageConfig
-		err := envconfig.Process("audius", &newStorageConfig)
-		if err != nil {
-			log.Fatal("failed to load storage config: ", err.Error())
-		}
-		storageConfig = &newStorageConfig
-		log.Printf(
-			"Parsed StorageConfig:\nDelegatePrivateKey: [hidden]\nDelegatePublicKey: %v\nStorageDriverUrl: %v\nDevOnlyRegisteredNodes: %v\n",
-			storageConfig.DelegatePublicKey,
-			storageConfig.StorageDriverUrl,
-			storageConfig.DevOnlyRegisteredNodes,
-		)
+		storageConfig = &StorageConfig{}
+		shared.EnsurePrivKeyAndLoadConf(storageConfig)
 	}
 	return storageConfig
-}
-
-// convertLegacyEnvVars handles all the ugly logic of ensuring all env vars are set correctly.
-func convertLegacyEnvVars() {
-	// Ensure private key env var is set by checking deprecated env var or generating random private key
-	if os.Getenv("AUDIUS_DELEGATE_PRIVATE_KEY") == "" {
-		if os.Getenv("delegatePrivateKey") == "" {
-			log.Print("WARN: Missing 'AUDIUS_DELEGATE_PRIVATE_KEY' and deprecated fallback delegatePrivateKey env vars. Generating random private key.")
-			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", generatePrivateKeyHex())
-		} else {
-			log.Print("WARN: Using DEPRECATED 'delegatePrivateKey' env var. Please set 'AUDIUS_DELEGATE_PRIVATE_KEY' env var to the same value.")
-			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", os.Getenv("delegatePrivateKey"))
-		}
-	}
-}
-
-func (pkd *PrivateKeyDecoder) Decode(value string) error {
-	privateBytes, err := hex.DecodeString(value)
-	if err != nil {
-		return fmt.Errorf("failed to decode private key: %v", err)
-	}
-	privateKey, err := crypto.ToECDSA(privateBytes)
-	if err != nil {
-		return fmt.Errorf("failed to convert private key to ecdsa: %v", err)
-	}
-	*pkd = PrivateKeyDecoder(*privateKey)
-	return nil
-}
-
-func (pkd *PublicKeyDecoder) Decode(value string) error {
-	var privateKey PrivateKeyDecoder
-	err := privateKey.Decode(value)
-	if err != nil {
-		return err
-	}
-	publicKeyHex := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
-	*pkd = PublicKeyDecoder(PublicKey{Hex: publicKeyHex})
-	return nil
-}
-
-func (snd *ServiceNodesDecoder) Decode(value string) error {
-	var nodes []peering.ServiceNode
-	err := json.Unmarshal([]byte(value), &nodes)
-	if err != nil {
-		return fmt.Errorf("failed to decode service nodes: %v", err)
-	}
-	*snd = ServiceNodesDecoder(nodes)
-	return nil
-}
-
-func generatePrivateKeyHex() string {
-	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		log.Fatal(err)
-	}
-	privateKeyBytes := crypto.FromECDSA(privateKey)
-	return hex.EncodeToString(privateKeyBytes)
 }

--- a/comms/storage/storage_main.go
+++ b/comms/storage/storage_main.go
@@ -18,12 +18,11 @@ import (
 )
 
 func StorageMain() {
+	storageConfig := config.GetStorageConfig()
 
 	// TODO: We need to change a bunch of stuff in shared/peering/ before we can remove this.
 	//       Make each config usage in shared/peering take the needed arguments instead of the whole config.
-	discoveryConfig.Init()
-
-	storageConfig := config.GetStorageConfig()
+	discoveryConfig.Init(storageConfig.Keys)
 
 	ctx := context.Background()
 
@@ -31,8 +30,8 @@ func StorageMain() {
 	tp := telemetry.InitTracing(logger)
 	defer func() { _ = tp.Shutdown(ctx) }()
 
+	peering := peering.New(storageConfig.DevOnlyRegisteredNodes)
 	jsc, err := func() (nats.JetStreamContext, error) {
-		peering.New(storageConfig.DevOnlyRegisteredNodes)
 		err := peering.PollRegisteredNodes()
 		if err != nil {
 			return nil, err
@@ -45,7 +44,11 @@ func StorageMain() {
 		log.Fatal(err)
 	}
 
-	ss := storageserver.NewProd(storageConfig, jsc)
+	allNodes, err := peering.GetContentNodes()
+	if err != nil {
+		log.Fatal("Error getting all nodes: ", err)
+	}
+	ss := storageserver.NewProd(storageConfig, jsc, allNodes)
 
 	// Start server
 	go func() {

--- a/comms/storage/storageserver/storageserver.go
+++ b/comms/storage/storageserver/storageserver.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"comms.audius.co/shared/peering"
+	sharedConfig "comms.audius.co/shared/config"
 	"comms.audius.co/storage/config"
 	"comms.audius.co/storage/decider"
 	"comms.audius.co/storage/monitor"
@@ -40,12 +40,8 @@ type StorageServer struct {
 	Monitor        *monitor.Monitor
 }
 
-func NewProd(config *config.StorageConfig, jsc nats.JetStreamContext) *StorageServer {
-	thisNodePubKey := config.DelegatePublicKey.Hex
-	allNodes, err := peering.GetContentNodes()
-	if err != nil {
-		log.Fatal("Error getting all nodes: ", err)
-	}
+func NewProd(config *config.StorageConfig, jsc nats.JetStreamContext, allNodes []sharedConfig.ServiceNode) *StorageServer {
+	thisNodePubKey := config.Keys.DelegatePublicKey
 	var host string
 	var allStorageNodePubKeys []string
 	for _, node := range allNodes {

--- a/comms/storage/storageserver/storageserver_test.go
+++ b/comms/storage/storageserver/storageserver_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	sharedConfig "comms.audius.co/shared/config"
 	"comms.audius.co/storage/config"
 	"comms.audius.co/storage/transcode"
 	"github.com/labstack/echo/v4"
@@ -139,7 +140,7 @@ func startNatsCluster(t *testing.T) [5]*testServer {
 		case 3:
 			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb")
 		}
-		ss := NewProd(config.GetStorageConfig(), jsc)
+		ss := NewProd(config.GetStorageConfig(), jsc, []sharedConfig.ServiceNode{}) // TODO: Pass all nodes
 		go ss.WebServer.Start(fmt.Sprintf("127.0.0.1:%d", 1222+i+5))
 		nodes[i].ss = ss
 	}


### PR DESCRIPTION
### Description
Part 3 of comms/storage v2 config (this one is a large enough change and works - there will be a final part 4).
- Adds envconfig struct to discovery and natsd, and extracts duplicated key derivation to shared config
  - Discovery's `config.Init()` now accepts a new `KeysConfig` struct that Discovery, Nats, and Storage all have as part of their own configs
- Adds default data to Docker .base file to reduce repetition in .dev and .multi files
- Changes peering to struct that takes top-level params to set up for future work to use more params instead of calling discovery config throughout
- Removes remaining usages of `audius_delegate_private_key` env var in favor of `AUDIUS_DELEGATE_PRIVATE_KEY`
- Nit: Makes env var comments uppercase since the envconfig package transforms everything to uppercase



### Tests
- `make storage.dev` and `make storage.multi`
- `make reset && make test`
- `make reset && make dev.discovery` (looks healthy to me but could use an extra check for verifying actual usage if something looks risky to you @stereosteve)


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
These are mostly top-level config changes that should fail-fast, so make sure comms and storage v2 are able to start up after deploying to staging.