### PR TITLE
fix indexing stall

### DIFF
--- a/discovery-provider/alembic/trigger_sql/ddl.sql
+++ b/discovery-provider/alembic/trigger_sql/ddl.sql
@@ -232,3 +232,8 @@ BEGIN;
   END IF;
   END $$;
 COMMIT;
+
+-- 5/25/23 fix indexing stall
+BEGIN;
+  delete from users where txhash='0xa25516594adc42562e498b2c9f4e4365c9cbfea223a4e55624ae0ac316708a62' and not is_current;
+COMMIT;


### PR DESCRIPTION
### Description
`IndexingError(\\'(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint \"users_pkey\"\\\\nDETAIL:  Key (is_current, user_id, txhash)=(f, 433967780, 0xa25516594adc42562e498b2c9f4e4365c9cbfea223a4e55624ae0ac316708a62)`


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->