### PR TITLE
Fix listen milestone email

### DIFF
--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/milestone.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/milestone.ts
@@ -3,6 +3,7 @@ import { NotificationRow, PlaylistRow, TrackRow, UserRow } from '../../types/dn'
 import {
   AppEmailNotification,
   FollowerMilestoneNotification,
+  ListenCountMilestoneNotifications,
   MilestoneType,
   PlaylistMilestoneNotification,
   TrackMilestoneNotification
@@ -144,7 +145,12 @@ export class Milestone extends BaseNotification<MilestoneRow> {
 
     const title = 'Congratulations! 🎉'
     const body = this.getPushBodyText(entityName, isAlbum)
-    await sendBrowserNotification(userNotificationSettings, this.receiverUserId, title, body)
+    await sendBrowserNotification(
+      userNotificationSettings,
+      this.receiverUserId,
+      title,
+      body
+    )
 
     // If the user has devices to the notification to, proceed
     if (
@@ -255,6 +261,9 @@ export class Milestone extends BaseNotification<MilestoneRow> {
     ) {
       const data = this.notification.data as PlaylistMilestoneNotification
       playlists.add(data.playlist_id)
+    } else if (this.type === MilestoneType.LISTEN_COUNT) {
+      const data = this.notification.data as ListenCountMilestoneNotifications
+      tracks.add(data.track_id)
     }
     return {
       users: new Set([this.receiverUserId]),

--- a/discovery-provider/plugins/notifications/src/types/notifications.ts
+++ b/discovery-provider/plugins/notifications/src/types/notifications.ts
@@ -188,6 +188,13 @@ export type PlaylistMilestoneNotification = {
   threshold: number
 }
 
+export type ListenCountMilestoneNotifications = {
+  type: MilestoneType.LISTEN_COUNT
+  track_id: number
+  threshold: number
+}
+
+
 export type TierChangeNotification = {
   new_tier: string
   new_tier_value: number


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fixes this error

```
Error in renderAndSendNotificationEmail TypeError: Cannot read property 'title' of undefined\n    at Milestone.formatEmailProps (/notifications/src/processNotifications/mappers/milestone.ts:273:21)\n    at /notifications/src/email/notifications
```

Listen milestone email wasn't implemented.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->