### PR TITLE
Support local S3 compat and move config check

### DIFF
--- a/comms/storage/config/config.go
+++ b/comms/storage/config/config.go
@@ -2,8 +2,44 @@
 package config
 
 import (
+	"errors"
+	"os"
+	"strings"
+
 	shared "comms.audius.co/shared/config"
+	"comms.audius.co/shared/utils"
+	"golang.org/x/exp/slog"
 )
+
+const (
+	AWS_ACCESS_KEY_ID     = "AWS_ACCESS_KEY_ID"
+	AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+	AWS_REGION            = "AWS_REGION"
+
+	GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS"
+
+	AZURE_STORAGE_ACCOUNT = "AZURE_STORAGE_ACCOUNT"
+	AZURE_STORAGE_KEY     = "AZURE_STORAGE_KEY"
+)
+
+type StorageDriverPrefix int
+
+const (
+	FILE StorageDriverPrefix = iota
+	HTTP
+	GS
+	S3
+	AZBLOB
+)
+
+var prefixWhitelist = map[string]StorageDriverPrefix{
+	"file":   FILE,
+	"http":   HTTP,
+	"https":  HTTP,
+	"gs":     GS,
+	"s3":     S3,
+	"azblob": AZBLOB,
+}
 
 type StorageConfig struct {
 	PeeringConfig           shared.PeeringConfig `json:"peeringConfig"`
@@ -22,6 +58,77 @@ func GetStorageConfig() *StorageConfig {
 	if storageConfig == nil {
 		storageConfig = &StorageConfig{}
 		shared.EnsurePrivKeyAndLoadConf(storageConfig)
+		err := verifyStorageCredentials(storageConfig.StorageDriverUrl)
+		if err != nil {
+			slog.Error("failed to verify storage credentials", err)
+			os.Exit(1)
+		}
 	}
 	return storageConfig
+}
+
+func parseStorageDriverPrefix(rawPrefix string) (StorageDriverPrefix, bool) {
+	prefix, ok := prefixWhitelist[rawPrefix]
+	return prefix, ok
+}
+
+func verifyStorageCredentials(blobDriverUrl string) error {
+	rawPrefix, uri, found := strings.Cut(blobDriverUrl, "://")
+
+	prefix, ok := parseStorageDriverPrefix(rawPrefix)
+	if !ok {
+		return errors.New("blobDriverURL's prefix isn't valid. Valid prefixes include: " + strings.Join(utils.Keys(prefixWhitelist), ","))
+	}
+
+	// S3: https://github.com/google/go-cloud/blob/master/blob/s3blob/example_test.go#L73
+	// GS: https://github.com/google/go-cloud/blob/master/blob/gcsblob/example_test.go#L57
+	// AZBLOB: https://github.com/google/go-cloud/blob/master/blob/azureblob/example_test.go#L71
+	switch prefix {
+	case FILE:
+		// no credentials needed for the file storage driver
+		// but we do make sure the directory exists
+		if found {
+			if err := os.MkdirAll(uri, os.ModePerm); err != nil {
+				slog.Error("failed to create local persistent storage dir", err)
+				return err
+			}
+		}
+
+		return nil
+	case GS:
+		// Check for gcloud cred env vars
+		googleAppCredentials := os.Getenv(GOOGLE_APPLICATION_CREDENTIALS)
+
+		if googleAppCredentials == "" {
+			return errors.New("missing credentials required for persistent GS backing (i.e. GOOGLE_APPLICATION_CREDENTIALS)")
+		}
+
+		return nil
+	case AZBLOB:
+		azureStorageAccount := os.Getenv(AZURE_STORAGE_ACCOUNT)
+		azureStorageKey := os.Getenv(AZURE_STORAGE_KEY)
+
+		if azureStorageAccount == "" || azureStorageKey == "" {
+			return errors.New("missing credentials required for persistent Azure backing (i.e. AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY)")
+		}
+
+		return nil
+	case HTTP, S3:
+		// HTTP and HTTPS default to S3.
+		// Solutions like MinIO use HTTPS links for storage but use an S3 compatible API specified by the "endpoint" param in the storage driver URL
+
+		accessKey := os.Getenv(AWS_ACCESS_KEY_ID)
+		secretKey := os.Getenv(AWS_SECRET_ACCESS_KEY)
+		region := os.Getenv(AWS_REGION)
+
+		if strings.Contains(uri, "endpoint=") {
+			slog.Info("Using custom 'endpoint' param in blobDriverURL for S3-compatible storage. This means you're using something like MinIO, Ceph, or SeaweedFS instead of S3.")
+		} else if accessKey == "" || secretKey == "" || region == "" {
+			return errors.New("missing credentials required for persistent S3 backing (i.e. AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY)")
+		}
+
+		return nil
+	}
+
+	return errors.New("unknown presistent storage type")
 }

--- a/comms/storage/config/config_test.go
+++ b/comms/storage/config/config_test.go
@@ -1,4 +1,5 @@
-package persistence
+// Package config provides the configuration for the storage node by reading env vars.
+package config
 
 import (
 	"os"
@@ -8,7 +9,7 @@ import (
 func TestParsePrefix(t *testing.T) {
 	tests := []struct {
 		input          string
-		expectedPrefix Prefix
+		expectedPrefix StorageDriverPrefix
 		expectedOk     bool
 	}{
 		{
@@ -49,7 +50,7 @@ func TestParsePrefix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		actual, ok := parsePrefix(tt.input)
+		actual, ok := parseStorageDriverPrefix(tt.input)
 
 		if ok != tt.expectedOk {
 			t.Fatalf("`%s` failed unexpectedly and isn't a valid Prefix", tt.input)
@@ -158,7 +159,7 @@ func TestCheckStorageCredentials(t *testing.T) {
 			os.Setenv(key, value)
 		}
 
-		actual := checkStorageCredentials(tt.url)
+		actual := verifyStorageCredentials(tt.url)
 		if (actual == nil) == tt.expectedError {
 			t.Fatalf("`%s` didn't check creds correctly with these env vars %+v, got error=%+v", tt.url, tt.envVars, actual)
 		}

--- a/comms/storage/persistence/README.md
+++ b/comms/storage/persistence/README.md
@@ -1,7 +1,7 @@
 **Storage Location**
 
 The default storage driver url is `file:///tmp/audius_storage`.
-This is the directory on your node where files will stored post transcoding.
+This is the directory on your node where files will be stored post transcoding.
 
 To update the local storage location set the `AUDIUS_STORAGE_DRIVER_URL` environment variable
 ```
@@ -16,7 +16,7 @@ The driver is determined based on the `storage_url` (eg `s3://your-bucket` uses 
 
 To use cloud object storage instead of local storage, you will need to:
 
-- create either an s3 bucket, gcs bucket or azure storage container
+- create either an s3 bucket, gcs bucket, or azure storage container
 - your bucket access policy should <u>NOT BE PUBLIC</u>
 - provision credentials that allow object storage access
 
@@ -26,6 +26,13 @@ AWS_ACCESS_KEY_ID="<my-access-key-id>"
 AWS_SECRET_ACCESS_KEY="<my-secret-access-key>"
 AWS_REGION="<my-aws-region>"
 AUDIUS_STORAGE_DRIVER_URL="s3://my-bucket?region=us-west-1"
+```
+
+
+S3-compatible storage [MinIO](https://www.minio.io/), [Ceph](https://ceph.com/), [SeaweedFS](https://github.com/chrislusf/seaweedfs)
+For these S3-compatible storage servers that recognize the same HTTP endpoints as S3, change the endpoint to the storage server you're using. Example for MinIO:
+```
+AUDIUS_STORAGE_DRIVER_URL="s3://my-bucket?endpoint=my.minio.local:8080&disableSSL=true&s3ForcePathStyle=true"
 ```
 
 [GCS storage](https://cloud.google.com/storage/docs/creating-buckets)

--- a/comms/storage/persistence/persistence.go
+++ b/comms/storage/persistence/persistence.go
@@ -5,13 +5,10 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
-	"comms.audius.co/shared/utils"
 	"comms.audius.co/storage/decider"
 	"comms.audius.co/storage/transcode"
 	"github.com/nats-io/nats.go"
@@ -24,36 +21,6 @@ import (
 	_ "gocloud.dev/blob/s3blob"
 )
 
-const (
-	AWS_ACCESS_KEY_ID     = "AWS_ACCESS_KEY_ID"
-	AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
-	AWS_REGION            = "AWS_REGION"
-
-	GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS"
-
-	AZURE_STORAGE_ACCOUNT = "AZURE_STORAGE_ACCOUNT"
-	AZURE_STORAGE_KEY     = "AZURE_STORAGE_KEY"
-)
-
-type Prefix int
-
-const (
-	FILE Prefix = iota
-	HTTP
-	GS
-	S3
-	AZBLOB
-)
-
-var prefixWhitelist = map[string]Prefix{
-	"file":   FILE,
-	"http":   HTTP,
-	"https":  HTTP,
-	"gs":     GS,
-	"s3":     S3,
-	"azblob": AZBLOB,
-}
-
 type Persistence struct {
 	streamToStoreFrom string
 	storageDecider    decider.StorageDecider
@@ -63,14 +30,9 @@ type Persistence struct {
 
 // New creates a struct that listens to streamToStoreFrom and downloads content from the temp store to the persistent store.
 func New(thisNodePubKey, streamToStoreFrom, blobDriverURL string, storageDecider decider.StorageDecider, jsc nats.JetStreamContext) (*Persistence, error) {
-
-	if err := checkStorageCredentials(blobDriverURL); err != nil {
-		return nil, err
-	}
-
 	b, err := blob.OpenBucket(context.Background(), blobDriverURL)
 	if err != nil {
-		slog.Error("failed to open bucket" + blobDriverURL, err)
+		slog.Error("failed to open bucket "+blobDriverURL, err)
 		return nil, err
 	}
 
@@ -335,70 +297,4 @@ func (persist *Persistence) moveTempToPersistent(job transcode.Job) error {
 	}
 
 	return nil
-}
-
-func parsePrefix(rawPrefix string) (Prefix, bool) {
-	prefix, ok := prefixWhitelist[rawPrefix]
-	return prefix, ok
-}
-
-func checkStorageCredentials(blobDriverUrl string) error {
-	// TODO: this logic should probably be in the config module
-	rawPrefix, uri, found := strings.Cut(blobDriverUrl, "://")
-
-	prefix, ok := parsePrefix(rawPrefix)
-	if !ok {
-		return errors.New("blobDriverURL's prefix isn't valid. Valid prefixes include: " + strings.Join(utils.Keys(prefixWhitelist), ","))
-	}
-
-	// S3: https://github.com/google/go-cloud/blob/master/blob/s3blob/example_test.go#L73
-	// GS: https://github.com/google/go-cloud/blob/master/blob/gcsblob/example_test.go#L57
-	// AZBLOB: https://github.com/google/go-cloud/blob/master/blob/azureblob/example_test.go#L71
-	switch prefix {
-	case FILE:
-		// no credentials needed for the file storage driver
-		// but we do make sure the directory exists
-		if found {
-			if err := os.MkdirAll(uri, os.ModePerm); err != nil {
-				slog.Error("failed to create local persistent storage dir", err)
-				return err
-			}
-		}
-
-		return nil
-	case GS:
-		// Check for gcloud cred env vars
-		googleAppCredentials := os.Getenv(GOOGLE_APPLICATION_CREDENTIALS)
-
-		if googleAppCredentials == "" {
-			return errors.New("Missing credentials required for persistent GS backing (i.e. GOOGLE_APPLICATION_CREDENTIALS)")
-		}
-
-		return nil
-	case AZBLOB:
-		azureStorageAccount := os.Getenv(AZURE_STORAGE_ACCOUNT)
-		azureStorageKey := os.Getenv(AZURE_STORAGE_KEY)
-
-		if azureStorageAccount == "" || azureStorageKey == "" {
-			return errors.New("Missing credentials required for persistent Azure backing (i.e. AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY)")
-		}
-
-		return nil
-	case HTTP, S3:
-		// https defaults to S3
-		// solutions like Minio use https links for storage but use an S3 compatible API
-
-		accessKey := os.Getenv(AWS_ACCESS_KEY_ID)
-		secretKey := os.Getenv(AWS_SECRET_ACCESS_KEY)
-		region := os.Getenv(AWS_REGION)
-
-		if accessKey == "" || secretKey == "" || region == "" {
-			return errors.New("Missing credentials required for persistent S3 backing (i.e. AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY)")
-		}
-
-		// check for s3 env vars
-		return nil
-	}
-
-	return errors.New("unknown presistent storage type")
 }


### PR DESCRIPTION
### Description

- Adds support for local S3 compatible backends like MinIO, Ceph, and SeaweedFS (it's simple - just don't assert S3 credentials if the the "endpoint" param is present. See https://gocloud.dev/howto/blob/#s3-compatible) 
- Moves the config check assertion from persistence package to config package to resolve a TODO

Note: no need to re-review `config_test.go` or `verifyStorageCredentials()` because the code is the same except for the "case HTTP, S3" block



### Tests
I only tested local storage v2 with `make`, but nothing changed for the backends besides checking for a local "endpoint" param so other backends should still work when we start using them.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A