### PR TITLE
[PLAT-821]: Fix announcement notification reads from discovery

### DIFF
--- a/discovery-provider/integration_tests/queries/test_notifications/test_announcement_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_announcement_notification.py
@@ -1,0 +1,50 @@
+import logging
+
+from integration_tests.utils import populate_mock_db
+from src.queries.get_notifications import (
+    get_notifications,
+    get_unread_notification_count,
+)
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+def test_get_announcement_notifications(app):
+    with app.app_context():
+        db_mock = get_db()
+
+        test_entities = {
+            "users": [{"user_id": i + 1} for i in range(20)],
+            "notification": [
+                {
+                    "type": "announcement",
+                    "group_id": "fake_group_id",
+                    "specifier": "1",
+                    "data": {"title": "my title", "short_description": "my desc"},
+                    "user_ids": [],
+                },
+                {
+                    "type": "repost",
+                    "group_id": "fake_group_id_repost",
+                    "specifier": "3",
+                    "data": {"title": "my title", "short_description": "my desc"},
+                    "user_ids": [3],
+                },
+            ],
+        }
+        populate_mock_db(db_mock, test_entities)
+
+        with db_mock.scoped_session() as session:
+            unread_count = get_unread_notification_count(session, {"user_id": 1})
+            assert unread_count == 1
+            args = {"limit": 10, "user_id": 1}
+            u1_notifications = get_notifications(session, args)
+            assert len(u1_notifications) == 1
+            assert u1_notifications[0]["type"] == "announcement"
+            assert u1_notifications[0]["group_id"] == "fake_group_id"
+            assert len(u1_notifications[0]["actions"]) == 1
+            assert u1_notifications[0]["actions"][0]["data"] == {
+                "title": "my title",
+                "short_description": "my desc",
+            }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -49,7 +49,7 @@ FROM
 LEFT JOIN user_seen on
   user_seen.seen_at >= n.timestamp and user_seen.prev_seen_at < n.timestamp
 WHERE
-  ARRAY[:user_id] && n.user_ids AND
+  (ARRAY[:user_id] && n.user_ids OR n.type = 'announcement') AND
   (:valid_types is NOT NULL AND n.type in :valid_types) AND
   (
     (:timestamp_offset is NULL AND :group_id_offset is NULL) OR
@@ -83,7 +83,7 @@ FROM (
    from
        notification n
   WHERE
-    ARRAY[:user_id] && n.user_ids AND
+    (ARRAY[:user_id] && n.user_ids OR n.type = 'announcement') AND
     (:valid_types is NOT NULL AND n.type in :valid_types) AND
     n.timestamp > COALESCE((
         SELECT


### PR DESCRIPTION
### Description
the get_notifications query doesn't know to include an announcement notification in its results for a given user because the announcement notification has an empty user_ids array for users to notify (since the entire user id list would be too large to store)

this updates the query so that we get notifications where a given user id is part of a notifications user_ids OR the notif type is an announcement, in which case it doesn't matter who the user_ids are, we always include

same goes for unread count query


### Tests
updated tests
