### PR TITLE
fix failing repost reposts test and specify repost type in trigger

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_repost.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_repost.sql
@@ -117,16 +117,17 @@ begin
 	            r.repost_item_id = new.repost_item_id
 	            and new.created_at - INTERVAL '1 month' < r.created_at
 	            and new.created_at > r.created_at
-				and r.is_delete is false
-				and r.is_current is true
+              and r.is_delete is false
+              and r.is_current is true
+              and r.repost_type = new.repost_type
 	            and r.user_id in (
 	                select
 	                    followee_user_id
 	                from follows
 	                where
 	                    follower_user_id = new.user_id
-						and is_delete is false
-						and is_current is true
+                      and is_delete is false
+                      and is_current is true
 	            )
 	    )
 	insert into notification

--- a/discovery-provider/integration_tests/notifications/test_repost_repost.py
+++ b/discovery-provider/integration_tests/notifications/test_repost_repost.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from typing import List
+from unittest import TestCase
 
 import pytest
 from integration_tests.utils import populate_mock_db
@@ -47,7 +48,7 @@ def assert_notification(
     assert notification.slot == slot
     assert notification.blocknumber == blocknumber
     assert notification.data == data
-    assert notification.user_ids == user_ids
+    TestCase().assertCountEqual(notification.user_ids, user_ids)
 
 
 # ========================================== Start Tests ==========================================

--- a/discovery-provider/integration_tests/queries/test_notifications/test_repost_repost_notifications.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_repost_repost_notifications.py
@@ -1,6 +1,7 @@
 import logging
 
 from integration_tests.utils import populate_mock_db
+from src.models.notifications.notification import Notification
 from src.queries.get_notifications import get_notifications
 from src.utils.db_session import get_db
 

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -98,6 +98,7 @@ class NotificationType(str, Enum):
     TIP_RECEIVE = "tip_receive"
     TIP_SEND = "tip_send"
     CHALLENGE_REWARD = "challenge_reward"
+    REPOST_REPOST = "repost_repost"
     REACTION = "reaction"
     SUPPORTER_DETRONED = "supporter_dethroned"
     SUPPORTER_RANK_UP = "supporter_rank_up"
@@ -114,6 +115,7 @@ class NotificationType(str, Enum):
 
 default_valid_types = [
     NotificationType.REPOST,
+    NotificationType.REPOST_REPOST,
     NotificationType.SAVE,
     NotificationType.FOLLOW,
     NotificationType.TIP_SEND,
@@ -374,7 +376,6 @@ def get_notifications(session: Session, args: GetNotificationArgs):
     rows = session.execute(notifications_sql, {"notification_ids": notification_ids})
 
     notification_id_data: Dict[int, NotificationAction] = defaultdict()
-
     for row in rows:
         notification_id_data[row[0]] = {
             "type": row[1],
@@ -393,5 +394,4 @@ def get_notifications(session: Session, args: GetNotificationArgs):
         }
         for notification in notifications
     ]
-
     return notifications_and_actions


### PR DESCRIPTION
### Description
Didn't realize a valid types criteria was introduced for notifications, so added new repost of a repost notification back in to fix failing test


### Tests
should fix failing discovery test