### PR TITLE
Fix DN re-selection in SDK

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -241,7 +241,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
    */
   private async select() {
     if (this.reselectLock) {
-      const prevNode = (' ' + this.selectedNode).slice(1) // Force make a copy of the string
+      const prevNode = this.selectedNode
       await new Promise<void>((resolve) => {
         this.eventEmitter.once('reselectAttemptComplete', () => {
           resolve()

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -247,9 +247,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
           resolve()
         })
       })
-      console.log(
-        `'waited. prevnode and new node ${prevNode}, ${this.selectedNode}`
-      )
+
       if (prevNode !== this.selectedNode && this.selectedNode != null) {
         return this.selectedNode
       }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -123,7 +123,13 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
     this._isBehind = false
     this.unhealthyServices = new Set([])
     this.backupServices = {}
-    this.selectedNode = this.config.initialSelectedNode
+    this.selectedNode =
+      this.config.initialSelectedNode &&
+      (!this.config.allowlist ||
+        this.config.allowlist?.has(this.config.initialSelectedNode)) &&
+      !this.config.blocklist?.has(this.config.initialSelectedNode)
+        ? this.config.initialSelectedNode
+        : null
     this.eventEmitter =
       new EventEmitter() as TypedEventEmitter<ServiceSelectionEvents>
     // Potentially need many event listeners for discovery reselection (to prevent race condition)

--- a/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
@@ -81,6 +81,7 @@ export type DiscoveryNodeSelectorServiceConfig =
 
 export type ServiceSelectionEvents = {
   change: (endpoint: string) => void
+  reselectAttemptComplete: () => void
 }
 
 export type DiscoveryNodeSelectorService =


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->
Fixes two issues
-> DN re-selection didn't work if the initial `fetch` request threw an error altogether. We were missing `onError` method.
-> Race condition when making a bunch of failed requests -> URL parsing for the fetch retry would fail since it relied on the old endpoint being constant -> Stuck in retry loop
--> Fixed by only allowing one ongoing reselection at a time + parsing the URL using a regex (maybe will change to URL if compatible w all platforms)

### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->