### PR TITLE
[PAY-1166] Make SDK respect DN override (sdk-side)

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -39,6 +39,11 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   private selectedNode: string | null
 
   /**
+   * Manual override endpoint
+   */
+  private overrideEndpoint: string | null
+
+  /**
    * Configuration passed in by consumer (with defaults)
    */
   private config: DiscoveryNodeSelectorServiceConfigInternal
@@ -114,6 +119,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
       !this.config.blocklist?.has(this.config.initialSelectedNode)
         ? this.config.initialSelectedNode
         : null
+    this.overrideEndpoint = this.config.overrideEndpoint
     this.eventEmitter =
       new EventEmitter() as TypedEventEmitter<ServiceSelectionEvents>
     this.addEventListener = this.eventEmitter.addListener.bind(
@@ -220,10 +226,13 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   }
 
   /**
-   * Selects a discovery node or returns the existing selection
+   * Selects a discovery node, or returns the existing selection or override endpoint
    * @returns a discovery node endpoint
    */
   public async getSelectedEndpoint() {
+    if (this.overrideEndpoint) {
+      return this.overrideEndpoint
+    }
     if (this.selectedNode !== null) {
       return this.selectedNode
     }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
@@ -20,5 +20,6 @@ export const defaultDiscoveryNodeSelectorConfig: DiscoveryNodeSelectorServiceCon
       maxSlotDiffPlays: null,
       maxBlockDiff: 15
     },
-    bootstrapServices: productionConfig.discoveryNodes
+    bootstrapServices: productionConfig.discoveryNodes,
+    overrideEndpoint: null
   }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
@@ -74,6 +74,10 @@ export type DiscoveryNodeSelectorServiceConfigInternal = {
    * @example ['https://discoverynode.audius.co', 'https://disoverynode2.audius.co']
    */
   bootstrapServices: string[]
+  /**
+   * Manual override endpoint
+   */
+  overrideEndpoint: string | null
 }
 
 export type DiscoveryNodeSelectorServiceConfig =


### PR DESCRIPTION
### Description
SDK-side counterpart to https://github.com/AudiusProject/audius-client/pull/3246. Makes it so the SDK respects DN override set from the client.


### Tests
Tested on local web + linked libs. Confirmed setting/unsetting DN override works by inspecting comms requests.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->