### PR TITLE
Create notifs for newly unlisted tracks or newly public playlists

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_playlist.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_playlist.sql
@@ -34,9 +34,13 @@ begin
   end if;
   -- Create playlist notification
   begin
-    if new.created_at = new.updated_at AND 
-    new.is_private = FALSE AND 
-    new.is_delete = FALSE then
+    if new.is_private = FALSE AND 
+    new.is_delete = FALSE AND
+    (
+      new.created_at = new.updated_at OR
+      old_row.is_private = TRUE
+    )
+    then
       select array(
         select subscriber_id 
           from subscriptions 


### PR DESCRIPTION
### Description
This wasn't accounted for

### Tests
Deploy to stage, verify create notifs created when marking a track as unlisted -> listed and a playlist as private -> public.
Verify normal create path still works.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->