### PR TITLE
Filter chats with no messages in /chats response

### DIFF
--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -56,6 +56,7 @@ SELECT
 FROM chat_member
 JOIN chat ON chat.chat_id = chat_member.chat_id
 WHERE chat_member.user_id = $1
+  AND chat.last_message IS NOT NULL
 	AND chat.last_message_at < $3
 	AND chat.last_message_at > $4
   AND (chat_member.cleared_history_at IS NULL

--- a/comms/discovery/db/queries/get_summaries.go
+++ b/comms/discovery/db/queries/get_summaries.go
@@ -51,6 +51,7 @@ WITH user_chats AS (
   FROM chat_member
   JOIN chat ON chat.chat_id = chat_member.chat_id
   WHERE chat_member.user_id = $1
+	  AND chat.last_message IS NOT NULL
 	  AND (chat_member.cleared_history_at IS NULL
 		  OR chat.last_message_at > chat_member.cleared_history_at)
 )

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -67,6 +67,10 @@ func TestGetChats(t *testing.T) {
 	assert.NoError(t, err)
 	wallet3 := crypto.PubkeyToAddress(privateKey3.PublicKey).Hex()
 
+	privateKey4, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+	wallet4 := crypto.PubkeyToAddress(privateKey4.PublicKey).Hex()
+
 	// Set up db
 	_, err = db.Conn.Exec("truncate table chat cascade")
 	assert.NoError(t, err)
@@ -79,33 +83,45 @@ func TestGetChats(t *testing.T) {
 	user1Id := seededRand.Int31()
 	user2Id := seededRand.Int31()
 	user3Id := seededRand.Int31()
+	user4Id := seededRand.Int31()
 
-	// Create 3 users
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true), ($5, lower($6), true)", user1Id, wallet1, user2Id, wallet2, user3Id, wallet3)
+	// Create 4 users
+	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true), ($5, lower($6), true), ($7, lower($8), true)", user1Id, wallet1, user2Id, wallet2, user3Id, wallet3, user4Id, wallet4)
 	assert.NoError(t, err)
 
-	// Create 2 chats
+	// Create 3 chats
 	chatId1 := strconv.Itoa(seededRand.Int())
 	chatId2 := strconv.Itoa(seededRand.Int())
+	chatId3 := strconv.Itoa(seededRand.Int())
 	chat1CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(60))
 	chat2CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(30))
-	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2), ($3, $4, $4)", chatId1, chat1CreatedAt, chatId2, chat2CreatedAt)
+	chat3CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(30))
+	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2), ($3, $4, $4), ($5, $6, $6)", chatId1, chat1CreatedAt, chatId2, chat2CreatedAt, chatId3, chat3CreatedAt)
 	assert.NoError(t, err)
 
-	// Insert members into chats (1 and 2, 1 and 3)
-	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3), ($4, $2, $4, $2), ($4, $2, $4, $5)", chatId1, user1Id, user2Id, chatId2, user3Id)
+	// Insert members into chats (1 and 2, 1 and 3, 1 and 4)
+	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3), ($4, $2, $4, $2), ($4, $2, $4, $5), ($6, $2, $6, $2), ($6, $2, $6, $7)", chatId1, user1Id, user2Id, chatId2, user3Id, chatId3, user4Id)
 	assert.NoError(t, err)
 
 	// Insert 2 messages into chat 1
 	messageId1 := strconv.Itoa(seededRand.Int())
 	message1CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(59))
-	message1 := "first message"
+	message1 := "chat 1 first message"
 	messageId2 := strconv.Itoa(seededRand.Int())
 	message2CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(45))
-	message2 := "second message"
+	message2 := "chat 1 second message"
 	_, err = tx.Exec("insert into chat_message (message_id, chat_id, user_id, created_at, ciphertext) values ($1, $2, $3, $4, $5), ($6, $2, $7, $8, $9)", messageId1, chatId1, user1Id, message1CreatedAt, message1, messageId2, user2Id, message2CreatedAt, message2)
 	assert.NoError(t, err)
 	_, err = tx.Exec("update chat set last_message_at = $1, last_message = $2 where chat_id = $3", message2CreatedAt, message2, chatId1)
+	assert.NoError(t, err)
+
+	// Insert 1 message into chat 2
+	messageId3 := strconv.Itoa(seededRand.Int())
+	message3CreatedAt := chat2CreatedAt
+	message3 := "chat 2 first message"
+	_, err = tx.Exec("insert into chat_message (message_id, chat_id, user_id, created_at, ciphertext) values ($1, $2, $3, $4, $5)", messageId3, chatId2, user1Id, message3CreatedAt, message3)
+	assert.NoError(t, err)
+	_, err = tx.Exec("update chat set last_message_at = $1, last_message = $2 where chat_id = $3", message3CreatedAt, message3, chatId2)
 	assert.NoError(t, err)
 
 	err = tx.Commit()
@@ -119,11 +135,16 @@ func TestGetChats(t *testing.T) {
 	assert.NoError(t, err)
 	encodedUser2, err := misc.EncodeHashId(int(user2Id))
 	assert.NoError(t, err)
+	encodedUser3, err := misc.EncodeHashId(int(user3Id))
+	assert.NoError(t, err)
 	expectedMember1 := schema.ChatMember{
 		UserID: encodedUser1,
 	}
 	expectedMember2 := schema.ChatMember{
 		UserID: encodedUser2,
+	}
+	expectedMember3 := schema.ChatMember{
+		UserID: encodedUser3,
 	}
 	expectedChat1Data := schema.UserChat{
 		ChatID:             chatId1,
@@ -134,6 +155,17 @@ func TestGetChats(t *testing.T) {
 		ChatMembers: []schema.ChatMember{
 			expectedMember1,
 			expectedMember2,
+		},
+	}
+	expectedChat2Data := schema.UserChat{
+		ChatID:             chatId2,
+		LastMessage:        message3,
+		LastMessageAt:      message3CreatedAt.Format(time.RFC3339Nano),
+		InviteCode:         chatId2,
+		UnreadMessageCount: float64(0),
+		ChatMembers: []schema.ChatMember{
+			expectedMember1,
+			expectedMember3,
 		},
 	}
 
@@ -158,12 +190,13 @@ func TestGetChats(t *testing.T) {
 		// Assertions
 		// Excludes chats with no messages in response
 		expectedData := []schema.UserChat{
+			expectedChat2Data,
 			expectedChat1Data,
 		}
 		expectedSummary := schema.Summary{
-			TotalCount: float64(1),
+			TotalCount: float64(2),
 			NextCount:  float64(0),
-			NextCursor: message2CreatedAt.Format(time.RFC3339Nano),
+			NextCursor: chat2CreatedAt.Format(time.RFC3339Nano),
 			PrevCount:  float64(0),
 			PrevCursor: message2CreatedAt.Format(time.RFC3339Nano),
 		}
@@ -183,18 +216,6 @@ func TestGetChats(t *testing.T) {
 
 	// Test paginated GET /comms/chats
 	{
-		// Insert 1 message into chat 2 so that it is included in the /chats response
-		tx := db.Conn.MustBegin()
-		messageId3 := strconv.Itoa(seededRand.Int())
-		message3CreatedAt := time.Now().UTC().Add(-time.Minute * time.Duration(15))
-		message3 := "chat2 first message"
-		_, err = tx.Exec("insert into chat_message (message_id, chat_id, user_id, created_at, ciphertext) values ($1, $2, $3, $4, $5)", messageId3, chatId2, user1Id, message3CreatedAt, message3)
-		assert.NoError(t, err)
-		_, err = tx.Exec("update chat set last_message_at = $1, last_message = $2 where chat_id = $3", message3CreatedAt, message3, chatId2)
-		assert.NoError(t, err)
-		err = tx.Commit()
-		assert.NoError(t, err)
-
 		// Query /comms/chats
 		reqUrl := fmt.Sprintf("/comms/chats?timestamp=%d", time.Now().UnixMilli())
 		req, err := http.NewRequest(http.MethodGet, reqUrl, nil)


### PR DESCRIPTION
### Description
Don't return chats with no messages from the /chats endpoint (leave them for the /chats/<id> endpoint)

### Tests
Updated server tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->