### PR TITLE
[PLAT-982] Join comms and server health checks

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -97,16 +97,23 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location /server_health_check {
+            proxy_pass http://127.0.0.1:3000/health_check;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location /health_check {
             content_by_lua_block {
-                ngx.req.set_header("Host", $http_host);
-                ngx.req.set_header("X-Forwarded-For" $proxy_add_x_forwarded_for);
+                local cjson = require "cjson"
                 local resps = {ngx.location.capture_multi({
-                    {"http://127.0.0.1:3000/health_check"},
+                    {"/server_health_check"},
                     {"/comms"},
                 })}
-
-                ngx.say(resps[1].body .. resps[2].body)
+                local server_health = cjson.decode(resps[1].body)
+                local comms_health = cjson.decode(resps[2].body)
+                server_health['comms'] = comms_health
+                ngx.say(cjson.encode(server_health))
             }
         }
 

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -97,6 +97,19 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location /health_check {
+            content_by_lua_block {
+                ngx.req.set_header("Host", $http_host);
+                ngx.req.set_header("X-Forwarded-For" $proxy_add_x_forwarded_for);
+                local resps = {ngx.location.capture_multi({
+                    {"http://127.0.0.1:3000/health_check"},
+                    {"/comms"},
+                })}
+
+                ngx.say(resps[1].body .. resps[2].body)
+            }
+        }
+
         location /v1/tracks/unclaimed_id {
             access_by_lua_block {
                 local main = require "main"
@@ -233,13 +246,6 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /nats {
-            resolver 127.0.0.11 valid=30s;
-            set $upstream nats:8924;
-            proxy_pass http://$upstream;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
         location /comms {
             client_max_body_size 500M;
             resolver 127.0.0.11 valid=30s;


### PR DESCRIPTION
### Description

While this is not the most elegant solution, it works well and doesn't seem to have major performance impact.
It definitely is _less_ performant, but I don't think substantially enough for us to care.

I would like to get out of this world though. Perhaps we think about a way to move health check to a higher level construct or something....

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

sandbox: http://34.72.186.34:5000/health_check
wraps existing /comms endpoint json into json from health_check