### PR TITLE
Add selectionCallback to sdk discovery-node-selector

### DIFF
--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -409,12 +409,13 @@ export class Track extends Base {
     this._validateTrackMetadata(metadata)
 
     // Upload track audio and cover art to storage node
-    const updatedMetadata = await this.creatorNode.uploadTrackAudioAndCoverArtV2(
-      trackFile,
-      coverArtFile,
-      metadata,
-      onProgress
-    )
+    const updatedMetadata =
+      await this.creatorNode.uploadTrackAudioAndCoverArtV2(
+        trackFile,
+        coverArtFile,
+        metadata,
+        onProgress
+      )
 
     // Write metadata to chain
     const trackId = await this._generateTrackId()

--- a/libs/src/api/Users.test.js
+++ b/libs/src/api/Users.test.js
@@ -1,3 +1,0 @@
-const assert = require('assert')
-
-const { Users } = require('./Users')

--- a/libs/src/services/dataContracts/AudiusContracts.ts
+++ b/libs/src/services/dataContracts/AudiusContracts.ts
@@ -50,7 +50,7 @@ export class AudiusContracts {
   }
 
   getEmptyRegistryAddress: GetRegistryAddress = async () => {
-    return Promise.resolve('')
+    return await Promise.resolve('')
   }
 
   async init() {

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -1254,7 +1254,8 @@ export class DiscoveryProvider {
     if (this.discoveryNodeSelector) {
       return await this._makeRequestInternalNext<Response>(
         requestObj,
-        throwError
+        throwError,
+        blockNumber
       )
     }
 
@@ -1415,7 +1416,8 @@ export class DiscoveryProvider {
 
   async _makeRequestInternalNext<Response>(
     requestObj: Record<string, unknown>,
-    throwError = false
+    throwError = false,
+    blockNumber?: number
   ) {
     if (!this.discoveryProviderEndpoint || !this.discoveryNodeMiddleware) return
 
@@ -1468,6 +1470,13 @@ export class DiscoveryProvider {
       })) ?? response
 
     const responseBody: DiscoveryResponse<Response> = await response.json()
+
+    if (blockNumber && responseBody.latest_indexed_block < blockNumber) {
+      throw new Error(
+        `Requested blocknumber ${blockNumber}, but discovery is behind at ${responseBody.latest_indexed_block}`
+      )
+    }
+
     return responseBody
   }
 

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -117,6 +117,7 @@ export class DiscoveryProvider {
   isInitialized = false
   discoveryNodeSelector?: DiscoveryNodeSelector
   discoveryNodeMiddleware?: Middleware
+  selectionCallback?: DiscoveryProviderSelectionConfig['selectionCallback']
 
   constructor({
     whitelist,
@@ -139,6 +140,7 @@ export class DiscoveryProvider {
     this.userStateManager = userStateManager
     this.ethContracts = ethContracts
     this.web3Manager = web3Manager
+    this.selectionCallback = selectionCallback
 
     this.unhealthyBlockDiff = unhealthyBlockDiff ?? DEFAULT_UNHEALTHY_BLOCK_DIFF
     this.serviceSelector = new DiscoveryProviderSelection(
@@ -177,6 +179,7 @@ export class DiscoveryProvider {
         'change',
         (endpoint: string) => {
           this.setEndpoint(endpoint)
+          this.selectionCallback?.(endpoint, [])
         }
       )
 

--- a/libs/src/utils/fileHasher.ts
+++ b/libs/src/utils/fileHasher.ts
@@ -237,7 +237,7 @@ export const fileHasher = {
     logger: any = console
   ): Promise<string> {
     const buffer = await fileHasher.convertToBuffer(content, logger)
-    return fileHasher.hashNonImages(buffer)
+    return await fileHasher.hashNonImages(buffer)
   },
 
   /**
@@ -250,6 +250,6 @@ export const fileHasher = {
     content: ImportCandidate,
     _: any = console
   ): Promise<HashedImage[]> {
-    return fileHasher.hashImages(content)
+    return await fileHasher.hashImages(content)
   }
 }


### PR DESCRIPTION
### Description
- Fixes issue where sdk discovery-node-selector was not calling the selection-callback, leading to issue where libs caller using new discovery-node-selector wasn't aware a discovery node was selected.
- Also fixes issue where blocknumber check was not being respected in new _makeRequestInternal
- Fixes lint, we should prob add a ci step for it