### PR TITLE
Sanitize cid metadata from chain

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_helper.py
+++ b/discovery-provider/integration_tests/tasks/test_index_helper.py
@@ -193,6 +193,8 @@ def test_fetch_cid_metadata(app, mocker):
         user1_tx_metadata = expected_metadata["QmUpdateUser1"].copy()
         user1_tx_metadata.pop("collectibles")
         user1_tx_metadata["incorrect_key"] = True
+        # Add invalid unicode to verify fetch_cid_metadata sanitizes metadata
+        user1_tx_metadata["name"] += "\ud835"
         user1_json = json.dumps(user1_tx_metadata)
 
         track1_tx_metadata = expected_metadata["QmCreateTrack1"].copy()

--- a/discovery-provider/src/tasks/index.py
+++ b/discovery-provider/src/tasks/index.py
@@ -44,7 +44,7 @@ from src.tasks.metadata import (
 )
 from src.tasks.sort_block_transactions import sort_block_transactions
 from src.utils import helpers
-from src.utils.cid_metadata_client import get_metadata_from_json
+from src.utils.cid_metadata_client import get_metadata_from_json, sanitize_json
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
 from src.utils.index_blocks_performance import (
     record_add_indexed_block_to_db_ms,
@@ -255,7 +255,7 @@ def fetch_cid_metadata(db, entity_manager_txs):
                     # TODO remove legacy CN path after CID metadata migration.
                     if len(cid) > 0 and cid[0] == "{" and cid[-1] == "}":
                         try:
-                            data = json.loads(cid)
+                            data = sanitize_json(json.loads(cid))
 
                             # If metadata blob does not contain the required keys, skip
                             if "cid" not in data.keys() or "data" not in data.keys():

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -46,7 +46,7 @@ from src.tasks.metadata import (
 )
 from src.tasks.sort_block_transactions import sort_block_transactions
 from src.utils import helpers, web3_provider
-from src.utils.cid_metadata_client import get_metadata_from_json
+from src.utils.cid_metadata_client import get_metadata_from_json, sanitize_json
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
 from src.utils.index_blocks_performance import (
     record_add_indexed_block_to_db_ms,
@@ -272,7 +272,7 @@ def fetch_cid_metadata(db, entity_manager_txs):
                     # TODO remove legacy CN path after CID metadata migration.
                     if len(cid) > 0 and cid[0] == "{" and cid[-1] == "}":
                         try:
-                            data = json.loads(cid)
+                            data = sanitize_json(json.loads(cid))
 
                             # If metadata blob does not contain the required keys, skip
                             if "cid" not in data.keys() or "data" not in data.keys():

--- a/discovery-provider/src/utils/cid_metadata_client.py
+++ b/discovery-provider/src/utils/cid_metadata_client.py
@@ -28,6 +28,15 @@ def get_metadata_from_json(default_metadata_fields, resp_json):
     return metadata
 
 
+def sanitize_json(json_resp):
+    sanitized_data = (
+        json.dumps(json_resp, ensure_ascii=False)
+        .encode("utf-8", "ignore")
+        .decode("utf-8", "ignore")
+    )
+    return json.loads(sanitized_data)
+
+
 class CIDMetadataClient:
     """Helper class for Audius Discovery Provider + CID Metadata interaction"""
 
@@ -80,12 +89,8 @@ class CIDMetadataClient:
             ) as resp:
                 if resp.status == 200:
                     json_resp = await resp.json(content_type=None)
-                    sanitized_data = (
-                        json.dumps(json_resp, ensure_ascii=False)
-                        .encode("utf-8", "ignore")
-                        .decode("utf-8", "ignore")
-                    )
-                    return (multihash, json.loads(sanitized_data))
+                    metadata = sanitize_json(json_resp)
+                    return (multihash, metadata)
         except asyncio.TimeoutError:
             logger.info(
                 f"CIDMetadataClient | _get_metadata_async TimeoutError fetching gateway address - {url}"


### PR DESCRIPTION
### Description
Sanitize metadata blobs from chain the same way /content/<cid> responses are currently sanitized 


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->