### PR TITLE
Fix flaky dm notifs tests

### DIFF
--- a/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
@@ -48,7 +48,7 @@ describe('Email Notifications', () => {
     await createUsers(discoveryDB, [{ user_id: user1 }, { user_id: user2 }])
     const { email: user2Email } = await setUserEmailAndSettings(identityDB, userFrequency, user2)
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
@@ -221,7 +221,7 @@ describe('Email Notifications', () => {
     await createUsers(discoveryDB, [{ user_id: user1 }, { user_id: user2 }])
     await setUserEmailAndSettings(identityDB, frequency, user2)
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
@@ -241,7 +241,7 @@ describe('Email Notifications', () => {
     await createUsers(discoveryDB, [{ user_id: user1 }, { user_id: user2 }])
     const { email: user2Email } = await setUserEmailAndSettings(identityDB, frequency, user2)
 
-    // User 1 sent message to user 2 config.dmNotificationDelay mins ago
+    // User 1 sent message to user 2 config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
@@ -350,7 +350,7 @@ describe('Email Notifications', () => {
       },
     ])
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)

--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -80,7 +80,7 @@ describe('Push Notifications', () => {
 
     // Start processor
     processor.start()
-    // Let notifications job run for 1 cycle to initialize the min cursors in redis
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 1 sent message config.dmNotificationDelay ms ago
@@ -129,7 +129,7 @@ describe('Push Notifications', () => {
 
     // Start processor
     processor.start()
-    // Let notifications job run for 1 cycle to initialize the min cursors in redis
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 1 sent message config.dmNotificationDelay ms ago
@@ -169,7 +169,7 @@ describe('Push Notifications', () => {
 
     // Start processor
     processor.start()
-    // Let notifications job run for 1 cycle to initialize the min cursors in redis
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 1 sends message now
@@ -197,7 +197,7 @@ describe('Push Notifications', () => {
 
     // Start processor
     processor.start()
-    // Let notifications job run for 1 cycle to initialize the min cursors in redis
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 2 reacts to user 1's message now
@@ -213,7 +213,7 @@ describe('Push Notifications', () => {
 
     // Start processor
     processor.start()
-    // Let notifications job run for 1 cycle to initialize the min cursors in redis
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 1 sent message config.dmNotificationDelay ms ago

--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -81,9 +81,9 @@ describe('Push Notifications', () => {
     // Start processor
     processor.start()
     // Let notifications job run for 1 cycle to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
@@ -106,7 +106,7 @@ describe('Push Notifications', () => {
 
     jest.clearAllMocks()
 
-    // User 2 reacted to user 1's message config.dmNotificationDelay mins ago
+    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
     const reaction = "fire"
     const reactionTimestampMs = Date.now() - config.dmNotificationDelay
     await insertReaction(processor.discoveryDB, user2.userId, messageId, reaction, new Date(reactionTimestampMs))
@@ -130,9 +130,9 @@ describe('Push Notifications', () => {
     // Start processor
     processor.start()
     // Let notifications job run for 1 cycle to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
@@ -155,7 +155,7 @@ describe('Push Notifications', () => {
 
     jest.clearAllMocks()
 
-    // User 1 reacted to user 1's message config.dmNotificationDelay mins ago
+    // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
     const reaction = "fire"
     const reactionTimestampMs = Date.now() - config.dmNotificationDelay
     await insertReaction(processor.discoveryDB, user1.userId, messageId, reaction, new Date(reactionTimestampMs))
@@ -170,7 +170,7 @@ describe('Push Notifications', () => {
     // Start processor
     processor.start()
     // Let notifications job run for 1 cycle to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 1 sends message now
     const message = "hi from user 1"
@@ -198,7 +198,7 @@ describe('Push Notifications', () => {
     // Start processor
     processor.start()
     // Let notifications job run for 1 cycle to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
     // User 2 reacts to user 1's message now
     const reaction = "fire"
@@ -214,9 +214,9 @@ describe('Push Notifications', () => {
     // Start processor
     processor.start()
     // Let notifications job run for 1 cycle to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay mins ago
+    // User 1 sent message config.dmNotificationDelay ms ago
     const message = "hi from user 1"
     const messageId = randId().toString()
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
@@ -232,7 +232,7 @@ describe('Push Notifications', () => {
 
     jest.clearAllMocks()
 
-    // User 2 reacted to user 1's message config.dmNotificationDelay mins ago
+    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
     const reaction = "fire"
     const reactionTimestampMs = Date.now() - config.dmNotificationDelay
     await insertReaction(processor.discoveryDB, user2.userId, messageId, reaction, new Date(reactionTimestampMs))


### PR DESCRIPTION
### Description
Some dm tests were failing sometimes... increate timeout between startup and adding/testing for messages in case this is because of timing.


### Tests
Ran tests 3+ times. No errors


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->