### PR TITLE
[CON-681] Reconcile storage v2 ffmpeg differences

### DIFF
--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -249,10 +249,12 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 		cmd := exec.Command("ffmpeg",
 			"-y",
 			"-i", srcPath,
-			"-b:a", "320k",
-			"-f", "mp3",
-			"-metadata", "fileName="+upload.OrigFileName,
-			"-metadata", "uuid="+upload.ID,
+			"-b:a", "320k", // set bitrate to 320k
+			"-ar", "48000", // set sample rate to 48000 Hz
+			"-f", "mp3", // force output to mp3
+			"-metadata", fmt.Sprintf(`fileName="%s"`, upload.OrigFileName),
+			"-metadata", fmt.Sprintf(`uuid="%s"`, upload.ID), // make each upload unique so artists can re-upload same file with different CID if it gets delisted
+			"-vn", // no video
 			"-progress", "pipe:2",
 			destPath)
 


### PR DESCRIPTION
### Description
Makes ffmpeg in storage v2 more closely match v1. The only difference now is that v2 forces the output to mp3 and pipes output, which I think are both desired. [V1 command](https://github.com/AudiusProject/audius-protocol/blob/main/creator-node/src/ffmpeg.ts#L155-L164) vs [V2 command](https://github.com/AudiusProject/audius-protocol/compare/theo-reconcile-ffmpeg?expand=1#diff-0c98ca7458ea2ac5dec8b58db13fb093d2dfad8e20047ff31aa94f0be2404521R249-R259)


### Tests
Uploaded and played back a transcoded track


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
V2 uploads on staging should continue working