### PR TITLE
Add min followers to feeling lucky query

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -123,6 +123,7 @@ def extend_search(resp):
 
 
 def extend_user(user, current_user_id=None):
+    print(f"helpers.py: extend_user: user: {user}")
     if not user.get("user_id"):
         return user
     user_id = encode_int_id(user["user_id"])

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -123,7 +123,7 @@ def extend_search(resp):
 
 
 def extend_user(user, current_user_id=None):
-    print(f"helpers.py: extend_user: user: {user}")
+    print(f"get_random_tracks.py: helpers.py: extend_user: user: {user}")
     if not user.get("user_id"):
         return user
     user_id = encode_int_id(user["user_id"])

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -123,8 +123,6 @@ def extend_search(resp):
 
 
 def extend_user(user, current_user_id=None):
-    if (type(user) is list):
-        print(f"get_random_tracks.py: helpers.py: extend_user: user: {user}")
     if not user.get("user_id"):
         return user
     user_id = encode_int_id(user["user_id"])
@@ -199,7 +197,11 @@ def extend_track(track):
     track_id = encode_int_id(track["track_id"])
     owner_id = encode_int_id(track["owner_id"])
     if "user" in track:
-        track["user"] = extend_user(track["user"])
+        if isinstance(track["user"], list):
+            user = track["user"][0]
+        else:
+            user = track["user"]
+        track["user"] = extend_user(user)
     track["id"] = track_id
     track["user_id"] = owner_id
     if "followee_saves" in track:

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -123,7 +123,8 @@ def extend_search(resp):
 
 
 def extend_user(user, current_user_id=None):
-    print(f"get_random_tracks.py: helpers.py: extend_user: user: {user}")
+    if (type(user) is list):
+        print(f"get_random_tracks.py: helpers.py: extend_user: user: {user}")
     if not user.get("user_id"):
         return user
     user_id = encode_int_id(user["user_id"])

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1211,8 +1211,16 @@ feeling_lucky_parser.add_argument(
 feeling_lucky_parser.add_argument(
     "with_users",
     required=False,
+    default=False,
     type=bool,
     description="Boolean to include user info with tracks",
+)
+feeling_lucky_parser.add_argument(
+    "min_followers",
+    required=False,
+    default=100,
+    type=int,
+    description="Fetch tracks from users with at least this number of followers",
 )
 
 
@@ -1232,6 +1240,7 @@ class FeelingLucky(Resource):
             "with_users": request_args.get("with_users"),
             "limit": format_limit(request_args, max_limit=100, default_limit=25),
             "user_id": get_current_user_id(request_args),
+            "min_followers": request_args.get("min_followers")
         }
         tracks = get_random_tracks(args)
         tracks = list(map(extend_track, tracks))

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 from flask import redirect
 from flask.globals import request
 from flask_restx import Namespace, Resource, fields, inputs, marshal_with, reqparse
+from flask_restplus import inputs
 from src.api.v1.helpers import (
     DescriptiveArgument,
     abort_bad_path_param,
@@ -1212,7 +1213,7 @@ feeling_lucky_parser.add_argument(
     "with_users",
     required=False,
     default=False,
-    type=bool,
+    type=inputs.boolean,
     description="Boolean to include user info with tracks",
 )
 feeling_lucky_parser.add_argument(

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -7,7 +7,6 @@ from urllib.parse import urljoin
 from flask import redirect
 from flask.globals import request
 from flask_restx import Namespace, Resource, fields, inputs, marshal_with, reqparse
-from flask_restplus import inputs
 from src.api.v1.helpers import (
     DescriptiveArgument,
     abort_bad_path_param,

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -1,5 +1,6 @@
 from sqlalchemy import func
 from src.models.tracks.track import Track
+from src.models.users.aggregate_user import AggregateUser
 from src.queries.query_helpers import (
     get_users_by_id,
     get_users_ids,
@@ -21,11 +22,13 @@ def get_random_tracks(args):
             session.query(
                 Track,
             )
+            .join(AggregateUser, Track.owner_id == AggregateUser.user_id)
             .filter(
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.is_unlisted == False,
-                Track.stem_of == None,
+                Track.is_current is True,
+                Track.is_delete is False,
+                Track.is_unlisted is False,
+                Track.stem_of is None,
+                AggregateUser.follower_count > 10,
             )
             .order_by(func.random())
             .limit(limit)

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -33,7 +33,6 @@ def get_random_tracks(args):
             .order_by(func.random())
             .limit(limit)
         )
-        print(f"get_random_tracks.py query: {str(tracks_query)}")
 
         tracks_query_results = tracks_query.all()
         tracks = helpers.query_result_to_list(tracks_query_results)

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -28,7 +28,7 @@ def get_random_tracks(args):
                 Track.is_delete is False,
                 Track.is_unlisted is False,
                 Track.stem_of is None,
-                AggregateUser.follower_count > 10,
+                AggregateUser.follower_count > args.get("min_followers", 100),
             )
             .order_by(func.random())
             .limit(limit)
@@ -41,12 +41,15 @@ def get_random_tracks(args):
         # bundle peripheral info into track results
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 
+        print("get_randome_tracks.py")
         if args.get("with_users", False):
+            print("get_randome_tracks.py: retrieving users info")
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:
                 user = users[track["owner_id"]]
                 if user:
+                    print(f"user: {user}")
                     track["user"] = user
 
     return tracks

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -24,15 +24,16 @@ def get_random_tracks(args):
             )
             .join(AggregateUser, Track.owner_id == AggregateUser.user_id)
             .filter(
-                Track.is_current is True,
-                Track.is_delete is False,
-                Track.is_unlisted is False,
-                Track.stem_of is None,
-                AggregateUser.follower_count > args.get("min_followers", 100),
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.is_unlisted == False,
+                Track.stem_of == None,
+                AggregateUser.follower_count >= args.get("min_followers", 100),
             )
             .order_by(func.random())
             .limit(limit)
         )
+        print(f"get_random_tracks.py query: {str(tracks_query)}")
 
         tracks_query_results = tracks_query.all()
         tracks = helpers.query_result_to_list(tracks_query_results)
@@ -41,9 +42,9 @@ def get_random_tracks(args):
         # bundle peripheral info into track results
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 
-        print("get_randome_tracks.py")
+        print("get_random_tracks.py")
         if args.get("with_users", False):
-            print("get_randome_tracks.py: retrieving users info")
+            print("get_random_tracks.py: retrieving users info")
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:

--- a/discovery-provider/src/queries/get_random_tracks.py
+++ b/discovery-provider/src/queries/get_random_tracks.py
@@ -41,15 +41,12 @@ def get_random_tracks(args):
         # bundle peripheral info into track results
         tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
 
-        print("get_random_tracks.py")
         if args.get("with_users", False):
-            print("get_random_tracks.py: retrieving users info")
             user_id_list = get_users_ids(tracks)
             users = get_users_by_id(session, user_id_list)
             for track in tracks:
                 user = users[track["owner_id"]]
                 if user:
-                    print(f"user: {user}")
                     track["user"] = user
 
     return tracks

--- a/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -54,6 +54,7 @@ export interface GetFeelingLuckyTracksRequest {
     userId?: string;
     limit?: number;
     withUsers?: boolean;
+    minFollowers?: number;
 }
 
 export interface GetMostLovedTracksRequest {
@@ -264,6 +265,10 @@ export class TracksApi extends runtime.BaseAPI {
 
         if (requestParameters.withUsers !== undefined) {
             queryParameters['with_users'] = requestParameters.withUsers;
+        }
+
+        if (requestParameters.minFollowers !== undefined) {
+            queryParameters['min_followers'] = requestParameters.minFollowers;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
### Description
- Return random tracks from users with at least `min_followers` followers.
Some fixes for existing bugs:
- Use restx's inputs.boolean type for with_users query param because bool doesn't actually work as expected... it parses any input as truthy, even with_users=False. inputs.boolean works correctly. See https://github.com/noirbizarre/flask-restplus/issues/199.
- /tracks/feeling_lucky with no with_users query param was returning a 500 because tracks["user"] from querying Tracks and populating track metadata is a list with 1 element (the track owner). Not sure why. In other places in the code we just do tracks["user"][0] so did that here as well.

### Tests
Query /tracks/feeling_lucky. Play w query params and make sure responses are correct.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->