### PR TITLE
[CON-661] mediorum enforces signature on cidstream endpoint

### DIFF
--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -44,6 +44,7 @@ func (p *PeerClient) Send(data []byte) bool {
 	case p.outbox <- data:
 		return true
 	default:
+		p.logger.Info("outbox full, dropping message", "msg", string(data), "len", len(p.outbox), "cap", cap(p.outbox))
 		return false
 	}
 }

--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -58,7 +58,7 @@ func (p *PeerClient) startSender() {
 		resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(data))
 		if err != nil {
 			log.Println("push failed", "host", p.Host, "err", err)
-			return
+			continue
 		}
 
 		if resp.StatusCode != 200 {

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -12,13 +12,16 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-func main() {
+func init() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout))
 	slog.SetDefault(logger)
+}
 
-	preset := os.Getenv("MEDIORUM_ENV")
+func main() {
+	mediorumEnv := os.Getenv("MEDIORUM_ENV")
+	slog.Info("starting", "MEDIORUM_ENV", mediorumEnv)
 
-	switch preset {
+	switch mediorumEnv {
 	case "prod":
 		startStagingOrProd(true)
 	case "stage":
@@ -39,6 +42,7 @@ func startStagingOrProd(isProd bool) {
 	if err != nil {
 		panic(err)
 	}
+	slog.Info("fetched peers", "count", len(peers))
 
 	creatorNodeEndpoint := mustGetenv("creatorNodeEndpoint")
 	delegateOwnerWallet := mustGetenv("delegateOwnerWallet")

--- a/mediorum/server/serve_status.go
+++ b/mediorum/server/serve_status.go
@@ -29,3 +29,10 @@ func (ss *MediorumServer) dumpUploads(c echo.Context) error {
 	ss.crud.DB.Unscoped().Order("id").Find(&uploads)
 	return c.JSON(200, uploads)
 }
+
+func (ss *MediorumServer) debugPeers(c echo.Context) error {
+	return c.JSON(200, map[string]interface{}{
+		"peers":   ss.Config.Peers,
+		"signers": ss.Config.Signers,
+	})
+}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -194,6 +194,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/debug/blobs", ss.dumpBlobs)
 	routes.GET("/debug/uploads", ss.dumpUploads)
 	routes.GET("/debug/ls", ss.getLs)
+	routes.GET("/debug/peers", ss.debugPeers)
 
 	// legacy:
 	routes.GET("/cid/:cid", ss.serveLegacyCid)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -186,7 +186,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/content/:cid", ss.getBlob)
 	routes.GET("/ipfs/:jobID/:variant", ss.getV1CIDBlob)
 	routes.GET("/content/:jobID/:variant", ss.getV1CIDBlob)
-	routes.GET("/tracks/cidstream/:cid", ss.getBlob) // TODO: Log listen, check delisted status, respect cache in payload, and use `signature` queryparam for premium content
+	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireSignature) // TODO: Log listen, check delisted status, respect cache in payload, and use `signature` queryparam for premium content
 
 	// status + debug:
 	routes.GET("/status", ss.getStatus)
@@ -216,7 +216,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	internalApi.GET("/blobs/problems", ss.getBlobProblems)
 	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation)
 	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo)
-	internalApi.GET("/blobs/:cid", ss.getBlob)
 	internalApi.POST("/blobs", ss.postBlob, middleware.BasicAuth(ss.checkBasicAuth))
 
 	// WIP internal: metrics
@@ -235,7 +234,6 @@ func (ss *MediorumServer) MustStart() {
 
 	// start server
 	go func() {
-
 		err := ss.echo.Start(":" + ss.Config.ListenPort)
 		if err != nil && err != http.ErrServerClosed {
 			panic(err)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -37,6 +37,7 @@ type MediorumConfig struct {
 	Env               string
 	Self              Peer
 	Peers             []Peer
+	Signers           []Peer
 	ReplicationFactor int
 	Dir               string `default:"/tmp/mediorum"`
 	BlobStoreDSN      string `json:"-"`

--- a/mediorum/server/uis/upload.html
+++ b/mediorum/server/uis/upload.html
@@ -61,7 +61,7 @@
       connectedCallback() {
         super.connectedCallback();
         this.doPoll();
-        setInterval(this.doPoll.bind(this), 1000);
+        setInterval(this.doPoll.bind(this), 10000);
       }
 
       doPoll() {
@@ -264,9 +264,7 @@
           @mouseenter=${this._show}
           @mouseleave=${this._hide}
         >
-          <a href=${"/internal/blobs/" + this.key} target="_blank">
-            ${this.label}
-          </a>
+          <a href=${"/content/" + this.key} target="_blank"> ${this.label} </a>
           ${this.isOpen ? this.detailPanel : null}
         </div>`;
       }

--- a/mediorum/server/version.go
+++ b/mediorum/server/version.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"log"
 	"runtime/debug"
+
+	"golang.org/x/exp/slog"
 )
 
 var (
@@ -25,5 +26,5 @@ func init() {
 		}
 	}
 
-	log.Printf("MEDIORUM revision=%s built_at=%s dirty=%s", vcsRevision, vcsBuildTime, vcsDirty)
+	slog.Info("MEDIORUM", "revision", vcsRevision, "built", vcsBuildTime, "wip", vcsDirty)
 }


### PR DESCRIPTION
### Description

Adds a middleware function to `cidstream` route to enforce signatures.

This is fine for now... at some future point we'll want to prevent accessing an mp3 via `/ipfs/` or `/content/` routes.

I think an okay solution would be to look at the mimetype + route and not stream result if mimetype = mp3 and route = ipfs or content...  This would work for both v0 and v1 CIDs without requiring extra lookups and whatnot.