### PR TITLE
Change /etc/hosts update from auto to manual

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -40,6 +40,9 @@ exit
 
 # In new terminal
 audius-compose build # takes about 10 min
+
+# Allows you to connect to containers via hostname like http://audius-protocol-discovery-provider-1/health_check
+sudo echo "127.0.0.1       ingress audius-protocol-storage-1 audius-protocol-storage-2 audius-protocol-storage-3 audius-protocol-storage-4 audius-protocol-storage-5 audius-protocol-comms-discovery-1 audius-protocol-comms-discovery-2 audius-protocol-comms-discovery-3 audius-protocol-comms-discovery-4 audius-protocol-comms-discovery-5 audius-protocol-discovery-provider-1 audius-protocol-discovery-provider-2 audius-protocol-discovery-provider-3 audius-protocol-creator-node-1 audius-protocol-creator-node-2 audius-protocol-creator-node-3 audius-protocol-identity-service-1 audius-protocol-solana-test-validator-1 audius-protocol-eth-ganache-1 audius-protocol-poa-ganache-1" >> /etc/hosts
 ```
 
 ### Bring up protocol stack

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -12,18 +12,6 @@ import dotenv
 import eth_account
 import solana.keypair
 
-LOCALHOSTS = """
-127.0.0.1       ingress \
-audius-protocol-storage-1 audius-protocol-storage-2 audius-protocol-storage-3 audius-protocol-storage-4 audius-protocol-storage-5 \
-audius-protocol-comms-discovery-1 audius-protocol-comms-discovery-2 audius-protocol-comms-discovery-3 audius-protocol-comms-discovery-4 audius-protocol-comms-discovery-5 \
-audius-protocol-discovery-provider-1 audius-protocol-discovery-provider-2 audius-protocol-discovery-provider-3 \
-audius-protocol-creator-node-1 audius-protocol-creator-node-2 audius-protocol-creator-node-3 \
-audius-protocol-identity-service-1 \
-audius-protocol-solana-test-validator-1 \
-audius-protocol-eth-ganache-1 \
-audius-protocol-poa-ganache-1
-"""
-
 
 class DefaultCommandGroup(click.Group):
     """allow a default command for a group"""
@@ -332,12 +320,6 @@ def up(
     )
 
     AAO_DIR = pathlib.Path(os.getenv("AAO_DIR", protocol_dir / "../anti-abuse-oracle"))
-
-    # TODO: Consider removing /etc/hosts change on audius-compose down
-    hosts_file = pathlib.Path("/etc/hosts")
-    if LOCALHOSTS not in hosts_file.read_text():
-        print("Adding development hosts to /etc/hosts")
-        hosts_file.write_text(hosts_file.read_text() + "\n" + LOCALHOSTS + "\n")
 
     sys.exit(
         subprocess.run(


### PR DESCRIPTION
### Description
Removes logic that auto-updates /etc/hosts and instead adds a README instruction to do it once manually.

### Tests
Make sure audius-compose comes up.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A - dev facing