### PR TITLE
[CON-660] Set duration metadata property on v2 track uploads

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -76,4 +76,10 @@ commit;
 -- 4/18/23: add is_available index
 begin;
     create index if not exists users_is_available_false_idx on users (is_available) where is_available = false;
-commit;  
+commit;
+
+-- 4/25/23: add duration to tracks table
+begin;
+    alter table tracks
+    add column if not exists duration integer default 0;
+commit;

--- a/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/TrackIndexer.ts
@@ -167,7 +167,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
     row.tag_list = splitTags(row.tags)
     row.repost_count = row.reposted_by.length
     row.favorite_count = row.saved_by.length
-    row.duration = Math.ceil(
+    row.duration = row.duration || Math.ceil(
       row.track_segments.reduce((acc, s) => acc + parseFloat(s.duration), 0)
     )
     row.length = row.duration

--- a/discovery-provider/integration_tests/tasks/test_index_helper.py
+++ b/discovery-provider/integration_tests/tasks/test_index_helper.py
@@ -135,6 +135,7 @@ def test_fetch_cid_metadata(app, mocker):
                 "owner_id": 1,
                 "title": "track 1",
                 "route_id": None,
+                "duration": 0,
                 "length": 0,
                 "cover_art": None,
                 "cover_art_sizes": "QmdxhDiRUC3zQEKqwnqksaSsSSeHiRghjwKzwoRvm77yaZ",

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -224,11 +224,11 @@ def extend_track(track):
 
     # TODO: This block is only for legacy tracks that have track_segments instead of duration. Remove after storage v2 uploads are rolled out
     if not track["duration"]:
-      duration = 0.0
-      for segment in track["track_segments"]:
-          # NOTE: Legacy track segments store the duration as a string
-          duration += float(segment["duration"])
-      track["duration"] = round(duration)
+        duration = 0.0
+        for segment in track["track_segments"]:
+            # NOTE: Legacy track segments store the duration as a string
+            duration += float(segment["duration"])
+        track["duration"] = round(duration)
 
     downloadable = (
         "download" in track

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -222,11 +222,13 @@ def extend_track(track):
         "is_deactivated"
     )
 
-    duration = 0.0
-    for segment in track["track_segments"]:
-        # NOTE: Legacy track segments store the duration as a string
-        duration += float(segment["duration"])
-    track["duration"] = round(duration)
+    # TODO: This block is only for legacy tracks that have track_segments instead of duration. Remove after storage v2 uploads are rolled out
+    if not track["duration"]:
+      duration = 0.0
+      for segment in track["track_segments"]:
+          # NOTE: Legacy track segments store the duration as a string
+          duration += float(segment["duration"])
+      track["duration"] = round(duration)
 
     downloadable = (
         "download" in track

--- a/discovery-provider/src/models/tracks/track.py
+++ b/discovery-provider/src/models/tracks/track.py
@@ -34,6 +34,7 @@ class Track(Base, RepresentableMixin):
         String, index=True
     )  # todo: after backfill, add nullable=False, both here and in a db migration
     title = Column(Text)
+    duration = Column(Integer)
     length = Column(Integer)
     cover_art = Column(String)
     tags = Column(String)

--- a/discovery-provider/src/schemas/track_schema.json
+++ b/discovery-provider/src/schemas/track_schema.json
@@ -11,6 +11,10 @@
                     "type": "string",
                     "default": null
                 },
+                "duration": {
+                  "type": "integer",
+                  "default": 0
+                },
                 "length": {
                     "type": [
                         "integer",

--- a/discovery-provider/src/tasks/entity_manager/track.py
+++ b/discovery-provider/src/tasks/entity_manager/track.py
@@ -156,6 +156,7 @@ def is_valid_json_field(metadata, field):
 def populate_track_record_metadata(track_record, track_metadata, handle):
     track_record.track_cid = track_metadata["track_cid"]
     track_record.title = track_metadata["title"]
+    track_record.duration = track_metadata.get("duration", 0) or 0
     track_record.length = track_metadata.get("length", 0) or 0
     track_record.cover_art = track_metadata["cover_art"]
     if track_metadata["cover_art_sizes"]:

--- a/discovery-provider/src/tasks/metadata.py
+++ b/discovery-provider/src/tasks/metadata.py
@@ -41,6 +41,7 @@ class TrackMetadata(TypedDict):
     owner_id: Optional[int]
     title: Optional[str]
     route_id: Optional[str]
+    duration: int
     length: int
     cover_art: Optional[str]
     cover_art_sizes: Optional[str]
@@ -71,6 +72,7 @@ track_metadata_format: TrackMetadata = {
     "owner_id": None,
     "title": None,
     "route_id": None,
+    "duration": 0,
     "length": 0,
     "cover_art": None,
     "cover_art_sizes": None,

--- a/libs/src/sdk/services/StorageService/StorageService.ts
+++ b/libs/src/sdk/services/StorageService/StorageService.ts
@@ -57,6 +57,7 @@ export class StorageService {
 
     // Update metadata to include uploaded CIDs
     updatedMetadata.track_segments = []
+    updatedMetadata.duration = parseInt(audioResp.probe.format.duration, 10)
     updatedMetadata.track_cid = audioResp.results['320']
     if (updatedMetadata.download?.is_downloadable) {
       updatedMetadata.download.cid = updatedMetadata.track_cid

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -253,7 +253,6 @@ export class CreatorNode {
   /**
    * Switch from one creatorNodeEndpoint to another including logging out from the old node, updating the endpoint and logging into new node */
   async setEndpoint(creatorNodeEndpoint: string) {
-    console.log('theo calling setEndpoint with endpoint: ', creatorNodeEndpoint)
     // If the endpoints are the same, no-op.
     if (this.creatorNodeEndpoint === creatorNodeEndpoint) return
 
@@ -420,6 +419,7 @@ export class CreatorNode {
 
     // Update metadata to include uploaded CIDs
     updatedMetadata.track_segments = []
+    updatedMetadata.duration = parseInt(audioResp.probe.format.duration, 10)
     updatedMetadata.track_cid = audioResp.results['320']
     if (updatedMetadata.download?.is_downloadable) {
       updatedMetadata.download.cid = updatedMetadata.track_cid


### PR DESCRIPTION
### Description
Makes v2 uploads compute track duration and set it in the track's metadata as `duration`. Legacy uploads instead compute the duration of each track segment in `track_segments`, which clients later sum.

Note that this stores duration as a truncated integer (number of seconds), which I think is a fair tradeoff (ignoring milliseconds, that is). Please comment if you disagree.

### Tests
- Confirmed that existing tracks have "duration" set from the DN `extend_track` function, but they don't set "length" (which is good because that's a hard name to search for in a JS/TS codebase…). See prod track metadata for example: https://discoveryprovider2.audius.co/v1/full/users/handle/micahofficially/tracks
- Verified that "duration" is now set properly for v2 uploads locally and displays correctly on the track page instead of showing "0:00"
  - `audius-compose up -e 1 --no-libs --no-solana` in protocol repo, `npm run build:legacy:browser` in libs, and `npm run web:dev` in client repo
- Verified that v1 uploads still work locally



### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Look for any upload failures in staging. We'll be actively trying v1 and v2 uploads, so we should spot errors pretty quickly.