### PR TITLE
Fix flaky DMs tests

### DIFF
--- a/discovery-provider/plugins/notifications/scripts/test-push-notification.ts
+++ b/discovery-provider/plugins/notifications/scripts/test-push-notification.ts
@@ -137,7 +137,7 @@ export const main = async () => {
   Object.entries(values).forEach(([k, v]) => {
     message[k] = message[k] || v
   })
-  console.table(Object.entries(message).map(([k, v]) => ({ key: k, val: v })));
+  console.table(Object.entries(message).map(([k, v]) => ({ key: k, val: v })))
 
   if (values.type.includes('android')) {
     console.log('sending android notification')

--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -9,8 +9,6 @@ import {
   insertMessage,
   insertReaction,
   setupTwoUsersWithDevices,
-  setupTest,
-  resetTests,
   createTestDB,
   replaceDBName,
   dropTestDB
@@ -64,148 +62,148 @@ describe('Push Notifications', () => {
     ])
   })
 
-  // test('Process DM for ios', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Process DM for ios', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const messageId = randId().toString()
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = randId().toString()
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const messageId = randId().toString()
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = randId().toString()
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 20))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user2.deviceType,
-  //       targetARN: user2.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Message',
-  //       body: `New message from ${user1.name}`,
-  //       data: {}
-  //     }
-  //   )
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: user2.deviceType,
+        targetARN: user2.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Message',
+        body: `New message from ${user1.name}`,
+        data: {}
+      }
+    )
 
-  //   jest.clearAllMocks()
+    jest.clearAllMocks()
 
-  //   // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
-  //   const reaction = 'fire'
-  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user2.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(reactionTimestampMs)
-  //   )
+    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
+    const reaction = 'fire'
+    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+    await insertReaction(
+      processor.discoveryDB,
+      user2.userId,
+      messageId,
+      reaction,
+      new Date(reactionTimestampMs)
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 5))
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user1.deviceType,
-  //       targetARN: user1.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Reaction',
-  //       body: `${user2.name} reacted ${reaction} to your message`,
-  //       data: {}
-  //     }
-  //   )
-  // }, 40000)
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: user1.deviceType,
+        targetARN: user1.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Reaction',
+        body: `${user2.name} reacted ${reaction} to your message`,
+        data: {}
+      }
+    )
+  }, 40000)
 
-  // test('Does not send DM notifications when sender is receiver', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Does not send DM notifications when sender is receiver', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 20))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const messageId = randId().toString()
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = randId().toString()
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const messageId = randId().toString()
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = randId().toString()
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user2.deviceType,
-  //       targetARN: user2.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Message',
-  //       body: `New message from ${user1.name}`,
-  //       data: {}
-  //     }
-  //   )
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: user2.deviceType,
+        targetARN: user2.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Message',
+        body: `New message from ${user1.name}`,
+        data: {}
+      }
+    )
 
-  //   jest.clearAllMocks()
+    jest.clearAllMocks()
 
-  //   // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
-  //   const reaction = 'fire'
-  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(reactionTimestampMs)
-  //   )
+    // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
+    const reaction = 'fire'
+    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+    await insertReaction(
+      processor.discoveryDB,
+      user1.userId,
+      messageId,
+      reaction,
+      new Date(reactionTimestampMs)
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled()
-  // }, 40000)
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled()
+  }, 40000)
 
   test('Does not send DM notifications created fewer than delay minutes ago', async () => {
     const { user1, user2 } = await setupTwoUsersWithDevices(

--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -10,7 +10,6 @@ import { AppNotificationsProcessor } from './processNotifications/indexAppNotifi
 import { sendDMNotifications } from './tasks/dmNotifications'
 import { processEmailNotifications } from './email/notifications/index'
 import { sendAppNotifications } from './tasks/appNotifications'
-import { getRedisConnection } from './utils/redisConnection'
 import {
   EmailPluginMappings,
   NotificationsEmailPlugin,
@@ -97,22 +96,10 @@ export class Processor {
     // process events
     logger.info('processing events')
     this.isRunning = true
-    const redis = await getRedisConnection()
-    await redis.set(
-      config.lastIndexedMessageRedisKey,
-      new Date(Date.now()).toISOString()
-    )
-    await redis.set(
-      config.lastIndexedReactionRedisKey,
-      new Date(Date.now()).toISOString()
-    )
     while (this.isRunning) {
-      // Comment out to prevent app notifications until complete
       await sendAppNotifications(this.listener, this.appNotificationsProcessor)
       await sendDMNotifications(this.discoveryDB, this.identityDB)
 
-      // NOTE: Temp to test DM email notifs in staging
-      // TODO run job for all email frequencies
       if (
         this.getIsScheduledEmailEnabled() &&
         (!this.lastDailyEmailSent ||


### PR DESCRIPTION
### Description
- Uncomment flaky tests
- Remove hardcoded redis values on start (so plugin will retroactively send any missed notifs on restart)


### Tests
audius-compose test run "discovery-provider-notifications" with package.json updated to run processPushNotification.test.js only. Re-run several times, ensure no failures.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->