### PR TITLE
Send metadata blobs through chain

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -1,3 +1,4 @@
+import json
 import logging  # pylint: disable=C0302
 from typing import List
 
@@ -32,78 +33,6 @@ def test_index_valid_track(app, mocker):
         challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
         update_task = UpdateTask(None, web3, challenge_event_bus)
 
-    tx_receipts = {
-        "CreateTrack1Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": TRACK_ID_OFFSET,
-                        "_entityType": "Track",
-                        "_userId": 1,
-                        "_action": "Create",
-                        "_metadata": "QmCreateTrack1",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "UpdateTrack1Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": TRACK_ID_OFFSET,
-                        "_entityType": "Track",
-                        "_userId": 1,
-                        "_action": "Update",
-                        "_metadata": "QmUpdateTrack1",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "DeleteTrack1Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": TRACK_ID_OFFSET,
-                        "_entityType": "Track",
-                        "_userId": 1,
-                        "_action": "Delete",
-                        "_metadata": "",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "CreateTrack2Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": TRACK_ID_OFFSET + 1,
-                        "_entityType": "Track",
-                        "_userId": 1,
-                        "_action": "Create",
-                        "_metadata": "QmCreateTrack2",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-    }
-
-    entity_manager_txs = [
-        AttributeDict({"transactionHash": update_task.web3.toBytes(text=tx_receipt)})
-        for tx_receipt in tx_receipts
-    ]
-
-    def get_events_side_effect(_, tx_receipt):
-        return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
-
-    mocker.patch(
-        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
-        side_effect=get_events_side_effect,
-        autospec=True,
-    )
     test_metadata = {
         "QmCreateTrack1": {
             "owner_id": 1,
@@ -194,6 +123,44 @@ def test_index_valid_track(app, mocker):
             "isrc": "",
             "iswc": "",
         },
+        "QmCreateTrack3": {
+            "owner_id": 1,
+            "track_cid": "some-track-cid-3",
+            "title": "track 3",
+            "length": None,
+            "cover_art": None,
+            "cover_art_sizes": "QmQKXkVxGBbCFjcnhgxftzYDhph1CT8PJCuPEsRpffjjGC",
+            "tags": None,
+            "genre": "Rock",
+            "mood": None,
+            "credits_splits": None,
+            "created_at": None,
+            "create_date": None,
+            "updated_at": None,
+            "release_date": None,
+            "file_type": None,
+            "track_segments": [],
+            "has_current_user_reposted": False,
+            "is_current": True,
+            "is_unlisted": False,
+            "is_premium": False,
+            "premium_conditions": None,
+            "field_visibility": {
+                "genre": True,
+                "mood": True,
+                "tags": True,
+                "share": True,
+                "play_count": True,
+                "remixes": True,
+            },
+            "remix_of": None,
+            "repost_count": 0,
+            "save_count": 0,
+            "description": "",
+            "license": "",
+            "isrc": "",
+            "iswc": "",
+        },
         "QmUpdateTrack1": {
             "owner_id": 1,
             "track_cid": "some-track-cid",
@@ -246,6 +213,94 @@ def test_index_valid_track(app, mocker):
         },
     }
 
+    track3_json = json.dumps(test_metadata["QmCreateTrack3"])
+    tx_receipts = {
+        "CreateTrack1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET,
+                        "_entityType": "Track",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": "QmCreateTrack1",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "UpdateTrack1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET,
+                        "_entityType": "Track",
+                        "_userId": 1,
+                        "_action": "Update",
+                        "_metadata": "QmUpdateTrack1",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "DeleteTrack1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET,
+                        "_entityType": "Track",
+                        "_userId": 1,
+                        "_action": "Delete",
+                        "_metadata": "",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "CreateTrack2Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET + 1,
+                        "_entityType": "Track",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": "QmCreateTrack2",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "CreateTrack3Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET + 2,
+                        "_entityType": "Track",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "QmCreateTrack3", "data": {track3_json}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    entity_manager_txs = [
+        AttributeDict({"transactionHash": update_task.web3.toBytes(text=tx_receipt)})
+        for tx_receipt in tx_receipts
+    ]
+
+    def get_events_side_effect(_, tx_receipt):
+        return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
+
     entities = {
         "users": [
             {"user_id": 1, "handle": "user-1", "wallet": "user1wallet"},
@@ -268,7 +323,7 @@ def test_index_valid_track(app, mocker):
 
         # validate db records
         all_tracks: List[Track] = session.query(Track).all()
-        assert len(all_tracks) == 4
+        assert len(all_tracks) == 5
 
         track_1: Track = (
             session.query(Track)
@@ -288,6 +343,17 @@ def test_index_valid_track(app, mocker):
         )
         assert track_2.title == "track 2"
         assert track_2.is_delete == False
+
+        track_3: Track = (
+            session.query(Track)
+            .filter(
+                Track.is_current == True,
+                Track.track_id == TRACK_ID_OFFSET + 2,
+            )
+            .first()
+        )
+        assert track_3.title == "track 3"
+        assert track_3.is_delete == False
 
         # Check that track routes are updated appropriately
         track_routes = (

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import List
 from unittest import mock
@@ -60,92 +61,6 @@ def test_index_valid_user(app, mocker):
         web3 = Web3()
         update_task = UpdateTask(None, web3, bus_mock)
 
-    tx_receipts = {
-        "CreateUser1Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": USER_ID_OFFSET,
-                        "_entityType": "User",
-                        "_userId": USER_ID_OFFSET,
-                        "_action": "Create",
-                        "_metadata": "1,2,3",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "UpdateArtistPickTrack": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": TRACK_ID_OFFSET,
-                        "_entityType": "Track",
-                        "_userId": USER_ID_OFFSET,
-                        "_action": "Update",
-                        "_metadata": "QmUpdateArtistPickTrack",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "UpdateUser1Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": USER_ID_OFFSET,
-                        "_entityType": "User",
-                        "_userId": USER_ID_OFFSET,
-                        "_action": "Update",
-                        "_metadata": "QmUpdateUser1",
-                        "_signer": "user1wallet",
-                    }
-                )
-            },
-        ],
-        "CreateUser2Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": USER_ID_OFFSET + 1,
-                        "_entityType": "User",
-                        "_userId": USER_ID_OFFSET + 1,
-                        "_action": "Create",
-                        "_metadata": "2,3,4",
-                        "_signer": "user2wallet",
-                    }
-                )
-            },
-        ],
-        "UpdateUser2Tx": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": USER_ID_OFFSET + 1,
-                        "_entityType": "User",
-                        "_userId": USER_ID_OFFSET + 1,
-                        "_action": "Update",
-                        "_metadata": "QmUpdateUser2",
-                        "_signer": "user2wallet",
-                    }
-                )
-            },
-        ],
-    }
-
-    entity_manager_txs = [
-        AttributeDict({"transactionHash": update_task.web3.toBytes(text=tx_receipt)})
-        for tx_receipt in tx_receipts
-    ]
-
-    def get_events_side_effect(_, tx_receipt):
-        return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
-
-    mocker.patch(
-        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
-        side_effect=get_events_side_effect,
-        autospec=True,
-    )
     test_metadata = {
         "QmUpdateUser2": {
             "is_verified": False,
@@ -236,6 +151,94 @@ def test_index_valid_user(app, mocker):
             "user_id": USER_ID_OFFSET,
         },
     }
+
+    user1_update_json = json.dumps(test_metadata["QmUpdateArtistPickTrack"])
+    tx_receipts = {
+        "CreateUser1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": USER_ID_OFFSET,
+                        "_entityType": "User",
+                        "_userId": USER_ID_OFFSET,
+                        "_action": "Create",
+                        "_metadata": "1,2,3",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "UpdateArtistPickTrack": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": TRACK_ID_OFFSET,
+                        "_entityType": "Track",
+                        "_userId": USER_ID_OFFSET,
+                        "_action": "Update",
+                        "_metadata": f'{{"cid": "QmUpdateArtistPickTrack", "data": {user1_update_json}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "UpdateUser1Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": USER_ID_OFFSET,
+                        "_entityType": "User",
+                        "_userId": USER_ID_OFFSET,
+                        "_action": "Update",
+                        "_metadata": "QmUpdateUser1",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "CreateUser2Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": USER_ID_OFFSET + 1,
+                        "_entityType": "User",
+                        "_userId": USER_ID_OFFSET + 1,
+                        "_action": "Create",
+                        "_metadata": "2,3,4",
+                        "_signer": "user2wallet",
+                    }
+                )
+            },
+        ],
+        "UpdateUser2Tx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": USER_ID_OFFSET + 1,
+                        "_entityType": "User",
+                        "_userId": USER_ID_OFFSET + 1,
+                        "_action": "Update",
+                        "_metadata": "QmUpdateUser2",
+                        "_signer": "user2wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    entity_manager_txs = [
+        AttributeDict({"transactionHash": update_task.web3.toBytes(text=tx_receipt)})
+        for tx_receipt in tx_receipts
+    ]
+
+    def get_events_side_effect(_, tx_receipt):
+        return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
 
     entities = {
         "users": [

--- a/discovery-provider/integration_tests/tasks/test_index_helper.py
+++ b/discovery-provider/integration_tests/tasks/test_index_helper.py
@@ -1,7 +1,15 @@
+import json
+
+from integration_tests.challenges.index_helpers import UpdateTask
 from sqlalchemy import desc
 from src.models.indexing.cid_data import CIDData
+from src.tasks.entity_manager.utils import TRACK_ID_OFFSET, USER_ID_OFFSET
 from src.tasks.index import save_cid_metadata
+from src.tasks.index_nethermind import fetch_cid_metadata
+from src.utils.cid_metadata_client import CIDMetadataClient
 from src.utils.db_session import get_db
+from web3 import Web3
+from web3.datastructures import AttributeDict
 
 
 def test_save_cid_metadata(app):
@@ -43,3 +51,121 @@ def test_save_cid_metadata(app):
             )
             assert len(playlists) == 1
             assert playlists[0].data == {"playlist_id": 3}
+
+
+def test_fetch_cid_metadata(app, mocker):
+    """Test that cid metadata blobs are processed correctly"""
+    # Only test case where metadata blobs are passed directly
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        update_task = UpdateTask(CIDMetadataClient, web3, None)
+
+        expected_cid_type = {"QmUpdateUser1": "user"}
+        expected_metadata = {
+            "QmUpdateUser1": {
+                "is_verified": False,
+                "is_deactivated": False,
+                "name": "raymont updated",
+                "handle": "rayjacobsonupdated",
+                "profile_picture": None,
+                "profile_picture_sizes": "QmYRHAJ4YuLjT4fLLRMg5STnQA4yDpiBmzk5R3iCDTmkmk",
+                "cover_photo": None,
+                "cover_photo_sizes": "QmUk61QDUTzhNqjnCAWipSp3jnMmXBmtTUC2mtF5F6VvUy",
+                "bio": "ðŸŒžðŸ‘„ðŸŒž",
+                "location": "chik fil yay!!",
+                "artist_pick_track_id": TRACK_ID_OFFSET,
+                "creator_node_endpoint": "https://creatornode.audius.co,https://content-node.audius.co,https://blockdaemon-audius-content-06.bdnodes.net",
+                "associated_wallets": None,
+                "associated_sol_wallets": None,
+                "playlist_library": {
+                    "contents": [
+                        {"playlist_id": "Audio NFTs", "type": "explore_playlist"},
+                        {"playlist_id": 4327, "type": "playlist"},
+                        {"playlist_id": 52792, "type": "playlist"},
+                        {"playlist_id": 63949, "type": "playlist"},
+                        {
+                            "contents": [
+                                {"playlist_id": 6833, "type": "playlist"},
+                                {"playlist_id": 4735, "type": "playlist"},
+                                {"playlist_id": 114799, "type": "playlist"},
+                                {"playlist_id": 115049, "type": "playlist"},
+                                {"playlist_id": 89495, "type": "playlist"},
+                            ],
+                            "id": "d515f4db-1db2-41df-9e0c-0180302a24f9",
+                            "name": "WIP",
+                            "type": "folder",
+                        },
+                        {
+                            "contents": [
+                                {"playlist_id": 9616, "type": "playlist"},
+                                {"playlist_id": 112826, "type": "playlist"},
+                            ],
+                            "id": "a0da6552-ddc4-4d13-a19e-ecc63ca23e90",
+                            "name": "Community",
+                            "type": "folder",
+                        },
+                        {
+                            "contents": [
+                                {"playlist_id": 128608, "type": "playlist"},
+                                {"playlist_id": 90778, "type": "playlist"},
+                                {"playlist_id": 94395, "type": "playlist"},
+                                {"playlist_id": 97193, "type": "playlist"},
+                            ],
+                            "id": "1163fbab-e710-4d33-8769-6fcb02719d7b",
+                            "name": "Actually Albums",
+                            "type": "folder",
+                        },
+                        {"playlist_id": 131423, "type": "playlist"},
+                        {"playlist_id": 40151, "type": "playlist"},
+                    ]
+                },
+                "events": {"is_mobile_user": True},
+                "user_id": USER_ID_OFFSET,
+            },
+        }
+
+        user1JSON = json.dumps(expected_metadata["QmUpdateUser1"])
+        tx_receipts = {
+            "UpdateUser1Tx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": USER_ID_OFFSET,
+                            "_entityType": "User",
+                            "_userId": USER_ID_OFFSET,
+                            "_action": "Update",
+                            "_metadata": f'{{"cid": "QmUpdateUser1", "data": {user1JSON}}}',
+                            "_signer": "user1wallet",
+                        }
+                    )
+                },
+            ],
+        }
+
+        def get_events_side_effect(_, _event_type, tx_receipt):
+            return tx_receipts[tx_receipt.transactionHash.decode("utf-8")]
+
+        mocker.patch(
+            "src.tasks.index_nethermind.get_entity_manager_events_tx",
+            side_effect=get_events_side_effect,
+            autospec=True,
+        )
+        mocker.patch(
+            "src.tasks.index_nethermind.update_task",
+            return_value=update_task.cid_metadata_client,
+        )
+        mocker.patch(
+            "src.utils.cid_metadata_client.CIDMetadataClient.fetch_metadata_from_gateway_endpoints",
+            return_value={},
+        )
+
+        entity_manager_txs = [
+            AttributeDict(
+                {"transactionHash": update_task.web3.toBytes(text=tx_receipt)}
+            )
+            for tx_receipt in tx_receipts
+        ]
+        cid_metadata, cid_type = fetch_cid_metadata(db, entity_manager_txs)
+        assert cid_metadata == expected_metadata
+        assert cid_type == expected_cid_type

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from collections import defaultdict
@@ -313,13 +314,17 @@ def collect_entities_to_fetch(update_task, entity_manager_txs, metadata):
 
             # Add playlist track ids in entities to fetch
             # to prevent playlists from including premium tracks
-            metadata_cid = helpers.get_tx_arg(event, "_metadata")
-            if metadata_cid in metadata:
-                tracks = (
-                    metadata[metadata_cid]
-                    .get("playlist_contents", {})
-                    .get("track_ids", [])
-                )
+            cid = helpers.get_tx_arg(event, "_metadata")
+            # Check if metadata blob was passed directly and use if so.
+            # TODO remove after CID metadata migration.
+            try:
+                data = json.loads(cid)
+                cid = data["cid"]
+            except Exception:
+                pass
+
+            if cid in metadata:
+                tracks = metadata[cid].get("playlist_contents", {}).get("track_ids", [])
                 for track in tracks:
                     entities_to_fetch[EntityType.TRACK].add(track["track"])
 

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Set, Tuple, TypedDict, Union
@@ -123,7 +124,13 @@ class ManageEntityParameters:
         self.entity_id = helpers.get_tx_arg(event, "_entityId")
         self.entity_type = helpers.get_tx_arg(event, "_entityType")
         self.action = helpers.get_tx_arg(event, "_action")
-        self.metadata_cid = helpers.get_tx_arg(event, "_metadata")
+        # Check if metadata blob was passed directly.
+        # TODO remove after CID metadata migration.
+        try:
+            data = json.loads(helpers.get_tx_arg(event, "_metadata"))
+            self.metadata_cid = data["cid"]
+        except Exception:
+            self.metadata_cid = helpers.get_tx_arg(event, "_metadata")
         self.signer = helpers.get_tx_arg(event, "_signer")
         self.block_datetime = datetime.utcfromtimestamp(block_timestamp)
         self.block_integer_time = int(block_timestamp)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -240,7 +240,8 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         continue
 
                     # Check if metadata blob was passed directly.
-                    # If so, add to cid_metadata and cid_type dicts and continue.
+                    # If so, add to cid_metadata_from_chain and cid_type_from_chain
+                    # dicts and do not query CNs for these CIDs.
                     # TODO remove after CID metadata migration.
                     try:
                         data = json.loads(cid)

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -37,8 +37,14 @@ from src.queries.skipped_transactions import add_network_level_skipped_transacti
 from src.tasks.celery_app import celery
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
+from src.tasks.metadata import (
+    playlist_metadata_format,
+    track_metadata_format,
+    user_metadata_format,
+)
 from src.tasks.sort_block_transactions import sort_block_transactions
 from src.utils import helpers
+from src.utils.cid_metadata_client import get_metadata_from_json
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
 from src.utils.index_blocks_performance import (
     record_add_indexed_block_to_db_ms,
@@ -246,15 +252,25 @@ def fetch_cid_metadata(db, entity_manager_txs):
                     try:
                         data = json.loads(cid)
                         cid = data["cid"]
-                        metadata = data["data"]
-                        # do not add to cid_metadata or cid_type yet to avoid interfering with the retry conditions
-                        cid_metadata_from_chain[cid] = metadata
+                        metadata_json = data["data"]
+
+                        metadata_format: Any = None
+                        metadata_type = None
                         if event_type == EntityType.PLAYLIST:
-                            cid_type_from_chain[cid] = "playlist_data"
+                            metadata_type = "playlist_data"
+                            metadata_format = playlist_metadata_format
                         elif event_type == EntityType.TRACK:
-                            cid_type_from_chain[cid] = "track"
+                            metadata_type = "track"
+                            metadata_format = track_metadata_format
                         elif event_type == EntityType.USER:
-                            cid_type_from_chain[cid] = "user"
+                            metadata_type = "user"
+                            metadata_format = user_metadata_format
+                        formatted_json = get_metadata_from_json(
+                            metadata_format, metadata_json
+                        )
+                        # do not add to cid_metadata or cid_type yet to avoid interfering with the retry conditions
+                        cid_type_from_chain[cid] = metadata_type
+                        cid_metadata_from_chain[cid] = formatted_json
                         continue
                     except Exception:
                         pass

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -282,6 +282,7 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         # do not add to cid_metadata or cid_type yet to avoid interfering with the retry conditions
                         cid_type_from_chain[cid] = metadata_type
                         cid_metadata_from_chain[cid] = formatted_json
+                        logger.info(f"using metadata from tx. cid_type: {metadata_type}, formatted_json: {formatted_json}")
                         continue
                     except Exception:
                         pass

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -251,7 +251,8 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         continue
 
                     # Check if metadata blob was passed directly.
-                    # If so, add to cid_metadata and cid_type dicts and continue.
+                    # If so, add to cid_metadata_from_chain and cid_type_from_chain
+                    # dicts and do not query CNs for these CIDs.
                     # TODO remove after CID metadata migration.
                     try:
                         data = json.loads(cid)

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -282,7 +282,6 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         # do not add to cid_metadata or cid_type yet to avoid interfering with the retry conditions
                         cid_type_from_chain[cid] = metadata_type
                         cid_metadata_from_chain[cid] = formatted_json
-                        logger.info(f"using metadata from tx. cid_type: {metadata_type}, formatted_json: {formatted_json}")
                         continue
                     except Exception:
                         pass

--- a/discovery-provider/src/utils/cid_metadata_client.py
+++ b/discovery-provider/src/utils/cid_metadata_client.py
@@ -19,6 +19,15 @@ GET_METADATA_TIMEOUT_SECONDS = 2
 GET_METADATA_ALL_GATEWAY_TIMEOUT_SECONDS = 5
 
 
+def get_metadata_from_json(default_metadata_fields, resp_json):
+    metadata = {}
+    for parameter, value in default_metadata_fields.items():
+        metadata[parameter] = (
+            resp_json.get(parameter) if resp_json.get(parameter) is not None else value
+        )
+    return metadata
+
+
 class CIDMetadataClient:
     """Helper class for Audius Discovery Provider + CID Metadata interaction"""
 
@@ -55,14 +64,6 @@ class CIDMetadataClient:
                 f"CIDMetadataClient | update_cnode_urls with endpoints {cnode_endpoints}"
             )
             self._cnode_endpoints = cnode_endpoints
-
-    def _get_metadata_from_json(self, default_metadata_fields, resp_json):
-        metadata = {}
-        for parameter, value in default_metadata_fields.items():
-            metadata[parameter] = (
-                resp_json.get(parameter) if resp_json.get(parameter) != None else value
-            )
-        return metadata
 
     async def _get_metadata_async(self, async_session, multihash, gateway_endpoint):
         url = gateway_endpoint + "/content/" + multihash
@@ -176,7 +177,7 @@ class CIDMetadataClient:
                     else:
                         raise Exception(f"Unknown metadata type ${cid_type[cid]}")
 
-                    formatted_json = self._get_metadata_from_json(
+                    formatted_json = get_metadata_from_json(
                         metadata_format, metadata_json
                     )
 

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -5,7 +5,6 @@ import { CreatorNode } from '../services/creatorNode'
 import { Nullable, TrackMetadata, Utils } from '../utils'
 import retry from 'async-retry'
 import type { TransactionReceipt } from 'web3-core'
-import type { ManageEntityCIDMetadata } from '../services/dataContracts/EntityManagerClient'
 import { EntityManagerClient } from '../services/dataContracts/EntityManagerClient'
 
 const TRACK_PROPS = [

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -519,26 +519,14 @@ export class Track extends Base {
       )
       phase = phases.ADDING_TRACK
 
-      const txMetadata: ManageEntityCIDMetadata = {
-        cid: metadataMultihash,
-        data: metadata
-      }
-
       // Write metadata to chain
       const trackId = await this._generateTrackId()
-      // const response = await this.contracts.EntityManagerClient!.manageEntity(
-      //   ownerId,
-      //   EntityManagerClient.EntityType.TRACK,
-      //   trackId,
-      //   EntityManagerClient.Action.CREATE,
-      //   metadataMultihash
-      // )
       const response = await this.contracts.EntityManagerClient!.manageEntity(
         ownerId,
         EntityManagerClient.EntityType.TRACK,
         trackId,
         EntityManagerClient.Action.CREATE,
-        JSON.stringify(txMetadata)
+        metadataMultihash
       )
       const txReceipt = response.txReceipt
 

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -5,6 +5,7 @@ import { CreatorNode } from '../services/creatorNode'
 import { Nullable, TrackMetadata, Utils } from '../utils'
 import retry from 'async-retry'
 import type { TransactionReceipt } from 'web3-core'
+import type { ManageEntityCIDMetadata } from '../services/dataContracts/EntityManagerClient'
 import { EntityManagerClient } from '../services/dataContracts/EntityManagerClient'
 
 const TRACK_PROPS = [
@@ -518,14 +519,26 @@ export class Track extends Base {
       )
       phase = phases.ADDING_TRACK
 
+      const txMetadata: ManageEntityCIDMetadata = {
+        cid: metadataMultihash,
+        data: metadata
+      }
+
       // Write metadata to chain
       const trackId = await this._generateTrackId()
+      // const response = await this.contracts.EntityManagerClient!.manageEntity(
+      //   ownerId,
+      //   EntityManagerClient.EntityType.TRACK,
+      //   trackId,
+      //   EntityManagerClient.Action.CREATE,
+      //   metadataMultihash
+      // )
       const response = await this.contracts.EntityManagerClient!.manageEntity(
         ownerId,
         EntityManagerClient.EntityType.TRACK,
         trackId,
         EntityManagerClient.Action.CREATE,
-        metadataMultihash
+        JSON.stringify(txMetadata)
       )
       const txReceipt = response.txReceipt
 

--- a/libs/src/services/dataContracts/EntityManagerClient.ts
+++ b/libs/src/services/dataContracts/EntityManagerClient.ts
@@ -5,6 +5,7 @@ import { Buffer as SafeBuffer } from 'safe-buffer'
 import { ContractClient } from '../contracts/ContractClient'
 import * as signatureSchemas from '../../data-contracts/signatureSchemas'
 import type { Web3Manager } from '../web3Manager'
+import type { TrackMetadata, UserMetadata } from '../../utils'
 
 export enum Action {
   CREATE = 'Create',
@@ -29,6 +30,11 @@ export enum EntityType {
   USER = 'User',
   USER_REPLICA_SET = 'UserReplicaSet',
   NOTIFICATION = 'Notification'
+}
+
+export type ManageEntityCIDMetadata = {
+  cid: string
+  data: TrackMetadata | UserMetadata
 }
 
 /**
@@ -91,7 +97,7 @@ export class EntityManagerClient extends ContractClient {
    * @param {EntityType} entityType The type of entity being modified
    * @param {number} entityId The id of the entity
    * @param {Action} action Action being performed on the entity
-   * @param {string} metadataMultihash CID multihash or metadata associated with action
+   * @param {string} metadata CID multihash or metadata associated with action
    * @param {string}privateKey The private key used to sign the transaction
    */
   async manageEntity(
@@ -99,7 +105,7 @@ export class EntityManagerClient extends ContractClient {
     entityType: EntityType,
     entityId: number,
     action: Action,
-    metadataMultihash: string,
+    metadata: string,
     privateKey?: string
   ): Promise<{ txReceipt: TransactionReceipt }> {
     const nonce = signatureSchemas.getNonce()
@@ -113,7 +119,7 @@ export class EntityManagerClient extends ContractClient {
       entityType,
       entityId,
       action,
-      metadataMultihash,
+      metadata,
       nonce
     )
     let sig
@@ -133,7 +139,7 @@ export class EntityManagerClient extends ContractClient {
       entityType,
       entityId,
       action,
-      metadataMultihash,
+      metadata,
       nonce,
       sig
     )
@@ -148,7 +154,7 @@ export class EntityManagerClient extends ContractClient {
           entityType,
           entityId,
           action,
-          metadataMultihash,
+          metadata,
           nonce
         )
       const nethermindSig = await this.web3Manager.signTypedData(
@@ -161,7 +167,7 @@ export class EntityManagerClient extends ContractClient {
         entityType,
         entityId,
         action,
-        metadataMultihash,
+        metadata,
         nonce,
         nethermindSig
       )


### PR DESCRIPTION
### Description
Index metadata from chain via `manageEntity`. Indexer can handle both legacy CID requests and requests with actual metadata.
Still need the CID along with the metadata, so format the `metadata` field in `manageEntity` like this: (JSON stringified)
```
{
    "cid": <cid>,
    "data": <normal metadata blob>
}
```
The `manageEntity` `entityType` and `action` params remain the same.

Also edit `txRelay` in identity to insert a hash of the nonce + sig in the ABI to the `Transactions` table rather than the entire encoded ABI. For large blobs the encoded ABI is too large to fit in a postgres pkey col, and what really makes it unique is just the nonce and sig anyway. The `Transactions` table is used to avoid re-sending txs we've already sent.

### Tests
Python integration tests; will deploy to stage and test further before merging.
Tested identity relay changes via browser console.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->