### PR TITLE
Silence logs when running notification tests

### DIFF
--- a/discovery-provider/plugins/notifications/src/logger.ts
+++ b/discovery-provider/plugins/notifications/src/logger.ts
@@ -4,4 +4,5 @@ export const logger = pino({
   name: `notifications`,
   base: undefined,
   timestamp: stdTimeFunctions.isoTime,
+  level: process.env.NODE_ENV === 'test' ? 'error' : undefined,
 })


### PR DESCRIPTION
### Description
Silences a bunch of redundant-seeming logs when running notification tests. Curious what your thoughts are