### PR TITLE
double money for docker

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -381,7 +381,7 @@ services:
     extends:
       file: docker-compose.yml
       service: identity-service
-    entrypoint: sh -c '[ ! "$$1" = "test" ] && echo $(ls) && sleep inf || (shift; ./node_modules/.bin/mocha "$$@")' -
+    entrypoint: sh -c '[ ! "$$1" = "test" ] && echo $$(ls) && sleep inf || (shift; ./node_modules/.bin/mocha "$$@")' -
     command: ""
     environment:
       isTestRun: "true"


### PR DESCRIPTION
### Description
docker requires a second "$" when running scripts because of the way its parser works, this was missing on the echo


### Tests
ran `audius-compose test run "identity-service"` locally successfully


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
None