### PR TITLE
Stream seq is the correct one to use.

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -313,7 +313,7 @@ func (proc *RPCProcessor) Apply(msg *nats.Msg) {
 
 	// notify any waiters of apply result
 	proc.Lock()
-	if waiter, ok := proc.waiters[meta.Sequence.Consumer]; ok {
+	if waiter, ok := proc.waiters[meta.Sequence.Stream]; ok {
 		waiter <- err
 	}
 	proc.Unlock()


### PR DESCRIPTION
Consumer seq can contain extra events:
https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/consumers
