### PR TITLE
Better v0 CID sync

### DIFF
--- a/mediorum/Makefile
+++ b/mediorum/Makefile
@@ -40,7 +40,6 @@ pg.bounce::
 	docker compose up -d --wait
 	rm -rf /tmp/mediorum*
 	sleep 2
-	docker push audius/mediorum:${GIT_HASH}
 
 cmd.loadtest::
 	go run cmd/main.go test -num 10

--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/inconshreveable/log15"
+	"golang.org/x/exp/slog"
 	"gorm.io/gorm/clause"
 )
 
@@ -16,7 +16,7 @@ type PeerClient struct {
 	Host   string
 	outbox chan []byte
 	crudr  *Crudr
-	logger log15.Logger
+	logger *slog.Logger
 }
 
 func NewPeerClient(host string, crudr *Crudr) *PeerClient {
@@ -29,7 +29,7 @@ func NewPeerClient(host string, crudr *Crudr) *PeerClient {
 		Host:   host,
 		outbox: make(chan []byte, outboxBufferSize),
 		crudr:  crudr,
-		logger: log15.New("cruder_client", host),
+		logger: slog.With("cruder_client", host),
 	}
 }
 

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/inconshreveable/log15"
 	"github.com/oklog/ulid/v2"
+	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -32,7 +32,7 @@ type Crudr struct {
 	DB *gorm.DB
 
 	host    string
-	logger  log15.Logger
+	logger  *slog.Logger
 	typeMap map[string]reflect.Type
 
 	peerClients []*PeerClient
@@ -68,7 +68,7 @@ func New(host string, peerHosts []string, db *gorm.DB) *Crudr {
 		DB: db,
 
 		host:    host,
-		logger:  log15.New("module", "crud", "from", host),
+		logger:  slog.With("module", "crud", "from", host),
 		typeMap: map[string]reflect.Type{},
 
 		peerClients: make([]*PeerClient, len(peerHosts)),

--- a/mediorum/ddl/cid_lookup.sql
+++ b/mediorum/ddl/cid_lookup.sql
@@ -1,3 +1,5 @@
+begin;
+
 -- cid_lookup is the main table used to determine which host has a given CID
 -- multihash column is used for both multihash and dirMultihash
 create table if not exists cid_lookup (
@@ -74,10 +76,9 @@ end;
 $$ language plpgsql;
 
 -- trigger trigger
-begin;
-  drop trigger if exists handle_cid_change on "Files";
-  create trigger handle_cid_change
-      after insert or delete on "Files"
-      for each row execute procedure handle_cid_change();
-commit;
+drop trigger if exists handle_cid_change on "Files";
+create trigger handle_cid_change
+    after insert or delete on "Files"
+    for each row execute procedure handle_cid_change();
 
+commit;

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -8,11 +8,11 @@ import (
 	_ "embed"
 )
 
-//go:embed files_trigger.sql
-var filesTrigger string
+//go:embed cid_lookup.sql
+var cidLookupDDL string
 
 func Migrate(db *sql.DB) {
-	mustExec(db, filesTrigger)
+	mustExec(db, cidLookupDDL)
 }
 
 func mustExec(db *sql.DB, ddl string) {

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -1,0 +1,25 @@
+package ddl
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	_ "embed"
+)
+
+//go:embed files_trigger.sql
+var filesTrigger string
+
+func Migrate(db *sql.DB) {
+	mustExec(db, filesTrigger)
+}
+
+func mustExec(db *sql.DB, ddl string) {
+	_, err := db.Exec(ddl)
+	if err != nil {
+		fmt.Println(ddl)
+		log.Fatal(err)
+	}
+	// fmt.Println("OK", ddl)
+}

--- a/mediorum/ddl/files_trigger.sql
+++ b/mediorum/ddl/files_trigger.sql
@@ -1,0 +1,47 @@
+
+-- cid_log tracks inserts and deletes on the local Files table
+create table if not exists cid_log (
+    multihash text primary key,
+    is_deleted boolean default false,
+    updated_at timestamp with time zone NOT NULL
+);
+
+-- initial backfill
+insert into cid_log (multihash, updated_at)
+  select distinct "multihash", "createdAt" from "Files"
+  union
+  select distinct "dirMultihash", "createdAt" from "Files" where "dirMultihash" is not null
+  on conflict do nothing;
+
+create index if not exists idx_cid_log_updated_at on cid_log(updated_at);
+
+-- trigger code
+create or replace function handle_cid_change() returns trigger as $$
+declare
+begin
+
+    case tg_op
+    when 'DELETE' then
+        update cid_log set is_deleted = true, updated_at = now() where multihash = old.multihash;
+        update cid_log set is_deleted = true, updated_at = now() where multihash = old."dirMultihash";
+    else
+        insert into cid_log (multihash, updated_at) values (new.multihash, new."createdAt")
+          on conflict do nothing;
+        if new."dirMultihash" is not null then
+          insert into cid_log (multihash, updated_at) values (new."dirMultihash", new."createdAt")
+            on conflict do nothing;
+        end if;
+    end case;
+    return null;
+
+end;
+$$ language plpgsql;
+
+-- trigger
+begin;
+  drop trigger if exists handle_cid_change on "Files";
+  create trigger handle_cid_change
+      after insert or delete on "Files"
+      for each row execute procedure handle_cid_change();
+commit;
+

--- a/mediorum/ddl/test/cid_lookup_test.sql
+++ b/mediorum/ddl/test/cid_lookup_test.sql
@@ -1,9 +1,9 @@
 -- run from project root:
--- psql -q -f ddl/test/files_trigger_test.sql
+-- psql -q -f ddl/test/cid_lookup_test.sql
 
-drop database if exists files_trigger_test;
-create database files_trigger_test;
-\c files_trigger_test
+drop database if exists cid_lookup_test;
+create database cid_lookup_test;
+\c cid_lookup_test
 
 -- subset of fields we actually use
 CREATE TABLE IF NOT EXISTS "Files" (
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS "Files" (
 
 
 -- load code under test
-\i ddl/files_trigger.sql
+\i ddl/cid_lookup.sql
 
 
 

--- a/mediorum/ddl/test/files_trigger_test.sql
+++ b/mediorum/ddl/test/files_trigger_test.sql
@@ -1,0 +1,79 @@
+-- run from project root:
+-- psql -q -f ddl/test/files_trigger_test.sql
+
+drop database if exists files_trigger_test;
+create database files_trigger_test;
+\c files_trigger_test
+
+-- subset of fields we actually use
+CREATE TABLE IF NOT EXISTS "Files" (
+    multihash text NOT NULL,
+    "dirMultihash" text,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL
+);
+
+
+
+-- load code under test
+\i ddl/files_trigger.sql
+
+
+
+LISTEN cid_log;
+
+
+-- test: insert
+insert into "Files" values
+  ('cid1', NULL, now(), now()),
+  ('cid2', NULL, now(), now());
+
+do $$ begin
+  assert (select count(*) from cid_log) = 2;
+  assert (select updated_at from cid_log where multihash = 'cid1') =
+         (select updated_at from cid_log where multihash = 'cid2');
+end; $$;
+
+
+-- test: delete
+delete from "Files" where multihash = 'cid2';
+
+do $$ begin
+  assert (select count(*) from cid_log) = 2;
+  assert (select count(*) from cid_log where is_deleted) = 1;
+  -- cid2 has a newer updated_at
+  assert (select updated_at from cid_log where multihash = 'cid1') <
+         (select updated_at from cid_log where multihash = 'cid2');
+end; $$;
+
+
+-- test: dirMultihash
+truncate "Files";
+truncate cid_log;
+
+insert into "Files" values
+  ('dir1v1', 'dir1', now(), now()),
+  ('dir1v2', 'dir1', now(), now()),
+  ('dir2v1', 'dir2', now(), now()),
+  ('dir2v2', 'dir2', now(), now())
+  ;
+
+do $$ begin
+  assert (select count(*) from cid_log where multihash = 'dir1') = 1;
+  -- cid_log has 3 rows: dir1, dir1v1, dir1v2
+  assert (select count(*) from cid_log where multihash like 'dir1%') = 3;
+end; $$;
+
+-- test: dirMultihash delete
+
+delete from "Files" where multihash = 'dir1v1';
+
+do $$ begin
+  -- dir1v1 is deleted
+  assert (select is_deleted from cid_log where multihash = 'dir1v1');
+  -- but dir1v2 is still present
+  assert (select is_deleted from cid_log where multihash = 'dir1v2') = false;
+  -- still, we mark the dirMultihash as deleted if any member cid is deleted
+  -- since the dirMultihash is incomplete
+  assert (select is_deleted from cid_log where multihash = 'dir1');
+end; $$;

--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/ethereum/go-ethereum v1.11.4
 	github.com/georgysavva/scany/v2 v2.0.0
-	github.com/inconshreveable/log15 v2.16.0+incompatible
 	github.com/ipfs/go-cid v0.3.2
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/labstack/echo/v4 v4.10.0
@@ -26,7 +25,6 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
-	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -58,7 +56,6 @@ require (
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.2.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/mediorum/go.sum
+++ b/mediorum/go.sum
@@ -914,7 +914,6 @@ github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
@@ -1197,8 +1196,6 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/inconshreveable/log15 v2.16.0+incompatible h1:6nvMKxtGcpgm7q0KiGs+Vc+xDvUXaBqsPKHWKsinccw=
-github.com/inconshreveable/log15 v2.16.0+incompatible/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
@@ -2261,8 +2258,6 @@ golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
-golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -10,9 +10,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/slog"
 )
 
 func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout))
+	slog.SetDefault(logger)
+
 	preset := os.Getenv("MEDIORUM_ENV")
 
 	switch preset {

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -62,7 +62,7 @@ func (ss *MediorumServer) startBeamClient() {
 				if err != nil {
 					log.Println("beam failed", peer.Host, err)
 				} else {
-					log.Println("beam OK", result)
+					log.Printf("beam OK %+v \n", result)
 				}
 				wg.Done()
 			}()
@@ -79,6 +79,7 @@ func jitterSeconds(min, n int) time.Duration {
 }
 
 type beamResult struct {
+	Host         string
 	RowCount     int64
 	InsertCount  int64
 	DeleteCount  int64
@@ -147,6 +148,7 @@ func (ss *MediorumServer) beamFromPeer(peer Peer) (*beamResult, error) {
 	conn.Exec(ctx, `drop table if exists cid_log_temp`)
 
 	r := &beamResult{
+		Host:         peer.Host,
 		RowCount:     copys.RowsAffected(),
 		InsertCount:  inserts.RowsAffected(),
 		DeleteCount:  deletes.RowsAffected(),

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inconshreveable/log15"
+	"golang.org/x/exp/slog"
 )
 
 func (ss *MediorumServer) startBeamClient() {
@@ -99,7 +99,7 @@ func (ss *MediorumServer) beamFromPeer(peer Peer) (*beamResult, error) {
 
 	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("beam/files"), url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
 	startedAt := time.Now()
-	logger := log15.New("beam_client", peer.Host)
+	logger := slog.With("beam_client", peer.Host)
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -18,6 +18,7 @@ func (ss *MediorumServer) startBeamClient() {
 	ctx := context.Background()
 
 	// migration: create cid_lookup table
+	// todo: move this to ddl zone
 	ddl := `
 
 	create table if not exists cid_cursor (
@@ -42,7 +43,7 @@ func (ss *MediorumServer) startBeamClient() {
 	// polling:
 	// beam cid lookup from peers on an interval
 	for {
-		time.Sleep(jitterSeconds(30, 60))
+		time.Sleep(jitterSeconds(20, 40))
 
 		if err != nil {
 			log.Println("create temp table failed", err)
@@ -57,9 +58,11 @@ func (ss *MediorumServer) startBeamClient() {
 			peer := peer
 			wg.Add(1)
 			go func() {
-				err := ss.beamFromPeer(peer)
+				result, err := ss.beamFromPeer(peer)
 				if err != nil {
 					log.Println("beam failed", peer.Host, err)
+				} else {
+					log.Println("beam OK", result)
 				}
 				wg.Done()
 			}()
@@ -75,52 +78,81 @@ func jitterSeconds(min, n int) time.Duration {
 	return time.Second * time.Duration(min+rand.Intn(n-min))
 }
 
-func (ss *MediorumServer) beamFromPeer(peer Peer) error {
+type beamResult struct {
+	RowCount     int64
+	InsertCount  int64
+	DeleteCount  int64
+	CursorBefore time.Time
+	CursorAfter  time.Time
+	Took         time.Duration
+}
+
+func (ss *MediorumServer) beamFromPeer(peer Peer) (*beamResult, error) {
 	ctx := context.Background()
 	client := http.Client{
 		Timeout: 5 * time.Minute,
 	}
 
-	var lastUpdatedAt time.Time
-	ss.pgPool.QueryRow(ctx, `select updated_at from cid_cursor where `).Scan(&lastUpdatedAt)
+	var cursorBefore time.Time
+	ss.pgPool.QueryRow(ctx, `select updated_at from cid_cursor where host = $1`, peer.Host).Scan(&cursorBefore)
 
-	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("beam/files"), url.QueryEscape(lastUpdatedAt.Format(time.RFC3339)))
+	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("beam/files"), url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
 	startedAt := time.Now()
 	logger := log15.New("beam_client", peer.Host)
 	resp, err := client.Get(endpoint)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
+		return nil, errors.New(resp.Status)
 	}
 
 	// pgx COPY FROM
 	conn, err := ss.pgPool.Acquire(ctx)
 	if err != nil {
 		logger.Warn(err.Error())
-		return err
+		return nil, err
 	}
 	defer conn.Release()
 
 	conn.Exec(ctx, `create temp table cid_log_temp (like cid_log)`)
 
 	copySql := `COPY cid_log_temp FROM STDIN`
-	result, err := conn.Conn().PgConn().CopyFrom(ctx, resp.Body, copySql)
+	copys, err := conn.Conn().PgConn().CopyFrom(ctx, resp.Body, copySql)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	conn.Exec(ctx, `insert into cid_lookup (select multihash, $1 from cid_log_temp) on conflict do nothing;`, peer.Host)
+	// inserts
+	inserts, err := conn.Exec(ctx, `insert into cid_lookup (select multihash, $1 from cid_log_temp where is_deleted = false) on conflict do nothing;`, peer.Host)
+	if err != nil {
+		return nil, err
+	}
 
-	conn.QueryRow(ctx, `select max(updated_at) from cid_log_temp`).Scan(&lastUpdatedAt)
-	if !lastUpdatedAt.IsZero() {
-		_, err := conn.Exec(ctx, `insert into cid_cursor values ($1, $2) on conflict (host) do update set updated_at = $2`, peer.Host, lastUpdatedAt)
+	// deletes
+	deletes, err := conn.Exec(ctx, `delete from cid_lookup where (multihash, host) in (select multihash, $1 from cid_log_temp where is_deleted = true)`, peer.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	var cursorAfter time.Time
+	conn.QueryRow(ctx, `select max(updated_at) from cid_log_temp`).Scan(&cursorAfter)
+	if !cursorAfter.IsZero() {
+		_, err := conn.Exec(ctx, `insert into cid_cursor values ($1, $2) on conflict (host) do update set updated_at = $2`, peer.Host, cursorAfter)
 		fmt.Println("update cid_cursor", err)
 	}
 
-	logger.Info("beamed", "count", result.RowsAffected(), "took", time.Since(startedAt))
-	return nil
+	conn.Exec(ctx, `drop table if exists cid_log_temp`)
+
+	r := &beamResult{
+		RowCount:     copys.RowsAffected(),
+		InsertCount:  inserts.RowsAffected(),
+		DeleteCount:  deletes.RowsAffected(),
+		CursorBefore: cursorBefore,
+		CursorAfter:  cursorAfter,
+		Took:         time.Since(startedAt),
+	}
+	return r, nil
 }

--- a/mediorum/server/cid_log_server.go
+++ b/mediorum/server/cid_log_server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -9,12 +11,21 @@ import (
 func (ss *MediorumServer) servePgBeam(c echo.Context) error {
 	ctx := c.Request().Context()
 
+	after := time.Time{}
+	if t, err := time.Parse(time.RFC3339, c.QueryParam("after")); err == nil {
+		after = t
+	}
+
 	query := fmt.Sprintf(`
-		select distinct "multihash", '%s' from "Files"
-		union
-		select distinct "dirMultihash", '%[1]s' from "Files" where "dirMultihash" is not null`,
-		ss.Config.Self.Host)
+		select *
+		from cid_log
+		where updated_at > '%s'
+		order by updated_at
+		`,
+		after.Format(time.RFC3339))
 	copySql := fmt.Sprintf("COPY (%s) TO STDOUT", query)
+
+	log.Println("COPY", after, copySql)
 
 	// pg COPY TO
 	conn, err := ss.pgPool.Acquire(ctx)

--- a/mediorum/server/cid_log_server.go
+++ b/mediorum/server/cid_log_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -12,7 +11,7 @@ func (ss *MediorumServer) servePgBeam(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	after := time.Time{}
-	if t, err := time.Parse(time.RFC3339, c.QueryParam("after")); err == nil {
+	if t, err := time.Parse(time.RFC3339Nano, c.QueryParam("after")); err == nil {
 		after = t
 	}
 
@@ -22,10 +21,8 @@ func (ss *MediorumServer) servePgBeam(c echo.Context) error {
 		where updated_at > '%s'
 		order by updated_at
 		`,
-		after.Format(time.RFC3339))
+		after.Format(time.RFC3339Nano))
 	copySql := fmt.Sprintf("COPY (%s) TO STDOUT", query)
-
-	log.Println("COPY", after, copySql)
 
 	// pg COPY TO
 	conn, err := ss.pgPool.Acquire(ctx)

--- a/mediorum/server/cid_log_test.go
+++ b/mediorum/server/cid_log_test.go
@@ -2,42 +2,64 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCidLog(t *testing.T) {
-	fmt.Println("_________________________________")
 	ctx := context.Background()
 
 	s1 := testNetwork[0]
 	s2 := testNetwork[1]
 
-	// this truncate could be danger
-	// should add some checks to ensure we never run this on a real DB
+	// since we're about to truncate "Files"
+	// let's just double tripple check we're in test mode:
+	assert.Equal(t, "test", s1.Config.Env)
+
 	s1.pgPool.Exec(ctx, `
+	truncate "Files";
 	truncate cid_log;
 
 	insert into "Files"
 		(multihash, "storagePath", "createdAt", "updatedAt", "fileUUID", "clock", "skipped")
 	values
-		(gen_random_uuid(), gen_random_uuid(), now(), now(), gen_random_uuid(), 1, false),
-		(gen_random_uuid(), gen_random_uuid(), now(), now(), gen_random_uuid(), 1, false)
+		('cid1', '/files/cid1', now(), now(), gen_random_uuid(), 1, false),
+		('cid2', '/files/cid2', now(), now(), gen_random_uuid(), 1, false)
 	`)
 
 	_, err := s2.pgPool.Exec(ctx, `truncate cid_lookup; truncate cid_cursor`)
 	assert.NoError(t, err)
 
-	err = s2.beamFromPeer(s1.Config.Self)
+	r1, err := s2.beamFromPeer(s1.Config.Self)
 	assert.NoError(t, err)
+	assert.True(t, r1.CursorBefore.IsZero())
+	assert.False(t, r1.CursorAfter.IsZero())
+	assert.EqualValues(t, 2, r1.RowCount)
+	assert.EqualValues(t, 2, r1.InsertCount)
+	assert.EqualValues(t, 0, r1.DeleteCount)
 
 	var lookupCount, cursorCount int
-	s2.pgPool.QueryRow(ctx, `select count(*) from cid_lookup;`).Scan(&lookupCount)
-	s2.pgPool.QueryRow(ctx, `select count(*) from cid_cursor;`).Scan(&cursorCount)
+	s2.pgPool.QueryRow(ctx, `select count(*) from cid_lookup`).Scan(&lookupCount)
+	s2.pgPool.QueryRow(ctx, `select count(*) from cid_cursor`).Scan(&cursorCount)
 
-	assert.Equal(t, 2, lookupCount)
-	assert.Equal(t, 1, cursorCount)
+	assert.EqualValues(t, 2, lookupCount)
+	assert.EqualValues(t, 1, cursorCount)
+
+	// do a delete
+	{
+		_, err := s1.pgPool.Exec(ctx, `delete from "Files" where multihash = 'cid1'`)
+		assert.NoError(t, err)
+
+		r1, err := s2.beamFromPeer(s1.Config.Self)
+		assert.NoError(t, err)
+		assert.False(t, r1.CursorBefore.IsZero())
+		assert.EqualValues(t, 1, r1.RowCount)
+		assert.EqualValues(t, 0, r1.InsertCount)
+		assert.EqualValues(t, 1, r1.DeleteCount)
+
+		s2.pgPool.QueryRow(ctx, `select count(*) from cid_lookup`).Scan(&lookupCount)
+		assert.EqualValues(t, 1, lookupCount)
+	}
 
 }

--- a/mediorum/server/cid_log_test.go
+++ b/mediorum/server/cid_log_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCidLog(t *testing.T) {
+	fmt.Println("_________________________________")
+	ctx := context.Background()
+
+	s1 := testNetwork[0]
+	s2 := testNetwork[1]
+
+	// this truncate could be danger
+	// should add some checks to ensure we never run this on a real DB
+	s1.pgPool.Exec(ctx, `
+	truncate cid_log;
+
+	insert into "Files"
+		(multihash, "storagePath", "createdAt", "updatedAt", "fileUUID", "clock", "skipped")
+	values
+		(gen_random_uuid(), gen_random_uuid(), now(), now(), gen_random_uuid(), 1, false),
+		(gen_random_uuid(), gen_random_uuid(), now(), now(), gen_random_uuid(), 1, false)
+	`)
+
+	_, err := s2.pgPool.Exec(ctx, `truncate cid_lookup; truncate cid_cursor`)
+	assert.NoError(t, err)
+
+	err = s2.beamFromPeer(s1.Config.Self)
+	assert.NoError(t, err)
+
+	var lookupCount, cursorCount int
+	s2.pgPool.QueryRow(ctx, `select count(*) from cid_lookup;`).Scan(&lookupCount)
+	s2.pgPool.QueryRow(ctx, `select count(*) from cid_cursor;`).Scan(&cursorCount)
+
+	assert.Equal(t, 2, lookupCount)
+	assert.Equal(t, 1, cursorCount)
+
+}

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"mediorum/crudr"
+	"mediorum/ddl"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -84,5 +85,8 @@ func dbMigrate(crud *crudr.Crudr) {
 
 	// register any models to be managed by crudr
 	crud.RegisterModels(&LogLine{}, &Blob{}, &Upload{}, &ServerHealth{})
+
+	sqlDb, _ := crud.DB.DB()
+	ddl.Migrate(sqlDb)
 
 }

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -85,7 +85,7 @@ func (ss *MediorumServer) findProblemBlobsCount(overReplicated bool) (int64, err
 func (ss *MediorumServer) repairUnderReplicatedBlobs() error {
 	// find under-replicated content
 	ctx := context.Background()
-	logger := ss.logger.New("svc", "repair")
+	logger := ss.logger.With("svc", "repair")
 
 	problems, err := ss.findProblemBlobs(false)
 	if err != nil {

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -12,12 +12,12 @@ import (
 )
 
 func (ss *MediorumServer) replicateFile(fileName string, file io.ReadSeeker) ([]string, error) {
-	logger := ss.logger.New("key", fileName)
+	logger := ss.logger.With("key", fileName)
 
 	healthyHostNames := ss.findHealthyHostNames("5 minutes")
 	success := []string{}
 	for _, peer := range ss.placement.topAll(fileName) {
-		logger := logger.New("to", peer.Host)
+		logger := logger.With("to", peer.Host)
 
 		if !slices.Contains(healthyHostNames, peer.Host) {
 			logger.Debug("skipping unhealthy host", "healthy", healthyHostNames)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -14,12 +14,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
+	"golang.org/x/exp/slog"
 )
 
 type Peer struct {
@@ -57,7 +57,7 @@ type MediorumServer struct {
 	echo      *echo.Echo
 	bucket    *blob.Bucket
 	placement *placement
-	logger    log15.Logger
+	logger    *slog.Logger
 	crud      *crudr.Crudr
 	pgPool    *pgxpool.Pool
 	quit      chan os.Signal
@@ -111,8 +111,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	}
 
 	// logger
-	logger := log15.New("self", config.Self.Host)
-	logger.SetHandler(log15.CallerFileHandler(log15.StdoutHandler))
+	logger := slog.With("self", config.Self.Host)
 
 	// db
 	db := dbMustDial(config.PostgresDSN)
@@ -274,12 +273,12 @@ func (ss *MediorumServer) Stop() {
 	defer cancel()
 
 	if err := ss.echo.Shutdown(ctx); err != nil {
-		ss.logger.Crit("echo shutdown: " + err.Error())
+		ss.logger.Error("echo shutdown", err)
 	}
 
 	if db, err := ss.crud.DB.DB(); err == nil {
 		if err := db.Close(); err != nil {
-			ss.logger.Crit("db shutdown: " + err.Error())
+			ss.logger.Error("db shutdown", err)
 		}
 	}
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -71,7 +71,9 @@ var (
 )
 
 func New(config MediorumConfig) (*MediorumServer, error) {
-	config.Env = os.Getenv("MEDIORUM_ENV")
+	if env := os.Getenv("MEDIORUM_ENV"); env != "" {
+		config.Env = env
+	}
 
 	// validate host config
 	if config.Self.Host == "" {

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -54,7 +54,9 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 }
 
 func TestMain(m *testing.M) {
-	testNetwork = setupTestNetwork(5, 9)
+	// testNetwork = setupTestNetwork(5, 9)
+	testNetwork = setupTestNetwork(3, 3)
+
 	exitVal := m.Run()
 	// todo: tear down testNetwork
 

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -28,6 +28,7 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 	for idx, peer := range network {
 		peer := peer
 		config := MediorumConfig{
+			Env:               "test",
 			Self:              peer,
 			Peers:             network,
 			ReplicationFactor: replicationFactor,

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -55,8 +55,7 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 }
 
 func TestMain(m *testing.M) {
-	// testNetwork = setupTestNetwork(5, 9)
-	testNetwork = setupTestNetwork(3, 3)
+	testNetwork = setupTestNetwork(5, 9)
 
 	exitVal := m.Run()
 	// todo: tear down testNetwork

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -181,7 +181,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 	ss.crud.Update(upload)
 
 	fileHash := upload.OrigFileCID
-	logger := ss.logger.New("template", upload.Template, "hash", fileHash)
+	logger := ss.logger.With("template", upload.Template, "hash", fileHash)
 
 	onError := func(err error, info ...string) error {
 		errMsg := fmt.Errorf("%s %s", err, strings.Join(info, " "))


### PR DESCRIPTION
### Description

* Adds trigger to Files table so we can track CID additions + deletes.
* Consumers have a cursor for polling each peer
* Polls on a 20 - 40 second interval, takes ~1s per poll on staging.

TODO:

* [x] initial backfill of `cid_log` table is commented out for now because it's expensive... need to add migration mechanism to only run it once.