### PR TITLE
Revoke app delegate EM action C-2559

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -175,6 +175,8 @@ BEGIN;
     alter table app_delegates
     add column if not exists updated_at timestamp not null;
 
+    alter table app_delegates rename column is_revoked to is_delete;
+
     alter table app_delegates drop constraint app_delegates_pkey;
     alter table public.app_delegates add constraint app_delegates_pkey primary key (address, is_current, txhash);    
 COMMIT;

--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -166,3 +166,15 @@ BEGIN;
     primary key (shared_address, is_current, txhash)
   );
 COMMIT;
+
+-- 5/4/23: fix app_delegates table to support revokes
+BEGIN;
+    alter table app_delegates
+    add column if not exists is_current boolean not null;
+
+    alter table app_delegates
+    add column if not exists updated_at timestamp not null;
+
+    alter table app_delegates drop constraint app_delegates_pkey;
+    alter table public.app_delegates add constraint app_delegates_pkey primary key (address, is_current, txhash);    
+COMMIT;

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_delegate_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_delegate_entity_manager.py
@@ -406,5 +406,5 @@ def test_index_delegate(app, mocker):
                 and updated.is_personal_access
                 == expected_delegate["is_personal_access"]
             )
-            assert old.is_revoked == False and updated.is_revoked == True
+            assert old.is_delete == False and updated.is_delete == True
             assert old.blocknumber == 0 and updated.blocknumber == 1

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -287,7 +287,9 @@ def populate_mock_db(db, entities, block_offset=None):
                 is_personal_access=delegate_meta.get("is_personal_access", False),
                 blockhash=hex(i + block_offset),
                 blocknumber=(i + block_offset),
+                is_current=True,
                 txhash=delegate_meta.get("txhash", str(i + block_offset)),
+                updated_at=delegate_meta.get("updated_at", datetime.now()),
                 created_at=delegate_meta.get("created_at", datetime.now()),
             )
             session.add(delegate)

--- a/discovery-provider/src/models/delegates/app_delegate.py
+++ b/discovery-provider/src/models/delegates/app_delegate.py
@@ -13,10 +13,15 @@ class AppDelegate(Base, RepresentableMixin):
     name = Column(String, nullable=False, index=False)
     is_personal_access = Column(Boolean, nullable=False, server_default=text("false"))
     is_revoked = Column(Boolean, nullable=False, server_default=text("false"))
+    is_current = Column(Boolean, nullable=False, primary_key=True)
     created_at = Column(DateTime, nullable=False)
+    updated_at = Column(DateTime, nullable=False)
     txhash = Column(
         String,
         primary_key=True,
         nullable=False,
         server_default=text("''::character varying"),
     )
+
+    def get_attributes_dict(self):
+        return {col.name: getattr(self, col.name) for col in self.__table__.columns}

--- a/discovery-provider/src/models/delegates/app_delegate.py
+++ b/discovery-provider/src/models/delegates/app_delegate.py
@@ -12,7 +12,7 @@ class AppDelegate(Base, RepresentableMixin):
     user_id = Column(Integer, nullable=True, index=True)
     name = Column(String, nullable=False, index=False)
     is_personal_access = Column(Boolean, nullable=False, server_default=text("false"))
-    is_revoked = Column(Boolean, nullable=False, server_default=text("false"))
+    is_delete = Column(Boolean, nullable=False, server_default=text("false"))
     is_current = Column(Boolean, nullable=False, primary_key=True)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)

--- a/discovery-provider/src/tasks/entity_manager/app_delegate.py
+++ b/discovery-provider/src/tasks/entity_manager/app_delegate.py
@@ -78,7 +78,8 @@ def get_delete_app_delegate_metadata_from_raw(
 
 
 def validate_app_delegate_tx(
-    params: ManageEntityParameters, metadata: CreateAppDelegateMetadata
+    params: ManageEntityParameters,
+    metadata: Union[CreateAppDelegateMetadata, RevokeAppDelegateMetadata],
 ):
     user_id = params.user_id
 

--- a/discovery-provider/src/tasks/entity_manager/app_delegate.py
+++ b/discovery-provider/src/tasks/entity_manager/app_delegate.py
@@ -27,7 +27,7 @@ class RevokeAppDelegateMetadata(TypedDict):
 
 def get_app_delegate_metadata_from_raw(
     raw_metadata: Optional[str],
-) -> Optional[Union[CreateAppDelegateMetadata, RevokeAppDelegateMetadata]]:
+) -> Optional[CreateAppDelegateMetadata]:
     metadata: CreateAppDelegateMetadata = {
         "address": None,
         "name": None,

--- a/discovery-provider/src/tasks/entity_manager/app_delegate.py
+++ b/discovery-provider/src/tasks/entity_manager/app_delegate.py
@@ -77,10 +77,7 @@ def get_delete_app_delegate_metadata_from_raw(
     return metadata
 
 
-def validate_app_delegate_tx(
-    params: ManageEntityParameters,
-    metadata: Union[CreateAppDelegateMetadata, RevokeAppDelegateMetadata],
-):
+def validate_app_delegate_tx(params: ManageEntityParameters, metadata):
     user_id = params.user_id
 
     if params.entity_type != EntityType.APP_DELEGATE:

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -20,7 +20,10 @@ from src.models.social.subscription import Subscription
 from src.models.tracks.track import Track
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.user import User
-from src.tasks.entity_manager.app_delegate import create_app_delegate
+from src.tasks.entity_manager.app_delegate import (
+    create_app_delegate,
+    delete_app_delegate,
+)
 from src.tasks.entity_manager.delegation import create_delegation
 from src.tasks.entity_manager.notification import (
     create_notification,
@@ -225,6 +228,11 @@ def entity_manager_update(
                         and params.entity_type == EntityType.APP_DELEGATE
                     ):
                         create_app_delegate(params)
+                    elif (
+                        params.action == Action.DELETE
+                        and params.entity_type == EntityType.APP_DELEGATE
+                    ):
+                        delete_app_delegate(params)
                     elif (
                         params.action == Action.CREATE
                         and params.entity_type == EntityType.DELEGATION


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Changes to allow revoking app delegate (i.e. revoking an API key + secret) in Discovery
An app owner would revoke their API key if it was compromised or simply no longer needed. This implicitly invalidates all delegations to that app delegate (we can also do this explicitly, but I felt that that isn't needed - lmk what you think.)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->