### PR TITLE
Fix milestone save / repost data id

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_repost.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_repost.sql
@@ -69,7 +69,7 @@ begin
         'milestone:' || milestone_name  || ':id:' || new.repost_item_id || ':threshold:' || milestone,
         new.blocknumber,
         new.created_at,
-        json_build_object('type', milestone_name, 'threshold', milestone)
+        json_build_object('type', milestone_name, new.repost_type::text || '_id', new.repost_item_id, 'threshold', milestone)
       )
       on conflict do nothing;
   end if;

--- a/discovery-provider/alembic/trigger_sql/handle_save.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_save.sql
@@ -79,7 +79,7 @@ begin
         'milestone:' || milestone_name  || ':id:' || new.save_item_id || ':threshold:' || milestone,
         new.blocknumber,
         new.created_at,
-        json_build_object('type', milestone_name, 'threshold', milestone)
+        json_build_object('type', milestone_name, new.save_type::text || '_id', new.save_item_id, 'threshold', milestone)
       )
       on conflict do nothing;
   end if;

--- a/discovery-provider/integration_tests/queries/test_notifications/test_repost_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_repost_notification.py
@@ -79,7 +79,7 @@ def test_get_repost_notifications(app):
                 == "PLAYLIST_REPOST_COUNT"
             )
             assert (
-                u1_notifications[2]["actions"][0]["data"]["type"]
-                == "PLAYLIST_REPOST_COUNT"
+                u1_notifications[2]["actions"][0]["data"]["playlist_id"]
+                == 1
             )
             assert u1_notifications[2]["actions"][0]["data"]["threshold"] == 10

--- a/discovery-provider/integration_tests/queries/test_notifications/test_save_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_save_notification.py
@@ -57,10 +57,7 @@ def test_get_save_notifications(app):
                 u1_notifications[1]["actions"][0]["data"]["type"]
                 == "PLAYLIST_SAVE_COUNT"
             )
-            assert (
-                u1_notifications[1]["actions"][0]["data"]["type"]
-                == "PLAYLIST_SAVE_COUNT"
-            )
+            assert u1_notifications[1]["actions"][0]["playlist_id"] == 1
             assert u1_notifications[1]["actions"][0]["data"]["threshold"] == 10
 
             assert u1_notifications[2]["group_id"] == "save:1:type:track"


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Save and repost milestone emails weren't working because the notification data didn't have item IDs.

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Tested on stage.

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->