### PR TITLE
Fix celery worker startup by removing prometheus

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -29,7 +29,6 @@ from src.queries import (
     health_check,
     index_block_stats,
     notifications,
-    prometheus_metrics_exporter,
     queries,
     search,
     search_queries,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
I assumed this change had made it to the release but it didn't. Ray merged my PR while I was away https://github.com/AudiusProject/audius-protocol/pull/4879
 and it was missing this import removal which is the actual problem. I'm not sure if it'll fix all cases but I've observed a few situations where the indexer restarts but celery is not able to be configured because of this error in app.py


This change is already on main from another PR thanks to linting from this PR https://github.com/AudiusProject/audius-protocol/pull/4872

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->