### PR TITLE
Clean up CN nginx and don't serve stale /health_check

### DIFF
--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -90,11 +90,6 @@ http {
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
 
-            # proxy_cache_use_stale + proxy_cache_background_update -> deliver stale content when client requests
-            # an item that is expired or in the process of being updated from origin server
-            proxy_cache_use_stale timeout updating http_500 http_502 http_503 http_504;
-            proxy_cache_background_update on;
-
             # Cache all responses for 1s
             proxy_cache_valid any 1s;
 
@@ -122,25 +117,6 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /nats {
-            resolver 127.0.0.11 valid=30s;
-            set $upstream nats:8924;
-            proxy_pass http://$upstream;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location /storage {
-            client_max_body_size 500M;
-            resolver 127.0.0.11 valid=30s;
-            set $upstream storage:8926;
-            proxy_pass http://$upstream;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            # for websockets:
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-        }
         location /mediorum {
             client_max_body_size 500M;
             resolver 127.0.0.11 valid=30s;

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -83,15 +83,10 @@ http {
         # Regex matches any path that begins with /health_check (case-sensitive)
         # Note this will also include other health check routes /health_check/verbose, /health_check/sync, /health_check/duration, /health_check/duration/heartbeat, /health_check/fileupload
         location ~ (/health_check) {
-            proxy_cache cache;
-
             proxy_pass http://127.0.0.1:3000;
 
             # Set client IP as `X-Forwarded-For` response header
             proxy_set_header X-Forwarded-For $remote_addr;
-
-            # Cache all responses for 1s
-            proxy_cache_valid any 1s;
 
             # Bypass cache with bypasscache=true query string and save new response to proxy cache
             proxy_cache_bypass $arg_bypasscache;


### PR DESCRIPTION
### Description
- Removes unused Content Node nginx blocks for /nats and /storage
- Removes Content Node cache for /health_check route