### PR TITLE
Make storage v2 work without CNs in audius-compose

### DIFF
--- a/creator-node/sequelize/migrations/20181122035259-create-file.js
+++ b/creator-node/sequelize/migrations/20181122035259-create-file.js
@@ -1,44 +1,20 @@
 'use strict'
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('Files', {
-      id: {
-        allowNull: false,
-        autoIncrement: true,
-        primaryKey: true,
-        type: Sequelize.INTEGER
-      },
-      ownerId: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-        onDelete: 'RESTRICT',
-        references: {
-          model: 'Users',
-          key: 'id',
-          as: 'ownerId'
-        }
-      },
-      multihash: {
-        type: Sequelize.TEXT,
-        allowNull: false
-      },
-      sourceFile: {
-        type: Sequelize.TEXT,
-        allowNull: true // `true` as we use File entries for more than just uploaded tracks
-      },
-      storagePath: {
-        type: Sequelize.TEXT,
-        allowNull: false
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      }
-    })
+    return queryInterface.sequelize.query(
+      `
+      CREATE TABLE IF NOT EXISTS "Files" (
+        "id" SERIAL PRIMARY KEY,
+        "ownerId" INTEGER NOT NULL,
+        "multihash" TEXT NOT NULL,
+        "sourceFile" TEXT,
+        "storagePath" TEXT NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL,
+        "updatedAt" TIMESTAMP NOT NULL,
+        FOREIGN KEY ("ownerId") REFERENCES "Users" ("id") ON DELETE RESTRICT
+      )
+    `
+    )
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.dropTable('Files')

--- a/creator-node/sequelize/migrations/20190711143402-add_uuid_to_users.js
+++ b/creator-node/sequelize/migrations/20190711143402-add_uuid_to_users.js
@@ -34,10 +34,7 @@ async function createColumns (queryInterface, Sequelize, t) {
     unique: true
   }, { transaction: t })
 
-  await queryInterface.addColumn('Files', 'fileUUID', {
-    type: Sequelize.UUID,
-    unique: true
-  }, { transaction: t })
+  await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "fileUUID" UUID UNIQUE`, { transaction: t })
 
   // Run these after, order doesn't matter
 
@@ -93,29 +90,13 @@ async function createColumns (queryInterface, Sequelize, t) {
    * Files
    */
 
-  await queryInterface.addColumn('Files', 'cnodeUserUUID', {
-    type: Sequelize.UUID,
-    onDelete: 'RESTRICT',
-    references: {
-      model: 'Users',
-      key: 'cnodeUserUUID',
-      as: 'cnodeUserUUID'
-    }
-  }, { transaction: t })
-
-  await queryInterface.addColumn('Files', 'trackUUID', {
-    type: Sequelize.UUID,
-    onDelete: 'RESTRICT',
-    references: {
-      model: 'Tracks',
-      key: 'trackUUID',
-      as: 'trackUUID'
-    }
-  }, { transaction: t })
-
-  await queryInterface.addColumn('Files', 'type', {
-    type: Sequelize.STRING(16)
-  }, { transaction: t })
+  await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "cnodeUserUUID" UUID`, { transaction: t });
+  // Below constraint isn't really needed, and these migrations have all run on prod and staging nodes
+  // await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD CONSTRAINT "Files_cnodeUserUUID_fkey" FOREIGN KEY ("cnodeUserUUID") REFERENCES "Users" ("cnodeUserUUID") ON DELETE RESTRICT`, { transaction: t });
+  await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "trackUUID" UUID`, { transaction: t });
+  // Below constraint isn't really needed, and these migrations have all run on prod and staging nodes
+  // await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD CONSTRAINT "Files_trackUUID_fkey" FOREIGN KEY ("trackUUID") REFERENCES "Tracks" ("trackUUID") ON DELETE RESTRICT`, { transaction: t });
+  await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "type" VARCHAR(16)`, { transaction: t });
 
   /**
    * Tracks

--- a/creator-node/sequelize/migrations/20200623002237-add-parent-file-data.js
+++ b/creator-node/sequelize/migrations/20200623002237-add-parent-file-data.js
@@ -9,24 +9,8 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     const transaction = await queryInterface.sequelize.transaction()
     try {
-      await queryInterface.addColumn(
-        'Files',
-        'fileName',
-        {
-          type: Sequelize.TEXT,
-          allowNull: true
-        },
-        { transaction }
-      )
-      await queryInterface.addColumn(
-        'Files',
-        'dirMultihash',
-        {
-          type: Sequelize.TEXT,
-          allowNull: true
-        },
-        { transaction }
-      )
+      await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "fileName" TEXT`, { transaction })
+      await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "dirMultihash" TEXT`, { transaction })
       await queryInterface.addIndex('Files', ['dirMultihash'], { transaction })
 
       // For reference, this is what the values of the columns should be

--- a/creator-node/sequelize/migrations/20200918150546-add-clock.js
+++ b/creator-node/sequelize/migrations/20200918150546-add-clock.js
@@ -43,11 +43,7 @@ async function addClockColumn (queryInterface, Sequelize, transaction) {
     unique: false,
     allowNull: true
   }, { transaction })
-  await queryInterface.addColumn('Files', 'clock', {
-    type: Sequelize.INTEGER,
-    unique: false,
-    allowNull: true
-  }, { transaction })
+  await queryInterface.sequelize.query(`ALTER TABLE "Files" ADD COLUMN IF NOT EXISTS "clock" INTEGER`, { transaction })
 }
 
 async function addCompositeUniqueConstraints (queryInterface, Sequelize, transaction) {

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -403,6 +403,7 @@ def down(protocol_dir):
             "docker",
             "compose",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
+            f"--project-name={protocol_dir.name}",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
             "--profile=*",
             "down",

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -222,7 +222,7 @@ def extend_track(track):
         "is_deactivated"
     )
 
-    # TODO: This block is only for legacy tracks that have track_segments instead of duration. Remove after storage v2 uploads are rolled out
+    # TODO: This block is only for legacy tracks that have track_segments instead of duration
     if not track["duration"]:
         duration = 0.0
         for segment in track["track_segments"]:

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -418,13 +418,16 @@ export class Track extends Base {
       )
 
     // Write metadata to chain
+    const metadataCid = await Utils.fileHasher.generateMetadataCidV1(
+      updatedMetadata
+    )
     const trackId = await this._generateTrackId()
     const response = await this.contracts.EntityManagerClient!.manageEntity(
       ownerId,
       EntityManagerClient.EntityType.TRACK,
       trackId,
       EntityManagerClient.Action.CREATE,
-      JSON.stringify({ cid: updatedMetadata.track_cid, data: updatedMetadata })
+      JSON.stringify({ cid: metadataCid.toString(), data: updatedMetadata })
     )
     const txReceipt = response.txReceipt
 
@@ -736,6 +739,40 @@ export class Track extends Base {
       metadataFileUUID,
       txReceipt.blockNumber
     )
+    return {
+      blockHash: txReceipt.blockHash,
+      blockNumber: txReceipt.blockNumber,
+      trackId
+    }
+  }
+
+  /**
+   * Updates an existing track given metadata using only chain and not creator node.
+   * @param metadata json of the track metadata with all fields, missing fields will error
+   */
+  async updateTrackV2(metadata: TrackMetadata) {
+    this.IS_OBJECT(metadata)
+
+    const ownerId = this.userStateManager.getCurrentUserId()
+
+    if (!ownerId) {
+      throw new Error('No users loaded for this wallet')
+    }
+    metadata.owner_id = ownerId
+    this._validateTrackMetadata(metadata)
+
+    // Write the new metadata to chain
+    const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+    const trackId: number = metadata.track_id
+    const response = await this.contracts.EntityManagerClient!.manageEntity(
+      ownerId,
+      EntityManagerClient.EntityType.TRACK,
+      trackId,
+      EntityManagerClient.Action.UPDATE,
+      JSON.stringify({ cid: metadataCid.toString(), data: metadata })
+    )
+    const txReceipt = response.txReceipt
+
     return {
       blockHash: txReceipt.blockHash,
       blockNumber: txReceipt.blockNumber,

--- a/libs/src/sdk/services/StorageService/StorageService.ts
+++ b/libs/src/sdk/services/StorageService/StorageService.ts
@@ -94,7 +94,7 @@ export class StorageService {
     formData.append('files', isNodeFile(file) ? file.buffer : file, file.name)
     const response = await this._makeRequest({
       method: 'post',
-      url: '/mediorum/uploads',
+      url: '/uploads',
       data: formData,
       headers: {
         'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`
@@ -146,7 +146,7 @@ export class StorageService {
   async getProcessingStatus(id: string) {
     const { data } = await this._makeRequest({
       method: 'get',
-      url: `/mediorum/uploads/${id}`
+      url: `/uploads/${id}`
     })
     return data
   }

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -455,7 +455,7 @@ export class CreatorNode {
     formData.append('files', file, file.name)
     const response = await this._makeRequestV2({
       method: 'post',
-      url: '/mediorum/uploads',
+      url: '/uploads',
       data: formData,
       headers: { 'Content-Type': 'multipart/form-data' },
       onUploadProgress: (progressEvent) =>
@@ -505,7 +505,7 @@ export class CreatorNode {
   async getProcessingStatusV2(id: string) {
     const { data } = await this._makeRequestV2({
       method: 'get',
-      url: `/mediorum/uploads/${id}`
+      url: `/uploads/${id}`
     })
     return data
   }

--- a/mediorum/.initdb/init.sql
+++ b/mediorum/.initdb/init.sql
@@ -1,17 +1,20 @@
-CREATE TABLE public."Files" (
-    multihash text NOT NULL,
+-- Only called through `make` - not used by audius-compose and not compatible with audius-compose
+CREATE TABLE IF NOT EXISTS public."Files" (
+    "id" SERIAL PRIMARY KEY,
+    "ownerId" INTEGER NOT NULL,
+    "multihash" text NOT NULL,
     "sourceFile" text,
     "storagePath" text NOT NULL,
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
-    "fileUUID" uuid NOT NULL,
+    "fileUUID" uuid NOT NULL UNIQUE,
     "cnodeUserUUID" uuid,
-    type character varying(16),
+    "type" character varying(16),
     "fileName" text,
     "dirMultihash" text,
     "trackBlockchainId" integer,
-    clock integer NOT NULL,
-    skipped boolean DEFAULT false NOT NULL
+    "clock" integer NOT NULL,
+    "skipped" boolean DEFAULT false NOT NULL
 );
 
 

--- a/mediorum/cmd/loadtest/client.go
+++ b/mediorum/cmd/loadtest/client.go
@@ -50,7 +50,7 @@ func (tc *TestClient) pingPeer(wg *sync.WaitGroup, peer server.Peer) {
 	defer wg.Done()
 
 	client := &http.Client{Timeout: 1000 * time.Millisecond} // fail fast for heath check
-	res, err := client.Get(fmt.Sprintf("%s%s", peer.Host, "/mediorum/internal/health"))
+	res, err := client.Get(fmt.Sprintf("%s%s", peer.Host, "/internal/health"))
 
 	if err != nil {
 		fmt.Printf("e")

--- a/mediorum/cmd/loadtest/metrics.go
+++ b/mediorum/cmd/loadtest/metrics.go
@@ -24,7 +24,7 @@ func RunM(tc *TestClient) {
 
 		for i, peer := range tc.UpPeers {
 
-			resp, err := tc.HttpClient.Get(fmt.Sprintf("%s/mediorum/internal/metrics", peer.Host))
+			resp, err := tc.HttpClient.Get(fmt.Sprintf("%s/internal/metrics", peer.Host))
 			if err != nil {
 				fmt.Println(err)
 			}

--- a/mediorum/cmd/loadtest/report.go
+++ b/mediorum/cmd/loadtest/report.go
@@ -12,7 +12,7 @@ import (
 
 func (tc *TestClient) problems(wg *sync.WaitGroup, peer *server.Peer) {
 	defer wg.Done()
-	url := fmt.Sprintf("%s%s", peer.Host, "/mediorum/internal/blobs/problems")
+	url := fmt.Sprintf("%s%s", peer.Host, "/internal/blobs/problems")
 	resp, err := tc.HttpClient.Get(url)
 	if err != nil {
 		fmt.Println(err)

--- a/mediorum/cmd/loadtest/upload.go
+++ b/mediorum/cmd/loadtest/upload.go
@@ -55,7 +55,7 @@ func (tc *TestClient) upload(data []byte, filename string) error {
 	}()
 
 	host := tc.UpPeers[rand.Intn(len(tc.UpPeers))].Host
-	url := fmt.Sprintf("%s%s", host, "/mediorum/uploads")
+	url := fmt.Sprintf("%s%s", host, "/uploads")
 
 	req, err := http.NewRequest("POST", url, r)
 	if err != nil {

--- a/mediorum/ddl/cid_lookup.sql
+++ b/mediorum/ddl/cid_lookup.sql
@@ -7,6 +7,25 @@ create table if not exists cid_lookup (
     "host" text
 );
 
+-- creator-node creates the Files table, but we need to create it here in case we're running via audius-compose without CNs
+CREATE TABLE IF NOT EXISTS "Files" (
+    "id" SERIAL PRIMARY KEY,
+    "ownerId" INTEGER NOT NULL,
+    "multihash" text NOT NULL,
+    "sourceFile" text,
+    "storagePath" text NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "fileUUID" uuid NOT NULL UNIQUE,
+    "cnodeUserUUID" uuid,
+    "type" character varying(16),
+    "fileName" text,
+    "dirMultihash" text,
+    -- "trackBlockchainId" integer, -- this is part of the table, but CN migration sets it and breaks if it already exists. initdb/init.sql will create it if running without CNs
+    "clock" integer NOT NULL,
+    "skipped" boolean DEFAULT false NOT NULL
+);
+
 create unique index if not exists "idx_multihash" on cid_lookup("multihash", "host");
 
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -142,6 +142,9 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	echoServer.HideBanner = true
 	echoServer.Debug = true
 
+	// CORS should only be in the `routes` group, but we need it here because /mediorum is rewritten to /
+	echoServer.Use(middleware.CORS())
+
 	// echoServer is the root server
 	// it mostly exists to serve the catch all reverse proxy rule at the end
 	// most routes and middleware should be added to the `routes` group
@@ -170,9 +173,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// routes holds all of our handled routes
 	// and related middleware like CORS
 	routes := echoServer.Group(apiBasePath)
-
-	// Middleware
-	routes.Use(middleware.CORS())
 
 	// public: uis
 	routes.GET("", ss.serveUploadUI)

--- a/monitoring/healthz/src/Mediorum.tsx
+++ b/monitoring/healthz/src/Mediorum.tsx
@@ -31,13 +31,13 @@ export function Mediorum() {
 
 export function MediorumRow({ sp }: { sp: SP }) {
   const { data: deets } = useQuery(
-    [sp.endpoint + '/mediorum/internal/health'],
+    [sp.endpoint + '/internal/health'],
     fetchUrl
   )
   return (
     <tr>
       <td>
-        <a href={sp.endpoint + '/mediorum/internal/health'} target="_blank">
+        <a href={sp.endpoint + '/internal/health'} target="_blank">
           {sp.endpoint}
         </a>
       </td>


### PR DESCRIPTION
### Description
- Gives mediorum a create-if-not-exists query for the Files table so storage v2 can start up via audius-compose without CNs
- Changes CN migrations to have if-not-exists for various Files table alterations so storage v2 can start up _with_ CNs (CN fails on migrations without these changes)
  - Note that this involved changing some sequelize to raw SQL. I could've used the `ifNotExists` property that was added [here](https://github.com/sequelize/sequelize/pull/15119), but our sequelize version is 3 major versions behind the version containing this property
- Unrelated fixes: removes /mediorum usages+route rewrite, adds explicit OPTIONS handler for /upload to fix local CORS error, and fix `audius-compose down` (the directory of docker-compose.yml changed in a previous PR, which changed the project name)


### Tests
Signed up and uploaded through audius-compose with and without CNs:
- With CNs `audius-compose up -e 1 --no-libs --no-solana`
- Without CNs: `audius-compose up -e 1 --no-libs --no-solana -c 0`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Local dev should continue working