### PR TITLE
Fix followee_reposts for albums

### DIFF
--- a/discovery-provider/src/queries/get_feed_es.py
+++ b/discovery-provider/src/queries/get_feed_es.py
@@ -348,8 +348,6 @@ def item_key(item):
     elif "track_id" in item:
         return "track:" + str(item["track_id"])
     elif "playlist_id" in item:
-        if item["is_album"]:
-            return "album:" + str(item["playlist_id"])
         return "playlist:" + str(item["playlist_id"])
     elif "user_id" in item:
         return "user:" + str(item["user_id"])

--- a/discovery-provider/src/queries/get_feed_es.py
+++ b/discovery-provider/src/queries/get_feed_es.py
@@ -1,5 +1,3 @@
-import logging
-
 from src.queries.query_helpers import _populate_premium_track_metadata, get_users_ids
 from src.utils.db_session import get_db_read_replica
 from src.utils.elasticdsl import (
@@ -14,7 +12,6 @@ from src.utils.elasticdsl import (
     populate_user_metadata_es,
 )
 
-logger = logging.getLogger(__name__)
 
 def get_feed_es(args, limit=10):
 
@@ -298,17 +295,12 @@ def fetch_followed_saves_and_reposts(current_user, items):
     item_keys = [item_key(i) for i in items]
     follow_reposts = {k: [] for k in item_keys}
     follow_saves = {k: [] for k in item_keys}
-    logger.info(f"asdf current_user {current_user}")
-    logger.info(f"asdf items {items}")
 
-    logger.info(f"asdf item_keys {item_keys}")
     if not current_user or not item_keys:
         return (follow_saves, follow_reposts)
 
     mget_social_activity = []
     my_friends = set(current_user.get("following_ids", []))
-
-    logger.info(f"asdf my_friends {my_friends}")
 
     for item in items:
         key = item_key(item)
@@ -323,8 +315,6 @@ def fetch_followed_saves_and_reposts(current_user, items):
         for id in repost_friends[0:5]:
             mget_social_activity.append({"_index": ES_REPOSTS, "_id": id})
 
-    logger.info(f"asdf mget_social_activity {mget_social_activity}")
-
     if mget_social_activity:
         social_activity = esclient.mget(docs=mget_social_activity)
         for doc in social_activity["docs"]:
@@ -336,8 +326,6 @@ def fetch_followed_saves_and_reposts(current_user, items):
                 follow_reposts[s["item_key"]].append(s)
             else:
                 follow_saves[s["item_key"]].append(s)
-
-    logger.info(f"asdf (follow_saves, follow_reposts) {(follow_saves, follow_reposts)}")
 
     return (follow_saves, follow_reposts)
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
When getting feed, followee_reposts for albums were always empty. This is because the item_key included `:album:` when the repost_type is actually considered playlist so the document IDs in the reposts index were actually `:playlist:`.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on sandbox, followee_reposts populated correctly.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->