### PR TITLE
Remove prod dp4 from auto deploy

### DIFF
--- a/.circleci/workflows/main.yml
+++ b/.circleci/workflows/main.yml
@@ -157,7 +157,6 @@ jobs:
       requires:
         - deploy-prod-discovery-provider-trigger
       hosts: >-
-        prod-discovery-4
         prod-discovery-1
         prod-discovery-2
         prod-discovery-3


### PR DESCRIPTION
### Description
See title

Removing stage DP4 from autodeploy and moving to autoupgrade flow


### Tests
NA

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA