### PR TITLE
Send metadata directly through chain

### DIFF
--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -231,8 +231,11 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         or action
                         in [
                             Action.REPOST,
+                            Action.UNREPOST,
                             Action.SAVE,
+                            Action.UNSAVE,
                             Action.FOLLOW,
+                            Action.UNFOLLOW,
                             Action.SUBSCRIBE,
                             Action.UNSUBSCRIBE,
                         ]
@@ -257,7 +260,7 @@ def fetch_cid_metadata(db, entity_manager_txs):
                             # If metadata blob does not contain the required keys, skip
                             if "cid" not in data.keys() or "data" not in data.keys():
                                 logger.info(
-                                    f"index_nethermind.py | required keys missing in metadata {cid}"
+                                    f"index.py | required keys missing in metadata {cid}"
                                 )
                                 continue
                             cid = data["cid"]
@@ -286,11 +289,11 @@ def fetch_cid_metadata(db, entity_manager_txs):
                                 cid_metadata_from_chain[cid] = formatted_json
                         except Exception as e:
                             logger.info(
-                                f"index_nethermind.py | error deserializing metadata {cid}: {e}"
+                                f"index.py | error deserializing metadata {cid}: {e}"
                             )
                         continue
 
-                    logger.info(f"index_nethermind.py | falling back to fetching cid metadata from content nodes for metadata {cid}, event type {event_type}, action {action}, user {user_id}")
+                    logger.info(f"index.py | falling back to fetching cid metadata from content nodes for metadata {cid}, event type {event_type}, action {action}, user {user_id}")
 
                     cids_txhash_set.add((cid, txhash))
                     cid_to_user_id[cid] = user_id

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -230,10 +230,11 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         or event_type == EntityType.USER_REPLICA_SET
                         or action
                         in [
-                            EntityType.REPOST,
-                            EntityType.SAVE,
-                            EntityType.FOLLOW,
-                            EntityType.SUBSCRIPTION,
+                            Action.REPOST,
+                            Action.SAVE,
+                            Action.FOLLOW,
+                            Action.SUBSCRIBE,
+                            Action.UNSUBSCRIBE,
                         ]
                     ):
                         continue
@@ -288,6 +289,8 @@ def fetch_cid_metadata(db, entity_manager_txs):
                                 f"index_nethermind.py | error deserializing metadata {cid}: {e}"
                             )
                         continue
+
+                    logger.info(f"index_nethermind.py | falling back to fetching cid metadata from content nodes for metadata {cid}, event type {event_type}, action {action}, user {user_id}")
 
                     cids_txhash_set.add((cid, txhash))
                     cid_to_user_id[cid] = user_id

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -255,8 +255,11 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         or action
                         in [
                             Action.REPOST,
+                            Action.UNREPOST,
                             Action.SAVE,
+                            Action.UNSAVE,
                             Action.FOLLOW,
+                            Action.UNFOLLOW,
                             Action.SUBSCRIBE,
                             Action.UNSUBSCRIBE,
                         ]

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -254,10 +254,11 @@ def fetch_cid_metadata(db, entity_manager_txs):
                         or event_type == EntityType.USER_REPLICA_SET
                         or action
                         in [
-                            EntityType.REPOST,
-                            EntityType.SAVE,
-                            EntityType.FOLLOW,
-                            EntityType.SUBSCRIPTION,
+                            Action.REPOST,
+                            Action.SAVE,
+                            Action.FOLLOW,
+                            Action.SUBSCRIBE,
+                            Action.UNSUBSCRIBE,
                         ]
                     ):
                         continue

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -307,6 +307,8 @@ def fetch_cid_metadata(db, entity_manager_txs):
                             )
                         continue
 
+                    logger.info(f"index_nethermind.py | falling back to fetching cid metadata from content nodes for metadata {cid}, event type {event_type}, action {action}, user {user_id}")
+
                     cids_txhash_set.add((cid, txhash))
                     cid_to_user_id[cid] = user_id
                     if event_type == EntityType.PLAYLIST:

--- a/libs/src/api/File.ts
+++ b/libs/src/api/File.ts
@@ -266,12 +266,16 @@ export class File extends Base {
    * Uploads an image to the connected Content Node.
    * @param file
    */
-  async uploadImage(file: globalThis.File, square: boolean, timeoutMs = null) {
+  async uploadImage(
+    file: globalThis.File,
+    square: boolean, timeoutMs = null,
+    writeMetadataThroughChain = false
+  ) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.FILE_IS_VALID(file)
 
     // Assign a creator_node_endpoint to the user if necessary
-    await this.User.assignReplicaSetIfNecessary()
+    await this.User.assignReplicaSetIfNecessary(writeMetadataThroughChain)
 
     const resp = await this.creatorNode.uploadImage(
       file,

--- a/libs/src/api/File.ts
+++ b/libs/src/api/File.ts
@@ -268,7 +268,8 @@ export class File extends Base {
    */
   async uploadImage(
     file: globalThis.File,
-    square: boolean, timeoutMs = null,
+    square: boolean,
+    timeoutMs = null,
     writeMetadataThroughChain = false
   ) {
     this.REQUIRES(Services.CREATOR_NODE)

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -736,7 +736,7 @@ export class Track extends Base {
    */
   async updateTrack(
     metadata: TrackMetadata,
-    writeMetadataThroughChain = false,
+    writeMetadataThroughChain = false
   ) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.IS_OBJECT(metadata)

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -587,7 +587,8 @@ export class Track extends Base {
       metadataMultihash,
       metadataFileUUID,
       transcodedTrackCID,
-      transcodedTrackUUID
+      transcodedTrackUUID,
+      metadata: respMetadata
     } = await retry(
       async () => {
         return await this.creatorNode.uploadTrackContent(
@@ -615,7 +616,8 @@ export class Track extends Base {
       metadataMultihash,
       metadataFileUUID,
       transcodedTrackCID,
-      transcodedTrackUUID
+      transcodedTrackUUID,
+      metadata: respMetadata
     }
   }
 

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -247,7 +247,7 @@ export class Track extends Base {
     time: Nullable<string> = null,
     idsArray: Nullable<number[]> = null,
     limit: Nullable<number> = null,
-    offset: Nullable<number> = null,
+    offset: Nullable<number> = null
   ) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
     return await this.discoveryProvider.getTrendingTracks(

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -458,8 +458,8 @@ export class Track extends Base {
     trackFile: File,
     coverArtFile: File,
     metadata: TrackMetadata,
-    writeMetadataThroughChain = false,
-    onProgress: () => void
+    onProgress: () => void,
+    writeMetadataThroughChain = false
   ) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.FILE_IS_VALID(trackFile)

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -323,7 +323,10 @@ export class Users extends Base {
    * Assigns a replica set to the user's metadata and adds new metadata to chain.
    * This creates a record for that user on the connected creator node.
    */
-  async assignReplicaSet({ userId }: { userId: number }) {
+  async assignReplicaSet(
+    { userId }: { userId: number },
+    writeMetadataThroughChain = false
+  ) {
     this.REQUIRES(Services.CREATOR_NODE)
     const phases = {
       CLEAN_AND_VALIDATE_METADATA: 'CLEAN_AND_VALIDATE_METADATA',
@@ -389,7 +392,8 @@ export class Users extends Base {
       phase = phases.UPLOAD_METADATA_AND_UPDATE_ON_CHAIN
       await this.updateAndUploadMetadata({
         newMetadata,
-        userId
+        userId,
+        writeMetadataThroughChain
       })
       console.log(
         `${logPrefix} [phase: ${phase}] updateAndUploadMetadata() completed in ${
@@ -423,7 +427,8 @@ export class Users extends Base {
   async uploadProfileImages(
     profilePictureFile: File,
     coverPhotoFile: File,
-    metadata: UserMetadata
+    metadata: UserMetadata,
+    writeMetadataThroughChain = false
   ) {
     let didMetadataUpdate = false
     if (profilePictureFile) {
@@ -440,7 +445,8 @@ export class Users extends Base {
     if (didMetadataUpdate) {
       await this.updateAndUploadMetadata({
         newMetadata: metadata,
-        userId: metadata.user_id
+        userId: metadata.user_id,
+        writeMetadataThroughChain
       })
     }
 
@@ -476,7 +482,10 @@ export class Users extends Base {
     return metadata
   }
 
-  async createEntityManagerUser({ metadata }: { metadata: UserMetadata }) {
+  async createEntityManagerUser(
+    { metadata }: { metadata: UserMetadata },
+    writeMetadataThroughChain = false
+  ) {
     this.REQUIRES(Services.CREATOR_NODE)
     const phases = {
       CLEAN_AND_VALIDATE_METADATA: 'CLEAN_AND_VALIDATE_METADATA',
@@ -569,7 +578,8 @@ export class Users extends Base {
       phase = phases.UPLOAD_METADATA_AND_UPDATE_ON_CHAIN
       const { blockHash, blockNumber } = await this.updateAndUploadMetadata({
         newMetadata,
-        userId
+        userId,
+        writeMetadataThroughChain
       })
       console.log(
         `${logPrefix} [phase: ${phase}] updateAndUploadMetadata() completed in ${
@@ -845,6 +855,7 @@ export class Users extends Base {
   }: {
     newMetadata: UserMetadata
     userId: number
+    writeMetadataThroughChain?: boolean
   }) {
     this.REQUIRES(Services.CREATOR_NODE, Services.DISCOVERY_PROVIDER)
     this.IS_OBJECT(newMetadata)
@@ -1021,7 +1032,7 @@ export class Users extends Base {
    * If a user's creator_node_endpoint is null, assign a replica set.
    * Used during the sanity check and in uploadImage() in files.js
    */
-  async assignReplicaSetIfNecessary() {
+  async assignReplicaSetIfNecessary(writeMetadataThroughChain = false) {
     const user = this.userStateManager.getCurrentUser()
 
     // If no user is logged in, or a creator node endpoint is already assigned,
@@ -1030,7 +1041,10 @@ export class Users extends Base {
 
     // Generate a replica set and assign to user
     try {
-      await this.assignReplicaSet({ userId: user.user_id })
+      await this.assignReplicaSet(
+        { userId: user.user_id },
+        writeMetadataThroughChain
+      )
     } catch (e) {
       const errorMsg = `assignReplicaSetIfNecessary error - ${e}`
       if (e instanceof Error) {

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -740,7 +740,7 @@ export class Users extends Base {
       EntityManagerClient.EntityType.USER,
       userId,
       EntityManagerClient.Action.UPDATE,
-      metadataMultihash
+      JSON.stringify({ cid: metadataMultihash, data: newMetadata })
     )
     const txReceipt = response.txReceipt
     const latestBlockNumber = txReceipt.blockNumber
@@ -912,7 +912,7 @@ export class Users extends Base {
         EntityManagerClient.EntityType.USER,
         userId,
         EntityManagerClient.Action.UPDATE,
-        metadataMultihash
+        JSON.stringify({ cid: metadataMultihash, data: newMetadata })
       )
       const txReceipt = response.txReceipt
       const blockNumber = txReceipt.blockNumber

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -106,7 +106,8 @@ export class EntityManager extends Base {
   /** Playlist */
 
   async createPlaylist(
-    playlist: PlaylistParam
+    playlist: PlaylistParam,
+    writeMetadataThroughChain = false
   ): Promise<EntityManagerResponse> {
     const responseValues: EntityManagerResponse =
       this.getDefaultEntityManagerResponseValues()
@@ -141,12 +142,15 @@ export class EntityManager extends Base {
 
       const { metadataMultihash } =
         await this.creatorNode.uploadPlaylistMetadata(metadata)
+      const entityManagerMetadata = writeMetadataThroughChain
+        ? JSON.stringify({ cid: metadataMultihash, data: metadata })
+        : metadataMultihash
       return await this.manageEntity({
         userId: userId,
         entityType,
         entityId: playlist.playlist_id,
         action: createAction,
-        metadata: JSON.stringify({ cid: metadataMultihash, data: metadata })
+        metadata: entityManagerMetadata
       })
     } catch (e) {
       const error = (e as Error).message
@@ -179,7 +183,8 @@ export class EntityManager extends Base {
   }
 
   async updatePlaylist(
-    playlist: PlaylistParam
+    playlist: PlaylistParam,
+    writeMetadataThroughChain = false
   ): Promise<EntityManagerResponse> {
     const responseValues: EntityManagerResponse =
       this.getDefaultEntityManagerResponseValues()
@@ -220,12 +225,15 @@ export class EntityManager extends Base {
       }
       const { metadataMultihash } =
         await this.creatorNode.uploadPlaylistMetadata(metadata)
+      const entityManagerMetadata = writeMetadataThroughChain
+        ? JSON.stringify({ cid: metadataMultihash, data: metadata })
+        : metadataMultihash
       return await this.manageEntity({
         userId,
         entityType,
         entityId: playlist.playlist_id,
         action: updateAction,
-        metadata: JSON.stringify({ cid: metadataMultihash, data: metadata })
+        metadata: entityManagerMetadata
       })
     } catch (e) {
       const error = (e as Error).message

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -71,10 +71,7 @@ export class EntityManager extends Base {
   /** Social Features */
   createSocialMethod =
     (entityType: EntityType, action: Action) =>
-    async (
-      entityId: number,
-      metadata: string = ''
-    ): Promise<EntityManagerResponse> => {
+    async (entityId: number, metadata = ''): Promise<EntityManagerResponse> => {
       const responseValues: EntityManagerResponse =
         this.getDefaultEntityManagerResponseValues()
       try {
@@ -83,7 +80,7 @@ export class EntityManager extends Base {
           entityType,
           entityId,
           action,
-          metadataMultihash: metadata
+          metadata
         })
       } catch (e) {
         const error = (e as Error).message
@@ -149,7 +146,7 @@ export class EntityManager extends Base {
         entityType,
         entityId: playlist.playlist_id,
         action: createAction,
-        metadataMultihash
+        metadata: JSON.stringify({ cid: metadataMultihash, data: metadata })
       })
     } catch (e) {
       const error = (e as Error).message
@@ -172,7 +169,7 @@ export class EntityManager extends Base {
         entityType: EntityType.PLAYLIST,
         entityId: playlistId,
         action: Action.DELETE,
-        metadataMultihash: ''
+        metadata: ''
       })
     } catch (e) {
       const error = (e as Error).message
@@ -228,7 +225,7 @@ export class EntityManager extends Base {
         entityType,
         entityId: playlist.playlist_id,
         action: updateAction,
-        metadataMultihash
+        metadata: JSON.stringify({ cid: metadataMultihash, data: metadata })
       })
     } catch (e) {
       const error = (e as Error).message
@@ -246,13 +243,13 @@ export class EntityManager extends Base {
     entityType,
     entityId,
     action,
-    metadataMultihash
+    metadata
   }: {
     userId: number
     entityType: EntityType
     entityId: number
     action: Action
-    metadataMultihash?: string
+    metadata?: string
   }): Promise<EntityManagerResponse> {
     const responseValues: EntityManagerResponse =
       this.getDefaultEntityManagerResponseValues()
@@ -266,7 +263,7 @@ export class EntityManager extends Base {
         entityType,
         entityId,
         action,
-        metadataMultihash ?? ''
+        metadata ?? ''
       )
       responseValues.blockHash = resp.txReceipt.blockHash
       responseValues.blockNumber = resp.txReceipt.blockNumber

--- a/libs/src/sanityChecks/addSecondaries.ts
+++ b/libs/src/sanityChecks/addSecondaries.ts
@@ -5,7 +5,10 @@ import { CreatorNode } from '../services/creatorNode'
  * Add secondary creator nodes for a user if they don't have any
  * Goal: Make it so users always have a replica set
  */
-export const addSecondaries = async (libs: AudiusLibs) => {
+export const addSecondaries = async (
+  libs: AudiusLibs,
+  writeMetadataThroughChain = false
+) => {
   console.debug('Sanity Check - addSecondaries')
   const user = libs.userStateManager?.getCurrentUser()
 
@@ -52,6 +55,10 @@ export const addSecondaries = async (libs: AudiusLibs) => {
     console.debug(
       `Sanity Check - addSecondaries - new nodes ${newMetadata.creator_node_endpoint}`
     )
-    await libs.User?.updateCreator(user.user_id, newMetadata)
+    await libs.User?.updateCreator(
+      user.user_id,
+      newMetadata,
+      writeMetadataThroughChain
+    )
   }
 }

--- a/libs/src/sanityChecks/assignReplicaSetIfNecessary.ts
+++ b/libs/src/sanityChecks/assignReplicaSetIfNecessary.ts
@@ -1,8 +1,11 @@
 import type { AudiusLibs } from '../AudiusLibs'
 
-export const assignReplicaSetIfNecessary = async (libs: AudiusLibs) => {
+export const assignReplicaSetIfNecessary = async (
+  libs: AudiusLibs,
+  writeMetadataThroughChain = false
+) => {
   try {
-    await libs.User?.assignReplicaSetIfNecessary()
+    await libs.User?.assignReplicaSetIfNecessary(writeMetadataThroughChain)
   } catch (e) {
     // If sanity check fails, do not block main thread and log error
     console.error((e as Error).message)

--- a/libs/src/sanityChecks/index.ts
+++ b/libs/src/sanityChecks/index.ts
@@ -9,9 +9,18 @@ import type { Nullable } from '../utils'
 // Checks to run at startup to ensure a user is in a good state.
 export class SanityChecks {
   libs: AudiusLibs
-  options: { skipRollover: boolean }
+  options: {
+    skipRollover: boolean
+    writeMetadataThroughChain: boolean
+  }
 
-  constructor(libsInstance: AudiusLibs, options = { skipRollover: false }) {
+  constructor(
+    libsInstance: AudiusLibs,
+    options = {
+      skipRollover: false,
+      writeMetadataThroughChain: false
+    }
+  ) {
     this.libs = libsInstance
     this.options = options
   }
@@ -23,11 +32,19 @@ export class SanityChecks {
     creatorNodeWhitelist: Nullable<Set<string>> = null,
     creatorNodeBlacklist: Nullable<Set<string>> = null
   ) {
-    await addSecondaries(this.libs)
-    await assignReplicaSetIfNecessary(this.libs)
+    await addSecondaries(this.libs, this.options.writeMetadataThroughChain)
+    await assignReplicaSetIfNecessary(
+      this.libs,
+      this.options.writeMetadataThroughChain
+    )
     await syncNodes(this.libs)
     if (!this.options.skipRollover) {
-      await rolloverNodes(this.libs, creatorNodeWhitelist, creatorNodeBlacklist)
+      await rolloverNodes(
+        this.libs,
+        creatorNodeWhitelist,
+        creatorNodeBlacklist,
+        this.options.writeMetadataThroughChain
+      )
     }
     await needsRecoveryEmail(this.libs)
   }

--- a/libs/src/sanityChecks/rolloverNodes.ts
+++ b/libs/src/sanityChecks/rolloverNodes.ts
@@ -49,7 +49,8 @@ const getNewPrimary = async (secondaries: string[], wallet: string) => {
 export const rolloverNodes = async (
   libs: AudiusLibs,
   creatorNodeWhitelist: Nullable<Set<string>>,
-  creatorNodeBlacklist: Nullable<Set<string>>
+  creatorNodeBlacklist: Nullable<Set<string>>,
+  writeMetadataThroughChain = false
 ) => {
   console.debug('Sanity Check - rolloverNodes')
   const user = libs.userStateManager?.getCurrentUser()
@@ -97,7 +98,11 @@ export const rolloverNodes = async (
     console.debug(
       `Sanity Check - rolloverNodes - new nodes ${newMetadata.creator_node_endpoint}`
     )
-    await libs.User?.updateCreator(user.user_id, newMetadata)
+    await libs.User?.updateCreator(
+      user.user_id,
+      newMetadata,
+      writeMetadataThroughChain
+    )
   } catch (e) {
     console.error(e)
   }

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -390,7 +390,7 @@ export class CreatorNode {
     // Creates new track entity on creator node, making track's metadata available
     // @returns {Object} {cid: CID of track metadata, id: id of track to be used with associate function}
     const metadataResp = await this.uploadTrackMetadata(metadata, sourceFile)
-    return { ...metadataResp, ...trackContentResp }
+    return { ...metadataResp, ...trackContentResp, metadata: { ...metadata } }
   }
 
   async uploadTrackAudioAndCoverArtV2(


### PR DESCRIPTION
### Description
For everything currently uploading metadata and sending the CID through `manageEntity` (track, playlist, and user events except create user).
Log when we fall back to CID route for debugging.
Still upload to content nodes.

### Tests
Deploy to stage, tail logs, edit user, create tracks, create playlists, create albums etc. Make sure all succeed with no fallbacks.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->