### PR TITLE
Fix duplicate create EM validation failure on follow 

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -269,7 +269,7 @@ def validate_social_feature(params: ManageEntityParameters):
     for record_type in record_types:
         existing_record = params.existing_records.get(record_type, {}).get(key)
         logger.info(
-            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, existing record: {existing_record}"
+            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, params.action: {params.action}, is_delete: {existing_record.is_delete}, type of is_delete: {type(existing_record.is_delete)}, not is_delete: {not existing_record.is_delete}, existing record: {existing_record}"
         )
         if existing_record:
             duplicate_create = (

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -64,7 +64,7 @@ def create_social_record(params: ManageEntityParameters):
     record_types = action_to_record_types[params.action]
     create_record: Union[Save, Follow, Repost, Subscription, None] = None
     for record_type in record_types:
-        if validate_duplicate_social_feature(record_type, params):
+        if not validate_duplicate_social_feature(record_type, params):
             continue
         if record_type == EntityType.FOLLOW:
             create_record = Follow(
@@ -268,6 +268,10 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
     key = get_record_key(params.user_id, params.entity_type, params.entity_id)
 
     existing_record = params.existing_records.get(record_type, {}).get(key)
+    logger.info(
+        f"entity_manager.py | social_features.py | record_type: {record_type}, key: {key}, existing record: {existing_record}"
+    )
+
     if existing_record:
         duplicate_create = (
             record_type
@@ -282,7 +286,7 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
 
         if duplicate_create or duplicate_delete:
             logger.info(
-                f"User {params.user_id} has already sent a {record_type} for {params.entity_type} {params.entity_id}. Skipping"
+                f"entity_manager.py | User {params.user_id} has already sent a {record_type} for {params.entity_type} {params.entity_id}. Skipping"
             )
             return False
         return True

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -64,6 +64,7 @@ def create_social_record(params: ManageEntityParameters):
     record_types = action_to_record_types[params.action]
     create_record: Union[Save, Follow, Repost, Subscription, None] = None
     for record_type in record_types:
+        logger.info(f"entity_manager.py | social_features.py | before validating duplicate for record type: {record_type}, params: {params}")
         if not validate_duplicate_social_feature(record_type, params):
             continue
         if record_type == EntityType.FOLLOW:
@@ -289,5 +290,5 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
                 f"entity_manager.py | User {params.user_id} has already sent a {record_type} for {params.entity_type} {params.entity_id}. Skipping"
             )
             return False
-        return True
+    return True
 

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -169,6 +169,8 @@ def delete_social_record(params):
     record_types = action_to_record_types[params.action]
     deleted_record = None
     for record_type in record_types:
+        if not validate_duplicate_social_feature(record_type, params):
+            continue
         if record_type == EntityType.FOLLOW:
             deleted_record = Follow(
                 blockhash=params.event_blockhash,
@@ -252,7 +254,7 @@ def validate_social_feature(params: ManageEntityParameters):
         Action.UNSUBSCRIBE,
     ):
         if params.user_id == params.entity_id:
-            raise Exception(f"User {params.user_id} cannot follow themself")
+            raise Exception(f"User {params.user_id} cannot {params.action} themself")
     else:
         target_entity = params.existing_records[params.entity_type][params.entity_id]
         owner_id = (

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -269,21 +269,21 @@ def validate_social_feature(params: ManageEntityParameters):
     for record_type in record_types:
         existing_record = params.existing_records.get(record_type, {}).get(key)
         logger.info(
-            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, params.action: {params.action}, is_delete: {existing_record.is_delete}, type of is_delete: {type(existing_record.is_delete)}, not is_delete: {not existing_record.is_delete}, existing record: {existing_record}"
+            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, params.action: {params.action}, existing record: {existing_record}"
         )
         if existing_record:
             duplicate_create = (
-                params.action
-                in (Action.REPOST, Action.SAVE, Action.FOLLOW, Action.SUBSCRIBE)
+                record_type
+                in (EntityType.REPOST, EntityType.SAVE, EntityType.FOLLOW, EntityType.SUBSCRIBE)
                 and not existing_record.is_delete
             )
             duplicate_delete = (
-                params.action
-                in (Action.UNREPOST, Action.UNSAVE, Action.UNFOLLOW, Action.UNSUBSCRIBE)
+                record_type
+                in (EntityType.UNREPOST, EntityType.UNSAVE, EntityType.UNFOLLOW, EntityType.UNSUBSCRIBE)
                 and existing_record.is_delete
             )
 
             if duplicate_create or duplicate_delete:
                 raise Exception(
-                    f"User {params.user_id} has already sent a {params.action} for {params.entity_type} {params.entity_id}"
+                    f"User {params.user_id} has already sent a {record_type} for {params.entity_type} {params.entity_id}"
                 )

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -64,7 +64,6 @@ def create_social_record(params: ManageEntityParameters):
     record_types = action_to_record_types[params.action]
     create_record: Union[Save, Follow, Repost, Subscription, None] = None
     for record_type in record_types:
-        logger.info(f"entity_manager.py | social_features.py | before validating duplicate for record type: {record_type}, params: {params}")
         if not validate_duplicate_social_feature(record_type, params):
             continue
         if record_type == EntityType.FOLLOW:
@@ -269,9 +268,6 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
     key = get_record_key(params.user_id, params.entity_type, params.entity_id)
 
     existing_record = params.existing_records.get(record_type, {}).get(key)
-    logger.info(
-        f"entity_manager.py | social_features.py | record_type: {record_type}, key: {key}, existing record: {existing_record}"
-    )
 
     if existing_record:
         duplicate_create = (

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -268,6 +268,9 @@ def validate_social_feature(params: ManageEntityParameters):
 
     for record_type in record_types:
         existing_record = params.existing_records.get(record_type, {}).get(key)
+        logger.info(
+            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, existing record: {existing_record}"
+        )
         if existing_record:
             duplicate_create = (
                 params.action

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -268,9 +268,6 @@ def validate_social_feature(params: ManageEntityParameters):
 
     for record_type in record_types:
         existing_record = params.existing_records.get(record_type, {}).get(key)
-        logger.info(
-            f"entity_manager | social_features.py | record_type: {record_type}, key: {key}, params.action: {params.action}, existing record: {existing_record}"
-        )
         if existing_record:
             duplicate_create = (
                 record_type

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -273,19 +273,19 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
 
     if existing_record:
         duplicate_create = (
-            record_type
-            in (EntityType.REPOST, EntityType.SAVE, EntityType.FOLLOW, EntityType.SUBSCRIBE)
+            params.action
+            in (Action.REPOST, Action.SAVE, Action.FOLLOW, Action.SUBSCRIBE)
             and not existing_record.is_delete
         )
         duplicate_delete = (
-            record_type
-            in (EntityType.UNREPOST, EntityType.UNSAVE, EntityType.UNFOLLOW, EntityType.UNSUBSCRIBE)
+            params.action
+            in (Action.UNREPOST, Action.UNSAVE, Action.UNFOLLOW, Action.UNSUBSCRIBE)
             and existing_record.is_delete
         )
 
         if duplicate_create or duplicate_delete:
             logger.info(
-                f"entity_manager.py | User {params.user_id} has already sent a {record_type} for {params.entity_type} {params.entity_id}. Skipping"
+                f"entity_manager.py | User {params.user_id} has already sent a {params.action} for record type {record_type} for {params.entity_type} {params.entity_id}. Skipping"
             )
             return False
     return True

--- a/discovery-provider/src/tasks/entity_manager/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/social_features.py
@@ -265,7 +265,10 @@ def validate_social_feature(params: ManageEntityParameters):
         if params.user_id == owner_id:
             raise Exception(f"User {params.user_id} cannot {params.action} themself")
 
-def validate_duplicate_social_feature(record_type: EntityType, params: ManageEntityParameters):
+
+def validate_duplicate_social_feature(
+    record_type: EntityType, params: ManageEntityParameters
+):
     # Cannot duplicate a social feature
     key = get_record_key(params.user_id, params.entity_type, params.entity_id)
 
@@ -289,4 +292,3 @@ def validate_duplicate_social_feature(record_type: EntityType, params: ManageEnt
             )
             return False
     return True
-


### PR DESCRIPTION
### Description
Was incorrectly failing EM validations on follow in a specific edge case because of the recent subscriptions backfill. 

For some reason on 1/31/23 in stage when my user unfollowed another user, the corresponding subscriptions row in identity wasn't removed (this is the legacy code path). Then recently I backfilled the subscriptions table in discovery with the subscriptions table in identity as a source of truth. This caused a duplicate create validation error in EM because it was validating both the subscribe and follow records in order for the follow action to succeed. The information in the db for the current follow record was correct - it was an unfollow with `is_delete=True` so EM should have processed the follow event. However, the current subscriptions record was `is_delete=False` because identity (source of truth) was wrong.

The changes in this PR decouple the subscribe and follow validations/actions so even if for some reason there are simultaneous unfollow and subscribe records for a pair of users, the follow should succeed.

Not sure why identity had incorrect info. It might have been because of a bug deployed to a stage node while testing that day. Manually verified that the legacy identity path is working correctly on stage now.

### Tests
Integration tests + tested on stage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->