### PR TITLE
Update /etc/hosts via audius-compose connect

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -40,9 +40,6 @@ exit
 
 # In new terminal
 audius-compose build # takes about 10 min
-
-# Allows you to connect to containers via hostname like http://audius-protocol-discovery-provider-1/health_check
-sudo echo "127.0.0.1       ingress audius-protocol-storage-1 audius-protocol-storage-2 audius-protocol-storage-3 audius-protocol-storage-4 audius-protocol-storage-5 audius-protocol-comms-discovery-1 audius-protocol-comms-discovery-2 audius-protocol-comms-discovery-3 audius-protocol-comms-discovery-4 audius-protocol-comms-discovery-5 audius-protocol-discovery-provider-1 audius-protocol-discovery-provider-2 audius-protocol-discovery-provider-3 audius-protocol-creator-node-1 audius-protocol-creator-node-2 audius-protocol-creator-node-3 audius-protocol-identity-service-1 audius-protocol-solana-test-validator-1 audius-protocol-eth-ganache-1 audius-protocol-poa-ganache-1" >> /etc/hosts
 ```
 
 ### Bring up protocol stack

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -52,10 +52,17 @@ audius-compose up
 ```
 This command completes in 1-2 min, but use `watch docker ps -a` to ensure that all servicees report "Status" as Healthy. It currently takes ~10min for this to happen.
 
+## Connect via hostname or client
+
+To use the client from a mac, we need to route hostnames to the audius-compose nginx reverse proxy by running:
+```
+audius-compose connect
+```
+
 ### Perform actions with `audius-cmd`
 
 You can confirm that things are wired up correctly by running `audius-cmd create-user`.
-Note that `audius-cmd` requires the stack to be up and healthy, per [Bring up protocol stack](#bring-up-protocol-stack)
+Note that `audius-cmd` requires the stack to be up and healthy, per [Bring up protocol stack](#bring-up-protocol-stack), and to have run `audius-compose connect`.
 
 # Helpful Commands
 

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import getpass
 import json
 import os
 import pathlib
@@ -12,6 +13,17 @@ import dotenv
 import eth_account
 import solana.keypair
 
+LOCALHOSTS = """
+127.0.0.1       ingress \
+audius-protocol-storage-1 audius-protocol-storage-2 audius-protocol-storage-3 audius-protocol-storage-4 audius-protocol-storage-5 \
+audius-protocol-comms-discovery-1 audius-protocol-comms-discovery-2 audius-protocol-comms-discovery-3 audius-protocol-comms-discovery-4 audius-protocol-comms-discovery-5 \
+audius-protocol-discovery-provider-1 audius-protocol-discovery-provider-2 audius-protocol-discovery-provider-3 \
+audius-protocol-creator-node-1 audius-protocol-creator-node-2 audius-protocol-creator-node-3 \
+audius-protocol-identity-service-1 \
+audius-protocol-solana-test-validator-1 \
+audius-protocol-eth-ganache-1 \
+audius-protocol-poa-ganache-1
+"""
 
 class DefaultCommandGroup(click.Group):
     """allow a default command for a group"""
@@ -362,6 +374,19 @@ def down(protocol_dir):
             "--volumes",
         ],
     )
+
+
+@cli.command()
+def connect():
+    hosts_file = pathlib.Path("/etc/hosts")
+    if LOCALHOSTS in hosts_file.read_text():
+        print("/etc/hosts already up to date")
+    else:
+        password = getpass.getpass("Adding development hosts to /etc/hosts. Enter your sudo password: ")
+        cmd = f"echo '{password}' | sudo -S sh -c 'echo \"{LOCALHOSTS}\" >> /etc/hosts'"
+        subprocess.run(cmd, shell=True)
+        print("Updated /etc/hosts")
+    
 
 
 @cli.group(cls=DefaultCommandGroup)

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -25,6 +25,7 @@ audius-protocol-eth-ganache-1 \
 audius-protocol-poa-ganache-1
 """
 
+
 class DefaultCommandGroup(click.Group):
     """allow a default command for a group"""
 
@@ -382,11 +383,12 @@ def connect():
     if LOCALHOSTS in hosts_file.read_text():
         print("/etc/hosts already up to date")
     else:
-        password = getpass.getpass("Adding development hosts to /etc/hosts. Enter your sudo password: ")
+        password = getpass.getpass(
+            "Adding development hosts to /etc/hosts. Enter your sudo password: "
+        )
         cmd = f"echo '{password}' | sudo -S sh -c 'echo \"{LOCALHOSTS}\" >> /etc/hosts'"
         subprocess.run(cmd, shell=True)
         print("Updated /etc/hosts")
-    
 
 
 @cli.group(cls=DefaultCommandGroup)


### PR DESCRIPTION
### Description
Makes `audius-compose connect` update /etc/hosts if it's not already up to date.


### Tests
Reset my /etc/hosts permissions to be only writeable by root, and ran `audius-compose connect` twice (confirms the update path and the already-exists path).


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A