### PR TITLE
Fix duplicate track create notifications

### DIFF
--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -119,7 +119,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
     logger.info(`got unread ${subscriberIdsWithoutNotification.length}`)
 
     if (subscriberIdsWithoutNotification.length > 0) {
-      // Bulk create notifications for users that do not have a un-viewed notification
+      // Bulk create notifications for users that do not have new notifications
       const createTrackNotifTx = await models.Notification.bulkCreate(
         subscriberIdsWithoutNotification.map(
           (id) => ({
@@ -147,7 +147,7 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
       )
     }
     if (subscriberIdsWithNotification.length > 0) {
-      // find existing unread notification
+      // Find existing unread notifications
       const createTrackNotifTx = await models.Notification.findAll({
         where: {
           userId: { [models.Sequelize.Op.in]: subscriberIdsWithNotification },
@@ -157,6 +157,8 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
         }
       })
       const createdNotificationIds = createTrackNotifTx.map((notif) => notif.id)
+
+      // Append new notification actions to those existing unread notifications
       await models.NotificationAction.bulkCreate(
         createdNotificationIds.map((notificationId) => ({
           notificationId,

--- a/identity-service/src/notifications/processNotifications/createNotification.js
+++ b/identity-service/src/notifications/processNotifications/createNotification.js
@@ -147,11 +147,13 @@ async function processCreateNotifications(notifications, tx, optimizelyClient) {
       )
     }
     if (subscriberIdsWithNotification.length > 0) {
+      // find existing unread notification
       const createTrackNotifTx = await models.Notification.findAll({
         where: {
           userId: { [models.Sequelize.Op.in]: subscriberIdsWithNotification },
           type: createType,
-          entityId: notificationEntityId
+          entityId: notificationEntityId,
+          isViewed: false
         }
       })
       const createdNotificationIds = createTrackNotifTx.map((notif) => notif.id)


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fixes a bug in track create notifications.
Before, if you're subscribed to a user and you have viewed track create notifications from them before and then they upload new tracks, it would add the new notification actions to ALL existing notifications from that user. So the new upload would actually add a track creation to existing track creation notifications.  

<img width="522" alt="Screenshot 2023-04-10 at 4 08 03 PM" src="https://user-images.githubusercontent.com/6413636/231016031-9218a0c2-d8b0-4482-a981-5072a606b3f5.png">

Instead, the correct behavior is to add new actions only to the existing unread notification.  

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage. Uploaded multiple tracks and single tracks. Verified notifications are as expected.



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->