### PR TITLE
[PLAT-694] Add underground-trending notification indexing

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_trending_underground_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending_underground_notification.py
@@ -20,7 +20,7 @@ REDIS_URL = shared_config["redis"]["url"]
 BASE_TIME = datetime(2023, 1, 1, 0, 0)
 
 
-def index_underground_trending_mock(db, track_ids: list[int]) -> None:
+def index_trending_underground_mock(db, track_ids: list[int]) -> None:
     redis = get_redis()
     trending_strategy_factory = TrendingStrategyFactory()
     trending_strategy = trending_strategy_factory.get_strategy(
@@ -74,7 +74,7 @@ def test_index_trending_underground_notification(app, caplog):
         populate_mock_db(db, entities)
 
         # Test that if there are no prev notifications, all trending in top are generated
-        index_underground_trending_mock(db, list(range(1, 21)))
+        index_trending_underground_mock(db, list(range(1, 21)))
         base_time_int = int(round(BASE_TIME.timestamp()))
         index_trending_underground_notifications(db, base_time_int)
 
@@ -120,7 +120,7 @@ def test_index_trending_underground_notification(app, caplog):
         # new notifications for track_id: 2, 4, 5, 7
         # no new notification for track_id: 1
 
-        index_underground_trending_mock(db, [2, 4, 5, 1, 7, 8, 9, 10])
+        index_trending_underground_mock(db, [2, 4, 5, 1, 7, 8, 9, 10])
         updated_time = BASE_TIME + timedelta(hours=1)
         updated_time_int = int(round(updated_time.timestamp()))
         index_trending_underground_notifications(db, updated_time_int)

--- a/discovery-provider/integration_tests/tasks/test_index_trending_underground_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending_underground_notification.py
@@ -1,0 +1,179 @@
+from datetime import datetime, timedelta
+
+from integration_tests.utils import populate_mock_db
+from sqlalchemy import asc
+from src.models.notifications.notification import Notification
+from src.models.tracks.track import Track
+from src.queries.get_underground_trending import make_underground_trending_cache_key
+from src.tasks.index_trending import index_trending_underground_notifications
+from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
+from src.trending_strategies.trending_type_and_version import TrendingType
+from src.utils import helpers
+from src.utils.config import shared_config
+from src.utils.db_session import get_db
+from src.utils.redis_cache import set_json_cached_key
+from src.utils.redis_connection import get_redis
+
+REDIS_URL = shared_config["redis"]["url"]
+
+BASE_TIME = datetime(2023, 1, 1, 0, 0)
+
+
+def test_index_trending_underground_notification(app):
+    """
+    Test that underground notifications are correctly calculated
+    based on current trending standings
+    """
+
+    with app.app_context():
+        db = get_db()
+        # Add some users to the db so we have blocks
+        entities = {
+            "tracks": [
+                {
+                    "track_id": i,
+                    "owner_id": i % 2 + 1,
+                }
+                for i in range(100)
+            ],
+            "users": [{}] * 3,
+        }
+        populate_mock_db(db, entities)
+
+        redis = get_redis()
+        trending_strategy_factory = TrendingStrategyFactory()
+        trending_strategy = trending_strategy_factory.get_strategy(
+            TrendingType.UNDERGROUND_TRACKS
+        )
+        # Test that if there are no prev notifications, all trending in top are generated
+
+        trending_key = make_underground_trending_cache_key(trending_strategy.version)
+        with db.scoped_session() as session:
+            trending_underground_tracks = (
+                session.query(Track)
+                .filter(Track.track_id.in_(range(1, 21)))
+                .order_by(asc(Track.track_id))
+                .all()
+            )
+            trending_underground_tracks = helpers.query_result_to_list(
+                trending_underground_tracks
+            )
+            track_ids = [track["track_id"] for track in trending_underground_tracks]
+            trending_underground_tracks = (trending_underground_tracks, track_ids)
+            set_json_cached_key(redis, trending_key, trending_underground_tracks)
+
+        base_time_int = int(round(BASE_TIME.timestamp()))
+
+        index_trending_underground_notifications(db, base_time_int)
+        with db.scoped_session() as session:
+            notifications = (
+                session.query(Notification).order_by(asc(Notification.specifier)).all()
+            )
+            assert len(notifications) == 5
+
+            notification_0 = notifications[0]
+            assert notification_0.specifier == "1"
+            assert (
+                notification_0.group_id
+                == "trending_underground:time_range:week:genre:all:rank:1:track_id:1:timestamp:1672531200"
+            )
+            assert notification_0.type == "trending"
+            assert notification_0.data == {
+                "rank": 1,
+                "genre": "all",
+                "track_id": 1,
+                "time_range": "week",
+            }
+            assert notification_0.user_ids == [2]
+
+            notification_1 = notifications[1]
+            assert notification_1.specifier == "2"
+            assert (
+                notification_1.group_id
+                == "trending_underground:time_range:week:genre:all:rank:2:track_id:2:timestamp:1672531200"
+            )
+            assert notification_1.type == "trending"
+            assert notification_1.data == {
+                "rank": 2,
+                "genre": "all",
+                "track_id": 2,
+                "time_range": "week",
+            }
+            assert notification_1.user_ids == [1]
+
+        # Test that on second iteration of trending, only new notifications appear
+        # Prev: 1, 2, 3, 4, 5
+        # New: 2, 4, 5, 1, 7
+        # new notifications for track_id: 2, 4, 5, 7
+        # no new notification for track_id: 1
+
+        trending_underground_tracks = [
+            {
+                "track_id": i,
+                "owner_id": i % 2 + 1,
+                "user": [{"user_id": i % 2 + 1, "wallet": "0x0"}],
+            }
+            for i in [2, 4, 5, 1, 7, 8, 9, 10]
+        ]
+        track_ids = [track["track_id"] for track in trending_underground_tracks]
+        trending_underground_tracks = (trending_underground_tracks, track_ids)
+        set_json_cached_key(redis, trending_key, trending_underground_tracks)
+        updated_time = BASE_TIME + timedelta(hours=1)
+        updated_time_int = int(round(updated_time.timestamp()))
+
+        index_trending_underground_notifications(db, updated_time_int)
+        with db.scoped_session() as session:
+            all_notifications = session.query(Notification).all()
+            assert len(all_notifications) == 6
+
+            updated_notifications = (
+                session.query(Notification)
+                .filter(Notification.timestamp == updated_time)
+                .order_by(asc(Notification.specifier))
+                .all()
+            )
+            assert len(updated_notifications) == 1
+
+            assert updated_notifications[0].data == {
+                "rank": 5,
+                "genre": "all",
+                "track_id": 7,
+                "time_range": "week",
+            }
+
+        updated_time = BASE_TIME + timedelta(hours=24)
+        updated_time_int = int(round(updated_time.timestamp()))
+
+        index_trending_underground_notifications(db, updated_time_int)
+        with db.scoped_session() as session:
+            all_notifications = session.query(Notification).all()
+            assert len(all_notifications) == 9
+
+            updated_notifications = (
+                session.query(Notification)
+                .filter(Notification.timestamp == updated_time)
+                .order_by(asc(Notification.specifier))
+                .all()
+            )
+            assert len(updated_notifications) == 3
+
+            assert updated_notifications[0].data == {
+                "rank": 1,
+                "genre": "all",
+                "track_id": 2,
+                "time_range": "week",
+            }
+
+            assert updated_notifications[1].data == {
+                "rank": 2,
+                "genre": "all",
+                "track_id": 4,
+                "time_range": "week",
+            }
+
+            assert updated_notifications[2].data == {
+                "rank": 3,
+                "genre": "all",
+                "track_id": 5,
+                "time_range": "week",
+            }

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -179,7 +179,15 @@ def populate_mock_db(db, entities, block_offset=None):
                 is_delete=track_meta.get("is_delete", False),
                 owner_id=track_meta.get("owner_id", 1),
                 route_id=track_meta.get("route_id", ""),
-                track_segments=track_meta.get("track_segments", []),
+                track_segments=track_meta.get(
+                    "track_segments",
+                    [
+                        {
+                            "duration": 0,
+                            "multihash": "QmURbJr815cnDWwYLJmJtYW8ZiAqMre5QzxpW5kahrNTYE",
+                        }
+                    ],
+                ),
                 tags=track_meta.get("tags", None),
                 genre=track_meta.get("genre", ""),
                 remix_of=track_meta.get("remix_of", None),

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -28,6 +28,8 @@ from src.queries.get_notifications import (
     TipSendNotification,
     TrackMilestoneNotification,
     TrendingNotification,
+    TrendingPlaylistNotification,
+    TrendingUndergroundNotification,
 )
 from src.utils.helpers import encode_int_id
 from src.utils.spl_audio import to_wei_string
@@ -388,6 +390,42 @@ def extend_trending(action: NotificationAction):
     return notification
 
 
+def extend_trending_playlist(action: NotificationAction):
+    data: TrendingPlaylistNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "rank": data["rank"],
+            "genre": data["genre"],
+            "playlist_id": encode_int_id(data["playlist_id"]),
+            "time_range": data["time_range"],
+        },
+    }
+    return notification
+
+
+def extend_trending_underground(action: NotificationAction):
+    data: TrendingUndergroundNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "rank": data["rank"],
+            "genre": data["genre"],
+            "track_id": encode_int_id(data["track_id"]),
+            "time_range": data["time_range"],
+        },
+    }
+    return notification
+
+
 def extend_announcement(action: NotificationAction):
     data: AnnouncementNotification = action["data"]  # type: ignore
     notification = {
@@ -420,5 +458,7 @@ notification_action_handler = {
     "reaction": extend_reaction,
     "tier_change": extend_tier_change,
     "trending": extend_trending,
+    "trending_playlist": extend_trending_playlist,
+    "trending_undeground": extend_trending_underground,
     "announcement": extend_announcement,
 }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -142,6 +142,8 @@ class NotificationType(str, Enum):
     PLAYLIST_MILSTONE = "playlist_milestone"
     TIER_CHANGE = "tier_change"
     TRENDING = "trending"
+    TRENDING_PLAYLIST = "trending_playlist"
+    TRENDING_UNDERGROUND = "trending_underground"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -335,6 +337,20 @@ class TierChangeNotification(TypedDict):
 
 
 class TrendingNotification(TypedDict):
+    rank: int
+    genre: str
+    track_id: int
+    time_range: str
+
+
+class TrendingPlaylistNotification(TypedDict):
+    rank: int
+    genre: str
+    playlist_id: int
+    time_range: str
+
+
+class TrendingUndergroundNotification(TypedDict):
     rank: int
     genre: str
     track_id: int

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -169,15 +169,15 @@ def get_scorable_track_data(session, redis_instance, strategy):
     karma_scores = get_karma(session, tuple(track_ids), strategy, None, False, xf)
 
     # Associate all the extra data
-    for (track_id, repost_count) in repost_counts:
+    for track_id, repost_count in repost_counts:
         tracks_map[track_id]["repost_count"] = repost_count
-    for (track_id, repost_count) in windowed_repost_counts:
+    for track_id, repost_count in windowed_repost_counts:
         tracks_map[track_id]["windowed_repost_count"] = repost_count
-    for (track_id, save_count) in save_counts:
+    for track_id, save_count in save_counts:
         tracks_map[track_id]["save_count"] = save_count
-    for (track_id, save_count) in windowed_save_counts:
+    for track_id, save_count in windowed_save_counts:
         tracks_map[track_id]["windowed_save_count"] = save_count
-    for (track_id, karma) in karma_scores:
+    for track_id, karma in karma_scores:
         tracks_map[track_id]["karma"] = karma
 
     return list(tracks_map.values())

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -215,6 +215,7 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
     set_last_trending_datetime(redis, timestamp)
 
     index_trending_notifications(db, timestamp)
+    index_trending_underground_notifications(db, timestamp)
 
 
 def index_trending_notifications(db: SessionManager, timestamp: int):
@@ -327,6 +328,11 @@ def index_trending_notifications(db: SessionManager, timestamp: int):
 
 
 last_trending_timestamp = "last_trending_timestamp"
+
+
+def index_trending_underground_notifications(db: SessionManager, timestamp: int):
+    # TODO
+    return None
 
 
 def get_last_trending_datetime(redis: Redis):

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -17,6 +17,7 @@ from src.queries.get_trending_tracks import (
     make_trending_cache_key,
 )
 from src.queries.get_underground_trending import (
+    _get_underground_trending_with_session,
     make_get_unpopulated_tracks,
     make_underground_trending_cache_key,
 )
@@ -331,8 +332,112 @@ last_trending_timestamp = "last_trending_timestamp"
 
 
 def index_trending_underground_notifications(db: SessionManager, timestamp: int):
-    # TODO
-    return None
+    # Get the top 5 trending tracks from the new trending calculations
+    # Get the most recent trending tracks notifications
+    # Calculate any diff and write the new notifications if the trending track has moved up in rank
+    # Skip if the user was notified of the trending track within the last TRENDING_INTERVAL_HOURS
+    # Skip If the new rank is not less than the old rank, skip
+    #   ie. Skip if track moved from #2 trending to #3 trending or stayed the same
+    trending_strategy_factory = TrendingStrategyFactory()
+    # The number of tracks to notify for in the top
+    NOTIFICATIONS_TRACK_LIMIT = 5
+    with db.scoped_session() as session:
+        top_trending = _get_underground_trending_with_session(
+            session,
+            {"offset": 0, "limit": NOTIFICATIONS_TRACK_LIMIT},
+            trending_strategy_factory.get_strategy(TrendingType.UNDERGROUND_TRACKS),
+            False,
+        )
+        top_trending_track_ids = [str(t["track_id"]) for t in top_trending]
+
+        previous_trending_notifications = (
+            session.query(Notification)
+            .filter(
+                Notification.type == "trending_underground",
+                Notification.specifier.in_(top_trending_track_ids),
+            )
+            .all()
+        )
+
+        latest_notification_query = text(
+            """
+                SELECT 
+                    DISTINCT ON (specifier) specifier,
+                    timestamp,
+                    data
+                FROM notification
+                WHERE 
+                    type=:type AND
+                    specifier in :track_ids
+                ORDER BY
+                    specifier desc,
+                    timestamp desc
+            """
+        )
+        latest_notification_query = latest_notification_query.bindparams(
+            bindparam("track_ids", expanding=True)
+        )
+
+        previous_trending_notifications = session.execute(
+            latest_notification_query,
+            {"track_ids": top_trending_track_ids, "type": "trending_undeground"},
+        )
+        previous_trending = {
+            n[0]: {"timestamp": n[1], **n[2]} for n in previous_trending_notifications
+        }
+
+        notifications = []
+
+        # Do not send notifications for the same track trending within 24 hours
+        NOTIFICATION_INTERVAL_SEC = 60 * 60 * 24
+
+        for index, track in enumerate(top_trending):
+            track_id = track["track_id"]
+            rank = index + 1
+            previous_track_notification = previous_trending.get(str(track["track_id"]))
+            if previous_track_notification is not None:
+                current_datetime = datetime.fromtimestamp(timestamp)
+                prev_notification_datetime = datetime.fromtimestamp(
+                    previous_track_notification["timestamp"].timestamp()
+                )
+                if (
+                    current_datetime - prev_notification_datetime
+                ).total_seconds() < NOTIFICATION_INTERVAL_SEC:
+                    continue
+                prev_rank = previous_track_notification["rank"]
+                if prev_rank <= rank:
+                    continue
+            notifications.append(
+                {
+                    "owner_id": track["owner_id"],
+                    "group_id": f"trending_underground:time_range:week:genre:all:rank:{rank}:track_id:{track_id}:timestamp:{timestamp}",
+                    "track_id": track_id,
+                    "rank": rank,
+                }
+            )
+
+        session.bulk_save_objects(
+            [
+                Notification(
+                    user_ids=[n["owner_id"]],
+                    timestamp=datetime.fromtimestamp(timestamp),
+                    type="trending",
+                    group_id=n["group_id"],
+                    specifier=n["track_id"],
+                    data={
+                        "time_range": "week",
+                        "genre": "all",
+                        "rank": n["rank"],
+                        "track_id": n["track_id"],
+                    },
+                )
+                for n in notifications
+            ]
+        )
+        logger.info(
+            "index_trending.py | Created trending notifications",
+            extra={"job": "index_trending", "subtask": "trending notification"},
+        )
 
 
 def get_last_trending_datetime(redis: Redis):

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -380,7 +380,7 @@ def index_trending_underground_notifications(db: SessionManager, timestamp: int)
 
         previous_trending_notifications = session.execute(
             latest_notification_query,
-            {"track_ids": top_trending_track_ids, "type": "trending_undeground"},
+            {"track_ids": top_trending_track_ids, "type": "trending_underground"},
         )
         previous_trending = {
             n[0]: {"timestamp": n[1], **n[2]} for n in previous_trending_notifications
@@ -421,7 +421,7 @@ def index_trending_underground_notifications(db: SessionManager, timestamp: int)
                 Notification(
                     user_ids=[n["owner_id"]],
                     timestamp=datetime.fromtimestamp(timestamp),
-                    type="trending",
+                    type="trending_underground",
                     group_id=n["group_id"],
                     specifier=n["track_id"],
                     data={
@@ -435,7 +435,7 @@ def index_trending_underground_notifications(db: SessionManager, timestamp: int)
             ]
         )
         logger.info(
-            "index_trending.py | Created trending notifications",
+            "index_trending.py | Created underground trending notifications",
             extra={"job": "index_trending", "subtask": "trending notification"},
         )
 

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -435,7 +435,7 @@ def index_trending_underground_notifications(db: SessionManager, timestamp: int)
             ]
         )
         logger.info(
-            "index_trending.py | Created underground trending notifications",
+            "index_trending.py | Created underground-trending notifications",
             extra={"job": "index_trending", "subtask": "trending notification"},
         )
 


### PR DESCRIPTION
### Description
- Adds underground-trending notification indexing
- Adds tests
- Updates test-data to reduce warnings
> Note the test is mostly ripped from the index_notifications test, but it could use a bit of work as far as cleanliness. if folks have thoughts im down to update, but also would want to update the trending test too.

### TODO
After implementing the feature, there are lots of opportunity for code-sharing and cleanup. I can potentially do that as part of this pr, or in a follow-up

Also, it would be good for us to decide on "trending_underground" or "underground_trending" for the notification type before a merge. Both types of naming appear in various places