### PR TITLE
Fix loop of block number adjustment

### DIFF
--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -853,24 +853,26 @@ def notifications():
         # within the notification block range
         track_added_to_playlist_notifications = []
         track_ids = []
+
+        final_poa_block = helpers.get_final_poa_block(shared_config)
+        min_adjusted_block = min_block_number
+        max_adjusted_block = max_block_number
+        if final_poa_block and web3.provider.endpoint_uri == os.getenv(
+            "audius_web3_nethermind_rpc"
+        ):
+            # if migrated to ACDC
+            min_adjusted_block -= final_poa_block
+            max_adjusted_block -= final_poa_block
+
+        min_block = web3.eth.get_block(min_adjusted_block)
+        max_block = web3.eth.get_block(max_adjusted_block)
+
         for entry in playlist_track_added_results:
             # Get the track_ids from entry["playlist_contents"]
             if not entry.playlist_contents["track_ids"]:
                 # skip empty playlists
                 continue
             playlist_contents = entry.playlist_contents
-
-            final_poa_block = helpers.get_final_poa_block(shared_config)
-
-            if final_poa_block and web3.provider.endpoint_uri == os.getenv(
-                "audius_web3_nethermind_rpc"
-            ):
-                # if migrated to ACDC
-                min_block_number -= final_poa_block
-                max_block_number -= final_poa_block
-
-            min_block = web3.eth.get_block(min_block_number)
-            max_block = web3.eth.get_block(max_block_number)
 
             for track in playlist_contents["track_ids"]:
                 track_id = track["track"]


### PR DESCRIPTION
### Description
The adjustment of the blocknumber was in a loop for acdc which it should not have been 
It led to subtracting too the adjustment amount several times and ultimately this error preventing identity notifications from indexing 

```
ValueError: Value did not match any of the recognized block identifiers: -31375545", "timestamp": "2023-03-16 02:07:04,107", "pathname": "/audius-discovery-provider/src/app.py", "funcName": "handle_exception", "lineno": 190, "service": "server", "otelSpanID": "65baf8030cfff15e", "otelTraceID": "999301702e6a281580c1b3d84c8110d6", "otelServiceName": "discovery-provider"}
```


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->