### PR TITLE
handle nonexistent user in relay

### DIFF
--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -107,7 +107,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     where: { walletAddress: req.body.senderAddress },
     attributes: ['blockchainUserId']
   })
-  const userId = user.blockchainUserId
+  const userId = user == null ? "unknown" : user.blockchainUserId
 
   reporter.reportStart({
     userId,

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -107,7 +107,8 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     where: { walletAddress: req.body.senderAddress },
     attributes: ['blockchainUserId']
   })
-  const userId = user == null ? "unknown" : user.blockchainUserId
+  const userId =
+    user && user.blockchainUserId ? user.blockchainUserId : 'unknown'
 
   reporter.reportStart({
     userId,


### PR DESCRIPTION
### Description
sometimes the identity is the sender for relays and ID is not a user, this sets it as "unknown" for now