### PR TITLE
PLAT-981: fix peer count in health z

### DIFF
--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -80,7 +80,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     health.auto_upgrade_enabled || health.autoUpgradeEnabled
   const getPeers = (str: string | undefined) => {
     if (str === undefined) return "chain health undefined"
-    const match = str.match(/Peers: (.)/)
+    const match = str.match(/Peers: (\d+)\./)
     return (match && match[1]) ? match[1] : "no peers found"
   }
   const getProducing = (str: string | undefined) => {


### PR DESCRIPTION
### Description
healthz previously only brought in the first character for peers, this broke when on prod there would sometimes be double digit sets of peers


### Tests
ran in stage and prod mode locally and saw the correct peer count


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
healthz is the monitor