### PR TITLE
StorageV2: hex encode signature for content access middleware

### DIFF
--- a/comms/storage/contentaccess/content_access_checker.go
+++ b/comms/storage/contentaccess/content_access_checker.go
@@ -15,7 +15,7 @@ const (
 )
 
 type SignedAccessData struct {
-	Signature []byte          `json:"signature"`
+	Signature string          `json:"signature"`
 	Data      json.RawMessage `json:"data"`
 }
 

--- a/comms/storage/contentaccess/content_access_middleware.go
+++ b/comms/storage/contentaccess/content_access_middleware.go
@@ -1,6 +1,7 @@
 package contentaccess
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func ContentAccessMiddleware(p peering.Peering) func(next echo.HandlerFunc) echo
 				return echo.ErrInternalServerError
 			}
 
-			err = VerifySignature(nodes, *signatureData, []byte(signature), requestedCid)
+			err = VerifySignature(nodes, *signatureData, signature, requestedCid)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
@@ -60,7 +61,12 @@ func parseQueryParams(values url.Values) (*SignatureData, []byte, error) {
 		return nil, nil, err
 	}
 
-	return signatureData, signedAccessData.Signature, nil
+	rawSignature, err := hex.DecodeString(signedAccessData.Signature)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return signatureData, rawSignature, nil
 }
 
 func parseSignature(rawSignature string) (*SignedAccessData, error) {

--- a/comms/storage/contentaccess/content_access_middleware.go
+++ b/comms/storage/contentaccess/content_access_middleware.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"comms.audius.co/shared/peering"
 	"github.com/labstack/echo/v4"
@@ -60,6 +61,9 @@ func parseQueryParams(values url.Values) (*SignatureData, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Remove the "0x" signatures since it'll break hex decoding
+	signedAccessData.Signature = strings.TrimPrefix(signedAccessData.Signature, "0x")
 
 	rawSignature, err := hex.DecodeString(signedAccessData.Signature)
 	if err != nil {


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

This PR makes content access checking more in line with the current implementation used in production. Signatures are treated has hex encoded strings that're decoded when a request comes in. 

I looked at requests in staging 
e.g.
```
https://creatornode9.staging.audius.co/tracks/cidstream/QmfKLRvcq1hEXvX1vXKgPX9P58orVNg5YE9ioEhCPchwhp?signature=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%2010753%2C%20%5C%22cid%5C%22%3A%20%5C%22QmfKLRvcq1hEXvX1vXKgPX9P58orVNg5YE9ioEhCPchwhp%5C%22%2C%20%5C%22timestamp%5C%22%3A%201677714403243%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xd3b08c5a0e116d1e76b886763d3d99c9f6c5288b389c908b70bd2cc2645b491d306ba1ce86a0fe863f2b28a8f6c98247bf7b40fec0e08d6e5cb1e48b8e7bb6c91c%22%7D
```

And made sure the middleware was able to parse and decode the signature correctly

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

By correcting this issue, the flaky content access tests should be more consistent. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->