### PR TITLE
ACDC migraiton: enable identity final_poa_block, improve web3 provider switch, indexing parity

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -464,6 +464,8 @@ def configure_celery(celery, test_config=None):
     # Clear existing locks used in tasks if present
     redis_inst.delete(eth_indexing_last_scanned_block_key)
     redis_inst.delete("disc_prov_lock")
+    redis_inst.delete("disc_prov_lock_nethermind")
+
     redis_inst.delete("network_peers_lock")
     redis_inst.delete("update_metrics_lock")
     redis_inst.delete("update_play_count_lock")

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -336,7 +336,11 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
 
     if latest_block_num is not None and latest_indexed_block_num is not None:
-        if final_poa_block and latest_block_num < final_poa_block:
+        # adjust latest block if web3 is pointed to ACDC
+        # indicating POA has finished indexing
+        if final_poa_block and web3.provider.endpoint_uri == os.getenv(
+            "audius_web3_nethermind_rpc"
+        ):
             latest_block_num += final_poa_block
         block_difference = abs(
             latest_block_num - latest_indexed_block_num

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -1,4 +1,5 @@
 import logging  # pylint: disable=C0302
+import os
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Tuple, TypedDict
@@ -860,7 +861,11 @@ def notifications():
             playlist_contents = entry.playlist_contents
 
             final_poa_block = helpers.get_final_poa_block(shared_config)
-            if final_poa_block:
+
+            if final_poa_block and web3.provider.endpoint_uri == os.getenv(
+                "audius_web3_nethermind_rpc"
+            ):
+                # if migrated to ACDC
                 min_block_number -= final_poa_block
                 max_block_number -= final_poa_block
 

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -93,7 +93,7 @@ def get_contract_info_if_exists(self, address):
     return None
 
 
-def get_latest_block(db: SessionManager):
+def get_latest_block(db: SessionManager, final_poa_block):
     latest_block = None
     block_processing_window = int(
         update_task.shared_config["discprov"]["block_processing_window"]
@@ -117,6 +117,8 @@ def get_latest_block(db: SessionManager):
         target_latest_block_number = min(
             target_latest_block_number, latest_block_number_from_chain
         )
+        if final_poa_block:
+            target_latest_block_number = min(target_latest_block_number, final_poa_block)
 
         logger.info(
             f"index.py | get_latest_block | current={current_block_number} target={target_latest_block_number}"
@@ -1018,7 +1020,7 @@ def update_task(self):
                 f"index.py | {self.request.id} | update_task | Acquired disc_prov_lock"
             )
 
-            latest_block = get_latest_block(db)
+            latest_block = get_latest_block(db, final_poa_block)
 
             # Capture block information between latest and target block hash
             index_blocks_list = []

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -454,7 +454,7 @@ def index_blocks(self, db, blocks_list):
         final_poa_block = helpers.get_final_poa_block(shared_config)
         if final_poa_block and block_number > final_poa_block:
             logger.info("index.py | skipping block {block_number} past final_poa_block")
-            continue
+            break
 
         logger.info(
             f"index.py | index_blocks | {self.request.id} | block {block.number} - {block_index}/{num_blocks}"

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -118,7 +118,9 @@ def get_latest_block(db: SessionManager, final_poa_block):
             target_latest_block_number, latest_block_number_from_chain
         )
         if final_poa_block:
-            target_latest_block_number = min(target_latest_block_number, final_poa_block)
+            target_latest_block_number = min(
+                target_latest_block_number, final_poa_block
+            )
 
         logger.info(
             f"index.py | get_latest_block | current={current_block_number} target={target_latest_block_number}"
@@ -448,6 +450,12 @@ def index_blocks(self, db, blocks_list):
         block_number, block_hash, latest_block_timestamp = itemgetter(
             "number", "hash", "timestamp"
         )(block)
+
+        final_poa_block = helpers.get_final_poa_block(shared_config)
+        if final_poa_block and block_number > final_poa_block:
+            logger.info("index.py | skipping block {block_number} past final_poa_block")
+            continue
+
         logger.info(
             f"index.py | index_blocks | {self.request.id} | block {block.number} - {block_index}/{num_blocks}"
         )

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -217,13 +217,23 @@ def fetch_cid_metadata(db, entity_manager_txs):
                     cid = event_args._metadata
                     event_type = event_args._entityType
                     action = event_args._action
-                    if not cid or event_type == EntityType.USER_REPLICA_SET:
-                        continue
                     if action == Action.CREATE and event_type == EntityType.USER:
                         continue
                     if (
                         action == Action.CREATE
                         and event_type == EntityType.NOTIFICATION
+                    ):
+                        continue
+                    if (
+                        not cid
+                        or event_type == EntityType.USER_REPLICA_SET
+                        or action
+                        in [
+                            EntityType.REPOST,
+                            EntityType.SAVE,
+                            EntityType.FOLLOW,
+                            EntityType.SUBSCRIPTION,
+                        ]
                     ):
                         continue
 
@@ -817,7 +827,6 @@ def revert_blocks(self, db, revert_blocks_list):
                 )
                 if previous_subscription_entry:
                     previous_subscription_entry.is_current = True
-                logger.info(f"Reverting subscription: {subscription_to_revert}")
                 session.delete(subscription_to_revert)
 
             for playlist_to_revert in revert_playlist_entries:

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import List, Optional, Tuple
@@ -376,7 +377,9 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
 
 def get_block(web3, block_number: int):
     final_poa_block = helpers.get_final_poa_block(shared_config)
-    if final_poa_block:
+    if final_poa_block and web3.provider.endpoint_uri == os.getenv(
+        "audius_web3_nethermind_rpc"
+    ):
         nethermind_block_number = block_number - final_poa_block
         return web3.eth.get_block(nethermind_block_number, True)
     else:

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -535,9 +535,6 @@ def get_account_index(instruction: TransactionMessageInstruction, index: int):
 def get_final_poa_block(shared_config) -> Optional[int]:
     # get final poa block from identity and cache result
     # marks the transition to nethermind
-    # returns None if still on POA
-    if os.getenv("audius_discprov_env") != "stage":
-        return None
 
     redis = redis_connection.get_redis()
     cached_final_poa_block = redis.get(final_poa_block_redis_key)
@@ -555,7 +552,10 @@ def get_final_poa_block(shared_config) -> Optional[int]:
         response.raise_for_status()
         response_json = response.json()
 
-        final_poa_block = int(response_json.get("finalPOABlock", None))
+        if not response_json.get("finalPOABlock"):
+            return None
+
+        final_poa_block = int(response_json.get("finalPOABlock"))
 
         redis.set(final_poa_block_redis_key, final_poa_block)
     except requests.exceptions.ConnectionError:

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -535,6 +535,7 @@ def get_account_index(instruction: TransactionMessageInstruction, index: int):
 def get_final_poa_block(shared_config) -> Optional[int]:
     # get final poa block from identity and cache result
     # marks the transition to nethermind
+    # depend on identity responding with final_poa_block or the redis cached value
 
     redis = redis_connection.get_redis()
     cached_final_poa_block = redis.get(final_poa_block_redis_key)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Final changes before ACDC migration
* Correct some differences in index.py and index_nethermind.py.
* Depend on identity for final_poa_block and switch to ACDC web3 provider when final_poa_block is indexed.
* Check for this final_poa_block throughout indexing to ensure we don't index past it. 
* Separate redis locks for index.py and index_nethermind.py.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on sandbox nodes and migration worked in various situations:
* when indexing is caught up to POA. 
* when indexing is behind POA. 

confirmed final_poa_block is from POA and final_block_poa+1 is from ACDC. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->