### PR TITLE
Fix discovery notifications endpoint for unread

### DIFF
--- a/discovery-provider/src/api/v1/notifications.py
+++ b/discovery-provider/src/api/v1/notifications.py
@@ -50,7 +50,7 @@ class GetNotifications(Resource):
             "user_id": decoded_id,
             "timestamp": datetime.fromtimestamp(parsed_args.get("timestamp"))
             if parsed_args.get("timestamp")
-            else datetime.now(),
+            else None,
             "group_id": parsed_args.get("group_id"),
             "limit": parsed_args.get("limit"),
             "valid_types": parsed_args.get("valid_types") or [],


### PR DESCRIPTION
### Description
Removes default timestamp of current datetime bc it gets compared to another datetime.now() which is invalid


### Tests
Has not been tested, but sure it works

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->