### PR TITLE
Remove join on userbank in undisbursed challenges endpoint

### DIFF
--- a/discovery-provider/src/queries/get_undisbursed_challenges.py
+++ b/discovery-provider/src/queries/get_undisbursed_challenges.py
@@ -5,7 +5,6 @@ from src.models.rewards.challenge import Challenge
 from src.models.rewards.challenge_disbursement import ChallengeDisbursement
 from src.models.rewards.user_challenge import UserChallenge
 from src.models.users.user import User
-from src.models.users.user_bank import UserBankAccount
 
 
 class UndisbursedChallengeResponse(TypedDict):
@@ -21,7 +20,6 @@ class UndisbursedChallengeResponse(TypedDict):
 def to_challenge_response(
     user_challenge: UserChallenge, challenge: Challenge, handle: str, wallet: str
 ) -> UndisbursedChallengeResponse:
-
     return {
         "challenge_id": challenge.id,
         "user_id": user_challenge.user_id,
@@ -64,8 +62,6 @@ def get_undisbursed_challenges(
             Challenge.id == UserChallenge.challenge_id,
         )
         .join(User, UserChallenge.user_id == User.user_id)
-        # Join against UserBank to ensure only users with banks are disbursable
-        .join(UserBankAccount, UserBankAccount.ethereum_address == User.wallet)
         .filter(
             # Check that there is no matching challenge disburstment
             ChallengeDisbursement.challenge_id == None,


### PR DESCRIPTION
### Description

Stopping creating Userbanks at the time of account creation inadvertently breaks the `undisbursed_challenges` endpoint, which assumes a userbank for every user. The fix is to simply remove this join.


<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests

Have not tested this yet. Need to test on stage & do another pass on the DN codebase and see if there are any other sneaky places we assume userbanks exists.
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->