### PR TITLE
[CON-625] Silence app logs for new cli cmds

### DIFF
--- a/comms/cmd/getFile.go
+++ b/comms/cmd/getFile.go
@@ -11,9 +11,10 @@ import (
 var outputFile string
 
 var getFileCmd = &cobra.Command{
-	Use:   "getFile",
+	Use:   "getFile [filename]",
 	Short: "",
 	Long: ``,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			return

--- a/comms/cmd/getFile.go
+++ b/comms/cmd/getFile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"comms.audius.co/storage/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ var getFileCmd = &cobra.Command{
 
 		filename := args[0]
 
+		telemetry.DiscardLogs()
 		clientCount, err := initClients()
 		if err != nil || clientCount < 1 {
 			fmt.Println("Couldn't find any clients")

--- a/comms/cmd/job.go
+++ b/comms/cmd/job.go
@@ -9,9 +9,10 @@ import (
 )
 
 var jobCmd = &cobra.Command{
-	Use:   "job",
+	Use:   "job [jobId]",
 	Short: "",
 	Long:  ``,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			return

--- a/comms/cmd/job.go
+++ b/comms/cmd/job.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"comms.audius.co/storage/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ var jobCmd = &cobra.Command{
 
 		jobId := args[0]
 
+		telemetry.DiscardLogs()
 		clientCount, err := initClients()
 		if err != nil || clientCount < 1 {
 			fmt.Println("Couldn't find any clients")

--- a/comms/cmd/jobs.go
+++ b/comms/cmd/jobs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"comms.audius.co/storage/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,7 @@ var jobsCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		telemetry.DiscardLogs()
 		clientCount, err := initClients()
 		if err != nil || clientCount < 1 {
 			fmt.Println("Couldn't find any clients")

--- a/comms/cmd/nodesToShards.go
+++ b/comms/cmd/nodesToShards.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"comms.audius.co/storage/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,7 @@ var nodeStatusesCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		telemetry.DiscardLogs()
 		clientCount, err := initClients()
 		if err != nil || clientCount < 1 {
 			fmt.Println("Couldn't find any clients")

--- a/comms/cmd/results.go
+++ b/comms/cmd/results.go
@@ -9,9 +9,10 @@ import (
 )
 
 var resultsCmd = &cobra.Command{
-	Use:   "results",
+	Use:   "results [jobId]",
 	Short: "",
 	Long: ``,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			return

--- a/comms/cmd/results.go
+++ b/comms/cmd/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"comms.audius.co/storage/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ var resultsCmd = &cobra.Command{
 
 		jobId := args[0]
 
+		telemetry.DiscardLogs()
 		clientCount, err := initClients()
 		if err != nil || clientCount < 1 {
 			fmt.Println("Couldn't find any clients")


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Yesterday some PRs got merged in a weird order so logs didn't get silenced on the new cli cmds. This PR is just a follow up for completeness

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Ran the cli cmds locally to make sure logs were actually silenced

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->