### PR TITLE
Use last index instead of 0th for CN getUsers

### DIFF
--- a/creator-node/src/services/ContentNodeInfoManager.ts
+++ b/creator-node/src/services/ContentNodeInfoManager.ts
@@ -316,7 +316,7 @@ export async function getReplicaSetEndpointsByWallet({
   parentLogger
 }: GetReplicaSetEndpointsByWalletParams): Promise<ReplicaSetEndpoints> {
   const userAsc: { user_id: number }[] = await libs.User.getUsers(
-    1,
+    1000,
     0,
     null,
     wallet

--- a/creator-node/src/services/ContentNodeInfoManager.ts
+++ b/creator-node/src/services/ContentNodeInfoManager.ts
@@ -315,9 +315,13 @@ export async function getReplicaSetEndpointsByWallet({
   wallet,
   parentLogger
 }: GetReplicaSetEndpointsByWalletParams): Promise<ReplicaSetEndpoints> {
-  const user: { user_id: number } = (
-    await libs.User.getUsers(1, 0, null, wallet)
-  )[0]
+  const userAsc: { user_id: number }[] = await libs.User.getUsers(
+    1,
+    0,
+    null,
+    wallet
+  )
+  const user = userAsc[userAsc.length - 1]
   const replicaSetEndpoints = await getReplicaSetEndpointsByUserId({
     libs,
     userId: user.user_id,


### PR DESCRIPTION
### Description
Fixes Content Node's function that gets a user's replica set by wallet. It used an outdated replica set for users who had previous replica set updates because it assumed sorting in descending order instead of ascending order. I spot checked some users to confirm that the result is sorted in ascending and double-checked discovery code [here](https://github.com/AudiusProject/audius-protocol/blob/main/discovery-provider/src/queries/get_users.py#L48) as well.


### Tests
Try to perform orphaned data recovery manually in prod after this is deployed:
```
POST https://creatornode.audius.prod-us-west-2.staked.cloud/merge_primary_and_secondary?wallet=0xb35bbd6fba0521c4558f9a3040b0e43b70724a76&endpoint=https://audius-content-1.decentralizeaudio.xyz&forceWipe=true&syncEvenIfDisabled=true
```

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Logs for "abort_sync_correctness" should reduce significantly. Search loggly or look for a Grafana panel for syncs that includes this as a sync abort reason.