### PR TITLE
PLAT-955: default to local RPC and fallback to gateway

### DIFF
--- a/discovery-provider/integration_tests/queries/test_search.py
+++ b/discovery-provider/integration_tests/queries/test_search.py
@@ -245,7 +245,7 @@ def setup_search(app_module):
         capture_output=True,
         text=True,
         cwd="es-indexer",
-        timeout=10,
+        timeout=30,
     )
 
 

--- a/discovery-provider/integration_tests/queries/test_search_track_tags.py
+++ b/discovery-provider/integration_tests/queries/test_search_track_tags.py
@@ -49,7 +49,7 @@ def test_search_track_tags(app_module):
         capture_output=True,
         text=True,
         cwd="es-indexer",
-        timeout=10,
+        timeout=30,
     )
 
     result = search_tags_es("pop", kind="tracks")

--- a/discovery-provider/integration_tests/queries/test_search_user_tags.py
+++ b/discovery-provider/integration_tests/queries/test_search_user_tags.py
@@ -42,7 +42,7 @@ def test_search_user_tags(app):
         capture_output=True,
         text=True,
         cwd="es-indexer",
-        timeout=10,
+        timeout=30,
     )
 
     result = search_tags_es("pop", kind="users")

--- a/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -86,7 +86,7 @@ def test_get_feed_es(app):
         capture_output=True,
         text=True,
         cwd="es-indexer",
-        timeout=10,
+        timeout=30,
     )
     esclient.indices.refresh(index="*")
     search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]

--- a/discovery-provider/src/utils/web3_provider.py
+++ b/discovery-provider/src/utils/web3_provider.py
@@ -2,26 +2,35 @@
 Interface for using a web3 provider
 """
 
+import logging
 import os
 from typing import Optional
 
+import requests
 from src.utils.config import shared_config
 from src.utils.multi_provider import MultiProvider
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
+logger = logging.getLogger(__name__)
+
 web3: Optional[Web3] = None
-LOCAL_RPC = "http://chain:8545"  # TODO: Needs nethermind locally I think
+LOCAL_RPC = "http://chain:8545"
 
 
 def get_web3(web3endpoint=None):
-    # only use ACDC web3 provider when
-    # final_poa_block is indexed
-
     # pylint: disable=W0603
     global web3
     if not web3endpoint:
-        web3endpoint = os.getenv("audius_web3_host")
+        # attempt local rpc, check if healthy
+        r = requests.get(LOCAL_RPC + "/health")
+        if r.status_code == 200:
+            web3endpoint = LOCAL_RPC
+            logger.info("web3_provider.py | using local RPC")
+        else:
+            # if local rpc isn't healthy fall back to gateway
+            web3endpoint = os.getenv("audius_web3_host")
+            logger.warn("web3_provider.py | falling back to gateway RPC")
     web3 = Web3(HTTPProvider(web3endpoint))
 
     # required middleware for POA
@@ -33,6 +42,7 @@ def get_web3(web3endpoint=None):
 eth_web3: Optional[Web3] = None
 
 
+# mainnet eth, not ACDC
 def get_eth_web3():
     # pylint: disable=W0603
     global eth_web3

--- a/discovery-provider/src/utils/web3_provider.py
+++ b/discovery-provider/src/utils/web3_provider.py
@@ -24,17 +24,14 @@ def get_web3(web3endpoint=None):
     if not web3endpoint:
         # attempt local rpc, check if healthy
         try:
-            r = requests.get(LOCAL_RPC + "/health")
-            if r.status_code == 200:
+            if requests.get(LOCAL_RPC + "/health").status_code == 200:
                 web3endpoint = LOCAL_RPC
                 logger.info("web3_provider.py | using local RPC")
             else:
-                # if local rpc isn't healthy fall back to gateway
-                web3endpoint = os.getenv("audius_web3_host")
-                logger.warn("web3_provider.py | falling back to gateway RPC")
-        except:
+                raise Exception("local RPC unhealthy or unreachable")
+        except Exception as e:
             web3endpoint = os.getenv("audius_web3_host")
-            logger.warn("web3_provider.py | exception, falling back to gateway RPC")
+            logger.warn(e)
     web3 = Web3(HTTPProvider(web3endpoint))
 
     # required middleware for POA

--- a/discovery-provider/src/utils/web3_provider.py
+++ b/discovery-provider/src/utils/web3_provider.py
@@ -23,14 +23,18 @@ def get_web3(web3endpoint=None):
     global web3
     if not web3endpoint:
         # attempt local rpc, check if healthy
-        r = requests.get(LOCAL_RPC + "/health")
-        if r.status_code == 200:
-            web3endpoint = LOCAL_RPC
-            logger.info("web3_provider.py | using local RPC")
-        else:
-            # if local rpc isn't healthy fall back to gateway
+        try:
+            r = requests.get(LOCAL_RPC + "/health")
+            if r.status_code == 200:
+                web3endpoint = LOCAL_RPC
+                logger.info("web3_provider.py | using local RPC")
+            else:
+                # if local rpc isn't healthy fall back to gateway
+                web3endpoint = os.getenv("audius_web3_host")
+                logger.warn("web3_provider.py | falling back to gateway RPC")
+        except:
             web3endpoint = os.getenv("audius_web3_host")
-            logger.warn("web3_provider.py | falling back to gateway RPC")
+            logger.warn("web3_provider.py | exception, falling back to gateway RPC")
     web3 = Web3(HTTPProvider(web3endpoint))
 
     # required middleware for POA


### PR DESCRIPTION
### Description
Since ACDC has been functioning correctly for awhile discprov should be using its local node to index. This will reduce network latency and traffic to cloudflare will only be external RPC clients like web and mobile. There is a fallback if the node is unhealthy to use the RPC gateway should one node not report healthy. 

### Tests
Will run on a node on stage once build is complete.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
Logs showing which web3 provider was chosen will appear on startup. This will tell us if discprov thinks its local node is unhealthy and if it fell back to the gateway.