### PR TITLE
DMs: Allow multiple websocket connections, backfill pubkeys

### DIFF
--- a/comms/discovery/db/migrations/20230316193251_pubkey_table.sql
+++ b/comms/discovery/db/migrations/20230316193251_pubkey_table.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+create table user_pubkeys (
+  user_id int primary key,
+  pubkey_base64 text not null
+)
+
+-- migrate:down
+drop table if exists user_pubkeys cascade;

--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -48,10 +48,12 @@ func DiscoveryMain() {
 			return err
 		}
 
-		err = pubkeystore.Dial(jsc)
+		err = pubkeystore.Dial()
 		if err != nil {
 			return err
 		}
+
+		go pubkeystore.StartPubkeyBackfill()
 
 		return nil
 

--- a/comms/discovery/pubkeystore/backfill.go
+++ b/comms/discovery/pubkeystore/backfill.go
@@ -1,0 +1,56 @@
+package pubkeystore
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"comms.audius.co/discovery/db"
+)
+
+func StartPubkeyBackfill() {
+	ctx := context.Background()
+
+	sql := `
+	select user_id from users where
+	is_current = true
+	and user_id > (select coalesce(max(user_id), 0) from user_pubkeys)
+	order by user_id asc
+	limit 100000;
+	`
+
+	for {
+		// space it out a bit
+		time.Sleep(time.Minute * 5)
+
+		ids := []int{}
+		err := db.Conn.Select(&ids, sql)
+		if err != nil {
+			log.Println("pubkey backfill: select failed", err)
+			break
+		}
+		if len(ids) == 0 {
+			log.Println("pubkey backfill: done")
+			break
+		}
+		for _, id := range ids {
+			_, err := RecoverUserPublicKeyBase64(ctx, id)
+			if err != nil {
+				log.Println("pubkey backfill: failed to recover", "user_id", id, "err", err)
+			}
+		}
+
+	}
+
+}
+
+func getPubkey(userId int) (string, error) {
+	var pk string
+	err := db.Conn.Get(&pk, `select pubkey_base64 from user_pubkeys where user_id = $1`, userId)
+	return pk, err
+}
+
+func setPubkey(userId int, pubkeyBase64 string) error {
+	_, err := db.Conn.Exec(`insert into user_pubkeys values ($1, $2) on conflict do nothing`, userId, pubkeyBase64)
+	return err
+}

--- a/comms/discovery/pubkeystore/recover_test.go
+++ b/comms/discovery/pubkeystore/recover_test.go
@@ -17,7 +17,7 @@ func TestRecovery(t *testing.T) {
 
 	// dagron
 	os.Setenv("AUDIUS_IS_STAGING", "true")
-	err = Dial(nil)
+	err = Dial()
 	assert.NoError(t, err)
 
 	// addUser on POA

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -373,10 +373,7 @@ func websocketNotify(rawRpc schema.RawRPC, userId int32, timestamp time.Time) {
 			encodedUserId, _ := misc.EncodeHashId(int(userId))
 			data := schema.ChatWebsocketEventData{RPC: payload, Metadata: schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), UserID: encodedUserId}}
 			for _, subscribedUserId := range userIds {
-				// Don't send events sent by a user to that same user
-				if subscribedUserId != userId {
-					websocketPush(subscribedUserId, data)
-				}
+				websocketPush(subscribedUserId, data)
 			}
 		}
 

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -236,14 +236,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /comms {
-            resolver 127.0.0.11 valid=55s;
+            client_max_body_size 500M;
+            resolver 127.0.0.11 valid=30s;
             set $upstream comms:8925;
             proxy_pass http://$upstream;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             # for websockets:
-            proxy_read_timeout 60m;
-            proxy_send_timeout 60m;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -236,13 +236,14 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /comms {
-            client_max_body_size 500M;
-            resolver 127.0.0.11 valid=30s;
+            resolver 127.0.0.11 valid=55s;
             set $upstream comms:8925;
             proxy_pass http://$upstream;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             # for websockets:
+            proxy_read_timeout 60m;
+            proxy_send_timeout 60m;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
### Description

* User can have multiple websocket connections to avoid client reconnect loops
* Sends ws event back to user who performed the action
* User pubkeys stored in postgres.  Code to backfill table when server starts.