### PR TITLE
[PLAT-963] plugin should not send emails if no valid notifs available

### DIFF
--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/supporterDethroned.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/supporterDethroned.test.ts
@@ -1,6 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 import { Processor } from '../../main'
 import * as sns from '../../sns'
+import * as sendEmailFns from '../../email/notifications/sendEmail'
 
 import {
   createUsers,
@@ -18,6 +19,10 @@ describe('Supporter Dethroned Notification', () => {
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')
     .mockImplementation(() => Promise.resolve())
+
+  const sendEmailNotificationSpy = jest
+    .spyOn(sendEmailFns, 'sendNotificationEmail')
+    .mockImplementation(() => Promise.resolve(true))
 
   beforeEach(async () => {
     const setup = await setupTest()
@@ -81,5 +86,6 @@ describe('Supporter Dethroned Notification', () => {
         }
       }
     )
+    expect(sendEmailNotificationSpy).not.toHaveBeenCalled()
   })
 })

--- a/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
@@ -324,14 +324,6 @@ const getEmailSubject = (
   return subject
 }
 
-// Set of notifications that we do NOT send out emails for
-// NOTE: This is to match parity with what identity does
-const notificationsWithoutEmail = new Set([
-  'supporter_dethroned',
-  'tier_change',
-  'tip_send'
-])
-
 // Master function to render and send email for a given userId
 export const renderEmail = async ({
   userId,
@@ -346,14 +338,12 @@ export const renderEmail = async ({
     `renderAndSendNotificationEmail | ${userId}, ${email}, ${frequency}`
   )
 
-  const validNotifications = notifications.filter(
-    (n) => !notificationsWithoutEmail.has(n.type)
-  )
-  const notificationCount = validNotifications.length
+  const notificationCount = notifications.length
+
   // Get first 5 distinct notifications
   const notificationsToSend: EmailNotification[] = []
   const groupedNotifications: { [id: string]: AppEmailNotification[] } = {}
-  for (const notification of validNotifications) {
+  for (const notification of notifications) {
     const isAleadyIncluded = notificationsToSend.some(
       (n) =>
         'group_id' in notification &&

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/supporterDethroned.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/supporterDethroned.ts
@@ -121,27 +121,6 @@ export class SupporterDethroned extends BaseNotification<SupporterDethronedNotif
       )
       await this.incrementBadgeCount(this.receiverUserId)
     }
-    if (
-      isLiveEmailEnabled &&
-      userNotificationSettings.shouldSendEmailAtFrequency({
-        initiatorUserId: this.tipSenderUserId,
-        receiverUserId: this.receiverUserId,
-        frequency: 'live'
-      })
-    ) {
-      const notification: AppEmailNotification = {
-        receiver_user_id: this.receiverUserId,
-        ...this.notification
-      }
-      await sendNotificationEmail({
-        userId: this.receiverUserId,
-        email: userNotificationSettings.getUserEmail(this.receiverUserId),
-        frequency: 'live',
-        notifications: [notification],
-        dnDb: this.dnDB,
-        identityDb: this.identityDB
-      })
-    }
   }
 
   getResourcesForEmail(): ResourceIds {


### PR DESCRIPTION
### Description
- remove sending emails from supporter dethroned
- do not send emails if no valid notifications to send (e.g. if all the notifs are supporter dethroned, do not send email) by moving the verification out of renderEmail into sendEmail


### Tests
updated unit tests

