### PR TITLE
[PAY-1166] Make SDK respect DN override

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -123,9 +123,10 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
       !this.config.blocklist?.has(this.config.initialSelectedNode)
         ? this.config.initialSelectedNode
         : null
-    this.localStorage = window
-      ? new LocalStorage({ localStorage: window.localStorage })
-      : undefined
+    this.localStorage =
+      typeof window !== undefined
+        ? new LocalStorage({ localStorage: window.localStorage })
+        : undefined
     this.eventEmitter =
       new EventEmitter() as TypedEventEmitter<ServiceSelectionEvents>
     this.addEventListener = this.eventEmitter.addListener.bind(

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -29,7 +29,7 @@ import type TypedEventEmitter from 'typed-emitter'
 import EventEmitter from 'events'
 import { AbortController as AbortControllerPolyfill } from 'node-abort-controller'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
-import type { LocalStorageType } from '../LocalStorage'
+import { LocalStorage } from '../LocalStorage'
 
 export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   /**
@@ -50,7 +50,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   /**
    * Local storage (currently only available on web)
    */
-  private localStorage?: LocalStorageType
+  private localStorage?: LocalStorage
 
   /**
    * Whether or not we are using a backup, meaning we were
@@ -123,7 +123,9 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
       !this.config.blocklist?.has(this.config.initialSelectedNode)
         ? this.config.initialSelectedNode
         : null
-    this.localStorage = window ? window.localStorage : undefined
+    this.localStorage = window
+      ? new LocalStorage({ localStorage: window.localStorage })
+      : undefined
     this.eventEmitter =
       new EventEmitter() as TypedEventEmitter<ServiceSelectionEvents>
     this.addEventListener = this.eventEmitter.addListener.bind(
@@ -252,8 +254,8 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   }
 
   private async getOverrideEndpoint() {
-    const override = JSON.parse(
-      (await this.localStorage?.getItem(DISCOVERY_PROVIDER_TIMESTAMP)) ?? '{}'
+    const override = await this.localStorage?.getJSONItem<{ endpoint: string }>(
+      DISCOVERY_PROVIDER_TIMESTAMP
     )
     return override?.endpoint
   }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
@@ -6,19 +6,25 @@ import type { DiscoveryNodeSelectorServiceConfigInternal } from './types'
  */
 export const DISCOVERY_SERVICE_NAME = 'discovery-node'
 
+/**
+ * Key for Discovery Node override in local storage
+ */
+export const DISCOVERY_PROVIDER_TIMESTAMP =
+  '@audius/libs:discovery-node-timestamp'
+
 export const defaultDiscoveryNodeSelectorConfig: DiscoveryNodeSelectorServiceConfigInternal =
-  {
-    initialSelectedNode: null,
-    blocklist: null,
-    allowlist: null,
-    maxConcurrentRequests: 6,
-    requestTimeout: 30000, // 30s
-    unhealthyTTL: 3600000, // 1 hour
-    backupsTTL: 120000, // 2 min
-    healthCheckThresholds: {
-      minVersion: productionConfig.minVersion,
-      maxSlotDiffPlays: null,
-      maxBlockDiff: 15
-    },
-    bootstrapServices: productionConfig.discoveryNodes
-  }
+{
+  initialSelectedNode: null,
+  blocklist: null,
+  allowlist: null,
+  maxConcurrentRequests: 6,
+  requestTimeout: 30000, // 30s
+  unhealthyTTL: 3600000, // 1 hour
+  backupsTTL: 120000, // 2 min
+  healthCheckThresholds: {
+    minVersion: productionConfig.minVersion,
+    maxSlotDiffPlays: null,
+    maxBlockDiff: 15
+  },
+  bootstrapServices: productionConfig.discoveryNodes
+}

--- a/libs/src/sdk/services/LocalStorage/LocalStorage.ts
+++ b/libs/src/sdk/services/LocalStorage/LocalStorage.ts
@@ -1,0 +1,39 @@
+import type { LocalStorageType, LocalStorageConfig } from './types'
+
+export class LocalStorage {
+  localStorage: LocalStorageType
+
+  constructor(config: LocalStorageConfig) {
+    this.localStorage = config.localStorage
+  }
+
+  getItem = async (key: string) => {
+    return await this.localStorage.getItem(key)
+  }
+
+  async getJSONItem<T>(key: string): Promise<T | null> {
+    const val = await this.getItem(key)
+    if (val) {
+      try {
+        const parsed = JSON.parse(val)
+        return parsed
+      } catch (e) {
+        return null
+      }
+    }
+    return null
+  }
+
+  setItem = async (key: string, value: string) => {
+    return await this.localStorage.setItem(key, value)
+  }
+
+  async setJSONItem(key: string, value: any) {
+    const string = JSON.stringify(value)
+    await this.setItem(key, string)
+  }
+
+  async removeItem(key: string) {
+    await this.localStorage.removeItem(key)
+  }
+}

--- a/libs/src/sdk/services/LocalStorage/index.ts
+++ b/libs/src/sdk/services/LocalStorage/index.ts
@@ -1,0 +1,2 @@
+export * from './LocalStorage'
+export * from './types'

--- a/libs/src/sdk/services/LocalStorage/types.ts
+++ b/libs/src/sdk/services/LocalStorage/types.ts
@@ -1,0 +1,9 @@
+export type LocalStorageType = {
+  getItem: (key: string) => Promise<string | null> | string | null
+  setItem: (key: string, value: string) => Promise<void> | void
+  removeItem: (key: string) => Promise<void> | void
+}
+
+export type LocalStorageConfig = {
+  localStorage: LocalStorageType
+}

--- a/libs/src/sdk/services/index.ts
+++ b/libs/src/sdk/services/index.ts
@@ -1,2 +1,3 @@
 export * from './DiscoveryNodeSelector'
 export * from './WalletApi'
+export * from './LocalStorage'


### PR DESCRIPTION
### Description
SDK now respects DN override endpoint set from client (by hitting "d" key).

Adding localStorage service was beyond scope so feel free to comment on or veto this change, I can just use window.localStorage in discoveryNodeSelector directly for now.

Not sure how to test OAuth flow, seems like we use that for account verification, would appreciate any pointers!

Obviously more work to be done here eg. mobile.


### Tests
Tested on local web by checking that comms requests were going to the DN I'd set through the client.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->