### PR TITLE
Revert "[PAY-1166] Make SDK respect DN override (sdk-side) (#5124)"

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -39,11 +39,6 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   private selectedNode: string | null
 
   /**
-   * Manual override endpoint
-   */
-  private overrideEndpoint: string | null
-
-  /**
    * Configuration passed in by consumer (with defaults)
    */
   private config: DiscoveryNodeSelectorServiceConfigInternal
@@ -119,7 +114,6 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
       !this.config.blocklist?.has(this.config.initialSelectedNode)
         ? this.config.initialSelectedNode
         : null
-    this.overrideEndpoint = this.config.overrideEndpoint
     this.eventEmitter =
       new EventEmitter() as TypedEventEmitter<ServiceSelectionEvents>
     this.addEventListener = this.eventEmitter.addListener.bind(
@@ -226,13 +220,10 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
   }
 
   /**
-   * Selects a discovery node, or returns the existing selection or override endpoint
+   * Selects a discovery node or returns the existing selection
    * @returns a discovery node endpoint
    */
   public async getSelectedEndpoint() {
-    if (this.overrideEndpoint) {
-      return this.overrideEndpoint
-    }
     if (this.selectedNode !== null) {
       return this.selectedNode
     }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/constants.ts
@@ -20,6 +20,5 @@ export const defaultDiscoveryNodeSelectorConfig: DiscoveryNodeSelectorServiceCon
       maxSlotDiffPlays: null,
       maxBlockDiff: 15
     },
-    bootstrapServices: productionConfig.discoveryNodes,
-    overrideEndpoint: null
+    bootstrapServices: productionConfig.discoveryNodes
   }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
@@ -74,10 +74,6 @@ export type DiscoveryNodeSelectorServiceConfigInternal = {
    * @example ['https://discoverynode.audius.co', 'https://disoverynode2.audius.co']
    */
   bootstrapServices: string[]
-  /**
-   * Manual override endpoint
-   */
-  overrideEndpoint: string | null
 }
 
 export type DiscoveryNodeSelectorServiceConfig =


### PR DESCRIPTION
This reverts commit 65e2b2662d3c618ef6b2d1e064fc328ea5e55060.

Turns out there was already a way to configure an `initialSelectedNode` in the sdk so these changes were unnecessary.

### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->


### Tests
Tested on local web stage with linked libs.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->