### PR TITLE
Increase csv field size limit in metadata backfill

### DIFF
--- a/discovery-provider/src/tasks/backfill_cid_data.py
+++ b/discovery-provider/src/tasks/backfill_cid_data.py
@@ -41,6 +41,8 @@ def backfill_cid_data(db: SessionManager):
         with db.scoped_session() as session:
             # Load cid data from csv in chunks...
             with open(tmp.name, "r") as file:
+                # Set 370KB limit for csv fields
+                csv.field_size_limit(370_000)
                 while True:
                     csv_reader = csv.reader(file, delimiter="\t")
                     lines = list(islice(csv_reader, chunk_size))


### PR DESCRIPTION
### Description
There are 2 rows with metadata that is larger than python csv's default max field size of 128KB. Increase to 370KB
```
360KB playlist QmSrqsk9qUekNtWGqxKKHnGtJjBWG4boudgNpPwYveFqGr https://creatornode3.audius.co/ipfs/QmSrqsk9qUekNtWGqxKKHnGtJjBWG4boudgNpPwYveFqGr
203KB track QmWNpoS5oM1ZxEBts4HkK93bfD6m5CPEaMGHfZHzmgofJ2 https://creatornode.audius.co/ipfs/QmWNpoS5oM1ZxEBts4HkK93bfD6m5CPEaMGHfZHzmgofJ2
```


### Tests
Ran prod backfill locally; succeeded

### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->