### PR TITLE
Is fix worker 2

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -264,8 +264,6 @@ def configure_flask(test_config, app, mode="app"):
     app.register_blueprint(block_confirmation.bp)
     app.register_blueprint(skipped_transactions.bp)
     app.register_blueprint(user_signals.bp)
-    app.register_blueprint(prometheus_metrics_exporter.bp)
-
     app.register_blueprint(api_v1.bp)
     app.register_blueprint(api_v1.bp_full)
     app.register_blueprint(playlist_stream_bp)

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -551,10 +551,8 @@ def get_final_poa_block(shared_config) -> Optional[int]:
         identity_endpoint = (
             f"{shared_config['discprov']['identity_service_url']}/health_check/poa"
         )
+
         response = requests.get(identity_endpoint, timeout=1)
-        trigger_http_error = redis.get("trigger_http_error")
-        if trigger_http_error:
-            response.status_code = 502
         response.raise_for_status()
         response_json = response.json()
 

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -551,8 +551,10 @@ def get_final_poa_block(shared_config) -> Optional[int]:
         identity_endpoint = (
             f"{shared_config['discprov']['identity_service_url']}/health_check/poa"
         )
-
         response = requests.get(identity_endpoint, timeout=1)
+        trigger_http_error = redis.get("trigger_http_error")
+        if trigger_http_error:
+            response.status_code = 502
         response.raise_for_status()
         response_json = response.json()
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fixes celery_app startup on indexer restart. Before, indexing would halt when the container restarts because it would fail to remove a file.

```
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/audius-discovery-provider/src/worker.py", line 4, in <module>
    from src.app import create_celery
  File "/audius-discovery-provider/src/app.py", line 26, in <module>
    from src.queries import (
  File "/audius-discovery-provider/src/queries/prometheus_metrics_exporter.py", line 28, in <module>
    remove(f)
FileNotFoundError: [Errno 2] No such file or directory: '//prometheus_data/gauge_all_server_89706.db'
```

Probably because of multiple processes trying to remove the same file? Sometimes indexing would continue if we're lucky. I think this is because this would succeed eventually.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

I verified this by using `docker restart indexer` to confirm indexing halts with the error above ^. Then testing changes without prometheus. 

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->