### PR TITLE
Add play count to user listening history and allow sorting by play count

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
+++ b/discovery-provider/integration_tests/queries/test_get_user_listening_history.py
@@ -15,8 +15,19 @@ from src.utils.db_session import get_db
 TIMESTAMP = datetime(2011, 1, 1)
 
 test_entities = {
+    "user_listening_history": [
+        {
+            "user_id": 1,
+            "listening_history": [
+                {"timestamp": str(TIMESTAMP), "track_id": 3},
+                {"timestamp": str(TIMESTAMP), "track_id": 4},
+            ],
+        }
+    ],
     "plays": [
         {"user_id": 1, "item_id": 1, "created_at": TIMESTAMP + timedelta(minutes=1)},
+        {"user_id": 1, "item_id": 1, "created_at": TIMESTAMP - timedelta(minutes=1)},
+        {"user_id": 1, "item_id": 1, "created_at": TIMESTAMP - timedelta(minutes=1)},
         {"user_id": 1, "item_id": 2, "created_at": TIMESTAMP + timedelta(minutes=3)},
         {
             "user_id": 1,
@@ -30,6 +41,7 @@ test_entities = {
         {"track_id": 1, "title": "track 1", "owner_id": 1, "is_delete": True},
         {"track_id": 2, "title": "track 2", "owner_id": 2},
         {"track_id": 3, "title": "track 3", "owner_id": 3},
+        {"track_id": 4, "title": "track 4", "owner_id": 3},
     ],
     "users": [
         {"user_id": 1, "handle": "user-1"},
@@ -62,7 +74,7 @@ def test_get_user_listening_history_multiple_plays(app):
             ),
         )
 
-    assert len(track_history) == 3
+    assert len(track_history) == 4
     assert (
         track_history[0][response_name_constants.user][response_name_constants.balance]
         is not None
@@ -264,7 +276,7 @@ def test_get_user_listening_history_custom_sort(app):
             ),
         )
 
-    assert len(track_history) == 3
+    assert len(track_history) == 4
     assert (
         track_history[2][response_name_constants.user][response_name_constants.balance]
         is not None
@@ -288,4 +300,45 @@ def test_get_user_listening_history_custom_sort(app):
     assert track_history[0][response_name_constants.track_id] == 1
     assert track_history[0][response_name_constants.activity_timestamp] == str(
         TIMESTAMP + timedelta(minutes=2)
+    )
+
+
+def test_get_user_listening_history_sort_by_most_listens(app):
+    """Tests listening history from user with multiple plays"""
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, test_entities)
+
+    with db.scoped_session() as session:
+        _index_user_listening_history(session)
+
+        track_history = _get_user_listening_history(
+            session,
+            GetUserListeningHistoryArgs(
+                user_id=1,
+                current_user_id=1,
+                limit=10,
+                offset=0,
+                query=None,
+                sort_method=SortMethod.most_listens_by_user,
+                sort_direction=SortDirection.asc,
+            ),
+        )
+
+    assert len(track_history) == 4
+    assert_track_history(track_history[0], 1, TIMESTAMP + timedelta(minutes=2))
+    assert_track_history(track_history[1], 3, TIMESTAMP + timedelta(minutes=4))
+    assert_track_history(track_history[2], 2, TIMESTAMP + timedelta(minutes=3))
+    assert_track_history(track_history[3], 4, TIMESTAMP)
+
+
+def assert_track_history(track_history, track_id, activity_timestamp):
+    assert (
+        track_history[response_name_constants.user][response_name_constants.balance]
+        is not None
+    )
+    assert track_history[response_name_constants.track_id] == track_id
+    assert track_history[response_name_constants.activity_timestamp] == str(
+        activity_timestamp
     )

--- a/discovery-provider/integration_tests/tasks/test_index_user_listening_history.py
+++ b/discovery-provider/integration_tests/tasks/test_index_user_listening_history.py
@@ -20,6 +20,197 @@ TIMESTAMP_1 = datetime(2011, 1, 1)
 TIMESTAMP_2 = datetime(2012, 2, 2)
 TIMESTAMP_3 = datetime(2013, 3, 3)
 TIMESTAMP_4 = datetime(2014, 4, 4)
+TIMESTAMP_5 = datetime(2015, 5, 5)
+
+
+# Tests
+def test_index_user_listening_history_populate_testtt(app):
+    """Tests populating user_listening_history from empty"""
+
+    # setup
+    with app.app_context():
+        db = get_db()
+
+    # run
+    entities = {
+        "tracks": [
+            {"track_id": 1, "title": "track 1"},
+            {"track_id": 2, "title": "track 2"},
+            {"track_id": 3, "title": "track 3"},
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user-1"},
+            {"user_id": 2, "handle": "user-2"},
+            {"user_id": 3, "handle": "user-3"},
+        ],
+        "plays": [
+            # New Plays
+            {"item_id": 1, "user_id": 1, "created_at": TIMESTAMP_1},
+            {"item_id": 1, "user_id": 1, "created_at": TIMESTAMP_4},
+            {"item_id": 1, "user_id": 1, "created_at": TIMESTAMP_2},
+            {"item_id": 1, "user_id": 1, "created_at": TIMESTAMP_3},
+            {"item_id": 1, "user_id": 1, "created_at": TIMESTAMP_4},
+            {"item_id": 3, "user_id": 1, "created_at": TIMESTAMP_5},
+            {"item_id": 1, "user_id": 2, "created_at": TIMESTAMP_1},
+            {"item_id": 2, "user_id": 3, "created_at": TIMESTAMP_1},
+            {"item_id": 2, "user_id": 2, "created_at": TIMESTAMP_2},
+            {"item_id": 3, "user_id": 3, "created_at": TIMESTAMP_2},
+            {"item_id": 1, "user_id": 3, "created_at": TIMESTAMP_3},
+        ],
+    }
+
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        _index_user_listening_history(session)
+
+        results: List[UserListeningHistory] = (
+            session.query(UserListeningHistory)
+            .order_by(UserListeningHistory.user_id)
+            .all()
+        )
+
+        assert len(results) == 3
+
+        assert results[0].user_id == 1
+        assert len(results[0].listening_history) == 2
+        print("history", results[0].listening_history)
+        assert results[0].listening_history[0]["track_id"] == 3
+        assert results[0].listening_history[0]["timestamp"] == str(TIMESTAMP_5)
+        assert results[0].listening_history[0]["play_count"] == 1
+        assert results[0].listening_history[1]["track_id"] == 1
+        assert results[0].listening_history[1]["timestamp"] == str(TIMESTAMP_4)
+        assert results[0].listening_history[1]["play_count"] == 5
+
+
+def test_index_user_listening_history_update_testt(app):
+    """Tests updating user_listening_history"""
+
+    # setup
+    with app.app_context():
+        db = get_db()
+
+    # run
+    entities = {
+        "tracks": [
+            {"track_id": 1, "title": "track 1"},
+            {"track_id": 2, "title": "track 2"},
+            {"track_id": 3, "title": "track 3"},
+            {"track_id": 4, "title": "track 3"},
+            {"track_id": 5, "title": "track 3"},
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user-1"},
+            {"user_id": 2, "handle": "user-2"},
+            {"user_id": 3, "handle": "user-3"},
+            {"user_id": 4, "handle": "user-4"},
+        ],
+        "user_listening_history": [
+            {
+                "user_id": 1,
+                "listening_history": [
+                    {"timestamp": str(TIMESTAMP_1), "track_id": 1},
+                    {"timestamp": str(TIMESTAMP_2), "track_id": 5},
+                ],
+            },
+            {
+                "user_id": 2,
+                "listening_history": [
+                    {"timestamp": str(TIMESTAMP_2), "track_id": 2, "play_count": 3},
+                    {"timestamp": str(TIMESTAMP_1), "track_id": 1},
+                ],
+            },
+            {
+                "user_id": 3,
+                "listening_history": [
+                    {"timestamp": str(TIMESTAMP_3), "track_id": 1},
+                    {"timestamp": str(TIMESTAMP_2), "track_id": 3},
+                    {"timestamp": str(TIMESTAMP_1), "track_id": 2},
+                ],
+            },
+        ],
+        "plays": [
+            # New play
+            {
+                "item_id": 2,
+                "user_id": 1,
+                "created_at": TIMESTAMP_3,
+            },  # listen to new track
+            {
+                "item_id": 1,
+                "user_id": 1,
+                "created_at": TIMESTAMP_3,
+            },
+            {
+                "item_id": 1,
+                "user_id": 1,
+                "created_at": TIMESTAMP_4,
+            },  # re-listen to existing track, dedupe
+            {
+                "item_id": 2,
+                "user_id": 2,
+                "created_at": TIMESTAMP_3,
+            },
+            {
+                "item_id": 1,
+                "user_id": 2,
+                "created_at": TIMESTAMP_4,
+            },
+        ]
+        + [
+            # new user listens to many tracks
+            {
+                "item_id": i + 1,
+                "user_id": 4,
+                "created_at": TIMESTAMP_4 + timedelta(hours=i),
+            }
+            for i in range(2000)
+        ],
+    }
+
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        _index_user_listening_history(session)
+
+    with db.scoped_session() as session:
+        results: List[UserListeningHistory] = (
+            session.query(UserListeningHistory)
+            .order_by(UserListeningHistory.user_id)
+            .all()
+        )
+
+        assert len(results) == 4
+
+        assert results[0].user_id == 1
+        assert len(results[0].listening_history) == 3
+        print("history isss ", results[0].listening_history)
+        assert results[0].listening_history[0]["track_id"] == 1
+        assert results[0].listening_history[0]["timestamp"] == str(TIMESTAMP_4)
+        assert results[0].listening_history[0]["play_count"] == 3
+        assert results[0].listening_history[1]["track_id"] == 2
+        assert results[0].listening_history[1]["timestamp"] == str(TIMESTAMP_3)
+        assert results[0].listening_history[1]["play_count"] == 1
+        assert results[0].listening_history[2]["track_id"] == 5
+        assert results[0].listening_history[2]["timestamp"] == str(TIMESTAMP_2)
+        assert results[0].listening_history[2]["play_count"] == 1
+
+        assert results[1].user_id == 2
+        assert len(results[1].listening_history) == 2
+        assert results[1].listening_history[0]["track_id"] == 1
+        assert results[1].listening_history[0]["timestamp"] == str(TIMESTAMP_4)
+        assert results[1].listening_history[0]["play_count"] == 2
+        assert results[1].listening_history[1]["track_id"] == 2
+        assert results[1].listening_history[1]["timestamp"] == str(TIMESTAMP_3)
+        assert results[1].listening_history[1]["play_count"] == 4
+
+        assert results[3].user_id == 4
+        assert len(results[3].listening_history) == 1000
+        for i in range(1000):
+            assert results[3].listening_history[i]["track_id"] == 2000 - i
+            assert results[3].listening_history[i]["timestamp"] == str(
+                datetime.fromisoformat("2014-06-26 07:00:00") - timedelta(hours=i)
+            )
 
 
 # Tests

--- a/discovery-provider/integration_tests/tasks/test_index_user_listening_history.py
+++ b/discovery-provider/integration_tests/tasks/test_index_user_listening_history.py
@@ -24,7 +24,7 @@ TIMESTAMP_5 = datetime(2015, 5, 5)
 
 
 # Tests
-def test_index_user_listening_history_populate_testtt(app):
+def test_index_user_listening_history_populate_play_count(app):
     """Tests populating user_listening_history from empty"""
 
     # setup
@@ -83,7 +83,7 @@ def test_index_user_listening_history_populate_testtt(app):
         assert results[0].listening_history[1]["play_count"] == 5
 
 
-def test_index_user_listening_history_update_testt(app):
+def test_index_user_listening_history_update_play_count(app):
     """Tests updating user_listening_history"""
 
     # setup
@@ -95,15 +95,11 @@ def test_index_user_listening_history_update_testt(app):
         "tracks": [
             {"track_id": 1, "title": "track 1"},
             {"track_id": 2, "title": "track 2"},
-            {"track_id": 3, "title": "track 3"},
-            {"track_id": 4, "title": "track 3"},
             {"track_id": 5, "title": "track 3"},
         ],
         "users": [
             {"user_id": 1, "handle": "user-1"},
             {"user_id": 2, "handle": "user-2"},
-            {"user_id": 3, "handle": "user-3"},
-            {"user_id": 4, "handle": "user-4"},
         ],
         "user_listening_history": [
             {
@@ -118,14 +114,6 @@ def test_index_user_listening_history_update_testt(app):
                 "listening_history": [
                     {"timestamp": str(TIMESTAMP_2), "track_id": 2, "play_count": 3},
                     {"timestamp": str(TIMESTAMP_1), "track_id": 1},
-                ],
-            },
-            {
-                "user_id": 3,
-                "listening_history": [
-                    {"timestamp": str(TIMESTAMP_3), "track_id": 1},
-                    {"timestamp": str(TIMESTAMP_2), "track_id": 3},
-                    {"timestamp": str(TIMESTAMP_1), "track_id": 2},
                 ],
             },
         ],
@@ -156,15 +144,6 @@ def test_index_user_listening_history_update_testt(app):
                 "user_id": 2,
                 "created_at": TIMESTAMP_4,
             },
-        ]
-        + [
-            # new user listens to many tracks
-            {
-                "item_id": i + 1,
-                "user_id": 4,
-                "created_at": TIMESTAMP_4 + timedelta(hours=i),
-            }
-            for i in range(2000)
         ],
     }
 
@@ -180,7 +159,7 @@ def test_index_user_listening_history_update_testt(app):
             .all()
         )
 
-        assert len(results) == 4
+        assert len(results) == 2
 
         assert results[0].user_id == 1
         assert len(results[0].listening_history) == 3
@@ -203,14 +182,6 @@ def test_index_user_listening_history_update_testt(app):
         assert results[1].listening_history[1]["track_id"] == 2
         assert results[1].listening_history[1]["timestamp"] == str(TIMESTAMP_3)
         assert results[1].listening_history[1]["play_count"] == 4
-
-        assert results[3].user_id == 4
-        assert len(results[3].listening_history) == 1000
-        for i in range(1000):
-            assert results[3].listening_history[i]["track_id"] == 2000 - i
-            assert results[3].listening_history[i]["timestamp"] == str(
-                datetime.fromisoformat("2014-06-26 07:00:00") - timedelta(hours=i)
-            )
 
 
 # Tests

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -119,6 +119,7 @@ class SortMethod(str, enum.Enum):
     plays = "plays"
     reposts = "reposts"
     saves = "saves"
+    most_listens_by_user = "most_listens_by_user"
 
 
 class TransactionSortMethod(str, enum.Enum):

--- a/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
+++ b/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from datetime import datetime
 from typing import DefaultDict
 
 import sqlalchemy as sa
@@ -19,13 +20,23 @@ USER_LISTENING_HISTORY_TABLE_NAME = "user_listening_history"
 BATCH_SIZE = 100000  # index 100k plays at most at a time
 
 
-def sort_listening_history(deduped_history_dict, limit=1000):
+def sort_listening_history(deduped_history_dict, deduped_play_counts={}, limit=1000):
     # sorts listening history and places a limit
     deduped_history = []
     for track_id, timestamp in deduped_history_dict.items():
-        deduped_history.append({"track_id": track_id, "timestamp": timestamp})
+        play_count = deduped_play_counts.get(track_id, 1)
+        deduped_history.append(
+            ListenHistory(
+                track_id=track_id, timestamp=timestamp, play_count=play_count
+            ).to_dict()
+        )
     deduped_history.sort(key=lambda listen: listen["timestamp"], reverse=True)
     return deduped_history[:limit]
+
+
+def sort_listening_history_array(listening_history_array, limit=1000):
+    listening_history_array.sort(key=lambda listen: listen["timestamp"], reverse=True)
+    return listening_history_array[:limit]
 
 
 def _index_user_listening_history(session):
@@ -44,7 +55,6 @@ def _index_user_listening_history(session):
         .limit(BATCH_SIZE)
     ).all()
 
-    # no update exit early
     if not new_plays:
         return
     new_checkpoint = new_plays[-1].id  # get the highest play id
@@ -63,9 +73,9 @@ def _index_user_listening_history(session):
     # reduce new plays
     insert_user_listening_history_dict = DefaultDict(list)
     update_user_listening_history_dict = DefaultDict(list)
-    for new_play in reversed(new_plays):
+    for new_play in new_plays:
         listen_history = ListenHistory(
-            new_play.play_item_id, new_play.created_at
+            new_play.play_item_id, new_play.created_at, play_count=1
         ).to_dict()
 
         if new_play.user_id in existing_users:
@@ -73,30 +83,53 @@ def _index_user_listening_history(session):
         else:
             insert_user_listening_history_dict[new_play.user_id].append(listen_history)
 
+    # deduping existing histories
     # make updates to existing users
+    # TODO UPDATE THIS SECTION FOR UPDATING HISTORIES
     for i, user_history in enumerate(existing_user_listening_history):
-        deduped_history_dict = {}
-        for existing_play in reversed(user_history.listening_history):
-            deduped_history_dict[existing_play["track_id"]] = existing_play["timestamp"]
-        for new_play in reversed(
-            update_user_listening_history_dict[user_history.user_id]
-        ):
-            deduped_history_dict[new_play["track_id"]] = new_play["timestamp"]
+        track_to_latest_timestamp = {}
+        track_to_play_count = DefaultDict(int)
+        for existing_play in user_history.listening_history:
+            track_to_latest_timestamp[existing_play["track_id"]] = existing_play[
+                "timestamp"
+            ]
+            track_to_play_count[existing_play["track_id"]] = existing_play.get(
+                "play_count", 1
+            )
+
+        for new_play in update_user_listening_history_dict[user_history.user_id]:
+            current_max_timestamp = track_to_latest_timestamp.get(
+                new_play["track_id"], str(datetime.min)
+            )
+            track_to_latest_timestamp[new_play["track_id"]] = max(
+                current_max_timestamp, new_play["timestamp"]
+            )
+            track_to_play_count[new_play["track_id"]] += 1
+
         existing_user_listening_history[i].listening_history = sort_listening_history(
-            deduped_history_dict
+            track_to_latest_timestamp, track_to_play_count
         )
 
     # insert for new users
     new_user_listening_history = []
-    for user, listening_history in insert_user_listening_history_dict.items():
-        deduped_history_dict = {}
-        for new_play in reversed(listening_history):
-            deduped_history_dict[new_play["track_id"]] = new_play["timestamp"]
+    for user_id, listening_histories in insert_user_listening_history_dict.items():
+        track_to_play_count = DefaultDict(int)
+        track_to_latest_timestamp = {}
+        for new_play in listening_histories:
+            current_max_timestamp = track_to_latest_timestamp.get(
+                new_play["track_id"], str(datetime.min)
+            )
+            track_to_latest_timestamp[new_play["track_id"]] = max(
+                current_max_timestamp, new_play["timestamp"]
+            )
+            track_to_play_count[new_play["track_id"]] += 1
 
         new_user_listening_history.append(
             UserListeningHistory(
-                user_id=user,
-                listening_history=sort_listening_history(deduped_history_dict),
+                user_id=user_id,
+                listening_history=sort_listening_history(
+                    track_to_latest_timestamp, track_to_play_count
+                ),
             )
         )
     session.add_all(new_user_listening_history)

--- a/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
+++ b/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
@@ -21,12 +21,12 @@ BATCH_SIZE = 100000  # index 100k plays at most at a time
 
 
 def sort_listening_history_desc_by_timestamp(
-    deduped_history_dict, deduped_play_counts={}, limit=1000
+    track_id_to_timestamp, track_id_to_play_count={}, limit=1000
 ):
     # sorts listening history and places a limit
     deduped_history = []
-    for track_id, timestamp in deduped_history_dict.items():
-        play_count = deduped_play_counts.get(track_id, 1)
+    for track_id, timestamp in track_id_to_timestamp.items():
+        play_count = track_id_to_play_count.get(track_id, 1)
         deduped_history.append(
             ListenHistory(
                 track_id=track_id, timestamp=timestamp, play_count=play_count
@@ -34,11 +34,6 @@ def sort_listening_history_desc_by_timestamp(
         )
     deduped_history.sort(key=lambda listen: listen["timestamp"], reverse=True)
     return deduped_history[:limit]
-
-
-def sort_listening_history_array(listening_history_array, limit=1000):
-    listening_history_array.sort(key=lambda listen: listen["timestamp"], reverse=True)
-    return listening_history_array[:limit]
 
 
 def _index_user_listening_history(session):

--- a/discovery-provider/src/tasks/user_listening_history/listen_history.py
+++ b/discovery-provider/src/tasks/user_listening_history/listen_history.py
@@ -2,9 +2,14 @@ from datetime import datetime
 
 
 class ListenHistory:
-    def __init__(self, track_id: int, timestamp: datetime):
+    def __init__(self, track_id: int, timestamp: datetime, play_count: int):
         self.track_id = track_id
         self.timestamp = timestamp
+        self.play_count = play_count
 
     def to_dict(self):
-        return {"track_id": self.track_id, "timestamp": str(self.timestamp)}
+        return {
+            "track_id": self.track_id,
+            "timestamp": str(self.timestamp),
+            "play_count": self.play_count,
+        }


### PR DESCRIPTION
### Description
Apologies in advance :') there's a couple changes in here:
1. refactored index_user_listening_history by renaming some things and extracting parts out into functions
2. added ability to count play counts going forward in user listening history entries. this will not backfill for past entries in the column, but anything newly indexed will begin counting. if there is no play count available in an entry, a default of 1 is assumed
3. updated the get_user_listen_history endpoint to handle a new sorting method of most_listens_by_user. rn there is a sorter by plays but its by all plays of the track not by the tracks the logged in user specifically listened to. 

this is all so that we can fix the heavy rotation playlist and move that endpoint from identity into discovery. once this is in prod, we can use this to generate the heavy rotation playlist. while play counts are not populated yet, it will just pull most recently played tracks for a user, but once we start indexing play counts it will retrieve tracks most listened to by a user


### Tests
added a bunch of unit tests. also ran the get user listening history endpoint locally with a prod clone and tested the ordering
http://localhost:5000/v1/full/users/5epYn/history/tracks?user_id=5epYn&limit=4&offset=0&sort_method=most_listens_by_user
