### PR TITLE
Add network ID and latest block to chain health check

### DIFF
--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -41,6 +41,7 @@ from src.utils.redis_constants import (
     trending_tracks_last_completion_redis_key,
     user_balances_refresh_last_completion_redis_key,
 )
+from src.utils.web3_provider import LOCAL_RPC, get_nethermind_web3
 
 logger = logging.getLogger(__name__)
 MONITORS = monitors.MONITORS
@@ -61,8 +62,6 @@ infra_setup = shared_config["discprov"]["infra_setup"]
 min_number_of_cpus: int = 8  # 8 cpu
 min_total_memory: int = 15500000000  # 15.5 GB of RAM
 min_filesystem_size: int = 240000000000  # 240 GB of file system storage
-
-CHAIN_HEALTH_ENDPOINT = "http://chain:8545/health"
 
 
 def get_elapsed_time_redis(redis, redis_key):
@@ -107,8 +106,15 @@ def _get_query_insights():
 
 def _get_chain_health():
     try:
-        response = requests.get(CHAIN_HEALTH_ENDPOINT, timeout=0.02)
-        return response.json()
+        health_res = requests.get(LOCAL_RPC + '/health')
+        chain_res = health_res.json()
+
+        web3 = get_nethermind_web3()
+        latest_block = web3.eth.get_block('latest')
+        chain_res['block_number'] = latest_block.number
+        chain_res['hash'] = latest_block.hash.hex
+        chain_res['chain_id'] = web3.eth.chain_id
+        return chain_res
     except:
         pass
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -109,7 +109,7 @@ def _get_chain_health():
         health_res = requests.get(LOCAL_RPC + "/health")
         chain_res = health_res.json()
 
-        web3 = get_nethermind_web3()
+        web3 = get_nethermind_web3(LOCAL_RPC)
         latest_block = web3.eth.get_block("latest")
         chain_res["block_number"] = latest_block.number
         chain_res["hash"] = latest_block.hash.hex()

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -106,14 +106,14 @@ def _get_query_insights():
 
 def _get_chain_health():
     try:
-        health_res = requests.get(LOCAL_RPC + '/health')
+        health_res = requests.get(LOCAL_RPC + "/health")
         chain_res = health_res.json()
 
         web3 = get_nethermind_web3()
-        latest_block = web3.eth.get_block('latest')
-        chain_res['block_number'] = latest_block.number
-        chain_res['hash'] = latest_block.hash.hex
-        chain_res['chain_id'] = web3.eth.chain_id
+        latest_block = web3.eth.get_block("latest")
+        chain_res["block_number"] = latest_block.number
+        chain_res["hash"] = latest_block.hash.hex()
+        chain_res["chain_id"] = web3.eth.chain_id
         return chain_res
     except:
         pass

--- a/discovery-provider/src/utils/web3_provider.py
+++ b/discovery-provider/src/utils/web3_provider.py
@@ -2,7 +2,6 @@
 Interface for using a web3 provider
 """
 
-import os
 from typing import Optional
 
 from src.utils import helpers
@@ -12,6 +11,7 @@ from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
 web3: Optional[Web3] = None
+LOCAL_RPC = "http://chain:8545"
 
 
 def get_web3():
@@ -28,8 +28,7 @@ def get_web3():
 
 
 def get_nethermind_web3():
-    web3endpoint = os.getenv("audius_web3_nethermind_rpc")
-    web3 = Web3(HTTPProvider(web3endpoint))
+    web3 = Web3(HTTPProvider(LOCAL_RPC))
 
     # required middleware for POA
     # https://web3py.readthedocs.io/en/latest/middleware.html#proof-of-authority

--- a/discovery-provider/src/utils/web3_provider.py
+++ b/discovery-provider/src/utils/web3_provider.py
@@ -2,6 +2,7 @@
 Interface for using a web3 provider
 """
 
+import os
 from typing import Optional
 
 from src.utils import helpers
@@ -27,8 +28,10 @@ def get_web3():
     return web3
 
 
-def get_nethermind_web3():
-    web3 = Web3(HTTPProvider(LOCAL_RPC))
+def get_nethermind_web3(web3endpoint=None):
+    if not web3endpoint:
+        web3endpoint = os.getenv("audius_web3_nethermind_rpc")
+    web3 = Web3(HTTPProvider(web3endpoint))
 
     # required middleware for POA
     # https://web3py.readthedocs.io/en/latest/middleware.html#proof-of-authority


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Use local RPC in indexing instead of a gateway.

Ideally, nodes would use their own RPC but we need to make sure their RPC is synced up and on the correct network. Right now `/nethermind` is only available on some nodes so we can't use web3 externally but that should be ok as long as they can peer and sync. Those nodes will still be able to use their RPC internally. This change will confirm that. 

```
"chain_health": {
"block_number": 1114902,
"chain_id": 1056801,
"entries": {
"node-health": {
"data": {},
"description": "The node is now fully synced with a network. Peers: 3. The node stopped producing blocks.",
"duration": "00:00:00.0000302",
"status": "Unhealthy",
"tags": []
}
},
"hash": "0x1b1fc4aaf4b8446606a0fe0a286cb84d17f1428d1b4b0ef5371f3cbbd3cab660",
"status": "Unhealthy",
"totalDuration": "00:00:00.0002991"
},

```
### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage DN4. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->