### PR TITLE
[C-2268] Add missing valid_types params to get-notifications endpoint

### DIFF
--- a/discovery-provider/src/api/v1/notifications.py
+++ b/discovery-provider/src/api/v1/notifications.py
@@ -53,6 +53,7 @@ class GetNotifications(Resource):
             else datetime.now(),
             "group_id": parsed_args.get("group_id"),
             "limit": parsed_args.get("limit"),
+            "valid_types": parsed_args.get("valid_types") or [],
         }
         unread_args = {
             "user_id": decoded_id,

--- a/libs/src/api/Notifications.ts
+++ b/libs/src/api/Notifications.ts
@@ -4,6 +4,7 @@ import {
   Action,
   EntityType
 } from '../services/dataContracts/EntityManagerClient'
+import type { GetUserNotificationsParams } from '../services/discoveryProvider/requests'
 
 type AnnouncementData = {}
 
@@ -113,23 +114,8 @@ export class Notifications extends Base {
     }
   }
 
-  async getNotifications({
-    encodedUserId,
-    timestamp,
-    groupId,
-    limit
-  }: {
-    encodedUserId: string
-    timestamp: number
-    groupId?: string
-    limit?: number
-  }): Promise<any> {
+  async getNotifications(params: GetUserNotificationsParams): Promise<any> {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
-    return await this.discoveryProvider.getUserNotifications({
-      encodedUserId,
-      timestamp,
-      groupId,
-      limit
-    })
+    return await this.discoveryProvider.getUserNotifications(params)
   }
 }

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -865,23 +865,8 @@ export class DiscoveryProvider {
     return await this._makeRequest(req)
   }
 
-  async getUserNotifications({
-    encodedUserId,
-    timestamp,
-    groupId,
-    limit
-  }: {
-    encodedUserId: string
-    timestamp: number
-    groupId?: string
-    limit?: number
-  }) {
-    const req = Requests.getUserNotifications({
-      encodedUserId,
-      timestamp,
-      groupId,
-      limit
-    })
+  async getUserNotifications(params: Requests.GetUserNotificationsParams) {
+    const req = Requests.getUserNotifications(params)
     return await this._makeRequest(req)
   }
 

--- a/libs/src/services/discoveryProvider/requests.ts
+++ b/libs/src/services/discoveryProvider/requests.ts
@@ -651,23 +651,28 @@ export const getNotifications = (
   }
 }
 
-export const getUserNotifications = ({
-  encodedUserId,
-  timestamp,
-  groupId,
-  limit
-}: {
+export type GetUserNotificationsParams = {
   encodedUserId: string
   timestamp: number
   groupId?: string
   limit?: number
-}) => {
+  validTypes?: string[]
+}
+
+export const getUserNotifications = ({
+  encodedUserId,
+  timestamp,
+  groupId,
+  limit,
+  validTypes
+}: GetUserNotificationsParams) => {
   return {
     endpoint: `v1/full/notifications/${encodedUserId}`,
     queryParams: {
       timestamp,
       group_id: groupId,
-      limit
+      limit,
+      valid_types: validTypes
     }
   }
 }


### PR DESCRIPTION
### Description
Fixes discovery-provider get-notifications endpoint to pass through valid_types arg.
Fixes libs getUserNotifications method to also pass through this arg.


### Tests
Used cloned stage database, found which users have repost_of_repost notifications, and hit this endpoint http://audius-protocol-discovery-provider-1:5000/v1/full/notifications/5epYn?valid_types=repost_of_repost&valid_types=save_of_repost to confirm we get them back.

Still need to test libs e2e, so may reach out on how best to do that