### PR TITLE
Force python3.10

### DIFF
--- a/dev-tools/audius-cloud
+++ b/dev-tools/audius-cloud
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.10
 
 import subprocess
 import time

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.10
 
 import json
 import os

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -199,6 +199,7 @@ def build(
             f"--file={protocol_dir / 'docker-compose.yml'}",
             "--profile=*",
             "build",
+            "--no-cache",
             *services,
         ],
     )

--- a/dev-tools/setup-dev.sh
+++ b/dev-tools/setup-dev.sh
@@ -18,15 +18,5 @@ npm i
 npm run build
 npm link
 
-cd $PROTOCOL_DIR/service-commands
-npm i
-npm link @audius/sdk
-npm link
-
-cd $PROTOCOL_DIR/mad-dog
-npm i
-npm link @audius/sdk
-npm link @audius/service-commands
-
 cd $PROTOCOL_DIR/libs
 npm link

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -67,7 +67,7 @@ else
     export PROTOCOL_DIR="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
 fi
 
-python3 -m pip install -r "$PROTOCOL_DIR/dev-tools/requirements.txt"
+python3.10 -m pip install -r "$PROTOCOL_DIR/dev-tools/requirements.txt"
 
 mkdir -p "$HOME/.local/bin"
 

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -19,8 +19,8 @@ debian | ubuntu)
     sudo apt-get update
     sudo apt-get install -y \
         git \
-        python3 \
-        python3-pip \
+        python3.10 \
+        python3.10-pip \
         docker-ce \
         docker-ce-cli \
         containerd.io
@@ -43,8 +43,8 @@ debian | ubuntu)
         exit 1
     fi
 
-    if ! command -v python3 &>/dev/null; then
-        echo "Python3 is not installed. Please install python3 and try again."
+    if ! command -v python3.10 &>/dev/null; then
+        echo "Python3.10 is not installed. Please install python3.10 and try again."
         exit 1
     fi
 

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -20,7 +20,7 @@ debian | ubuntu)
     sudo apt-get install -y \
         git \
         python3.10 \
-        python3.10-pip \
+        python3-pip \
         docker-ce \
         docker-ce-cli \
         containerd.io

--- a/dev-tools/startup/sshuttle-server.sh
+++ b/dev-tools/startup/sshuttle-server.sh
@@ -4,7 +4,7 @@
 # - installs python3 which is required by sshuttle
 # - keeps /etc/hosts updated so sshuttle's auto-hosts functionality is fast
 
-apk add python3 nmap
+apk add python3.10 nmap
 
 # Splits cidr to /24 ranges
 function split_cidr {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Homebrew defaults to 3.11 and it breaks on installing eth-accounts. See https://github.com/ethereum/eth-account/pull/212/files


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Both linux & macos:
```
bash setup.sh
audius-compose build # starts running correctly
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->