### PR TITLE
Stage cid metadata backfill url, validate cid metadata structure in EM txs

### DIFF
--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -19,6 +19,7 @@ indexing_transaction_index_sort_order_start_block =
 get_users_cnode_ttl_sec = 5
 enable_save_cid = true
 max_signers = 0
+backfill_cid_data_url = https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv
 
 [flask]
 debug = true

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -19,7 +19,6 @@ indexing_transaction_index_sort_order_start_block =
 get_users_cnode_ttl_sec = 5
 enable_save_cid = true
 max_signers = 0
-stage_backfill_cid_data_url = https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv
 
 [flask]
 debug = true

--- a/discovery-provider/default_config.ini
+++ b/discovery-provider/default_config.ini
@@ -19,7 +19,7 @@ indexing_transaction_index_sort_order_start_block =
 get_users_cnode_ttl_sec = 5
 enable_save_cid = true
 max_signers = 0
-backfill_cid_data_url = https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv
+stage_backfill_cid_data_url = https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv
 
 [flask]
 debug = true

--- a/discovery-provider/integration_tests/tasks/test_backfill_cid_data.py
+++ b/discovery-provider/integration_tests/tasks/test_backfill_cid_data.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from sqlalchemy import desc
 from src.models.indexing.cid_data import CIDData
 from src.tasks.backfill_cid_data import backfill_cid_data
+from src.utils import redis_connection
 from src.utils.db_session import get_db
 from web3.datastructures import AttributeDict
 
@@ -19,11 +20,16 @@ cid_3\ttrack\t"{""name"": ""ray""}"
     "src.tasks.backfill_cid_data.requests.get",
     return_value=AttributeDict({"iter_content": lambda _: [bytes(csv, "utf-8")]}),
 )
-def test_backfill_cid_data(request_get, app):
+def test_backfill_cid_data(request_get, app, mocker):
     """Happy path test: test that we get all valid listens from prior year"""
     # setup
     with app.app_context():
         db = get_db()
+
+    mocker.patch(
+        "os.getenv",
+        return_value="stage",
+    )
 
     backfill_cid_data(db)
     with db.scoped_session() as session:
@@ -37,3 +43,4 @@ def test_backfill_cid_data(request_get, app):
         assert len(users) == 2
         assert users[0].data == {"user_id": 2}
         assert users[1].data == {"user_id": 1}
+        assert redis_connection.get_redis().get("backfilled_cid_data").decode() == "true"

--- a/discovery-provider/integration_tests/tasks/test_index_helper.py
+++ b/discovery-provider/integration_tests/tasks/test_index_helper.py
@@ -245,6 +245,48 @@ def test_fetch_cid_metadata(app, mocker):
                     )
                 },
             ],
+            "CreateTrack2InvalidTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": TRACK_ID_OFFSET + 1,
+                            "_entityType": "Track",
+                            "_userId": 1,
+                            "_action": "Create",
+                            "_metadata": f'{{"cid": "QmCreateInvalidTrack", "data": "{track1_json}"}}',  # stringified value for data key
+                            "_signer": "user1wallet",
+                        }
+                    )
+                },
+            ],
+            "CreateTrack3InvalidTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": TRACK_ID_OFFSET + 2,
+                            "_entityType": "Track",
+                            "_userId": 1,
+                            "_action": "Create",
+                            "_metadata": f'{{"data": {track1_json}}}',  # missing cid key
+                            "_signer": "user1wallet",
+                        }
+                    )
+                },
+            ],
+            "CreateTrack4InvalidTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": TRACK_ID_OFFSET + 3,
+                            "_entityType": "Track",
+                            "_userId": 1,
+                            "_action": "Create",
+                            "_metadata": '{"cid": "QmCreateInvalidTrack", "data": {}}',  # no values in data json
+                            "_signer": "user1wallet",
+                        }
+                    )
+                },
+            ],
         }
 
         def get_events_side_effect(_, _event_type, tx_receipt):

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -438,7 +438,11 @@ def configure_celery(celery, test_config=None):
     )
 
     # backfill cid data if url is provided
-    if os.getenv("backfill_cid_data_url"):
+    backfill_cid_data_url = None
+    env = os.getenv("audius_discprov_env")
+    if env == "stage":
+        backfill_cid_data_url = "https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv"
+    if backfill_cid_data_url:
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -438,11 +438,8 @@ def configure_celery(celery, test_config=None):
     )
 
     # backfill cid data if url is provided
-    backfill_cid_data_url = None
     env = os.getenv("audius_discprov_env")
     if env == "stage":
-        backfill_cid_data_url = "https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv"
-    if backfill_cid_data_url:
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -438,13 +438,7 @@ def configure_celery(celery, test_config=None):
     )
 
     # backfill cid data if url is provided
-    env = os.getenv("audius_discprov_env")
-    backfill_cid_data_url = None
-    if env == "stage":
-        backfill_cid_data_url = "stage_backfill_cid_data_url"
-    elif env == "prod":
-        backfill_cid_data_url = "prod_backfill_cid_data_url"
-    if backfill_cid_data_url and backfill_cid_data_url in shared_config["discprov"]:
+    if os.getenv("backfill_cid_data_url"):
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -437,9 +437,12 @@ def configure_celery(celery, test_config=None):
         broker_url=redis_url,
     )
 
+    # Initialize Redis connection
+    redis_inst = redis.Redis.from_url(url=redis_url)
+
     # backfill cid data if url is provided
     env = os.getenv("audius_discprov_env")
-    if env == "stage":
+    if env == "stage" and not redis_inst.get("backfilled_cid_data"):
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context
@@ -451,9 +454,6 @@ def configure_celery(celery, test_config=None):
         ast.literal_eval(shared_config["db"]["engine_args_literal"]),
     )
     logger.info("Database instance initialized!")
-
-    # Initialize Redis connection
-    redis_inst = redis.Redis.from_url(url=redis_url)
 
     # Initialize CIDMetadataClient for celery task context
     cid_metadata_client = CIDMetadataClient(

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -438,7 +438,13 @@ def configure_celery(celery, test_config=None):
     )
 
     # backfill cid data if url is provided
-    if "backfill_cid_data_url" in shared_config["discprov"]:
+    env = os.getenv("audius_discprov_env")
+    backfill_cid_data_url = None
+    if env == "stage":
+        backfill_cid_data_url = "stage_backfill_cid_data_url"
+    elif env == "prod":
+        backfill_cid_data_url = "prod_backfill_cid_data_url"
+    if backfill_cid_data_url and backfill_cid_data_url in shared_config["discprov"]:
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -327,6 +327,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     )
     discovery_nodes = get_all_other_nodes.get_all_other_nodes_cached(redis)
     final_poa_block = get_final_poa_block()
+    backfilled_cid_data = redis.get("backfilled_cid_data") or False
     health_results = {
         "web": {
             "blocknumber": latest_block_num,
@@ -366,6 +367,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "latest_indexed_block_num": latest_indexed_block_num,
         "final_poa_block": final_poa_block,
         "network": {"discovery_nodes": discovery_nodes},
+        "backfilled_cid_data": backfilled_cid_data,
     }
 
     if os.getenv("AUDIUS_DOCKER_COMPOSE_GIT_SHA") is not None:

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -78,6 +78,9 @@ def get_elapsed_time_redis(redis, redis_key):
     elapsed_time_in_sec = (int(time.time()) - int(last_seen)) if last_seen else None
     return elapsed_time_in_sec
 
+def get_backfilled_cid_data(redis):
+    backfilled_cid_data = redis.get("backfilled_cid_data")
+    return backfilled_cid_data.decode() if backfilled_cid_data else False
 
 # Returns DB block state & diff
 def _get_db_block_state():
@@ -327,7 +330,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     )
     discovery_nodes = get_all_other_nodes.get_all_other_nodes_cached(redis)
     final_poa_block = get_final_poa_block()
-    backfilled_cid_data = redis.get("backfilled_cid_data") or False
+    backfilled_cid_data = get_backfilled_cid_data(redis)
     health_results = {
         "web": {
             "blocknumber": latest_block_num,

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -1,8 +1,8 @@
 import csv
 import json
 import logging
-import tempfile
 import os
+import tempfile
 from itertools import islice
 
 import requests

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -21,12 +21,7 @@ chunk_size = 1_000
 
 def backfill_cid_data(db: SessionManager):
     logger.info("backfill_cid_data.py | starting backfill")
-    source_tsv_url = ""
-    env = os.getenv("audius_discprov_env")
-    if env == "stage" and "stage_backfill_cid_data_url" in shared_config["discprov"]:
-        source_tsv_url = shared_config["discprov"]["stage_backfill_cid_data_url"]
-    elif env == "prod" and "prod_backfill_cid_data_url" in shared_config["discprov"]:
-        source_tsv_url = shared_config["discprov"]["prod_backfill_cid_data_url"]
+    source_tsv_url = os.getenv("backfill_cid_data_url") or ""
 
     response = requests.get(source_tsv_url, stream=True)
     with tempfile.NamedTemporaryFile() as tmp:

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -8,7 +8,6 @@ from itertools import islice
 import requests
 from src.tasks.celery_app import celery
 from src.tasks.index import save_cid_metadata
-from src.utils.config import shared_config
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.session_manager import SessionManager
 

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -54,7 +54,7 @@ def backfill_cid_data(db: SessionManager):
                         cid_type[cid] = type
                     # Write chunk to db
                     save_cid_metadata(session, cid_metadata, cid_type)
-    redis.set("backfilled_cid_data", True)
+    redis.set("backfilled_cid_data", "true")
 
 
 # ####### CELERY TASKS ####### #

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -20,7 +20,10 @@ chunk_size = 1_000
 
 def backfill_cid_data(db: SessionManager):
     logger.info("backfill_cid_data.py | starting backfill")
-    source_tsv_url = os.getenv("backfill_cid_data_url") or ""
+    source_tsv_url = ""
+    env = os.getenv("audius_discprov_env")
+    if env == "stage":
+        source_tsv_url = "https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv"
 
     response = requests.get(source_tsv_url, stream=True)
     with tempfile.NamedTemporaryFile() as tmp:

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -47,7 +47,6 @@ def backfill_cid_data(db: SessionManager):
                         cid_type[cid] = type
                     # Write chunk to db
                     save_cid_metadata(session, cid_metadata, cid_type)
-    logger.info("backfill_cid_data.py | finished backfill")
 
 
 # ####### CELERY TASKS ####### #

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -316,7 +316,6 @@ def collect_entities_to_fetch(update_task, entity_manager_txs, metadata):
             # to prevent playlists from including premium tracks
             cid = helpers.get_tx_arg(event, "_metadata")
             # Check if metadata blob was passed directly and use if so.
-            # TODO remove after CID metadata migration.
             try:
                 data = json.loads(cid)
                 cid = data["cid"]

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -125,7 +125,6 @@ class ManageEntityParameters:
         self.entity_type = helpers.get_tx_arg(event, "_entityType")
         self.action = helpers.get_tx_arg(event, "_action")
         # Check if metadata blob was passed directly.
-        # TODO remove after CID metadata migration.
         try:
             data = json.loads(helpers.get_tx_arg(event, "_metadata"))
             self.metadata_cid = data["cid"]

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -255,6 +255,9 @@ def fetch_cid_metadata(db, entity_manager_txs):
 
                             # If metadata blob does not contain the required keys, skip
                             if "cid" not in data.keys() or "data" not in data.keys():
+                                logger.info(
+                                    f"index_nethermind.py | required keys missing in metadata {cid}"
+                                )
                                 continue
                             cid = data["cid"]
                             metadata_json = data["data"]

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -259,32 +259,43 @@ def fetch_cid_metadata(db, entity_manager_txs):
                     # Check if metadata blob was passed directly.
                     # If so, add to cid_metadata_from_chain and cid_type_from_chain
                     # dicts and do not query CNs for these CIDs.
-                    # TODO remove after CID metadata migration.
-                    try:
-                        data = json.loads(cid)
-                        cid = data["cid"]
-                        metadata_json = data["data"]
+                    # TODO remove legacy CN path after CID metadata migration.
+                    if len(cid) > 0 and cid[0] == "{" and cid[-1] == "}":
+                        try:
+                            data = json.loads(cid)
 
-                        metadata_format: Any = None
-                        metadata_type = None
-                        if event_type == EntityType.PLAYLIST:
-                            metadata_type = "playlist_data"
-                            metadata_format = playlist_metadata_format
-                        elif event_type == EntityType.TRACK:
-                            metadata_type = "track"
-                            metadata_format = track_metadata_format
-                        elif event_type == EntityType.USER:
-                            metadata_type = "user"
-                            metadata_format = user_metadata_format
-                        formatted_json = get_metadata_from_json(
-                            metadata_format, metadata_json
-                        )
-                        # do not add to cid_metadata or cid_type yet to avoid interfering with the retry conditions
-                        cid_type_from_chain[cid] = metadata_type
-                        cid_metadata_from_chain[cid] = formatted_json
+                            # If metadata blob does not contain the required keys, skip
+                            if "cid" not in data.keys() or "data" not in data.keys():
+                                continue
+                            cid = data["cid"]
+                            metadata_json = data["data"]
+
+                            metadata_format: Any = None
+                            metadata_type = None
+                            if event_type == EntityType.PLAYLIST:
+                                metadata_type = "playlist_data"
+                                metadata_format = playlist_metadata_format
+                            elif event_type == EntityType.TRACK:
+                                metadata_type = "track"
+                                metadata_format = track_metadata_format
+                            elif event_type == EntityType.USER:
+                                metadata_type = "user"
+                                metadata_format = user_metadata_format
+
+                            formatted_json = get_metadata_from_json(
+                                metadata_format, metadata_json
+                            )
+                            # Only index valid changes
+                            if formatted_json != metadata_format:
+                                # Do not add to cid_metadata or cid_type yet to avoid
+                                # interfering with the retry conditions
+                                cid_type_from_chain[cid] = metadata_type
+                                cid_metadata_from_chain[cid] = formatted_json
+                        except Exception as e:
+                            logger.info(
+                                f"index_nethermind.py | error deserializing metadata {cid}: {e}"
+                            )
                         continue
-                    except Exception:
-                        pass
 
                     cids_txhash_set.add((cid, txhash))
                     cid_to_user_id[cid] = user_id

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -266,6 +266,9 @@ def fetch_cid_metadata(db, entity_manager_txs):
 
                             # If metadata blob does not contain the required keys, skip
                             if "cid" not in data.keys() or "data" not in data.keys():
+                                logger.info(
+                                    f"index_nethermind.py | required keys missing in metadata {cid}"
+                                )
                                 continue
                             cid = data["cid"]
                             metadata_json = data["data"]


### PR DESCRIPTION
### Description
- shared_config was not pulling in stage.env vars as expected when testing on stage -- changed to use os.getenv
- cache key in redis to ensure backfill only runs once. expose key in DN /health_check
- Validate metadata structure in tx's if passed in directly. Don't add to the cid_metadata map in the indexer upon validation failure. Downstream, the entity manager will swallow any ensuing errors caused by not finding a metadata entry and skip the tx. cc @theoilie 


### Tests
Updated integration tests.
Deployed to stage and made sure backfill ran successfully by comparing the before/after record count of cid_data 
Made sure backfilled_cid_data value was in health check and  was set after backfill completion
Restarted indexer, made sure backfill did not run again


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->