### PR TITLE
Set is_playlist_upload correctly in EM

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -122,6 +122,7 @@ def test_index_valid_track(app, mocker):
             "license": "",
             "isrc": "",
             "iswc": "",
+            "is_playlist_upload": True,
         },
         "QmCreateTrack3": {
             "owner_id": 1,
@@ -160,6 +161,7 @@ def test_index_valid_track(app, mocker):
             "license": "",
             "isrc": "",
             "iswc": "",
+            "is_playlist_upload": False,
         },
         "QmUpdateTrack1": {
             "owner_id": 1,
@@ -210,6 +212,7 @@ def test_index_valid_track(app, mocker):
             },
             "track_id": 77955,
             "stem_of": None,
+            "is_playlist_upload": False,
         },
     }
 

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -176,6 +176,7 @@ def populate_track_record_metadata(track_record, track_metadata, handle):
     track_record.field_visibility = track_metadata["field_visibility"]
 
     track_record.is_premium = track_metadata["is_premium"]
+    track_record.is_playlist_upload = track_metadata["is_playlist_upload"]
     if is_valid_json_field(track_metadata, "premium_conditions"):
         track_record.premium_conditions = track_metadata["premium_conditions"]
     else:

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -634,7 +634,9 @@ def index_blocks(self, db, blocks_list):
                     logger.debug(
                         f"index.py | index_blocks - process_state_changes in {time.time() - process_state_changes_start_time}s"
                     )
-                    is_save_cid_enabled = shared_config["discprov"]["enable_save_cid"] == "true"
+                    is_save_cid_enabled = (
+                        shared_config["discprov"]["enable_save_cid"] == "true"
+                    )
                     if is_save_cid_enabled:
                         """
                         Add CID Metadata to db (cid -> json blob, etc.)

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -628,7 +628,9 @@ def index_blocks(self, db, blocks_list):
                     logger.debug(
                         f"index_nethermind.py | index_blocks - process_state_changes in {time.time() - process_state_changes_start_time}s"
                     )
-                    is_save_cid_enabled = shared_config["discprov"]["enable_save_cid"] == "true"
+                    is_save_cid_enabled = (
+                        shared_config["discprov"]["enable_save_cid"] == "true"
+                    )
                     if is_save_cid_enabled:
                         """
                         Add CID Metadata to db (cid -> json blob, etc.)


### PR DESCRIPTION
### Description
Represents whether the track was uploaded as part of a playlist or album so we can create the correct notification. Entity manager wasn't persisting the value correctly.


### Tests
Tested on stage. Value in db is true for album and playlist tracks, false for standalone.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->