### PR TITLE
Fix remixes failure for gated tracks

### DIFF
--- a/discovery-provider/src/queries/get_remixes_of.py
+++ b/discovery-provider/src/queries/get_remixes_of.py
@@ -52,7 +52,7 @@ def get_remixes_of(args):
             parent_track = parent_track_res[0]
 
             if parent_track["is_premium"]:
-                return {"tracks": [], "count": 0}
+                return ([], [], 0)
 
             track_owner_id = parent_track["owner_id"]
 


### PR DESCRIPTION
### Description

- Returned wrong signature for early exit of gated track remixes retrieval. This fixes it.

### Tests

deployed change to stage dn5 and tested local dapp against it. it works!

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?

none

<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->