### PR TITLE
Update storage seed cmd to use new config

### DIFF
--- a/comms/cmd/seed.go
+++ b/comms/cmd/seed.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	discoveryConfig "comms.audius.co/discovery/config"
 	"comms.audius.co/shared/peering"
 	"comms.audius.co/storage/client"
 	"comms.audius.co/storage/config"
@@ -41,11 +40,7 @@ func init() {
 func initClients() (int, error) {
 	storageConfig := config.GetStorageConfig()
 
-	// TODO: We need to change a bunch of stuff in shared/peering/ before we can remove this.
-	//       Make each config usage in shared/peering take the needed arguments instead of the whole config.
-	discoveryConfig.Init(storageConfig.Keys)
-
-	peering := peering.New(storageConfig.DevOnlyRegisteredNodes)
+	peering := peering.New(&storageConfig.PeeringConfig)
 	_, err := func() (nats.JetStreamContext, error) {
 		err := peering.PollRegisteredNodes()
 		if err != nil {

--- a/comms/storage/storageserver/storageserver.go
+++ b/comms/storage/storageserver/storageserver.go
@@ -44,10 +44,9 @@ func NewProd(config *config.StorageConfig, jsc nats.JetStreamContext, allNodes [
 	var host string
 	var allStorageNodePubKeys []string
 	for _, node := range allNodes {
-		allStorageNodePubKeys = append(allStorageNodePubKeys, node.DelegateOwnerWallet)
+		allStorageNodePubKeys = append(allStorageNodePubKeys, strings.ToLower(node.DelegateOwnerWallet))
 		if strings.EqualFold(node.DelegateOwnerWallet, thisNodePubKey) {
 			host = node.Endpoint
-			break
 		}
 	}
 	if host == "" {


### PR DESCRIPTION
### Description
Updates seed command to use new config since it's currently broken after merging https://github.com/AudiusProject/audius-protocol/pull/4810.


### Tests
I ran `make` and `make storage.seed.image`, and then uploaded an audio file manually at http://node1-storage/storage and verified that data was where it was supposed to be.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A