### PR TITLE
Support /ipfs routes for CID V0 and CID V1

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -4,6 +4,9 @@
 #   - any value below prefixed with $arg indicates a request query param, e.g. $arg_bypasscache will match query param `bypasscache=<value>`
 # Nginx location regex examples: https://linuxhint.com/nginx-location-regex-examples/
 
+# Significantly speeds up regular expression processing for /ipfs routes
+pcre_jit on;
+
 worker_processes 8;
 
 events {
@@ -35,9 +38,8 @@ http {
         # Match the paths /ipfs/<cid: string> and /content/<cid: string>.
         # If present in cache, serve. Else, hit upstream server + update cache + serve.
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
-        location ~ (/ipfs/|/content/) {
+        location ~* (/ipfs/|/content/) {
             proxy_cache cache;
-            proxy_pass http://127.0.0.1:3000;
 
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
@@ -64,6 +66,18 @@ http {
 
             # Add header to indicate the status of the cache with this request
             add_header X-Cache-Status $upstream_cache_status always;
+
+            # Use Content Node for legacy CID V0 (46-char Qm hash)
+            location ~* "^(/ipfs/|/content/)(Qm[a-zA-Z0-9]{44})(/.*|$)" {
+                proxy_pass http://127.0.0.1:3000;
+            }
+
+            # Use Storage V2 for CID V1
+            location ~* ^(/ipfs/|/content/) {
+                resolver 127.0.0.11 valid=30s;
+                set $storagev2 http://mediorum:1991; # mediorum container only exists on staging and prod. nginx_ingress.conf handles this for local dev
+                proxy_pass $storagev2;
+            }
         }
 
         # Regex matches any path that begins with /health_check (case-sensitive)

--- a/discovery-provider/integration_tests/queries/test_get_playlists.py
+++ b/discovery-provider/integration_tests/queries/test_get_playlists.py
@@ -31,13 +31,13 @@ def test_entities():
                 "playlist_name": "playlist 3",
                 "is_current": True,
                 "playlist_contents": {
-                   "track_ids": [
-                        {"track": 1}, 
-                        {"track": 2}, 
-                        {"track": 3}, 
-                        {"track": 4}, 
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                        {"track": 4},
                     ]
-                }
+                },
             },
             {
                 "playlist_id": 4,
@@ -46,13 +46,13 @@ def test_entities():
                 "is_private": True,
                 "is_current": True,
                 "playlist_contents": {
-                   "track_ids": [
-                        {"track": 1}, 
-                        {"track": 2}, 
-                        {"track": 3}, 
-                        {"track": 4}, 
+                    "track_ids": [
+                        {"track": 1},
+                        {"track": 2},
+                        {"track": 3},
+                        {"track": 4},
                     ]
-                }
+                },
             },
         ],
         "users": [
@@ -216,11 +216,7 @@ def test_get_playlist_with_listed_and_unlisted_tracks(app, test_entities):
         populate_mock_db(db, test_entities)
         with db.scoped_session() as session:
             playlists = get_playlist_tracks(
-                session,
-                { 
-                    "playlist_ids": [3, 4],
-                    "current_user_id": 3
-                }
+                session, {"playlist_ids": [3, 4], "current_user_id": 3}
             )
             assert len(playlists) == 2
             tracks_playlist_3 = playlists[3]
@@ -239,9 +235,3 @@ def test_get_playlist_with_listed_and_unlisted_tracks(app, test_entities):
             assert not t2_p4["is_unlisted"]
             assert t3_p4["is_unlisted"]
             assert t4_p4["is_unlisted"]
-            
-            
-
-
-
-

--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -4,8 +4,11 @@ go 1.20
 
 require (
 	github.com/disintegration/imaging v1.6.2
+	github.com/ethereum/go-ethereum v1.11.4
 	github.com/inconshreveable/log15 v2.16.0+incompatible
+	github.com/ipfs/go-cid v0.3.2
 	github.com/labstack/echo/v4 v4.10.0
+	github.com/multiformats/go-multihash v0.2.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/spf13/cast v1.5.0
@@ -14,21 +17,18 @@ require (
 	gocloud.dev v0.28.0
 	golang.org/x/exp v0.0.0-20230223210539-50820d90acfd
 	gorm.io/driver/sqlite v1.4.4
-	gorm.io/gorm v1.24.5
+	gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11
 )
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
-	github.com/ethereum/go-ethereum v1.11.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
-	github.com/ipfs/go-cid v0.3.2 // indirect
-	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
@@ -36,20 +36,18 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect
-	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
-	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/mediorum/go.sum
+++ b/mediorum/go.sum
@@ -572,6 +572,7 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -755,6 +756,7 @@ github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjI
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
@@ -1199,8 +1201,6 @@ github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9
 github.com/ionos-cloud/sdk-go/v6 v6.1.3/go.mod h1:Ox3W0iiEz0GHnfY9e5LmAxwklsxguuNFEUSu0gVRTME=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
 github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
-github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
-github.com/ipfs/go-ipfs-util v0.0.2/go.mod h1:CbPtkWJzjLdEcezDns2XYaehFVNXG9zrdrtMecczcsQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -1282,7 +1282,6 @@ github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -1375,9 +1374,6 @@ github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJys
 github.com/miekg/dns v1.1.48/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
 github.com/miekg/dns v1.1.50/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
-github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
-github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
@@ -1418,7 +1414,6 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
-github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
@@ -1428,12 +1423,8 @@ github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ8
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
-github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
-github.com/multiformats/go-multihash v0.0.15 h1:hWOPdrNqDjwHDx82vsYGSDZNyktOJJ2dzZJzFkOV1jM=
-github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJzmCl4jb1alC0OvHiHg=
 github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d16Vve9l108=
 github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
-github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -1906,8 +1897,9 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20221012134737-56aed061732a/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
-golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
+golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -2176,7 +2168,6 @@ golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2674,8 +2665,8 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/sqlite v1.4.4 h1:gIufGoR0dQzjkyqDyYSCvsYR6fba1Gw5YKDqKeChxFc=
 gorm.io/driver/sqlite v1.4.4/go.mod h1:0Aq3iPO+v9ZKbcdiz8gLWRw5VOPcBOPUQJFLq5e2ecI=
 gorm.io/gorm v1.24.0/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
-gorm.io/gorm v1.24.5 h1:g6OPREKqqlWq4kh/3MCQbZKImeB9e6Xgc4zD+JgNZGE=
-gorm.io/gorm v1.24.5/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
+gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11 h1:9qNbmu21nNThCNnF5i2R3kw2aL27U8ZwbzccNjOmW0g=
+gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -17,7 +17,7 @@ type Blob struct {
 type Upload struct {
 	ID string `json:"id"` // base32 file hash
 
-	Template     string         `json:"template"`
+	Template     JobTemplate    `json:"template"`
 	OrigFileName string         `json:"orig_filename"`
 	OrigFileCID  string         `json:"orig_file_cid"`
 	FFProbe      *FFProbeResult `json:"probe" gorm:"serializer:json"`

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -148,6 +148,18 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	basePath.Use(middleware.Recover())
 	basePath.Use(middleware.CORS())
 
+	// TODO: Use middleware to cache whenever content is streamed, except if it's premium content.
+	// See Johannes's previous PR for reference. From CN:
+	// If content is gated, set cache-control to no-cache.
+	// Otherwise, set the CID cache-control so that client caches the response for 30 days.
+	// The contentAccessMiddleware sets the req.contentAccess object so that we do not
+	// have to make another database round trip to get this info.
+	// if (req.shouldCache) {
+	//   res.setHeader('cache-control', 'public, max-age=2592000, immutable')
+	// } else {
+	//   res.setHeader('cache-control', 'no-cache')
+	// }
+
 	basePath.GET("", ss.serveUploadUI)
 	basePath.GET("/", ss.serveUploadUI)
 
@@ -155,6 +167,11 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	basePath.GET("/uploads", ss.getUploads)
 	basePath.GET("/uploads/:id", ss.getUpload)
 	basePath.POST("/uploads", ss.postUpload)
+
+	echoServer.GET("/ipfs/:key", ss.getBlob)
+	echoServer.GET("/content/:key", ss.getBlob)
+	echoServer.GET("/ipfs/:jobID/:variant", ss.getJobResult)
+	echoServer.GET("/content/:jobID/:variant", ss.getJobResult)
 
 	// status + debug:
 	basePath.GET("/status", ss.getStatus)

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -214,7 +214,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 			}
 			logger.Debug("did square", "w", w, "h", h, "key", resultHash, "mirrors", mirrors)
 
-			variantName := fmt.Sprintf("%dx%[1]d", targetBox)
+			variantName := fmt.Sprintf("%dx%[1]d.jpg", targetBox)
 			upload.TranscodeResults[variantName] = resultHash
 		}
 
@@ -234,13 +234,13 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 			}
 			logger.Debug("did backdrop", "w", w, "h", h, "key", resultHash, "mirrors", mirrors)
 
-			variantName := fmt.Sprintf("%dwide", targetWidth)
+			variantName := fmt.Sprintf("%x.jpg", targetWidth)
 			upload.TranscodeResults[variantName] = resultHash
 		}
 
 	case JobTemplateAudio, "":
 		if upload.Template == "" {
-			fmt.Println("empty template, falling back to audio")
+			logger.Warn("empty template (shouldn't happen), falling back to audio")
 		}
 
 		srcPath := temp.Name()

--- a/nginx_ingress.conf
+++ b/nginx_ingress.conf
@@ -32,17 +32,36 @@ server {
     server_name audius-protocol-creator-node-1;
 
     location / {
+        location ~* ^(/ipfs/|/content/|/mediorum/) {
+            add_header X-debug-message1 "Matched /ipfs/content/mediorum" always;
+            # Use Content Node for legacy CID V0 (46-char Qm hash)
+            location ~* "^(/ipfs/|/content/)(Qm[a-zA-Z0-9]{44})(/.*|$)" {
+                add_header X-debug-message2 "Matched legacy CID V0 - routing to Content Node" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-creator-node-1:4000;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+            # Use Storage V2 for CID V1 and /mediorum route
+            location ~* ^(/ipfs/|/content/mediorum/) {
+                add_header X-debug-message3 "Matched CID V1 - routing to Storage V2" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-storagev2-1:1991;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+        }
+
+        # Use Content Node for everything else
+        add_header X-debug-message4 "Matched / - routing to Content Node" always;
         resolver 127.0.0.11 valid=30s;
         set $upstream audius-protocol-creator-node-1:4000;
-        proxy_pass http://$upstream;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location /mediorum {
-        client_max_body_size 500M;
-        resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-storagev2-1:1991;
         proxy_pass http://$upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -55,17 +74,36 @@ server {
     server_name audius-protocol-creator-node-2;
 
     location / {
-        resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-creator-node-2:4000;
-        proxy_pass http://$upstream;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
+        location ~* ^(/ipfs/|/content/|/mediorum/) {
+            add_header X-debug-message1 "Matched /ipfs/content/mediorum" always;
+            # Use Content Node for legacy CID V0 (46-char Qm hash)
+            location ~* "^(/ipfs/|/content/)(Qm[a-zA-Z0-9]{44})(/.*|$)" {
+                add_header X-debug-message2 "Matched legacy CID V0 - routing to Content Node" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-creator-node-2:4000;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+            # Use Storage V2 for CID V1 and /mediorum route
+            location ~* ^(/ipfs/|/content/mediorum/) {
+                add_header X-debug-message3 "Matched CID V1 - routing to Storage V2" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-storagev2-2:1991;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+        }
 
-    location /mediorum {
-        client_max_body_size 500M;
+        # Use Content Node for everything else
+        add_header X-debug-message4 "Matched / - routing to Content Node" always;
         resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-storagev2-2:1991;
+        set $upstream audius-protocol-creator-node-1:4000;
         proxy_pass http://$upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -78,17 +116,36 @@ server {
     server_name audius-protocol-creator-node-3;
 
     location / {
-        resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-creator-node-3:4000;
-        proxy_pass http://$upstream;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
+        location ~* ^(/ipfs/|/content/|/mediorum/) {
+            add_header X-debug-message1 "Matched /ipfs/content/mediorum" always;
+            # Use Content Node for legacy CID V0 (46-char Qm hash)
+            location ~* "^(/ipfs/|/content/)(Qm[a-zA-Z0-9]{44})(/.*|$)" {
+                add_header X-debug-message2 "Matched legacy CID V0 - routing to Content Node" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-creator-node-3:4000;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+            # Use Storage V2 for CID V1 and /mediorum route
+            location ~* ^(/ipfs/|/content/mediorum/) {
+                add_header X-debug-message3 "Matched CID V1 - routing to Storage V2" always;
+                resolver 127.0.0.11 valid=30s;
+                set $upstream audius-protocol-storagev2-3:1991;
+                proxy_pass http://$upstream;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+            }
+        }
 
-    location /mediorum {
-        client_max_body_size 500M;
+        # Use Content Node for everything else
+        add_header X-debug-message4 "Matched / - routing to Content Node" always;
         resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-storagev2-3:1991;
+        set $upstream audius-protocol-creator-node-1:4000;
         proxy_pass http://$upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### Description
Makes sure Storage V2 is compatible with the `/[ipfs|content]/:CID` and `/[ipfs|content]/:dirCID/:filename` routes, and updates nginx config to route requests accordingly. Note that the `/tracks/stream/:encodedId` route takes in an ID that is indistinguishable between Content Node and Storage V2, so we'll need a different workaround such as the client sending a queryparam for V2 tracks (can be a field in metadata).

### Tests
Locally and on stage CN10:
- CID V0 track goes to CN: https://creatornode10.staging.audius.co/ipfs/QmetKanZMhZaZnTH4fcJvDatN78CqGsTcAeaqWPodC8w52 (why does this track go so hard? 🤩)
- CID V0 image goes to CN: https://creatornode10.staging.audius.co/ipfs/QmYy7S8ee2wTb98Hsbcqz5dGgBh6uzJR9uyPAm2dtFFdVc/150x150.jpg
- CID V1 track goes to Storage V2: https://creatornode10.staging.audius.co/ipfs/CIDV1_or_anything_not_in_CIDV0_format
- CID V1 image goes to Storage V2: https://creatornode10.staging.audius.co/ipfs/CIDV1_or_anything_not_in_CIDV0_format/150x150.jpg

I also added debug headers to local dev for extra assurance about the regex.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
- Make sure image files are still accessible. It should be pretty obvious if they go missing
- There should not be any logs for `Invalid request, CID V0 provided - should've redirected to Content Node`
- If a file is missing its error should NOT look like this (this error means it incorrectly routed to Storage v2 instead of Content Node):
```
{
  "error": "record not found",
  "message": "Internal Server Error"
}
```