### PR TITLE
[PAY-827][PAY-1115] Always use cid streaming and include filename in redirect if exists

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -385,6 +385,12 @@ stream_parser.add_argument(
         user signature and the user for whom the DN signed are the same.""",
     type=str,
 )
+stream_parser.add_argument(
+    "filename",
+    description="""Optional - Filename in case user is trying to download track.
+        This is needed by the CN in order to set the Content-Disposition response header.""",
+    type=str,
+)
 
 
 def tranform_stream_cache(stream_url):
@@ -424,7 +430,7 @@ class TrackStream(Resource):
 
         track_cid = track["track_cid"]
         if not track_cid:
-            logger.warning(
+            logger.error(
                 f"tracks.py | stream | We should not reach here! Track with id {track_id} has no track_cid. Please investigate."
             )
             abort_not_found(track_id, ns)
@@ -450,7 +456,7 @@ class TrackStream(Resource):
         signature_param = urllib.parse.quote(json.dumps(signature))
         path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
 
-        # Grab filemame in case the user is requesting track download
+        # Grab filename in case the user is requesting track download
         filename = request_args.get("filename", None)
         if filename:
             path = f"{path}&filename={filename}"

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -55,10 +55,7 @@ from src.queries.get_subsequent_tracks import get_subsequent_tracks
 from src.queries.get_top_followee_saves import get_top_followee_saves
 from src.queries.get_top_followee_windowed import get_top_followee_windowed
 from src.queries.get_track_stream_info import get_track_stream_info
-from src.queries.get_track_stream_signature import (
-    CID_STREAM_ENABLED,
-    get_track_stream_signature,
-)
+from src.queries.get_track_stream_signature import get_track_stream_signature
 from src.queries.get_tracks import RouteArgs, get_tracks
 from src.queries.get_tracks_including_unlisted import get_tracks_including_unlisted
 from src.queries.get_trending import get_full_trending, get_trending
@@ -425,6 +422,13 @@ class TrackStream(Resource):
         if not creator_nodes or not track:
             abort_not_found(track_id, ns)
 
+        track_cid = track["track_cid"]
+        if not track_cid:
+            logger.warning(
+                f"tracks.py | stream | We should not reach here! Track with id {track_id} has no track_cid. Please investigate."
+            )
+            abort_not_found(track_id, ns)
+
         creator_nodes = creator_nodes.split(",")
         primary_node = creator_nodes[0]
         request_args = stream_parser.parse_args()
@@ -444,16 +448,13 @@ class TrackStream(Resource):
             abort_not_found(track_id, ns)
 
         signature_param = urllib.parse.quote(json.dumps(signature))
-        track_cid = track["track_cid"]
-        if not track_cid:
-            logger.warning(
-                f"tracks.py | stream | We should not reach here! If you see this, it's because the track with id {track_id} has no track_cid. Please investigate."
-            )
-            path = f"tracks/stream/{track_id}"
-        elif not CID_STREAM_ENABLED:
-            path = f"tracks/stream/{track_id}"
-        else:
-            path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
+        path = f"tracks/cidstream/{track_cid}?signature={signature_param}"
+
+        # Grab filemame in case the user is requesting track download
+        filename = request_args.get("filename", None)
+        if filename:
+            path = f"{path}&filename={filename}"
+
         stream_url = urljoin(primary_node, path)
 
         return stream_url

--- a/discovery-provider/src/queries/get_track_stream_signature.py
+++ b/discovery-provider/src/queries/get_track_stream_signature.py
@@ -10,8 +10,6 @@ from src.premium_content.signature import get_premium_content_signature
 from src.queries.get_authed_user import get_authed_user
 from src.utils import db_session
 
-CID_STREAM_ENABLED = True
-
 
 class GetTrackStreamSignature(TypedDict):
     track: Track


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Remove CN track id stream redirect. Also include filename query param in case the user is wanting to download the track. Related to https://github.com/AudiusProject/audius-client/pull/3202 and helps us towards deperecating all non-cid DN + CN stream paths.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Deployed to stage DN and tested local web app against it.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->