### PR TITLE
Add 60s sleep

### DIFF
--- a/.circleci/jobs/test-audius-cmd.yml
+++ b/.circleci/jobs/test-audius-cmd.yml
@@ -38,4 +38,4 @@ steps:
         - run:
             name: audius-cmd test
             no_output_timeout: 15m
-            command: . ~/.profile; audius-compose up -w && audius-cmd test
+            command: . ~/.profile; audius-compose up -w && sleep 60 && audius-cmd test


### PR DESCRIPTION
### Description
Attempt to fix audius-cmd tests in CI by adding sleep


### Tests
Circle CI


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
NA