### PR TITLE
Fix time in delist-status test to match postgres

### DIFF
--- a/mediorum/server/delist_statuses.go
+++ b/mediorum/server/delist_statuses.go
@@ -18,9 +18,12 @@ import (
 )
 
 // Constants
-const DelistStatusPollingInterval = 20 * time.Second
-const HTTPTimeout = 5 * time.Minute
-const DelistBatchSize = 5000
+const (
+	DelistStatusPollingInterval = 20 * time.Second
+	HTTPTimeout                 = 5 * time.Minute
+	DelistBatchSize             = 5000
+	TimeFormat                  = "2006-01-02 15:04:05.999999-07"
+)
 
 type (
 	TrackDelistStatus struct {
@@ -62,7 +65,7 @@ func (t *TrackDelistStatus) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var err error
-	t.CreatedAt, err = time.Parse("2006-01-02 15:04:05.999999-07", temp.CreatedAt)
+	t.CreatedAt, err = time.Parse(TimeFormat, temp.CreatedAt)
 	if err != nil {
 		return err
 	}
@@ -77,7 +80,7 @@ func (u *UserDelistStatus) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var err error
-	u.CreatedAt, err = time.Parse("2006-01-02 15:04:05.999999-07", temp.CreatedAt)
+	u.CreatedAt, err = time.Parse(TimeFormat, temp.CreatedAt)
 	if err != nil {
 		return err
 	}

--- a/mediorum/server/delist_statuses_test.go
+++ b/mediorum/server/delist_statuses_test.go
@@ -13,8 +13,8 @@ import (
 
 type MockedDelistResponse struct {
 	Result struct {
-		Tracks []TrackDelistStatus `json:"tracks"`
-		Users  []UserDelistStatus  `json:"users"`
+		Tracks []jsonTrackDelistStatus `json:"tracks"`
+		Users  []jsonUserDelistStatus  `json:"users"`
 	} `json:"result"`
 	Timestamp string `json:"timestamp"`
 	Signature string `json:"signature"`
@@ -28,61 +28,75 @@ func TestPollDelistStatuses(t *testing.T) {
 
 	mockResponse := MockedDelistResponse{
 		Result: struct {
-			Tracks []TrackDelistStatus `json:"tracks"`
-			Users  []UserDelistStatus  `json:"users"`
+			Tracks []jsonTrackDelistStatus `json:"tracks"`
+			Users  []jsonUserDelistStatus  `json:"users"`
 		}{
-			Tracks: []TrackDelistStatus{
+			Tracks: []jsonTrackDelistStatus{
 				{
-					CreatedAt: time.Now(),
-					TrackID:   1,
-					OwnerID:   100,
-					TrackCID:  "trackCid1",
-					Delisted:  true,
-					Reason:    "ACR",
+					CreatedAt: time.Now().Format(TimeFormat),
+					aliasTrackDelistStatus: &aliasTrackDelistStatus{
+						TrackID:  1,
+						OwnerID:  100,
+						TrackCID: "trackCid1",
+						Delisted: true,
+						Reason:   "ACR",
+					},
 				},
 				{
-					CreatedAt: time.Now(),
-					TrackID:   2,
-					OwnerID:   100,
-					TrackCID:  "trackCid2",
-					Delisted:  true,
-					Reason:    "DMCA",
+					CreatedAt: time.Now().Format(TimeFormat),
+					aliasTrackDelistStatus: &aliasTrackDelistStatus{
+						TrackID:  2,
+						OwnerID:  100,
+						TrackCID: "trackCid2",
+						Delisted: true,
+						Reason:   "DMCA",
+					},
 				},
 				{
-					CreatedAt: time.Now().Add(time.Hour + time.Minute),
-					TrackID:   1,
-					OwnerID:   100,
-					TrackCID:  "trackCid1",
-					Delisted:  false,
-					Reason:    "MANUAL",
+					CreatedAt: time.Now().Add(time.Hour + time.Minute).Format(TimeFormat),
+					aliasTrackDelistStatus: &aliasTrackDelistStatus{
+						TrackID:  1,
+						OwnerID:  100,
+						TrackCID: "trackCid1",
+						Delisted: false,
+						Reason:   "MANUAL",
+					},
 				},
 				{
-					CreatedAt: time.Now(),
-					TrackID:   3,
-					OwnerID:   200,
-					TrackCID:  "trackCid3",
-					Delisted:  true,
-					Reason:    "DMCA",
+					CreatedAt: time.Now().Format(TimeFormat),
+					aliasTrackDelistStatus: &aliasTrackDelistStatus{
+						TrackID:  3,
+						OwnerID:  200,
+						TrackCID: "trackCid3",
+						Delisted: true,
+						Reason:   "DMCA",
+					},
 				},
 			},
-			Users: []UserDelistStatus{
+			Users: []jsonUserDelistStatus{
 				{
-					CreatedAt: time.Now(),
-					UserID:    100,
-					Delisted:  true,
-					Reason:    "STRIKE_THRESHOLD",
+					CreatedAt: time.Now().Format(TimeFormat),
+					aliasUserDelistStatus: &aliasUserDelistStatus{
+						UserID:   100,
+						Delisted: true,
+						Reason:   "STRIKE_THRESHOLD",
+					},
 				},
 				{
-					CreatedAt: time.Now().Add(time.Hour + time.Minute),
-					UserID:    100,
-					Delisted:  false,
-					Reason:    "COPYRIGHT_SCHOOL",
+					CreatedAt: time.Now().Add(time.Hour + time.Minute).Format(TimeFormat),
+					aliasUserDelistStatus: &aliasUserDelistStatus{
+						UserID:   100,
+						Delisted: false,
+						Reason:   "COPYRIGHT_SCHOOL",
+					},
 				},
 				{
-					CreatedAt: time.Now(),
-					UserID:    300,
-					Delisted:  true,
-					Reason:    "STRIKE_THRESHOLD",
+					CreatedAt: time.Now().Format(TimeFormat),
+					aliasUserDelistStatus: &aliasUserDelistStatus{
+						UserID:   300,
+						Delisted: true,
+						Reason:   "STRIKE_THRESHOLD",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### Description
Fixes delist-status test to reflect changes to time format that make it match what trusted notifier returns, which is a precision 6 string returned directly from postgres


### Tests
`make test`


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
N/A - tests