### PR TITLE
Create userbanks lazily in Identity Auto-Attester

### DIFF
--- a/libs/src/api/Rewards.ts
+++ b/libs/src/api/Rewards.ts
@@ -9,6 +9,7 @@ import { Utils } from '../utils/utils'
 import type { ServiceProvider } from './ServiceProvider'
 import type { Logger, Nullable } from '../utils'
 import type { AttestationMeta } from '../services/solana/rewards'
+import type { DiscoveryProvider } from '../services/discoveryProvider'
 
 const { decodeHashId } = Utils
 
@@ -518,7 +519,14 @@ export class Rewards extends Base {
     } = {
       logger: console
     }
-  ) {
+  ): Promise<
+    | {
+        success: Awaited<
+          ReturnType<DiscoveryProvider['getUndisbursedChallenges']>
+        >
+      }
+    | { error: string }
+  > {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
     try {
       const res = await this.discoveryProvider.getUndisbursedChallenges(
@@ -527,12 +535,11 @@ export class Rewards extends Base {
         completedBlockNumber,
         encodedUserId
       )
-      return { success: res, error: null }
+      return { success: res }
     } catch (e) {
       const error = (e as Error).message
       logger.error(`Failed to get undisbursed challenges with error: ${error}`)
       return {
-        success: null,
         error
       }
     }

--- a/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -82,6 +82,16 @@ export type UserProfile = {
   iat: string
 }
 
+type DiscoveryNodeChallenge = {
+  challenge_id: string
+  user_id: string
+  specifier: string
+  amount: string
+  handle: string
+  wallet: string
+  completed_blocknumber: number
+}
+
 /**
  * Constructs a service class for a discovery node
  * @param whitelist whether or not to only include specified nodes in selection
@@ -1006,7 +1016,7 @@ export class DiscoveryProvider {
       completedBlockNumber,
       encodedUserId
     )
-    const res = await this._makeRequest<Array<{ amount: string }>>(req)
+    const res = await this._makeRequest<Array<DiscoveryNodeChallenge>>(req)
     if (!res) return []
     return res.map((r) => ({ ...r, amount: parseInt(r.amount) }))
   }


### PR DESCRIPTION
### Description

I want to rip out / rewrite this auto-attesting code... but in the mean time, we need trending to work with lazy-userbanks. So that's this PR.

Other things:
- Fixes a lot of types. Properly types libs in the attester.
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests

Testing on stage identity. 
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->