### PR TITLE
Add /internal nginx proxy rule. Enable cid beam in prod

### DIFF
--- a/comms/discovery/rpcz/broadcast.go
+++ b/comms/discovery/rpcz/broadcast.go
@@ -1,13 +1,5 @@
 package rpcz
 
-// this is a crappy version of POST broadcast
-// that does fire and forget style to all peers...
-//
-// a better version will have a chan of messages to send and will send them with N workers
-// and also do the "pull" consumer code in `sync_client.go`
-// and also keep track of if server is up and healthy and only push if yes.
-//
-// if push fails, it's okay because the pull consumer has a cursor and will come along and get it on an interval.
 func (proc *RPCProcessor) broadcast(payload []byte) {
 	for _, pc := range proc.peerClients {
 		pc.Send(payload)

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -95,6 +95,15 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        # so you can access some mediorum screens before mediorum first
+        location /mediorum {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream mediorum:1991;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         # $upstream references the audius-docker-compose network'd containers
         location /prometheus/postgres {
             resolver 127.0.0.11 valid=30s;

--- a/creator-node/nginx_conf/nginx.conf
+++ b/creator-node/nginx_conf/nginx.conf
@@ -85,6 +85,16 @@ http {
             add_header X-Cache-Status $upstream_cache_status always;
         }
 
+        # make's mediorum's /internal path prefix available even if the node is not mediorum first.
+        # so that crudr, replication, cid beam stuff can all work.
+        location /internal {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream mediorum:1991;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         # $upstream references the audius-docker-compose network'd containers
         location /prometheus/postgres {
             resolver 127.0.0.11 valid=30s;

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -97,7 +97,7 @@ func (ss *MediorumServer) beamFromPeer(peer Peer) (*beamResult, error) {
 	var cursorBefore time.Time
 	ss.pgPool.QueryRow(ctx, `select updated_at from cid_cursor where host = $1`, peer.Host).Scan(&cursorBefore)
 
-	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("beam/files"), url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
+	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("internal/beam/files"), url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
 	startedAt := time.Now()
 	logger := slog.With("beam_client", peer.Host)
 	resp, err := client.Get(endpoint)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -198,10 +198,11 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/cid/:dirCid/:fileName", ss.serveLegacyDirCid)
 	routes.GET("/metadata", ss.serveCidMetadata)
 
-	routes.GET("/beam/files", ss.servePgBeam)
-
+	// -------------------
 	// internal
 	internalApi := routes.Group("/internal")
+
+	internalApi.GET("/beam/files", ss.servePgBeam)
 
 	// internal: crud
 	internalApi.GET("/crud/sweep", ss.serveCrudSweep)
@@ -247,12 +248,7 @@ func (ss *MediorumServer) MustStart() {
 
 	ss.crud.StartClients()
 
-	// disable pg_beam in prod for now.
-	// plan is to make it more evented and enable everywhere
-	// before making mediorum "first"
-	if ss.Config.Env != "prod" {
-		go ss.startBeamClient()
-	}
+	go ss.startBeamClient()
 
 	// signals
 	signal.Notify(ss.quit, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
make's mediorum's /internal path prefix available even if the node is not mediorum first
so that crudr, replication, cid pg_beam stuff can all work.