### PR TITLE
[PLAT-990] add notifications logs to axiom

### DIFF
--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -10,7 +10,8 @@
     "indexer",
     "postgres",
     "redis",
-    "comms"
+    "comms",
+    "notifications"
   ]
   exclude_containers = [
     # System containers


### PR DESCRIPTION
### Description
following the instructions on [plat-990](https://linear.app/audius/issue/PLAT-990/add-notifs-logs-to-axiom), i believe this allows the notifications container logs to pipe into axiom as well
