### PR TITLE
Create tastemaker notifications in index trending

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_tastemaker_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_tastemaker_notification.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta
+
+from integration_tests.utils import populate_mock_db
+from sqlalchemy import asc
+from src.models.notifications.notification import Notification
+from src.models.social.repost import Repost
+from src.models.social.save import Save
+from src.models.tracks.track import Track
+from src.models.users.user import User
+from src.queries.get_trending_tracks import make_trending_cache_key
+from src.tasks.index_trending import index_tastemaker_notifications
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.utils.config import shared_config
+from src.utils.db_session import get_db
+from src.utils.redis_cache import set_json_cached_key
+from src.utils.redis_connection import get_redis
+
+REDIS_URL = shared_config["redis"]["url"]
+
+BASE_TIME = datetime(2023, 1, 1, 0, 0)
+
+
+def test_index_tastemaker_notification_no_trending(app):
+    pass
+
+
+def test_index_tastemaker_notification_deleted_reposts(app):
+    pass
+
+
+def test_index_tastemaker_notification(app):
+    """
+    Test that given when new trending values are calculated
+    the correct notifications are generated
+    """
+
+    with app.app_context():
+        db = get_db()
+
+        # Add some users to the db so we have blocks
+        entities = {
+            "tracks": [{"track_id": i} for i in range(5)],
+            "users": [{"user_id": i} for i in range(10)],
+        }
+        populate_mock_db(db, entities)
+
+        index_tastemaker_notifications(db, [])
+        with db.scoped_session() as session:
+            tracks = session.query(Track).all()
+            notifications = (
+                session.query(Notification).order_by(asc(Notification.specifier)).all()
+            )
+            users = session.query(User).all()
+            reposts = session.query(Repost).all()
+            favorites = session.query(Save).all()
+            print("tracksss", tracks)
+            print("userssss", users)
+            print("repostssss", reposts)
+            print("favoritessss", favorites)
+            print("notificationssss", notifications)

--- a/discovery-provider/src/tasks/index_tastemaker_notifications.py
+++ b/discovery-provider/src/tasks/index_tastemaker_notifications.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import asc
+from src.models.notifications.notification import Notification
+from src.models.social.repost import Repost
+from src.models.social.save import Save
+from src.models.tracks.track import Track
+from src.utils.session_manager import SessionManager
+
+
+def create_tastemaker_group_id(user_id, repost_item_id):
+    return f"tastemaker:{user_id}:tastemaker_item_id:{repost_item_id}"
+
+
+def index_tastemaker_notifications(
+    db: SessionManager,
+    top_trending_tracks: List[Track],
+    tastemaker_notification_threshold=10,
+):
+    with db.scoped_session() as session:
+        tastemaker_notifications = []
+        for track in top_trending_tracks:
+            (
+                repost_tastemaker_notifications,
+                existing_group_ids,
+            ) = create_action_tastemaker_notifications(
+                tastemaker_notification_threshold,
+                session,
+                existing_group_ids=set(),
+                track=track,
+                action_type=Repost,
+            )
+            tastemaker_notifications.extend(repost_tastemaker_notifications)
+
+            (
+                save_tastemaker_notifications,
+                existing_group_ids,
+            ) = create_action_tastemaker_notifications(
+                tastemaker_notification_threshold,
+                session,
+                existing_group_ids=existing_group_ids,
+                track=track,
+                action_type=Save,
+            )
+            tastemaker_notifications.extend(save_tastemaker_notifications)
+
+        session.bulk_save_objects(
+            [notification for notification in tastemaker_notifications]
+        )
+
+
+def create_action_tastemaker_notifications(
+    tastemaker_notification_threshold,
+    session,
+    existing_group_ids,
+    track,
+    action_type,
+):
+    query_action_item_id = (
+        action_type.repost_item_id
+        if action_type == Repost
+        else action_type.save_item_id
+    )
+    tastemaker_action_notifications = []
+    earliest_actions = (
+        session.query(action_type)
+        .filter(
+            action_type.is_current == True,
+            action_type.is_delete == False,
+            query_action_item_id == track["track_id"],
+        )
+        .order_by(asc(action_type.created_at))
+        .limit(tastemaker_notification_threshold)
+    )
+
+    for action in earliest_actions.all():
+        action_item_id = (
+            action.repost_item_id if action_type == Repost else action.save_item_id
+        )
+        action_as_string = "repost" if type(action) == Repost else "save"
+        group_id = create_tastemaker_group_id(action.user_id, action_item_id)
+        if group_id not in existing_group_ids:
+            tastemaker_action_notifications.append(
+                create_tastemaker_notification(
+                    track,
+                    action_item_id=action_item_id,
+                    action_user_id=action.user_id,
+                    action_as_string=action_as_string,
+                    group_id=group_id,
+                )
+            )
+            existing_group_ids.add(group_id)
+    return tastemaker_action_notifications, existing_group_ids
+
+
+def create_tastemaker_notification(
+    track, action_item_id, action_user_id, action_as_string, group_id
+):
+    return Notification(
+        timestamp=datetime.now(),
+        user_ids=[action_user_id],
+        type="tastemaker",
+        group_id=group_id,
+        specifier=action_item_id,
+        data={
+            "track_id": action_item_id,
+            "track_owner_id": track["owner_id"],
+            "action": action_as_string,
+            "tastemaker_user_id": action_user_id,
+        },
+    )


### PR DESCRIPTION
### Description
This indexes tastemaker notifications in index trending. For each of the trending tracks we get the first ten reposters and savers and create tastemaker notifications for them. If a user is one of the earliest saves and reposts of a trending track, they only get one tastemaker notification still (wanna double check is this desired behavior?)

two quick q's - 
- wondering how to test this from index_trending to make sure tracks are getting passed in correctly.. the index trending tests dont seem to test index trending itself?
- what should the specifier be for this notification? in general what is the specifier intended to be? who caused the notification? i put it as the person reposting/favoriting, but maybe it should be track id? lmk


### Tests
added integration test for the function index_tastemaker_notification

** Add relevant labels as necessary. **
-->