### PR TITLE
Dedupe reaction notifs

### DIFF
--- a/discovery-provider/alembic/trigger_sql/handle_reaction.sql
+++ b/discovery-provider/alembic/trigger_sql/handle_reaction.sql
@@ -23,27 +23,29 @@ begin
     IF tip_sender_user_id IS NOT NULL AND tip_receiver_user_id IS NOT NULL THEN
       raise NOTICE 'have ids';
 
-      INSERT INTO notification
-        (slot, user_ids, timestamp, type, specifier, group_id, data)
-      VALUES
-        (
-        new.slot,
-        ARRAY [tip_sender_user_id],
-        new.timestamp,
-        'reaction',
-        tip_receiver_user_id,
-        'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value || ':timestamp:' || new.timestamp,
-        json_build_object(
-          'sender_wallet', new.sender_wallet,
-          'reaction_type', new.reaction_type,
-          'reacted_to', new.reacted_to,
-          'reaction_value', new.reaction_value,
-          'receiver_user_id', tip_receiver_user_id,
-          'sender_user_id', tip_sender_user_id,
-          'tip_amount', tip_amount::varchar(255)
+      if new.reaction_value != 0 then
+        INSERT INTO notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+          new.slot,
+          ARRAY [tip_sender_user_id],
+          new.timestamp,
+          'reaction',
+          tip_receiver_user_id,
+          'reaction:' || 'reaction_to:' || new.reacted_to || ':reaction_type:' || new.reaction_type || ':reaction_value:' || new.reaction_value,
+          json_build_object(
+            'sender_wallet', new.sender_wallet,
+            'reaction_type', new.reaction_type,
+            'reacted_to', new.reacted_to,
+            'reaction_value', new.reaction_value,
+            'receiver_user_id', tip_receiver_user_id,
+            'sender_user_id', tip_sender_user_id,
+            'tip_amount', tip_amount::varchar(255)
+          )
         )
-      )
-      on conflict do nothing;
+        on conflict do nothing;
+      end if;
 
       -- find the notification for tip send - update the data to include reaction value
       UPDATE notification

--- a/discovery-provider/integration_tests/notifications/test_reaction.py
+++ b/discovery-provider/integration_tests/notifications/test_reaction.py
@@ -59,44 +59,30 @@ def test_reaction_notification(app):
             .order_by(asc(Notification.slot))
             .all()
         )
-        assert len(notifications) == 3
-        assert notifications[0].specifier == "2"
+        logger.info(f"asdf notifications: {notifications}")
+
+        assert len(notifications) == 2
+        assert notifications[0].specifier == "3"
         assert notifications[
             0
-        ].group_id == "reaction:reaction_to:sig_0:reaction_type:tip:reaction_value:0:timestamp:" + now.strftime(
-            "%Y-%m-%d %H:%M:%S.%f"
-        ).rstrip(
-            "0"
-        )
-        assert notifications[1].specifier == "3"
+        ].group_id == "reaction:reaction_to:sig_1:reaction_type:tip:reaction_value:1"
+        assert notifications[1].specifier == "4"
         assert notifications[
             1
-        ].group_id == "reaction:reaction_to:sig_1:reaction_type:tip:reaction_value:1:timestamp:" + now.strftime(
-            "%Y-%m-%d %H:%M:%S.%f"
-        ).rstrip(
-            "0"
-        )
-        assert notifications[2].specifier == "4"
-        assert notifications[
-            2
-        ].group_id == "reaction:reaction_to:sig_2:reaction_type:tip:reaction_value:2:timestamp:" + now.strftime(
-            "%Y-%m-%d %H:%M:%S.%f"
-        ).rstrip(
-            "0"
-        )
+        ].group_id == "reaction:reaction_to:sig_2:reaction_type:tip:reaction_value:2"
         assert notifications[0].type == "reaction"
-        assert notifications[0].slot == 0
+        assert notifications[0].slot == 1
         assert notifications[0].blocknumber == None
         assert notifications[0].data == {
-            "reacted_to": "sig_0",
+            "reacted_to": "sig_1",
             "reaction_type": "tip",
-            "sender_wallet": "0x0",
-            "reaction_value": 0,
-            "receiver_user_id": 2,
-            "sender_user_id": 1,
-            "tip_amount": "100000000",
+            "sender_wallet": "0x1",
+            "reaction_value": 1,
+            "receiver_user_id": 3,
+            "sender_user_id": 2,
+            "tip_amount": "200000000",
         }
-        assert notifications[0].user_ids == [1]
+        assert notifications[0].user_ids == [2]
 
         notifications: List[Notification] = (
             session.query(Notification)

--- a/discovery-provider/integration_tests/notifications/test_reaction.py
+++ b/discovery-provider/integration_tests/notifications/test_reaction.py
@@ -59,7 +59,6 @@ def test_reaction_notification(app):
             .order_by(asc(Notification.slot))
             .all()
         )
-        logger.info(f"asdf notifications: {notifications}")
 
         assert len(notifications) == 2
         assert notifications[0].specifier == "3"
@@ -83,6 +82,20 @@ def test_reaction_notification(app):
             "tip_amount": "200000000",
         }
         assert notifications[0].user_ids == [2]
+
+        assert notifications[1].type == "reaction"
+        assert notifications[1].slot == 2
+        assert notifications[1].blocknumber == None
+        assert notifications[1].data == {
+            "reacted_to": "sig_2",
+            "reaction_type": "tip",
+            "sender_wallet": "0x2",
+            "reaction_value": 2,
+            "receiver_user_id": 4,
+            "sender_user_id": 3,
+            "tip_amount": "300000000",
+        }
+        assert notifications[1].user_ids == [3]
 
         notifications: List[Notification] = (
             session.query(Notification)

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/reaction.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/reaction.test.ts
@@ -73,7 +73,7 @@ describe('Reaction Notification', () => {
         body: `User_1 reacted to your tip of 5 $AUDIO`,
         data: {
           entityId: 1,
-          id: 'timestamp:1589373217:group_id:reaction:reaction_to:sig_2_1:reaction_type:tip:reaction_value:2:timestamp:2020-05-13 12:33:37',
+          id: 'timestamp:1589373217:group_id:reaction:reaction_to:sig_2_1:reaction_type:tip:reaction_value:2',
           type: 'Reaction'
         }
       }
@@ -110,8 +110,7 @@ describe('Reaction Notification', () => {
         type: 'reaction',
         timestamp: new Date(),
         specifier: '1',
-        group_id:
-          'reaction:reaction_to:0x1:reaction_type:tip:reaction_value:1:timestamp:2022-08-10 19:59:45.743',
+        group_id: 'reaction:reaction_to:0x1:reaction_type:tip:reaction_value:1',
         data,
         user_ids: [2],
         receiver_user_id: 2


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Undoing and re-sending a reaction would send dupe notifs. Removing timestamp makes it act more like favorite / reposting. Also, undoing a reaction (reaction_value 0) would previously insert into notifs and create a push notif. 

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->
Updated tests

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->