### PR TITLE
Fix mobile notification settings endpoints

### DIFF
--- a/identity-service/src/models/userNotificationBrowserSettings.js
+++ b/identity-service/src/models/userNotificationBrowserSettings.js
@@ -36,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
       messages: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: true
+        defaultValue: false
       }
     },
     {}

--- a/identity-service/src/models/userNotificationMobileSettings.js
+++ b/identity-service/src/models/userNotificationMobileSettings.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
       messages: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: true
+        defaultValue: false
       }
     },
     {}

--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -67,15 +67,9 @@ module.exports = function (app) {
         return errorResponseBadRequest(`Did not pass in a valid userId`)
 
       try {
-        let settings = await models.UserNotificationMobileSettings.findOne({
+        const settings = await models.UserNotificationMobileSettings.findOne({
           where: { userId }
         })
-        if (!settings) {
-          settings = await models.UserNotificationMobileSettings.create({
-            userId
-          })
-        }
-
         return successResponse({ settings })
       } catch (e) {
         req.logger.error(

--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -67,10 +67,15 @@ module.exports = function (app) {
         return errorResponseBadRequest(`Did not pass in a valid userId`)
 
       try {
-        const [settings] =
-          await models.UserNotificationMobileSettings.findOrCreate({
-            where: { userId }
+        let settings = await models.UserNotificationMobileSettings.findOne({
+          where: { userId }
+        })
+        if (!settings) {
+          settings = await models.UserNotificationMobileSettings.create({
+            userId
           })
+        }
+
         return successResponse({ settings })
       } catch (e) {
         req.logger.error(
@@ -114,9 +119,6 @@ module.exports = function (app) {
 
         return successResponse()
       } catch (e) {
-        req.logger.error(
-          `push_notifications.js: settings: ${JSON.stringify(settings)}`
-        )
         req.logger.error(
           `Unable to create or update push notification settings for userId: ${userId}`,
           e

--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -115,6 +115,9 @@ module.exports = function (app) {
         return successResponse()
       } catch (e) {
         req.logger.error(
+          `push_notifications.js: settings: ${JSON.stringify(settings)}`
+        )
+        req.logger.error(
           `Unable to create or update push notification settings for userId: ${userId}`,
           e
         )

--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -67,10 +67,10 @@ module.exports = function (app) {
         return errorResponseBadRequest(`Did not pass in a valid userId`)
 
       try {
-        const settings = await models.UserNotificationMobileSettings.findOne({
-          where: { userId }
-        })
-
+        const [settings] =
+          await models.UserNotificationMobileSettings.findOrCreate({
+            where: { userId }
+          })
         return successResponse({ settings })
       } catch (e) {
         req.logger.error(
@@ -100,12 +100,12 @@ module.exports = function (app) {
 
       try {
         // pseudo-upsert without sequlize magic
-        try {
-          await models.UserNotificationMobileSettings.update({
-            userId,
-            ...settings
-          })
-        } catch (e) {
+        const userSettings = await models.UserNotificationMobileSettings.findOne({
+          where: { userId }
+        })
+        if (userSettings) {
+          await userSettings.update({ ...settings })
+        } else {
           await models.UserNotificationMobileSettings.create({
             userId,
             ...settings


### PR DESCRIPTION
### Description
This POST endpoint was changed a few months ago while trying to hotfix during a flare... but the sequelize syntax was wrong so this has been broken for a few months now, meaning users currently aren't able to toggle specific notification types on/off and have their change persist. (But disabling the top-level notification control still works without this change because that value isn't persisted and is instead handled in the client.)


### Tests
Deployed and tested on stage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->