### PR TITLE
[PLAT-1007] Fix sort by coelesce

### DIFF
--- a/discovery-provider/src/queries/get_tracks.py
+++ b/discovery-provider/src/queries/get_tracks.py
@@ -172,12 +172,14 @@ def _get_tracks(session, args):
         elif sort_method == SortMethod.release_date:
             base_query = base_query.order_by(
                 sort_fn(
-                    func.to_timestamp_safe(
-                        TrackWithAggregates.release_date,
-                        "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
+                    coalesce(
+                        func.to_timestamp_safe(
+                            TrackWithAggregates.release_date,
+                            "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
+                        ),
+                        TrackWithAggregates.created_at
                     )
                 ),
-                sort_fn(TrackWithAggregates.created_at),
                 TrackWithAggregates.track_id
             )
         elif sort_method == SortMethod.plays:
@@ -215,12 +217,14 @@ def _get_tracks(session, args):
     if "sort" in args and args.get("sort") is not None:
         if args["sort"] == "date":
             base_query = base_query.order_by(
-                # This func is defined in alembic migrations
-                func.to_timestamp_safe(
-                    TrackWithAggregates.release_date,
-                    "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
+                coalesce(
+                    # This func is defined in alembic migrations
+                    func.to_timestamp_safe(
+                        TrackWithAggregates.release_date,
+                        "Dy Mon DD YYYY HH24:MI:SS GMTTZHTZM",
+                    ),
+                    TrackWithAggregates.created_at,
                 ).desc(),
-                TrackWithAggregates.created_at.desc(),
                 TrackWithAggregates.track_id
             )
         elif args["sort"] == "plays":


### PR DESCRIPTION
### Description
<!--
What is the purpose of this PR?
What is the current behavior? New behavior?
Relevant links and/or information pertaining to PR?
-->

Tests on CI are failing and they don't lie!
https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/37540/workflows/ca5c1575-1fc0-47a8-9e46-ae1f9c8e40b9/jobs/484413

This is because the coalesce here was actually intentional -- it allows for tracks with missing release dates to treat created at as if it was the release date. This order should be stable though with the new tiebreaking.


### Tests
<!--
List any automated test coverage added, if current automated tests are not sufficient.
List the manual tests and repro instructions to verify that this PR works as anticipated.
Include log analysis if possible.
If this change impacts clients, make sure that you have tested the clients!
-->

```
 pytest integration_tests/queries/test_get_tracks.py
```


### Monitoring - How will this change be monitored? Are there sufficient logs / alerts?
<!-- For features that are critical or could fail silently please describe the monitoring/alerting being added. -->


<!--
================ REMINDER: ================
If this PR touches a critical flow (such as Indexing, Uploads, Gateway or the Filesystem), make sure to add the `requires-special-attention` label.

** Add relevant labels as necessary. **
-->