### PR TITLE
Check that row is track creation instead of track update before creat…

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -74,6 +74,7 @@ begin
   -- If remix, create notification
   begin
     if new.remix_of is not null AND
+    new.created_at = new.updated_at AND 
     new.is_unlisted = FALSE AND
     new.is_available = true AND
     new.is_delete = FALSE AND

--- a/discovery-provider/alembic/trigger_sql/handle_track.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_track.sql
@@ -37,7 +37,8 @@ begin
 
   -- If new track, create notification
   begin
-    if new.is_unlisted = FALSE AND 
+    if new.created_at = new.updated_at AND 
+    new.is_unlisted = FALSE AND 
     new.is_available = True AND 
     new.is_delete = FALSE AND 
     new.is_playlist_upload = FALSE AND

--- a/discovery-provider/integration_tests/notifications/test_playlist.py
+++ b/discovery-provider/integration_tests/notifications/test_playlist.py
@@ -47,7 +47,6 @@ def test_playlist_track_added_notification(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-
         notifications: List[Notification] = (
             session.query(Notification).order_by(asc(Notification.specifier)).all()
         )
@@ -109,7 +108,6 @@ def test_playlist_create_notification(app):
     populate_mock_db(db, entities)
 
     with db.scoped_session() as session:
-
         notifications: List[Notification] = (
             session.query(Notification).filter(Notification.type == "create").all()
         )
@@ -120,3 +118,42 @@ def test_playlist_create_notification(app):
         assert notifications[0].slot == None
         assert notifications[0].data == {"playlist_id": 1, "is_album": False}
         assert notifications[0].user_ids == list(range(1, 5))
+
+
+def test_playlist_create_notification_on_playlist_update(app):
+    with app.app_context():
+        db = get_db()
+
+    # Insert Playlist with two new tracks and check that a notificaiton is created for the track owners
+    now = datetime.now()
+    entities = {
+        "users": [{"user_id": i + 1} for i in range(5)],
+        "subscriptions": [{"subscriber_id": i, "user_id": 1} for i in range(1, 5)],
+    }
+    populate_mock_db(db, entities)
+
+    entities = {
+        "tracks": [
+            {"track_id": 20, "owner_id": 1, "is_playlist_upload": True},
+        ],
+        "playlists": [
+            {
+                "playlist_id": 1,
+                "playlist_owner_id": 1,
+                "created_at": now,
+                "updated_at": now + timedelta(days=1),
+                "playlist_contents": {
+                    "track_ids": [
+                        {"time": datetime.timestamp(now), "track": 20},
+                    ]
+                },
+            },
+        ],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        notifications: List[Notification] = (
+            session.query(Notification).filter(Notification.type == "create").all()
+        )
+        assert len(notifications) == 0

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -173,7 +173,7 @@ def populate_mock_db(db, entities, block_offset=None):
             session.query(Track).filter(Track.is_current == True).filter(
                 Track.track_id == track_id
             ).update({"is_current": False})
-
+            track_created_atplaylist_created_at = datetime.now()
             track = Track(
                 blockhash=hex(i + block_offset),
                 blocknumber=i + block_offset,
@@ -196,8 +196,12 @@ def populate_mock_db(db, entities, block_offset=None):
                 tags=track_meta.get("tags", None),
                 genre=track_meta.get("genre", ""),
                 remix_of=track_meta.get("remix_of", None),
-                updated_at=track_meta.get("updated_at", datetime.now()),
-                created_at=track_meta.get("created_at", datetime.now()),
+                updated_at=track_meta.get(
+                    "updated_at", track_created_atplaylist_created_at
+                ),
+                created_at=track_meta.get(
+                    "created_at", track_created_atplaylist_created_at
+                ),
                 release_date=track_meta.get("release_date", None),
                 is_unlisted=track_meta.get("is_unlisted", False),
                 is_premium=track_meta.get("is_premium", False),
@@ -207,6 +211,7 @@ def populate_mock_db(db, entities, block_offset=None):
             )
             session.add(track)
         for i, playlist_meta in enumerate(playlists):
+            playlist_created_at = datetime.now()
             playlist = Playlist(
                 blockhash=hex(i + block_offset),
                 blocknumber=i + block_offset,
@@ -229,8 +234,8 @@ def populate_mock_db(db, entities, block_offset=None):
                 ),
                 description=playlist_meta.get("description", f"description_{i}"),
                 upc=playlist_meta.get("upc", f"upc_{i}"),
-                updated_at=playlist_meta.get("updated_at", datetime.now()),
-                created_at=playlist_meta.get("created_at", datetime.now()),
+                updated_at=playlist_meta.get("updated_at", playlist_created_at),
+                created_at=playlist_meta.get("created_at", playlist_created_at),
             )
             session.add(playlist)
 


### PR DESCRIPTION

### Description
want to confirm that a new track row is for a new track upload rather than just an existing track update before sending a notification to user subscribers. interestingly enough, this is already handled in the playlist trigger, but not in tracks.

added the check to track creation notifs and remix creation notifs
added regression tests to playlists and tracks 


### Tests
added unit tests