### PR TITLE
[PAY-1120] Apply recipient filtering to full tips api

### DIFF
--- a/discovery-provider/src/api/v1/tips.py
+++ b/discovery-provider/src/api/v1/tips.py
@@ -136,6 +136,7 @@ class FullTips(Resource):
                 "current_user_follows. Missing user_id",
                 full_ns,
             )
+        args["exclude_recipients"] = TIPS_EXCLUDED_RECIPIENTS
 
         tips = get_tips(args)
         tips = list(map(extend_tip, tips))


### PR DESCRIPTION
### Description
Follow-up from #5156 . I forgot to add the recipient list to the `full` version of the API. So it wouldn't have the intended effect in the client.
