### PR TITLE
Postgraphile

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -282,6 +282,26 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location /graphiql {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' '*';
+            resolver 127.0.0.11 valid=30s;
+            set $upstream postgraphile:5433;
+            proxy_pass http://$upstream/;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /graphql {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' '*';
+            resolver 127.0.0.11 valid=30s;
+            set $upstream postgraphile:5433;
+            proxy_pass http://$upstream/;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location / {
             proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;

--- a/discovery-provider/postgraphile/.env.example
+++ b/discovery-provider/postgraphile/.env.example
@@ -1,4 +1,0 @@
-# containerized db
-# DATABASE_URL=postgresql://postgres:postgres@db:5432/audius_discovery
-# houseparty local db
-DATABASE_URL=postgresql://postgres:pass@host.docker.internal:5432/default_db

--- a/discovery-provider/postgraphile/.env.example
+++ b/discovery-provider/postgraphile/.env.example
@@ -1,0 +1,4 @@
+# containerized db
+# DATABASE_URL=postgresql://postgres:postgres@db:5432/audius_discovery
+# houseparty local db
+DATABASE_URL=postgresql://postgres:pass@host.docker.internal:5432/default_db

--- a/discovery-provider/postgraphile/Dockerfile
+++ b/discovery-provider/postgraphile/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:alpine
+LABEL description="Instant high-performance GraphQL API for your PostgreSQL database https://github.com/graphile/postgraphile"
+
+# Install PostGraphile and PostGraphile connection filter plugin
+RUN npm install -g postgraphile
+RUN npm install -g postgraphile-plugin-connection-filter
+
+EXPOSE 5000
+ENTRYPOINT ["postgraphile", "-n", "0.0.0.0"]

--- a/discovery-provider/postgraphile/Makefile
+++ b/discovery-provider/postgraphile/Makefile
@@ -1,0 +1,5 @@
+up::
+	docker compose -f docker-compose.pgql.yml up -d
+
+down::
+	docker compose -f docker-compose.pgql.yml down

--- a/discovery-provider/postgraphile/README.md
+++ b/discovery-provider/postgraphile/README.md
@@ -1,0 +1,44 @@
+# Discprov Postgraphile
+
+Postgraphile is a tool used to generate a graphql API based on database schemas. This directory has the setup for being able to do this against a discprov database.
+
+## Configuration
+
+Write a `.env` file that contains the connection string for the postgres db. Here's an example with the containerized databases as well as running a local instance of [houseparty](https://github.com/AudiusProject/houseparty).
+```
+# containerized db
+# DATABASE_URL=postgresql://postgres:postgres@db:5432/audius_discovery
+# houseparty local db
+DATABASE_URL=postgresql://postgres:pass@host.docker.internal:5432/default_db
+```
+
+## Commands
+
+Starting the GQL and Graphiql server (this will also build on the first run)
+```
+alec in audius-protocol/discovery-provider/postgraphile on  as/postgraphile [$?⇡] on ☁️  alec@audius.co(us-central1)
+❯ make up
+docker compose -f docker-compose.pgql.yml up -d
+[+] Running 1/0
+ ⠿ Container postgraphile  Running
+```
+
+Stopping the GQL and Graphiql server
+```
+alec in audius-protocol/discovery-provider/postgraphile on  as/postgraphile [$?⇡] on ☁️  alec@audius.co(us-central1)
+❯ make down
+docker compose -f docker-compose.pgql.yml down
+[+] Running 2/2
+ ⠿ Container postgraphile        Removed                                                                                                                  10.2s
+ ⠿ Network postgraphile_default  Removed
+```
+
+## Usage
+
+You can then access the graphql api and graphiql at these locations! These logs are also present in the container.
+
+```
+postgraphile  | PostGraphile v4.13.0 server listening on port 5433 🚀
+postgraphile  |   ‣ GraphQL API:         http://0.0.0.0:5433/graphql (subscriptions enabled)
+postgraphile  |   ‣ GraphiQL GUI/IDE:    http://0.0.0.0:5433/graphiql
+```

--- a/discovery-provider/postgraphile/docker-compose.pgql.yml
+++ b/discovery-provider/postgraphile/docker-compose.pgql.yml
@@ -1,0 +1,37 @@
+version: '3.3'
+services:
+    graphql:
+      container_name: postgraphile
+      restart: always
+      image: postgraphile
+      build:
+          context: '.'
+      env_file:
+          - ./.env
+      ports:
+          - 5433:5433
+      volumes:
+        - "${PWD}:/local"
+      command: [
+          "--connection",
+          "${DATABASE_URL}",
+          "--port",
+          "5433",
+          "--schema",
+          "public",
+          "--append-plugins",
+          "postgraphile-plugin-connection-filter",
+          "--subscriptions",
+          "--watch",
+          "--dynamic-json",
+          "--export-schema-graphql",
+          "./local/schema.graphql",
+          "--graphiql",
+          "/graphiql",
+          "--enhance-graphiql",
+          "--allow-explain",
+          "--enable-query-batching",
+          "--no-setof-functions-contain-nulls",
+          "--no-ignore-rbac",
+          "--disable-default-mutations"
+        ]

--- a/discovery-provider/postgraphile/schema.graphql
+++ b/discovery-provider/postgraphile/schema.graphql
@@ -1,0 +1,14772 @@
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  Reads and enables pagination through a set of `AggregateDailyAppNameMetric`.
+  """
+  allAggregateDailyAppNameMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateDailyAppNameMetric`."""
+    orderBy: [AggregateDailyAppNameMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateDailyAppNameMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateDailyAppNameMetricFilter
+  ): AggregateDailyAppNameMetricsConnection
+
+  """
+  Reads and enables pagination through a set of `AggregateDailyTotalUsersMetric`.
+  """
+  allAggregateDailyTotalUsersMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateDailyTotalUsersMetric`."""
+    orderBy: [AggregateDailyTotalUsersMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateDailyTotalUsersMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateDailyTotalUsersMetricFilter
+  ): AggregateDailyTotalUsersMetricsConnection
+
+  """
+  Reads and enables pagination through a set of `AggregateDailyUniqueUsersMetric`.
+  """
+  allAggregateDailyUniqueUsersMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateDailyUniqueUsersMetric`."""
+    orderBy: [AggregateDailyUniqueUsersMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateDailyUniqueUsersMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateDailyUniqueUsersMetricFilter
+  ): AggregateDailyUniqueUsersMetricsConnection
+
+  """Reads and enables pagination through a set of `AggregateIntervalPlay`."""
+  allAggregateIntervalPlays(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateIntervalPlay`."""
+    orderBy: [AggregateIntervalPlaysOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateIntervalPlayCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateIntervalPlayFilter
+  ): AggregateIntervalPlaysConnection
+
+  """
+  Reads and enables pagination through a set of `AggregateMonthlyAppNameMetric`.
+  """
+  allAggregateMonthlyAppNameMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateMonthlyAppNameMetric`."""
+    orderBy: [AggregateMonthlyAppNameMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateMonthlyAppNameMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateMonthlyAppNameMetricFilter
+  ): AggregateMonthlyAppNameMetricsConnection
+
+  """Reads and enables pagination through a set of `AggregateMonthlyPlay`."""
+  allAggregateMonthlyPlays(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateMonthlyPlay`."""
+    orderBy: [AggregateMonthlyPlaysOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateMonthlyPlayCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateMonthlyPlayFilter
+  ): AggregateMonthlyPlaysConnection
+
+  """
+  Reads and enables pagination through a set of `AggregateMonthlyTotalUsersMetric`.
+  """
+  allAggregateMonthlyTotalUsersMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateMonthlyTotalUsersMetric`."""
+    orderBy: [AggregateMonthlyTotalUsersMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateMonthlyTotalUsersMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateMonthlyTotalUsersMetricFilter
+  ): AggregateMonthlyTotalUsersMetricsConnection
+
+  """
+  Reads and enables pagination through a set of `AggregateMonthlyUniqueUsersMetric`.
+  """
+  allAggregateMonthlyUniqueUsersMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateMonthlyUniqueUsersMetric`."""
+    orderBy: [AggregateMonthlyUniqueUsersMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateMonthlyUniqueUsersMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateMonthlyUniqueUsersMetricFilter
+  ): AggregateMonthlyUniqueUsersMetricsConnection
+
+  """Reads and enables pagination through a set of `AggregatePlaylist`."""
+  allAggregatePlaylists(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregatePlaylist`."""
+    orderBy: [AggregatePlaylistsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregatePlaylistCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregatePlaylistFilter
+  ): AggregatePlaylistsConnection
+
+  """Reads and enables pagination through a set of `AggregatePlay`."""
+  allAggregatePlays(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregatePlay`."""
+    orderBy: [AggregatePlaysOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregatePlayCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregatePlayFilter
+  ): AggregatePlaysConnection
+
+  """Reads and enables pagination through a set of `AggregateTrack`."""
+  allAggregateTracks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateTrack`."""
+    orderBy: [AggregateTracksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateTrackCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateTrackFilter
+  ): AggregateTracksConnection
+
+  """Reads and enables pagination through a set of `AggregateUser`."""
+  allAggregateUsers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateUser`."""
+    orderBy: [AggregateUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateUserFilter
+  ): AggregateUsersConnection
+
+  """Reads and enables pagination through a set of `AggregateUserTip`."""
+  allAggregateUserTips(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AggregateUserTip`."""
+    orderBy: [AggregateUserTipsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AggregateUserTipCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AggregateUserTipFilter
+  ): AggregateUserTipsConnection
+
+  """Reads and enables pagination through a set of `AlembicVersion`."""
+  allAlembicVersions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AlembicVersion`."""
+    orderBy: [AlembicVersionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AlembicVersionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AlembicVersionFilter
+  ): AlembicVersionsConnection
+
+  """Reads and enables pagination through a set of `AppNameMetric`."""
+  allAppNameMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AppNameMetric`."""
+    orderBy: [AppNameMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AppNameMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AppNameMetricFilter
+  ): AppNameMetricsConnection
+
+  """Reads and enables pagination through a set of `AppNameMetricsAllTime`."""
+  allAppNameMetricsAllTimes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AppNameMetricsAllTime`."""
+    orderBy: [AppNameMetricsAllTimesOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AppNameMetricsAllTimeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AppNameMetricsAllTimeFilter
+  ): AppNameMetricsAllTimesConnection
+
+  """
+  Reads and enables pagination through a set of `AppNameMetricsTrailingMonth`.
+  """
+  allAppNameMetricsTrailingMonths(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AppNameMetricsTrailingMonth`."""
+    orderBy: [AppNameMetricsTrailingMonthsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AppNameMetricsTrailingMonthCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AppNameMetricsTrailingMonthFilter
+  ): AppNameMetricsTrailingMonthsConnection
+
+  """
+  Reads and enables pagination through a set of `AppNameMetricsTrailingWeek`.
+  """
+  allAppNameMetricsTrailingWeeks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AppNameMetricsTrailingWeek`."""
+    orderBy: [AppNameMetricsTrailingWeeksOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AppNameMetricsTrailingWeekCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AppNameMetricsTrailingWeekFilter
+  ): AppNameMetricsTrailingWeeksConnection
+
+  """Reads and enables pagination through a set of `AssociatedWallet`."""
+  allAssociatedWallets(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AssociatedWallet`."""
+    orderBy: [AssociatedWalletsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AssociatedWalletCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AssociatedWalletFilter
+  ): AssociatedWalletsConnection
+
+  """
+  Reads and enables pagination through a set of `AudioTransactionsHistory`.
+  """
+  allAudioTransactionsHistories(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AudioTransactionsHistory`."""
+    orderBy: [AudioTransactionsHistoriesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AudioTransactionsHistoryCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AudioTransactionsHistoryFilter
+  ): AudioTransactionsHistoriesConnection
+
+  """Reads and enables pagination through a set of `AudiusDataTx`."""
+  allAudiusDataTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `AudiusDataTx`."""
+    orderBy: [AudiusDataTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AudiusDataTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: AudiusDataTxFilter
+  ): AudiusDataTxesConnection
+
+  """Reads and enables pagination through a set of `Block`."""
+  allBlocks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Block`."""
+    orderBy: [BlocksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BlockCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: BlockFilter
+  ): BlocksConnection
+
+  """Reads and enables pagination through a set of `BlocksCopy`."""
+  allBlocksCopies(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `BlocksCopy`."""
+    orderBy: [BlocksCopiesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BlocksCopyCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: BlocksCopyFilter
+  ): BlocksCopiesConnection
+
+  """Reads and enables pagination through a set of `ChallengeDisbursement`."""
+  allChallengeDisbursements(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChallengeDisbursement`."""
+    orderBy: [ChallengeDisbursementsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChallengeDisbursementCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChallengeDisbursementFilter
+  ): ChallengeDisbursementsConnection
+
+  """Reads and enables pagination through a set of `ChallengeListenStreak`."""
+  allChallengeListenStreaks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChallengeListenStreak`."""
+    orderBy: [ChallengeListenStreaksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChallengeListenStreakCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChallengeListenStreakFilter
+  ): ChallengeListenStreaksConnection
+
+  """
+  Reads and enables pagination through a set of `ChallengeProfileCompletion`.
+  """
+  allChallengeProfileCompletions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChallengeProfileCompletion`."""
+    orderBy: [ChallengeProfileCompletionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChallengeProfileCompletionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChallengeProfileCompletionFilter
+  ): ChallengeProfileCompletionsConnection
+
+  """Reads and enables pagination through a set of `Challenge`."""
+  allChallenges(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Challenge`."""
+    orderBy: [ChallengesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChallengeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChallengeFilter
+  ): ChallengesConnection
+
+  """Reads and enables pagination through a set of `Chat`."""
+  allChats(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Chat`."""
+    orderBy: [ChatsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatFilter
+  ): ChatsConnection
+
+  """Reads and enables pagination through a set of `ChatBlockedUser`."""
+  allChatBlockedUsers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatBlockedUser`."""
+    orderBy: [ChatBlockedUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatBlockedUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatBlockedUserFilter
+  ): ChatBlockedUsersConnection
+
+  """Reads and enables pagination through a set of `ChatMember`."""
+  allChatMembers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMember`."""
+    orderBy: [ChatMembersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMemberCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMemberFilter
+  ): ChatMembersConnection
+
+  """Reads and enables pagination through a set of `ChatMessage`."""
+  allChatMessages(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMessage`."""
+    orderBy: [ChatMessagesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMessageCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMessageFilter
+  ): ChatMessagesConnection
+
+  """Reads and enables pagination through a set of `ChatMessageReaction`."""
+  allChatMessageReactions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMessageReaction`."""
+    orderBy: [ChatMessageReactionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMessageReactionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMessageReactionFilter
+  ): ChatMessageReactionsConnection
+
+  """Reads and enables pagination through a set of `ChatPermission`."""
+  allChatPermissions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatPermission`."""
+    orderBy: [ChatPermissionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatPermissionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatPermissionFilter
+  ): ChatPermissionsConnection
+
+  """Reads and enables pagination through a set of `CidDatum`."""
+  allCidData(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CidDatum`."""
+    orderBy: [CidDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CidDatumCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CidDatumFilter
+  ): CidDataConnection
+
+  """Reads and enables pagination through a set of `EthBlock`."""
+  allEthBlocks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `EthBlock`."""
+    orderBy: [EthBlocksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: EthBlockCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: EthBlockFilter
+  ): EthBlocksConnection
+
+  """Reads and enables pagination through a set of `Follow`."""
+  allFollows(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Follow`."""
+    orderBy: [FollowsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FollowCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: FollowFilter
+  ): FollowsConnection
+
+  """Reads and enables pagination through a set of `HourlyPlayCount`."""
+  allHourlyPlayCounts(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `HourlyPlayCount`."""
+    orderBy: [HourlyPlayCountsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HourlyPlayCountCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: HourlyPlayCountFilter
+  ): HourlyPlayCountsConnection
+
+  """Reads and enables pagination through a set of `IndexingCheckpoint`."""
+  allIndexingCheckpoints(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `IndexingCheckpoint`."""
+    orderBy: [IndexingCheckpointsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: IndexingCheckpointCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: IndexingCheckpointFilter
+  ): IndexingCheckpointsConnection
+
+  """Reads and enables pagination through a set of `Milestone`."""
+  allMilestones(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Milestone`."""
+    orderBy: [MilestonesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MilestoneCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: MilestoneFilter
+  ): MilestonesConnection
+
+  """Reads and enables pagination through a set of `Notification`."""
+  allNotifications(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Notification`."""
+    orderBy: [NotificationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: NotificationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: NotificationFilter
+  ): NotificationsConnection
+
+  """Reads and enables pagination through a set of `NotificationSeen`."""
+  allNotificationSeens(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `NotificationSeen`."""
+    orderBy: [NotificationSeensOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: NotificationSeenCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: NotificationSeenFilter
+  ): NotificationSeensConnection
+
+  """Reads and enables pagination through a set of `PlaylistRoute`."""
+  allPlaylistRoutes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `PlaylistRoute`."""
+    orderBy: [PlaylistRoutesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaylistRouteCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaylistRouteFilter
+  ): PlaylistRoutesConnection
+
+  """Reads and enables pagination through a set of `PlaylistSeen`."""
+  allPlaylistSeens(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `PlaylistSeen`."""
+    orderBy: [PlaylistSeensOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaylistSeenCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaylistSeenFilter
+  ): PlaylistSeensConnection
+
+  """Reads and enables pagination through a set of `Playlist`."""
+  allPlaylists(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Playlist`."""
+    orderBy: [PlaylistsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaylistCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaylistFilter
+  ): PlaylistsConnection
+
+  """Reads and enables pagination through a set of `Play`."""
+  allPlays(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Play`."""
+    orderBy: [PlaysOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlayCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlayFilter
+  ): PlaysConnection
+
+  """Reads and enables pagination through a set of `PlaysArchive`."""
+  allPlaysArchives(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `PlaysArchive`."""
+    orderBy: [PlaysArchivesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaysArchiveCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaysArchiveFilter
+  ): PlaysArchivesConnection
+
+  """Reads and enables pagination through a set of `Reaction`."""
+  allReactions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Reaction`."""
+    orderBy: [ReactionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ReactionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ReactionFilter
+  ): ReactionsConnection
+
+  """Reads and enables pagination through a set of `RelatedArtist`."""
+  allRelatedArtists(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RelatedArtist`."""
+    orderBy: [RelatedArtistsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RelatedArtistCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RelatedArtistFilter
+  ): RelatedArtistsConnection
+
+  """Reads and enables pagination through a set of `Remix`."""
+  allRemixes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Remix`."""
+    orderBy: [RemixesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RemixCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RemixFilter
+  ): RemixesConnection
+
+  """Reads and enables pagination through a set of `Repost`."""
+  allReposts(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Repost`."""
+    orderBy: [RepostsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RepostCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RepostFilter
+  ): RepostsConnection
+
+  """Reads and enables pagination through a set of `RewardManagerTx`."""
+  allRewardManagerTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RewardManagerTx`."""
+    orderBy: [RewardManagerTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RewardManagerTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RewardManagerTxFilter
+  ): RewardManagerTxesConnection
+
+  """
+  Reads and enables pagination through a set of `RewardsManagerBackfillTx`.
+  """
+  allRewardsManagerBackfillTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RewardsManagerBackfillTx`."""
+    orderBy: [RewardsManagerBackfillTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RewardsManagerBackfillTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RewardsManagerBackfillTxFilter
+  ): RewardsManagerBackfillTxesConnection
+
+  """Reads and enables pagination through a set of `RouteMetric`."""
+  allRouteMetrics(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetric`."""
+    orderBy: [RouteMetricsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricFilter
+  ): RouteMetricsConnection
+
+  """Reads and enables pagination through a set of `RouteMetricsAllTime`."""
+  allRouteMetricsAllTimes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetricsAllTime`."""
+    orderBy: [RouteMetricsAllTimesOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricsAllTimeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricsAllTimeFilter
+  ): RouteMetricsAllTimesConnection
+
+  """Reads and enables pagination through a set of `RouteMetricsDayBucket`."""
+  allRouteMetricsDayBuckets(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetricsDayBucket`."""
+    orderBy: [RouteMetricsDayBucketsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricsDayBucketCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricsDayBucketFilter
+  ): RouteMetricsDayBucketsConnection
+
+  """
+  Reads and enables pagination through a set of `RouteMetricsMonthBucket`.
+  """
+  allRouteMetricsMonthBuckets(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetricsMonthBucket`."""
+    orderBy: [RouteMetricsMonthBucketsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricsMonthBucketCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricsMonthBucketFilter
+  ): RouteMetricsMonthBucketsConnection
+
+  """
+  Reads and enables pagination through a set of `RouteMetricsTrailingMonth`.
+  """
+  allRouteMetricsTrailingMonths(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetricsTrailingMonth`."""
+    orderBy: [RouteMetricsTrailingMonthsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricsTrailingMonthCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricsTrailingMonthFilter
+  ): RouteMetricsTrailingMonthsConnection
+
+  """
+  Reads and enables pagination through a set of `RouteMetricsTrailingWeek`.
+  """
+  allRouteMetricsTrailingWeeks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RouteMetricsTrailingWeek`."""
+    orderBy: [RouteMetricsTrailingWeeksOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RouteMetricsTrailingWeekCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RouteMetricsTrailingWeekFilter
+  ): RouteMetricsTrailingWeeksConnection
+
+  """Reads and enables pagination through a set of `RpcLog`."""
+  allRpcLogs(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `RpcLog`."""
+    orderBy: [RpcLogsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RpcLogCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RpcLogFilter
+  ): RpcLogsConnection
+
+  """Reads and enables pagination through a set of `Save`."""
+  allSaves(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Save`."""
+    orderBy: [SavesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SaveCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SaveFilter
+  ): SavesConnection
+
+  """Reads and enables pagination through a set of `SchemaMigration`."""
+  allSchemaMigrations(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `SchemaMigration`."""
+    orderBy: [SchemaMigrationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SchemaMigrationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SchemaMigrationFilter
+  ): SchemaMigrationsConnection
+
+  """Reads and enables pagination through a set of `SkippedTransaction`."""
+  allSkippedTransactions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `SkippedTransaction`."""
+    orderBy: [SkippedTransactionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SkippedTransactionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SkippedTransactionFilter
+  ): SkippedTransactionsConnection
+
+  """Reads and enables pagination through a set of `SplTokenBackfillTx`."""
+  allSplTokenBackfillTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `SplTokenBackfillTx`."""
+    orderBy: [SplTokenBackfillTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SplTokenBackfillTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SplTokenBackfillTxFilter
+  ): SplTokenBackfillTxesConnection
+
+  """Reads and enables pagination through a set of `SplTokenTx`."""
+  allSplTokenTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `SplTokenTx`."""
+    orderBy: [SplTokenTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SplTokenTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SplTokenTxFilter
+  ): SplTokenTxesConnection
+
+  """Reads and enables pagination through a set of `Stem`."""
+  allStems(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Stem`."""
+    orderBy: [StemsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StemCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: StemFilter
+  ): StemsConnection
+
+  """Reads and enables pagination through a set of `Subscription`."""
+  allSubscriptions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Subscription`."""
+    orderBy: [SubscriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SubscriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SubscriptionFilter
+  ): SubscriptionsConnection
+
+  """Reads and enables pagination through a set of `SupporterRankUp`."""
+  allSupporterRankUps(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `SupporterRankUp`."""
+    orderBy: [SupporterRankUpsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SupporterRankUpCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SupporterRankUpFilter
+  ): SupporterRankUpsConnection
+
+  """Reads and enables pagination through a set of `TagTrackUser`."""
+  allTagTrackUsers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `TagTrackUser`."""
+    orderBy: [TagTrackUsersOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagTrackUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TagTrackUserFilter
+  ): TagTrackUsersConnection
+
+  """Reads and enables pagination through a set of `TrackRoute`."""
+  allTrackRoutes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `TrackRoute`."""
+    orderBy: [TrackRoutesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrackRouteCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrackRouteFilter
+  ): TrackRoutesConnection
+
+  """Reads and enables pagination through a set of `TrackTrendingScore`."""
+  allTrackTrendingScores(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `TrackTrendingScore`."""
+    orderBy: [TrackTrendingScoresOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrackTrendingScoreCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrackTrendingScoreFilter
+  ): TrackTrendingScoresConnection
+
+  """Reads and enables pagination through a set of `Track`."""
+  allTracks(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Track`."""
+    orderBy: [TracksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrackCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrackFilter
+  ): TracksConnection
+
+  """Reads and enables pagination through a set of `TrendingParam`."""
+  allTrendingParams(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `TrendingParam`."""
+    orderBy: [TrendingParamsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrendingParamCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrendingParamFilter
+  ): TrendingParamsConnection
+
+  """Reads and enables pagination through a set of `TrendingResult`."""
+  allTrendingResults(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `TrendingResult`."""
+    orderBy: [TrendingResultsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrendingResultCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrendingResultFilter
+  ): TrendingResultsConnection
+
+  """Reads and enables pagination through a set of `UrsmContentNode`."""
+  allUrsmContentNodes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UrsmContentNode`."""
+    orderBy: [UrsmContentNodesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UrsmContentNodeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UrsmContentNodeFilter
+  ): UrsmContentNodesConnection
+
+  """Reads and enables pagination through a set of `UserBalanceChange`."""
+  allUserBalanceChanges(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserBalanceChange`."""
+    orderBy: [UserBalanceChangesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserBalanceChangeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserBalanceChangeFilter
+  ): UserBalanceChangesConnection
+
+  """Reads and enables pagination through a set of `UserBalance`."""
+  allUserBalances(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserBalance`."""
+    orderBy: [UserBalancesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserBalanceCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserBalanceFilter
+  ): UserBalancesConnection
+
+  """Reads and enables pagination through a set of `UserBankAccount`."""
+  allUserBankAccounts(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserBankAccount`."""
+    orderBy: [UserBankAccountsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserBankAccountCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserBankAccountFilter
+  ): UserBankAccountsConnection
+
+  """Reads and enables pagination through a set of `UserBankBackfillTx`."""
+  allUserBankBackfillTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserBankBackfillTx`."""
+    orderBy: [UserBankBackfillTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserBankBackfillTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserBankBackfillTxFilter
+  ): UserBankBackfillTxesConnection
+
+  """Reads and enables pagination through a set of `UserBankTx`."""
+  allUserBankTxes(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserBankTx`."""
+    orderBy: [UserBankTxesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserBankTxCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserBankTxFilter
+  ): UserBankTxesConnection
+
+  """Reads and enables pagination through a set of `UserChallenge`."""
+  allUserChallenges(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserChallenge`."""
+    orderBy: [UserChallengesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserChallengeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserChallengeFilter
+  ): UserChallengesConnection
+
+  """Reads and enables pagination through a set of `UserEvent`."""
+  allUserEvents(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserEvent`."""
+    orderBy: [UserEventsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserEventCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserEventFilter
+  ): UserEventsConnection
+
+  """Reads and enables pagination through a set of `UserListeningHistory`."""
+  allUserListeningHistories(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserListeningHistory`."""
+    orderBy: [UserListeningHistoriesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserListeningHistoryCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserListeningHistoryFilter
+  ): UserListeningHistoriesConnection
+
+  """Reads and enables pagination through a set of `UserTip`."""
+  allUserTips(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserTip`."""
+    orderBy: [UserTipsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserTipCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserTipFilter
+  ): UserTipsConnection
+
+  """Reads and enables pagination through a set of `User`."""
+  allUsers(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserFilter
+  ): UsersConnection
+  aggregateDailyAppNameMetricById(id: Int!): AggregateDailyAppNameMetric
+  aggregateDailyTotalUsersMetricById(id: Int!): AggregateDailyTotalUsersMetric
+  aggregateDailyUniqueUsersMetricById(id: Int!): AggregateDailyUniqueUsersMetric
+  aggregateMonthlyAppNameMetricById(id: Int!): AggregateMonthlyAppNameMetric
+  aggregateMonthlyPlayByPlayItemIdAndTimestamp(playItemId: Int!, timestamp: Date!): AggregateMonthlyPlay
+  aggregateMonthlyTotalUsersMetricById(id: Int!): AggregateMonthlyTotalUsersMetric
+  aggregateMonthlyUniqueUsersMetricById(id: Int!): AggregateMonthlyUniqueUsersMetric
+  aggregatePlaylistByPlaylistId(playlistId: Int!): AggregatePlaylist
+  aggregatePlayByPlayItemId(playItemId: Int!): AggregatePlay
+  aggregateTrackByTrackId(trackId: Int!): AggregateTrack
+  aggregateUserByUserId(userId: Int!): AggregateUser
+  aggregateUserTipBySenderUserIdAndReceiverUserId(senderUserId: Int!, receiverUserId: Int!): AggregateUserTip
+  alembicVersionByVersionNum(versionNum: String!): AlembicVersion
+  appNameMetricById(id: BigInt!): AppNameMetric
+  associatedWalletById(id: Int!): AssociatedWallet
+  audioTransactionsHistoryByUserBankAndSignature(userBank: String!, signature: String!): AudioTransactionsHistory
+  audiusDataTxBySignature(signature: String!): AudiusDataTx
+  blockByBlockhash(blockhash: String!): Block
+  blockByNumber(number: Int!): Block
+  blocksCopyByBlockhash(blockhash: String!): BlocksCopy
+  blocksCopyByNumber(number: Int!): BlocksCopy
+  challengeDisbursementByChallengeIdAndSpecifier(challengeId: String!, specifier: String!): ChallengeDisbursement
+  challengeListenStreakByUserId(userId: Int!): ChallengeListenStreak
+  challengeProfileCompletionByUserId(userId: Int!): ChallengeProfileCompletion
+  challengeById(id: String!): Challenge
+  chatByChatId(chatId: String!): Chat
+  chatBlockedUserByBlockerUserIdAndBlockeeUserId(blockerUserId: Int!, blockeeUserId: Int!): ChatBlockedUser
+  chatMemberByChatIdAndUserId(chatId: String!, userId: Int!): ChatMember
+  chatMessageByMessageId(messageId: String!): ChatMessage
+  chatMessageReactionByUserIdAndMessageId(userId: Int!, messageId: String!): ChatMessageReaction
+  chatPermissionByUserId(userId: Int!): ChatPermission
+  cidDatumByCid(cid: String!): CidDatum
+  ethBlockByLastScannedBlock(lastScannedBlock: Int!): EthBlock
+  followByIsCurrentAndFollowerUserIdAndFolloweeUserIdAndTxhash(isCurrent: Boolean!, followerUserId: Int!, followeeUserId: Int!, txhash: String!): Follow
+  hourlyPlayCountByHourlyTimestamp(hourlyTimestamp: Datetime!): HourlyPlayCount
+  indexingCheckpointByTablename(tablename: String!): IndexingCheckpoint
+  milestoneByIdAndNameAndThreshold(id: Int!, name: String!, threshold: Int!): Milestone
+  notificationById(id: Int!): Notification
+  notificationByGroupIdAndSpecifier(groupId: String!, specifier: String!): Notification
+  notificationSeenByUserIdAndSeenAt(userId: Int!, seenAt: Datetime!): NotificationSeen
+  playlistRouteByOwnerIdAndSlug(ownerId: Int!, slug: String!): PlaylistRoute
+  playlistSeenByIsCurrentAndUserIdAndPlaylistIdAndSeenAt(isCurrent: Boolean!, userId: Int!, playlistId: Int!, seenAt: Datetime!): PlaylistSeen
+  playlistByIsCurrentAndPlaylistIdAndTxhash(isCurrent: Boolean!, playlistId: Int!, txhash: String!): Playlist
+  playById(id: Int!): Play
+  playsArchiveById(id: Int!): PlaysArchive
+  reactionById(id: Int!): Reaction
+  relatedArtistByUserIdAndRelatedArtistUserId(userId: Int!, relatedArtistUserId: Int!): RelatedArtist
+  remixByParentTrackIdAndChildTrackId(parentTrackId: Int!, childTrackId: Int!): Remix
+  repostByIsCurrentAndUserIdAndRepostItemIdAndRepostTypeAndTxhash(isCurrent: Boolean!, userId: Int!, repostItemId: Int!, repostType: Reposttype!, txhash: String!): Repost
+  rewardManagerTxBySignature(signature: String!): RewardManagerTx
+  rewardsManagerBackfillTxBySignature(signature: String!): RewardsManagerBackfillTx
+  routeMetricById(id: BigInt!): RouteMetric
+  rpcLogByJetstreamSequence(jetstreamSequence: Int!): RpcLog
+  saveByIsCurrentAndUserIdAndSaveItemIdAndSaveTypeAndTxhash(isCurrent: Boolean!, userId: Int!, saveItemId: Int!, saveType: Savetype!, txhash: String!): Save
+  schemaMigrationByVersion(version: String!): SchemaMigration
+  skippedTransactionById(id: Int!): SkippedTransaction
+  splTokenBackfillTxByLastScannedSlot(lastScannedSlot: Int!): SplTokenBackfillTx
+  splTokenTxByLastScannedSlot(lastScannedSlot: Int!): SplTokenTx
+  stemByParentTrackIdAndChildTrackId(parentTrackId: Int!, childTrackId: Int!): Stem
+  subscriptionBySubscriberIdAndUserIdAndIsCurrentAndTxhash(subscriberId: Int!, userId: Int!, isCurrent: Boolean!, txhash: String!): Subscription
+  supporterRankUpBySlotAndSenderUserIdAndReceiverUserId(slot: Int!, senderUserId: Int!, receiverUserId: Int!): SupporterRankUp
+  trackRouteByOwnerIdAndSlug(ownerId: Int!, slug: String!): TrackRoute
+  trackTrendingScoreByTrackIdAndTypeAndVersionAndTimeRange(trackId: Int!, type: String!, version: String!, timeRange: String!): TrackTrendingScore
+  trackByIsCurrentAndTrackIdAndTxhash(isCurrent: Boolean!, trackId: Int!, txhash: String!): Track
+  trendingResultByRankAndTypeAndVersionAndWeek(rank: Int!, type: String!, version: String!, week: Date!): TrendingResult
+  ursmContentNodeByIsCurrentAndCnodeSpIdAndTxhash(isCurrent: Boolean!, cnodeSpId: Int!, txhash: String!): UrsmContentNode
+  userBalanceChangeByUserId(userId: Int!): UserBalanceChange
+  userBalanceByUserId(userId: Int!): UserBalance
+  userBankAccountBySignature(signature: String!): UserBankAccount
+  userBankBackfillTxBySignature(signature: String!): UserBankBackfillTx
+  userBankTxBySignature(signature: String!): UserBankTx
+  userChallengeByChallengeIdAndSpecifier(challengeId: String!, specifier: String!): UserChallenge
+  userEventById(id: Int!): UserEvent
+  userListeningHistoryByUserId(userId: Int!): UserListeningHistory
+  userTipBySlotAndSignature(slot: Int!, signature: String!): UserTip
+  userByIsCurrentAndUserIdAndTxhash(isCurrent: Boolean!, userId: Int!, txhash: String!): User
+
+  """
+  Reads a single `AggregateDailyAppNameMetric` using its globally unique `ID`.
+  """
+  aggregateDailyAppNameMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateDailyAppNameMetric`.
+    """
+    nodeId: ID!
+  ): AggregateDailyAppNameMetric
+
+  """
+  Reads a single `AggregateDailyTotalUsersMetric` using its globally unique `ID`.
+  """
+  aggregateDailyTotalUsersMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateDailyTotalUsersMetric`.
+    """
+    nodeId: ID!
+  ): AggregateDailyTotalUsersMetric
+
+  """
+  Reads a single `AggregateDailyUniqueUsersMetric` using its globally unique `ID`.
+  """
+  aggregateDailyUniqueUsersMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateDailyUniqueUsersMetric`.
+    """
+    nodeId: ID!
+  ): AggregateDailyUniqueUsersMetric
+
+  """
+  Reads a single `AggregateMonthlyAppNameMetric` using its globally unique `ID`.
+  """
+  aggregateMonthlyAppNameMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateMonthlyAppNameMetric`.
+    """
+    nodeId: ID!
+  ): AggregateMonthlyAppNameMetric
+
+  """Reads a single `AggregateMonthlyPlay` using its globally unique `ID`."""
+  aggregateMonthlyPlay(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateMonthlyPlay`.
+    """
+    nodeId: ID!
+  ): AggregateMonthlyPlay
+
+  """
+  Reads a single `AggregateMonthlyTotalUsersMetric` using its globally unique `ID`.
+  """
+  aggregateMonthlyTotalUsersMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateMonthlyTotalUsersMetric`.
+    """
+    nodeId: ID!
+  ): AggregateMonthlyTotalUsersMetric
+
+  """
+  Reads a single `AggregateMonthlyUniqueUsersMetric` using its globally unique `ID`.
+  """
+  aggregateMonthlyUniqueUsersMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateMonthlyUniqueUsersMetric`.
+    """
+    nodeId: ID!
+  ): AggregateMonthlyUniqueUsersMetric
+
+  """Reads a single `AggregatePlaylist` using its globally unique `ID`."""
+  aggregatePlaylist(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregatePlaylist`.
+    """
+    nodeId: ID!
+  ): AggregatePlaylist
+
+  """Reads a single `AggregatePlay` using its globally unique `ID`."""
+  aggregatePlay(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregatePlay`.
+    """
+    nodeId: ID!
+  ): AggregatePlay
+
+  """Reads a single `AggregateTrack` using its globally unique `ID`."""
+  aggregateTrack(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateTrack`.
+    """
+    nodeId: ID!
+  ): AggregateTrack
+
+  """Reads a single `AggregateUser` using its globally unique `ID`."""
+  aggregateUser(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateUser`.
+    """
+    nodeId: ID!
+  ): AggregateUser
+
+  """Reads a single `AggregateUserTip` using its globally unique `ID`."""
+  aggregateUserTip(
+    """
+    The globally unique `ID` to be used in selecting a single `AggregateUserTip`.
+    """
+    nodeId: ID!
+  ): AggregateUserTip
+
+  """Reads a single `AlembicVersion` using its globally unique `ID`."""
+  alembicVersion(
+    """
+    The globally unique `ID` to be used in selecting a single `AlembicVersion`.
+    """
+    nodeId: ID!
+  ): AlembicVersion
+
+  """Reads a single `AppNameMetric` using its globally unique `ID`."""
+  appNameMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `AppNameMetric`.
+    """
+    nodeId: ID!
+  ): AppNameMetric
+
+  """Reads a single `AssociatedWallet` using its globally unique `ID`."""
+  associatedWallet(
+    """
+    The globally unique `ID` to be used in selecting a single `AssociatedWallet`.
+    """
+    nodeId: ID!
+  ): AssociatedWallet
+
+  """
+  Reads a single `AudioTransactionsHistory` using its globally unique `ID`.
+  """
+  audioTransactionsHistory(
+    """
+    The globally unique `ID` to be used in selecting a single `AudioTransactionsHistory`.
+    """
+    nodeId: ID!
+  ): AudioTransactionsHistory
+
+  """Reads a single `AudiusDataTx` using its globally unique `ID`."""
+  audiusDataTx(
+    """
+    The globally unique `ID` to be used in selecting a single `AudiusDataTx`.
+    """
+    nodeId: ID!
+  ): AudiusDataTx
+
+  """Reads a single `Block` using its globally unique `ID`."""
+  block(
+    """The globally unique `ID` to be used in selecting a single `Block`."""
+    nodeId: ID!
+  ): Block
+
+  """Reads a single `BlocksCopy` using its globally unique `ID`."""
+  blocksCopy(
+    """
+    The globally unique `ID` to be used in selecting a single `BlocksCopy`.
+    """
+    nodeId: ID!
+  ): BlocksCopy
+
+  """Reads a single `ChallengeDisbursement` using its globally unique `ID`."""
+  challengeDisbursement(
+    """
+    The globally unique `ID` to be used in selecting a single `ChallengeDisbursement`.
+    """
+    nodeId: ID!
+  ): ChallengeDisbursement
+
+  """Reads a single `ChallengeListenStreak` using its globally unique `ID`."""
+  challengeListenStreak(
+    """
+    The globally unique `ID` to be used in selecting a single `ChallengeListenStreak`.
+    """
+    nodeId: ID!
+  ): ChallengeListenStreak
+
+  """
+  Reads a single `ChallengeProfileCompletion` using its globally unique `ID`.
+  """
+  challengeProfileCompletion(
+    """
+    The globally unique `ID` to be used in selecting a single `ChallengeProfileCompletion`.
+    """
+    nodeId: ID!
+  ): ChallengeProfileCompletion
+
+  """Reads a single `Challenge` using its globally unique `ID`."""
+  challenge(
+    """The globally unique `ID` to be used in selecting a single `Challenge`."""
+    nodeId: ID!
+  ): Challenge
+
+  """Reads a single `Chat` using its globally unique `ID`."""
+  chat(
+    """The globally unique `ID` to be used in selecting a single `Chat`."""
+    nodeId: ID!
+  ): Chat
+
+  """Reads a single `ChatBlockedUser` using its globally unique `ID`."""
+  chatBlockedUser(
+    """
+    The globally unique `ID` to be used in selecting a single `ChatBlockedUser`.
+    """
+    nodeId: ID!
+  ): ChatBlockedUser
+
+  """Reads a single `ChatMember` using its globally unique `ID`."""
+  chatMember(
+    """
+    The globally unique `ID` to be used in selecting a single `ChatMember`.
+    """
+    nodeId: ID!
+  ): ChatMember
+
+  """Reads a single `ChatMessage` using its globally unique `ID`."""
+  chatMessage(
+    """
+    The globally unique `ID` to be used in selecting a single `ChatMessage`.
+    """
+    nodeId: ID!
+  ): ChatMessage
+
+  """Reads a single `ChatMessageReaction` using its globally unique `ID`."""
+  chatMessageReaction(
+    """
+    The globally unique `ID` to be used in selecting a single `ChatMessageReaction`.
+    """
+    nodeId: ID!
+  ): ChatMessageReaction
+
+  """Reads a single `ChatPermission` using its globally unique `ID`."""
+  chatPermission(
+    """
+    The globally unique `ID` to be used in selecting a single `ChatPermission`.
+    """
+    nodeId: ID!
+  ): ChatPermission
+
+  """Reads a single `CidDatum` using its globally unique `ID`."""
+  cidDatum(
+    """The globally unique `ID` to be used in selecting a single `CidDatum`."""
+    nodeId: ID!
+  ): CidDatum
+
+  """Reads a single `EthBlock` using its globally unique `ID`."""
+  ethBlock(
+    """The globally unique `ID` to be used in selecting a single `EthBlock`."""
+    nodeId: ID!
+  ): EthBlock
+
+  """Reads a single `Follow` using its globally unique `ID`."""
+  follow(
+    """The globally unique `ID` to be used in selecting a single `Follow`."""
+    nodeId: ID!
+  ): Follow
+
+  """Reads a single `HourlyPlayCount` using its globally unique `ID`."""
+  hourlyPlayCount(
+    """
+    The globally unique `ID` to be used in selecting a single `HourlyPlayCount`.
+    """
+    nodeId: ID!
+  ): HourlyPlayCount
+
+  """Reads a single `IndexingCheckpoint` using its globally unique `ID`."""
+  indexingCheckpoint(
+    """
+    The globally unique `ID` to be used in selecting a single `IndexingCheckpoint`.
+    """
+    nodeId: ID!
+  ): IndexingCheckpoint
+
+  """Reads a single `Milestone` using its globally unique `ID`."""
+  milestone(
+    """The globally unique `ID` to be used in selecting a single `Milestone`."""
+    nodeId: ID!
+  ): Milestone
+
+  """Reads a single `Notification` using its globally unique `ID`."""
+  notification(
+    """
+    The globally unique `ID` to be used in selecting a single `Notification`.
+    """
+    nodeId: ID!
+  ): Notification
+
+  """Reads a single `NotificationSeen` using its globally unique `ID`."""
+  notificationSeen(
+    """
+    The globally unique `ID` to be used in selecting a single `NotificationSeen`.
+    """
+    nodeId: ID!
+  ): NotificationSeen
+
+  """Reads a single `PlaylistRoute` using its globally unique `ID`."""
+  playlistRoute(
+    """
+    The globally unique `ID` to be used in selecting a single `PlaylistRoute`.
+    """
+    nodeId: ID!
+  ): PlaylistRoute
+
+  """Reads a single `PlaylistSeen` using its globally unique `ID`."""
+  playlistSeen(
+    """
+    The globally unique `ID` to be used in selecting a single `PlaylistSeen`.
+    """
+    nodeId: ID!
+  ): PlaylistSeen
+
+  """Reads a single `Playlist` using its globally unique `ID`."""
+  playlist(
+    """The globally unique `ID` to be used in selecting a single `Playlist`."""
+    nodeId: ID!
+  ): Playlist
+
+  """Reads a single `Play` using its globally unique `ID`."""
+  play(
+    """The globally unique `ID` to be used in selecting a single `Play`."""
+    nodeId: ID!
+  ): Play
+
+  """Reads a single `PlaysArchive` using its globally unique `ID`."""
+  playsArchive(
+    """
+    The globally unique `ID` to be used in selecting a single `PlaysArchive`.
+    """
+    nodeId: ID!
+  ): PlaysArchive
+
+  """Reads a single `Reaction` using its globally unique `ID`."""
+  reaction(
+    """The globally unique `ID` to be used in selecting a single `Reaction`."""
+    nodeId: ID!
+  ): Reaction
+
+  """Reads a single `RelatedArtist` using its globally unique `ID`."""
+  relatedArtist(
+    """
+    The globally unique `ID` to be used in selecting a single `RelatedArtist`.
+    """
+    nodeId: ID!
+  ): RelatedArtist
+
+  """Reads a single `Remix` using its globally unique `ID`."""
+  remix(
+    """The globally unique `ID` to be used in selecting a single `Remix`."""
+    nodeId: ID!
+  ): Remix
+
+  """Reads a single `Repost` using its globally unique `ID`."""
+  repost(
+    """The globally unique `ID` to be used in selecting a single `Repost`."""
+    nodeId: ID!
+  ): Repost
+
+  """Reads a single `RewardManagerTx` using its globally unique `ID`."""
+  rewardManagerTx(
+    """
+    The globally unique `ID` to be used in selecting a single `RewardManagerTx`.
+    """
+    nodeId: ID!
+  ): RewardManagerTx
+
+  """
+  Reads a single `RewardsManagerBackfillTx` using its globally unique `ID`.
+  """
+  rewardsManagerBackfillTx(
+    """
+    The globally unique `ID` to be used in selecting a single `RewardsManagerBackfillTx`.
+    """
+    nodeId: ID!
+  ): RewardsManagerBackfillTx
+
+  """Reads a single `RouteMetric` using its globally unique `ID`."""
+  routeMetric(
+    """
+    The globally unique `ID` to be used in selecting a single `RouteMetric`.
+    """
+    nodeId: ID!
+  ): RouteMetric
+
+  """Reads a single `RpcLog` using its globally unique `ID`."""
+  rpcLog(
+    """The globally unique `ID` to be used in selecting a single `RpcLog`."""
+    nodeId: ID!
+  ): RpcLog
+
+  """Reads a single `Save` using its globally unique `ID`."""
+  save(
+    """The globally unique `ID` to be used in selecting a single `Save`."""
+    nodeId: ID!
+  ): Save
+
+  """Reads a single `SchemaMigration` using its globally unique `ID`."""
+  schemaMigration(
+    """
+    The globally unique `ID` to be used in selecting a single `SchemaMigration`.
+    """
+    nodeId: ID!
+  ): SchemaMigration
+
+  """Reads a single `SkippedTransaction` using its globally unique `ID`."""
+  skippedTransaction(
+    """
+    The globally unique `ID` to be used in selecting a single `SkippedTransaction`.
+    """
+    nodeId: ID!
+  ): SkippedTransaction
+
+  """Reads a single `SplTokenBackfillTx` using its globally unique `ID`."""
+  splTokenBackfillTx(
+    """
+    The globally unique `ID` to be used in selecting a single `SplTokenBackfillTx`.
+    """
+    nodeId: ID!
+  ): SplTokenBackfillTx
+
+  """Reads a single `SplTokenTx` using its globally unique `ID`."""
+  splTokenTx(
+    """
+    The globally unique `ID` to be used in selecting a single `SplTokenTx`.
+    """
+    nodeId: ID!
+  ): SplTokenTx
+
+  """Reads a single `Stem` using its globally unique `ID`."""
+  stem(
+    """The globally unique `ID` to be used in selecting a single `Stem`."""
+    nodeId: ID!
+  ): Stem
+
+  """Reads a single `Subscription` using its globally unique `ID`."""
+  subscription(
+    """
+    The globally unique `ID` to be used in selecting a single `Subscription`.
+    """
+    nodeId: ID!
+  ): Subscription
+
+  """Reads a single `SupporterRankUp` using its globally unique `ID`."""
+  supporterRankUp(
+    """
+    The globally unique `ID` to be used in selecting a single `SupporterRankUp`.
+    """
+    nodeId: ID!
+  ): SupporterRankUp
+
+  """Reads a single `TrackRoute` using its globally unique `ID`."""
+  trackRoute(
+    """
+    The globally unique `ID` to be used in selecting a single `TrackRoute`.
+    """
+    nodeId: ID!
+  ): TrackRoute
+
+  """Reads a single `TrackTrendingScore` using its globally unique `ID`."""
+  trackTrendingScore(
+    """
+    The globally unique `ID` to be used in selecting a single `TrackTrendingScore`.
+    """
+    nodeId: ID!
+  ): TrackTrendingScore
+
+  """Reads a single `Track` using its globally unique `ID`."""
+  track(
+    """The globally unique `ID` to be used in selecting a single `Track`."""
+    nodeId: ID!
+  ): Track
+
+  """Reads a single `TrendingResult` using its globally unique `ID`."""
+  trendingResult(
+    """
+    The globally unique `ID` to be used in selecting a single `TrendingResult`.
+    """
+    nodeId: ID!
+  ): TrendingResult
+
+  """Reads a single `UrsmContentNode` using its globally unique `ID`."""
+  ursmContentNode(
+    """
+    The globally unique `ID` to be used in selecting a single `UrsmContentNode`.
+    """
+    nodeId: ID!
+  ): UrsmContentNode
+
+  """Reads a single `UserBalanceChange` using its globally unique `ID`."""
+  userBalanceChange(
+    """
+    The globally unique `ID` to be used in selecting a single `UserBalanceChange`.
+    """
+    nodeId: ID!
+  ): UserBalanceChange
+
+  """Reads a single `UserBalance` using its globally unique `ID`."""
+  userBalance(
+    """
+    The globally unique `ID` to be used in selecting a single `UserBalance`.
+    """
+    nodeId: ID!
+  ): UserBalance
+
+  """Reads a single `UserBankAccount` using its globally unique `ID`."""
+  userBankAccount(
+    """
+    The globally unique `ID` to be used in selecting a single `UserBankAccount`.
+    """
+    nodeId: ID!
+  ): UserBankAccount
+
+  """Reads a single `UserBankBackfillTx` using its globally unique `ID`."""
+  userBankBackfillTx(
+    """
+    The globally unique `ID` to be used in selecting a single `UserBankBackfillTx`.
+    """
+    nodeId: ID!
+  ): UserBankBackfillTx
+
+  """Reads a single `UserBankTx` using its globally unique `ID`."""
+  userBankTx(
+    """
+    The globally unique `ID` to be used in selecting a single `UserBankTx`.
+    """
+    nodeId: ID!
+  ): UserBankTx
+
+  """Reads a single `UserChallenge` using its globally unique `ID`."""
+  userChallenge(
+    """
+    The globally unique `ID` to be used in selecting a single `UserChallenge`.
+    """
+    nodeId: ID!
+  ): UserChallenge
+
+  """Reads a single `UserEvent` using its globally unique `ID`."""
+  userEvent(
+    """The globally unique `ID` to be used in selecting a single `UserEvent`."""
+    nodeId: ID!
+  ): UserEvent
+
+  """Reads a single `UserListeningHistory` using its globally unique `ID`."""
+  userListeningHistory(
+    """
+    The globally unique `ID` to be used in selecting a single `UserListeningHistory`.
+    """
+    nodeId: ID!
+  ): UserListeningHistory
+
+  """Reads a single `UserTip` using its globally unique `ID`."""
+  userTip(
+    """The globally unique `ID` to be used in selecting a single `UserTip`."""
+    nodeId: ID!
+  ): UserTip
+
+  """Reads a single `User` using its globally unique `ID`."""
+  user(
+    """The globally unique `ID` to be used in selecting a single `User`."""
+    nodeId: ID!
+  ): User
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""A connection to a list of `AggregateDailyAppNameMetric` values."""
+type AggregateDailyAppNameMetricsConnection {
+  """A list of `AggregateDailyAppNameMetric` objects."""
+  nodes: [AggregateDailyAppNameMetric!]!
+
+  """
+  A list of edges which contains the `AggregateDailyAppNameMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateDailyAppNameMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateDailyAppNameMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateDailyAppNameMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  applicationName: String!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""The day, does not include a time."""
+scalar Date
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
+"""A `AggregateDailyAppNameMetric` edge in the connection."""
+type AggregateDailyAppNameMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateDailyAppNameMetric` at the end of the edge."""
+  node: AggregateDailyAppNameMetric!
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""Methods to use when ordering `AggregateDailyAppNameMetric`."""
+enum AggregateDailyAppNameMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_NAME_ASC
+  APPLICATION_NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateDailyAppNameMetric` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateDailyAppNameMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `applicationName` field."""
+  applicationName: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `AggregateDailyAppNameMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateDailyAppNameMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `applicationName` field."""
+  applicationName: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateDailyAppNameMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateDailyAppNameMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateDailyAppNameMetricFilter
+}
+
+"""
+A filter to be used against Int fields. All fields are combined with a logical ‘and.’
+"""
+input IntFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Int
+
+  """Not equal to the specified value."""
+  notEqualTo: Int
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Int
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Int
+
+  """Included in the specified list."""
+  in: [Int!]
+
+  """Not included in the specified list."""
+  notIn: [Int!]
+
+  """Less than the specified value."""
+  lessThan: Int
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Int
+
+  """Greater than the specified value."""
+  greaterThan: Int
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Int
+}
+
+"""
+A filter to be used against String fields. All fields are combined with a logical ‘and.’
+"""
+input StringFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: String
+
+  """Not equal to the specified value."""
+  notEqualTo: String
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: String
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: String
+
+  """Included in the specified list."""
+  in: [String!]
+
+  """Not included in the specified list."""
+  notIn: [String!]
+
+  """Less than the specified value."""
+  lessThan: String
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: String
+
+  """Greater than the specified value."""
+  greaterThan: String
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: String
+
+  """Contains the specified string (case-sensitive)."""
+  includes: String
+
+  """Does not contain the specified string (case-sensitive)."""
+  notIncludes: String
+
+  """Contains the specified string (case-insensitive)."""
+  includesInsensitive: String
+
+  """Does not contain the specified string (case-insensitive)."""
+  notIncludesInsensitive: String
+
+  """Starts with the specified string (case-sensitive)."""
+  startsWith: String
+
+  """Does not start with the specified string (case-sensitive)."""
+  notStartsWith: String
+
+  """Starts with the specified string (case-insensitive)."""
+  startsWithInsensitive: String
+
+  """Does not start with the specified string (case-insensitive)."""
+  notStartsWithInsensitive: String
+
+  """Ends with the specified string (case-sensitive)."""
+  endsWith: String
+
+  """Does not end with the specified string (case-sensitive)."""
+  notEndsWith: String
+
+  """Ends with the specified string (case-insensitive)."""
+  endsWithInsensitive: String
+
+  """Does not end with the specified string (case-insensitive)."""
+  notEndsWithInsensitive: String
+
+  """
+  Matches the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  like: String
+
+  """
+  Does not match the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLike: String
+
+  """
+  Matches the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  likeInsensitive: String
+
+  """
+  Does not match the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLikeInsensitive: String
+
+  """Equal to the specified value (case-insensitive)."""
+  equalToInsensitive: String
+
+  """Not equal to the specified value (case-insensitive)."""
+  notEqualToInsensitive: String
+
+  """
+  Not equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  distinctFromInsensitive: String
+
+  """
+  Equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  notDistinctFromInsensitive: String
+
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """Less than the specified value (case-insensitive)."""
+  lessThanInsensitive: String
+
+  """Less than or equal to the specified value (case-insensitive)."""
+  lessThanOrEqualToInsensitive: String
+
+  """Greater than the specified value (case-insensitive)."""
+  greaterThanInsensitive: String
+
+  """Greater than or equal to the specified value (case-insensitive)."""
+  greaterThanOrEqualToInsensitive: String
+}
+
+"""
+A filter to be used against Date fields. All fields are combined with a logical ‘and.’
+"""
+input DateFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Date
+
+  """Not equal to the specified value."""
+  notEqualTo: Date
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Date
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Date
+
+  """Included in the specified list."""
+  in: [Date!]
+
+  """Not included in the specified list."""
+  notIn: [Date!]
+
+  """Less than the specified value."""
+  lessThan: Date
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Date
+
+  """Greater than the specified value."""
+  greaterThan: Date
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Date
+}
+
+"""
+A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
+"""
+input DatetimeFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Datetime
+
+  """Not equal to the specified value."""
+  notEqualTo: Datetime
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Datetime
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Datetime
+
+  """Included in the specified list."""
+  in: [Datetime!]
+
+  """Not included in the specified list."""
+  notIn: [Datetime!]
+
+  """Less than the specified value."""
+  lessThan: Datetime
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Datetime
+
+  """Greater than the specified value."""
+  greaterThan: Datetime
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Datetime
+}
+
+"""A connection to a list of `AggregateDailyTotalUsersMetric` values."""
+type AggregateDailyTotalUsersMetricsConnection {
+  """A list of `AggregateDailyTotalUsersMetric` objects."""
+  nodes: [AggregateDailyTotalUsersMetric!]!
+
+  """
+  A list of edges which contains the `AggregateDailyTotalUsersMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateDailyTotalUsersMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateDailyTotalUsersMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateDailyTotalUsersMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `AggregateDailyTotalUsersMetric` edge in the connection."""
+type AggregateDailyTotalUsersMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateDailyTotalUsersMetric` at the end of the edge."""
+  node: AggregateDailyTotalUsersMetric!
+}
+
+"""Methods to use when ordering `AggregateDailyTotalUsersMetric`."""
+enum AggregateDailyTotalUsersMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateDailyTotalUsersMetric` object types.
+All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateDailyTotalUsersMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `AggregateDailyTotalUsersMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateDailyTotalUsersMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateDailyTotalUsersMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateDailyTotalUsersMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateDailyTotalUsersMetricFilter
+}
+
+"""A connection to a list of `AggregateDailyUniqueUsersMetric` values."""
+type AggregateDailyUniqueUsersMetricsConnection {
+  """A list of `AggregateDailyUniqueUsersMetric` objects."""
+  nodes: [AggregateDailyUniqueUsersMetric!]!
+
+  """
+  A list of edges which contains the `AggregateDailyUniqueUsersMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateDailyUniqueUsersMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateDailyUniqueUsersMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateDailyUniqueUsersMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  summedCount: Int
+}
+
+"""A `AggregateDailyUniqueUsersMetric` edge in the connection."""
+type AggregateDailyUniqueUsersMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateDailyUniqueUsersMetric` at the end of the edge."""
+  node: AggregateDailyUniqueUsersMetric!
+}
+
+"""Methods to use when ordering `AggregateDailyUniqueUsersMetric`."""
+enum AggregateDailyUniqueUsersMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SUMMED_COUNT_ASC
+  SUMMED_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateDailyUniqueUsersMetric` object types.
+All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateDailyUniqueUsersMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `summedCount` field."""
+  summedCount: Int
+}
+
+"""
+A filter to be used against `AggregateDailyUniqueUsersMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateDailyUniqueUsersMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `summedCount` field."""
+  summedCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateDailyUniqueUsersMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateDailyUniqueUsersMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateDailyUniqueUsersMetricFilter
+}
+
+"""A connection to a list of `AggregateIntervalPlay` values."""
+type AggregateIntervalPlaysConnection {
+  """A list of `AggregateIntervalPlay` objects."""
+  nodes: [AggregateIntervalPlay!]!
+
+  """
+  A list of edges which contains the `AggregateIntervalPlay` and cursor to aid in pagination.
+  """
+  edges: [AggregateIntervalPlaysEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateIntervalPlay` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateIntervalPlay {
+  trackId: Int
+  genre: String
+  createdAt: Datetime
+  weekListenCounts: BigInt
+  monthListenCounts: BigInt
+}
+
+"""
+A signed eight-byte integer. The upper big integer values are greater than the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+"""
+scalar BigInt
+
+"""A `AggregateIntervalPlay` edge in the connection."""
+type AggregateIntervalPlaysEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateIntervalPlay` at the end of the edge."""
+  node: AggregateIntervalPlay!
+}
+
+"""Methods to use when ordering `AggregateIntervalPlay`."""
+enum AggregateIntervalPlaysOrderBy {
+  NATURAL
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  GENRE_ASC
+  GENRE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  WEEK_LISTEN_COUNTS_ASC
+  WEEK_LISTEN_COUNTS_DESC
+  MONTH_LISTEN_COUNTS_ASC
+  MONTH_LISTEN_COUNTS_DESC
+}
+
+"""
+A condition to be used against `AggregateIntervalPlay` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateIntervalPlayCondition {
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `genre` field."""
+  genre: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `weekListenCounts` field."""
+  weekListenCounts: BigInt
+
+  """Checks for equality with the object’s `monthListenCounts` field."""
+  monthListenCounts: BigInt
+}
+
+"""
+A filter to be used against `AggregateIntervalPlay` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateIntervalPlayFilter {
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `genre` field."""
+  genre: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `weekListenCounts` field."""
+  weekListenCounts: BigIntFilter
+
+  """Filter by the object’s `monthListenCounts` field."""
+  monthListenCounts: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateIntervalPlayFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateIntervalPlayFilter!]
+
+  """Negates the expression."""
+  not: AggregateIntervalPlayFilter
+}
+
+"""
+A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
+"""
+input BigIntFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: BigInt
+
+  """Not equal to the specified value."""
+  notEqualTo: BigInt
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: BigInt
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: BigInt
+
+  """Included in the specified list."""
+  in: [BigInt!]
+
+  """Not included in the specified list."""
+  notIn: [BigInt!]
+
+  """Less than the specified value."""
+  lessThan: BigInt
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: BigInt
+
+  """Greater than the specified value."""
+  greaterThan: BigInt
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: BigInt
+}
+
+"""A connection to a list of `AggregateMonthlyAppNameMetric` values."""
+type AggregateMonthlyAppNameMetricsConnection {
+  """A list of `AggregateMonthlyAppNameMetric` objects."""
+  nodes: [AggregateMonthlyAppNameMetric!]!
+
+  """
+  A list of edges which contains the `AggregateMonthlyAppNameMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateMonthlyAppNameMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateMonthlyAppNameMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateMonthlyAppNameMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  applicationName: String!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `AggregateMonthlyAppNameMetric` edge in the connection."""
+type AggregateMonthlyAppNameMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateMonthlyAppNameMetric` at the end of the edge."""
+  node: AggregateMonthlyAppNameMetric!
+}
+
+"""Methods to use when ordering `AggregateMonthlyAppNameMetric`."""
+enum AggregateMonthlyAppNameMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_NAME_ASC
+  APPLICATION_NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateMonthlyAppNameMetric` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateMonthlyAppNameMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `applicationName` field."""
+  applicationName: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `AggregateMonthlyAppNameMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateMonthlyAppNameMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `applicationName` field."""
+  applicationName: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateMonthlyAppNameMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateMonthlyAppNameMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateMonthlyAppNameMetricFilter
+}
+
+"""A connection to a list of `AggregateMonthlyPlay` values."""
+type AggregateMonthlyPlaysConnection {
+  """A list of `AggregateMonthlyPlay` objects."""
+  nodes: [AggregateMonthlyPlay!]!
+
+  """
+  A list of edges which contains the `AggregateMonthlyPlay` and cursor to aid in pagination.
+  """
+  edges: [AggregateMonthlyPlaysEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateMonthlyPlay` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateMonthlyPlay implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  playItemId: Int!
+  timestamp: Date!
+  count: Int!
+}
+
+"""A `AggregateMonthlyPlay` edge in the connection."""
+type AggregateMonthlyPlaysEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateMonthlyPlay` at the end of the edge."""
+  node: AggregateMonthlyPlay!
+}
+
+"""Methods to use when ordering `AggregateMonthlyPlay`."""
+enum AggregateMonthlyPlaysOrderBy {
+  NATURAL
+  PLAY_ITEM_ID_ASC
+  PLAY_ITEM_ID_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  COUNT_ASC
+  COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateMonthlyPlay` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateMonthlyPlayCondition {
+  """Checks for equality with the object’s `playItemId` field."""
+  playItemId: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+}
+
+"""
+A filter to be used against `AggregateMonthlyPlay` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateMonthlyPlayFilter {
+  """Filter by the object’s `playItemId` field."""
+  playItemId: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateMonthlyPlayFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateMonthlyPlayFilter!]
+
+  """Negates the expression."""
+  not: AggregateMonthlyPlayFilter
+}
+
+"""A connection to a list of `AggregateMonthlyTotalUsersMetric` values."""
+type AggregateMonthlyTotalUsersMetricsConnection {
+  """A list of `AggregateMonthlyTotalUsersMetric` objects."""
+  nodes: [AggregateMonthlyTotalUsersMetric!]!
+
+  """
+  A list of edges which contains the `AggregateMonthlyTotalUsersMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateMonthlyTotalUsersMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateMonthlyTotalUsersMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateMonthlyTotalUsersMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `AggregateMonthlyTotalUsersMetric` edge in the connection."""
+type AggregateMonthlyTotalUsersMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateMonthlyTotalUsersMetric` at the end of the edge."""
+  node: AggregateMonthlyTotalUsersMetric!
+}
+
+"""Methods to use when ordering `AggregateMonthlyTotalUsersMetric`."""
+enum AggregateMonthlyTotalUsersMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateMonthlyTotalUsersMetric` object types.
+All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateMonthlyTotalUsersMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `AggregateMonthlyTotalUsersMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateMonthlyTotalUsersMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateMonthlyTotalUsersMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateMonthlyTotalUsersMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateMonthlyTotalUsersMetricFilter
+}
+
+"""A connection to a list of `AggregateMonthlyUniqueUsersMetric` values."""
+type AggregateMonthlyUniqueUsersMetricsConnection {
+  """A list of `AggregateMonthlyUniqueUsersMetric` objects."""
+  nodes: [AggregateMonthlyUniqueUsersMetric!]!
+
+  """
+  A list of edges which contains the `AggregateMonthlyUniqueUsersMetric` and cursor to aid in pagination.
+  """
+  edges: [AggregateMonthlyUniqueUsersMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateMonthlyUniqueUsersMetric` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateMonthlyUniqueUsersMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  count: Int!
+  timestamp: Date!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  summedCount: Int
+}
+
+"""A `AggregateMonthlyUniqueUsersMetric` edge in the connection."""
+type AggregateMonthlyUniqueUsersMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateMonthlyUniqueUsersMetric` at the end of the edge."""
+  node: AggregateMonthlyUniqueUsersMetric!
+}
+
+"""Methods to use when ordering `AggregateMonthlyUniqueUsersMetric`."""
+enum AggregateMonthlyUniqueUsersMetricsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SUMMED_COUNT_ASC
+  SUMMED_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateMonthlyUniqueUsersMetric` object types.
+All fields are tested for equality and combined with a logical ‘and.’
+"""
+input AggregateMonthlyUniqueUsersMetricCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Date
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `summedCount` field."""
+  summedCount: Int
+}
+
+"""
+A filter to be used against `AggregateMonthlyUniqueUsersMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateMonthlyUniqueUsersMetricFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DateFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `summedCount` field."""
+  summedCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateMonthlyUniqueUsersMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateMonthlyUniqueUsersMetricFilter!]
+
+  """Negates the expression."""
+  not: AggregateMonthlyUniqueUsersMetricFilter
+}
+
+"""A connection to a list of `AggregatePlaylist` values."""
+type AggregatePlaylistsConnection {
+  """A list of `AggregatePlaylist` objects."""
+  nodes: [AggregatePlaylist!]!
+
+  """
+  A list of edges which contains the `AggregatePlaylist` and cursor to aid in pagination.
+  """
+  edges: [AggregatePlaylistsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregatePlaylist` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregatePlaylist implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  playlistId: Int!
+  isAlbum: Boolean
+  repostCount: Int
+  saveCount: Int
+}
+
+"""A `AggregatePlaylist` edge in the connection."""
+type AggregatePlaylistsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregatePlaylist` at the end of the edge."""
+  node: AggregatePlaylist!
+}
+
+"""Methods to use when ordering `AggregatePlaylist`."""
+enum AggregatePlaylistsOrderBy {
+  NATURAL
+  PLAYLIST_ID_ASC
+  PLAYLIST_ID_DESC
+  IS_ALBUM_ASC
+  IS_ALBUM_DESC
+  REPOST_COUNT_ASC
+  REPOST_COUNT_DESC
+  SAVE_COUNT_ASC
+  SAVE_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregatePlaylist` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AggregatePlaylistCondition {
+  """Checks for equality with the object’s `playlistId` field."""
+  playlistId: Int
+
+  """Checks for equality with the object’s `isAlbum` field."""
+  isAlbum: Boolean
+
+  """Checks for equality with the object’s `repostCount` field."""
+  repostCount: Int
+
+  """Checks for equality with the object’s `saveCount` field."""
+  saveCount: Int
+}
+
+"""
+A filter to be used against `AggregatePlaylist` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregatePlaylistFilter {
+  """Filter by the object’s `playlistId` field."""
+  playlistId: IntFilter
+
+  """Filter by the object’s `isAlbum` field."""
+  isAlbum: BooleanFilter
+
+  """Filter by the object’s `repostCount` field."""
+  repostCount: IntFilter
+
+  """Filter by the object’s `saveCount` field."""
+  saveCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregatePlaylistFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregatePlaylistFilter!]
+
+  """Negates the expression."""
+  not: AggregatePlaylistFilter
+}
+
+"""
+A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
+"""
+input BooleanFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Boolean
+
+  """Not equal to the specified value."""
+  notEqualTo: Boolean
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Boolean
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Boolean
+
+  """Included in the specified list."""
+  in: [Boolean!]
+
+  """Not included in the specified list."""
+  notIn: [Boolean!]
+
+  """Less than the specified value."""
+  lessThan: Boolean
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Boolean
+
+  """Greater than the specified value."""
+  greaterThan: Boolean
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Boolean
+}
+
+"""A connection to a list of `AggregatePlay` values."""
+type AggregatePlaysConnection {
+  """A list of `AggregatePlay` objects."""
+  nodes: [AggregatePlay!]!
+
+  """
+  A list of edges which contains the `AggregatePlay` and cursor to aid in pagination.
+  """
+  edges: [AggregatePlaysEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AggregatePlay` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AggregatePlay implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  playItemId: Int!
+  count: BigInt
+}
+
+"""A `AggregatePlay` edge in the connection."""
+type AggregatePlaysEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregatePlay` at the end of the edge."""
+  node: AggregatePlay!
+}
+
+"""Methods to use when ordering `AggregatePlay`."""
+enum AggregatePlaysOrderBy {
+  NATURAL
+  PLAY_ITEM_ID_ASC
+  PLAY_ITEM_ID_DESC
+  COUNT_ASC
+  COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregatePlay` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AggregatePlayCondition {
+  """Checks for equality with the object’s `playItemId` field."""
+  playItemId: Int
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `AggregatePlay` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregatePlayFilter {
+  """Filter by the object’s `playItemId` field."""
+  playItemId: IntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregatePlayFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregatePlayFilter!]
+
+  """Negates the expression."""
+  not: AggregatePlayFilter
+}
+
+"""A connection to a list of `AggregateTrack` values."""
+type AggregateTracksConnection {
+  """A list of `AggregateTrack` objects."""
+  nodes: [AggregateTrack!]!
+
+  """
+  A list of edges which contains the `AggregateTrack` and cursor to aid in pagination.
+  """
+  edges: [AggregateTracksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AggregateTrack` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AggregateTrack implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  trackId: Int!
+  repostCount: Int!
+  saveCount: Int!
+}
+
+"""A `AggregateTrack` edge in the connection."""
+type AggregateTracksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateTrack` at the end of the edge."""
+  node: AggregateTrack!
+}
+
+"""Methods to use when ordering `AggregateTrack`."""
+enum AggregateTracksOrderBy {
+  NATURAL
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  REPOST_COUNT_ASC
+  REPOST_COUNT_DESC
+  SAVE_COUNT_ASC
+  SAVE_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateTrack` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AggregateTrackCondition {
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `repostCount` field."""
+  repostCount: Int
+
+  """Checks for equality with the object’s `saveCount` field."""
+  saveCount: Int
+}
+
+"""
+A filter to be used against `AggregateTrack` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateTrackFilter {
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `repostCount` field."""
+  repostCount: IntFilter
+
+  """Filter by the object’s `saveCount` field."""
+  saveCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateTrackFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateTrackFilter!]
+
+  """Negates the expression."""
+  not: AggregateTrackFilter
+}
+
+"""A connection to a list of `AggregateUser` values."""
+type AggregateUsersConnection {
+  """A list of `AggregateUser` objects."""
+  nodes: [AggregateUser!]!
+
+  """
+  A list of edges which contains the `AggregateUser` and cursor to aid in pagination.
+  """
+  edges: [AggregateUsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AggregateUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AggregateUser implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  trackCount: BigInt
+  playlistCount: BigInt
+  albumCount: BigInt
+  followerCount: BigInt
+  followingCount: BigInt
+  repostCount: BigInt
+  trackSaveCount: BigInt
+  supporterCount: Int!
+  supportingCount: Int!
+}
+
+"""A `AggregateUser` edge in the connection."""
+type AggregateUsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateUser` at the end of the edge."""
+  node: AggregateUser!
+}
+
+"""Methods to use when ordering `AggregateUser`."""
+enum AggregateUsersOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  TRACK_COUNT_ASC
+  TRACK_COUNT_DESC
+  PLAYLIST_COUNT_ASC
+  PLAYLIST_COUNT_DESC
+  ALBUM_COUNT_ASC
+  ALBUM_COUNT_DESC
+  FOLLOWER_COUNT_ASC
+  FOLLOWER_COUNT_DESC
+  FOLLOWING_COUNT_ASC
+  FOLLOWING_COUNT_DESC
+  REPOST_COUNT_ASC
+  REPOST_COUNT_DESC
+  TRACK_SAVE_COUNT_ASC
+  TRACK_SAVE_COUNT_DESC
+  SUPPORTER_COUNT_ASC
+  SUPPORTER_COUNT_DESC
+  SUPPORTING_COUNT_ASC
+  SUPPORTING_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateUser` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AggregateUserCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `trackCount` field."""
+  trackCount: BigInt
+
+  """Checks for equality with the object’s `playlistCount` field."""
+  playlistCount: BigInt
+
+  """Checks for equality with the object’s `albumCount` field."""
+  albumCount: BigInt
+
+  """Checks for equality with the object’s `followerCount` field."""
+  followerCount: BigInt
+
+  """Checks for equality with the object’s `followingCount` field."""
+  followingCount: BigInt
+
+  """Checks for equality with the object’s `repostCount` field."""
+  repostCount: BigInt
+
+  """Checks for equality with the object’s `trackSaveCount` field."""
+  trackSaveCount: BigInt
+
+  """Checks for equality with the object’s `supporterCount` field."""
+  supporterCount: Int
+
+  """Checks for equality with the object’s `supportingCount` field."""
+  supportingCount: Int
+}
+
+"""
+A filter to be used against `AggregateUser` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateUserFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `trackCount` field."""
+  trackCount: BigIntFilter
+
+  """Filter by the object’s `playlistCount` field."""
+  playlistCount: BigIntFilter
+
+  """Filter by the object’s `albumCount` field."""
+  albumCount: BigIntFilter
+
+  """Filter by the object’s `followerCount` field."""
+  followerCount: BigIntFilter
+
+  """Filter by the object’s `followingCount` field."""
+  followingCount: BigIntFilter
+
+  """Filter by the object’s `repostCount` field."""
+  repostCount: BigIntFilter
+
+  """Filter by the object’s `trackSaveCount` field."""
+  trackSaveCount: BigIntFilter
+
+  """Filter by the object’s `supporterCount` field."""
+  supporterCount: IntFilter
+
+  """Filter by the object’s `supportingCount` field."""
+  supportingCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateUserFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateUserFilter!]
+
+  """Negates the expression."""
+  not: AggregateUserFilter
+}
+
+"""A connection to a list of `AggregateUserTip` values."""
+type AggregateUserTipsConnection {
+  """A list of `AggregateUserTip` objects."""
+  nodes: [AggregateUserTip!]!
+
+  """
+  A list of edges which contains the `AggregateUserTip` and cursor to aid in pagination.
+  """
+  edges: [AggregateUserTipsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AggregateUserTip` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AggregateUserTip implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  senderUserId: Int!
+  receiverUserId: Int!
+  amount: BigInt!
+}
+
+"""A `AggregateUserTip` edge in the connection."""
+type AggregateUserTipsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AggregateUserTip` at the end of the edge."""
+  node: AggregateUserTip!
+}
+
+"""Methods to use when ordering `AggregateUserTip`."""
+enum AggregateUserTipsOrderBy {
+  NATURAL
+  SENDER_USER_ID_ASC
+  SENDER_USER_ID_DESC
+  RECEIVER_USER_ID_ASC
+  RECEIVER_USER_ID_DESC
+  AMOUNT_ASC
+  AMOUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AggregateUserTip` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AggregateUserTipCondition {
+  """Checks for equality with the object’s `senderUserId` field."""
+  senderUserId: Int
+
+  """Checks for equality with the object’s `receiverUserId` field."""
+  receiverUserId: Int
+
+  """Checks for equality with the object’s `amount` field."""
+  amount: BigInt
+}
+
+"""
+A filter to be used against `AggregateUserTip` object types. All fields are combined with a logical ‘and.’
+"""
+input AggregateUserTipFilter {
+  """Filter by the object’s `senderUserId` field."""
+  senderUserId: IntFilter
+
+  """Filter by the object’s `receiverUserId` field."""
+  receiverUserId: IntFilter
+
+  """Filter by the object’s `amount` field."""
+  amount: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AggregateUserTipFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AggregateUserTipFilter!]
+
+  """Negates the expression."""
+  not: AggregateUserTipFilter
+}
+
+"""A connection to a list of `AlembicVersion` values."""
+type AlembicVersionsConnection {
+  """A list of `AlembicVersion` objects."""
+  nodes: [AlembicVersion!]!
+
+  """
+  A list of edges which contains the `AlembicVersion` and cursor to aid in pagination.
+  """
+  edges: [AlembicVersionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AlembicVersion` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AlembicVersion implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  versionNum: String!
+}
+
+"""A `AlembicVersion` edge in the connection."""
+type AlembicVersionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AlembicVersion` at the end of the edge."""
+  node: AlembicVersion!
+}
+
+"""Methods to use when ordering `AlembicVersion`."""
+enum AlembicVersionsOrderBy {
+  NATURAL
+  VERSION_NUM_ASC
+  VERSION_NUM_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AlembicVersion` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AlembicVersionCondition {
+  """Checks for equality with the object’s `versionNum` field."""
+  versionNum: String
+}
+
+"""
+A filter to be used against `AlembicVersion` object types. All fields are combined with a logical ‘and.’
+"""
+input AlembicVersionFilter {
+  """Filter by the object’s `versionNum` field."""
+  versionNum: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [AlembicVersionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AlembicVersionFilter!]
+
+  """Negates the expression."""
+  not: AlembicVersionFilter
+}
+
+"""A connection to a list of `AppNameMetric` values."""
+type AppNameMetricsConnection {
+  """A list of `AppNameMetric` objects."""
+  nodes: [AppNameMetric!]!
+
+  """
+  A list of edges which contains the `AppNameMetric` and cursor to aid in pagination.
+  """
+  edges: [AppNameMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AppNameMetric` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AppNameMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  applicationName: String!
+  count: Int!
+  timestamp: Datetime!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  id: BigInt!
+  ip: String
+}
+
+"""A `AppNameMetric` edge in the connection."""
+type AppNameMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AppNameMetric` at the end of the edge."""
+  node: AppNameMetric!
+}
+
+"""Methods to use when ordering `AppNameMetric`."""
+enum AppNameMetricsOrderBy {
+  NATURAL
+  APPLICATION_NAME_ASC
+  APPLICATION_NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ID_ASC
+  ID_DESC
+  IP_ASC
+  IP_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AppNameMetric` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AppNameMetricCondition {
+  """Checks for equality with the object’s `applicationName` field."""
+  applicationName: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Datetime
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `id` field."""
+  id: BigInt
+
+  """Checks for equality with the object’s `ip` field."""
+  ip: String
+}
+
+"""
+A filter to be used against `AppNameMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input AppNameMetricFilter {
+  """Filter by the object’s `applicationName` field."""
+  applicationName: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DatetimeFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `id` field."""
+  id: BigIntFilter
+
+  """Filter by the object’s `ip` field."""
+  ip: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [AppNameMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AppNameMetricFilter!]
+
+  """Negates the expression."""
+  not: AppNameMetricFilter
+}
+
+"""A connection to a list of `AppNameMetricsAllTime` values."""
+type AppNameMetricsAllTimesConnection {
+  """A list of `AppNameMetricsAllTime` objects."""
+  nodes: [AppNameMetricsAllTime!]!
+
+  """
+  A list of edges which contains the `AppNameMetricsAllTime` and cursor to aid in pagination.
+  """
+  edges: [AppNameMetricsAllTimesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AppNameMetricsAllTime` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AppNameMetricsAllTime {
+  name: String
+  count: BigInt
+}
+
+"""A `AppNameMetricsAllTime` edge in the connection."""
+type AppNameMetricsAllTimesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AppNameMetricsAllTime` at the end of the edge."""
+  node: AppNameMetricsAllTime!
+}
+
+"""Methods to use when ordering `AppNameMetricsAllTime`."""
+enum AppNameMetricsAllTimesOrderBy {
+  NATURAL
+  NAME_ASC
+  NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `AppNameMetricsAllTime` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input AppNameMetricsAllTimeCondition {
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `AppNameMetricsAllTime` object types. All fields are combined with a logical ‘and.’
+"""
+input AppNameMetricsAllTimeFilter {
+  """Filter by the object’s `name` field."""
+  name: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AppNameMetricsAllTimeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AppNameMetricsAllTimeFilter!]
+
+  """Negates the expression."""
+  not: AppNameMetricsAllTimeFilter
+}
+
+"""A connection to a list of `AppNameMetricsTrailingMonth` values."""
+type AppNameMetricsTrailingMonthsConnection {
+  """A list of `AppNameMetricsTrailingMonth` objects."""
+  nodes: [AppNameMetricsTrailingMonth!]!
+
+  """
+  A list of edges which contains the `AppNameMetricsTrailingMonth` and cursor to aid in pagination.
+  """
+  edges: [AppNameMetricsTrailingMonthsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AppNameMetricsTrailingMonth` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AppNameMetricsTrailingMonth {
+  name: String
+  count: BigInt
+}
+
+"""A `AppNameMetricsTrailingMonth` edge in the connection."""
+type AppNameMetricsTrailingMonthsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AppNameMetricsTrailingMonth` at the end of the edge."""
+  node: AppNameMetricsTrailingMonth!
+}
+
+"""Methods to use when ordering `AppNameMetricsTrailingMonth`."""
+enum AppNameMetricsTrailingMonthsOrderBy {
+  NATURAL
+  NAME_ASC
+  NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `AppNameMetricsTrailingMonth` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input AppNameMetricsTrailingMonthCondition {
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `AppNameMetricsTrailingMonth` object types. All fields are combined with a logical ‘and.’
+"""
+input AppNameMetricsTrailingMonthFilter {
+  """Filter by the object’s `name` field."""
+  name: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AppNameMetricsTrailingMonthFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AppNameMetricsTrailingMonthFilter!]
+
+  """Negates the expression."""
+  not: AppNameMetricsTrailingMonthFilter
+}
+
+"""A connection to a list of `AppNameMetricsTrailingWeek` values."""
+type AppNameMetricsTrailingWeeksConnection {
+  """A list of `AppNameMetricsTrailingWeek` objects."""
+  nodes: [AppNameMetricsTrailingWeek!]!
+
+  """
+  A list of edges which contains the `AppNameMetricsTrailingWeek` and cursor to aid in pagination.
+  """
+  edges: [AppNameMetricsTrailingWeeksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AppNameMetricsTrailingWeek` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AppNameMetricsTrailingWeek {
+  name: String
+  count: BigInt
+}
+
+"""A `AppNameMetricsTrailingWeek` edge in the connection."""
+type AppNameMetricsTrailingWeeksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AppNameMetricsTrailingWeek` at the end of the edge."""
+  node: AppNameMetricsTrailingWeek!
+}
+
+"""Methods to use when ordering `AppNameMetricsTrailingWeek`."""
+enum AppNameMetricsTrailingWeeksOrderBy {
+  NATURAL
+  NAME_ASC
+  NAME_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `AppNameMetricsTrailingWeek` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input AppNameMetricsTrailingWeekCondition {
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `AppNameMetricsTrailingWeek` object types. All fields are combined with a logical ‘and.’
+"""
+input AppNameMetricsTrailingWeekFilter {
+  """Filter by the object’s `name` field."""
+  name: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AppNameMetricsTrailingWeekFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AppNameMetricsTrailingWeekFilter!]
+
+  """Negates the expression."""
+  not: AppNameMetricsTrailingWeekFilter
+}
+
+"""A connection to a list of `AssociatedWallet` values."""
+type AssociatedWalletsConnection {
+  """A list of `AssociatedWallet` objects."""
+  nodes: [AssociatedWallet!]!
+
+  """
+  A list of edges which contains the `AssociatedWallet` and cursor to aid in pagination.
+  """
+  edges: [AssociatedWalletsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AssociatedWallet` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AssociatedWallet implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  userId: Int!
+  wallet: String!
+  blockhash: String!
+  blocknumber: Int!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  chain: WalletChain!
+}
+
+enum WalletChain {
+  ETH
+  SOL
+}
+
+"""A `AssociatedWallet` edge in the connection."""
+type AssociatedWalletsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AssociatedWallet` at the end of the edge."""
+  node: AssociatedWallet!
+}
+
+"""Methods to use when ordering `AssociatedWallet`."""
+enum AssociatedWalletsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  WALLET_ASC
+  WALLET_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  CHAIN_ASC
+  CHAIN_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AssociatedWallet` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AssociatedWalletCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `wallet` field."""
+  wallet: String
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `chain` field."""
+  chain: WalletChain
+}
+
+"""
+A filter to be used against `AssociatedWallet` object types. All fields are combined with a logical ‘and.’
+"""
+input AssociatedWalletFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `wallet` field."""
+  wallet: StringFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `chain` field."""
+  chain: WalletChainFilter
+
+  """Checks for all expressions in this list."""
+  and: [AssociatedWalletFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AssociatedWalletFilter!]
+
+  """Negates the expression."""
+  not: AssociatedWalletFilter
+}
+
+"""
+A filter to be used against WalletChain fields. All fields are combined with a logical ‘and.’
+"""
+input WalletChainFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: WalletChain
+
+  """Not equal to the specified value."""
+  notEqualTo: WalletChain
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: WalletChain
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: WalletChain
+
+  """Included in the specified list."""
+  in: [WalletChain!]
+
+  """Not included in the specified list."""
+  notIn: [WalletChain!]
+
+  """Less than the specified value."""
+  lessThan: WalletChain
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: WalletChain
+
+  """Greater than the specified value."""
+  greaterThan: WalletChain
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: WalletChain
+}
+
+"""A connection to a list of `AudioTransactionsHistory` values."""
+type AudioTransactionsHistoriesConnection {
+  """A list of `AudioTransactionsHistory` objects."""
+  nodes: [AudioTransactionsHistory!]!
+
+  """
+  A list of edges which contains the `AudioTransactionsHistory` and cursor to aid in pagination.
+  """
+  edges: [AudioTransactionsHistoriesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `AudioTransactionsHistory` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type AudioTransactionsHistory implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userBank: String!
+  slot: Int!
+  signature: String!
+  transactionType: String!
+  method: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  transactionCreatedAt: Datetime!
+  change: BigFloat!
+  balance: BigFloat!
+  txMetadata: String
+}
+
+"""
+A floating point number that requires more precision than IEEE 754 binary 64
+"""
+scalar BigFloat
+
+"""A `AudioTransactionsHistory` edge in the connection."""
+type AudioTransactionsHistoriesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AudioTransactionsHistory` at the end of the edge."""
+  node: AudioTransactionsHistory!
+}
+
+"""Methods to use when ordering `AudioTransactionsHistory`."""
+enum AudioTransactionsHistoriesOrderBy {
+  NATURAL
+  USER_BANK_ASC
+  USER_BANK_DESC
+  SLOT_ASC
+  SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  TRANSACTION_TYPE_ASC
+  TRANSACTION_TYPE_DESC
+  METHOD_ASC
+  METHOD_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  TRANSACTION_CREATED_AT_ASC
+  TRANSACTION_CREATED_AT_DESC
+  CHANGE_ASC
+  CHANGE_DESC
+  BALANCE_ASC
+  BALANCE_DESC
+  TX_METADATA_ASC
+  TX_METADATA_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AudioTransactionsHistory` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input AudioTransactionsHistoryCondition {
+  """Checks for equality with the object’s `userBank` field."""
+  userBank: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `transactionType` field."""
+  transactionType: String
+
+  """Checks for equality with the object’s `method` field."""
+  method: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `transactionCreatedAt` field."""
+  transactionCreatedAt: Datetime
+
+  """Checks for equality with the object’s `change` field."""
+  change: BigFloat
+
+  """Checks for equality with the object’s `balance` field."""
+  balance: BigFloat
+
+  """Checks for equality with the object’s `txMetadata` field."""
+  txMetadata: String
+}
+
+"""
+A filter to be used against `AudioTransactionsHistory` object types. All fields are combined with a logical ‘and.’
+"""
+input AudioTransactionsHistoryFilter {
+  """Filter by the object’s `userBank` field."""
+  userBank: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `transactionType` field."""
+  transactionType: StringFilter
+
+  """Filter by the object’s `method` field."""
+  method: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `transactionCreatedAt` field."""
+  transactionCreatedAt: DatetimeFilter
+
+  """Filter by the object’s `change` field."""
+  change: BigFloatFilter
+
+  """Filter by the object’s `balance` field."""
+  balance: BigFloatFilter
+
+  """Filter by the object’s `txMetadata` field."""
+  txMetadata: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [AudioTransactionsHistoryFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AudioTransactionsHistoryFilter!]
+
+  """Negates the expression."""
+  not: AudioTransactionsHistoryFilter
+}
+
+"""
+A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
+"""
+input BigFloatFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: BigFloat
+
+  """Not equal to the specified value."""
+  notEqualTo: BigFloat
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: BigFloat
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: BigFloat
+
+  """Included in the specified list."""
+  in: [BigFloat!]
+
+  """Not included in the specified list."""
+  notIn: [BigFloat!]
+
+  """Less than the specified value."""
+  lessThan: BigFloat
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: BigFloat
+
+  """Greater than the specified value."""
+  greaterThan: BigFloat
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: BigFloat
+}
+
+"""A connection to a list of `AudiusDataTx` values."""
+type AudiusDataTxesConnection {
+  """A list of `AudiusDataTx` objects."""
+  nodes: [AudiusDataTx!]!
+
+  """
+  A list of edges which contains the `AudiusDataTx` and cursor to aid in pagination.
+  """
+  edges: [AudiusDataTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `AudiusDataTx` you could get from the connection."""
+  totalCount: Int!
+}
+
+type AudiusDataTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  slot: Int!
+}
+
+"""A `AudiusDataTx` edge in the connection."""
+type AudiusDataTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `AudiusDataTx` at the end of the edge."""
+  node: AudiusDataTx!
+}
+
+"""Methods to use when ordering `AudiusDataTx`."""
+enum AudiusDataTxesOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `AudiusDataTx` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input AudiusDataTxCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `AudiusDataTx` object types. All fields are combined with a logical ‘and.’
+"""
+input AudiusDataTxFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [AudiusDataTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [AudiusDataTxFilter!]
+
+  """Negates the expression."""
+  not: AudiusDataTxFilter
+}
+
+"""A connection to a list of `Block` values."""
+type BlocksConnection {
+  """A list of `Block` objects."""
+  nodes: [Block!]!
+
+  """
+  A list of edges which contains the `Block` and cursor to aid in pagination.
+  """
+  edges: [BlocksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Block` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Block implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String!
+  parenthash: String
+  isCurrent: Boolean
+  number: Int
+
+  """Reads and enables pagination through a set of `Track`."""
+  tracksByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Track`."""
+    orderBy: [TracksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrackCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrackFilter
+  ): TracksConnection!
+
+  """Reads and enables pagination through a set of `Track`."""
+  tracksByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Track`."""
+    orderBy: [TracksOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TrackCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: TrackFilter
+  ): TracksConnection!
+
+  """Reads and enables pagination through a set of `Follow`."""
+  followsByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Follow`."""
+    orderBy: [FollowsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FollowCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: FollowFilter
+  ): FollowsConnection!
+
+  """Reads and enables pagination through a set of `Follow`."""
+  followsByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Follow`."""
+    orderBy: [FollowsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FollowCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: FollowFilter
+  ): FollowsConnection!
+
+  """Reads and enables pagination through a set of `Playlist`."""
+  playlistsByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Playlist`."""
+    orderBy: [PlaylistsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaylistCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaylistFilter
+  ): PlaylistsConnection!
+
+  """Reads and enables pagination through a set of `Playlist`."""
+  playlistsByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Playlist`."""
+    orderBy: [PlaylistsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PlaylistCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: PlaylistFilter
+  ): PlaylistsConnection!
+
+  """Reads and enables pagination through a set of `Repost`."""
+  repostsByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Repost`."""
+    orderBy: [RepostsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RepostCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RepostFilter
+  ): RepostsConnection!
+
+  """Reads and enables pagination through a set of `Repost`."""
+  repostsByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Repost`."""
+    orderBy: [RepostsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: RepostCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: RepostFilter
+  ): RepostsConnection!
+
+  """Reads and enables pagination through a set of `Save`."""
+  savesByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Save`."""
+    orderBy: [SavesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SaveCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SaveFilter
+  ): SavesConnection!
+
+  """Reads and enables pagination through a set of `Save`."""
+  savesByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Save`."""
+    orderBy: [SavesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: SaveCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: SaveFilter
+  ): SavesConnection!
+
+  """Reads and enables pagination through a set of `User`."""
+  usersByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserFilter
+  ): UsersConnection!
+
+  """Reads and enables pagination through a set of `User`."""
+  usersByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `User`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserFilter
+  ): UsersConnection!
+
+  """Reads and enables pagination through a set of `UrsmContentNode`."""
+  ursmContentNodesByBlockhash(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UrsmContentNode`."""
+    orderBy: [UrsmContentNodesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UrsmContentNodeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UrsmContentNodeFilter
+  ): UrsmContentNodesConnection!
+
+  """Reads and enables pagination through a set of `UrsmContentNode`."""
+  ursmContentNodesByBlocknumber(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UrsmContentNode`."""
+    orderBy: [UrsmContentNodesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UrsmContentNodeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UrsmContentNodeFilter
+  ): UrsmContentNodesConnection!
+}
+
+"""A connection to a list of `Track` values."""
+type TracksConnection {
+  """A list of `Track` objects."""
+  nodes: [Track!]!
+
+  """
+  A list of edges which contains the `Track` and cursor to aid in pagination.
+  """
+  edges: [TracksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Track` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Track implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  trackId: Int!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  ownerId: Int!
+  title: String
+  length: Int
+  coverArt: String
+  tags: String
+  genre: String
+  mood: String
+  creditsSplits: String
+  createDate: String
+  releaseDate: String
+  fileType: String
+  metadataMultihash: String
+  blocknumber: Int
+  trackSegments: JSON!
+  createdAt: Datetime!
+  description: String
+  isrc: String
+  iswc: String
+  license: String
+  updatedAt: Datetime!
+  coverArtSizes: String
+  download: JSON
+  isUnlisted: Boolean!
+  fieldVisibility: JSON
+  routeId: String
+  stemOf: JSON
+  remixOf: JSON
+  txhash: String!
+  slot: Int
+  isAvailable: Boolean!
+  isPremium: Boolean!
+  premiumConditions: JSON
+  trackCid: String
+  isPlaylistUpload: Boolean!
+
+  """Reads a single `Block` that is related to this `Track`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `Track`."""
+  blockByBlocknumber: Block
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+"""A `Track` edge in the connection."""
+type TracksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Track` at the end of the edge."""
+  node: Track!
+}
+
+"""Methods to use when ordering `Track`."""
+enum TracksOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  OWNER_ID_ASC
+  OWNER_ID_DESC
+  TITLE_ASC
+  TITLE_DESC
+  LENGTH_ASC
+  LENGTH_DESC
+  COVER_ART_ASC
+  COVER_ART_DESC
+  TAGS_ASC
+  TAGS_DESC
+  GENRE_ASC
+  GENRE_DESC
+  MOOD_ASC
+  MOOD_DESC
+  CREDITS_SPLITS_ASC
+  CREDITS_SPLITS_DESC
+  CREATE_DATE_ASC
+  CREATE_DATE_DESC
+  RELEASE_DATE_ASC
+  RELEASE_DATE_DESC
+  FILE_TYPE_ASC
+  FILE_TYPE_DESC
+  METADATA_MULTIHASH_ASC
+  METADATA_MULTIHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  TRACK_SEGMENTS_ASC
+  TRACK_SEGMENTS_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  ISRC_ASC
+  ISRC_DESC
+  ISWC_ASC
+  ISWC_DESC
+  LICENSE_ASC
+  LICENSE_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  COVER_ART_SIZES_ASC
+  COVER_ART_SIZES_DESC
+  DOWNLOAD_ASC
+  DOWNLOAD_DESC
+  IS_UNLISTED_ASC
+  IS_UNLISTED_DESC
+  FIELD_VISIBILITY_ASC
+  FIELD_VISIBILITY_DESC
+  ROUTE_ID_ASC
+  ROUTE_ID_DESC
+  STEM_OF_ASC
+  STEM_OF_DESC
+  REMIX_OF_ASC
+  REMIX_OF_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  SLOT_ASC
+  SLOT_DESC
+  IS_AVAILABLE_ASC
+  IS_AVAILABLE_DESC
+  IS_PREMIUM_ASC
+  IS_PREMIUM_DESC
+  PREMIUM_CONDITIONS_ASC
+  PREMIUM_CONDITIONS_DESC
+  TRACK_CID_ASC
+  TRACK_CID_DESC
+  IS_PLAYLIST_UPLOAD_ASC
+  IS_PLAYLIST_UPLOAD_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Track` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TrackCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `ownerId` field."""
+  ownerId: Int
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
+
+  """Checks for equality with the object’s `length` field."""
+  length: Int
+
+  """Checks for equality with the object’s `coverArt` field."""
+  coverArt: String
+
+  """Checks for equality with the object’s `tags` field."""
+  tags: String
+
+  """Checks for equality with the object’s `genre` field."""
+  genre: String
+
+  """Checks for equality with the object’s `mood` field."""
+  mood: String
+
+  """Checks for equality with the object’s `creditsSplits` field."""
+  creditsSplits: String
+
+  """Checks for equality with the object’s `createDate` field."""
+  createDate: String
+
+  """Checks for equality with the object’s `releaseDate` field."""
+  releaseDate: String
+
+  """Checks for equality with the object’s `fileType` field."""
+  fileType: String
+
+  """Checks for equality with the object’s `metadataMultihash` field."""
+  metadataMultihash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `trackSegments` field."""
+  trackSegments: JSON
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `description` field."""
+  description: String
+
+  """Checks for equality with the object’s `isrc` field."""
+  isrc: String
+
+  """Checks for equality with the object’s `iswc` field."""
+  iswc: String
+
+  """Checks for equality with the object’s `license` field."""
+  license: String
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `coverArtSizes` field."""
+  coverArtSizes: String
+
+  """Checks for equality with the object’s `download` field."""
+  download: JSON
+
+  """Checks for equality with the object’s `isUnlisted` field."""
+  isUnlisted: Boolean
+
+  """Checks for equality with the object’s `fieldVisibility` field."""
+  fieldVisibility: JSON
+
+  """Checks for equality with the object’s `routeId` field."""
+  routeId: String
+
+  """Checks for equality with the object’s `stemOf` field."""
+  stemOf: JSON
+
+  """Checks for equality with the object’s `remixOf` field."""
+  remixOf: JSON
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `isAvailable` field."""
+  isAvailable: Boolean
+
+  """Checks for equality with the object’s `isPremium` field."""
+  isPremium: Boolean
+
+  """Checks for equality with the object’s `premiumConditions` field."""
+  premiumConditions: JSON
+
+  """Checks for equality with the object’s `trackCid` field."""
+  trackCid: String
+
+  """Checks for equality with the object’s `isPlaylistUpload` field."""
+  isPlaylistUpload: Boolean
+}
+
+"""
+A filter to be used against `Track` object types. All fields are combined with a logical ‘and.’
+"""
+input TrackFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `ownerId` field."""
+  ownerId: IntFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
+
+  """Filter by the object’s `length` field."""
+  length: IntFilter
+
+  """Filter by the object’s `coverArt` field."""
+  coverArt: StringFilter
+
+  """Filter by the object’s `tags` field."""
+  tags: StringFilter
+
+  """Filter by the object’s `genre` field."""
+  genre: StringFilter
+
+  """Filter by the object’s `mood` field."""
+  mood: StringFilter
+
+  """Filter by the object’s `creditsSplits` field."""
+  creditsSplits: StringFilter
+
+  """Filter by the object’s `createDate` field."""
+  createDate: StringFilter
+
+  """Filter by the object’s `releaseDate` field."""
+  releaseDate: StringFilter
+
+  """Filter by the object’s `fileType` field."""
+  fileType: StringFilter
+
+  """Filter by the object’s `metadataMultihash` field."""
+  metadataMultihash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `trackSegments` field."""
+  trackSegments: JSONFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `description` field."""
+  description: StringFilter
+
+  """Filter by the object’s `isrc` field."""
+  isrc: StringFilter
+
+  """Filter by the object’s `iswc` field."""
+  iswc: StringFilter
+
+  """Filter by the object’s `license` field."""
+  license: StringFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `coverArtSizes` field."""
+  coverArtSizes: StringFilter
+
+  """Filter by the object’s `download` field."""
+  download: JSONFilter
+
+  """Filter by the object’s `isUnlisted` field."""
+  isUnlisted: BooleanFilter
+
+  """Filter by the object’s `fieldVisibility` field."""
+  fieldVisibility: JSONFilter
+
+  """Filter by the object’s `routeId` field."""
+  routeId: StringFilter
+
+  """Filter by the object’s `stemOf` field."""
+  stemOf: JSONFilter
+
+  """Filter by the object’s `remixOf` field."""
+  remixOf: JSONFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `isAvailable` field."""
+  isAvailable: BooleanFilter
+
+  """Filter by the object’s `isPremium` field."""
+  isPremium: BooleanFilter
+
+  """Filter by the object’s `premiumConditions` field."""
+  premiumConditions: JSONFilter
+
+  """Filter by the object’s `trackCid` field."""
+  trackCid: StringFilter
+
+  """Filter by the object’s `isPlaylistUpload` field."""
+  isPlaylistUpload: BooleanFilter
+
+  """Checks for all expressions in this list."""
+  and: [TrackFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TrackFilter!]
+
+  """Negates the expression."""
+  not: TrackFilter
+}
+
+"""
+A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
+"""
+input JSONFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: JSON
+
+  """Not equal to the specified value."""
+  notEqualTo: JSON
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: JSON
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: JSON
+
+  """Included in the specified list."""
+  in: [JSON!]
+
+  """Not included in the specified list."""
+  notIn: [JSON!]
+
+  """Less than the specified value."""
+  lessThan: JSON
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: JSON
+
+  """Greater than the specified value."""
+  greaterThan: JSON
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: JSON
+
+  """Contains the specified JSON."""
+  contains: JSON
+
+  """Contains the specified key."""
+  containsKey: String
+
+  """Contains all of the specified keys."""
+  containsAllKeys: [String!]
+
+  """Contains any of the specified keys."""
+  containsAnyKeys: [String!]
+
+  """Contained by the specified JSON."""
+  containedBy: JSON
+}
+
+"""A connection to a list of `Follow` values."""
+type FollowsConnection {
+  """A list of `Follow` objects."""
+  nodes: [Follow!]!
+
+  """
+  A list of edges which contains the `Follow` and cursor to aid in pagination.
+  """
+  edges: [FollowsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Follow` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Follow implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  followerUserId: Int!
+  followeeUserId: Int!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  createdAt: Datetime!
+  txhash: String!
+  slot: Int
+
+  """Reads a single `Block` that is related to this `Follow`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `Follow`."""
+  blockByBlocknumber: Block
+}
+
+"""A `Follow` edge in the connection."""
+type FollowsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Follow` at the end of the edge."""
+  node: Follow!
+}
+
+"""Methods to use when ordering `Follow`."""
+enum FollowsOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  FOLLOWER_USER_ID_ASC
+  FOLLOWER_USER_ID_DESC
+  FOLLOWEE_USER_ID_ASC
+  FOLLOWEE_USER_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Follow` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input FollowCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `followerUserId` field."""
+  followerUserId: Int
+
+  """Checks for equality with the object’s `followeeUserId` field."""
+  followeeUserId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `Follow` object types. All fields are combined with a logical ‘and.’
+"""
+input FollowFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `followerUserId` field."""
+  followerUserId: IntFilter
+
+  """Filter by the object’s `followeeUserId` field."""
+  followeeUserId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [FollowFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [FollowFilter!]
+
+  """Negates the expression."""
+  not: FollowFilter
+}
+
+"""A connection to a list of `Playlist` values."""
+type PlaylistsConnection {
+  """A list of `Playlist` objects."""
+  nodes: [Playlist!]!
+
+  """
+  A list of edges which contains the `Playlist` and cursor to aid in pagination.
+  """
+  edges: [PlaylistsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Playlist` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Playlist implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  playlistId: Int!
+  playlistOwnerId: Int!
+  isAlbum: Boolean!
+  isPrivate: Boolean!
+  playlistName: String
+  playlistContents: JSON!
+  playlistImageMultihash: String
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  description: String
+  createdAt: Datetime!
+  upc: String
+  updatedAt: Datetime!
+  playlistImageSizesMultihash: String
+  txhash: String!
+  lastAddedTo: Datetime
+  slot: Int
+  metadataMultihash: String
+
+  """Reads a single `Block` that is related to this `Playlist`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `Playlist`."""
+  blockByBlocknumber: Block
+}
+
+"""A `Playlist` edge in the connection."""
+type PlaylistsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Playlist` at the end of the edge."""
+  node: Playlist!
+}
+
+"""Methods to use when ordering `Playlist`."""
+enum PlaylistsOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  PLAYLIST_ID_ASC
+  PLAYLIST_ID_DESC
+  PLAYLIST_OWNER_ID_ASC
+  PLAYLIST_OWNER_ID_DESC
+  IS_ALBUM_ASC
+  IS_ALBUM_DESC
+  IS_PRIVATE_ASC
+  IS_PRIVATE_DESC
+  PLAYLIST_NAME_ASC
+  PLAYLIST_NAME_DESC
+  PLAYLIST_CONTENTS_ASC
+  PLAYLIST_CONTENTS_DESC
+  PLAYLIST_IMAGE_MULTIHASH_ASC
+  PLAYLIST_IMAGE_MULTIHASH_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPC_ASC
+  UPC_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PLAYLIST_IMAGE_SIZES_MULTIHASH_ASC
+  PLAYLIST_IMAGE_SIZES_MULTIHASH_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  LAST_ADDED_TO_ASC
+  LAST_ADDED_TO_DESC
+  SLOT_ASC
+  SLOT_DESC
+  METADATA_MULTIHASH_ASC
+  METADATA_MULTIHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Playlist` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input PlaylistCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `playlistId` field."""
+  playlistId: Int
+
+  """Checks for equality with the object’s `playlistOwnerId` field."""
+  playlistOwnerId: Int
+
+  """Checks for equality with the object’s `isAlbum` field."""
+  isAlbum: Boolean
+
+  """Checks for equality with the object’s `isPrivate` field."""
+  isPrivate: Boolean
+
+  """Checks for equality with the object’s `playlistName` field."""
+  playlistName: String
+
+  """Checks for equality with the object’s `playlistContents` field."""
+  playlistContents: JSON
+
+  """Checks for equality with the object’s `playlistImageMultihash` field."""
+  playlistImageMultihash: String
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `description` field."""
+  description: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `upc` field."""
+  upc: String
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """
+  Checks for equality with the object’s `playlistImageSizesMultihash` field.
+  """
+  playlistImageSizesMultihash: String
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `lastAddedTo` field."""
+  lastAddedTo: Datetime
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `metadataMultihash` field."""
+  metadataMultihash: String
+}
+
+"""
+A filter to be used against `Playlist` object types. All fields are combined with a logical ‘and.’
+"""
+input PlaylistFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `playlistId` field."""
+  playlistId: IntFilter
+
+  """Filter by the object’s `playlistOwnerId` field."""
+  playlistOwnerId: IntFilter
+
+  """Filter by the object’s `isAlbum` field."""
+  isAlbum: BooleanFilter
+
+  """Filter by the object’s `isPrivate` field."""
+  isPrivate: BooleanFilter
+
+  """Filter by the object’s `playlistName` field."""
+  playlistName: StringFilter
+
+  """Filter by the object’s `playlistContents` field."""
+  playlistContents: JSONFilter
+
+  """Filter by the object’s `playlistImageMultihash` field."""
+  playlistImageMultihash: StringFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `description` field."""
+  description: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `upc` field."""
+  upc: StringFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `playlistImageSizesMultihash` field."""
+  playlistImageSizesMultihash: StringFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `lastAddedTo` field."""
+  lastAddedTo: DatetimeFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `metadataMultihash` field."""
+  metadataMultihash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [PlaylistFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [PlaylistFilter!]
+
+  """Negates the expression."""
+  not: PlaylistFilter
+}
+
+"""A connection to a list of `Repost` values."""
+type RepostsConnection {
+  """A list of `Repost` objects."""
+  nodes: [Repost!]!
+
+  """
+  A list of edges which contains the `Repost` and cursor to aid in pagination.
+  """
+  edges: [RepostsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Repost` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Repost implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  userId: Int!
+  repostItemId: Int!
+  repostType: Reposttype!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  createdAt: Datetime!
+  txhash: String!
+  slot: Int
+
+  """Reads a single `Block` that is related to this `Repost`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `Repost`."""
+  blockByBlocknumber: Block
+}
+
+enum Reposttype {
+  TRACK
+  PLAYLIST
+  ALBUM
+}
+
+"""A `Repost` edge in the connection."""
+type RepostsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Repost` at the end of the edge."""
+  node: Repost!
+}
+
+"""Methods to use when ordering `Repost`."""
+enum RepostsOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  REPOST_ITEM_ID_ASC
+  REPOST_ITEM_ID_DESC
+  REPOST_TYPE_ASC
+  REPOST_TYPE_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Repost` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input RepostCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `repostItemId` field."""
+  repostItemId: Int
+
+  """Checks for equality with the object’s `repostType` field."""
+  repostType: Reposttype
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `Repost` object types. All fields are combined with a logical ‘and.’
+"""
+input RepostFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `repostItemId` field."""
+  repostItemId: IntFilter
+
+  """Filter by the object’s `repostType` field."""
+  repostType: ReposttypeFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [RepostFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RepostFilter!]
+
+  """Negates the expression."""
+  not: RepostFilter
+}
+
+"""
+A filter to be used against Reposttype fields. All fields are combined with a logical ‘and.’
+"""
+input ReposttypeFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Reposttype
+
+  """Not equal to the specified value."""
+  notEqualTo: Reposttype
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Reposttype
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Reposttype
+
+  """Included in the specified list."""
+  in: [Reposttype!]
+
+  """Not included in the specified list."""
+  notIn: [Reposttype!]
+
+  """Less than the specified value."""
+  lessThan: Reposttype
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Reposttype
+
+  """Greater than the specified value."""
+  greaterThan: Reposttype
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Reposttype
+}
+
+"""A connection to a list of `Save` values."""
+type SavesConnection {
+  """A list of `Save` objects."""
+  nodes: [Save!]!
+
+  """
+  A list of edges which contains the `Save` and cursor to aid in pagination.
+  """
+  edges: [SavesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Save` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Save implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  userId: Int!
+  saveItemId: Int!
+  saveType: Savetype!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  createdAt: Datetime!
+  txhash: String!
+  slot: Int
+
+  """Reads a single `Block` that is related to this `Save`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `Save`."""
+  blockByBlocknumber: Block
+}
+
+enum Savetype {
+  TRACK
+  PLAYLIST
+  ALBUM
+}
+
+"""A `Save` edge in the connection."""
+type SavesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Save` at the end of the edge."""
+  node: Save!
+}
+
+"""Methods to use when ordering `Save`."""
+enum SavesOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  SAVE_ITEM_ID_ASC
+  SAVE_ITEM_ID_DESC
+  SAVE_TYPE_ASC
+  SAVE_TYPE_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Save` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input SaveCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `saveItemId` field."""
+  saveItemId: Int
+
+  """Checks for equality with the object’s `saveType` field."""
+  saveType: Savetype
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `Save` object types. All fields are combined with a logical ‘and.’
+"""
+input SaveFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `saveItemId` field."""
+  saveItemId: IntFilter
+
+  """Filter by the object’s `saveType` field."""
+  saveType: SavetypeFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [SaveFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SaveFilter!]
+
+  """Negates the expression."""
+  not: SaveFilter
+}
+
+"""
+A filter to be used against Savetype fields. All fields are combined with a logical ‘and.’
+"""
+input SavetypeFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Savetype
+
+  """Not equal to the specified value."""
+  notEqualTo: Savetype
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Savetype
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Savetype
+
+  """Included in the specified list."""
+  in: [Savetype!]
+
+  """Not included in the specified list."""
+  notIn: [Savetype!]
+
+  """Less than the specified value."""
+  lessThan: Savetype
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Savetype
+
+  """Greater than the specified value."""
+  greaterThan: Savetype
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Savetype
+}
+
+"""A connection to a list of `User` values."""
+type UsersConnection {
+  """A list of `User` objects."""
+  nodes: [User!]!
+
+  """
+  A list of edges which contains the `User` and cursor to aid in pagination.
+  """
+  edges: [UsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `User` you could get from the connection."""
+  totalCount: Int!
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  userId: Int!
+  isCurrent: Boolean!
+  handle: String
+  wallet: String
+  name: String
+  profilePicture: String
+  coverPhoto: String
+  bio: String
+  location: String
+  metadataMultihash: String
+  creatorNodeEndpoint: String
+  blocknumber: Int
+  isVerified: Boolean!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  handleLc: String
+  coverPhotoSizes: String
+  profilePictureSizes: String
+  primaryId: Int
+  secondaryIds: [Int]
+  replicaSetUpdateSigner: String
+  hasCollectibles: Boolean!
+  txhash: String!
+  playlistLibrary: JSON
+  isDeactivated: Boolean!
+  slot: Int
+  userStorageAccount: String
+  userAuthorityAccount: String
+  artistPickTrackId: Int
+
+  """Reads a single `Block` that is related to this `User`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `User`."""
+  blockByBlocknumber: Block
+}
+
+"""A `User` edge in the connection."""
+type UsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `User` at the end of the edge."""
+  node: User!
+}
+
+"""Methods to use when ordering `User`."""
+enum UsersOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  HANDLE_ASC
+  HANDLE_DESC
+  WALLET_ASC
+  WALLET_DESC
+  NAME_ASC
+  NAME_DESC
+  PROFILE_PICTURE_ASC
+  PROFILE_PICTURE_DESC
+  COVER_PHOTO_ASC
+  COVER_PHOTO_DESC
+  BIO_ASC
+  BIO_DESC
+  LOCATION_ASC
+  LOCATION_DESC
+  METADATA_MULTIHASH_ASC
+  METADATA_MULTIHASH_DESC
+  CREATOR_NODE_ENDPOINT_ASC
+  CREATOR_NODE_ENDPOINT_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  IS_VERIFIED_ASC
+  IS_VERIFIED_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  HANDLE_LC_ASC
+  HANDLE_LC_DESC
+  COVER_PHOTO_SIZES_ASC
+  COVER_PHOTO_SIZES_DESC
+  PROFILE_PICTURE_SIZES_ASC
+  PROFILE_PICTURE_SIZES_DESC
+  PRIMARY_ID_ASC
+  PRIMARY_ID_DESC
+  SECONDARY_IDS_ASC
+  SECONDARY_IDS_DESC
+  REPLICA_SET_UPDATE_SIGNER_ASC
+  REPLICA_SET_UPDATE_SIGNER_DESC
+  HAS_COLLECTIBLES_ASC
+  HAS_COLLECTIBLES_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PLAYLIST_LIBRARY_ASC
+  PLAYLIST_LIBRARY_DESC
+  IS_DEACTIVATED_ASC
+  IS_DEACTIVATED_DESC
+  SLOT_ASC
+  SLOT_DESC
+  USER_STORAGE_ACCOUNT_ASC
+  USER_STORAGE_ACCOUNT_DESC
+  USER_AUTHORITY_ACCOUNT_ASC
+  USER_AUTHORITY_ACCOUNT_DESC
+  ARTIST_PICK_TRACK_ID_ASC
+  ARTIST_PICK_TRACK_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `User` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `handle` field."""
+  handle: String
+
+  """Checks for equality with the object’s `wallet` field."""
+  wallet: String
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `profilePicture` field."""
+  profilePicture: String
+
+  """Checks for equality with the object’s `coverPhoto` field."""
+  coverPhoto: String
+
+  """Checks for equality with the object’s `bio` field."""
+  bio: String
+
+  """Checks for equality with the object’s `location` field."""
+  location: String
+
+  """Checks for equality with the object’s `metadataMultihash` field."""
+  metadataMultihash: String
+
+  """Checks for equality with the object’s `creatorNodeEndpoint` field."""
+  creatorNodeEndpoint: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `isVerified` field."""
+  isVerified: Boolean
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `handleLc` field."""
+  handleLc: String
+
+  """Checks for equality with the object’s `coverPhotoSizes` field."""
+  coverPhotoSizes: String
+
+  """Checks for equality with the object’s `profilePictureSizes` field."""
+  profilePictureSizes: String
+
+  """Checks for equality with the object’s `primaryId` field."""
+  primaryId: Int
+
+  """Checks for equality with the object’s `secondaryIds` field."""
+  secondaryIds: [Int]
+
+  """Checks for equality with the object’s `replicaSetUpdateSigner` field."""
+  replicaSetUpdateSigner: String
+
+  """Checks for equality with the object’s `hasCollectibles` field."""
+  hasCollectibles: Boolean
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `playlistLibrary` field."""
+  playlistLibrary: JSON
+
+  """Checks for equality with the object’s `isDeactivated` field."""
+  isDeactivated: Boolean
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `userStorageAccount` field."""
+  userStorageAccount: String
+
+  """Checks for equality with the object’s `userAuthorityAccount` field."""
+  userAuthorityAccount: String
+
+  """Checks for equality with the object’s `artistPickTrackId` field."""
+  artistPickTrackId: Int
+}
+
+"""
+A filter to be used against `User` object types. All fields are combined with a logical ‘and.’
+"""
+input UserFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `handle` field."""
+  handle: StringFilter
+
+  """Filter by the object’s `wallet` field."""
+  wallet: StringFilter
+
+  """Filter by the object’s `name` field."""
+  name: StringFilter
+
+  """Filter by the object’s `profilePicture` field."""
+  profilePicture: StringFilter
+
+  """Filter by the object’s `coverPhoto` field."""
+  coverPhoto: StringFilter
+
+  """Filter by the object’s `bio` field."""
+  bio: StringFilter
+
+  """Filter by the object’s `location` field."""
+  location: StringFilter
+
+  """Filter by the object’s `metadataMultihash` field."""
+  metadataMultihash: StringFilter
+
+  """Filter by the object’s `creatorNodeEndpoint` field."""
+  creatorNodeEndpoint: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `isVerified` field."""
+  isVerified: BooleanFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `handleLc` field."""
+  handleLc: StringFilter
+
+  """Filter by the object’s `coverPhotoSizes` field."""
+  coverPhotoSizes: StringFilter
+
+  """Filter by the object’s `profilePictureSizes` field."""
+  profilePictureSizes: StringFilter
+
+  """Filter by the object’s `primaryId` field."""
+  primaryId: IntFilter
+
+  """Filter by the object’s `secondaryIds` field."""
+  secondaryIds: IntListFilter
+
+  """Filter by the object’s `replicaSetUpdateSigner` field."""
+  replicaSetUpdateSigner: StringFilter
+
+  """Filter by the object’s `hasCollectibles` field."""
+  hasCollectibles: BooleanFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `playlistLibrary` field."""
+  playlistLibrary: JSONFilter
+
+  """Filter by the object’s `isDeactivated` field."""
+  isDeactivated: BooleanFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `userStorageAccount` field."""
+  userStorageAccount: StringFilter
+
+  """Filter by the object’s `userAuthorityAccount` field."""
+  userAuthorityAccount: StringFilter
+
+  """Filter by the object’s `artistPickTrackId` field."""
+  artistPickTrackId: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserFilter!]
+
+  """Negates the expression."""
+  not: UserFilter
+}
+
+"""
+A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
+"""
+input IntListFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: [Int]
+
+  """Not equal to the specified value."""
+  notEqualTo: [Int]
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: [Int]
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: [Int]
+
+  """Less than the specified value."""
+  lessThan: [Int]
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: [Int]
+
+  """Greater than the specified value."""
+  greaterThan: [Int]
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: [Int]
+
+  """Contains the specified list of values."""
+  contains: [Int]
+
+  """Contained by the specified list of values."""
+  containedBy: [Int]
+
+  """Overlaps the specified list of values."""
+  overlaps: [Int]
+
+  """Any array item is equal to the specified value."""
+  anyEqualTo: Int
+
+  """Any array item is not equal to the specified value."""
+  anyNotEqualTo: Int
+
+  """Any array item is less than the specified value."""
+  anyLessThan: Int
+
+  """Any array item is less than or equal to the specified value."""
+  anyLessThanOrEqualTo: Int
+
+  """Any array item is greater than the specified value."""
+  anyGreaterThan: Int
+
+  """Any array item is greater than or equal to the specified value."""
+  anyGreaterThanOrEqualTo: Int
+}
+
+"""A connection to a list of `UrsmContentNode` values."""
+type UrsmContentNodesConnection {
+  """A list of `UrsmContentNode` objects."""
+  nodes: [UrsmContentNode!]!
+
+  """
+  A list of edges which contains the `UrsmContentNode` and cursor to aid in pagination.
+  """
+  edges: [UrsmContentNodesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `UrsmContentNode` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type UrsmContentNode implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  createdAt: Datetime!
+  isCurrent: Boolean!
+  cnodeSpId: Int!
+  delegateOwnerWallet: String!
+  ownerWallet: String!
+  proposerSpIds: [Int]!
+  proposer1DelegateOwnerWallet: String!
+  proposer2DelegateOwnerWallet: String!
+  proposer3DelegateOwnerWallet: String!
+  endpoint: String
+  txhash: String!
+  slot: Int
+
+  """Reads a single `Block` that is related to this `UrsmContentNode`."""
+  blockByBlockhash: Block
+
+  """Reads a single `Block` that is related to this `UrsmContentNode`."""
+  blockByBlocknumber: Block
+}
+
+"""A `UrsmContentNode` edge in the connection."""
+type UrsmContentNodesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UrsmContentNode` at the end of the edge."""
+  node: UrsmContentNode!
+}
+
+"""Methods to use when ordering `UrsmContentNode`."""
+enum UrsmContentNodesOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  CNODE_SP_ID_ASC
+  CNODE_SP_ID_DESC
+  DELEGATE_OWNER_WALLET_ASC
+  DELEGATE_OWNER_WALLET_DESC
+  OWNER_WALLET_ASC
+  OWNER_WALLET_DESC
+  PROPOSER_SP_IDS_ASC
+  PROPOSER_SP_IDS_DESC
+  PROPOSER_1_DELEGATE_OWNER_WALLET_ASC
+  PROPOSER_1_DELEGATE_OWNER_WALLET_DESC
+  PROPOSER_2_DELEGATE_OWNER_WALLET_ASC
+  PROPOSER_2_DELEGATE_OWNER_WALLET_DESC
+  PROPOSER_3_DELEGATE_OWNER_WALLET_ASC
+  PROPOSER_3_DELEGATE_OWNER_WALLET_DESC
+  ENDPOINT_ASC
+  ENDPOINT_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UrsmContentNode` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input UrsmContentNodeCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `cnodeSpId` field."""
+  cnodeSpId: Int
+
+  """Checks for equality with the object’s `delegateOwnerWallet` field."""
+  delegateOwnerWallet: String
+
+  """Checks for equality with the object’s `ownerWallet` field."""
+  ownerWallet: String
+
+  """Checks for equality with the object’s `proposerSpIds` field."""
+  proposerSpIds: [Int]
+
+  """
+  Checks for equality with the object’s `proposer1DelegateOwnerWallet` field.
+  """
+  proposer1DelegateOwnerWallet: String
+
+  """
+  Checks for equality with the object’s `proposer2DelegateOwnerWallet` field.
+  """
+  proposer2DelegateOwnerWallet: String
+
+  """
+  Checks for equality with the object’s `proposer3DelegateOwnerWallet` field.
+  """
+  proposer3DelegateOwnerWallet: String
+
+  """Checks for equality with the object’s `endpoint` field."""
+  endpoint: String
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `UrsmContentNode` object types. All fields are combined with a logical ‘and.’
+"""
+input UrsmContentNodeFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `cnodeSpId` field."""
+  cnodeSpId: IntFilter
+
+  """Filter by the object’s `delegateOwnerWallet` field."""
+  delegateOwnerWallet: StringFilter
+
+  """Filter by the object’s `ownerWallet` field."""
+  ownerWallet: StringFilter
+
+  """Filter by the object’s `proposerSpIds` field."""
+  proposerSpIds: IntListFilter
+
+  """Filter by the object’s `proposer1DelegateOwnerWallet` field."""
+  proposer1DelegateOwnerWallet: StringFilter
+
+  """Filter by the object’s `proposer2DelegateOwnerWallet` field."""
+  proposer2DelegateOwnerWallet: StringFilter
+
+  """Filter by the object’s `proposer3DelegateOwnerWallet` field."""
+  proposer3DelegateOwnerWallet: StringFilter
+
+  """Filter by the object’s `endpoint` field."""
+  endpoint: StringFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [UrsmContentNodeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UrsmContentNodeFilter!]
+
+  """Negates the expression."""
+  not: UrsmContentNodeFilter
+}
+
+"""A `Block` edge in the connection."""
+type BlocksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Block` at the end of the edge."""
+  node: Block!
+}
+
+"""Methods to use when ordering `Block`."""
+enum BlocksOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  PARENTHASH_ASC
+  PARENTHASH_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  NUMBER_ASC
+  NUMBER_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Block` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input BlockCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `parenthash` field."""
+  parenthash: String
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `number` field."""
+  number: Int
+}
+
+"""
+A filter to be used against `Block` object types. All fields are combined with a logical ‘and.’
+"""
+input BlockFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `parenthash` field."""
+  parenthash: StringFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `number` field."""
+  number: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [BlockFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [BlockFilter!]
+
+  """Negates the expression."""
+  not: BlockFilter
+}
+
+"""A connection to a list of `BlocksCopy` values."""
+type BlocksCopiesConnection {
+  """A list of `BlocksCopy` objects."""
+  nodes: [BlocksCopy!]!
+
+  """
+  A list of edges which contains the `BlocksCopy` and cursor to aid in pagination.
+  """
+  edges: [BlocksCopiesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `BlocksCopy` you could get from the connection."""
+  totalCount: Int!
+}
+
+type BlocksCopy implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String!
+  parenthash: String
+  isCurrent: Boolean
+  number: Int
+}
+
+"""A `BlocksCopy` edge in the connection."""
+type BlocksCopiesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `BlocksCopy` at the end of the edge."""
+  node: BlocksCopy!
+}
+
+"""Methods to use when ordering `BlocksCopy`."""
+enum BlocksCopiesOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  PARENTHASH_ASC
+  PARENTHASH_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  NUMBER_ASC
+  NUMBER_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `BlocksCopy` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BlocksCopyCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `parenthash` field."""
+  parenthash: String
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `number` field."""
+  number: Int
+}
+
+"""
+A filter to be used against `BlocksCopy` object types. All fields are combined with a logical ‘and.’
+"""
+input BlocksCopyFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `parenthash` field."""
+  parenthash: StringFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `number` field."""
+  number: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [BlocksCopyFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [BlocksCopyFilter!]
+
+  """Negates the expression."""
+  not: BlocksCopyFilter
+}
+
+"""A connection to a list of `ChallengeDisbursement` values."""
+type ChallengeDisbursementsConnection {
+  """A list of `ChallengeDisbursement` objects."""
+  nodes: [ChallengeDisbursement!]!
+
+  """
+  A list of edges which contains the `ChallengeDisbursement` and cursor to aid in pagination.
+  """
+  edges: [ChallengeDisbursementsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChallengeDisbursement` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type ChallengeDisbursement implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  challengeId: String!
+  userId: Int!
+  specifier: String!
+  signature: String!
+  slot: Int!
+  amount: String!
+}
+
+"""A `ChallengeDisbursement` edge in the connection."""
+type ChallengeDisbursementsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChallengeDisbursement` at the end of the edge."""
+  node: ChallengeDisbursement!
+}
+
+"""Methods to use when ordering `ChallengeDisbursement`."""
+enum ChallengeDisbursementsOrderBy {
+  NATURAL
+  CHALLENGE_ID_ASC
+  CHALLENGE_ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  SPECIFIER_ASC
+  SPECIFIER_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  AMOUNT_ASC
+  AMOUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChallengeDisbursement` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input ChallengeDisbursementCondition {
+  """Checks for equality with the object’s `challengeId` field."""
+  challengeId: String
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `specifier` field."""
+  specifier: String
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `amount` field."""
+  amount: String
+}
+
+"""
+A filter to be used against `ChallengeDisbursement` object types. All fields are combined with a logical ‘and.’
+"""
+input ChallengeDisbursementFilter {
+  """Filter by the object’s `challengeId` field."""
+  challengeId: StringFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `specifier` field."""
+  specifier: StringFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `amount` field."""
+  amount: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChallengeDisbursementFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChallengeDisbursementFilter!]
+
+  """Negates the expression."""
+  not: ChallengeDisbursementFilter
+}
+
+"""A connection to a list of `ChallengeListenStreak` values."""
+type ChallengeListenStreaksConnection {
+  """A list of `ChallengeListenStreak` objects."""
+  nodes: [ChallengeListenStreak!]!
+
+  """
+  A list of edges which contains the `ChallengeListenStreak` and cursor to aid in pagination.
+  """
+  edges: [ChallengeListenStreaksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChallengeListenStreak` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type ChallengeListenStreak implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  lastListenDate: Datetime
+  listenStreak: Int!
+}
+
+"""A `ChallengeListenStreak` edge in the connection."""
+type ChallengeListenStreaksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChallengeListenStreak` at the end of the edge."""
+  node: ChallengeListenStreak!
+}
+
+"""Methods to use when ordering `ChallengeListenStreak`."""
+enum ChallengeListenStreaksOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  LAST_LISTEN_DATE_ASC
+  LAST_LISTEN_DATE_DESC
+  LISTEN_STREAK_ASC
+  LISTEN_STREAK_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChallengeListenStreak` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input ChallengeListenStreakCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `lastListenDate` field."""
+  lastListenDate: Datetime
+
+  """Checks for equality with the object’s `listenStreak` field."""
+  listenStreak: Int
+}
+
+"""
+A filter to be used against `ChallengeListenStreak` object types. All fields are combined with a logical ‘and.’
+"""
+input ChallengeListenStreakFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `lastListenDate` field."""
+  lastListenDate: DatetimeFilter
+
+  """Filter by the object’s `listenStreak` field."""
+  listenStreak: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChallengeListenStreakFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChallengeListenStreakFilter!]
+
+  """Negates the expression."""
+  not: ChallengeListenStreakFilter
+}
+
+"""A connection to a list of `ChallengeProfileCompletion` values."""
+type ChallengeProfileCompletionsConnection {
+  """A list of `ChallengeProfileCompletion` objects."""
+  nodes: [ChallengeProfileCompletion!]!
+
+  """
+  A list of edges which contains the `ChallengeProfileCompletion` and cursor to aid in pagination.
+  """
+  edges: [ChallengeProfileCompletionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChallengeProfileCompletion` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type ChallengeProfileCompletion implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  profileDescription: Boolean!
+  profileName: Boolean!
+  profilePicture: Boolean!
+  profileCoverPhoto: Boolean!
+  follows: Boolean!
+  favorites: Boolean!
+  reposts: Boolean!
+}
+
+"""A `ChallengeProfileCompletion` edge in the connection."""
+type ChallengeProfileCompletionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChallengeProfileCompletion` at the end of the edge."""
+  node: ChallengeProfileCompletion!
+}
+
+"""Methods to use when ordering `ChallengeProfileCompletion`."""
+enum ChallengeProfileCompletionsOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  PROFILE_DESCRIPTION_ASC
+  PROFILE_DESCRIPTION_DESC
+  PROFILE_NAME_ASC
+  PROFILE_NAME_DESC
+  PROFILE_PICTURE_ASC
+  PROFILE_PICTURE_DESC
+  PROFILE_COVER_PHOTO_ASC
+  PROFILE_COVER_PHOTO_DESC
+  FOLLOWS_ASC
+  FOLLOWS_DESC
+  FAVORITES_ASC
+  FAVORITES_DESC
+  REPOSTS_ASC
+  REPOSTS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChallengeProfileCompletion` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input ChallengeProfileCompletionCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `profileDescription` field."""
+  profileDescription: Boolean
+
+  """Checks for equality with the object’s `profileName` field."""
+  profileName: Boolean
+
+  """Checks for equality with the object’s `profilePicture` field."""
+  profilePicture: Boolean
+
+  """Checks for equality with the object’s `profileCoverPhoto` field."""
+  profileCoverPhoto: Boolean
+
+  """Checks for equality with the object’s `follows` field."""
+  follows: Boolean
+
+  """Checks for equality with the object’s `favorites` field."""
+  favorites: Boolean
+
+  """Checks for equality with the object’s `reposts` field."""
+  reposts: Boolean
+}
+
+"""
+A filter to be used against `ChallengeProfileCompletion` object types. All fields are combined with a logical ‘and.’
+"""
+input ChallengeProfileCompletionFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `profileDescription` field."""
+  profileDescription: BooleanFilter
+
+  """Filter by the object’s `profileName` field."""
+  profileName: BooleanFilter
+
+  """Filter by the object’s `profilePicture` field."""
+  profilePicture: BooleanFilter
+
+  """Filter by the object’s `profileCoverPhoto` field."""
+  profileCoverPhoto: BooleanFilter
+
+  """Filter by the object’s `follows` field."""
+  follows: BooleanFilter
+
+  """Filter by the object’s `favorites` field."""
+  favorites: BooleanFilter
+
+  """Filter by the object’s `reposts` field."""
+  reposts: BooleanFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChallengeProfileCompletionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChallengeProfileCompletionFilter!]
+
+  """Negates the expression."""
+  not: ChallengeProfileCompletionFilter
+}
+
+"""A connection to a list of `Challenge` values."""
+type ChallengesConnection {
+  """A list of `Challenge` objects."""
+  nodes: [Challenge!]!
+
+  """
+  A list of edges which contains the `Challenge` and cursor to aid in pagination.
+  """
+  edges: [ChallengesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Challenge` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Challenge implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: String!
+  type: Challengetype!
+  amount: String!
+  active: Boolean!
+  stepCount: Int
+  startingBlock: Int
+
+  """Reads and enables pagination through a set of `UserChallenge`."""
+  userChallengesByChallengeId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `UserChallenge`."""
+    orderBy: [UserChallengesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserChallengeCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: UserChallengeFilter
+  ): UserChallengesConnection!
+}
+
+enum Challengetype {
+  BOOLEAN
+  NUMERIC
+  AGGREGATE
+  TRENDING
+}
+
+"""A connection to a list of `UserChallenge` values."""
+type UserChallengesConnection {
+  """A list of `UserChallenge` objects."""
+  nodes: [UserChallenge!]!
+
+  """
+  A list of edges which contains the `UserChallenge` and cursor to aid in pagination.
+  """
+  edges: [UserChallengesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `UserChallenge` you could get from the connection."""
+  totalCount: Int!
+}
+
+type UserChallenge implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  challengeId: String!
+  userId: Int!
+  specifier: String!
+  isComplete: Boolean!
+  currentStepCount: Int
+  completedBlocknumber: Int
+
+  """Reads a single `Challenge` that is related to this `UserChallenge`."""
+  challengeByChallengeId: Challenge
+}
+
+"""A `UserChallenge` edge in the connection."""
+type UserChallengesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserChallenge` at the end of the edge."""
+  node: UserChallenge!
+}
+
+"""Methods to use when ordering `UserChallenge`."""
+enum UserChallengesOrderBy {
+  NATURAL
+  CHALLENGE_ID_ASC
+  CHALLENGE_ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  SPECIFIER_ASC
+  SPECIFIER_DESC
+  IS_COMPLETE_ASC
+  IS_COMPLETE_DESC
+  CURRENT_STEP_COUNT_ASC
+  CURRENT_STEP_COUNT_DESC
+  COMPLETED_BLOCKNUMBER_ASC
+  COMPLETED_BLOCKNUMBER_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserChallenge` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input UserChallengeCondition {
+  """Checks for equality with the object’s `challengeId` field."""
+  challengeId: String
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `specifier` field."""
+  specifier: String
+
+  """Checks for equality with the object’s `isComplete` field."""
+  isComplete: Boolean
+
+  """Checks for equality with the object’s `currentStepCount` field."""
+  currentStepCount: Int
+
+  """Checks for equality with the object’s `completedBlocknumber` field."""
+  completedBlocknumber: Int
+}
+
+"""
+A filter to be used against `UserChallenge` object types. All fields are combined with a logical ‘and.’
+"""
+input UserChallengeFilter {
+  """Filter by the object’s `challengeId` field."""
+  challengeId: StringFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `specifier` field."""
+  specifier: StringFilter
+
+  """Filter by the object’s `isComplete` field."""
+  isComplete: BooleanFilter
+
+  """Filter by the object’s `currentStepCount` field."""
+  currentStepCount: IntFilter
+
+  """Filter by the object’s `completedBlocknumber` field."""
+  completedBlocknumber: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserChallengeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserChallengeFilter!]
+
+  """Negates the expression."""
+  not: UserChallengeFilter
+}
+
+"""A `Challenge` edge in the connection."""
+type ChallengesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Challenge` at the end of the edge."""
+  node: Challenge!
+}
+
+"""Methods to use when ordering `Challenge`."""
+enum ChallengesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  TYPE_ASC
+  TYPE_DESC
+  AMOUNT_ASC
+  AMOUNT_DESC
+  ACTIVE_ASC
+  ACTIVE_DESC
+  STEP_COUNT_ASC
+  STEP_COUNT_DESC
+  STARTING_BLOCK_ASC
+  STARTING_BLOCK_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Challenge` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ChallengeCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: String
+
+  """Checks for equality with the object’s `type` field."""
+  type: Challengetype
+
+  """Checks for equality with the object’s `amount` field."""
+  amount: String
+
+  """Checks for equality with the object’s `active` field."""
+  active: Boolean
+
+  """Checks for equality with the object’s `stepCount` field."""
+  stepCount: Int
+
+  """Checks for equality with the object’s `startingBlock` field."""
+  startingBlock: Int
+}
+
+"""
+A filter to be used against `Challenge` object types. All fields are combined with a logical ‘and.’
+"""
+input ChallengeFilter {
+  """Filter by the object’s `id` field."""
+  id: StringFilter
+
+  """Filter by the object’s `type` field."""
+  type: ChallengetypeFilter
+
+  """Filter by the object’s `amount` field."""
+  amount: StringFilter
+
+  """Filter by the object’s `active` field."""
+  active: BooleanFilter
+
+  """Filter by the object’s `stepCount` field."""
+  stepCount: IntFilter
+
+  """Filter by the object’s `startingBlock` field."""
+  startingBlock: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChallengeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChallengeFilter!]
+
+  """Negates the expression."""
+  not: ChallengeFilter
+}
+
+"""
+A filter to be used against Challengetype fields. All fields are combined with a logical ‘and.’
+"""
+input ChallengetypeFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Challengetype
+
+  """Not equal to the specified value."""
+  notEqualTo: Challengetype
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Challengetype
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Challengetype
+
+  """Included in the specified list."""
+  in: [Challengetype!]
+
+  """Not included in the specified list."""
+  notIn: [Challengetype!]
+
+  """Less than the specified value."""
+  lessThan: Challengetype
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Challengetype
+
+  """Greater than the specified value."""
+  greaterThan: Challengetype
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Challengetype
+}
+
+"""A connection to a list of `Chat` values."""
+type ChatsConnection {
+  """A list of `Chat` objects."""
+  nodes: [Chat!]!
+
+  """
+  A list of edges which contains the `Chat` and cursor to aid in pagination.
+  """
+  edges: [ChatsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Chat` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Chat implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  chatId: String!
+  createdAt: Datetime!
+  lastMessageAt: Datetime!
+  lastMessage: String
+
+  """Reads and enables pagination through a set of `ChatMember`."""
+  chatMembersByChatId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMember`."""
+    orderBy: [ChatMembersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMemberCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMemberFilter
+  ): ChatMembersConnection!
+}
+
+"""A connection to a list of `ChatMember` values."""
+type ChatMembersConnection {
+  """A list of `ChatMember` objects."""
+  nodes: [ChatMember!]!
+
+  """
+  A list of edges which contains the `ChatMember` and cursor to aid in pagination.
+  """
+  edges: [ChatMembersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `ChatMember` you could get from the connection."""
+  totalCount: Int!
+}
+
+type ChatMember implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  chatId: String!
+  userId: Int!
+  clearedHistoryAt: Datetime
+  invitedByUserId: Int!
+  inviteCode: String!
+  lastActiveAt: Datetime
+  unreadCount: Int!
+
+  """Reads a single `Chat` that is related to this `ChatMember`."""
+  chatByChatId: Chat
+
+  """Reads and enables pagination through a set of `ChatMessage`."""
+  chatMessagesByChatIdAndUserId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMessage`."""
+    orderBy: [ChatMessagesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMessageCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMessageFilter
+  ): ChatMessagesConnection!
+}
+
+"""A connection to a list of `ChatMessage` values."""
+type ChatMessagesConnection {
+  """A list of `ChatMessage` objects."""
+  nodes: [ChatMessage!]!
+
+  """
+  A list of edges which contains the `ChatMessage` and cursor to aid in pagination.
+  """
+  edges: [ChatMessagesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `ChatMessage` you could get from the connection."""
+  totalCount: Int!
+}
+
+type ChatMessage implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  messageId: String!
+  chatId: String!
+  userId: Int!
+  createdAt: Datetime!
+  ciphertext: String!
+
+  """Reads a single `ChatMember` that is related to this `ChatMessage`."""
+  chatMemberByChatIdAndUserId: ChatMember
+
+  """Reads and enables pagination through a set of `ChatMessageReaction`."""
+  chatMessageReactionsByMessageId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChatMessageReaction`."""
+    orderBy: [ChatMessageReactionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChatMessageReactionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChatMessageReactionFilter
+  ): ChatMessageReactionsConnection!
+}
+
+"""A connection to a list of `ChatMessageReaction` values."""
+type ChatMessageReactionsConnection {
+  """A list of `ChatMessageReaction` objects."""
+  nodes: [ChatMessageReaction!]!
+
+  """
+  A list of edges which contains the `ChatMessageReaction` and cursor to aid in pagination.
+  """
+  edges: [ChatMessageReactionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChatMessageReaction` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type ChatMessageReaction implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  messageId: String!
+  reaction: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+
+  """
+  Reads a single `ChatMessage` that is related to this `ChatMessageReaction`.
+  """
+  chatMessageByMessageId: ChatMessage
+}
+
+"""A `ChatMessageReaction` edge in the connection."""
+type ChatMessageReactionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChatMessageReaction` at the end of the edge."""
+  node: ChatMessageReaction!
+}
+
+"""Methods to use when ordering `ChatMessageReaction`."""
+enum ChatMessageReactionsOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  MESSAGE_ID_ASC
+  MESSAGE_ID_DESC
+  REACTION_ASC
+  REACTION_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChatMessageReaction` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input ChatMessageReactionCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `messageId` field."""
+  messageId: String
+
+  """Checks for equality with the object’s `reaction` field."""
+  reaction: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `ChatMessageReaction` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatMessageReactionFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `messageId` field."""
+  messageId: StringFilter
+
+  """Filter by the object’s `reaction` field."""
+  reaction: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatMessageReactionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatMessageReactionFilter!]
+
+  """Negates the expression."""
+  not: ChatMessageReactionFilter
+}
+
+"""A `ChatMessage` edge in the connection."""
+type ChatMessagesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChatMessage` at the end of the edge."""
+  node: ChatMessage!
+}
+
+"""Methods to use when ordering `ChatMessage`."""
+enum ChatMessagesOrderBy {
+  NATURAL
+  MESSAGE_ID_ASC
+  MESSAGE_ID_DESC
+  CHAT_ID_ASC
+  CHAT_ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  CIPHERTEXT_ASC
+  CIPHERTEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChatMessage` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ChatMessageCondition {
+  """Checks for equality with the object’s `messageId` field."""
+  messageId: String
+
+  """Checks for equality with the object’s `chatId` field."""
+  chatId: String
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `ciphertext` field."""
+  ciphertext: String
+}
+
+"""
+A filter to be used against `ChatMessage` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatMessageFilter {
+  """Filter by the object’s `messageId` field."""
+  messageId: StringFilter
+
+  """Filter by the object’s `chatId` field."""
+  chatId: StringFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `ciphertext` field."""
+  ciphertext: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatMessageFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatMessageFilter!]
+
+  """Negates the expression."""
+  not: ChatMessageFilter
+}
+
+"""A `ChatMember` edge in the connection."""
+type ChatMembersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChatMember` at the end of the edge."""
+  node: ChatMember!
+}
+
+"""Methods to use when ordering `ChatMember`."""
+enum ChatMembersOrderBy {
+  NATURAL
+  CHAT_ID_ASC
+  CHAT_ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  CLEARED_HISTORY_AT_ASC
+  CLEARED_HISTORY_AT_DESC
+  INVITED_BY_USER_ID_ASC
+  INVITED_BY_USER_ID_DESC
+  INVITE_CODE_ASC
+  INVITE_CODE_DESC
+  LAST_ACTIVE_AT_ASC
+  LAST_ACTIVE_AT_DESC
+  UNREAD_COUNT_ASC
+  UNREAD_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChatMember` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ChatMemberCondition {
+  """Checks for equality with the object’s `chatId` field."""
+  chatId: String
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `clearedHistoryAt` field."""
+  clearedHistoryAt: Datetime
+
+  """Checks for equality with the object’s `invitedByUserId` field."""
+  invitedByUserId: Int
+
+  """Checks for equality with the object’s `inviteCode` field."""
+  inviteCode: String
+
+  """Checks for equality with the object’s `lastActiveAt` field."""
+  lastActiveAt: Datetime
+
+  """Checks for equality with the object’s `unreadCount` field."""
+  unreadCount: Int
+}
+
+"""
+A filter to be used against `ChatMember` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatMemberFilter {
+  """Filter by the object’s `chatId` field."""
+  chatId: StringFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `clearedHistoryAt` field."""
+  clearedHistoryAt: DatetimeFilter
+
+  """Filter by the object’s `invitedByUserId` field."""
+  invitedByUserId: IntFilter
+
+  """Filter by the object’s `inviteCode` field."""
+  inviteCode: StringFilter
+
+  """Filter by the object’s `lastActiveAt` field."""
+  lastActiveAt: DatetimeFilter
+
+  """Filter by the object’s `unreadCount` field."""
+  unreadCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatMemberFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatMemberFilter!]
+
+  """Negates the expression."""
+  not: ChatMemberFilter
+}
+
+"""A `Chat` edge in the connection."""
+type ChatsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Chat` at the end of the edge."""
+  node: Chat!
+}
+
+"""Methods to use when ordering `Chat`."""
+enum ChatsOrderBy {
+  NATURAL
+  CHAT_ID_ASC
+  CHAT_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  LAST_MESSAGE_AT_ASC
+  LAST_MESSAGE_AT_DESC
+  LAST_MESSAGE_ASC
+  LAST_MESSAGE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Chat` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ChatCondition {
+  """Checks for equality with the object’s `chatId` field."""
+  chatId: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `lastMessageAt` field."""
+  lastMessageAt: Datetime
+
+  """Checks for equality with the object’s `lastMessage` field."""
+  lastMessage: String
+}
+
+"""
+A filter to be used against `Chat` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatFilter {
+  """Filter by the object’s `chatId` field."""
+  chatId: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `lastMessageAt` field."""
+  lastMessageAt: DatetimeFilter
+
+  """Filter by the object’s `lastMessage` field."""
+  lastMessage: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatFilter!]
+
+  """Negates the expression."""
+  not: ChatFilter
+}
+
+"""A connection to a list of `ChatBlockedUser` values."""
+type ChatBlockedUsersConnection {
+  """A list of `ChatBlockedUser` objects."""
+  nodes: [ChatBlockedUser!]!
+
+  """
+  A list of edges which contains the `ChatBlockedUser` and cursor to aid in pagination.
+  """
+  edges: [ChatBlockedUsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChatBlockedUser` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type ChatBlockedUser implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockerUserId: Int!
+  blockeeUserId: Int!
+  createdAt: Datetime!
+}
+
+"""A `ChatBlockedUser` edge in the connection."""
+type ChatBlockedUsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChatBlockedUser` at the end of the edge."""
+  node: ChatBlockedUser!
+}
+
+"""Methods to use when ordering `ChatBlockedUser`."""
+enum ChatBlockedUsersOrderBy {
+  NATURAL
+  BLOCKER_USER_ID_ASC
+  BLOCKER_USER_ID_DESC
+  BLOCKEE_USER_ID_ASC
+  BLOCKEE_USER_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChatBlockedUser` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input ChatBlockedUserCondition {
+  """Checks for equality with the object’s `blockerUserId` field."""
+  blockerUserId: Int
+
+  """Checks for equality with the object’s `blockeeUserId` field."""
+  blockeeUserId: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `ChatBlockedUser` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatBlockedUserFilter {
+  """Filter by the object’s `blockerUserId` field."""
+  blockerUserId: IntFilter
+
+  """Filter by the object’s `blockeeUserId` field."""
+  blockeeUserId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatBlockedUserFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatBlockedUserFilter!]
+
+  """Negates the expression."""
+  not: ChatBlockedUserFilter
+}
+
+"""A connection to a list of `ChatPermission` values."""
+type ChatPermissionsConnection {
+  """A list of `ChatPermission` objects."""
+  nodes: [ChatPermission!]!
+
+  """
+  A list of edges which contains the `ChatPermission` and cursor to aid in pagination.
+  """
+  edges: [ChatPermissionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `ChatPermission` you could get from the connection."""
+  totalCount: Int!
+}
+
+type ChatPermission implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  permits: String
+}
+
+"""A `ChatPermission` edge in the connection."""
+type ChatPermissionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChatPermission` at the end of the edge."""
+  node: ChatPermission!
+}
+
+"""Methods to use when ordering `ChatPermission`."""
+enum ChatPermissionsOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  PERMITS_ASC
+  PERMITS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChatPermission` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input ChatPermissionCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `permits` field."""
+  permits: String
+}
+
+"""
+A filter to be used against `ChatPermission` object types. All fields are combined with a logical ‘and.’
+"""
+input ChatPermissionFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `permits` field."""
+  permits: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [ChatPermissionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChatPermissionFilter!]
+
+  """Negates the expression."""
+  not: ChatPermissionFilter
+}
+
+"""A connection to a list of `CidDatum` values."""
+type CidDataConnection {
+  """A list of `CidDatum` objects."""
+  nodes: [CidDatum!]!
+
+  """
+  A list of edges which contains the `CidDatum` and cursor to aid in pagination.
+  """
+  edges: [CidDataEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CidDatum` you could get from the connection."""
+  totalCount: Int!
+}
+
+type CidDatum implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  cid: String!
+  type: String
+  data: JSON
+}
+
+"""A `CidDatum` edge in the connection."""
+type CidDataEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CidDatum` at the end of the edge."""
+  node: CidDatum!
+}
+
+"""Methods to use when ordering `CidDatum`."""
+enum CidDataOrderBy {
+  NATURAL
+  CID_ASC
+  CID_DESC
+  TYPE_ASC
+  TYPE_DESC
+  DATA_ASC
+  DATA_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `CidDatum` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input CidDatumCondition {
+  """Checks for equality with the object’s `cid` field."""
+  cid: String
+
+  """Checks for equality with the object’s `type` field."""
+  type: String
+
+  """Checks for equality with the object’s `data` field."""
+  data: JSON
+}
+
+"""
+A filter to be used against `CidDatum` object types. All fields are combined with a logical ‘and.’
+"""
+input CidDatumFilter {
+  """Filter by the object’s `cid` field."""
+  cid: StringFilter
+
+  """Filter by the object’s `type` field."""
+  type: StringFilter
+
+  """Filter by the object’s `data` field."""
+  data: JSONFilter
+
+  """Checks for all expressions in this list."""
+  and: [CidDatumFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [CidDatumFilter!]
+
+  """Negates the expression."""
+  not: CidDatumFilter
+}
+
+"""A connection to a list of `EthBlock` values."""
+type EthBlocksConnection {
+  """A list of `EthBlock` objects."""
+  nodes: [EthBlock!]!
+
+  """
+  A list of edges which contains the `EthBlock` and cursor to aid in pagination.
+  """
+  edges: [EthBlocksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `EthBlock` you could get from the connection."""
+  totalCount: Int!
+}
+
+type EthBlock implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  lastScannedBlock: Int!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `EthBlock` edge in the connection."""
+type EthBlocksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `EthBlock` at the end of the edge."""
+  node: EthBlock!
+}
+
+"""Methods to use when ordering `EthBlock`."""
+enum EthBlocksOrderBy {
+  NATURAL
+  LAST_SCANNED_BLOCK_ASC
+  LAST_SCANNED_BLOCK_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `EthBlock` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input EthBlockCondition {
+  """Checks for equality with the object’s `lastScannedBlock` field."""
+  lastScannedBlock: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `EthBlock` object types. All fields are combined with a logical ‘and.’
+"""
+input EthBlockFilter {
+  """Filter by the object’s `lastScannedBlock` field."""
+  lastScannedBlock: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [EthBlockFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [EthBlockFilter!]
+
+  """Negates the expression."""
+  not: EthBlockFilter
+}
+
+"""A connection to a list of `HourlyPlayCount` values."""
+type HourlyPlayCountsConnection {
+  """A list of `HourlyPlayCount` objects."""
+  nodes: [HourlyPlayCount!]!
+
+  """
+  A list of edges which contains the `HourlyPlayCount` and cursor to aid in pagination.
+  """
+  edges: [HourlyPlayCountsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `HourlyPlayCount` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type HourlyPlayCount implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  hourlyTimestamp: Datetime!
+  playCount: Int!
+}
+
+"""A `HourlyPlayCount` edge in the connection."""
+type HourlyPlayCountsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `HourlyPlayCount` at the end of the edge."""
+  node: HourlyPlayCount!
+}
+
+"""Methods to use when ordering `HourlyPlayCount`."""
+enum HourlyPlayCountsOrderBy {
+  NATURAL
+  HOURLY_TIMESTAMP_ASC
+  HOURLY_TIMESTAMP_DESC
+  PLAY_COUNT_ASC
+  PLAY_COUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `HourlyPlayCount` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input HourlyPlayCountCondition {
+  """Checks for equality with the object’s `hourlyTimestamp` field."""
+  hourlyTimestamp: Datetime
+
+  """Checks for equality with the object’s `playCount` field."""
+  playCount: Int
+}
+
+"""
+A filter to be used against `HourlyPlayCount` object types. All fields are combined with a logical ‘and.’
+"""
+input HourlyPlayCountFilter {
+  """Filter by the object’s `hourlyTimestamp` field."""
+  hourlyTimestamp: DatetimeFilter
+
+  """Filter by the object’s `playCount` field."""
+  playCount: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [HourlyPlayCountFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [HourlyPlayCountFilter!]
+
+  """Negates the expression."""
+  not: HourlyPlayCountFilter
+}
+
+"""A connection to a list of `IndexingCheckpoint` values."""
+type IndexingCheckpointsConnection {
+  """A list of `IndexingCheckpoint` objects."""
+  nodes: [IndexingCheckpoint!]!
+
+  """
+  A list of edges which contains the `IndexingCheckpoint` and cursor to aid in pagination.
+  """
+  edges: [IndexingCheckpointsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `IndexingCheckpoint` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type IndexingCheckpoint implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  tablename: String!
+  lastCheckpoint: Int!
+  signature: String
+}
+
+"""A `IndexingCheckpoint` edge in the connection."""
+type IndexingCheckpointsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `IndexingCheckpoint` at the end of the edge."""
+  node: IndexingCheckpoint!
+}
+
+"""Methods to use when ordering `IndexingCheckpoint`."""
+enum IndexingCheckpointsOrderBy {
+  NATURAL
+  TABLENAME_ASC
+  TABLENAME_DESC
+  LAST_CHECKPOINT_ASC
+  LAST_CHECKPOINT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `IndexingCheckpoint` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input IndexingCheckpointCondition {
+  """Checks for equality with the object’s `tablename` field."""
+  tablename: String
+
+  """Checks for equality with the object’s `lastCheckpoint` field."""
+  lastCheckpoint: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+}
+
+"""
+A filter to be used against `IndexingCheckpoint` object types. All fields are combined with a logical ‘and.’
+"""
+input IndexingCheckpointFilter {
+  """Filter by the object’s `tablename` field."""
+  tablename: StringFilter
+
+  """Filter by the object’s `lastCheckpoint` field."""
+  lastCheckpoint: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [IndexingCheckpointFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [IndexingCheckpointFilter!]
+
+  """Negates the expression."""
+  not: IndexingCheckpointFilter
+}
+
+"""A connection to a list of `Milestone` values."""
+type MilestonesConnection {
+  """A list of `Milestone` objects."""
+  nodes: [Milestone!]!
+
+  """
+  A list of edges which contains the `Milestone` and cursor to aid in pagination.
+  """
+  edges: [MilestonesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Milestone` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Milestone implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+  threshold: Int!
+  blocknumber: Int
+  slot: Int
+  timestamp: Datetime!
+}
+
+"""A `Milestone` edge in the connection."""
+type MilestonesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Milestone` at the end of the edge."""
+  node: Milestone!
+}
+
+"""Methods to use when ordering `Milestone`."""
+enum MilestonesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  THRESHOLD_ASC
+  THRESHOLD_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  SLOT_ASC
+  SLOT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Milestone` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input MilestoneCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `threshold` field."""
+  threshold: Int
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Datetime
+}
+
+"""
+A filter to be used against `Milestone` object types. All fields are combined with a logical ‘and.’
+"""
+input MilestoneFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `name` field."""
+  name: StringFilter
+
+  """Filter by the object’s `threshold` field."""
+  threshold: IntFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [MilestoneFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [MilestoneFilter!]
+
+  """Negates the expression."""
+  not: MilestoneFilter
+}
+
+"""A connection to a list of `Notification` values."""
+type NotificationsConnection {
+  """A list of `Notification` objects."""
+  nodes: [Notification!]!
+
+  """
+  A list of edges which contains the `Notification` and cursor to aid in pagination.
+  """
+  edges: [NotificationsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Notification` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Notification implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  specifier: String!
+  groupId: String!
+  type: String!
+  slot: Int
+  blocknumber: Int
+  timestamp: Datetime!
+  data: JSON
+  userIds: [Int]
+}
+
+"""A `Notification` edge in the connection."""
+type NotificationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Notification` at the end of the edge."""
+  node: Notification!
+}
+
+"""Methods to use when ordering `Notification`."""
+enum NotificationsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  SPECIFIER_ASC
+  SPECIFIER_DESC
+  GROUP_ID_ASC
+  GROUP_ID_DESC
+  TYPE_ASC
+  TYPE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  DATA_ASC
+  DATA_DESC
+  USER_IDS_ASC
+  USER_IDS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Notification` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input NotificationCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `specifier` field."""
+  specifier: String
+
+  """Checks for equality with the object’s `groupId` field."""
+  groupId: String
+
+  """Checks for equality with the object’s `type` field."""
+  type: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Datetime
+
+  """Checks for equality with the object’s `data` field."""
+  data: JSON
+
+  """Checks for equality with the object’s `userIds` field."""
+  userIds: [Int]
+}
+
+"""
+A filter to be used against `Notification` object types. All fields are combined with a logical ‘and.’
+"""
+input NotificationFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `specifier` field."""
+  specifier: StringFilter
+
+  """Filter by the object’s `groupId` field."""
+  groupId: StringFilter
+
+  """Filter by the object’s `type` field."""
+  type: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DatetimeFilter
+
+  """Filter by the object’s `data` field."""
+  data: JSONFilter
+
+  """Filter by the object’s `userIds` field."""
+  userIds: IntListFilter
+
+  """Checks for all expressions in this list."""
+  and: [NotificationFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [NotificationFilter!]
+
+  """Negates the expression."""
+  not: NotificationFilter
+}
+
+"""A connection to a list of `NotificationSeen` values."""
+type NotificationSeensConnection {
+  """A list of `NotificationSeen` objects."""
+  nodes: [NotificationSeen!]!
+
+  """
+  A list of edges which contains the `NotificationSeen` and cursor to aid in pagination.
+  """
+  edges: [NotificationSeensEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `NotificationSeen` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type NotificationSeen implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  seenAt: Datetime!
+  blocknumber: Int
+  blockhash: String
+  txhash: String
+}
+
+"""A `NotificationSeen` edge in the connection."""
+type NotificationSeensEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `NotificationSeen` at the end of the edge."""
+  node: NotificationSeen!
+}
+
+"""Methods to use when ordering `NotificationSeen`."""
+enum NotificationSeensOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  SEEN_AT_ASC
+  SEEN_AT_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `NotificationSeen` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input NotificationSeenCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `seenAt` field."""
+  seenAt: Datetime
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+}
+
+"""
+A filter to be used against `NotificationSeen` object types. All fields are combined with a logical ‘and.’
+"""
+input NotificationSeenFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `seenAt` field."""
+  seenAt: DatetimeFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [NotificationSeenFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [NotificationSeenFilter!]
+
+  """Negates the expression."""
+  not: NotificationSeenFilter
+}
+
+"""A connection to a list of `PlaylistRoute` values."""
+type PlaylistRoutesConnection {
+  """A list of `PlaylistRoute` objects."""
+  nodes: [PlaylistRoute!]!
+
+  """
+  A list of edges which contains the `PlaylistRoute` and cursor to aid in pagination.
+  """
+  edges: [PlaylistRoutesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `PlaylistRoute` you could get from the connection."""
+  totalCount: Int!
+}
+
+type PlaylistRoute implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  slug: String!
+  titleSlug: String!
+  collisionId: Int!
+  ownerId: Int!
+  playlistId: Int!
+  isCurrent: Boolean!
+  blockhash: String!
+  blocknumber: Int!
+  txhash: String!
+}
+
+"""A `PlaylistRoute` edge in the connection."""
+type PlaylistRoutesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PlaylistRoute` at the end of the edge."""
+  node: PlaylistRoute!
+}
+
+"""Methods to use when ordering `PlaylistRoute`."""
+enum PlaylistRoutesOrderBy {
+  NATURAL
+  SLUG_ASC
+  SLUG_DESC
+  TITLE_SLUG_ASC
+  TITLE_SLUG_DESC
+  COLLISION_ID_ASC
+  COLLISION_ID_DESC
+  OWNER_ID_ASC
+  OWNER_ID_DESC
+  PLAYLIST_ID_ASC
+  PLAYLIST_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `PlaylistRoute` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input PlaylistRouteCondition {
+  """Checks for equality with the object’s `slug` field."""
+  slug: String
+
+  """Checks for equality with the object’s `titleSlug` field."""
+  titleSlug: String
+
+  """Checks for equality with the object’s `collisionId` field."""
+  collisionId: Int
+
+  """Checks for equality with the object’s `ownerId` field."""
+  ownerId: Int
+
+  """Checks for equality with the object’s `playlistId` field."""
+  playlistId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+}
+
+"""
+A filter to be used against `PlaylistRoute` object types. All fields are combined with a logical ‘and.’
+"""
+input PlaylistRouteFilter {
+  """Filter by the object’s `slug` field."""
+  slug: StringFilter
+
+  """Filter by the object’s `titleSlug` field."""
+  titleSlug: StringFilter
+
+  """Filter by the object’s `collisionId` field."""
+  collisionId: IntFilter
+
+  """Filter by the object’s `ownerId` field."""
+  ownerId: IntFilter
+
+  """Filter by the object’s `playlistId` field."""
+  playlistId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [PlaylistRouteFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [PlaylistRouteFilter!]
+
+  """Negates the expression."""
+  not: PlaylistRouteFilter
+}
+
+"""A connection to a list of `PlaylistSeen` values."""
+type PlaylistSeensConnection {
+  """A list of `PlaylistSeen` objects."""
+  nodes: [PlaylistSeen!]!
+
+  """
+  A list of edges which contains the `PlaylistSeen` and cursor to aid in pagination.
+  """
+  edges: [PlaylistSeensEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `PlaylistSeen` you could get from the connection."""
+  totalCount: Int!
+}
+
+type PlaylistSeen implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  playlistId: Int!
+  seenAt: Datetime!
+  isCurrent: Boolean!
+  blocknumber: Int
+  blockhash: String
+  txhash: String
+}
+
+"""A `PlaylistSeen` edge in the connection."""
+type PlaylistSeensEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PlaylistSeen` at the end of the edge."""
+  node: PlaylistSeen!
+}
+
+"""Methods to use when ordering `PlaylistSeen`."""
+enum PlaylistSeensOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  PLAYLIST_ID_ASC
+  PLAYLIST_ID_DESC
+  SEEN_AT_ASC
+  SEEN_AT_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `PlaylistSeen` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input PlaylistSeenCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `playlistId` field."""
+  playlistId: Int
+
+  """Checks for equality with the object’s `seenAt` field."""
+  seenAt: Datetime
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+}
+
+"""
+A filter to be used against `PlaylistSeen` object types. All fields are combined with a logical ‘and.’
+"""
+input PlaylistSeenFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `playlistId` field."""
+  playlistId: IntFilter
+
+  """Filter by the object’s `seenAt` field."""
+  seenAt: DatetimeFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [PlaylistSeenFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [PlaylistSeenFilter!]
+
+  """Negates the expression."""
+  not: PlaylistSeenFilter
+}
+
+"""A connection to a list of `Play` values."""
+type PlaysConnection {
+  """A list of `Play` objects."""
+  nodes: [Play!]!
+
+  """
+  A list of edges which contains the `Play` and cursor to aid in pagination.
+  """
+  edges: [PlaysEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Play` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Play implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  userId: Int
+  source: String
+  playItemId: Int!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  slot: Int
+  signature: String
+  city: String
+  region: String
+  country: String
+}
+
+"""A `Play` edge in the connection."""
+type PlaysEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Play` at the end of the edge."""
+  node: Play!
+}
+
+"""Methods to use when ordering `Play`."""
+enum PlaysOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  SOURCE_ASC
+  SOURCE_DESC
+  PLAY_ITEM_ID_ASC
+  PLAY_ITEM_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SLOT_ASC
+  SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  CITY_ASC
+  CITY_DESC
+  REGION_ASC
+  REGION_DESC
+  COUNTRY_ASC
+  COUNTRY_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Play` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PlayCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `source` field."""
+  source: String
+
+  """Checks for equality with the object’s `playItemId` field."""
+  playItemId: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `city` field."""
+  city: String
+
+  """Checks for equality with the object’s `region` field."""
+  region: String
+
+  """Checks for equality with the object’s `country` field."""
+  country: String
+}
+
+"""
+A filter to be used against `Play` object types. All fields are combined with a logical ‘and.’
+"""
+input PlayFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `source` field."""
+  source: StringFilter
+
+  """Filter by the object’s `playItemId` field."""
+  playItemId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `city` field."""
+  city: StringFilter
+
+  """Filter by the object’s `region` field."""
+  region: StringFilter
+
+  """Filter by the object’s `country` field."""
+  country: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [PlayFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [PlayFilter!]
+
+  """Negates the expression."""
+  not: PlayFilter
+}
+
+"""A connection to a list of `PlaysArchive` values."""
+type PlaysArchivesConnection {
+  """A list of `PlaysArchive` objects."""
+  nodes: [PlaysArchive!]!
+
+  """
+  A list of edges which contains the `PlaysArchive` and cursor to aid in pagination.
+  """
+  edges: [PlaysArchivesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `PlaysArchive` you could get from the connection."""
+  totalCount: Int!
+}
+
+type PlaysArchive implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  userId: Int
+  source: String
+  playItemId: Int!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  slot: Int
+  signature: String
+  archivedAt: Datetime
+}
+
+"""A `PlaysArchive` edge in the connection."""
+type PlaysArchivesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PlaysArchive` at the end of the edge."""
+  node: PlaysArchive!
+}
+
+"""Methods to use when ordering `PlaysArchive`."""
+enum PlaysArchivesOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  SOURCE_ASC
+  SOURCE_DESC
+  PLAY_ITEM_ID_ASC
+  PLAY_ITEM_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SLOT_ASC
+  SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `PlaysArchive` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input PlaysArchiveCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `source` field."""
+  source: String
+
+  """Checks for equality with the object’s `playItemId` field."""
+  playItemId: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+}
+
+"""
+A filter to be used against `PlaysArchive` object types. All fields are combined with a logical ‘and.’
+"""
+input PlaysArchiveFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `source` field."""
+  source: StringFilter
+
+  """Filter by the object’s `playItemId` field."""
+  playItemId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [PlaysArchiveFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [PlaysArchiveFilter!]
+
+  """Negates the expression."""
+  not: PlaysArchiveFilter
+}
+
+"""A connection to a list of `Reaction` values."""
+type ReactionsConnection {
+  """A list of `Reaction` objects."""
+  nodes: [Reaction!]!
+
+  """
+  A list of edges which contains the `Reaction` and cursor to aid in pagination.
+  """
+  edges: [ReactionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Reaction` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Reaction implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  slot: Int!
+  reactionValue: Int!
+  senderWallet: String!
+  reactionType: String!
+  reactedTo: String!
+  timestamp: Datetime!
+  txSignature: String
+}
+
+"""A `Reaction` edge in the connection."""
+type ReactionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Reaction` at the end of the edge."""
+  node: Reaction!
+}
+
+"""Methods to use when ordering `Reaction`."""
+enum ReactionsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  SLOT_ASC
+  SLOT_DESC
+  REACTION_VALUE_ASC
+  REACTION_VALUE_DESC
+  SENDER_WALLET_ASC
+  SENDER_WALLET_DESC
+  REACTION_TYPE_ASC
+  REACTION_TYPE_DESC
+  REACTED_TO_ASC
+  REACTED_TO_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  TX_SIGNATURE_ASC
+  TX_SIGNATURE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Reaction` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ReactionCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `reactionValue` field."""
+  reactionValue: Int
+
+  """Checks for equality with the object’s `senderWallet` field."""
+  senderWallet: String
+
+  """Checks for equality with the object’s `reactionType` field."""
+  reactionType: String
+
+  """Checks for equality with the object’s `reactedTo` field."""
+  reactedTo: String
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Datetime
+
+  """Checks for equality with the object’s `txSignature` field."""
+  txSignature: String
+}
+
+"""
+A filter to be used against `Reaction` object types. All fields are combined with a logical ‘and.’
+"""
+input ReactionFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `reactionValue` field."""
+  reactionValue: IntFilter
+
+  """Filter by the object’s `senderWallet` field."""
+  senderWallet: StringFilter
+
+  """Filter by the object’s `reactionType` field."""
+  reactionType: StringFilter
+
+  """Filter by the object’s `reactedTo` field."""
+  reactedTo: StringFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DatetimeFilter
+
+  """Filter by the object’s `txSignature` field."""
+  txSignature: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [ReactionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ReactionFilter!]
+
+  """Negates the expression."""
+  not: ReactionFilter
+}
+
+"""A connection to a list of `RelatedArtist` values."""
+type RelatedArtistsConnection {
+  """A list of `RelatedArtist` objects."""
+  nodes: [RelatedArtist!]!
+
+  """
+  A list of edges which contains the `RelatedArtist` and cursor to aid in pagination.
+  """
+  edges: [RelatedArtistsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `RelatedArtist` you could get from the connection."""
+  totalCount: Int!
+}
+
+type RelatedArtist implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  relatedArtistUserId: Int!
+  score: Float!
+  createdAt: Datetime!
+}
+
+"""A `RelatedArtist` edge in the connection."""
+type RelatedArtistsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RelatedArtist` at the end of the edge."""
+  node: RelatedArtist!
+}
+
+"""Methods to use when ordering `RelatedArtist`."""
+enum RelatedArtistsOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  RELATED_ARTIST_USER_ID_ASC
+  RELATED_ARTIST_USER_ID_DESC
+  SCORE_ASC
+  SCORE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `RelatedArtist` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input RelatedArtistCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `relatedArtistUserId` field."""
+  relatedArtistUserId: Int
+
+  """Checks for equality with the object’s `score` field."""
+  score: Float
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `RelatedArtist` object types. All fields are combined with a logical ‘and.’
+"""
+input RelatedArtistFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `relatedArtistUserId` field."""
+  relatedArtistUserId: IntFilter
+
+  """Filter by the object’s `score` field."""
+  score: FloatFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [RelatedArtistFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RelatedArtistFilter!]
+
+  """Negates the expression."""
+  not: RelatedArtistFilter
+}
+
+"""
+A filter to be used against Float fields. All fields are combined with a logical ‘and.’
+"""
+input FloatFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Float
+
+  """Not equal to the specified value."""
+  notEqualTo: Float
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Float
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Float
+
+  """Included in the specified list."""
+  in: [Float!]
+
+  """Not included in the specified list."""
+  notIn: [Float!]
+
+  """Less than the specified value."""
+  lessThan: Float
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Float
+
+  """Greater than the specified value."""
+  greaterThan: Float
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Float
+}
+
+"""A connection to a list of `Remix` values."""
+type RemixesConnection {
+  """A list of `Remix` objects."""
+  nodes: [Remix!]!
+
+  """
+  A list of edges which contains the `Remix` and cursor to aid in pagination.
+  """
+  edges: [RemixesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Remix` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Remix implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  parentTrackId: Int!
+  childTrackId: Int!
+}
+
+"""A `Remix` edge in the connection."""
+type RemixesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Remix` at the end of the edge."""
+  node: Remix!
+}
+
+"""Methods to use when ordering `Remix`."""
+enum RemixesOrderBy {
+  NATURAL
+  PARENT_TRACK_ID_ASC
+  PARENT_TRACK_ID_DESC
+  CHILD_TRACK_ID_ASC
+  CHILD_TRACK_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Remix` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input RemixCondition {
+  """Checks for equality with the object’s `parentTrackId` field."""
+  parentTrackId: Int
+
+  """Checks for equality with the object’s `childTrackId` field."""
+  childTrackId: Int
+}
+
+"""
+A filter to be used against `Remix` object types. All fields are combined with a logical ‘and.’
+"""
+input RemixFilter {
+  """Filter by the object’s `parentTrackId` field."""
+  parentTrackId: IntFilter
+
+  """Filter by the object’s `childTrackId` field."""
+  childTrackId: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [RemixFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RemixFilter!]
+
+  """Negates the expression."""
+  not: RemixFilter
+}
+
+"""A connection to a list of `RewardManagerTx` values."""
+type RewardManagerTxesConnection {
+  """A list of `RewardManagerTx` objects."""
+  nodes: [RewardManagerTx!]!
+
+  """
+  A list of edges which contains the `RewardManagerTx` and cursor to aid in pagination.
+  """
+  edges: [RewardManagerTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RewardManagerTx` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RewardManagerTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  slot: Int!
+  createdAt: Datetime!
+}
+
+"""A `RewardManagerTx` edge in the connection."""
+type RewardManagerTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RewardManagerTx` at the end of the edge."""
+  node: RewardManagerTx!
+}
+
+"""Methods to use when ordering `RewardManagerTx`."""
+enum RewardManagerTxesOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `RewardManagerTx` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input RewardManagerTxCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `RewardManagerTx` object types. All fields are combined with a logical ‘and.’
+"""
+input RewardManagerTxFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [RewardManagerTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RewardManagerTxFilter!]
+
+  """Negates the expression."""
+  not: RewardManagerTxFilter
+}
+
+"""A connection to a list of `RewardsManagerBackfillTx` values."""
+type RewardsManagerBackfillTxesConnection {
+  """A list of `RewardsManagerBackfillTx` objects."""
+  nodes: [RewardsManagerBackfillTx!]!
+
+  """
+  A list of edges which contains the `RewardsManagerBackfillTx` and cursor to aid in pagination.
+  """
+  edges: [RewardsManagerBackfillTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RewardsManagerBackfillTx` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RewardsManagerBackfillTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  slot: Int!
+  createdAt: Datetime!
+}
+
+"""A `RewardsManagerBackfillTx` edge in the connection."""
+type RewardsManagerBackfillTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RewardsManagerBackfillTx` at the end of the edge."""
+  node: RewardsManagerBackfillTx!
+}
+
+"""Methods to use when ordering `RewardsManagerBackfillTx`."""
+enum RewardsManagerBackfillTxesOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `RewardsManagerBackfillTx` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input RewardsManagerBackfillTxCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `RewardsManagerBackfillTx` object types. All fields are combined with a logical ‘and.’
+"""
+input RewardsManagerBackfillTxFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [RewardsManagerBackfillTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RewardsManagerBackfillTxFilter!]
+
+  """Negates the expression."""
+  not: RewardsManagerBackfillTxFilter
+}
+
+"""A connection to a list of `RouteMetric` values."""
+type RouteMetricsConnection {
+  """A list of `RouteMetric` objects."""
+  nodes: [RouteMetric!]!
+
+  """
+  A list of edges which contains the `RouteMetric` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `RouteMetric` you could get from the connection."""
+  totalCount: Int!
+}
+
+type RouteMetric implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  routePath: String!
+  version: String!
+  queryString: String!
+  count: Int!
+  timestamp: Datetime!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  id: BigInt!
+  ip: String
+}
+
+"""A `RouteMetric` edge in the connection."""
+type RouteMetricsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetric` at the end of the edge."""
+  node: RouteMetric!
+}
+
+"""Methods to use when ordering `RouteMetric`."""
+enum RouteMetricsOrderBy {
+  NATURAL
+  ROUTE_PATH_ASC
+  ROUTE_PATH_DESC
+  VERSION_ASC
+  VERSION_DESC
+  QUERY_STRING_ASC
+  QUERY_STRING_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ID_ASC
+  ID_DESC
+  IP_ASC
+  IP_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `RouteMetric` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input RouteMetricCondition {
+  """Checks for equality with the object’s `routePath` field."""
+  routePath: String
+
+  """Checks for equality with the object’s `version` field."""
+  version: String
+
+  """Checks for equality with the object’s `queryString` field."""
+  queryString: String
+
+  """Checks for equality with the object’s `count` field."""
+  count: Int
+
+  """Checks for equality with the object’s `timestamp` field."""
+  timestamp: Datetime
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `id` field."""
+  id: BigInt
+
+  """Checks for equality with the object’s `ip` field."""
+  ip: String
+}
+
+"""
+A filter to be used against `RouteMetric` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricFilter {
+  """Filter by the object’s `routePath` field."""
+  routePath: StringFilter
+
+  """Filter by the object’s `version` field."""
+  version: StringFilter
+
+  """Filter by the object’s `queryString` field."""
+  queryString: StringFilter
+
+  """Filter by the object’s `count` field."""
+  count: IntFilter
+
+  """Filter by the object’s `timestamp` field."""
+  timestamp: DatetimeFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `id` field."""
+  id: BigIntFilter
+
+  """Filter by the object’s `ip` field."""
+  ip: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricFilter
+}
+
+"""A connection to a list of `RouteMetricsAllTime` values."""
+type RouteMetricsAllTimesConnection {
+  """A list of `RouteMetricsAllTime` objects."""
+  nodes: [RouteMetricsAllTime!]!
+
+  """
+  A list of edges which contains the `RouteMetricsAllTime` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsAllTimesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RouteMetricsAllTime` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RouteMetricsAllTime {
+  uniqueCount: BigInt
+  count: BigInt
+}
+
+"""A `RouteMetricsAllTime` edge in the connection."""
+type RouteMetricsAllTimesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetricsAllTime` at the end of the edge."""
+  node: RouteMetricsAllTime!
+}
+
+"""Methods to use when ordering `RouteMetricsAllTime`."""
+enum RouteMetricsAllTimesOrderBy {
+  NATURAL
+  UNIQUE_COUNT_ASC
+  UNIQUE_COUNT_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `RouteMetricsAllTime` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input RouteMetricsAllTimeCondition {
+  """Checks for equality with the object’s `uniqueCount` field."""
+  uniqueCount: BigInt
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `RouteMetricsAllTime` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricsAllTimeFilter {
+  """Filter by the object’s `uniqueCount` field."""
+  uniqueCount: BigIntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricsAllTimeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricsAllTimeFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricsAllTimeFilter
+}
+
+"""A connection to a list of `RouteMetricsDayBucket` values."""
+type RouteMetricsDayBucketsConnection {
+  """A list of `RouteMetricsDayBucket` objects."""
+  nodes: [RouteMetricsDayBucket!]!
+
+  """
+  A list of edges which contains the `RouteMetricsDayBucket` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsDayBucketsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RouteMetricsDayBucket` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RouteMetricsDayBucket {
+  uniqueCount: BigInt
+  count: BigInt
+  time: Datetime
+}
+
+"""A `RouteMetricsDayBucket` edge in the connection."""
+type RouteMetricsDayBucketsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetricsDayBucket` at the end of the edge."""
+  node: RouteMetricsDayBucket!
+}
+
+"""Methods to use when ordering `RouteMetricsDayBucket`."""
+enum RouteMetricsDayBucketsOrderBy {
+  NATURAL
+  UNIQUE_COUNT_ASC
+  UNIQUE_COUNT_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIME_ASC
+  TIME_DESC
+}
+
+"""
+A condition to be used against `RouteMetricsDayBucket` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input RouteMetricsDayBucketCondition {
+  """Checks for equality with the object’s `uniqueCount` field."""
+  uniqueCount: BigInt
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+
+  """Checks for equality with the object’s `time` field."""
+  time: Datetime
+}
+
+"""
+A filter to be used against `RouteMetricsDayBucket` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricsDayBucketFilter {
+  """Filter by the object’s `uniqueCount` field."""
+  uniqueCount: BigIntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Filter by the object’s `time` field."""
+  time: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricsDayBucketFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricsDayBucketFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricsDayBucketFilter
+}
+
+"""A connection to a list of `RouteMetricsMonthBucket` values."""
+type RouteMetricsMonthBucketsConnection {
+  """A list of `RouteMetricsMonthBucket` objects."""
+  nodes: [RouteMetricsMonthBucket!]!
+
+  """
+  A list of edges which contains the `RouteMetricsMonthBucket` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsMonthBucketsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RouteMetricsMonthBucket` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RouteMetricsMonthBucket {
+  uniqueCount: BigInt
+  count: BigInt
+  time: Datetime
+}
+
+"""A `RouteMetricsMonthBucket` edge in the connection."""
+type RouteMetricsMonthBucketsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetricsMonthBucket` at the end of the edge."""
+  node: RouteMetricsMonthBucket!
+}
+
+"""Methods to use when ordering `RouteMetricsMonthBucket`."""
+enum RouteMetricsMonthBucketsOrderBy {
+  NATURAL
+  UNIQUE_COUNT_ASC
+  UNIQUE_COUNT_DESC
+  COUNT_ASC
+  COUNT_DESC
+  TIME_ASC
+  TIME_DESC
+}
+
+"""
+A condition to be used against `RouteMetricsMonthBucket` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input RouteMetricsMonthBucketCondition {
+  """Checks for equality with the object’s `uniqueCount` field."""
+  uniqueCount: BigInt
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+
+  """Checks for equality with the object’s `time` field."""
+  time: Datetime
+}
+
+"""
+A filter to be used against `RouteMetricsMonthBucket` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricsMonthBucketFilter {
+  """Filter by the object’s `uniqueCount` field."""
+  uniqueCount: BigIntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Filter by the object’s `time` field."""
+  time: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricsMonthBucketFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricsMonthBucketFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricsMonthBucketFilter
+}
+
+"""A connection to a list of `RouteMetricsTrailingMonth` values."""
+type RouteMetricsTrailingMonthsConnection {
+  """A list of `RouteMetricsTrailingMonth` objects."""
+  nodes: [RouteMetricsTrailingMonth!]!
+
+  """
+  A list of edges which contains the `RouteMetricsTrailingMonth` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsTrailingMonthsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RouteMetricsTrailingMonth` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RouteMetricsTrailingMonth {
+  uniqueCount: BigInt
+  count: BigInt
+}
+
+"""A `RouteMetricsTrailingMonth` edge in the connection."""
+type RouteMetricsTrailingMonthsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetricsTrailingMonth` at the end of the edge."""
+  node: RouteMetricsTrailingMonth!
+}
+
+"""Methods to use when ordering `RouteMetricsTrailingMonth`."""
+enum RouteMetricsTrailingMonthsOrderBy {
+  NATURAL
+  UNIQUE_COUNT_ASC
+  UNIQUE_COUNT_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `RouteMetricsTrailingMonth` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input RouteMetricsTrailingMonthCondition {
+  """Checks for equality with the object’s `uniqueCount` field."""
+  uniqueCount: BigInt
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `RouteMetricsTrailingMonth` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricsTrailingMonthFilter {
+  """Filter by the object’s `uniqueCount` field."""
+  uniqueCount: BigIntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricsTrailingMonthFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricsTrailingMonthFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricsTrailingMonthFilter
+}
+
+"""A connection to a list of `RouteMetricsTrailingWeek` values."""
+type RouteMetricsTrailingWeeksConnection {
+  """A list of `RouteMetricsTrailingWeek` objects."""
+  nodes: [RouteMetricsTrailingWeek!]!
+
+  """
+  A list of edges which contains the `RouteMetricsTrailingWeek` and cursor to aid in pagination.
+  """
+  edges: [RouteMetricsTrailingWeeksEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `RouteMetricsTrailingWeek` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type RouteMetricsTrailingWeek {
+  uniqueCount: BigInt
+  count: BigInt
+}
+
+"""A `RouteMetricsTrailingWeek` edge in the connection."""
+type RouteMetricsTrailingWeeksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RouteMetricsTrailingWeek` at the end of the edge."""
+  node: RouteMetricsTrailingWeek!
+}
+
+"""Methods to use when ordering `RouteMetricsTrailingWeek`."""
+enum RouteMetricsTrailingWeeksOrderBy {
+  NATURAL
+  UNIQUE_COUNT_ASC
+  UNIQUE_COUNT_DESC
+  COUNT_ASC
+  COUNT_DESC
+}
+
+"""
+A condition to be used against `RouteMetricsTrailingWeek` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input RouteMetricsTrailingWeekCondition {
+  """Checks for equality with the object’s `uniqueCount` field."""
+  uniqueCount: BigInt
+
+  """Checks for equality with the object’s `count` field."""
+  count: BigInt
+}
+
+"""
+A filter to be used against `RouteMetricsTrailingWeek` object types. All fields are combined with a logical ‘and.’
+"""
+input RouteMetricsTrailingWeekFilter {
+  """Filter by the object’s `uniqueCount` field."""
+  uniqueCount: BigIntFilter
+
+  """Filter by the object’s `count` field."""
+  count: BigIntFilter
+
+  """Checks for all expressions in this list."""
+  and: [RouteMetricsTrailingWeekFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RouteMetricsTrailingWeekFilter!]
+
+  """Negates the expression."""
+  not: RouteMetricsTrailingWeekFilter
+}
+
+"""A connection to a list of `RpcLog` values."""
+type RpcLogsConnection {
+  """A list of `RpcLog` objects."""
+  nodes: [RpcLog!]!
+
+  """
+  A list of edges which contains the `RpcLog` and cursor to aid in pagination.
+  """
+  edges: [RpcLogsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `RpcLog` you could get from the connection."""
+  totalCount: Int!
+}
+
+type RpcLog implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  jetstreamSequence: Int!
+  jetstreamTimestamp: Datetime!
+  fromWallet: String
+  rpc: JSON!
+  sig: String!
+}
+
+"""A `RpcLog` edge in the connection."""
+type RpcLogsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `RpcLog` at the end of the edge."""
+  node: RpcLog!
+}
+
+"""Methods to use when ordering `RpcLog`."""
+enum RpcLogsOrderBy {
+  NATURAL
+  JETSTREAM_SEQUENCE_ASC
+  JETSTREAM_SEQUENCE_DESC
+  JETSTREAM_TIMESTAMP_ASC
+  JETSTREAM_TIMESTAMP_DESC
+  FROM_WALLET_ASC
+  FROM_WALLET_DESC
+  RPC_ASC
+  RPC_DESC
+  SIG_ASC
+  SIG_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `RpcLog` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input RpcLogCondition {
+  """Checks for equality with the object’s `jetstreamSequence` field."""
+  jetstreamSequence: Int
+
+  """Checks for equality with the object’s `jetstreamTimestamp` field."""
+  jetstreamTimestamp: Datetime
+
+  """Checks for equality with the object’s `fromWallet` field."""
+  fromWallet: String
+
+  """Checks for equality with the object’s `rpc` field."""
+  rpc: JSON
+
+  """Checks for equality with the object’s `sig` field."""
+  sig: String
+}
+
+"""
+A filter to be used against `RpcLog` object types. All fields are combined with a logical ‘and.’
+"""
+input RpcLogFilter {
+  """Filter by the object’s `jetstreamSequence` field."""
+  jetstreamSequence: IntFilter
+
+  """Filter by the object’s `jetstreamTimestamp` field."""
+  jetstreamTimestamp: DatetimeFilter
+
+  """Filter by the object’s `fromWallet` field."""
+  fromWallet: StringFilter
+
+  """Filter by the object’s `sig` field."""
+  sig: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [RpcLogFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [RpcLogFilter!]
+
+  """Negates the expression."""
+  not: RpcLogFilter
+}
+
+"""A connection to a list of `SchemaMigration` values."""
+type SchemaMigrationsConnection {
+  """A list of `SchemaMigration` objects."""
+  nodes: [SchemaMigration!]!
+
+  """
+  A list of edges which contains the `SchemaMigration` and cursor to aid in pagination.
+  """
+  edges: [SchemaMigrationsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `SchemaMigration` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type SchemaMigration implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  version: String!
+}
+
+"""A `SchemaMigration` edge in the connection."""
+type SchemaMigrationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `SchemaMigration` at the end of the edge."""
+  node: SchemaMigration!
+}
+
+"""Methods to use when ordering `SchemaMigration`."""
+enum SchemaMigrationsOrderBy {
+  NATURAL
+  VERSION_ASC
+  VERSION_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `SchemaMigration` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input SchemaMigrationCondition {
+  """Checks for equality with the object’s `version` field."""
+  version: String
+}
+
+"""
+A filter to be used against `SchemaMigration` object types. All fields are combined with a logical ‘and.’
+"""
+input SchemaMigrationFilter {
+  """Filter by the object’s `version` field."""
+  version: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [SchemaMigrationFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SchemaMigrationFilter!]
+
+  """Negates the expression."""
+  not: SchemaMigrationFilter
+}
+
+"""A connection to a list of `SkippedTransaction` values."""
+type SkippedTransactionsConnection {
+  """A list of `SkippedTransaction` objects."""
+  nodes: [SkippedTransaction!]!
+
+  """
+  A list of edges which contains the `SkippedTransaction` and cursor to aid in pagination.
+  """
+  edges: [SkippedTransactionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `SkippedTransaction` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type SkippedTransaction implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  blocknumber: Int!
+  blockhash: String!
+  txhash: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  level: Skippedtransactionlevel!
+}
+
+enum Skippedtransactionlevel {
+  NODE
+  NETWORK
+}
+
+"""A `SkippedTransaction` edge in the connection."""
+type SkippedTransactionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `SkippedTransaction` at the end of the edge."""
+  node: SkippedTransaction!
+}
+
+"""Methods to use when ordering `SkippedTransaction`."""
+enum SkippedTransactionsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  LEVEL_ASC
+  LEVEL_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `SkippedTransaction` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input SkippedTransactionCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `level` field."""
+  level: Skippedtransactionlevel
+}
+
+"""
+A filter to be used against `SkippedTransaction` object types. All fields are combined with a logical ‘and.’
+"""
+input SkippedTransactionFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `level` field."""
+  level: SkippedtransactionlevelFilter
+
+  """Checks for all expressions in this list."""
+  and: [SkippedTransactionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SkippedTransactionFilter!]
+
+  """Negates the expression."""
+  not: SkippedTransactionFilter
+}
+
+"""
+A filter to be used against Skippedtransactionlevel fields. All fields are combined with a logical ‘and.’
+"""
+input SkippedtransactionlevelFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Skippedtransactionlevel
+
+  """Not equal to the specified value."""
+  notEqualTo: Skippedtransactionlevel
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Skippedtransactionlevel
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Skippedtransactionlevel
+
+  """Included in the specified list."""
+  in: [Skippedtransactionlevel!]
+
+  """Not included in the specified list."""
+  notIn: [Skippedtransactionlevel!]
+
+  """Less than the specified value."""
+  lessThan: Skippedtransactionlevel
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Skippedtransactionlevel
+
+  """Greater than the specified value."""
+  greaterThan: Skippedtransactionlevel
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Skippedtransactionlevel
+}
+
+"""A connection to a list of `SplTokenBackfillTx` values."""
+type SplTokenBackfillTxesConnection {
+  """A list of `SplTokenBackfillTx` objects."""
+  nodes: [SplTokenBackfillTx!]!
+
+  """
+  A list of edges which contains the `SplTokenBackfillTx` and cursor to aid in pagination.
+  """
+  edges: [SplTokenBackfillTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `SplTokenBackfillTx` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type SplTokenBackfillTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  lastScannedSlot: Int!
+  signature: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `SplTokenBackfillTx` edge in the connection."""
+type SplTokenBackfillTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `SplTokenBackfillTx` at the end of the edge."""
+  node: SplTokenBackfillTx!
+}
+
+"""Methods to use when ordering `SplTokenBackfillTx`."""
+enum SplTokenBackfillTxesOrderBy {
+  NATURAL
+  LAST_SCANNED_SLOT_ASC
+  LAST_SCANNED_SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `SplTokenBackfillTx` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input SplTokenBackfillTxCondition {
+  """Checks for equality with the object’s `lastScannedSlot` field."""
+  lastScannedSlot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `SplTokenBackfillTx` object types. All fields are combined with a logical ‘and.’
+"""
+input SplTokenBackfillTxFilter {
+  """Filter by the object’s `lastScannedSlot` field."""
+  lastScannedSlot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [SplTokenBackfillTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SplTokenBackfillTxFilter!]
+
+  """Negates the expression."""
+  not: SplTokenBackfillTxFilter
+}
+
+"""A connection to a list of `SplTokenTx` values."""
+type SplTokenTxesConnection {
+  """A list of `SplTokenTx` objects."""
+  nodes: [SplTokenTx!]!
+
+  """
+  A list of edges which contains the `SplTokenTx` and cursor to aid in pagination.
+  """
+  edges: [SplTokenTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `SplTokenTx` you could get from the connection."""
+  totalCount: Int!
+}
+
+type SplTokenTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  lastScannedSlot: Int!
+  signature: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `SplTokenTx` edge in the connection."""
+type SplTokenTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `SplTokenTx` at the end of the edge."""
+  node: SplTokenTx!
+}
+
+"""Methods to use when ordering `SplTokenTx`."""
+enum SplTokenTxesOrderBy {
+  NATURAL
+  LAST_SCANNED_SLOT_ASC
+  LAST_SCANNED_SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `SplTokenTx` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input SplTokenTxCondition {
+  """Checks for equality with the object’s `lastScannedSlot` field."""
+  lastScannedSlot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `SplTokenTx` object types. All fields are combined with a logical ‘and.’
+"""
+input SplTokenTxFilter {
+  """Filter by the object’s `lastScannedSlot` field."""
+  lastScannedSlot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [SplTokenTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SplTokenTxFilter!]
+
+  """Negates the expression."""
+  not: SplTokenTxFilter
+}
+
+"""A connection to a list of `Stem` values."""
+type StemsConnection {
+  """A list of `Stem` objects."""
+  nodes: [Stem!]!
+
+  """
+  A list of edges which contains the `Stem` and cursor to aid in pagination.
+  """
+  edges: [StemsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Stem` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Stem implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  parentTrackId: Int!
+  childTrackId: Int!
+}
+
+"""A `Stem` edge in the connection."""
+type StemsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Stem` at the end of the edge."""
+  node: Stem!
+}
+
+"""Methods to use when ordering `Stem`."""
+enum StemsOrderBy {
+  NATURAL
+  PARENT_TRACK_ID_ASC
+  PARENT_TRACK_ID_DESC
+  CHILD_TRACK_ID_ASC
+  CHILD_TRACK_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Stem` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input StemCondition {
+  """Checks for equality with the object’s `parentTrackId` field."""
+  parentTrackId: Int
+
+  """Checks for equality with the object’s `childTrackId` field."""
+  childTrackId: Int
+}
+
+"""
+A filter to be used against `Stem` object types. All fields are combined with a logical ‘and.’
+"""
+input StemFilter {
+  """Filter by the object’s `parentTrackId` field."""
+  parentTrackId: IntFilter
+
+  """Filter by the object’s `childTrackId` field."""
+  childTrackId: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [StemFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [StemFilter!]
+
+  """Negates the expression."""
+  not: StemFilter
+}
+
+"""A connection to a list of `Subscription` values."""
+type SubscriptionsConnection {
+  """A list of `Subscription` objects."""
+  nodes: [Subscription!]!
+
+  """
+  A list of edges which contains the `Subscription` and cursor to aid in pagination.
+  """
+  edges: [SubscriptionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Subscription` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Subscription implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  blockhash: String
+  blocknumber: Int
+  subscriberId: Int!
+  userId: Int!
+  isCurrent: Boolean!
+  isDelete: Boolean!
+  createdAt: Datetime!
+  txhash: String!
+}
+
+"""A `Subscription` edge in the connection."""
+type SubscriptionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Subscription` at the end of the edge."""
+  node: Subscription!
+}
+
+"""Methods to use when ordering `Subscription`."""
+enum SubscriptionsOrderBy {
+  NATURAL
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  SUBSCRIBER_ID_ASC
+  SUBSCRIBER_ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  IS_DELETE_ASC
+  IS_DELETE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Subscription` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input SubscriptionCondition {
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `subscriberId` field."""
+  subscriberId: Int
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `isDelete` field."""
+  isDelete: Boolean
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+}
+
+"""
+A filter to be used against `Subscription` object types. All fields are combined with a logical ‘and.’
+"""
+input SubscriptionFilter {
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `subscriberId` field."""
+  subscriberId: IntFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `isDelete` field."""
+  isDelete: BooleanFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [SubscriptionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SubscriptionFilter!]
+
+  """Negates the expression."""
+  not: SubscriptionFilter
+}
+
+"""A connection to a list of `SupporterRankUp` values."""
+type SupporterRankUpsConnection {
+  """A list of `SupporterRankUp` objects."""
+  nodes: [SupporterRankUp!]!
+
+  """
+  A list of edges which contains the `SupporterRankUp` and cursor to aid in pagination.
+  """
+  edges: [SupporterRankUpsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `SupporterRankUp` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type SupporterRankUp implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  slot: Int!
+  senderUserId: Int!
+  receiverUserId: Int!
+  rank: Int!
+}
+
+"""A `SupporterRankUp` edge in the connection."""
+type SupporterRankUpsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `SupporterRankUp` at the end of the edge."""
+  node: SupporterRankUp!
+}
+
+"""Methods to use when ordering `SupporterRankUp`."""
+enum SupporterRankUpsOrderBy {
+  NATURAL
+  SLOT_ASC
+  SLOT_DESC
+  SENDER_USER_ID_ASC
+  SENDER_USER_ID_DESC
+  RECEIVER_USER_ID_ASC
+  RECEIVER_USER_ID_DESC
+  RANK_ASC
+  RANK_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `SupporterRankUp` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input SupporterRankUpCondition {
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `senderUserId` field."""
+  senderUserId: Int
+
+  """Checks for equality with the object’s `receiverUserId` field."""
+  receiverUserId: Int
+
+  """Checks for equality with the object’s `rank` field."""
+  rank: Int
+}
+
+"""
+A filter to be used against `SupporterRankUp` object types. All fields are combined with a logical ‘and.’
+"""
+input SupporterRankUpFilter {
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `senderUserId` field."""
+  senderUserId: IntFilter
+
+  """Filter by the object’s `receiverUserId` field."""
+  receiverUserId: IntFilter
+
+  """Filter by the object’s `rank` field."""
+  rank: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [SupporterRankUpFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [SupporterRankUpFilter!]
+
+  """Negates the expression."""
+  not: SupporterRankUpFilter
+}
+
+"""A connection to a list of `TagTrackUser` values."""
+type TagTrackUsersConnection {
+  """A list of `TagTrackUser` objects."""
+  nodes: [TagTrackUser!]!
+
+  """
+  A list of edges which contains the `TagTrackUser` and cursor to aid in pagination.
+  """
+  edges: [TagTrackUsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `TagTrackUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+type TagTrackUser {
+  tag: String
+  trackId: Int
+  ownerId: Int
+}
+
+"""A `TagTrackUser` edge in the connection."""
+type TagTrackUsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `TagTrackUser` at the end of the edge."""
+  node: TagTrackUser!
+}
+
+"""Methods to use when ordering `TagTrackUser`."""
+enum TagTrackUsersOrderBy {
+  NATURAL
+  TAG_ASC
+  TAG_DESC
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  OWNER_ID_ASC
+  OWNER_ID_DESC
+}
+
+"""
+A condition to be used against `TagTrackUser` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input TagTrackUserCondition {
+  """Checks for equality with the object’s `tag` field."""
+  tag: String
+
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `ownerId` field."""
+  ownerId: Int
+}
+
+"""
+A filter to be used against `TagTrackUser` object types. All fields are combined with a logical ‘and.’
+"""
+input TagTrackUserFilter {
+  """Filter by the object’s `tag` field."""
+  tag: StringFilter
+
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `ownerId` field."""
+  ownerId: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [TagTrackUserFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TagTrackUserFilter!]
+
+  """Negates the expression."""
+  not: TagTrackUserFilter
+}
+
+"""A connection to a list of `TrackRoute` values."""
+type TrackRoutesConnection {
+  """A list of `TrackRoute` objects."""
+  nodes: [TrackRoute!]!
+
+  """
+  A list of edges which contains the `TrackRoute` and cursor to aid in pagination.
+  """
+  edges: [TrackRoutesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `TrackRoute` you could get from the connection."""
+  totalCount: Int!
+}
+
+type TrackRoute implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  slug: String!
+  titleSlug: String!
+  collisionId: Int!
+  ownerId: Int!
+  trackId: Int!
+  isCurrent: Boolean!
+  blockhash: String!
+  blocknumber: Int!
+  txhash: String!
+}
+
+"""A `TrackRoute` edge in the connection."""
+type TrackRoutesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `TrackRoute` at the end of the edge."""
+  node: TrackRoute!
+}
+
+"""Methods to use when ordering `TrackRoute`."""
+enum TrackRoutesOrderBy {
+  NATURAL
+  SLUG_ASC
+  SLUG_DESC
+  TITLE_SLUG_ASC
+  TITLE_SLUG_DESC
+  COLLISION_ID_ASC
+  COLLISION_ID_DESC
+  OWNER_ID_ASC
+  OWNER_ID_DESC
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  TXHASH_ASC
+  TXHASH_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `TrackRoute` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input TrackRouteCondition {
+  """Checks for equality with the object’s `slug` field."""
+  slug: String
+
+  """Checks for equality with the object’s `titleSlug` field."""
+  titleSlug: String
+
+  """Checks for equality with the object’s `collisionId` field."""
+  collisionId: Int
+
+  """Checks for equality with the object’s `ownerId` field."""
+  ownerId: Int
+
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `txhash` field."""
+  txhash: String
+}
+
+"""
+A filter to be used against `TrackRoute` object types. All fields are combined with a logical ‘and.’
+"""
+input TrackRouteFilter {
+  """Filter by the object’s `slug` field."""
+  slug: StringFilter
+
+  """Filter by the object’s `titleSlug` field."""
+  titleSlug: StringFilter
+
+  """Filter by the object’s `collisionId` field."""
+  collisionId: IntFilter
+
+  """Filter by the object’s `ownerId` field."""
+  ownerId: IntFilter
+
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `txhash` field."""
+  txhash: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [TrackRouteFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TrackRouteFilter!]
+
+  """Negates the expression."""
+  not: TrackRouteFilter
+}
+
+"""A connection to a list of `TrackTrendingScore` values."""
+type TrackTrendingScoresConnection {
+  """A list of `TrackTrendingScore` objects."""
+  nodes: [TrackTrendingScore!]!
+
+  """
+  A list of edges which contains the `TrackTrendingScore` and cursor to aid in pagination.
+  """
+  edges: [TrackTrendingScoresEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `TrackTrendingScore` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type TrackTrendingScore implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  trackId: Int!
+  type: String!
+  genre: String
+  version: String!
+  timeRange: String!
+  score: Float!
+  createdAt: Datetime!
+}
+
+"""A `TrackTrendingScore` edge in the connection."""
+type TrackTrendingScoresEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `TrackTrendingScore` at the end of the edge."""
+  node: TrackTrendingScore!
+}
+
+"""Methods to use when ordering `TrackTrendingScore`."""
+enum TrackTrendingScoresOrderBy {
+  NATURAL
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  TYPE_ASC
+  TYPE_DESC
+  GENRE_ASC
+  GENRE_DESC
+  VERSION_ASC
+  VERSION_DESC
+  TIME_RANGE_ASC
+  TIME_RANGE_DESC
+  SCORE_ASC
+  SCORE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `TrackTrendingScore` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input TrackTrendingScoreCondition {
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `type` field."""
+  type: String
+
+  """Checks for equality with the object’s `genre` field."""
+  genre: String
+
+  """Checks for equality with the object’s `version` field."""
+  version: String
+
+  """Checks for equality with the object’s `timeRange` field."""
+  timeRange: String
+
+  """Checks for equality with the object’s `score` field."""
+  score: Float
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `TrackTrendingScore` object types. All fields are combined with a logical ‘and.’
+"""
+input TrackTrendingScoreFilter {
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `type` field."""
+  type: StringFilter
+
+  """Filter by the object’s `genre` field."""
+  genre: StringFilter
+
+  """Filter by the object’s `version` field."""
+  version: StringFilter
+
+  """Filter by the object’s `timeRange` field."""
+  timeRange: StringFilter
+
+  """Filter by the object’s `score` field."""
+  score: FloatFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [TrackTrendingScoreFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TrackTrendingScoreFilter!]
+
+  """Negates the expression."""
+  not: TrackTrendingScoreFilter
+}
+
+"""A connection to a list of `TrendingParam` values."""
+type TrendingParamsConnection {
+  """A list of `TrendingParam` objects."""
+  nodes: [TrendingParam!]!
+
+  """
+  A list of edges which contains the `TrendingParam` and cursor to aid in pagination.
+  """
+  edges: [TrendingParamsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `TrendingParam` you could get from the connection."""
+  totalCount: Int!
+}
+
+type TrendingParam {
+  trackId: Int
+  genre: String
+  ownerId: Int
+  playCount: BigInt
+  ownerFollowerCount: BigInt
+  repostCount: Int
+  saveCount: Int
+  repostWeekCount: BigInt
+  repostMonthCount: BigInt
+  repostYearCount: BigInt
+  saveWeekCount: BigInt
+  saveMonthCount: BigInt
+  saveYearCount: BigInt
+  karma: BigFloat
+}
+
+"""A `TrendingParam` edge in the connection."""
+type TrendingParamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `TrendingParam` at the end of the edge."""
+  node: TrendingParam!
+}
+
+"""Methods to use when ordering `TrendingParam`."""
+enum TrendingParamsOrderBy {
+  NATURAL
+  TRACK_ID_ASC
+  TRACK_ID_DESC
+  GENRE_ASC
+  GENRE_DESC
+  OWNER_ID_ASC
+  OWNER_ID_DESC
+  PLAY_COUNT_ASC
+  PLAY_COUNT_DESC
+  OWNER_FOLLOWER_COUNT_ASC
+  OWNER_FOLLOWER_COUNT_DESC
+  REPOST_COUNT_ASC
+  REPOST_COUNT_DESC
+  SAVE_COUNT_ASC
+  SAVE_COUNT_DESC
+  REPOST_WEEK_COUNT_ASC
+  REPOST_WEEK_COUNT_DESC
+  REPOST_MONTH_COUNT_ASC
+  REPOST_MONTH_COUNT_DESC
+  REPOST_YEAR_COUNT_ASC
+  REPOST_YEAR_COUNT_DESC
+  SAVE_WEEK_COUNT_ASC
+  SAVE_WEEK_COUNT_DESC
+  SAVE_MONTH_COUNT_ASC
+  SAVE_MONTH_COUNT_DESC
+  SAVE_YEAR_COUNT_ASC
+  SAVE_YEAR_COUNT_DESC
+  KARMA_ASC
+  KARMA_DESC
+}
+
+"""
+A condition to be used against `TrendingParam` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input TrendingParamCondition {
+  """Checks for equality with the object’s `trackId` field."""
+  trackId: Int
+
+  """Checks for equality with the object’s `genre` field."""
+  genre: String
+
+  """Checks for equality with the object’s `ownerId` field."""
+  ownerId: Int
+
+  """Checks for equality with the object’s `playCount` field."""
+  playCount: BigInt
+
+  """Checks for equality with the object’s `ownerFollowerCount` field."""
+  ownerFollowerCount: BigInt
+
+  """Checks for equality with the object’s `repostCount` field."""
+  repostCount: Int
+
+  """Checks for equality with the object’s `saveCount` field."""
+  saveCount: Int
+
+  """Checks for equality with the object’s `repostWeekCount` field."""
+  repostWeekCount: BigInt
+
+  """Checks for equality with the object’s `repostMonthCount` field."""
+  repostMonthCount: BigInt
+
+  """Checks for equality with the object’s `repostYearCount` field."""
+  repostYearCount: BigInt
+
+  """Checks for equality with the object’s `saveWeekCount` field."""
+  saveWeekCount: BigInt
+
+  """Checks for equality with the object’s `saveMonthCount` field."""
+  saveMonthCount: BigInt
+
+  """Checks for equality with the object’s `saveYearCount` field."""
+  saveYearCount: BigInt
+
+  """Checks for equality with the object’s `karma` field."""
+  karma: BigFloat
+}
+
+"""
+A filter to be used against `TrendingParam` object types. All fields are combined with a logical ‘and.’
+"""
+input TrendingParamFilter {
+  """Filter by the object’s `trackId` field."""
+  trackId: IntFilter
+
+  """Filter by the object’s `genre` field."""
+  genre: StringFilter
+
+  """Filter by the object’s `ownerId` field."""
+  ownerId: IntFilter
+
+  """Filter by the object’s `playCount` field."""
+  playCount: BigIntFilter
+
+  """Filter by the object’s `ownerFollowerCount` field."""
+  ownerFollowerCount: BigIntFilter
+
+  """Filter by the object’s `repostCount` field."""
+  repostCount: IntFilter
+
+  """Filter by the object’s `saveCount` field."""
+  saveCount: IntFilter
+
+  """Filter by the object’s `repostWeekCount` field."""
+  repostWeekCount: BigIntFilter
+
+  """Filter by the object’s `repostMonthCount` field."""
+  repostMonthCount: BigIntFilter
+
+  """Filter by the object’s `repostYearCount` field."""
+  repostYearCount: BigIntFilter
+
+  """Filter by the object’s `saveWeekCount` field."""
+  saveWeekCount: BigIntFilter
+
+  """Filter by the object’s `saveMonthCount` field."""
+  saveMonthCount: BigIntFilter
+
+  """Filter by the object’s `saveYearCount` field."""
+  saveYearCount: BigIntFilter
+
+  """Filter by the object’s `karma` field."""
+  karma: BigFloatFilter
+
+  """Checks for all expressions in this list."""
+  and: [TrendingParamFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TrendingParamFilter!]
+
+  """Negates the expression."""
+  not: TrendingParamFilter
+}
+
+"""A connection to a list of `TrendingResult` values."""
+type TrendingResultsConnection {
+  """A list of `TrendingResult` objects."""
+  nodes: [TrendingResult!]!
+
+  """
+  A list of edges which contains the `TrendingResult` and cursor to aid in pagination.
+  """
+  edges: [TrendingResultsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `TrendingResult` you could get from the connection."""
+  totalCount: Int!
+}
+
+type TrendingResult implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  id: String
+  rank: Int!
+  type: String!
+  version: String!
+  week: Date!
+}
+
+"""A `TrendingResult` edge in the connection."""
+type TrendingResultsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `TrendingResult` at the end of the edge."""
+  node: TrendingResult!
+}
+
+"""Methods to use when ordering `TrendingResult`."""
+enum TrendingResultsOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  ID_ASC
+  ID_DESC
+  RANK_ASC
+  RANK_DESC
+  TYPE_ASC
+  TYPE_DESC
+  VERSION_ASC
+  VERSION_DESC
+  WEEK_ASC
+  WEEK_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `TrendingResult` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input TrendingResultCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `id` field."""
+  id: String
+
+  """Checks for equality with the object’s `rank` field."""
+  rank: Int
+
+  """Checks for equality with the object’s `type` field."""
+  type: String
+
+  """Checks for equality with the object’s `version` field."""
+  version: String
+
+  """Checks for equality with the object’s `week` field."""
+  week: Date
+}
+
+"""
+A filter to be used against `TrendingResult` object types. All fields are combined with a logical ‘and.’
+"""
+input TrendingResultFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `id` field."""
+  id: StringFilter
+
+  """Filter by the object’s `rank` field."""
+  rank: IntFilter
+
+  """Filter by the object’s `type` field."""
+  type: StringFilter
+
+  """Filter by the object’s `version` field."""
+  version: StringFilter
+
+  """Filter by the object’s `week` field."""
+  week: DateFilter
+
+  """Checks for all expressions in this list."""
+  and: [TrendingResultFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [TrendingResultFilter!]
+
+  """Negates the expression."""
+  not: TrendingResultFilter
+}
+
+"""A connection to a list of `UserBalanceChange` values."""
+type UserBalanceChangesConnection {
+  """A list of `UserBalanceChange` objects."""
+  nodes: [UserBalanceChange!]!
+
+  """
+  A list of edges which contains the `UserBalanceChange` and cursor to aid in pagination.
+  """
+  edges: [UserBalanceChangesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `UserBalanceChange` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type UserBalanceChange implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  blocknumber: Int!
+  currentBalance: String!
+  previousBalance: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `UserBalanceChange` edge in the connection."""
+type UserBalanceChangesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserBalanceChange` at the end of the edge."""
+  node: UserBalanceChange!
+}
+
+"""Methods to use when ordering `UserBalanceChange`."""
+enum UserBalanceChangesOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  CURRENT_BALANCE_ASC
+  CURRENT_BALANCE_DESC
+  PREVIOUS_BALANCE_ASC
+  PREVIOUS_BALANCE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserBalanceChange` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input UserBalanceChangeCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `currentBalance` field."""
+  currentBalance: String
+
+  """Checks for equality with the object’s `previousBalance` field."""
+  previousBalance: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `UserBalanceChange` object types. All fields are combined with a logical ‘and.’
+"""
+input UserBalanceChangeFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `currentBalance` field."""
+  currentBalance: StringFilter
+
+  """Filter by the object’s `previousBalance` field."""
+  previousBalance: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserBalanceChangeFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserBalanceChangeFilter!]
+
+  """Negates the expression."""
+  not: UserBalanceChangeFilter
+}
+
+"""A connection to a list of `UserBalance` values."""
+type UserBalancesConnection {
+  """A list of `UserBalance` objects."""
+  nodes: [UserBalance!]!
+
+  """
+  A list of edges which contains the `UserBalance` and cursor to aid in pagination.
+  """
+  edges: [UserBalancesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `UserBalance` you could get from the connection."""
+  totalCount: Int!
+}
+
+type UserBalance implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  balance: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  associatedWalletsBalance: String!
+  waudio: String
+  associatedSolWalletsBalance: String!
+}
+
+"""A `UserBalance` edge in the connection."""
+type UserBalancesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserBalance` at the end of the edge."""
+  node: UserBalance!
+}
+
+"""Methods to use when ordering `UserBalance`."""
+enum UserBalancesOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  BALANCE_ASC
+  BALANCE_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ASSOCIATED_WALLETS_BALANCE_ASC
+  ASSOCIATED_WALLETS_BALANCE_DESC
+  WAUDIO_ASC
+  WAUDIO_DESC
+  ASSOCIATED_SOL_WALLETS_BALANCE_ASC
+  ASSOCIATED_SOL_WALLETS_BALANCE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserBalance` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input UserBalanceCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `balance` field."""
+  balance: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """
+  Checks for equality with the object’s `associatedWalletsBalance` field.
+  """
+  associatedWalletsBalance: String
+
+  """Checks for equality with the object’s `waudio` field."""
+  waudio: String
+
+  """
+  Checks for equality with the object’s `associatedSolWalletsBalance` field.
+  """
+  associatedSolWalletsBalance: String
+}
+
+"""
+A filter to be used against `UserBalance` object types. All fields are combined with a logical ‘and.’
+"""
+input UserBalanceFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `balance` field."""
+  balance: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `associatedWalletsBalance` field."""
+  associatedWalletsBalance: StringFilter
+
+  """Filter by the object’s `waudio` field."""
+  waudio: StringFilter
+
+  """Filter by the object’s `associatedSolWalletsBalance` field."""
+  associatedSolWalletsBalance: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserBalanceFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserBalanceFilter!]
+
+  """Negates the expression."""
+  not: UserBalanceFilter
+}
+
+"""A connection to a list of `UserBankAccount` values."""
+type UserBankAccountsConnection {
+  """A list of `UserBankAccount` objects."""
+  nodes: [UserBankAccount!]!
+
+  """
+  A list of edges which contains the `UserBankAccount` and cursor to aid in pagination.
+  """
+  edges: [UserBankAccountsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `UserBankAccount` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type UserBankAccount implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  ethereumAddress: String!
+  createdAt: Datetime!
+  bankAccount: String!
+}
+
+"""A `UserBankAccount` edge in the connection."""
+type UserBankAccountsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserBankAccount` at the end of the edge."""
+  node: UserBankAccount!
+}
+
+"""Methods to use when ordering `UserBankAccount`."""
+enum UserBankAccountsOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  ETHEREUM_ADDRESS_ASC
+  ETHEREUM_ADDRESS_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  BANK_ACCOUNT_ASC
+  BANK_ACCOUNT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserBankAccount` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input UserBankAccountCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `ethereumAddress` field."""
+  ethereumAddress: String
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `bankAccount` field."""
+  bankAccount: String
+}
+
+"""
+A filter to be used against `UserBankAccount` object types. All fields are combined with a logical ‘and.’
+"""
+input UserBankAccountFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `ethereumAddress` field."""
+  ethereumAddress: StringFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `bankAccount` field."""
+  bankAccount: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserBankAccountFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserBankAccountFilter!]
+
+  """Negates the expression."""
+  not: UserBankAccountFilter
+}
+
+"""A connection to a list of `UserBankBackfillTx` values."""
+type UserBankBackfillTxesConnection {
+  """A list of `UserBankBackfillTx` objects."""
+  nodes: [UserBankBackfillTx!]!
+
+  """
+  A list of edges which contains the `UserBankBackfillTx` and cursor to aid in pagination.
+  """
+  edges: [UserBankBackfillTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `UserBankBackfillTx` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type UserBankBackfillTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  slot: Int!
+  createdAt: Datetime!
+}
+
+"""A `UserBankBackfillTx` edge in the connection."""
+type UserBankBackfillTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserBankBackfillTx` at the end of the edge."""
+  node: UserBankBackfillTx!
+}
+
+"""Methods to use when ordering `UserBankBackfillTx`."""
+enum UserBankBackfillTxesOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserBankBackfillTx` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input UserBankBackfillTxCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `UserBankBackfillTx` object types. All fields are combined with a logical ‘and.’
+"""
+input UserBankBackfillTxFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserBankBackfillTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserBankBackfillTxFilter!]
+
+  """Negates the expression."""
+  not: UserBankBackfillTxFilter
+}
+
+"""A connection to a list of `UserBankTx` values."""
+type UserBankTxesConnection {
+  """A list of `UserBankTx` objects."""
+  nodes: [UserBankTx!]!
+
+  """
+  A list of edges which contains the `UserBankTx` and cursor to aid in pagination.
+  """
+  edges: [UserBankTxesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `UserBankTx` you could get from the connection."""
+  totalCount: Int!
+}
+
+type UserBankTx implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  signature: String!
+  slot: Int!
+  createdAt: Datetime!
+}
+
+"""A `UserBankTx` edge in the connection."""
+type UserBankTxesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserBankTx` at the end of the edge."""
+  node: UserBankTx!
+}
+
+"""Methods to use when ordering `UserBankTx`."""
+enum UserBankTxesOrderBy {
+  NATURAL
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SLOT_ASC
+  SLOT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserBankTx` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input UserBankTxCondition {
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+}
+
+"""
+A filter to be used against `UserBankTx` object types. All fields are combined with a logical ‘and.’
+"""
+input UserBankTxFilter {
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserBankTxFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserBankTxFilter!]
+
+  """Negates the expression."""
+  not: UserBankTxFilter
+}
+
+"""A connection to a list of `UserEvent` values."""
+type UserEventsConnection {
+  """A list of `UserEvent` objects."""
+  nodes: [UserEvent!]!
+
+  """
+  A list of edges which contains the `UserEvent` and cursor to aid in pagination.
+  """
+  edges: [UserEventsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `UserEvent` you could get from the connection."""
+  totalCount: Int!
+}
+
+type UserEvent implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  blockhash: String
+  blocknumber: Int
+  isCurrent: Boolean!
+  userId: Int!
+  referrer: Int
+  isMobileUser: Boolean!
+  slot: Int
+}
+
+"""A `UserEvent` edge in the connection."""
+type UserEventsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserEvent` at the end of the edge."""
+  node: UserEvent!
+}
+
+"""Methods to use when ordering `UserEvent`."""
+enum UserEventsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  BLOCKHASH_ASC
+  BLOCKHASH_DESC
+  BLOCKNUMBER_ASC
+  BLOCKNUMBER_DESC
+  IS_CURRENT_ASC
+  IS_CURRENT_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  REFERRER_ASC
+  REFERRER_DESC
+  IS_MOBILE_USER_ASC
+  IS_MOBILE_USER_DESC
+  SLOT_ASC
+  SLOT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserEvent` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input UserEventCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `blockhash` field."""
+  blockhash: String
+
+  """Checks for equality with the object’s `blocknumber` field."""
+  blocknumber: Int
+
+  """Checks for equality with the object’s `isCurrent` field."""
+  isCurrent: Boolean
+
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `referrer` field."""
+  referrer: Int
+
+  """Checks for equality with the object’s `isMobileUser` field."""
+  isMobileUser: Boolean
+
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+}
+
+"""
+A filter to be used against `UserEvent` object types. All fields are combined with a logical ‘and.’
+"""
+input UserEventFilter {
+  """Filter by the object’s `id` field."""
+  id: IntFilter
+
+  """Filter by the object’s `blockhash` field."""
+  blockhash: StringFilter
+
+  """Filter by the object’s `blocknumber` field."""
+  blocknumber: IntFilter
+
+  """Filter by the object’s `isCurrent` field."""
+  isCurrent: BooleanFilter
+
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `referrer` field."""
+  referrer: IntFilter
+
+  """Filter by the object’s `isMobileUser` field."""
+  isMobileUser: BooleanFilter
+
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserEventFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserEventFilter!]
+
+  """Negates the expression."""
+  not: UserEventFilter
+}
+
+"""A connection to a list of `UserListeningHistory` values."""
+type UserListeningHistoriesConnection {
+  """A list of `UserListeningHistory` objects."""
+  nodes: [UserListeningHistory!]!
+
+  """
+  A list of edges which contains the `UserListeningHistory` and cursor to aid in pagination.
+  """
+  edges: [UserListeningHistoriesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `UserListeningHistory` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+type UserListeningHistory implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  userId: Int!
+  listeningHistory: JSON!
+}
+
+"""A `UserListeningHistory` edge in the connection."""
+type UserListeningHistoriesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserListeningHistory` at the end of the edge."""
+  node: UserListeningHistory!
+}
+
+"""Methods to use when ordering `UserListeningHistory`."""
+enum UserListeningHistoriesOrderBy {
+  NATURAL
+  USER_ID_ASC
+  USER_ID_DESC
+  LISTENING_HISTORY_ASC
+  LISTENING_HISTORY_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserListeningHistory` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input UserListeningHistoryCondition {
+  """Checks for equality with the object’s `userId` field."""
+  userId: Int
+
+  """Checks for equality with the object’s `listeningHistory` field."""
+  listeningHistory: JSON
+}
+
+"""
+A filter to be used against `UserListeningHistory` object types. All fields are combined with a logical ‘and.’
+"""
+input UserListeningHistoryFilter {
+  """Filter by the object’s `userId` field."""
+  userId: IntFilter
+
+  """Filter by the object’s `listeningHistory` field."""
+  listeningHistory: JSONFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserListeningHistoryFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserListeningHistoryFilter!]
+
+  """Negates the expression."""
+  not: UserListeningHistoryFilter
+}
+
+"""A connection to a list of `UserTip` values."""
+type UserTipsConnection {
+  """A list of `UserTip` objects."""
+  nodes: [UserTip!]!
+
+  """
+  A list of edges which contains the `UserTip` and cursor to aid in pagination.
+  """
+  edges: [UserTipsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `UserTip` you could get from the connection."""
+  totalCount: Int!
+}
+
+type UserTip implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  slot: Int!
+  signature: String!
+  senderUserId: Int!
+  receiverUserId: Int!
+  amount: BigInt!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+"""A `UserTip` edge in the connection."""
+type UserTipsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `UserTip` at the end of the edge."""
+  node: UserTip!
+}
+
+"""Methods to use when ordering `UserTip`."""
+enum UserTipsOrderBy {
+  NATURAL
+  SLOT_ASC
+  SLOT_DESC
+  SIGNATURE_ASC
+  SIGNATURE_DESC
+  SENDER_USER_ID_ASC
+  SENDER_USER_ID_DESC
+  RECEIVER_USER_ID_ASC
+  RECEIVER_USER_ID_DESC
+  AMOUNT_ASC
+  AMOUNT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `UserTip` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserTipCondition {
+  """Checks for equality with the object’s `slot` field."""
+  slot: Int
+
+  """Checks for equality with the object’s `signature` field."""
+  signature: String
+
+  """Checks for equality with the object’s `senderUserId` field."""
+  senderUserId: Int
+
+  """Checks for equality with the object’s `receiverUserId` field."""
+  receiverUserId: Int
+
+  """Checks for equality with the object’s `amount` field."""
+  amount: BigInt
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+}
+
+"""
+A filter to be used against `UserTip` object types. All fields are combined with a logical ‘and.’
+"""
+input UserTipFilter {
+  """Filter by the object’s `slot` field."""
+  slot: IntFilter
+
+  """Filter by the object’s `signature` field."""
+  signature: StringFilter
+
+  """Filter by the object’s `senderUserId` field."""
+  senderUserId: IntFilter
+
+  """Filter by the object’s `receiverUserId` field."""
+  receiverUserId: IntFilter
+
+  """Filter by the object’s `amount` field."""
+  amount: BigIntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Checks for all expressions in this list."""
+  and: [UserTipFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [UserTipFilter!]
+
+  """Negates the expression."""
+  not: UserTipFilter
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  toDateSafe(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ToDateSafeInput!
+  ): ToDateSafePayload
+}
+
+"""The output of our `toDateSafe` mutation."""
+type ToDateSafePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  date: Date
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `toDateSafe` mutation."""
+input ToDateSafeInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  pDate: String
+  pFormat: String
+}


### PR DESCRIPTION
### Description
Adds a postgraphile instance that we can run alongside a discovery node. While really powerful I don't think we'd want to actually use postgraphile for our server as it exposes too much data and we'd have to change a lot of stuff at the db level that we currently have at the app level. For our production use case we'd some something more slimmed down. This is still super useful to experiment with and discover new client flows without needing to build out an entire server first. Basically a fully functioning GQL server for discprov with tons of built in queries.

I also included the generated schema.graphql file in the PR should that be useful in the future. Either to use or for inspiration.

The graphql endpoint has subscriptions enabled as well so we can give those a go.

### Tests
Ran it locally against a PG db and will add it to one of the stage discprovs.

Here's a screenshot of what the graphiql interface looks like with all the built in queries:
![Screenshot 2023-05-13 at 3 02 20 PM](https://github.com/AudiusProject/audius-protocol/assets/16739903/ec103208-e525-488e-b14c-a9be78ec3f12)
