### PR TITLE
[INF-379] Make pre-commit hook fast

### DIFF
--- a/check_secrets.sh
+++ b/check_secrets.sh
@@ -17,5 +17,6 @@ git secrets --add '.*[a-z0-9]*.rds.amazonaws.com:[0-9]*\/.*'
 # match any postgres db with an IP hostname
 git secrets --add 'postgres:\/\/.*\:.*@([0-9]*\.?)*:[0-9]{4}\/.*'
 
-# scan the repository
-git secrets --scan --cached
+# scan the staged files
+git secrets --scan --cached $(git diff --cached --name-only)
+


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

`git-secrets` was scanning the entire repo before every commit...
* Scan only the staged files for secrets, reducing pre-commit hook time from ~25 secs to ~1 sec

> Shouldn't need to do --no-verify anymore! 🙌

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

Tested by staging a fake aws secret and attempting to commit

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->