### PR TITLE
Fix android push notif message struct

### DIFF
--- a/discovery-provider/plugins/notifications/src/sns.ts
+++ b/discovery-provider/plugins/notifications/src/sns.ts
@@ -91,16 +91,15 @@ export const sendAndroidMessage = async ({
 }) => {
   const message = JSON.stringify({
     default: body,
-    GCM: {
+    GCM: JSON.stringify({
       notification: {
         ...(title ? { title } : {}),
         body,
         sound: playSound && 'default'
       },
       data
-    }
+    })
   })
-
   await publish({
     TargetArn: targetARN,
     Message: message,


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Android push notifs were broken because the message structure was wrong. It should be stringified twice like it is for iOS.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Running on prod.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->