### PR TITLE
Maybe fix wrong CircleCI images being auto-deployed

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -216,6 +216,7 @@ def build(
             "compose",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
+            f"--project-name={protocol_dir.name}",
             "--profile=*",
             "build",
             *args,


### PR DESCRIPTION
### Description
My guess at the problem:
- Building the image [here](https://github.com/AudiusProject/audius-protocol/blob/main/dev-tools/audius-compose#L213) (triggered by circleci [here](https://github.com/AudiusProject/audius-protocol/blob/main/.circleci/jobs/build-gcp-image.yml#L41)) uses <default_project_name>-<service-name>. Ex: "compose-discovery-provider" because the docker-compose.yml file is in the "compose" directory
- Pushing the image [here](https://github.com/AudiusProject/audius-protocol/blob/main/dev-tools/audius-compose#L251) (triggered by circleci [here](https://github.com/AudiusProject/audius-protocol/blob/main/.circleci/jobs/push-docker-image.yml#L46)) uses <protocol_dir>-<service_name>. Ex: "audius-protocol-discovery-provider)

Solution if this is in fact the problem (lmk what you all think):
- Make build use "audius-protocol" for the project name again



### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->