### PR TITLE
[CON-639] Comms require minimum peers before starting NATS

### DIFF
--- a/comms/natsd/nats_main.go
+++ b/comms/natsd/nats_main.go
@@ -38,9 +38,9 @@ func NatsMain() {
 	for n := 0; ; n++ {
 		peerMap := peering.Solicit()
 		if natsConfig.EnableJetstream && peering.NatsIsReachable {
-			if len(peerMap) > 6 {
+			if len(peerMap) > (config.NatsReplicaCount * 2) {
 				// for stability, require minimum peers before starting nats
-				// 3 content, 3 discovery as per required replica counts
+				// for both content and discovery replicas
 				natsman.StartNats(peerMap, peering)
 			}
 		}

--- a/comms/storage/logstream/logstream.go
+++ b/comms/storage/logstream/logstream.go
@@ -9,6 +9,8 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/exp/slog"
+
+	natsdConfig "comms.audius.co/natsd/config"
 )
 
 const StreamName string = "storageLog"
@@ -50,7 +52,7 @@ func New(namespace string, pubKey string, jsc nats.JetStreamContext) (*LogStream
 			Name:        StreamName,
 			Description: "Core actions logged by each node",
 			Subjects:    []string{"storage.log.*.statusUpdate", "storage.log.updateHealthyNodeSet", "storage.log.*.rebalanceStart", "storage.log.*.rebalanceEnd"},
-			Replicas:    3,
+			Replicas:    natsdConfig.NatsReplicaCount,
 		})
 		return err
 	}, retry.Attempts(5))

--- a/comms/storage/storageserver/storageserver_test.go
+++ b/comms/storage/storageserver/storageserver_test.go
@@ -42,7 +42,7 @@ func TestE2EUpload(t *testing.T) {
 	}()
 
 	// TODO: Upload file with a hash that will fall in the 'aa' shard
-	jobman, err := transcode.NewJobsManager(nodes[0].ss.Jsc, nodes[0].ss.Namespace, 1)
+	jobman, err := transcode.NewJobsManager(nodes[0].ss.Jsc, nodes[0].ss.Namespace)
 	assert.NoError(err)
 	jobman.StartWorkers(3)
 

--- a/comms/storage/transcode/jobs_test.go
+++ b/comms/storage/transcode/jobs_test.go
@@ -20,7 +20,7 @@ func TestJobManager(t *testing.T) {
 	jsc, err := nc.JetStream()
 	assert.NoError(t, err)
 
-	jobm, err := NewJobsManager(jsc, namespace, 1)
+	jobm, err := NewJobsManager(jsc, namespace)
 	assert.NoError(t, err)
 
 	jobm.Update(&Job{


### PR DESCRIPTION
We are seeing a tonne of `nats authorization error: Nkey ""` particularly in prod envs.

This state appears to be uncrecoverable for some nodes. Resulting in a race to perfect conditions where we have enough peers to satisfy stream creation (i.e. 3 content, 3 discovery - min replicas 3 for each node type)

**TEST**

In dev. Run `make` then once services are running do
```
docker compose logs | grep "Nkey \"\""
```
There should be no logs.

Without this commit there will be many of those logs.
