### PR TITLE
Remove prod cn4 from deploy pipeline

### DIFF
--- a/.circleci/workflows/main.yml
+++ b/.circleci/workflows/main.yml
@@ -122,12 +122,11 @@ jobs:
       requires:
         - deploy-prod-creator-node-trigger
       hosts: >-
-        prod-creator-4
+        prod-user-metadata
         prod-creator-1
         prod-creator-2
         prod-creator-3
         prod-creator-5
-        prod-user-metadata
       service: creator-node
 
   - deploy-prod-discovery-provider-trigger:


### PR DESCRIPTION
### Description
Deploys to Prod UM first instead of CN4


### Tests
NA


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA