### PR TITLE
Use replica set for streaming

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -455,13 +455,14 @@ class TrackStream(Resource):
         else:
             path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
 
+        # Try primary first then fallback to replica set
+        # Perform a partial content request to verify 206 success
         for creator_node in creator_nodes:
             stream_url = urljoin(creator_node, path)
             headers = {"Range": "bytes=0-1"}
             try:
                 response = requests.get(stream_url, headers=headers)
-                logger.info(f"asdf {stream_url} {response.status}")
-                if response.status == 200:
+                if response.status == 206:
                     return stream_url
             except:
                 pass

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -460,6 +460,7 @@ class TrackStream(Resource):
             headers = {"Range": "bytes=0-1"}
             try:
                 response = requests.get(stream_url, headers=headers)
+                logger.info(f"asdf {stream_url} {response.status}")
                 if response.status == 200:
                     return stream_url
             except:

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -634,7 +634,9 @@ def index_blocks(self, db, blocks_list):
                     logger.debug(
                         f"index.py | index_blocks - process_state_changes in {time.time() - process_state_changes_start_time}s"
                     )
-                    is_save_cid_enabled = shared_config["discprov"]["enable_save_cid"] == "true"
+                    is_save_cid_enabled = (
+                        shared_config["discprov"]["enable_save_cid"] == "true"
+                    )
                     if is_save_cid_enabled:
                         """
                         Add CID Metadata to db (cid -> json blob, etc.)

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -628,7 +628,9 @@ def index_blocks(self, db, blocks_list):
                     logger.debug(
                         f"index_nethermind.py | index_blocks - process_state_changes in {time.time() - process_state_changes_start_time}s"
                     )
-                    is_save_cid_enabled = shared_config["discprov"]["enable_save_cid"] == "true"
+                    is_save_cid_enabled = (
+                        shared_config["discprov"]["enable_save_cid"] == "true"
+                    )
                     if is_save_cid_enabled:
                         """
                         Add CID Metadata to db (cid -> json blob, etc.)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Sometimes a primary node may be down so we can fall back to replica set for streaming. I tried to do this async but couldn't get async to work with the flask docs we have which look inaccurate as well.

Also fixing some linting.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage. Temporarily hardcoded a replica set and verified it fell back to a non primary node.
Latency impact is negligible.
### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->