### PR TITLE
Cast text to int in track cids migration

### DIFF
--- a/discovery-provider/alembic/versions/9b4e12c0c428_21523_track_cids.py
+++ b/discovery-provider/alembic/versions/9b4e12c0c428_21523_track_cids.py
@@ -40,7 +40,7 @@ def build_sql():
     inner_sql = """UPDATE tracks
     SET track_cid = data_table.track_cid
     FROM (SELECT unnest(:track_ids) AS track_id, unnest(:track_cids) AS track_cid) AS data_table
-    WHERE tracks.is_current = True AND tracks.track_id = data_table.track_id;"""
+    WHERE tracks.is_current = True AND tracks.track_id = data_table.track_id::int;"""
 
     sql = sa.text("begin; \n\n " + inner_sql + " \n\n commit;")
     sql = sql.bindparams(sa.bindparam("track_ids", ARRAY(String)))


### PR DESCRIPTION
### Description
Fix migration - it errors bc it's comparing an int with a text
The fix is to cast the data_table track_id as an int 

### Tests
Ran on prod and worked! This is a patch onto main

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->