### PR TITLE
flare-178: disable cid beam, truncate cid_lookup table.

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -13,6 +13,16 @@ var cidLookupDDL string
 
 func Migrate(db *sql.DB) {
 	mustExec(db, cidLookupDDL)
+
+	// flare-178: disable cid beam
+	// clear out existing data
+	db.Exec(`
+	drop trigger if exists handle_cid_change on "Files";
+	truncate table cid_cursor cascade;
+	truncate table cid_log cascade;
+	truncate table cid_lookup cascade;
+	drop table if exists cid_temp;
+	`)
 }
 
 func mustExec(db *sql.DB, ddl string) {

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -24,7 +24,7 @@ func (ss *MediorumServer) startBeamClients() {
 
 func (ss *MediorumServer) startBeamClientForPeer(peer Peer) {
 	for {
-		time.Sleep(jitterSeconds(10, 20))
+		time.Sleep(jitterSeconds(60, 90))
 
 		result, err := ss.beamFromPeer(peer)
 		if err != nil {

--- a/mediorum/server/health.go
+++ b/mediorum/server/health.go
@@ -22,7 +22,7 @@ func (ss *MediorumServer) startHealthBroadcaster() {
 			ss.crud.Patch(ss.healthReport())
 			count++
 			if count > 10 {
-				delay = time.Second * 10
+				delay = time.Second * 60
 			}
 		}
 	}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -248,7 +248,8 @@ func (ss *MediorumServer) MustStart() {
 
 	ss.crud.StartClients()
 
-	ss.startBeamClients()
+	// flare-178: disable cid beam
+	// ss.startBeamClients()
 
 	// signals
 	signal.Notify(ss.quit, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
### Description

building the CID index for all CIDs was too big... going to delete that and revisit later to omit track segment CIDs.

* disables cid client polling
* truncates cid_* tables
* lowers interval on health broadcast