### PR TITLE
Lower interval to 10min for availability checks

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -413,11 +413,11 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": timedelta(hours=3),
+                "schedule": timedelta(minutes=30),
             },
             "update_user_is_available": {
                 "task": "update_user_is_available",
-                "schedule": timedelta(hours=3),
+                "schedule": timedelta(minutes=30),
             },
             "index_profile_challenge_backfill": {
                 "task": "index_profile_challenge_backfill",

--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -413,11 +413,11 @@ def configure_celery(celery, test_config=None):
             },
             "update_track_is_available": {
                 "task": "update_track_is_available",
-                "schedule": timedelta(minutes=30),
+                "schedule": timedelta(minutes=10),
             },
             "update_user_is_available": {
                 "task": "update_user_is_available",
-                "schedule": timedelta(minutes=30),
+                "schedule": timedelta(minutes=10),
             },
             "index_profile_challenge_backfill": {
                 "task": "index_profile_challenge_backfill",

--- a/discovery-provider/src/tasks/update_track_is_available.py
+++ b/discovery-provider/src/tasks/update_track_is_available.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 UPDATE_TRACK_IS_AVAILABLE_LOCK = "update_track_is_available_lock"
 
 BATCH_SIZE = 1000
-DEFAULT_LOCK_TIMEOUT_SECONDS = 30  # 30 seconds
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 REQUESTS_TIMEOUT_SECONDS = 300  # 5 minutes
 
 

--- a/discovery-provider/src/tasks/update_user_is_available.py
+++ b/discovery-provider/src/tasks/update_user_is_available.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 UPDATE_USER_IS_AVAILABLE_LOCK = "update_user_is_available_lock"
 
 BATCH_SIZE = 1000
-DEFAULT_LOCK_TIMEOUT_SECONDS = 30  # 30 seconds
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 REQUESTS_TIMEOUT_SECONDS = 300  # 5 minutes
 
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Lower check to 10 min. This will make life much easier in terms of reasoning about availability state in UI vs. in content nodes.
Increase lock timeout so that we don't end up with overlapping jobs.
Existing requests to blacklist/track and blacklist/users are quite fast (sub-second). Even across all 60+ nodes, it is still very fast.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

n/a

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->