### PR TITLE
Allow health check when no sp id

### DIFF
--- a/creator-node/src/middlewares/readOnly/readOnlyMiddleware.ts
+++ b/creator-node/src/middlewares/readOnly/readOnlyMiddleware.ts
@@ -3,6 +3,7 @@ import { sendResponse, errorResponseServerError } from '../../apiHelpers'
 import config from '../../config'
 
 const EXCLUDED_ROUTES: string[] = [
+  '/health_check',
   '/batch_cids_exist',
   '/batch_image_cids_exist',
   '/batch_id_to_cid',
@@ -50,7 +51,7 @@ export function canProceedInReadOnlyMode(
   method: string,
   originalUrl: string
 ) {
-  if (spIDNotDefined) return false
+  if (spIDNotDefined && !EXCLUDED_ROUTES.includes(originalUrl)) return false
   if (
     isReadOnlyMode &&
     method !== 'GET' &&


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Allows health check when in read only/no SP id mode (prior to registration).
This unblocks registration from happening, which runs a health check on the service beforehand.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

`audius-compose up` without content node registration should still yield healthy nodes -- difficulty testing this.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->