### PR TITLE
[CON-642] Reindex unavailable users

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -71,3 +71,9 @@ begin;
     alter table users
     add column if not exists is_storage_v2 boolean not null default false;
 commit;
+
+
+-- 4/18/23: add is_available index
+begin;
+    create index if not exists users_is_available_false_idx on users (is_available) where is_available = false;
+commit;  

--- a/discovery-provider/integration_tests/tasks/test_update_user_is_available.py
+++ b/discovery-provider/integration_tests/tasks/test_update_user_is_available.py
@@ -316,7 +316,7 @@ def test_update_user_is_available(
     update_users_is_available_status(db, redis)
 
     with db.scoped_session() as session:
-        mock_available_users = [1, 2, 3]
+        mock_available_users = [1, 2, 3, 100]
         users = (
             session.query(User.user_id, User.is_available)
             .filter(User.user_id.in_(mock_available_users), User.is_current == True)
@@ -327,7 +327,7 @@ def test_update_user_is_available(
         for user in users:
             assert user[1] == False
 
-        mock_available_users = [4, 100]
+        mock_available_users = [4]
         users = (
             session.query(User.user_id, User.is_available)
             .filter(User.user_id.in_(mock_available_users), User.is_current == True)

--- a/discovery-provider/integration_tests/tasks/test_update_user_is_available.py
+++ b/discovery-provider/integration_tests/tasks/test_update_user_is_available.py
@@ -11,6 +11,7 @@ from src.tasks.update_user_is_available import (
     fetch_unavailable_user_ids_in_network,
     get_unavailable_users_redis_key,
     query_replica_set_by_user_id,
+    query_unavailable_users,
     query_users_by_user_ids,
     update_users_is_available_status,
 )
@@ -239,6 +240,18 @@ def test_query_users_by_user_id(app):
         assert sorted_user_ids == user_ids
 
 
+def test_query_unavailable_users(app):
+    with app.app_context():
+        db = get_db()
+
+    _seed_db_with_data(db)
+
+    with db.scoped_session() as session:
+        users = query_unavailable_users(session)
+        assert len(users) == 1
+        assert users[0].user_id == 100
+
+
 @mock.patch("src.tasks.update_user_is_available.query_registered_content_node_info")
 def test_update_user_is_available(
     mock_query_registered_content_node_info,
@@ -314,7 +327,7 @@ def test_update_user_is_available(
         for user in users:
             assert user[1] == False
 
-        mock_available_users = [4]
+        mock_available_users = [4, 100]
         users = (
             session.query(User.user_id, User.is_available)
             .filter(User.user_id.in_(mock_available_users), User.is_current == True)
@@ -371,6 +384,15 @@ def _seed_db_with_data(db):
                 "primary_id": 7,
                 "secondary_ids": [9, 1],
                 "is_current": False,
+            },
+            # Deactivated users
+            {
+                "user_id": 100,
+                "primary_id": 7,
+                "secondary_ids": [9, 1],
+                "is_current": True,
+                "is_available": False,
+                "is_deactivated": True,
             },
         ],
         # Created three defaulted Content Nodes

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -258,6 +258,8 @@ def populate_mock_db(db, entities, block_offset=None):
                 creator_node_endpoint=user_meta.get(
                     "creator_node_endpoint", "https://cn.io"
                 ),
+                is_available=user_meta.get("is_available", True),
+                is_deactivated=user_meta.get("is_deactivated", False),
             )
             user_bank = UserBankAccount(
                 signature=f"0x{i}",

--- a/discovery-provider/src/tasks/update_user_is_available.py
+++ b/discovery-provider/src/tasks/update_user_is_available.py
@@ -120,7 +120,11 @@ def update_users_is_available_status(db: SessionManager, redis: Redis) -> None:
 
     currently_unavailable_users = query_unavailable_users(session)
     for unavailable_users in currently_unavailable_users:
-        is_available = user_id_to_is_available_status[unavailable_users.user_id]
+        is_available = (
+            user_id_to_is_available_status[unavailable_users.user_id]
+            if unavailable_users.user_id in user_id_to_is_available_status
+            else True
+        )
         if is_available:
             unavailable_users.is_available = True
             unavailable_users.is_deactivated = False

--- a/discovery-provider/src/tasks/update_user_is_available.py
+++ b/discovery-provider/src/tasks/update_user_is_available.py
@@ -73,6 +73,7 @@ def update_users_is_available_status(db: SessionManager, redis: Redis) -> None:
         redis, ALL_UNAVAILABLE_USERS_REDIS_KEY
     )
 
+    user_id_to_is_available_status = {}
     for i in range(0, len(all_unavailable_user_ids), BATCH_SIZE):
         unavailable_user_ids_batch = all_unavailable_user_ids[i : i + BATCH_SIZE]
         try:
@@ -80,8 +81,6 @@ def update_users_is_available_status(db: SessionManager, redis: Redis) -> None:
                 user_ids_to_replica_set = query_replica_set_by_user_id(
                     session, unavailable_user_ids_batch
                 )
-
-                user_id_to_is_available_status = {}
 
                 for entry in user_ids_to_replica_set:
                     user_id = entry[0]
@@ -110,15 +109,21 @@ def update_users_is_available_status(db: SessionManager, redis: Redis) -> None:
                 for user in users:
                     is_available = user_id_to_is_available_status[user.user_id]
 
-                    # If user is not available, also flip 'is_delete' flag to True
+                    # If user is not available, also flip 'is_deactivated' flag to True
                     if not is_available:
                         user.is_available = False
                         user.is_deactivated = True
-
         except Exception as e:
             logger.warn(
                 f"update_user_is_available.py | Could not process batch {unavailable_user_ids_batch}: {e}\nContinuing..."
             )
+
+    currently_unavailable_users = query_unavailable_users(session)
+    for unavailable_users in currently_unavailable_users:
+        is_available = user_id_to_is_available_status[unavailable_users.user_id]
+        if is_available:
+            unavailable_users.is_available = True
+            unavailable_users.is_deactivated = False
 
 
 def fetch_unavailable_user_ids(node: str, session: Session) -> List[int]:
@@ -158,7 +163,7 @@ def query_replica_set_by_user_id(
     return user_ids_and_replica_sets
 
 
-def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[Any]:
+def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[User]:
     """Returns a list of User objects that has a user id in `user_ids`"""
     users = (
         session.query(User)
@@ -169,6 +174,16 @@ def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[Any]:
         .all()
     )
 
+    return users
+
+
+def query_unavailable_users(session: Session) -> List[User]:
+    """Returns a list of all users that have is_available = false"""
+    users = (
+        session.query(User)
+        .filter(User.is_current == True, User.is_available == False)
+        .all()
+    )
     return users
 
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Adds index for unavailable users, pulls users in with unavailability and switches them if they're not entirely in the delist working set.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Unit


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->