### PR TITLE
Make notif migration use temp step

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -50,13 +50,20 @@ begin;
 alter table notification
 add column if not exists type_v2 varchar default null;
 
+-- Step 1: Change 'supporting_rank_up' to temporary value 'temp_rank_up'
 update notification n
-set type = 'supporter_rank_up', type_v2 = 'supporter_rank_up', group_id = 'supporter_rank_up' || substring(group_id from position(':' in group_id))
+set type = 'temp_rank_up', type_v2 = 'temp_rank_up', group_id = 'temp_rank_up' || substring(group_id from position(':' in group_id))
 where type = 'supporting_rank_up' and type_v2 is null;
 
-update notification 
+-- Step 2: Change 'supporter_rank_up' to 'supporting_rank_up'
+update notification n
 set type = 'supporting_rank_up', type_v2 = 'supporting_rank_up', group_id = 'supporting_rank_up' || substring(group_id from position(':' in group_id))
 where type = 'supporter_rank_up' and type_v2 is null;
+
+-- Step 3: Change temporary value 'temp_rank_up' to 'supporter_rank_up'
+update notification n
+set type = 'supporter_rank_up', type_v2 = 'supporter_rank_up', group_id = 'supporter_rank_up' || substring(group_id from position(':' in group_id))
+where type = 'temp_rank_up' and type_v2 = 'temp_rank_up';
 commit;
 
 -- 4/13/23: add is_storage_v2 to users table


### PR DESCRIPTION
Makes notifications supporter/supporting migration have a temp step to avoid UniqueViolation errors. Previous error:
```
audius_discovery-# set type = 'supporter_rank_up', type_v2 = 'supporter_rank_up', group_id = 'supporter_rank_up' || substring(group_id from position(':' in group_id))
audius_discovery-# where type = 'supporting_rank_up' and type_v2 is null;
ERROR:  duplicate key value violates unique constraint "uq_notification"
DETAIL:  Key (group_id, specifier)=(supporter_rank_up:1:slot:185411112, 13) already exists.
```