### PR TITLE
Use >= check instead of exact version for dn selection

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
@@ -9,10 +9,10 @@ import {
 import { DISCOVERY_SERVICE_NAME } from './constants'
 import fetch from 'cross-fetch'
 
-const hasSameMajorAndMinorVersion = (version1: string, version2: string) => {
+const hasGteMajorAndMinorVersions = (version1: string, version2: string) => {
   return (
-    semver.major(version1) === semver.major(version2) &&
-    semver.minor(version1) === semver.minor(version2)
+    semver.major(version1) >= semver.major(version2) &&
+    semver.minor(version1) >= semver.minor(version2)
   )
 }
 
@@ -85,7 +85,7 @@ export const parseApiHealthStatusReason = ({
     if (
       data.version &&
       (!data.version.version ||
-        !hasSameMajorAndMinorVersion(data.version.version, minVersion))
+        !hasGteMajorAndMinorVersions(data.version.version, minVersion))
     ) {
       return {
         health: HealthCheckStatus.UNHEALTHY,
@@ -147,7 +147,7 @@ export const parseHealthStatusReason = ({
   if (minVersion) {
     if (
       !data.version ||
-      !hasSameMajorAndMinorVersion(data.version, minVersion)
+      !hasGteMajorAndMinorVersions(data.version, minVersion)
     ) {
       return {
         health: HealthCheckStatus.UNHEALTHY,


### PR DESCRIPTION
### Description
Fixes discovery selection failing locally when the min version is 0.0.0 and the DN version is 0.3.83. This was caused by the version check using strict equality rather than >=, so if it got to prod it would make clients only select nodes of a single version.


### Tests
Added debug logs (removed now for PR) and made sure discovery selection stopped failing when going through the signup flow locally.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A