### PR TITLE
Rename encodedABI in Transactions table in identity

### DIFF
--- a/identity-service/sequelize/migrations/20230518025711-rename-transactions-encodedABI.js
+++ b/identity-service/sequelize/migrations/20230518025711-rename-transactions-encodedABI.js
@@ -1,0 +1,19 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.renameColumn(
+      'Transactions',
+      'encodedABI',
+      'encodedNonceAndSig'
+    )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.renameColumn(
+      'Transactions',
+      'encodedNonceAndSig',
+      'encodedABI'
+    )
+  }
+}

--- a/identity-service/src/models/transaction.js
+++ b/identity-service/src/models/transaction.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
   const Transaction = sequelize.define(
     'Transaction',
     {
-      encodedABI: {
+      encodedNonceAndSig: {
         type: DataTypes.TEXT,
         allowNull: false,
         primaryKey: true

--- a/identity-service/src/relay/txRelay.js
+++ b/identity-service/src/relay/txRelay.js
@@ -150,7 +150,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
 
   const existingTx = await models.Transaction.findOne({
     where: {
-      encodedABI: hashedData // this should always be unique
+      encodedNonceAndSig: hashedData // this should always be unique
     }
   })
 
@@ -385,7 +385,7 @@ const sendTransactionInternal = async (req, web3, txProps, reqBodySHA) => {
     contractFn: decodedABI.name,
     contractAddress: contractAddress,
     senderAddress: senderAddress,
-    encodedABI: hashedData,
+    encodedNonceAndSig: hashedData,
     decodedABI: decodedABI,
     receipt: txReceipt
   })


### PR DESCRIPTION
### Description
We're no longer storing the encodedABI here (see https://github.com/AudiusProject/audius-protocol/pull/5046/files#diff-d35a1255c6214bf3c3e63c5d8101a87b4250c8a307d3f61f78057ba490674c3a). Rename col appropriately


### Tests
audius-compose up, make sure migration completes successfully.


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->