### PR TITLE
Rename leftover nodesToShards to nodeStatuses

### DIFF
--- a/comms/cmd/nodesToShards.go
+++ b/comms/cmd/nodesToShards.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var nodesToShardsCmd = &cobra.Command{
-	Use:   "nodesToShards",
+var nodeStatusesCmd = &cobra.Command{
+	Use:   "nodeStatuses",
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -19,13 +19,13 @@ var nodesToShardsCmd = &cobra.Command{
 		}
 
 		client := ClientList[0]
-		nodesToShards, err := client.GetNodeStatuses()
+		nodeStatuses, err := client.GetNodeStatuses()
 		if err != nil {
-			fmt.Printf("getting nodes to shards error, %+v\n", nodesToShards)
+			fmt.Printf("getting nodes to shards error, %+v\n", nodeStatuses)
 			return
 		}
 
-		prettyPrint, err := json.MarshalIndent(nodesToShards, "", "  ")
+		prettyPrint, err := json.MarshalIndent(nodeStatuses, "", "  ")
 		if err != nil {
 			return
 		}
@@ -35,5 +35,5 @@ var nodesToShardsCmd = &cobra.Command{
 }
 
 func init() {
-	storageCmd.AddCommand(nodesToShardsCmd)
+	storageCmd.AddCommand(nodeStatusesCmd)
 }

--- a/comms/storage/client/client.go
+++ b/comms/storage/client/client.go
@@ -204,7 +204,7 @@ func (sc *StorageClient) GetNodeStatuses() (*map[string]monitor.NodeStatus, erro
 }
 
 func (sc *StorageClient) GetStorageNodesFor(jobId string) ([]string, error) {
-	nodesToShards, err := sc.GetNodeStatuses()
+	nodeStatuses, err := sc.GetNodeStatuses()
 	if err != nil {
 		return nil, err
 	}
@@ -212,9 +212,9 @@ func (sc *StorageClient) GetStorageNodesFor(jobId string) ([]string, error) {
 	shard := jobId[len(jobId)-2:]
 
 	nodes := []string{}
-	for _, hostAndShards := range *nodesToShards {
-		if slices.Contains(hostAndShards.Shards, shard) {
-			nodes = append(nodes, hostAndShards.Host)
+	for _, nodeStatus := range *nodeStatuses {
+		if slices.Contains(nodeStatus.Shards, shard) {
+			nodes = append(nodes, nodeStatus.Host)
 		}
 	}
 


### PR DESCRIPTION
### Description
Some instances of the /nodes-to-shards endpoint slipped through, so this renames them to /node-statuses.


### Tests
`make`, `make test`, upload flow at http://node1-storage/storage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A