### PR TITLE
Tiebreak order_bys in get_tracks

### DIFF
--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -477,6 +477,8 @@ class HandleFullAITrackList(Resource):
         current_user_id = get_current_user_id(args)
 
         sort = args.get("sort", None)
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
         offset = format_offset(args)
         limit = format_limit(args)
         filter_tracks = args.get("filter_tracks", "all")
@@ -488,6 +490,8 @@ class HandleFullAITrackList(Resource):
             "with_users": True,
             "filter_deleted": True,
             "sort": sort,
+            "sort_method": sort_method,
+            "sort_direction": sort_direction,
             "limit": limit,
             "offset": offset,
             "filter_tracks": filter_tracks,

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -409,6 +409,8 @@ class HandleFullTrackList(Resource):
         current_user_id = get_current_user_id(args)
 
         sort = args.get("sort", None)
+        sort_method = format_sort_method(args)
+        sort_direction = format_sort_direction(args)
         offset = format_offset(args)
         limit = format_limit(args)
         filter_tracks = args.get("filter_tracks", "all")
@@ -420,6 +422,8 @@ class HandleFullTrackList(Resource):
             "with_users": True,
             "filter_deleted": True,
             "sort": sort,
+            "sort_method": sort_method,
+            "sort_direction": sort_direction,
             "limit": limit,
             "offset": offset,
             "filter_tracks": filter_tracks,

--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -158,34 +158,42 @@ def _get_tracks(session, args):
         sort_direction = args.get("sort_direction")
         sort_fn = desc if sort_direction == SortDirection.desc else asc
         if sort_method == SortMethod.title:
-            base_query = base_query.order_by(sort_fn(TrackWithAggregates.title))
+            base_query = base_query.order_by(
+                sort_fn(TrackWithAggregates.title),
+                TrackWithAggregates.track_id
+            )
         elif sort_method == SortMethod.artist_name:
             base_query = base_query.join(
                 TrackWithAggregates.user, aliased=True
-            ).order_by(sort_fn(User.name))
+            ).order_by(
+                sort_fn(User.name),
+                TrackWithAggregates.track_id
+            )
         elif sort_method == SortMethod.release_date:
             base_query = base_query.order_by(
                 sort_fn(
-                    coalesce(
-                        func.to_timestamp_safe(
-                            TrackWithAggregates.release_date,
-                            "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
-                        ),
-                        TrackWithAggregates.created_at,
+                    func.to_timestamp_safe(
+                        TrackWithAggregates.release_date,
+                        "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
                     )
-                )
+                ),
+                sort_fn(TrackWithAggregates.created_at),
+                TrackWithAggregates.track_id
             )
         elif sort_method == SortMethod.plays:
             base_query = base_query.join(TrackWithAggregates.aggregate_play).order_by(
-                sort_fn(AggregatePlay.count)
+                sort_fn(AggregatePlay.count),
+                TrackWithAggregates.track_id
             )
         elif sort_method == SortMethod.reposts:
             base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
-                sort_fn(AggregateTrack.repost_count)
+                sort_fn(AggregateTrack.repost_count),
+                TrackWithAggregates.track_id
             )
         elif sort_method == SortMethod.saves:
             base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
-                sort_fn(AggregateTrack.save_count)
+                sort_fn(AggregateTrack.save_count),
+                TrackWithAggregates.track_id
             )
     else:
         # Return the user's pinned track first if there is no specified sort_method
@@ -207,20 +215,22 @@ def _get_tracks(session, args):
     if "sort" in args and args.get("sort") is not None:
         if args["sort"] == "date":
             base_query = base_query.order_by(
-                coalesce(
-                    # This func is defined in alembic migrations
-                    func.to_timestamp_safe(
-                        TrackWithAggregates.release_date,
-                        "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
-                    ),
-                    TrackWithAggregates.created_at,
-                ).desc()
+                # This func is defined in alembic migrations
+                func.to_timestamp_safe(
+                    TrackWithAggregates.release_date,
+                    "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
+                ).desc(),
+                TrackWithAggregates.created_at.desc(),
+                TrackWithAggregates.track_id
             )
         elif args["sort"] == "plays":
             base_query = base_query.join(
                 AggregatePlay,
                 AggregatePlay.play_item_id == TrackWithAggregates.track_id,
-            ).order_by(AggregatePlay.count.desc())
+            ).order_by(
+                AggregatePlay.count.desc(),
+                TrackWithAggregates.track_id
+            )
         else:
             whitelist_params = [
                 "created_at",
@@ -230,7 +240,7 @@ def _get_tracks(session, args):
                 "track_id",
             ]
             base_query = parse_sort_param(
-                base_query, TrackWithAggregates, whitelist_params
+                base_query, TrackWithAggregates, whitelist_params, "track_id"
             )
 
     query_results = add_query_pagination(base_query, args["limit"], args["offset"])

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -83,7 +83,7 @@ def get_current_user_id(required=True):
     return uid
 
 
-def parse_sort_param(base_query, model, whitelist_sort_params):
+def parse_sort_param(base_query, model, whitelist_sort_params, tiebreak_field):
     sort = request.args.get("sort")
     if not sort:
         return base_query
@@ -105,6 +105,8 @@ def parse_sort_param(base_query, model, whitelist_sort_params):
         else:
             attr = attr.asc()
         order_bys.append(attr)
+    if tiebreak_field not in params.keys():
+        order_bys.append(getattr(model, tiebreak_field))
 
     return base_query.order_by(*order_bys)
 


### PR DESCRIPTION
### Description
Seeing some duplicate profile results perhaps because we are not tiebreaking order-by's in the `get_tracks` query, then attempting pagination.

https://audius-internal.slack.com/archives/C02JBA52NKZ/p1684948728168179

Also parse sort_direction and sort_method properly


### Tests
Make sure tracks API queries are working as expected


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->