### PR TITLE
disable auto deploy to stage discovery nodes

### DIFF
--- a/.circleci/workflows/main.yml
+++ b/.circleci/workflows/main.yml
@@ -185,21 +185,21 @@ jobs:
         stage-user-metadata
       service: creator-node
 
-  - deploy:
-      name: deploy-stage-discovery-provider
-      requires:
-        - push-discovery-provider
-      filters:
-        branches:
-          only: main
-      context: open-vpn
-      hosts: >-
-        stage-discovery-4
-        stage-discovery-1
-        stage-discovery-2
-        stage-discovery-3
-        stage-discovery-5
-      service: discovery-provider
+  # - deploy:
+  #     name: deploy-stage-discovery-provider
+  #     requires:
+  #       - push-discovery-provider
+  #     filters:
+  #       branches:
+  #         only: main
+  #     context: open-vpn
+  #     hosts: >-
+  #       stage-discovery-4
+  #       stage-discovery-1
+  #       stage-discovery-2
+  #       stage-discovery-3
+  #       stage-discovery-5
+  #     service: discovery-provider
 
   - deploy:
       name: deploy-stage-identity-service


### PR DESCRIPTION
Temporarily disabling auto deploy to stage discovery nodes while premium content is QA-ing this week. 