### PR TITLE
Remove wait in identity notifications

### DIFF
--- a/identity-service/src/notifications/index.js
+++ b/identity-service/src/notifications/index.js
@@ -33,8 +33,6 @@ const { indexTrendingTracks } = require('./trendingTrackProcessing')
 const sendNotifications = require('./sendNotifications/index.js')
 const audiusLibsWrapper = require('../audiusLibsInstance')
 
-const NOTIFICATION_INTERVAL_SEC = 3 * 1000
-const NOTIFICATION_SOLANA_INTERVAL_SEC = 3 * 1000
 const NOTIFICATION_ANNOUNCEMENTS_INTERVAL_SEC = 30 * 1000
 
 const NOTIFICATION_JOB_LAST_SUCCESS_KEY = 'notifications:last-success'
@@ -193,10 +191,6 @@ class NotificationProcessor {
           }
         )
       }
-      // Delay 3s
-      await new Promise((resolve) =>
-        setTimeout(resolve, NOTIFICATION_INTERVAL_SEC)
-      )
     })
 
     // Solana notification processing job
@@ -276,10 +270,6 @@ class NotificationProcessor {
           }
         )
       }
-      // Delay 3s
-      await new Promise((resolve) =>
-        setTimeout(resolve, NOTIFICATION_SOLANA_INTERVAL_SEC)
-      )
     })
 
     // Email notification queue


### PR DESCRIPTION
### Description
Remove unnecessary wait between processing runs of notification in identity service

### Tests
None

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->