### PR TITLE
add trending pages to healthz for trending underground and trending p…

### DIFF
--- a/monitoring/healthz/src/DiscoveryTrending.tsx
+++ b/monitoring/healthz/src/DiscoveryTrending.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
 import { SP, useDiscoveryProviders } from './useServiceProviders'
 
-export function DiscoveryTrending() {
+export function DiscoveryTrending(props: { trendingEndpoint: string }) {
   const { data: sps, error } = useDiscoveryProviders()
   if (error) return <div>error</div>
   if (!sps) return null
@@ -11,7 +11,7 @@ export function DiscoveryTrending() {
       <table className="table">
         <tbody>
           {sps.map((sp) => (
-            <TrendingRow key={sp.endpoint} sp={sp} />
+            <TrendingRow key={sp.endpoint} sp={sp} trendingEndpoint={props.trendingEndpoint} />
           ))}
         </tbody>
       </table>
@@ -21,9 +21,8 @@ export function DiscoveryTrending() {
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
-function TrendingRow({ sp }: { sp: SP }) {
-  const { data, error } = useSWR(sp.endpoint + '/v1/tracks/trending', fetcher)
-
+function TrendingRow({ sp, trendingEndpoint }: { sp: SP, trendingEndpoint: string }) {
+  const { data, error } = useSWR(sp.endpoint + trendingEndpoint, fetcher)
   if (!data)
     return (
       <tr>

--- a/monitoring/healthz/src/Router.tsx
+++ b/monitoring/healthz/src/Router.tsx
@@ -23,7 +23,9 @@ const routeList: RouteObject[] = [
         path: '/discovery',
         children: [
           { path: 'health', element: <DiscoveryHealth /> },
-          { path: 'trending', element: <DiscoveryTrending /> },
+          { path: 'trending', element: <DiscoveryTrending trendingEndpoint='/v1/tracks/trending' /> },
+          { path: 'trending_underground', element: <DiscoveryTrending trendingEndpoint='/v1/tracks/trending/underground' /> },
+          { path: 'trending_playlists', element: <DiscoveryTrending trendingEndpoint='/v1/playlists/trending/BDNxn' /> },
           { path: 'feed', element: <DiscoveryFeed /> },
           { path: 'search', element: <DiscoverySearch /> },
           { path: 'diff', element: <APIDiff /> },


### PR DESCRIPTION
…laylists

### Description
Update health z to include pages for trending underground and trending playlists. This will be helpful as we work on trending playlists and trending underground notifications and we want to verify what's trending on what node. Just generalized the DiscoveryTrending component with the appropriate trending endpoint as a prop

### Tests
tested by running locally and verifying that the list for a node matched what i saw for that node on prod