### PR TITLE
DMs permissions updates

### DIFF
--- a/comms/discovery/db/queries/get_chat_permissions.go
+++ b/comms/discovery/db/queries/get_chat_permissions.go
@@ -8,6 +8,16 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+const getChatPermissions = `
+select permits from chat_permissions where user_id = $1
+`
+
+func GetChatPermissions(q db.Queryable, ctx context.Context, userId int32) (schema.ChatPermission, error) {
+	var permits schema.ChatPermission
+	err := q.GetContext(ctx, &permits, getChatPermissions, userId)
+	return permits, err
+}
+
 type ChatPermissionsRow struct {
 	UserID  int32                 `db:"user_id" json:"user_id"`
 	Permits schema.ChatPermission `json:"permits"`

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -20,6 +20,19 @@ type UserChatRow struct {
 	ClearedHistoryAt sql.NullTime   `db:"cleared_history_at" json:"cleared_history_at"`
 }
 
+// Get a chat's last_message_at
+const chatLastMessageAt = `
+SELECT last_message_at
+FROM chat
+WHERE chat_id = $1
+`
+
+func ChatLastMessageAt(q db.Queryable, ctx context.Context, chatId string) (time.Time, error) {
+	var lastMessageAt time.Time
+	err := q.GetContext(ctx, &lastMessageAt, chatLastMessageAt, chatId)
+	return lastMessageAt, err
+}
+
 // Get a chat with user-specific details
 const userChat = `
 SELECT

--- a/comms/discovery/rpcz/chat_permissions_test.go
+++ b/comms/discovery/rpcz/chat_permissions_test.go
@@ -47,7 +47,7 @@ func TestChatPermissions(t *testing.T) {
 		}
 		err = testValidator.validateChatCreate(tx, sender, exampleRpc)
 		if errorExpected {
-			assert.ErrorContains(t, err, "Not permitted to send or receive messages from this user")
+			assert.ErrorContains(t, err, "Not permitted to send messages to this user")
 		} else {
 			assert.NoError(t, err)
 		}

--- a/comms/discovery/rpcz/chat_permissions_test.go
+++ b/comms/discovery/rpcz/chat_permissions_test.go
@@ -25,10 +25,8 @@ func TestChatPermissions(t *testing.T) {
 	user1Id := seededRand.Int31()
 	user2Id := seededRand.Int31()
 	user3Id := seededRand.Int31()
-	user4Id := seededRand.Int31()
 	chat1Id := strconv.Itoa(seededRand.Int())
 	chat2Id := strconv.Itoa(seededRand.Int())
-	chat3Id := strconv.Itoa(seededRand.Int())
 
 	tx := db.Conn.MustBegin()
 
@@ -74,15 +72,12 @@ func TestChatPermissions(t *testing.T) {
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, true)
 
 	// user 1 sets chat permissions to tippers or followees
-	err = chatSetPermissions(tx, int32(user1Id), schema.TippersOrFollowees)
+	err = chatSetPermissions(tx, int32(user1Id), schema.Tippers)
 	assert.NoError(t, err)
-	// user 2 can message user 1 since 1 follows 2 even though 2 has never tipped 1
-	assertPermissionValidation(tx, user2Id, user1Id, chat1Id, false)
+	// user 2 cannot message user 1 since 2 has never tipped 1
+	assertPermissionValidation(tx, user2Id, user1Id, chat1Id, true)
 	// user 3 can message user 1 since 3 has tipped 1
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, false)
-	// user 4 cannot message user 1 since 1 does not follow 4 and
-	// 4 has never tipped 1
-	assertPermissionValidation(tx, user4Id, user1Id, chat3Id, true)
 
 	// user 1 changes chat permissions to none
 	err = chatSetPermissions(tx, int32(user1Id), schema.None)

--- a/comms/discovery/rpcz/chat_permissions_test.go
+++ b/comms/discovery/rpcz/chat_permissions_test.go
@@ -71,7 +71,7 @@ func TestChatPermissions(t *testing.T) {
 	// user 3 cannot message user 1 since 1 does not follow 3
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, true)
 
-	// user 1 sets chat permissions to tippers or followees
+	// user 1 sets chat permissions to tippers only
 	err = chatSetPermissions(tx, int32(user1Id), schema.Tippers)
 	assert.NoError(t, err)
 	// user 2 cannot message user 1 since 2 has never tipped 1

--- a/comms/discovery/rpcz/validator.go
+++ b/comms/discovery/rpcz/validator.go
@@ -460,20 +460,14 @@ func validatePermissions(q db.Queryable, sender int32, receiver int32) error {
 		if !follows {
 			return permissionFailure
 		}
-	} else if permits == schema.TippersOrFollowees {
-		// Only allow messages from users that have tipped the receiver OR users that the receiver follows
-		follows, err := validateFollow(q, sender, receiver)
+	} else if permits == schema.Tippers {
+		// Only allow messages from users that have tipped the receiver
+		tipper, err := validateTipper(q, sender, receiver)
 		if err != nil {
 			return err
 		}
-		if !follows {
-			tipper, err := validateTipper(q, sender, receiver)
-			if err != nil {
-				return err
-			}
-			if !tipper {
-				return permissionFailure
-			}
+		if !tipper {
+			return permissionFailure
 		}
 	}
 

--- a/comms/discovery/rpcz/validator.go
+++ b/comms/discovery/rpcz/validator.go
@@ -158,8 +158,7 @@ func (vtor *Validator) validateChatMessage(tx *sqlx.Tx, userId int32, rpc schema
 		}
 
 		// re-validate permissions if a member of the chat has recently cleared their
-		// chat history, in case their permissions
-		// have changed.
+		// chat history, in case their permissions have changed
 		lastMessageAt, err := queries.ChatLastMessageAt(q, context.Background(), params.ChatID)
 		if err != nil {
 			return err
@@ -397,7 +396,7 @@ func validateNotBlocked(q db.Queryable, user1 int32, user2 int32) error {
 }
 
 // Recheck chat permissions before sending further messages if a member of the chat
-// has cleared their chat history.
+// has cleared their chat history
 func RecheckPermissionsRequired(lastMessageAt time.Time, members []db.ChatMember) bool {
 	for _, member := range members {
 		if member.ClearedHistoryAt.Valid && member.ClearedHistoryAt.Time.After(lastMessageAt) {
@@ -423,6 +422,7 @@ func validateFollow(q db.Queryable, sender int32, receiver int32) (bool, error) 
 	return true, nil
 }
 
+// Validate sender has tipped receiver
 func validateTipper(q db.Queryable, sender int32, receiver int32) (bool, error) {
 	count, err := queries.CountTips(q, context.Background(), queries.CountTipsParams{
 		SenderUserID:   sender,

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -137,6 +137,7 @@ type UserChat struct {
 	LastMessage        string       `json:"last_message"`
 	LastMessageAt      string       `json:"last_message_at"`
 	LastReadAt         string       `json:"last_read_at"`
+	RecheckPermissions bool         `json:"recheck_permissions"`
 	UnreadMessageCount float64      `json:"unread_message_count"`
 }
 
@@ -288,7 +289,7 @@ const (
 	All ChatPermission = "all"
 	Followees ChatPermission = "followees"
 	None ChatPermission = "none"
-	Tippers ChatPermission = "tippers"
+	TippersOrFollowees ChatPermission = "tippersOrFollowees"
 )
 
 type RPCMethod string

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -289,7 +289,7 @@ const (
 	All ChatPermission = "all"
 	Followees ChatPermission = "followees"
 	None ChatPermission = "none"
-	TippersOrFollowees ChatPermission = "tippersOrFollowees"
+	Tippers ChatPermission = "tippers"
 )
 
 type RPCMethod string

--- a/comms/discovery/schema/schema.ts
+++ b/comms/discovery/schema/schema.ts
@@ -156,9 +156,9 @@ export enum ChatPermission {
    */
   ALL = 'all',
   /**
-   * Messages are only allowed for users that have tipped me OR users I follow
+   * Messages are only allowed for users that have tipped me
    */
-  TIPPERS_OR_FOLLOWEES = 'tippersOrFollowees',
+  TIPPERS = 'tippers',
   /**
    * Messages are only allowed for users I follow
    */

--- a/comms/discovery/schema/schema.ts
+++ b/comms/discovery/schema/schema.ts
@@ -105,6 +105,7 @@ export type UserChat = {
   last_message: string
   last_message_at: string
   chat_members: Array<{ user_id: string }>
+  recheck_permissions: boolean
 
   // User specific
   invite_code: string
@@ -155,9 +156,9 @@ export enum ChatPermission {
    */
   ALL = 'all',
   /**
-   * Messages are only allowed for users that have tipped me
+   * Messages are only allowed for users that have tipped me OR users I follow
    */
-  TIPPERS = 'tippers',
+  TIPPERS_OR_FOLLOWEES = 'tippersOrFollowees',
   /**
    * Messages are only allowed for users I follow
    */

--- a/comms/discovery/server/response_mapper.go
+++ b/comms/discovery/server/response_mapper.go
@@ -7,6 +7,7 @@ import (
 	"comms.audius.co/discovery/db"
 	"comms.audius.co/discovery/db/queries"
 	"comms.audius.co/discovery/misc"
+	"comms.audius.co/discovery/rpcz"
 	"comms.audius.co/discovery/schema"
 )
 
@@ -34,6 +35,7 @@ func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.Us
 		UnreadMessageCount: float64(chat.UnreadCount),
 		ChatMembers:        Map(members, ToChatMemberResponse),
 	}
+	chatData.RecheckPermissions = rpcz.RecheckPermissionsRequired(chat.LastMessageAt, members)
 	if chat.LastMessage.Valid {
 		chatData.LastMessage = chat.LastMessage.String
 	}

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -642,7 +642,6 @@ func validateTipperPermissions(c echo.Context, userIds []int32, currentUserId in
 			(*validatedPermission).CurrentUserHasPermission = true
 		}
 	}
-
 	return nil
 }
 

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -601,66 +601,45 @@ func getValidatedPermission(userId int32, validatedPermissions map[string]*Valid
 	return validatedPermission, nil
 }
 
-func validateFolloweePermissions(c echo.Context, userIds []int32, currentUserId int32, validatedPermissions map[string]*ValidatedPermission) ([]int32, error) {
-	usersWithPermission := []int32{}
+func validateFolloweePermissions(c echo.Context, userIds []int32, currentUserId int32, validatedPermissions map[string]*ValidatedPermission) error {
 	// Query follows table to validate <sender, receiver> pair against users with followees only permissions
 	follows, err := queries.BulkGetFollowers(db.Conn, c.Request().Context(), queries.BulkGetFollowersParams{
 		FollowerUserIDs: userIds,
 		FolloweeUserID:  currentUserId,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return usersWithPermission, err
+		return err
 	}
 	if err != sql.ErrNoRows {
 		// Update response map if current follow record exists
 		for _, follow := range follows {
 			validatedPermission, err := getValidatedPermission(follow.FollowerUserID, validatedPermissions)
 			if err != nil {
-				return usersWithPermission, err
+				return err
 			}
 			(*validatedPermission).CurrentUserHasPermission = true
-			usersWithPermission = append(usersWithPermission, follow.FollowerUserID)
 		}
 	}
-	return usersWithPermission, nil
+	return nil
 }
 
 func validateTipperPermissions(c echo.Context, userIds []int32, currentUserId int32, validatedPermissions map[string]*ValidatedPermission) error {
-	// Query follows and tips tables to validate <sender, receiver> pair against users with tippers or followees only permissions
-	usersWithPermission, err := validateFolloweePermissions(c, userIds, currentUserId, validatedPermissions)
+	// Query tips table to validate <sender, receiver> pair against users with tippers only permissions
+	tips, err := queries.BulkGetTipReceivers(db.Conn, c.Request().Context(), queries.BulkGetTipReceiversParams{
+		SenderUserID:    currentUserId,
+		ReceiverUserIDs: userIds,
+	})
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
-
-	// Query tips table for remaining userIds without successfully validated permission
-	usersWithoutPermission := []int32{}
-	usersWithPermissionSet := make(map[int32]bool)
-	for _, id := range usersWithPermission {
-		usersWithPermissionSet[id] = true
-	}
-
-	for _, id := range userIds {
-		if _, ok := usersWithPermissionSet[id]; !ok {
-			usersWithoutPermission = append(usersWithoutPermission, id)
-		}
-	}
-	if len(usersWithoutPermission) > 0 {
-		tips, err := queries.BulkGetTipReceivers(db.Conn, c.Request().Context(), queries.BulkGetTipReceiversParams{
-			SenderUserID:    currentUserId,
-			ReceiverUserIDs: usersWithoutPermission,
-		})
-		if err != nil && err != sql.ErrNoRows {
-			return err
-		}
-		if err != sql.ErrNoRows {
-			// Update response map if aggregate tip record exists
-			for _, tip := range tips {
-				validatedPermission, err := getValidatedPermission(tip.ReceiverUserID, validatedPermissions)
-				if err != nil {
-					return err
-				}
-				(*validatedPermission).CurrentUserHasPermission = true
+	if err != sql.ErrNoRows {
+		// Update response map if aggregate tip record exists
+		for _, tip := range tips {
+			validatedPermission, err := getValidatedPermission(tip.ReceiverUserID, validatedPermissions)
+			if err != nil {
+				return err
 			}
+			(*validatedPermission).CurrentUserHasPermission = true
 		}
 	}
 
@@ -678,7 +657,7 @@ func validatePermissions(c echo.Context, permissions []queries.ChatPermissionsRo
 		if userPermission.UserID != currentUserId {
 			if userPermission.Permits == schema.Followees {
 				followeePermissions = append(followeePermissions, userPermission.UserID)
-			} else if userPermission.Permits == schema.TippersOrFollowees {
+			} else if userPermission.Permits == schema.Tippers {
 				tipperPermissions = append(tipperPermissions, userPermission.UserID)
 			}
 		}
@@ -698,7 +677,7 @@ func validatePermissions(c echo.Context, permissions []queries.ChatPermissionsRo
 	}
 
 	if len(followeePermissions) > 0 {
-		_, err := validateFolloweePermissions(c, followeePermissions, currentUserId, validatedPermissions)
+		err := validateFolloweePermissions(c, followeePermissions, currentUserId, validatedPermissions)
 		if err != nil {
 			return err
 		}

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -140,6 +140,7 @@ func TestGetChats(t *testing.T) {
 		ChatID:             chatId1,
 		LastMessage:        message2,
 		LastMessageAt:      message2CreatedAt.Round(time.Microsecond).Format(time.RFC3339Nano),
+		RecheckPermissions: false,
 		InviteCode:         chatId1,
 		UnreadMessageCount: float64(0),
 		ChatMembers: []schema.ChatMember{
@@ -151,6 +152,7 @@ func TestGetChats(t *testing.T) {
 		ChatID:             chatId2,
 		LastMessage:        message3,
 		LastMessageAt:      message3CreatedAt.Round(time.Microsecond).Format(time.RFC3339Nano),
+		RecheckPermissions: false,
 		InviteCode:         chatId2,
 		UnreadMessageCount: float64(0),
 		ChatMembers: []schema.ChatMember{
@@ -546,7 +548,7 @@ func TestGetPermissions(t *testing.T) {
 	// - user 4: followees
 	// - user 5: explicit all
 	// - user 6: none
-	_, err = tx.Exec("insert into chat_permissions (user_id, permits) values ($1, $2), ($3, $4), ($5, $6), ($7, $8), ($9, $10)", user2Id, schema.Followees, user3Id, schema.Tippers, user4Id, schema.Followees, user5Id, schema.All, user6Id, schema.None)
+	_, err = tx.Exec("insert into chat_permissions (user_id, permits) values ($1, $2), ($3, $4), ($5, $6), ($7, $8), ($9, $10)", user2Id, schema.Followees, user3Id, schema.TippersOrFollowees, user4Id, schema.Followees, user5Id, schema.All, user6Id, schema.None)
 
 	err = tx.Commit()
 	assert.NoError(t, err)
@@ -667,7 +669,7 @@ func TestGetPermissions(t *testing.T) {
 				CurrentUserHasPermission: true,
 			},
 			encodedUser3: {
-				Permits:                  schema.Tippers,
+				Permits:                  schema.TippersOrFollowees,
 				CurrentUserHasPermission: false,
 			},
 		})
@@ -705,7 +707,7 @@ func TestGetPermissions(t *testing.T) {
 		// Assertions
 		expectedData := ToChatPermissionsResponse(map[string]*ValidatedPermission{
 			encodedUser3: {
-				Permits:                  schema.Tippers,
+				Permits:                  schema.TippersOrFollowees,
 				CurrentUserHasPermission: true,
 			},
 			encodedUser4: {

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -548,7 +548,7 @@ func TestGetPermissions(t *testing.T) {
 	// - user 4: followees
 	// - user 5: explicit all
 	// - user 6: none
-	_, err = tx.Exec("insert into chat_permissions (user_id, permits) values ($1, $2), ($3, $4), ($5, $6), ($7, $8), ($9, $10)", user2Id, schema.Followees, user3Id, schema.TippersOrFollowees, user4Id, schema.Followees, user5Id, schema.All, user6Id, schema.None)
+	_, err = tx.Exec("insert into chat_permissions (user_id, permits) values ($1, $2), ($3, $4), ($5, $6), ($7, $8), ($9, $10)", user2Id, schema.Followees, user3Id, schema.Tippers, user4Id, schema.Followees, user5Id, schema.All, user6Id, schema.None)
 
 	err = tx.Commit()
 	assert.NoError(t, err)
@@ -669,7 +669,7 @@ func TestGetPermissions(t *testing.T) {
 				CurrentUserHasPermission: true,
 			},
 			encodedUser3: {
-				Permits:                  schema.TippersOrFollowees,
+				Permits:                  schema.Tippers,
 				CurrentUserHasPermission: false,
 			},
 		})
@@ -707,7 +707,7 @@ func TestGetPermissions(t *testing.T) {
 		// Assertions
 		expectedData := ToChatPermissionsResponse(map[string]*ValidatedPermission{
 			encodedUser3: {
-				Permits:                  schema.TippersOrFollowees,
+				Permits:                  schema.Tippers,
 				CurrentUserHasPermission: true,
 			},
 			encodedUser4: {

--- a/dev-tools/compose/docker-compose.comms.yml
+++ b/dev-tools/compose/docker-compose.comms.yml
@@ -35,7 +35,7 @@ services:
     environment:
       <<: *comms-environment
       audius_db_url: "postgresql://postgres:postgres@db:5432/com1?sslmode=disable"
-      AUDIUS_DELEGATE_PRIVATE_KEY: "c82ad757622db5a148089e0a8fc1741cefa8677ab56a2ac9e38dac905c5ad7c7" # Public key: "0x123d0813710D55A9C38A2D7BC502Ff00A1a0279e"
+      audius_delegate_private_key: "c82ad757622db5a148089e0a8fc1741cefa8677ab56a2ac9e38dac905c5ad7c7" # Public key: "0x123d0813710D55A9C38A2D7BC502Ff00A1a0279e"
 
   comms-discovery-2:
     container_name: audius-protocol-comms-discovery-2
@@ -43,7 +43,7 @@ services:
     environment:
       <<: *comms-environment
       audius_db_url: "postgresql://postgres:postgres@db:5432/com1?sslmode=disable"
-      AUDIUS_DELEGATE_PRIVATE_KEY: "d2b12371a062b73ce665288f894844ab75760d0ed0c580ff19d21b54d260ceb2" # Public key: "0x9262c9A1b172fF2A9C027B55862389d00b68A26a"
+      audius_delegate_private_key: "d2b12371a062b73ce665288f894844ab75760d0ed0c580ff19d21b54d260ceb2" # Public key: "0x9262c9A1b172fF2A9C027B55862389d00b68A26a"
 
   comms-discovery-3:
     container_name: audius-protocol-comms-discovery-3
@@ -51,7 +51,7 @@ services:
     environment:
       <<: *comms-environment
       audius_db_url: "postgresql://postgres:postgres@db:5432/com1?sslmode=disable"
-      AUDIUS_DELEGATE_PRIVATE_KEY: "6569932dff9fbe7c04382f87ac7098f90e7aa5cb0fe636b4e5c3cb4e30668812" # Public key: "0xBc2550Ae74fbbDF4eC30A8E65dd845a5a8510eb4"
+      audius_delegate_private_key: "6569932dff9fbe7c04382f87ac7098f90e7aa5cb0fe636b4e5c3cb4e30668812" # Public key: "0xBc2550Ae74fbbDF4eC30A8E65dd845a5a8510eb4"
 
   # TEST
 
@@ -65,7 +65,7 @@ services:
         GOARCH: arm64
     environment:
       <<: *comms-environment
-      AUDIUS_DELEGATE_PRIVATE_KEY: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
+      audius_delegate_private_key: "293589cdf207ed2f2253bb72b17bb7f2cfe399cdc34712b1d32908d969682238" # Public key: "0x1c185053c2259f72fd023ED89B9b3EBbD841DA0F"
       AUDIUS_TEST_HOST: "audius-protocol-nats-storage-1"
       audius_db_url: "postgresql://postgres:postgres@db:5432/comms_test?sslmode=disable"
     command: -c .air.test.toml

--- a/libs/src/sdk/api/chats/serverTypes.ts
+++ b/libs/src/sdk/api/chats/serverTypes.ts
@@ -156,9 +156,9 @@ export enum ChatPermission {
    */
   ALL = 'all',
   /**
-   * Messages are only allowed for users that have tipped me OR users I follow
+   * Messages are only allowed for users that have tipped me
    */
-  TIPPERS_OR_FOLLOWEES = 'tippersOrFollowees',
+  TIPPERS = 'tippers',
   /**
    * Messages are only allowed for users I follow
    */

--- a/libs/src/sdk/api/chats/serverTypes.ts
+++ b/libs/src/sdk/api/chats/serverTypes.ts
@@ -105,6 +105,7 @@ export type UserChat = {
   last_message: string
   last_message_at: string
   chat_members: Array<{ user_id: string }>
+  recheck_permissions: boolean
 
   // User specific
   invite_code: string
@@ -155,9 +156,9 @@ export enum ChatPermission {
    */
   ALL = 'all',
   /**
-   * Messages are only allowed for users that have tipped me
+   * Messages are only allowed for users that have tipped me OR users I follow
    */
-  TIPPERS = 'tippers',
+  TIPPERS_OR_FOLLOWEES = 'tippersOrFollowees',
   /**
    * Messages are only allowed for users I follow
    */


### PR DESCRIPTION
### Description
- Compute new field `recheck_permissions` on chats response (if any chat_member record for that chat has cleared_history_at > last_message_at, true, else false). Client will use to determine whether to recheck permissions after a member has cleared their chat
- Only validate permissions on message send if the computed `recheck_permissions` is true
- Make permissions check on chat create unidirectional
- Fix `make test`

### Tests
Unit/integration tests


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->