### PR TITLE
Bring back cid in responses

### DIFF
--- a/discovery-provider/src/queries/queries.py
+++ b/discovery-provider/src/queries/queries.py
@@ -82,6 +82,7 @@ def parse_id_array_param(list):
 
 # ####### ROUTES ####### #
 
+
 # Returns all users (paginated) with each user's follow count
 # Optionally filters by wallet or user ids
 @bp.route("/users", methods=("GET",))
@@ -101,7 +102,9 @@ def get_users_route():
     users = get_users(args)
 
     def validate_hidden_fields(user, current_user_id):
-        if "playlist_library" in user and (not current_user_id or current_user_id != user["user_id"]):
+        if "playlist_library" in user and (
+            not current_user_id or current_user_id != user["user_id"]
+        ):
             del user["playlist_library"]
         return user
 
@@ -130,9 +133,6 @@ def get_tracks_route():
     args["skip_unlisted_filter"] = True
     args["skip_stem_of_filter"] = True
     tracks = get_tracks(args)
-    # Remove track_cid from tracks response
-    for track in tracks:
-        track.pop("track_cid", None)
     return api_helpers.success_response(tracks)
 
 


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Bring back cid in responses to allow for requests to /tracks?id=xyz to find the cid



### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->