### PR TITLE
POST to /mutate doesn't return till apply is complete

### DIFF
--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -42,18 +42,8 @@ func DiscoveryMain() {
 			return err
 		}
 
-		// create streams
-		err = createJetstreamStreams(jsc)
-		if err != nil {
-			return err
-		}
-
+		// create RPC processor
 		proc, err = rpcz.NewProcessor(jsc)
-		if err != nil {
-			return err
-		}
-
-		err = createConsumer(jsc, proc)
 		if err != nil {
 			return err
 		}
@@ -86,66 +76,4 @@ func DiscoveryMain() {
 
 	e := server.NewServer(jsc, proc)
 	e.Logger.Fatal(e.Start(":8925"))
-}
-
-func createJetstreamStreams(jsc nats.JetStreamContext) error {
-
-	streamInfo, err := jsc.AddStream(&nats.StreamConfig{
-		Name:     config.GlobalStreamName,
-		Subjects: []string{config.GlobalStreamSubject},
-		Replicas: config.NatsReplicaCount,
-		// DenyDelete: true,
-		// DenyPurge:  true,
-		Placement: config.DiscoveryPlacement(),
-	})
-	if err != nil {
-		return err
-	}
-
-	config.Logger.Info("create stream", "strm", streamInfo)
-
-	// create kv buckets
-	_, err = jsc.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:    config.PubkeystoreBucketName,
-		Replicas:  config.NatsReplicaCount,
-		Placement: config.DiscoveryPlacement(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create pubkey kv %v", err)
-	}
-
-	_, err = jsc.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:    config.RateLimitRulesBucketName,
-		Replicas:  config.NatsReplicaCount,
-		Placement: config.DiscoveryPlacement(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create rate limit kv %v", err)
-	}
-
-	return nil
-}
-
-func createConsumer(jsc nats.JetStreamContext, proc *rpcz.RPCProcessor) error {
-
-	// ------------------------------------------------------------------------------
-	// TEMP: Subscribe to the subject for the demo
-	// this is the "processor" for DM messages... which just inserts them into comm log table for now
-	// it assumes that nats message has the signature header
-	// but this is not the case for identity relay messages, for instance, which should have their own consumer
-	// also, should be a pull consumer with explicit ack.
-	// matrix-org/dendrite codebase has some nice examples to follow...
-
-	sub, err := jsc.Subscribe(config.GlobalStreamSubject, proc.Apply, nats.Durable(config.WalletAddress))
-	if err != nil {
-		config.Logger.Error(err.Error())
-		return err
-	}
-
-	info, err := sub.ConsumerInfo()
-
-	if err == nil {
-		config.Logger.Info("create subscription", "sub", info)
-	}
-	return nil
 }

--- a/comms/discovery/pubkeystore/recover.go
+++ b/comms/discovery/pubkeystore/recover.go
@@ -32,6 +32,16 @@ func Dial(jetstreamContext nats.JetStreamContext) error {
 
 	jsc = jetstreamContext
 
+	// create kv buckets
+	_, err = jsc.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:    config.PubkeystoreBucketName,
+		Replicas:  config.NatsReplicaCount,
+		Placement: config.DiscoveryPlacement(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create pubkey kv %v", err)
+	}
+
 	endpoint := "https://poa-gateway.audius.co"
 
 	if config.IsStaging {

--- a/comms/discovery/rpcz/main_test.go
+++ b/comms/discovery/rpcz/main_test.go
@@ -37,16 +37,6 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	// create streams
-	_, err = jsc.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:    config.RateLimitRulesBucketName,
-		Replicas:  config.NatsReplicaCount,
-		Placement: config.DiscoveryPlacement(),
-	})
-	if err != nil {
-		log.Fatalf("failed to create rate limit kv %v", err)
-	}
-
 	// setup test validator
 	limiter, err := NewRateLimiter(jsc)
 	if err != nil {

--- a/comms/discovery/rpcz/rate_limit.go
+++ b/comms/discovery/rpcz/rate_limit.go
@@ -1,6 +1,7 @@
 package rpcz
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -11,9 +12,13 @@ import (
 func NewRateLimiter(jsc nats.JetStreamContext) (*RateLimiter, error) {
 
 	// kv
-	kv, err := jsc.KeyValue(config.RateLimitRulesBucketName)
+	kv, err := jsc.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:    config.RateLimitRulesBucketName,
+		Replicas:  config.NatsReplicaCount,
+		Placement: config.DiscoveryPlacement(),
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create rate limit kv %v", err)
 	}
 
 	watcher, err := kv.WatchAll()

--- a/comms/discovery/server/main_test.go
+++ b/comms/discovery/server/main_test.go
@@ -8,18 +8,20 @@ import (
 	"comms.audius.co/discovery/config"
 	"comms.audius.co/discovery/db"
 	"comms.audius.co/discovery/rpcz"
-	"github.com/labstack/echo/v4"
 	"github.com/nats-io/nats.go"
 )
 
 var (
-	testServer *echo.Echo
+	testServer *ChatServer
 )
 
 // this runs before all tests (not a per-test setup / teardown)
 func TestMain(m *testing.M) {
 	discoveryConfig := config.GetDiscoveryConfig()
 	config.Init(discoveryConfig.Keys)
+
+	// todo: config week
+	config.NatsReplicaCount = 1
 
 	// setup
 	os.Setenv("audius_db_url", "postgresql://postgres:postgres@localhost:5454/comtest?sslmode=disable")

--- a/comms/discovery/server/mutate_test.go
+++ b/comms/discovery/server/mutate_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"comms.audius.co/discovery/config"
+	"comms.audius.co/discovery/db"
+	"comms.audius.co/discovery/misc"
+	"comms.audius.co/discovery/schema"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMutateEndpoint(t *testing.T) {
+	// Generate user keys
+	privateKey1, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+	wallet1 := crypto.PubkeyToAddress(privateKey1.PublicKey).Hex()
+
+	privateKey2, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+	wallet2 := crypto.PubkeyToAddress(privateKey2.PublicKey).Hex()
+
+	// seed db
+	tx := db.Conn.MustBegin()
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	user1Id := seededRand.Int31()
+	user2Id := seededRand.Int31()
+	user1IdEncoded, _ := misc.EncodeHashId(int(user1Id))
+	user2IdEncoded, _ := misc.EncodeHashId(int(user2Id))
+
+	// Create 2 users
+	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true)", user1Id, wallet1, user2Id, wallet2)
+	assert.NoError(t, err)
+
+	err = tx.Commit()
+	assert.NoError(t, err)
+
+	// Prepare RPC
+	rawParams, _ := json.Marshal(schema.ChatCreateRPCParams{
+		ChatID: "asdf",
+		Invites: []schema.PurpleInvite{
+			{
+				InviteCode: "code1",
+				UserID:     user1IdEncoded,
+			},
+			{
+				InviteCode: "code2",
+				UserID:     user2IdEncoded,
+			},
+		},
+	})
+	rpc := schema.RawRPC{
+		Method:    string(schema.RPCMethodChatCreate),
+		Params:    rawParams,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	payload, _ := json.Marshal(rpc)
+	sigBase64 := signPayload(t, payload, privateKey1)
+
+	req, err := http.NewRequest(http.MethodPost, "/comms/mutate", bytes.NewReader(payload))
+	assert.NoError(t, err)
+	req.Header.Set(config.SigHeader, sigBase64)
+
+	// simulate request
+	rec := httptest.NewRecorder()
+	c := testServer.NewContext(req, rec)
+	assert.NoError(t, testServer.mutate(c))
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, 200, res.StatusCode)
+	body, _ := io.ReadAll(res.Body)
+	fmt.Println(string(body))
+
+}

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -190,7 +190,7 @@ func TestGetChats(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		if assert.NoError(t, getChats(c)) {
+		if assert.NoError(t, testServer.getChats(c)) {
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.JSONEq(t, string(expectedResponse), rec.Body.String())
 		}
@@ -240,7 +240,7 @@ func TestGetChats(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		if assert.NoError(t, getChats(c)) {
+		if assert.NoError(t, testServer.getChats(c)) {
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.JSONEq(t, string(expectedResponse), rec.Body.String())
 		}
@@ -276,7 +276,7 @@ func TestGetChats(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		if assert.NoError(t, getChat(c)) {
+		if assert.NoError(t, testServer.getChat(c)) {
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.JSONEq(t, string(expectedResponse), rec.Body.String())
 		}
@@ -295,12 +295,7 @@ func TestGetMessages(t *testing.T) {
 	assert.NoError(t, err)
 	wallet2 := crypto.PubkeyToAddress(privateKey2.PublicKey).Hex()
 
-	// Set up db
-	_, err = db.Conn.Exec("truncate table chat cascade")
-	assert.NoError(t, err)
-	_, err = db.Conn.Exec("truncate table users cascade")
-	assert.NoError(t, err)
-
+	// seed db
 	tx := db.Conn.MustBegin()
 
 	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -417,7 +412,7 @@ func TestGetMessages(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		if assert.NoError(t, getMessages(c)) {
+		if assert.NoError(t, testServer.getMessages(c)) {
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.JSONEq(t, string(expectedResponse), rec.Body.String())
 		}
@@ -470,7 +465,7 @@ func TestGetMessages(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		if assert.NoError(t, getMessages(c)) {
+		if assert.NoError(t, testServer.getMessages(c)) {
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.JSONEq(t, string(expectedResponse), rec.Body.String())
 		}


### PR DESCRIPTION
### Description

POST to `/comms/mutate` will block until processor has processed rpc message.

Will 500 if there is an error in apply or if times out (10s).

Did some refactors to make it easier to test:

* Structs like `RPCProcessor`, `RateLimiter` will create their own streams + consumers in constructor... so we don't have to worry about creating them elsewhere.  Altho we should pass in more config to ensure streams + consumers are created correctly.
* struct for `ChatServer` that holds echo server... routes are methods on `ChatServer`

