### PR TITLE
[PLAT-868]: Swap supporter rank up vs supporting rank up notifications in trigger

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -50,11 +50,11 @@ begin;
 alter table notification
 add column if not exists type_v2 varchar default null;
 
-UPDATE notification n
-SET type = 'supporter_rank_up', type_v2 = 'supporter_rank_up', group_id = 'supporter_rank_up' || substring(group_id from position(':' in group_id))
-WHERE type = 'supporting_rank_up' and type_v2 is null;
+update notification n
+set type = 'supporter_rank_up', type_v2 = 'supporter_rank_up', group_id = 'supporter_rank_up' || substring(group_id from position(':' in group_id))
+where type = 'supporting_rank_up' and type_v2 is null;
 
-UPDATE notification 
-SET type = 'supporting_rank_up', type_v2 = 'supporting_rank_up', group_id = 'supporting_rank_up' || substring(group_id from position(':' in group_id))
-WHERE type = 'supporter_rank_up' and type_v2 is null;
+update notification 
+set type = 'supporting_rank_up', type_v2 = 'supporting_rank_up', group_id = 'supporting_rank_up' || substring(group_id from position(':' in group_id))
+where type = 'supporter_rank_up' and type_v2 is null;
 commit;

--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -37,3 +37,18 @@ commit;
 begin;
   drop table if exists blocks_copy;
 commit;
+
+-- 4/10/23: inverse supporter rank up and supporting rank up notifications
+begin;
+  UPDATE notification
+  SET type = 'supporter_rank_up_old'
+  WHERE type = 'supporter_rank_up';
+
+  UPDATE notification
+  SET type = 'supporter_rank_up'
+  WHERE type = 'supporting_rank_up';
+
+  UPDATE notification
+  SET type = 'supporting_rank_up'
+  WHERE type = 'supporter_rank_up_old';
+commit;

--- a/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
@@ -14,18 +14,18 @@ begin
         new.slot,
         ARRAY [new.sender_user_id],
         user_bank_tx.created_at,
-        'supporter_rank_up',
+        'supporting_rank_up',
         new.sender_user_id,
-        'supporter_rank_up:' || new.rank || ':slot:' || new.slot,
+        'supporting_rank_up:' || new.rank || ':slot:' || new.slot,
         json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank)
       ),
       (
         new.slot,
         ARRAY [new.receiver_user_id],
         user_bank_tx.created_at,
-        'supporting_rank_up',
+        'supporter_rank_up',
         new.receiver_user_id,
-        'supporting_rank_up:' || new.rank || ':slot:' || new.slot,
+        'supporter_rank_up:' || new.rank || ':slot:' || new.slot,
         json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank)
       )
     on conflict do nothing;

--- a/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
@@ -8,7 +8,7 @@ begin
   if user_bank_tx is not null then
     -- create a notification for the sender and receiver
     insert into notification
-      (slot, user_ids, timestamp, type, specifier, group_id, data)
+      (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
     values
       (
         new.slot,
@@ -17,7 +17,8 @@ begin
         'supporting_rank_up',
         new.sender_user_id,
         'supporting_rank_up:' || new.rank || ':slot:' || new.slot,
-        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank)
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporting_rank_up'
       ),
       (
         new.slot,
@@ -26,7 +27,8 @@ begin
         'supporter_rank_up',
         new.receiver_user_id,
         'supporter_rank_up:' || new.rank || ':slot:' || new.slot,
-        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank)
+        json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'rank', new.rank),
+        'supporter_rank_up'
       )
     on conflict do nothing;
 
@@ -35,7 +37,7 @@ begin
       if dethroned_user_id is not NULL then
         -- create a notification for the sender and receiver
         insert into notification
-          (slot, user_ids, timestamp, type, specifier, group_id, data)
+          (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
         values
           (
             new.slot,
@@ -44,7 +46,8 @@ begin
             'supporter_dethroned',
             new.sender_user_id,
             'supporter_dethroned:receiver_user_id:' || new.receiver_user_id || ':slot:' || new.slot,
-            json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'dethroned_user_id', dethroned_user_id)
+            json_build_object('sender_user_id', new.sender_user_id, 'receiver_user_id', new.receiver_user_id, 'dethroned_user_id', dethroned_user_id),
+            'supporter_dethroned'
           ) on conflict do nothing;
 
       end if;

--- a/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_supporter_rank_ups.sql
@@ -11,6 +11,7 @@ begin
       (slot, user_ids, timestamp, type, specifier, group_id, data, type_v2)
     values
       (
+      -- supporting_rank_up notifs are sent to the sender of the tip
         new.slot,
         ARRAY [new.sender_user_id],
         user_bank_tx.created_at,
@@ -21,6 +22,7 @@ begin
         'supporting_rank_up'
       ),
       (
+      -- supporter_rank_up notifs are sent to the receiver of the tip
         new.slot,
         ARRAY [new.receiver_user_id],
         user_bank_tx.created_at,

--- a/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
+++ b/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
@@ -35,7 +35,6 @@ def test_supporter_rank_up_notification(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-
         supporter_notifications: List[Notification] = (
             session.query(Notification)
             .filter(Notification.type == "supporter_rank_up")
@@ -51,7 +50,7 @@ def test_supporter_rank_up_notification(app):
         assert len(supporter_notifications) == 3
         assert len(supporting_notifications) == 3
 
-        assert supporter_notifications[0].specifier == "1"
+        assert supporter_notifications[0].specifier == "3"
         assert supporter_notifications[0].group_id == "supporter_rank_up:3:slot:2"
         assert supporter_notifications[0].type == "supporter_rank_up"
         assert supporter_notifications[0].slot == 2
@@ -61,9 +60,9 @@ def test_supporter_rank_up_notification(app):
             "sender_user_id": 1,
             "receiver_user_id": 3,
         }
-        assert supporter_notifications[0].user_ids == [1]
+        assert supporter_notifications[0].user_ids == [3]
 
-        assert supporting_notifications[0].specifier == "3"
+        assert supporting_notifications[0].specifier == "1"
         assert supporting_notifications[0].group_id == "supporting_rank_up:3:slot:2"
         assert supporting_notifications[0].type == "supporting_rank_up"
         assert supporting_notifications[0].slot == 2
@@ -73,4 +72,4 @@ def test_supporter_rank_up_notification(app):
             "sender_user_id": 1,
             "receiver_user_id": 3,
         }
-        assert supporting_notifications[0].user_ids == [3]
+        assert supporting_notifications[0].user_ids == [1]

--- a/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
+++ b/discovery-provider/integration_tests/notifications/test_supporter_rank_ups.py
@@ -53,6 +53,7 @@ def test_supporter_rank_up_notification(app):
         assert supporter_notifications[0].specifier == "3"
         assert supporter_notifications[0].group_id == "supporter_rank_up:3:slot:2"
         assert supporter_notifications[0].type == "supporter_rank_up"
+        assert supporter_notifications[0].type_v2 == "supporter_rank_up"
         assert supporter_notifications[0].slot == 2
         assert supporter_notifications[0].blocknumber == None
         assert supporter_notifications[0].data == {
@@ -65,6 +66,7 @@ def test_supporter_rank_up_notification(app):
         assert supporting_notifications[0].specifier == "1"
         assert supporting_notifications[0].group_id == "supporting_rank_up:3:slot:2"
         assert supporting_notifications[0].type == "supporting_rank_up"
+        assert supporting_notifications[0].type_v2 == "supporting_rank_up"
         assert supporting_notifications[0].slot == 2
         assert supporting_notifications[0].blocknumber == None
         assert supporting_notifications[0].data == {

--- a/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
@@ -385,15 +385,16 @@ describe('Email Notifications', () => {
 
     const expectedNotifications = [
       {
-        type: DMEntityType.Message,
-        sender_user_id: user1,
-        receiver_user_id: user2
-      },
-      {
         receiver_user_id: user2,
         blocknumber: null,
         slot: null,
+        type_v2: null,
         ...notificationRow
+      },
+      {
+        type: DMEntityType.Message,
+        sender_user_id: user1,
+        receiver_user_id: user2
       }
     ]
     await processEmailNotifications(discoveryDB, identityDB, frequency)
@@ -402,7 +403,7 @@ describe('Email Notifications', () => {
       userId: user2,
       email: user2Email,
       frequency: frequency,
-      notifications: expect.arrayContaining(expectedNotifications),
+      notifications: expectedNotifications,
       dnDb: discoveryDB,
       identityDb: identityDB
     })
@@ -437,6 +438,7 @@ describe('Email Notifications', () => {
         receiver_user_id: user2,
         blocknumber: null,
         slot: null,
+        type_v2: null,
         ...notificationRow
       }
     ]

--- a/discovery-provider/src/models/notifications/notification.py
+++ b/discovery-provider/src/models/notifications/notification.py
@@ -29,6 +29,13 @@ class Notification(Base, RepresentableMixin):
     timestamp = Column(DateTime, nullable=False)
     data = Column(postgresql.JSONB())  # type: ignore
     user_ids = Column(postgresql.ARRAY(Integer()), index=True)
+    # When notifications were first created, we accidentally swapped
+    # supporter_rank_up (sent to the tip receiver)
+    # with supporting_rank_up (sent to the tip sender) in the db trigger
+    # on creation of these notifs. We added this type_v2 column to
+    # help us migrate only notifications created before we fixed the trigger.
+    # This column should not be used otherwise.
+    type_v2 = Column(String, nullable=True)
     UniqueConstraint("group_id", "specifier", name="uq_notification")
 
 


### PR DESCRIPTION
### Description
Swap supporter and supporting rank up notifications via migration. Added another column type_v2, which we use to determine whether a notification needs to be swapped. if type_v2 is null for a supporter or supporting rank up notification, that means the notif was created before this migration, and we want to swap their types and group id.

perhaps further down the line we'll want to delete this migration from the ddl and drop the column so we don't have this extra column that is confusing

### Tests
updated integration tests
made a prod clone and ran the migration on the clone, added extra rows after the migration ran, re-ran the migration and made sure it didn't update any new supporting/er_rank_up rows


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->