### PR TITLE
Fix libs startup race condition 

### DIFF
--- a/.circleci/jobs/test.yml
+++ b/.circleci/jobs/test.yml
@@ -1,9 +1,9 @@
 parameters:
   instance-name:
-    description: 'Name of gcp instance to use for the test'
+    description: "Name of gcp instance to use for the test"
     type: string
   service:
-    description: 'Service to test'
+    description: "Service to test"
     type: string
 resource_class: small
 docker:
@@ -27,7 +27,7 @@ steps:
 
         echo "export IMAGE_FLAG='$IMAGE_FLAG'" >> "$BASH_ENV"
   - gcp-run:
-      instance-name: '<< parameters.instance-name >>'
+      instance-name: "<< parameters.instance-name >>"
       create-instance-args: >-
         $IMAGE_FLAG
         --preemptible
@@ -38,7 +38,7 @@ steps:
       steps:
         - gcp-checkout
         - run: AUDIUS_DEV=false bash ~/audius-protocol/dev-tools/setup.sh
-        - run: 
+        - run:
             name: test run "<< parameters.service >>"
             no_output_timeout: 20m
-            command: . ~/.profile; audius-compose test run "<< parameters.service >>"
+            command: . ~/.profile; audius-compose test run "<< parameters.service >>" && sleep inf

--- a/.circleci/jobs/test.yml
+++ b/.circleci/jobs/test.yml
@@ -41,4 +41,4 @@ steps:
         - run:
             name: test run "<< parameters.service >>"
             no_output_timeout: 20m
-            command: . ~/.profile; audius-compose test run "<< parameters.service >>" && sleep inf
+            command: . ~/.profile; audius-compose test run "<< parameters.service >>"

--- a/dev-tools/compose/docker-compose.dev.yml
+++ b/dev-tools/compose/docker-compose.dev.yml
@@ -31,9 +31,9 @@ services:
       - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
     depends_on:
       poa-ganache:
-        condition: service_started
+        condition: service_healthy
       eth-ganache:
-        condition: service_started
+        condition: service_healthy
     deploy:
       mode: global
     profiles:


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Because ABIs are overwritten by the ones built from the ganache instances that are spun up here: https://github.com/AudiusProject/audius-protocol/blob/a0a3c286ab38ed0427683822cd3fe1df1a05601b/dev-tools/compose/docker-compose.dev.yml#L28, we should make sure to wait for `service_healthy` instead of just `service_started` to prevent a race condition



### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

`audius-compose test run identity-service`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->