### PR TITLE
Keep peering pointer in lifetime struct

### DIFF
--- a/comms/storage/storage_main.go
+++ b/comms/storage/storage_main.go
@@ -31,11 +31,7 @@ func StorageMain() {
 		log.Fatal(err)
 	}
 
-	allNodes, err := peering.GetContentNodes()
-	if err != nil {
-		log.Fatal("Error getting all nodes: ", err)
-	}
-	ss := storageserver.NewProd(storageConfig, jsc, allNodes)
+	ss := storageserver.NewProd(storageConfig, jsc, peering)
 
 	// Start server
 	go func() {

--- a/comms/storage/storageserver/storageserver_test.go
+++ b/comms/storage/storageserver/storageserver_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	sharedConfig "comms.audius.co/shared/config"
 	"comms.audius.co/shared/peering"
 	"comms.audius.co/storage/config"
 	"comms.audius.co/storage/transcode"
@@ -141,7 +140,7 @@ func startNatsCluster(t *testing.T) [5]*testServer {
 		case 3:
 			os.Setenv("AUDIUS_DELEGATE_PRIVATE_KEY", "2617e6258025c60b5aa270e02ff2247eefab37c7b463b2a870104862870ad3fb")
 		}
-		ss := NewProd(config.GetStorageConfig(), jsc, []sharedConfig.ServiceNode{}) // TODO: Pass all nodes
+		ss := NewProd(config.GetStorageConfig(), jsc, nil) // TODO: Pass all nodes
 		go ss.WebServer.Start(fmt.Sprintf("127.0.0.1:%d", 1222+i+5))
 		nodes[i].ss = ss
 	}


### PR DESCRIPTION
### Description
Passes `peering.Peering` pointer to storageserver lifetime struct so that the whole application can use peering code without re-initializing it and causing the nodes to do peering exchange again.


### Tests
`make`, `make test`, and upload flow at http://node1-storage/storage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A