### PR TITLE
[PAY-1120] Filter tips to Audius account from the /tips API

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_tips.py
+++ b/discovery-provider/integration_tests/queries/test_get_tips.py
@@ -1,0 +1,65 @@
+import logging
+
+import pytest
+from integration_tests.utils import populate_mock_db
+from src.queries.get_tips import get_tips, GetTipsArgs
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def test_entities():
+    return {
+        "users": [
+            {"user_id": 1, "handle": "user1"},
+            {"user_id": 2, "handle": "user2"},
+            {"user_id": 3, "handle": "DontShowMyTips"},
+        ],
+        "follows": [
+            {"follower_user_id": 1, "followee_user_id": 2},
+            {"follower_user_id": 1, "followee_user_id": 3},
+        ],
+        "user_tips": [
+            {
+                "slot": 0,
+                "signature": "abcdefg",
+                "sender_user_id": 1,
+                "receiver_user_id": 2,
+                "amount": 100000000,
+            },
+            {
+                "slot": 1,
+                "signature": "abcdefg",
+                "sender_user_id": 1,
+                "receiver_user_id": 3,
+                "amount": 100000000,
+            },
+        ],
+        "aggregate_user_tips": [
+            {"sender_user_id": 1, "receiver_user_id": 2, "amount": 100000000},
+            {"sender_user_id": 1, "receiver_user_id": 3, "amount": 100000000},
+        ],
+    }
+
+
+def test_exclude_receivers_from_query(app, test_entities):
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, test_entities)
+        with db.scoped_session():
+            tips = get_tips(
+                GetTipsArgs(
+                    user_id=1,
+                    current_user_follows=True,
+                    unique_by="receiver",
+                    exclude_recipients=[3],
+                    limit=1,
+                    offset=0,
+                )
+            )
+
+            assert len(tips) == 1
+            tip = tips[0]
+            assert tip["sender"] == 1
+            assert tip["receiver"] == 2

--- a/discovery-provider/src/api/v1/tips.py
+++ b/discovery-provider/src/api/v1/tips.py
@@ -1,4 +1,3 @@
-import os
 from flask_restx import Namespace, Resource, fields
 from src.api.v1.helpers import (
     abort_bad_request_param,
@@ -11,6 +10,7 @@ from src.api.v1.helpers import (
 )
 from src.api.v1.models.tips import tip_model, tip_model_full
 from src.queries.get_tips import get_tips
+from src.utils.config import shared_config
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
@@ -19,8 +19,7 @@ full_ns = Namespace("tips", description="Full tip related operations")
 
 
 TIPS_EXCLUDED_RECIPIENTS: list[int] = []
-
-env = os.getenv("audius_discprov_env")
+env = shared_config["discprov"]["env"]
 if env == "stage" or env == "dev":
     TIPS_EXCLUDED_RECIPIENTS = [12]
 else:

--- a/discovery-provider/src/api/v1/tips.py
+++ b/discovery-provider/src/api/v1/tips.py
@@ -16,6 +16,10 @@ from src.utils.redis_metrics import record_metrics
 ns = Namespace("tips", description="Tip related operations")
 full_ns = Namespace("tips", description="Full tip related operations")
 
+TIPS_EXCLUDED_RECIPIENTS: list[int] = (
+    51  # Audius account
+)
+
 
 tips_parser = pagination_with_current_user_parser.copy()
 tips_parser.add_argument(
@@ -74,6 +78,7 @@ class Tips(Resource):
                 "current_user_follows. Missing user_id",
                 full_ns,
             )
+        args["exclude_recipients"] = TIPS_EXCLUDED_RECIPIENTS
 
         tips = get_tips(args)
         tips = list(map(extend_tip, tips))

--- a/discovery-provider/src/api/v1/tips.py
+++ b/discovery-provider/src/api/v1/tips.py
@@ -1,3 +1,4 @@
+import os
 from flask_restx import Namespace, Resource, fields
 from src.api.v1.helpers import (
     abort_bad_request_param,
@@ -16,9 +17,14 @@ from src.utils.redis_metrics import record_metrics
 ns = Namespace("tips", description="Tip related operations")
 full_ns = Namespace("tips", description="Full tip related operations")
 
-TIPS_EXCLUDED_RECIPIENTS: list[int] = (
-    51  # Audius account
-)
+
+TIPS_EXCLUDED_RECIPIENTS: list[int] = []
+
+env = os.getenv("audius_discprov_env")
+if env == "stage" or env == "dev":
+    TIPS_EXCLUDED_RECIPIENTS = [12]
+else:
+    TIPS_EXCLUDED_RECIPIENTS = [51]  # Audius account
 
 
 tips_parser = pagination_with_current_user_parser.copy()

--- a/discovery-provider/src/queries/get_tips.py
+++ b/discovery-provider/src/queries/get_tips.py
@@ -144,6 +144,8 @@ def _get_tips(session: Session, args: GetTipsArgs):
     query: Query = session.query(UserTipAlias)
     has_pagination = False  # Keeps track if we already paginated
 
+    query = query.filter(UserTipAlias.receiver_user_id == 51)
+
     if args.get("tx_signatures"):
         query = query.filter(UserTipAlias.signature.in_(args["tx_signatures"]))
     if args.get("receiver_min_followers", 0) > 0:

--- a/discovery-provider/src/queries/get_tips.py
+++ b/discovery-provider/src/queries/get_tips.py
@@ -28,6 +28,7 @@ class GetTipsArgs(TypedDict):
     min_slot: int
     max_slot: int
     tx_signatures: List[int]
+    exclude_recipients: List[int]
 
 
 class TipResult(TypedDict):
@@ -144,7 +145,8 @@ def _get_tips(session: Session, args: GetTipsArgs):
     query: Query = session.query(UserTipAlias)
     has_pagination = False  # Keeps track if we already paginated
 
-    query = query.filter(UserTipAlias.receiver_user_id == 51)
+    if args.get("exclude_recipients"):
+        query = query.filter(UserTipAlias.receiver_user_id.notin_(args["exclude_recipients"]))
 
     if args.get("tx_signatures"):
         query = query.filter(UserTipAlias.signature.in_(args["tx_signatures"]))


### PR DESCRIPTION
### Description
This PR updates the `get_tips` query to support filtering out a list of recipient ids and adds a constant list of excluded recipients to the `tips` api (currently containing only the Audius account).

Also added a test file to verify the new behavior and updated the return type of `get_tips()`, since the resulting list has a `User` object in the `sender` and `receiver` fields (not just a user_id).

I'm definitely open to suggestions on better ways to do this. At this point, the plumbing is almost there to allow a list of exclusions through query parameters. But I think we wanted the API to just filter out accounts by default instead of requiring clients to do it.

### Tests
* Added `integration_tests/queries/test_get_tips.py`, contains one test to verify the with/without behavior of the new filter

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Verify tips API continues to work correctly in staging/prod. And in prod, verify that the tips API excludes the Audius account (most easily tested with users who aren't following many artists)

There is also a chance that adding the filter by default will increase the baseline latency of the `/tips` endpoint, so we should verify request latency doesn't increase by an unreasonable amount.