### PR TITLE
Validate to show playlist library in non-v1 /users endpoint

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -102,6 +102,7 @@ def get_users_route():
     def validate_hidden_fields(user, current_user_id):
         if "playlist_library" in user and (not current_user_id or current_user_id != user["user_id"]):
             del user["playlist_library"]
+        return user
 
     users = list(map(lambda user: validate_hidden_fields(user, current_user_id), users))
     return api_helpers.success_response(users)

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -98,6 +98,12 @@ def get_users_route():
     current_user_id = get_current_user_id(required=False)
     args["current_user_id"] = current_user_id
     users = get_users(args)
+
+    def validate_hidden_fields(user, current_user_id):
+        if "playlist_library" in user and (not current_user_id or current_user_id != user["user_id"]):
+            del user["playlist_library"]
+
+    users = list(map(validate_hidden_fields, users))
     return api_helpers.success_response(users)
 
 

--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -103,7 +103,7 @@ def get_users_route():
         if "playlist_library" in user and (not current_user_id or current_user_id != user["user_id"]):
             del user["playlist_library"]
 
-    users = list(map(validate_hidden_fields, users))
+    users = list(map(lambda user: validate_hidden_fields(user, current_user_id), users))
     return api_helpers.success_response(users)
 
 


### PR DESCRIPTION
### Description
v1/users already does this. Don't show anyone's playlist libraries except your own.

### Tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->