### PR TITLE
Reenable CID beam, omit tracks (segments) this time.

### DIFF
--- a/mediorum/.initdb/init.sql
+++ b/mediorum/.initdb/init.sql
@@ -1,20 +1,10 @@
 -- Only called through `make` - not used by audius-compose and not compatible with audius-compose
-CREATE TABLE IF NOT EXISTS public."Files" (
-    "id" SERIAL PRIMARY KEY,
-    "ownerId" INTEGER NOT NULL,
-    "multihash" text NOT NULL,
-    "sourceFile" text,
-    "storagePath" text NOT NULL,
-    "createdAt" timestamp with time zone NOT NULL,
-    "updatedAt" timestamp with time zone NOT NULL,
-    "fileUUID" uuid NOT NULL UNIQUE,
-    "cnodeUserUUID" uuid,
-    "type" character varying(16),
-    "fileName" text,
-    "dirMultihash" text,
-    "trackBlockchainId" integer,
-    "clock" integer NOT NULL,
-    "skipped" boolean DEFAULT false NOT NULL
+CREATE TABLE IF NOT EXISTS "Files" (
+  multihash text NOT NULL,
+  "dirMultihash" text,
+  "type" text,
+  "createdAt" timestamp with time zone NOT NULL,
+  "updatedAt" timestamp with time zone NOT NULL
 );
 
 

--- a/mediorum/bash_scripts/deploy_mediorum.sh
+++ b/mediorum/bash_scripts/deploy_mediorum.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+docker system prune -a --force
+
 cd audius-docker-compose/creator-node
 git fetch
 git checkout dev

--- a/mediorum/ddl/cid_lookup.sql
+++ b/mediorum/ddl/cid_lookup.sql
@@ -1,5 +1,27 @@
 begin;
 
+
+-- creator-node creates the Files table, but we need to create it here in case we're running via audius-compose without CNs
+CREATE TABLE IF NOT EXISTS "Files" (
+    "id" SERIAL PRIMARY KEY,
+    "ownerId" INTEGER NOT NULL,
+    "multihash" text NOT NULL,
+    "sourceFile" text,
+    "storagePath" text NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "fileUUID" uuid NOT NULL UNIQUE,
+    "cnodeUserUUID" uuid,
+    "type" character varying(16),
+    "fileName" text,
+    "dirMultihash" text,
+    -- "trackBlockchainId" integer, -- this is part of the table, but CN migration sets it and breaks if it already exists. initdb/init.sql will create it if running without CNs
+    "clock" integer NOT NULL,
+    "skipped" boolean DEFAULT false NOT NULL
+);
+
+
+
 -- cid_lookup is the main table used to determine which host has a given CID
 -- multihash column is used for both multihash and dirMultihash
 create table if not exists cid_lookup (

--- a/mediorum/ddl/cid_lookup.sql
+++ b/mediorum/ddl/cid_lookup.sql
@@ -7,25 +7,6 @@ create table if not exists cid_lookup (
     "host" text
 );
 
--- creator-node creates the Files table, but we need to create it here in case we're running via audius-compose without CNs
-CREATE TABLE IF NOT EXISTS "Files" (
-    "id" SERIAL PRIMARY KEY,
-    "ownerId" INTEGER NOT NULL,
-    "multihash" text NOT NULL,
-    "sourceFile" text,
-    "storagePath" text NOT NULL,
-    "createdAt" timestamp with time zone NOT NULL,
-    "updatedAt" timestamp with time zone NOT NULL,
-    "fileUUID" uuid NOT NULL UNIQUE,
-    "cnodeUserUUID" uuid,
-    "type" character varying(16),
-    "fileName" text,
-    "dirMultihash" text,
-    -- "trackBlockchainId" integer, -- this is part of the table, but CN migration sets it and breaks if it already exists. initdb/init.sql will create it if running without CNs
-    "clock" integer NOT NULL,
-    "skipped" boolean DEFAULT false NOT NULL
-);
-
 create unique index if not exists "idx_multihash" on cid_lookup("multihash", "host");
 
 
@@ -46,29 +27,18 @@ create table if not exists cid_cursor (
 
 
 -- initial backfill
--- this sql file runs on boot every time
--- but this backfill is expensive
--- and the index idx_cid_log_updated_at is created after the backfill runs
--- so use the presence of idx_cid_log_updated_at to not re-run this.
-do $$
-declare
-  has_index bool := false;
-begin
-  select count(*) = 1 into has_index from pg_indexes where indexname = 'idx_cid_log_updated_at';
-  if not has_index then
 
-    -- backfill multihash
-    insert into cid_log (multihash, updated_at)
-      select "multihash", "createdAt" from "Files"
-        on conflict do nothing;
+-- backfill multihash
+insert into cid_log (multihash, updated_at)
+  select "multihash", "createdAt" from "Files"
+    where "type" != 'track'
+      on conflict do nothing;
 
-    -- backfill dirMultihash
-    insert into cid_log (multihash, updated_at)
-      select "dirMultihash", "createdAt" from "Files" where "dirMultihash" is not null
-        on conflict do nothing;
+-- backfill dirMultihash
+insert into cid_log (multihash, updated_at)
+  select "dirMultihash", "createdAt" from "Files" where "dirMultihash" is not null
+    on conflict do nothing;
 
-  end if;
-end; $$;
 
 create index if not exists idx_cid_log_updated_at on cid_log(updated_at);
 
@@ -76,6 +46,10 @@ create index if not exists idx_cid_log_updated_at on cid_log(updated_at);
 create or replace function handle_cid_change() returns trigger as $$
 declare
 begin
+
+    if new."type" = 'track' or old."type" = 'track' then
+      return null;
+    end if;
 
     case tg_op
     when 'DELETE' then

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -32,16 +32,15 @@ func Migrate(db *sql.DB) {
 func runMigration(db *sql.DB, ddl string) {
 	h := md5string(ddl)
 
-	q := `select count(*) = 1 from mediorum_migrations where hash = $1`
 	var alreadyRan bool
-	db.QueryRow(q, h).Scan(&alreadyRan)
+	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, h).Scan(&alreadyRan)
 	if alreadyRan {
 		fmt.Printf("hash %s exists skipping ddl \n", h)
 		return
 	}
 
 	mustExec(db, ddl)
-	mustExec(db, `insert into mediorum_migrations values ($1, now())`, h)
+	mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, h)
 }
 
 func mustExec(db *sql.DB, ddl string, va ...interface{}) {

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -1,7 +1,9 @@
 package ddl
 
 import (
+	"crypto/md5"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -14,45 +16,43 @@ var cidLookupDDL string
 //go:embed delist_statuses.sql
 var delistStatusesDDL string
 
-func Migrate(db *sql.DB) {
-	mustExec(db, cidLookupDDL, true)
-	mustExec(db, delistStatusesDDL, false)
+var mediorumMigrationTable = `
+	create table if not exists mediorum_migrations (
+		"hash" text primary key,
+		"ts" timestamp
+	);
+`
 
-	// flare-178: disable cid beam
-	// clear out existing data
-	log.Println("truncate cid tables... ")
-	_, err := db.Exec(`
-	drop trigger if exists handle_cid_change on "Files";
-	truncate table cid_cursor cascade;
-	truncate table cid_log cascade;
-	truncate table cid_lookup cascade;
-	drop table if exists cid_temp;
-	`)
-	if err != nil {
-		log.Fatal("truncate cid failed", err)
-	} else {
-		log.Println("truncate cid ok")
-	}
+func Migrate(db *sql.DB) {
+	mustExec(db, mediorumMigrationTable)
+	runMigration(db, cidLookupDDL)
+	runMigration(db, delistStatusesDDL)
 }
 
-func mustExec(db *sql.DB, ddl string, skipIfExists bool) {
+func runMigration(db *sql.DB, ddl string) {
+	h := md5string(ddl)
 
-	// this is a hack to skip running ddl if the index exists...
-	// since ddl can block for several minutes
-	// pg_migrate.sh soon
-	if skipIfExists {
-		q := `select count(*) = 1 from pg_indexes where indexname = 'idx_cid_log_updated_at'`
-		var indexExists bool
-		db.QueryRow(q).Scan(&indexExists)
-		if indexExists {
-			fmt.Println("indexExists... skipping ddl")
-			return
-		}
+	q := `select count(*) = 1 from mediorum_migrations where hash = $1`
+	var alreadyRan bool
+	db.QueryRow(q, h).Scan(&alreadyRan)
+	if alreadyRan {
+		fmt.Printf("hash %s exists skipping ddl \n", h)
+		return
 	}
 
-	_, err := db.Exec(ddl)
+	mustExec(db, ddl)
+	mustExec(db, `insert into mediorum_migrations values ($1, now())`, h)
+}
+
+func mustExec(db *sql.DB, ddl string, va ...interface{}) {
+	_, err := db.Exec(ddl, va...)
 	if err != nil {
 		fmt.Println(ddl)
 		log.Fatal(err)
 	}
+}
+
+func md5string(s string) string {
+	hash := md5.Sum([]byte(s))
+	return hex.EncodeToString(hash[:])
 }

--- a/mediorum/server/cid_log_test.go
+++ b/mediorum/server/cid_log_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCidLog(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 
 	ctx := context.Background()
 
@@ -19,18 +19,20 @@ func TestCidLog(t *testing.T) {
 	// let's just double tripple check we're in test mode:
 	assert.Equal(t, "test", s1.Config.Env)
 
-	s1.pgPool.Exec(ctx, `
-	truncate "Files";
+	_, err := s1.pgPool.Exec(ctx, `
 	truncate cid_log;
 
+	-- this uses the fake "Files" from .initdb
 	insert into "Files"
-		(multihash, "storagePath", "createdAt", "updatedAt", "fileUUID", "clock", "skipped")
+		(multihash, "type", "createdAt", "updatedAt")
 	values
-		('cid1', '/files/cid1', now(), now(), gen_random_uuid(), 1, false),
-		('cid2', '/files/cid2', now(), now(), gen_random_uuid(), 1, false)
+		('cid1', 'image', now(), now()),
+		('cid2', 'copy320', now(), now()),
+		('cid3', 'track', now(), now())
 	`)
+	assert.NoError(t, err)
 
-	_, err := s2.pgPool.Exec(ctx, `truncate cid_lookup; truncate cid_cursor`)
+	_, err = s2.pgPool.Exec(ctx, `truncate cid_lookup; truncate cid_cursor`)
 	assert.NoError(t, err)
 
 	r1, err := s2.beamFromPeer(s1.Config.Self)

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -78,14 +78,6 @@ func dbMigrate(crud *crudr.Crudr) {
 		panic(err)
 	}
 
-	// bonus migrations
-	// must be idempotent
-	slog.Info("db: running misc migrations that should be merged with ddl migrate")
-	crud.DB.Exec(`
-		alter table uploads drop column if exists orig_file_c_id;
-		delete from uploads where orig_file_cid is null;
-	`)
-
 	// register any models to be managed by crudr
 	crud.RegisterModels(&LogLine{}, &Blob{}, &Upload{}, &ServerHealth{})
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -250,8 +250,7 @@ func (ss *MediorumServer) MustStart() {
 
 	ss.crud.StartClients()
 
-	// flare-178: disable cid beam
-	// ss.startBeamClients()
+	ss.startBeamClients()
 
 	go ss.startPollingDelistStatuses()
 


### PR DESCRIPTION
### Description

* update `ddl` to only re-run sql if hash changes to avoid slow boot (similar to pg_migrate.sh)
* update trigger + backfill to omit segments this time around
* simplify and fix cid_lookup tests