### PR TITLE
Remove unused TikTok share.sound.create scope

### DIFF
--- a/identity-service/src/routes/tiktok.js
+++ b/identity-service/src/routes/tiktok.js
@@ -32,7 +32,7 @@ module.exports = function (app) {
       let url = 'https://open-api.tiktok.com/platform/oauth/connect/'
 
       url += `?client_key=${config.get('tikTokAPIKey')}`
-      url += '&scope=user.info.basic,share.sound.create'
+      url += '&scope=user.info.basic'
       url += '&response_type=code'
       url += `&redirect_uri=${redirectUrl || config.get('tikTokAuthOrigin')}`
       url += '&state=' + csrfState


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

TikTok no longer allows this scope and it's breaking on staging


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->