### PR TITLE
Fix browser push when user doesn't have browsers

### DIFF
--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/userNotificationSettings.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/userNotificationSettings.ts
@@ -439,7 +439,7 @@ export class UserNotificationSettings {
   async getUserNotificationBrowsers(userId: number): Promise<WebPush[]> {
     if (!globalThis.webPushIsConfigured) return []
     const settings = await this.getUserBrowserSettings([userId])
-    const browsers = settings[userId].browser
+    const browsers = settings[userId]?.browser ?? []
 
     const isWebPush = (browser: Browser): boolean => {
       return (browser as WebPush).p256dhKey !== undefined


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
This would throw an error when user doesn't have browsers

```
{"level":50,"time":"2023-05-01T19:02:13.095Z","name":"notifications","msg":"Error in sending Push API browser notifications TypeError: Cannot read property 'browser' of undefined"}
```
### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested in testing environment.
### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->