### PR TITLE
[CON-674] Make track edit work for storage v2

### DIFF
--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -418,13 +418,16 @@ export class Track extends Base {
       )
 
     // Write metadata to chain
+    const metadataCid = await Utils.fileHasher.generateMetadataCidV1(
+      updatedMetadata
+    )
     const trackId = await this._generateTrackId()
     const response = await this.contracts.EntityManagerClient!.manageEntity(
       ownerId,
       EntityManagerClient.EntityType.TRACK,
       trackId,
       EntityManagerClient.Action.CREATE,
-      JSON.stringify({ cid: updatedMetadata.track_cid, data: updatedMetadata })
+      JSON.stringify({ cid: metadataCid.toString(), data: updatedMetadata })
     )
     const txReceipt = response.txReceipt
 
@@ -736,6 +739,40 @@ export class Track extends Base {
       metadataFileUUID,
       txReceipt.blockNumber
     )
+    return {
+      blockHash: txReceipt.blockHash,
+      blockNumber: txReceipt.blockNumber,
+      trackId
+    }
+  }
+
+  /**
+   * Updates an existing track given metadata using only chain and not creator node.
+   * @param metadata json of the track metadata with all fields, missing fields will error
+   */
+  async updateTrackV2(metadata: TrackMetadata) {
+    this.IS_OBJECT(metadata)
+
+    const ownerId = this.userStateManager.getCurrentUserId()
+
+    if (!ownerId) {
+      throw new Error('No users loaded for this wallet')
+    }
+    metadata.owner_id = ownerId
+    this._validateTrackMetadata(metadata)
+
+    // Write the new metadata to chain
+    const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+    const trackId: number = metadata.track_id
+    const response = await this.contracts.EntityManagerClient!.manageEntity(
+      ownerId,
+      EntityManagerClient.EntityType.TRACK,
+      trackId,
+      EntityManagerClient.Action.UPDATE,
+      JSON.stringify({ cid: metadataCid.toString(), data: metadata })
+    )
+    const txReceipt = response.txReceipt
+
     return {
       blockHash: txReceipt.blockHash,
       blockNumber: txReceipt.blockNumber,


### PR DESCRIPTION
### Description
- Makes track update/edit work for tracks uploaded via storage v2 flow - doesn't write metadata to CN
- Makes track upload use CID of metadata instead of CID of track


### Tests
Edit a track - separately for hidden->public, name, and cover art


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Only affects v2 tracks, so ensure track edit works on staging after these code changes are released in libs