### PR TITLE
PLAT-725: remove very expensive query

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_index_create_notification.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_index_create_notification.py
@@ -86,7 +86,8 @@ def test_index_create_notification(app, mocker):
         announcement_notification = notifications[0]
         assert announcement_notification.type == "announcement"
         assert announcement_notification.group_id == "announcement:blocknumber:20"
-        assert announcement_notification.user_ids == list(range(1, 121))
+        # test is modified to not return any users because it can break discprov, see .all() 
+        assert announcement_notification.user_ids == []  # list(range(1, 121))
         assert announcement_notification.data == {
             "userGroup": "all",
             "title": "Happy Halloween",

--- a/discovery-provider/src/tasks/entity_manager/notification.py
+++ b/discovery-provider/src/tasks/entity_manager/notification.py
@@ -66,31 +66,12 @@ def view_notification(params: ManageEntityParameters):
     params.add_notification_seen_record(key, notification_seen)
 
 
-def get_notification_user_ids(
-    params: ManageEntityParameters, user_group: str
-) -> List[int]:
-    if user_group == "all":
-        # Get all user ids
-        users = (
-            params.session.query(User.user_id)
-            .filter(
-                User.is_current == True,
-                User.is_deactivated == False,
-                User.handle_lc != None,
-            )
-            .all()
-        )
-        user_ids = [user[0] for user in users]
-        return user_ids
-    return []
-
-
 def create_notification(params: ManageEntityParameters):
     validate_notification_tx(params)
     # Get data from cid blob
     data = json.loads(params.metadata_cid)
     # Get all user ids
-    user_ids = get_notification_user_ids(params, data["userGroup"])
+    user_ids: list[int] = []  # get_notification_user_ids(params, data["userGroup"])
     notification = Notification(
         specifier="",
         group_id=f"announcement:blocknumber:{params.block_number}",


### PR DESCRIPTION
### Description
If we send announcements this can cause a very expensive operation to be run on discprov. Since it goes through entity manager it can crash all nodes. This removes it entirely as the plugin will paginate through users on it's own instead.

### Tests
Running on stage