### PR TITLE
ACDC migration: only allow eth calls + tolerate final_poa_block reque…

### DIFF
--- a/discovery-provider/nginx_conf/main.lua
+++ b/discovery-provider/nginx_conf/main.lua
@@ -266,8 +266,8 @@ function _M.validate_nethermind_rpc_request ()
     local data = ngx.req.get_body_data()
     if data then
         local body = cjson.decode(data)
-        is_bad = utils.starts_with(body.method, "clique_")
-        if is_bad then
+        is_ok = utils.starts_with(body.method, "eth_")
+        if not is_ok then
             ngx.exit(405)
         end
     end

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -547,7 +547,6 @@ def get_final_poa_block(shared_config) -> Optional[int]:
 
     final_poa_block = None
     try:
-
         identity_endpoint = (
             f"{shared_config['discprov']['identity_service_url']}/health_check/poa"
         )
@@ -555,14 +554,13 @@ def get_final_poa_block(shared_config) -> Optional[int]:
         response = requests.get(identity_endpoint, timeout=1)
         response.raise_for_status()
         response_json = response.json()
-
         if not response_json.get("finalPOABlock"):
             return None
 
         final_poa_block = int(response_json.get("finalPOABlock"))
 
         redis.set(final_poa_block_redis_key, final_poa_block)
-    except requests.exceptions.ConnectionError:
-        # while identity is not running e.g. test env
+    except:
+        # in case identity is down, default to None
         pass
     return final_poa_block


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
* Tolerate identity restarts and failing to get final_poa_block, default to using POA. This should be OK since a final_poa_block far ahead (beyond the block_processing_window) will be picked up and cached in time. We now check for inal_poa_block before indexing a single POA block. Before, the `requests.exceptions.ConnectionError` only tolerated identity going down with no response but not a 502. 
* Only allow eth_ calls for `/nethermind` outside a discovery node. 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on sandbox.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->