### PR TITLE
Comms: round timestamps to microseconds on read

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -326,7 +326,7 @@ func (proc *RPCProcessor) Apply(msg *nats.Msg) {
 		logger.Debug("commited", "took", takeSplit())
 
 		// send out websocket events fire + forget style
-		websocketNotify(rawRpc, userId, meta.Timestamp)
+		websocketNotify(rawRpc, userId, meta.Timestamp.Round(time.Microsecond))
 		logger.Debug("websocket push done", "took", takeSplit())
 
 		return nil


### PR DESCRIPTION
### Description
Postgres timestamps' max precision is microseconds but we format to nanoseconds in comms. Round on read (when not reading from postgres) to avoid issues. Writes and subsequent reads of timestamps from postgres are fine since postgres automatically rounds on write.

Tests will be fixed by https://github.com/AudiusProject/audius-protocol/commit/8a2762a42a96648243c219331b562cb2d3eaeff1


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->