### PR TITLE
Clean up libs writeMetadataThroughChain flags

### DIFF
--- a/libs/src/api/Account.ts
+++ b/libs/src/api/Account.ts
@@ -134,8 +134,7 @@ export class Account extends Base {
     coverPhotoFile: Nullable<File> = null,
     hasWallet = false,
     host = (typeof window !== 'undefined' && window.location.origin) || null,
-    generateRecoveryLink = true,
-    writeMetadataThroughChain = false
+    generateRecoveryLink = true
   ) {
     const phases = {
       ADD_REPLICA_SET: 'ADD_REPLICA_SET',
@@ -170,16 +169,12 @@ export class Account extends Base {
       // Add user to chain
       phase = phases.ADD_USER
       const { newMetadata, blockHash, blockNumber } =
-        await this.User.createEntityManagerUser(
-          { metadata },
-          writeMetadataThroughChain
-        )
+        await this.User.createEntityManagerUser({ metadata })
       phase = phases.UPLOAD_PROFILE_IMAGES
       await this.User.uploadProfileImages(
         profilePictureFile!,
         coverPhotoFile!,
-        newMetadata,
-        writeMetadataThroughChain
+        newMetadata
       )
       return { blockHash, blockNumber, userId: newMetadata.user_id }
     } catch (e: any) {
@@ -381,16 +376,13 @@ export class Account extends Base {
    * Updates a user's creator node endpoint. Sets the connected creator node in the libs instance
    * and updates the user's metadata blob.
    */
-  async updateCreatorNodeEndpoint(
-    url: string,
-    writeMetadataThroughChain = false
-  ) {
+  async updateCreatorNodeEndpoint(url: string) {
     this.REQUIRES(Services.CREATOR_NODE)
 
     const user = this.userStateManager.getCurrentUser() as User
     await this.creatorNode.setEndpoint(url)
     user.creator_node_endpoint = url
-    await this.User.updateCreator(user.user_id, user, writeMetadataThroughChain)
+    await this.User.updateCreator(user.user_id, user)
   }
 
   /**

--- a/libs/src/api/File.ts
+++ b/libs/src/api/File.ts
@@ -266,17 +266,12 @@ export class File extends Base {
    * Uploads an image to the connected Content Node.
    * @param file
    */
-  async uploadImage(
-    file: globalThis.File,
-    square: boolean,
-    timeoutMs = null,
-    writeMetadataThroughChain = false
-  ) {
+  async uploadImage(file: globalThis.File, square: boolean, timeoutMs = null) {
     this.REQUIRES(Services.CREATOR_NODE)
     this.FILE_IS_VALID(file)
 
     // Assign a creator_node_endpoint to the user if necessary
-    await this.User.assignReplicaSetIfNecessary(writeMetadataThroughChain)
+    await this.User.assignReplicaSetIfNecessary()
 
     const resp = await this.creatorNode.uploadImage(
       file,

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -1149,6 +1149,7 @@ export class Users extends Base {
     )
   }
 
+  // Throws an error upon validation failure
   _validateUserMetadata(metadata: UserMetadata) {
     this.OBJECT_HAS_PROPS(metadata, USER_PROPS, USER_REQUIRED_PROPS)
     this.creatorNode.validateUserSchema(metadata)

--- a/libs/src/api/Users.ts
+++ b/libs/src/api/Users.ts
@@ -731,7 +731,6 @@ export class Users extends Base {
     // Upload new metadata object to CN
     const { metadataMultihash, metadataFileUUID } =
       await this.creatorNode.uploadCreatorContent(
-        // @ts-expect-error pretty tough one to type
         newMetadata,
         updateEndpointTxBlockNumber
       )
@@ -901,7 +900,6 @@ export class Users extends Base {
       // Upload new metadata object to CN
       phase = phases.UPLOAD_METADATA
       const { metadataMultihash, metadataFileUUID } =
-        // @ts-expect-error tough converting UserMetadata to Metadata
         await this.creatorNode.uploadCreatorContent(newMetadata)
       console.log(
         `${logPrefix} [phase: ${phase}] creatorNode.uploadCreatorContent() completed in ${

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -148,38 +148,19 @@ export class EntityManager extends Base {
         is_private: playlist.is_private
       }
 
-      if (storageV2UploadEnabled) {
-        const metadataCid = await Utils.fileHasher.generateMetadataCidV1(
-          metadata
-        )
-        if (this.contracts.EntityManagerClient === undefined) {
-          throw new Error('EntityManagerClient is undefined')
-        }
-        const { txReceipt } =
-          await this.contracts.EntityManagerClient.manageEntity(
-            userId,
-            EntityType.PLAYLIST,
-            playlist.playlist_id,
-            Action.CREATE,
-            JSON.stringify({ cid: metadataCid.toString(), data: metadata })
-          )
-        responseValues.blockHash = txReceipt.blockHash
-        responseValues.blockNumber = txReceipt.blockNumber
-        return responseValues
-      } else {
-        const { metadataMultihash } =
-          await this.creatorNode.uploadPlaylistMetadata(metadata)
-        const entityManagerMetadata = writeMetadataThroughChain
-          ? JSON.stringify({ cid: metadataMultihash, data: metadata })
-          : metadataMultihash
-        return await this.manageEntity({
-          userId: userId,
-          entityType,
-          entityId: playlist.playlist_id,
-          action: createAction,
-          metadata: entityManagerMetadata
-        })
-      }
+      this.creatorNode.validatePlaylistSchema(metadata)
+      const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+      const entityManagerMetadata = JSON.stringify({
+        cid: metadataCid.toString(),
+        data: metadata
+      })
+      return await this.manageEntity({
+        userId: userId,
+        entityType,
+        entityId: playlist.playlist_id,
+        action: createAction,
+        metadata: entityManagerMetadata
+      })
     } catch (e) {
       const error = (e as Error).message
       responseValues.error = error
@@ -258,38 +239,19 @@ export class EntityManager extends Base {
         is_album: playlist.is_album,
         is_private: playlist.is_private
       }
-      if (storageV2UploadEnabled) {
-        const metadataCid = await Utils.fileHasher.generateMetadataCidV1(
-          metadata
-        )
-        if (this.contracts.EntityManagerClient === undefined) {
-          throw new Error('EntityManagerClient is undefined')
-        }
-        const { txReceipt } =
-          await this.contracts.EntityManagerClient.manageEntity(
-            userId,
-            EntityType.PLAYLIST,
-            playlist.playlist_id,
-            Action.UPDATE,
-            JSON.stringify({ cid: metadataCid.toString(), data: metadata })
-          )
-        responseValues.blockHash = txReceipt.blockHash
-        responseValues.blockNumber = txReceipt.blockNumber
-        return responseValues
-      } else {
-        const { metadataMultihash } =
-          await this.creatorNode.uploadPlaylistMetadata(metadata)
-        const entityManagerMetadata = writeMetadataThroughChain
-          ? JSON.stringify({ cid: metadataMultihash, data: metadata })
-          : metadataMultihash
-        return await this.manageEntity({
-          userId,
-          entityType,
-          entityId: playlist.playlist_id,
-          action: updateAction,
-          metadata: entityManagerMetadata
-        })
-      }
+      this.creatorNode.validatePlaylistSchema(metadata)
+      const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+      const entityManagerMetadata = JSON.stringify({
+        cid: metadataCid.toString(),
+        data: metadata
+      })
+      return await this.manageEntity({
+        userId,
+        entityType,
+        entityId: playlist.playlist_id,
+        action: updateAction,
+        metadata: entityManagerMetadata
+      })
     } catch (e) {
       const error = (e as Error).message
       responseValues.error = error

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -108,8 +108,7 @@ export class EntityManager extends Base {
 
   async createPlaylist(
     playlist: PlaylistParam,
-    storageV2UploadEnabled = false,
-    writeMetadataThroughChain = false
+    storageV2UploadEnabled = false
   ): Promise<EntityManagerResponse> {
     const responseValues: EntityManagerResponse =
       this.getDefaultEntityManagerResponseValues()
@@ -193,8 +192,7 @@ export class EntityManager extends Base {
 
   async updatePlaylist(
     playlist: PlaylistParam,
-    storageV2UploadEnabled = false,
-    writeMetadataThroughChain = false
+    storageV2UploadEnabled = false
   ): Promise<EntityManagerResponse> {
     const responseValues: EntityManagerResponse =
       this.getDefaultEntityManagerResponseValues()

--- a/libs/src/api/entityManager.ts
+++ b/libs/src/api/entityManager.ts
@@ -148,9 +148,20 @@ export class EntityManager extends Base {
       }
 
       this.creatorNode.validatePlaylistSchema(metadata)
-      const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+
+      let metadataCid = ''
+      if (storageV2UploadEnabled) {
+        metadataCid = (
+          await Utils.fileHasher.generateMetadataCidV1(metadata)
+        ).toString()
+      } else {
+        const { metadataMultihash } =
+          await this.creatorNode.uploadPlaylistMetadata(metadata)
+        metadataCid = metadataMultihash
+      }
+
       const entityManagerMetadata = JSON.stringify({
-        cid: metadataCid.toString(),
+        cid: metadataCid,
         data: metadata
       })
       return await this.manageEntity({
@@ -238,9 +249,20 @@ export class EntityManager extends Base {
         is_private: playlist.is_private
       }
       this.creatorNode.validatePlaylistSchema(metadata)
-      const metadataCid = await Utils.fileHasher.generateMetadataCidV1(metadata)
+
+      let metadataCid = ''
+      if (storageV2UploadEnabled) {
+        metadataCid = (
+          await Utils.fileHasher.generateMetadataCidV1(metadata)
+        ).toString()
+      } else {
+        const { metadataMultihash } =
+          await this.creatorNode.uploadPlaylistMetadata(metadata)
+        metadataCid = metadataMultihash
+      }
+
       const entityManagerMetadata = JSON.stringify({
-        cid: metadataCid.toString(),
+        cid: metadataCid,
         data: metadata
       })
       return await this.manageEntity({

--- a/libs/src/sanityChecks/addSecondaries.ts
+++ b/libs/src/sanityChecks/addSecondaries.ts
@@ -5,10 +5,7 @@ import { CreatorNode } from '../services/creatorNode'
  * Add secondary creator nodes for a user if they don't have any
  * Goal: Make it so users always have a replica set
  */
-export const addSecondaries = async (
-  libs: AudiusLibs,
-  writeMetadataThroughChain = false
-) => {
+export const addSecondaries = async (libs: AudiusLibs) => {
   console.debug('Sanity Check - addSecondaries')
   const user = libs.userStateManager?.getCurrentUser()
 
@@ -57,8 +54,7 @@ export const addSecondaries = async (
     )
     await libs.User?.updateCreator(
       user.user_id,
-      newMetadata,
-      writeMetadataThroughChain
+      newMetadata
     )
   }
 }

--- a/libs/src/sanityChecks/assignReplicaSetIfNecessary.ts
+++ b/libs/src/sanityChecks/assignReplicaSetIfNecessary.ts
@@ -1,11 +1,8 @@
 import type { AudiusLibs } from '../AudiusLibs'
 
-export const assignReplicaSetIfNecessary = async (
-  libs: AudiusLibs,
-  writeMetadataThroughChain = false
-) => {
+export const assignReplicaSetIfNecessary = async (libs: AudiusLibs) => {
   try {
-    await libs.User?.assignReplicaSetIfNecessary(writeMetadataThroughChain)
+    await libs.User?.assignReplicaSetIfNecessary()
   } catch (e) {
     // If sanity check fails, do not block main thread and log error
     console.error((e as Error).message)

--- a/libs/src/sanityChecks/index.ts
+++ b/libs/src/sanityChecks/index.ts
@@ -11,14 +11,12 @@ export class SanityChecks {
   libs: AudiusLibs
   options: {
     skipRollover: boolean
-    writeMetadataThroughChain: boolean
   }
 
   constructor(
     libsInstance: AudiusLibs,
     options = {
-      skipRollover: false,
-      writeMetadataThroughChain: false
+      skipRollover: false
     }
   ) {
     this.libs = libsInstance
@@ -32,19 +30,11 @@ export class SanityChecks {
     creatorNodeWhitelist: Nullable<Set<string>> = null,
     creatorNodeBlacklist: Nullable<Set<string>> = null
   ) {
-    await addSecondaries(this.libs, this.options.writeMetadataThroughChain)
-    await assignReplicaSetIfNecessary(
-      this.libs,
-      this.options.writeMetadataThroughChain
-    )
+    await addSecondaries(this.libs)
+    await assignReplicaSetIfNecessary(this.libs)
     await syncNodes(this.libs)
     if (!this.options.skipRollover) {
-      await rolloverNodes(
-        this.libs,
-        creatorNodeWhitelist,
-        creatorNodeBlacklist,
-        this.options.writeMetadataThroughChain
-      )
+      await rolloverNodes(this.libs, creatorNodeWhitelist, creatorNodeBlacklist)
     }
     await needsRecoveryEmail(this.libs)
   }

--- a/libs/src/sanityChecks/rolloverNodes.ts
+++ b/libs/src/sanityChecks/rolloverNodes.ts
@@ -49,8 +49,7 @@ const getNewPrimary = async (secondaries: string[], wallet: string) => {
 export const rolloverNodes = async (
   libs: AudiusLibs,
   creatorNodeWhitelist: Nullable<Set<string>>,
-  creatorNodeBlacklist: Nullable<Set<string>>,
-  writeMetadataThroughChain = false
+  creatorNodeBlacklist: Nullable<Set<string>>
 ) => {
   console.debug('Sanity Check - rolloverNodes')
   const user = libs.userStateManager?.getCurrentUser()
@@ -98,11 +97,7 @@ export const rolloverNodes = async (
     console.debug(
       `Sanity Check - rolloverNodes - new nodes ${newMetadata.creator_node_endpoint}`
     )
-    await libs.User?.updateCreator(
-      user.user_id,
-      newMetadata,
-      writeMetadataThroughChain
-    )
+    await libs.User?.updateCreator(user.user_id, newMetadata)
   } catch (e) {
     console.error(e)
   }

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -205,6 +205,10 @@ export class CreatorNode {
     }
   }
 
+  validatePlaylistSchema(metadata: PlaylistMetadata) {
+    this.schemas?.[playlistSchemaType].validate?.(metadata)
+  }
+
   /** Establishes a connection to a content node endpoint */
   async connect() {
     if (this.isStorageV2Only) return
@@ -539,9 +543,10 @@ export class CreatorNode {
   async uploadPlaylistMetadata(metadata: PlaylistMetadata) {
     // Validate object before sending
     try {
-      this.schemas?.[playlistSchemaType].validate?.(metadata)
+      this.validatePlaylistSchema(metadata)
     } catch (e) {
       console.error('Error validating playlist metadata', e)
+      throw e
     }
 
     const { data: body } = await this._makeRequest(

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -205,12 +205,19 @@ export class CreatorNode {
     }
   }
 
+  // Throws an error upon validation failure
   validatePlaylistSchema(metadata: PlaylistMetadata) {
     this.schemas?.[playlistSchemaType].validate?.(metadata)
   }
 
+  // Throws an error upon validation failure
   validateUserSchema(metadata: UserMetadata) {
     this.schemas?.[userSchemaType].validate?.(metadata)
+  }
+
+  // Throws an error upon validation failure
+  validateTrackSchema(metadata: TrackMetadata) {
+    this.schemas?.[trackSchemaType].validate?.(metadata)
   }
 
   /** Establishes a connection to a content node endpoint */
@@ -521,23 +528,24 @@ export class CreatorNode {
     // this does the actual validation before sending to the creator node
     // if validation fails, validate() will throw an error
     try {
-      this.schemas?.[trackSchemaType].validate?.(metadata)
+      this.validateTrackSchema(metadata)
+
+      const { data: body } = await this._makeRequest(
+        {
+          url: '/tracks/metadata',
+          method: 'post',
+          data: {
+            metadata,
+            sourceFile
+          }
+        },
+        true
+      )
+      return body
     } catch (e) {
       console.error('Error validating track metadata', e)
+      throw e
     }
-
-    const { data: body } = await this._makeRequest(
-      {
-        url: '/tracks/metadata',
-        method: 'post',
-        data: {
-          metadata,
-          sourceFile
-        }
-      },
-      true
-    )
-    return body
   }
 
   /**

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -285,22 +285,22 @@ export class CreatorNode {
     // if validation fails, validate() will throw an error
     try {
       this.validateUserSchema(metadata)
-
-      const requestObj: AxiosRequestConfig = {
-        url: '/audius_users/metadata',
-        method: 'post',
-        data: {
-          metadata,
-          blockNumber
-        }
-      }
-
-      const { data: body } = await this._makeRequest(requestObj)
-      return body
     } catch (e) {
       console.error('Error validating creator metadata', e)
       throw e
     }
+
+    const requestObj: AxiosRequestConfig = {
+      url: '/audius_users/metadata',
+      method: 'post',
+      data: {
+        metadata,
+        blockNumber
+      }
+    }
+
+    const { data: body } = await this._makeRequest(requestObj)
+    return body
   }
 
   /**
@@ -529,23 +529,23 @@ export class CreatorNode {
     // if validation fails, validate() will throw an error
     try {
       this.validateTrackSchema(metadata)
-
-      const { data: body } = await this._makeRequest(
-        {
-          url: '/tracks/metadata',
-          method: 'post',
-          data: {
-            metadata,
-            sourceFile
-          }
-        },
-        true
-      )
-      return body
-    } catch (e) {
+    } catch(e) {
       console.error('Error validating track metadata', e)
       throw e
     }
+
+    const { data: body } = await this._makeRequest(
+      {
+        url: '/tracks/metadata',
+        method: 'post',
+        data: {
+          metadata,
+          sourceFile
+        }
+      },
+      true
+    )
+    return body
   }
 
   /**
@@ -557,22 +557,22 @@ export class CreatorNode {
     // Validate object before sending
     try {
       this.validatePlaylistSchema(metadata)
-
-      const { data: body } = await this._makeRequest(
-        {
-          url: '/playlists/metadata',
-          method: 'post',
-          data: {
-            metadata
-          }
-        },
-        true
-      )
-      return body
     } catch (e) {
       console.error('Error validating playlist metadata', e)
       throw e
     }
+
+    const { data: body } = await this._makeRequest(
+      {
+        url: '/playlists/metadata',
+        method: 'post',
+        data: {
+          metadata
+        }
+      },
+      true
+    )
+    return body
   }
 
   /**


### PR DESCRIPTION
### Description
- Remove param flags gating metadata writes through chain. Write through chain for all metadata
- Still upload to CN since there is ensuing association logic that depends on the file UUID returned by CN. Storage v2 will get rid of this soon anyway; it's not worth detangling the dependency in v1. Besides, all metadata reads are from discovery now
- Make sure we are validating schemas for v1 and v2 flows

Accompanying client change: https://github.com/AudiusProject/audius-client/pull/3432

DO NOT MERGE until flags have been on in prod for a while and we are confident everything is working appropriately.

### Tests
Manually test all user, playlist, and tracks actions


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->