### PR TITLE
Add prod metadata tsv to backfill

### DIFF
--- a/discovery-provider/src/app.py
+++ b/discovery-provider/src/app.py
@@ -442,7 +442,7 @@ def configure_celery(celery, test_config=None):
 
     # backfill cid data if url is provided
     env = os.getenv("audius_discprov_env")
-    if env == "stage" and not redis_inst.get("backfilled_cid_data"):
+    if env in ("stage", "prod") and not redis_inst.get("backfilled_cid_data"):
         celery.send_task("backfill_cid_data")
 
     # Initialize DB object for celery task context

--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -29,6 +29,8 @@ def backfill_cid_data(db: SessionManager):
     source_tsv_url = ""
     if env == "stage":
         source_tsv_url = "https://s3.us-west-1.amazonaws.com/download.staging.audius.co/stage-cid-metadata.tsv"
+    elif env == "prod":
+        source_tsv_url = "https://s3.us-west-1.amazonaws.com/download.audius.co/prod-cid-metadata.tsv"
 
     response = requests.get(source_tsv_url, stream=True)
     with tempfile.NamedTemporaryFile() as tmp:


### PR DESCRIPTION
### Description
Data to backfill on prod. Will run once async on startup.

### Tests
Tested on stage


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->