### PR TITLE
Clean up notifications tests

### DIFF
--- a/.circleci/src/commands/gcp-run.yml
+++ b/.circleci/src/commands/gcp-run.yml
@@ -54,7 +54,7 @@ steps:
       shell: /tmp/bash.real
       command: touch /tmp/success
   - run:
-      name: Delete GCP resoruces
+      name: Delete GCP resources
       when: always
       shell: /tmp/bash.real
       command: |

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/announcement.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/announcement.test.ts
@@ -18,8 +18,6 @@ import { renderEmail } from '../../email/notifications/renderEmail'
 
 describe('Announcement Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
@@ -19,8 +19,6 @@ import {
 
 describe('Challenge Reward Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/cosign.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/cosign.test.ts
@@ -22,8 +22,6 @@ import { RepostType } from '../../types/dn'
 
 describe('Cosign Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/create.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/create.test.ts
@@ -10,8 +10,7 @@ import {
   createPlaylists,
   createSubscription,
   setupTest,
-  resetTests,
-  dropTestDB
+  resetTests
 } from '../../utils/populateDB'
 import { renderEmail } from '../../email/notifications/renderEmail'
 import {
@@ -36,16 +35,6 @@ describe('Create Notification', () => {
 
   afterEach(async () => {
     await resetTests(processor)
-    jest.clearAllMocks()
-    await processor?.close()
-    const testName = expect
-      .getState()
-      .currentTestName.replace(/\s/g, '_')
-      .toLocaleLowerCase()
-    await Promise.all([
-      dropTestDB(process.env.DN_DB_URL, testName),
-      dropTestDB(process.env.IDENTITY_DB_URL, testName)
-    ])
   })
 
   test('Process push notification for create track', async () => {

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/create.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/create.test.ts
@@ -21,8 +21,6 @@ import {
 
 describe('Create Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/multipleMappings.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/multipleMappings.test.ts
@@ -20,8 +20,6 @@ import { EntityType } from '../../email/notifications/types'
 
 describe('Multiple Mappings Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/reaction.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/reaction.test.ts
@@ -19,8 +19,6 @@ import {
 
 describe('Reaction Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/remix.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/remix.test.ts
@@ -19,8 +19,6 @@ import { renderEmail } from '../../email/notifications/renderEmail'
 
 describe('Remix Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/repost.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/repost.test.ts
@@ -22,8 +22,6 @@ import { EntityType } from '../../email/notifications/types'
 
 describe('Repost Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/repostOfRepost.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/repostOfRepost.test.ts
@@ -93,7 +93,7 @@ describe('Repost Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',
@@ -122,7 +122,7 @@ describe('Repost Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',
@@ -151,7 +151,7 @@ describe('Repost Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/save.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/save.test.ts
@@ -20,8 +20,6 @@ import { EntityType } from '../../email/notifications/types'
 
 describe('Save Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/saveOfRepost.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/saveOfRepost.test.ts
@@ -94,7 +94,7 @@ describe('Save Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',
@@ -123,7 +123,7 @@ describe('Save Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',
@@ -152,7 +152,7 @@ describe('Save Of Repost Notification', () => {
     expect(pending?.appNotifications).toHaveLength(4)
     // Assert single pending
     await processor.appNotificationsProcessor.process(pending.appNotifications)
-    expect(sendPushNotificationSpy.mock.lastCall).toStrictEqual([
+    expect(sendPushNotificationSpy.mock.lastCall).toMatchObject([
       {
         type: 'ios',
         targetARN: 'arn:2',

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/tip.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/tip.test.ts
@@ -18,8 +18,6 @@ import {
 
 describe('Tip Notification', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/userNotificationSettings.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/userNotificationSettings.test.ts
@@ -17,8 +17,6 @@ import { buildUserNotificationSettings } from '../../processNotifications/mapper
 
 describe('user notification settings', () => {
   let processor: Processor
-  // Mock current date for test result consistency
-  Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
 
   beforeEach(async () => {
     const setup = await setupTest()

--- a/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
@@ -12,7 +12,6 @@ import {
   createTestDB,
   dropTestDB,
   replaceDBName,
-  randId,
   createUsers,
   createChat,
   readChat,
@@ -89,9 +88,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -143,9 +142,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -221,9 +220,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent two messages config.dmNotificationDelay ms ago
     const message1 = 'hi from user 1'
-    const message1Id = randId().toString()
+    const message1Id = '1'
     const message1Timestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, message1Timestamp)
     await insertMessage(
       discoveryDB,
@@ -234,7 +233,7 @@ describe('Email Notifications', () => {
       message1Timestamp
     )
     const message2 = 'hello again'
-    const message2Id = randId().toString()
+    const message2Id = '2'
     const message2Timestamp = new Date(Date.now() - config.dmNotificationDelay)
     await insertMessage(
       discoveryDB,
@@ -319,9 +318,9 @@ describe('Email Notifications', () => {
 
     // User 1 sends message now
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now())
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -367,9 +366,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -403,9 +402,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message to user 2 config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -418,7 +417,7 @@ describe('Email Notifications', () => {
 
     // User 1 saves user 2's track
     const notificationRow = {
-      id: randId(),
+      id: 1,
       specifier: user1.toString(),
       group_id: `save:100:type:track`,
       type: 'save',
@@ -474,7 +473,7 @@ describe('Email Notifications', () => {
 
     // User 1 follows user 2
     const notificationRow = {
-      id: randId(),
+      id: 1,
       specifier: user1.toString(),
       group_id: `follow:${user2}`,
       type: 'follow',
@@ -543,9 +542,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,
@@ -579,9 +578,9 @@ describe('Email Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now() - config.dmNotificationDelay)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(discoveryDB, user1, user2, chatId, messageTimestamp)
     await insertMessage(
       discoveryDB,

--- a/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
@@ -19,7 +19,7 @@ import {
   insertReaction,
   insertNotifications,
   insertNotificationEmails,
-  setUserEmailAndSettings
+  setUserEmailAndSettings,
 } from '../utils/populateDB'
 import { RemoteConfig } from '../remoteConfig'
 
@@ -69,6 +69,10 @@ describe('Email Notifications', () => {
       dropTestDB(process.env.DN_DB_URL, testName),
       dropTestDB(process.env.IDENTITY_DB_URL, testName)
     ])
+  })
+
+  afterAll(() => {
+    mockRemoteConfig.close()
   })
 
   test('Process unread message', async () => {

--- a/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processEmailNotifications.test.ts
@@ -19,7 +19,7 @@ import {
   insertReaction,
   insertNotifications,
   insertNotificationEmails,
-  setUserEmailAndSettings,
+  setUserEmailAndSettings
 } from '../utils/populateDB'
 import { RemoteConfig } from '../remoteConfig'
 

--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -3,7 +3,6 @@ import { Processor } from '../main'
 import * as sns from '../sns'
 import { config } from './../config'
 import {
-  randId,
   createChat,
   readChat,
   insertMessage,
@@ -41,10 +40,10 @@ describe('Push Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
     const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(
       processor.discoveryDB,
       user1.userId,
@@ -119,10 +118,10 @@ describe('Push Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
     const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(
       processor.discoveryDB,
       user1.userId,
@@ -184,9 +183,9 @@ describe('Push Notifications', () => {
 
     // User 1 sends message now
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now())
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(
       processor.discoveryDB,
       user1.userId,
@@ -215,9 +214,9 @@ describe('Push Notifications', () => {
 
     // Set up chat and message
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestamp = new Date(Date.now())
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(
       processor.discoveryDB,
       user1.userId,
@@ -266,10 +265,10 @@ describe('Push Notifications', () => {
 
     // User 1 sent message config.dmNotificationDelay ms ago
     const message = 'hi from user 1'
-    const messageId = randId().toString()
+    const messageId = '1'
     const messageTimestampMs = Date.now() - config.dmNotificationDelay
     const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = randId().toString()
+    const chatId = '1'
     await createChat(
       processor.discoveryDB,
       user1.userId,

--- a/discovery-provider/plugins/notifications/src/listener.ts
+++ b/discovery-provider/plugins/notifications/src/listener.ts
@@ -64,6 +64,6 @@ const getNotification = async (client: Client, notificationId: number): Promise<
     return res.rows[0]
   } catch (e) {
     logger.error(`could not get notification ${notificationId} ${e}`)
-    return null;
+    return null
   }
 }

--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -140,6 +140,7 @@ export class Processor {
   }
 
   close = async () => {
+    this.remoteConfig.close()
     await this.listener?.close()
     await this.discoveryDB?.destroy()
     await this.identityDB?.destroy()

--- a/discovery-provider/plugins/notifications/src/remoteConfig.ts
+++ b/discovery-provider/plugins/notifications/src/remoteConfig.ts
@@ -94,6 +94,11 @@ export class RemoteConfig {
     await optimizelyPromise
   }
 
+  close = () => {
+    this.isInit = false
+    this.optimizelyClient.close()
+  }
+
   getFeatureVariableEnabled(featureName: string, variable: string): boolean {
     const optimizelyValue = this.optimizelyClient.getFeatureVariableBoolean(
       featureName,

--- a/discovery-provider/plugins/notifications/src/utils/populateDB.ts
+++ b/discovery-provider/plugins/notifications/src/utils/populateDB.ts
@@ -479,11 +479,6 @@ export const setUserEmailAndSettings = async (
   return user
 }
 
-// Generate random Id betweeen 0 and 999
-export function randId() {
-  return Math.floor(Math.random() * 1000)
-}
-
 export async function clearAllTables(db: Knex) {
   await db.raw(
     `
@@ -607,7 +602,7 @@ export async function insertMobileDevices(
   await db
     .insert(
       mobileDevices.map((device, idx) => ({
-        deviceToken: randId().toString(),
+        deviceToken: device.userId.toString(),
         createdAt: currentTimestamp,
         updatedAt: currentTimestamp,
         deviceType: 'ios',
@@ -689,9 +684,9 @@ export async function setupTwoUsersWithDevices(
   discoveryDB: Knex,
   identityDB: Knex
 ): Promise<{ user1: UserWithDevice; user2: UserWithDevice }> {
-  const user1 = randId()
+  const user1 = 1
   const user1Name = 'user 1'
-  const user2 = randId()
+  const user2 = 2
   const user2Name = 'user 2'
   await createUsers(discoveryDB, [
     { user_id: user1, name: user1Name, is_current: true },

--- a/discovery-provider/plugins/notifications/src/utils/populateDB.ts
+++ b/discovery-provider/plugins/notifications/src/utils/populateDB.ts
@@ -113,6 +113,7 @@ export const dropTestDB = async (
 
 export const resetTests = async (processor) => {
   jest.clearAllMocks()
+  await processor?.stop()
   await processor?.close()
   const testName = expect
     .getState()


### PR DESCRIPTION
### Description
- `toStrictEqual` was failing for me locally because the received was not an instance of Array despite serializing to the same string. Replaced with `toMatchObject`
- We weren't actually stopping the processor when cleaning up after each test. Was continuing to cycle and generating some error logs due to the db connection being destroyed
- Remove some duplicate cleanup logic in some `afterEach` blocks
- Tests were sometimes failing bc of duplicate key violations for tables we were using `randId()` to generate a random primary key value for (`NotificationDeviceTokens` in identity and `users` in discovery). `randId()` generates a random number between 0 - 1000 so there was a 1/1000 chance of conflict between 2 random keys. Fixed by replacing with hardcoded numbers -- since we set up an individual db per test, there's actually no need to randomize IDs.
- Close open handles from the optimizely SDK as indicated by the `--detectOpenHandles` debug flag. The tests still don't exit on their own though so there are still some open handles/resources somewhere
- Remove extraneous date mocks

### Tests
Notifs tests consistently pass locally.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->