### PR TITLE
Remove prod-creator-4 from ci deploy

### DIFF
--- a/.circleci/workflows/main.yml
+++ b/.circleci/workflows/main.yml
@@ -122,7 +122,6 @@ jobs:
       requires:
         - deploy-prod-creator-node-trigger
       hosts: >-
-        prod-creator-4
         prod-creator-1
         prod-creator-2
         prod-creator-3


### PR DESCRIPTION
This node is not registered
