### PR TITLE
Dedupe byte range requests

### DIFF
--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -23,6 +23,7 @@ const {
   currentNodeShouldHandleTranscode
 } = require('../utils')
 const { asyncRetry } = require('../utils/asyncRetry')
+const { isFirstByteRequest } = require('../utils/requestRange')
 const {
   authMiddleware,
   ensurePrimaryMiddleware,
@@ -733,6 +734,7 @@ router.get(
 /**
  * Gets a streamable mp3 link for a track by encodedId. Supports range request headers.
  * @dev - Wrapper around getCID, which retrieves track given its CID.
+ * @deprecated
  **/
 router.get(
   '/tracks/stream/:encodedId',
@@ -978,9 +980,8 @@ router.get(
       )
     }
 
-    const byteRangeHeader = req.header('range')
-    req.logger.info(`Byte range header ${byteRangeHeader}`)
-    if (libs.identityService) {
+    const isFirstByte = isFirstByteRequest(req)
+    if (libs.identityService && isFirstByte) {
       req.logger.info(
         `Logging listen for track ${trackId} by ${delegateOwnerWallet}`
       )

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -978,6 +978,8 @@ router.get(
       )
     }
 
+    const byteRangeHeader = req.headers('range')
+    req.logger.info(`Byte range header ${byteRangeHeader}`)
     if (libs.identityService) {
       req.logger.info(
         `Logging listen for track ${trackId} by ${delegateOwnerWallet}`

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -978,7 +978,7 @@ router.get(
       )
     }
 
-    const byteRangeHeader = req.headers('range')
+    const byteRangeHeader = req.header('range')
     req.logger.info(`Byte range header ${byteRangeHeader}`)
     if (libs.identityService) {
       req.logger.info(

--- a/creator-node/src/utils/requestRange.ts
+++ b/creator-node/src/utils/requestRange.ts
@@ -66,5 +66,6 @@ export const formatContentRange = (
 
 module.exports = {
   getRequestRange,
+  isFirstByteRequest,
   formatContentRange
 }

--- a/creator-node/src/utils/requestRange.ts
+++ b/creator-node/src/utils/requestRange.ts
@@ -40,6 +40,19 @@ export const getRequestRange = (req: Request) => {
 }
 
 /**
+ * Gets whether the first byte is being returned in the range request
+ * @param {Request} req express request object
+ *
+ * @returns true or false
+ */
+export const isFirstByteRequest = (req: Request) => {
+  const requestRange = getRequestRange(req)
+  if (!requestRange) return true
+  const { start, end } = requestRange
+  return start === 0 && (!end || end >= 1)
+}
+
+/**
  * Formats a Content-Range header response
  * @returns {string} Content-Range header value
  */


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Adds a check on the range header of a request to ensure that we're only tracking listen counts once per byte range request.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested on stage cn10

```
curl --header "range: bytes=0-" https://creatornode10.staging.audius.co/tracks/cidstream/QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD\?signature\=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%20439060106%2C%20%5C%22cid%5C%22%3A%20%5C%22QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD%5C%22%2C%20%5C%22timestamp%5C%22%3A%201679963665330%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xdc33bc35ae3cc8250d2c187873131973e7bfcad33f7ea0947e35713ed7b04ee57db94a9f5cd61c1660091148d5297e045174d790a26bc2e237fb80f9608fd8071c%22%7D
```
> records listen

```
curl https://creatornode10.staging.audius.co/tracks/cidstream/QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD\?signature\=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%20439060106%2C%20%5C%22cid%5C%22%3A%20%5C%22QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD%5C%22%2C%20%5C%22timestamp%5C%22%3A%201679963665330%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xdc33bc35ae3cc8250d2c187873131973e7bfcad33f7ea0947e35713ed7b04ee57db94a9f5cd61c1660091148d5297e045174d790a26bc2e237fb80f9608fd8071c%22%7D
```
> records listen

```
curl --header "range: bytes=1-" https://creatornode10.staging.audius.co/tracks/cidstream/QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD\?signature\=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%20439060106%2C%20%5C%22cid%5C%22%3A%20%5C%22QmYvyBQJVpfoLZ6x6LXt7AG3GdZEjJW4KV7F3Fr3YkoMyD%5C%22%2C%20%5C%22timestamp%5C%22%3A%201679963665330%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xdc33bc35ae3cc8250d2c187873131973e7bfcad33f7ea0947e35713ed7b04ee57db94a9f5cd61c1660091148d5297e045174d790a26bc2e237fb80f9608fd8071c%22%7D
```
> no listen

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->