### PR TITLE
More retries for unclaimed ID

### DIFF
--- a/discovery-provider/src/queries/get_unclaimed_id.py
+++ b/discovery-provider/src/queries/get_unclaimed_id.py
@@ -1,3 +1,4 @@
+import logging
 import random
 
 from src import exceptions
@@ -15,6 +16,8 @@ from src.utils.helpers import encode_int_id
 MAX_USER_ID = 999999999  # max for reward specifier id
 MAX_POSTGRES_ID = 2147483647
 
+logger = logging.getLogger(__name__)
+
 
 def get_unclaimed_id(type):
 
@@ -25,7 +28,7 @@ def get_unclaimed_id(type):
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        for _ in range(10):
+        for _ in range(50):
             is_claimed = True
             random_id = None
             if type == "user":
@@ -55,4 +58,5 @@ def get_unclaimed_id(type):
                 ).first()
 
             if not is_claimed:
+                logger.info(f"unclaimed_id | no unclaimed {type} ID found")
                 return encode_int_id(random_id)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
On rare occasions a few users have encounter `No unclaimed track IDs` meaning discovery has tried 10 random IDs and they were all claimed. For now, we can extend this retry.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->