### PR TITLE
[CON-671] Add mediorum track streaming byte ranges and filename downloads

### DIFF
--- a/discovery-provider/src/queries/get_related_artists.py
+++ b/discovery-provider/src/queries/get_related_artists.py
@@ -26,7 +26,9 @@ def _get_related_artists(session: Session, user_id: int, limit=100, offset=0):
 
 
 @time_method
-def get_related_artists(user_id: int, current_user_id: int, limit: int = 100, offset: int = 0):
+def get_related_artists(
+    user_id: int, current_user_id: int, limit: int = 100, offset: int = 0
+):
     db = get_db_read_replica()
     users = []
     with db.scoped_session() as session:

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"fmt"
+	"io"
 	"mediorum/server/signature"
+	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 )
@@ -59,6 +64,43 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 			return err
 		}
 		defer blob.Close()
+
+		if blob.ContentType() == "audio/mpeg" {
+			fileSize := blob.Size()
+			contentRange := c.Request().Header.Get("Range")
+			if contentRange == "" {
+				contentRange = "bytes=0-"
+			}
+
+			// Calculate ranges for streaming partial content
+			rangeParts := strings.Split(contentRange, "=")[1]
+			rangeVals := strings.Split(rangeParts, "-")
+			start, _ := strconv.ParseInt(rangeVals[0], 10, 64)
+			var end int64
+			if rangeVals[1] != "" {
+				end, _ = strconv.ParseInt(rangeVals[1], 10, 64)
+			} else {
+				end = fileSize - 1
+			}
+			length := end - start + 1
+
+			if start > end || end >= fileSize {
+				return c.String(http.StatusRequestedRangeNotSatisfiable, "Invalid range")
+			}
+
+			_, err = blob.Seek(start, 0)
+			if err != nil {
+				return err
+			}
+
+			c.Response().Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+			c.Response().Header().Set("Content-Length", fmt.Sprintf("%d", length))
+			c.Response().Header().Set("Accept-Ranges", "bytes")
+			c.Response().Header().Set("Content-Type", blob.ContentType())
+
+			return c.Stream(http.StatusPartialContent, blob.ContentType(), io.LimitReader(blob, length))
+		}
+
 		return c.Stream(200, blob.ContentType(), blob)
 	}
 

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/url"
 	"sync"
 	"time"
 
@@ -119,7 +120,14 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 	return c.JSON(200, uploads)
 }
 
-func (ss *MediorumServer) getV1CIDBlob(c echo.Context) error {
+func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
+	// If the client provided a filename, set it in the header to be auto-populated in download prompt
+	filenameForDownload := c.QueryParam("filename")
+	if filenameForDownload != "" {
+		contentDisposition := url.QueryEscape(filenameForDownload)
+		c.Response().Header().Set("Content-Disposition", "attachment; filename="+contentDisposition)
+	}
+
 	jobID := c.Param("jobID")
 	variant := c.Param("variant")
 	if isLegacyCID(jobID) {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -184,8 +184,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	routes.GET("/ipfs/:cid", ss.getBlob)
 	routes.GET("/content/:cid", ss.getBlob)
-	routes.GET("/ipfs/:jobID/:variant", ss.getV1CIDBlob)
-	routes.GET("/content/:jobID/:variant", ss.getV1CIDBlob)
+	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant)
+	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant)
 	routes.GET("/tracks/cidstream/:cid", ss.getBlob) // TODO: Log listen, check delisted status, respect cache in payload, and use `signature` queryparam for premium content
 
 	// status + debug:


### PR DESCRIPTION
### Description
Makes mediorum more closely resemble the NodeJS server when streaming tracks via `/tracks/cidstream/:CID` and when downloading images via `/ipfs/:dirCID/:size`


### Tests
- Seeking now works on mediorum-only uploads (`make pg.bounce && make dev`) and full stack via the Audius web client
- Downloading an image from the /ipfs route with the `filename` queryparam makes the file download with specified name, just like in the existing Content Node. Example: http://localhost:1991/ipfs/23G5DCBU6YD4INJ6BLAHSD2LZGRLSG35/1000x1000.jpg?filename=nameOfDownload.jpg


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
As we rollout to staging, we should be able to seek during track playback, and requests should return 206 instead of 200