### PR TITLE
cheaper get_users_cnode query

### DIFF
--- a/discovery-provider/src/queries/get_users_cnode.py
+++ b/discovery-provider/src/queries/get_users_cnode.py
@@ -37,8 +37,12 @@ def get_users_cnode(
               "user_id",
               "wallet",
               "creator_node_endpoint",
-              "primary_id",
-              "secondary_ids"
+              (string_to_array("creator_node_endpoint", ',')) [1] as "primary",
+              (string_to_array("creator_node_endpoint", ',')) [2] as "secondary1",
+              (string_to_array("creator_node_endpoint", ',')) [3] as "secondary2",
+              "primary_id" as "primarySpID",
+              ("secondary_ids") [1] as "secondary1SpID",
+              ("secondary_ids") [2] as "secondary2SpID"
             FROM "users"
             WHERE
               "creator_node_endpoint" IS NOT NULL
@@ -61,11 +65,14 @@ def get_users_cnode(
             """
         )
 
+        # if no replica_type: cnode anywhere in creator_node_endpoint
         cnode_like = "%" + cnode_endpoint_string + "%"
         if replica_type == ReplicaType.PRIMARY:
+            # if replica_type primary: at start of creator_node_endpoint
             cnode_like = cnode_endpoint_string + ",%"
         elif replica_type == ReplicaType.SECONDARY:
-            cnode_like = "%," + cnode_endpoint_string
+            # if replica_type secondary: has preceeding comma
+            cnode_like = "%," + cnode_endpoint_string + "%"
 
         users = session.execute(
             users_res,

--- a/discovery-provider/src/queries/get_users_cnode.py
+++ b/discovery-provider/src/queries/get_users_cnode.py
@@ -55,6 +55,7 @@ def get_users_cnode(
                 else
                 "AND t.user_id > :prev_user_id"
             }
+            ORDER BY "user_id" ASC
             {
                 ""
                 if max_users is None


### PR DESCRIPTION
### Description

motivation:

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/97163/227563982-d4d060e2-7fe2-452f-bb7a-733d73edc43c.png">


Avoid materializing intermediate tables when attempting to query `creator_node_endpoint` as an array.

Instead of projecting into array type in intermediate table, use `like` query with comma position to determine array location.

---

update: query planner actually does about the same thing:

before:
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/97163/227574774-5ea2a389-a44b-4b0c-b960-f092d6a89722.png">

after:
<img width="1558" alt="image" src="https://user-images.githubusercontent.com/97163/227574709-423ffd56-ff95-4f15-af23-939a4e4797a8.png">

request times on staging were not much different... lot of variance.

ex query:

```
https://discoveryprovider.staging.audius.co/v1/full/users/content_node/primary?max_users=2000&creator_node_endpoint=https://creatornode7.staging.audius.co
```