### PR TITLE
rpc id is the timestamp + md5(rpc)

### DIFF
--- a/comms/discovery/db/migrations/20230315135942_rpc_id.sql
+++ b/comms/discovery/db/migrations/20230315135942_rpc_id.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+
+alter table rpc_log add column id text;
+
+update rpc_log set id = to_char(jetstream_timestamp at time zone 'utc', 'YYYYMMDDHHMMSSMS') || '_' || md5(rpc::text);
+
+alter table rpc_log drop constraint rpc_log_pkey;
+
+alter table rpc_log add primary key (id);
+
+
+-- migrate:down
+
+alter table rpc_log drop column id;
+alter table rpc_log add primary key (jetstream_sequence);

--- a/comms/discovery/db/migrations/20230315135942_rpc_id.sql
+++ b/comms/discovery/db/migrations/20230315135942_rpc_id.sql
@@ -4,6 +4,11 @@ alter table rpc_log add column id text;
 
 update rpc_log set id = to_char(jetstream_timestamp at time zone 'utc', 'YYYYMMDDHHMMSSMS') || '_' || md5(rpc::text);
 
+-- delete dupes
+DELETE FROM rpc_log a WHERE a.ctid <> (SELECT min(b.ctid)
+                 FROM   rpc_log b
+                 WHERE  a.id = b.id);
+
 alter table rpc_log drop constraint rpc_log_pkey;
 
 alter table rpc_log add primary key (id);

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -2,9 +2,12 @@ package rpcz
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"expvar"
+	"strings"
 	"sync"
 	"time"
 
@@ -194,10 +197,18 @@ func (proc *RPCProcessor) Apply(msg *nats.Msg) {
 		defer tx.Rollback()
 		logger.Debug("begin tx", "took", takeSplit())
 
+		// build rpc_log id
+		hash := md5.Sum(msg.Data)
+		hashHex := hex.EncodeToString(hash[:])
+		tsString := strings.Replace(meta.Timestamp.Format("2006.01.02.15.04.05.000"), ".", "", -1)
+		idString := tsString + "_" + hashHex
+
 		query := `
-		INSERT INTO rpc_log (jetstream_sequence, jetstream_timestamp, from_wallet, rpc, sig) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING
+		INSERT INTO rpc_log (jetstream_sequence, jetstream_timestamp, from_wallet, rpc, sig, id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT DO NOTHING
 		`
-		result, err := tx.Exec(query, meta.Sequence.Stream, meta.Timestamp, wallet, msg.Data, signatureHeader)
+		result, err := tx.Exec(query, meta.Sequence.Stream, meta.Timestamp, wallet, msg.Data, signatureHeader, idString)
 		if err != nil {
 			return err
 		}

--- a/comms/discovery/rpcz/chat.go
+++ b/comms/discovery/rpcz/chat.go
@@ -11,7 +11,7 @@ import (
 func chatCreate(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatCreateRPCParams) error {
 	var err error
 
-	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, now(), now())", params.ChatID)
+	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2)", params.ChatID, ts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Adds a new `rpc_log.id` column which is `timestamp + md5(rpc)`.

This way we don't depend on `jetstream_sequence` to be unique and we are unaffected if jetstream is recreated.

We don't actually use `jetstream_sequence` for ordering anywhere, so this should be safe.