### PR TITLE
[PAY-951] SDK: Allow chat messages to have externally specified IDs, gracefully fail decryption

### DIFF
--- a/libs/package-lock.json
+++ b/libs/package-lock.json
@@ -7895,11 +7895,6 @@
         }
       }
     },
-    "cuid": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
-      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
-    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -18086,6 +18081,11 @@
       "requires": {
         "multiformats": "^9.4.2"
       }
+    },
+    "ulid": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
+      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw=="
     },
     "ultron": {
       "version": "1.1.1",

--- a/libs/package.json
+++ b/libs/package.json
@@ -74,7 +74,6 @@
     "bs58": "4.0.1",
     "cipher-base": "1.0.4",
     "cross-fetch": "3.1.5",
-    "cuid": "2.1.8",
     "elliptic": "6.5.4",
     "esm": "3.2.25",
     "eth-sig-util": "2.5.4",
@@ -100,6 +99,7 @@
     "secp256k1": "4.0.2",
     "semver": "6.3.0",
     "stream-browserify": "3.0.0",
+    "ulid": "^2.3.0",
     "web3": "1.7.1",
     "xmlhttprequest": "1.8.0"
   },

--- a/libs/package.json
+++ b/libs/package.json
@@ -99,7 +99,7 @@
     "secp256k1": "4.0.2",
     "semver": "6.3.0",
     "stream-browserify": "3.0.0",
-    "ulid": "^2.3.0",
+    "ulid": "2.3.0",
     "web3": "1.7.1",
     "xmlhttprequest": "1.8.0"
   },

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -7,7 +7,7 @@ import {
 } from '../generated/default'
 import * as aes from 'micro-aes-gcm'
 import { base64 } from '@scure/base'
-import cuid from 'cuid'
+import { ulid } from 'ulid'
 
 import * as secp from '@noble/secp256k1'
 import type {
@@ -295,7 +295,7 @@ export class ChatsApi
       method: 'chat.message',
       params: {
         chat_id: requestParameters.chatId,
-        message_id: requestParameters.messageId ?? cuid(),
+        message_id: requestParameters.messageId ?? ulid(),
         message
       }
     })

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -37,6 +37,7 @@ export type ChatInviteRequest = {
 
 export type ChatMessageRequest = {
   chatId: string
+  messageId?: string
   message: string
 }
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

- Catch errors when decrypting and gracefully exit
- Allow consumers to specify chat message IDs so that they can optimistically update their UIs.
  - Not in love with this.. would much prefer the SDK be in charge of how these IDs get generated. However, I'm not sure what a better solution is?
- Use ulid instead of cuid 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested by linking libs to a Client PR and throwing fake errors in the decrypt method

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->