### PR TITLE
[CON-572] add content-type checking in server

### DIFF
--- a/comms/storage/storageserver/storageserver.go
+++ b/comms/storage/storageserver/storageserver.go
@@ -174,7 +174,21 @@ func (ss *StorageServer) serveFileUpload(c echo.Context) error {
 	files := form.File["files"]
 	defer form.RemoveAll()
 
+	var expectedContentType string
+	if template == "audio" {
+		expectedContentType = "audio"
+	} else {
+		expectedContentType = "image"
+	}
+
 	for _, file := range files {
+
+		contentType := file.Header.Get("Content-Type")
+		if !strings.HasPrefix(contentType, expectedContentType) {
+			// return fmt.Errorf("unexpected content type, expected=%s", expectedContentType)
+			return echo.NewHTTPError(400, "invalid Content-Type, expected=" + expectedContentType)
+		}
+
 		job, err := ss.JobsManager.Add(transcode.JobTemplate(template), file)
 		if err != nil {
 			return err

--- a/comms/storage/storageserver/storageserver.go
+++ b/comms/storage/storageserver/storageserver.go
@@ -185,7 +185,6 @@ func (ss *StorageServer) serveFileUpload(c echo.Context) error {
 
 		contentType := file.Header.Get("Content-Type")
 		if !strings.HasPrefix(contentType, expectedContentType) {
-			// return fmt.Errorf("unexpected content type, expected=%s", expectedContentType)
 			return echo.NewHTTPError(400, "invalid Content-Type, expected=" + expectedContentType)
 		}
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR adds content-type checking on the storageserver

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested locally by disabling content-type checking on the client and sending incorrect files to the server

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->