### PR TITLE
Remove code that depends on or enforces segments

### DIFF
--- a/creator-node/src/logging.ts
+++ b/creator-node/src/logging.ts
@@ -47,7 +47,6 @@ const excludedRoutes = [
   '/health_check',
   '/ipfs',
   '/content',
-  '/tracks/download_status',
   '/db_check',
   '/version',
   '/disk_check',

--- a/creator-node/src/routes/tracks.js
+++ b/creator-node/src/routes/tracks.js
@@ -562,7 +562,7 @@ router.post(
         }
 
         // Associate all segment file db records with trackUUID
-        const trackFiles = await models.File.findAll({
+        await models.File.findAll({
           where: {
             multihash: trackSegmentCIDs,
             cnodeUserUUID,
@@ -572,14 +572,7 @@ router.post(
           },
           transaction
         })
-
-        if (trackFiles.length !== trackSegmentCIDs.length) {
-          req.logger.error(
-            `Did not find files for every track segment CID for user ${cnodeUserUUID} ${trackFiles} ${trackSegmentCIDs}`
-          )
-          throw new Error('Did not find files for every track segment CID.')
-        }
-        const segmentsAssociateNumAffectedRows = await models.File.update(
+        await models.File.update(
           { trackBlockchainId: track.blockchainId },
           {
             where: {
@@ -592,17 +585,6 @@ router.post(
             transaction
           }
         )
-        if (
-          parseInt(segmentsAssociateNumAffectedRows, 10) !==
-          trackSegmentCIDs.length
-        ) {
-          req.logger.error(
-            `Failed to associate files for every track segment CID ${cnodeUserUUID} ${track.blockchainId} ${segmentsAssociateNumAffectedRows} ${trackSegmentCIDs.length}`
-          )
-          throw new Error(
-            'Failed to associate files for every track segment CID.'
-          )
-        }
       } /** updateTrack scenario */ else {
         /**
          * If track updated, ensure files exist with trackBlockchainId
@@ -627,7 +609,7 @@ router.post(
         }
 
         // Ensure segment file db records exist for all CIDs
-        const trackFiles = await models.File.findAll({
+        await models.File.findAll({
           where: {
             multihash: trackSegmentCIDs,
             cnodeUserUUID,
@@ -636,11 +618,6 @@ router.post(
           },
           transaction
         })
-        if (trackFiles.length < trackSegmentCIDs.length) {
-          throw new Error(
-            'Did not find files for every track segment CID with trackBlockchainId.'
-          )
-        }
       }
 
       // Update cnodeUser's latestBlockNumber if higher than previous latestBlockNumber.

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -523,9 +523,9 @@ export class Track extends Base {
       const trackId = await this._generateTrackId()
       const entityManagerMetadata = writeMetadataThroughChain
         ? JSON.stringify({
-          cid: metadataMultihash,
-          data: metadata
-        })
+            cid: metadataMultihash,
+            data: metadata
+          })
         : metadataMultihash
       const response = await this.contracts.EntityManagerClient!.manageEntity(
         ownerId,

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -1,7 +1,6 @@
 import type { BaseConstructorArgs } from './base'
 
 import { Base, Services } from './base'
-import { CreatorNode } from '../services/creatorNode'
 import { Nullable, TrackMetadata, Utils } from '../utils'
 import retry from 'async-retry'
 import type { TransactionReceipt } from 'web3-core'

--- a/libs/src/api/Track.ts
+++ b/libs/src/api/Track.ts
@@ -53,7 +53,6 @@ export class Track extends Base {
     this.getRepostersForTrack = this.getRepostersForTrack.bind(this)
     this.getRepostersForPlaylist = this.getRepostersForPlaylist.bind(this)
     this.getListenHistoryTracks = this.getListenHistoryTracks.bind(this)
-    this.checkIfDownloadAvailable = this.checkIfDownloadAvailable.bind(this)
     this.uploadTrack = this.uploadTrack.bind(this)
     this.uploadTrackContentToCreatorNode =
       this.uploadTrackContentToCreatorNode.bind(this)
@@ -366,19 +365,6 @@ export class Track extends Base {
     )
   }
 
-  /**
-   * Checks if a download is available from provided creator node endpoints
-   */
-  async checkIfDownloadAvailable(
-    creatorNodeEndpoints: string,
-    trackId: number
-  ) {
-    return await CreatorNode.checkIfDownloadAvailable(
-      creatorNodeEndpoints,
-      trackId
-    )
-  }
-
   /* ------- SETTERS ------- */
 
   /**
@@ -537,9 +523,9 @@ export class Track extends Base {
       const trackId = await this._generateTrackId()
       const entityManagerMetadata = writeMetadataThroughChain
         ? JSON.stringify({
-            cid: metadataMultihash,
-            data: metadata
-          })
+          cid: metadataMultihash,
+          data: metadata
+        })
         : metadataMultihash
       const response = await this.contracts.EntityManagerClient!.manageEntity(
         ownerId,

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -144,26 +144,6 @@ export class CreatorNode {
     }
   }
 
-  /**
-   * Checks if a download is available from provided creator node endpoints
-   * @param endpoints creator node endpoints
-   * @param trackId
-   */
-  static async checkIfDownloadAvailable(endpoints: string, trackId: number) {
-    const primary = CreatorNode.getPrimary(endpoints)
-    if (primary) {
-      const req: AxiosRequestConfig = {
-        baseURL: primary,
-        url: `/tracks/download_status/${trackId}`,
-        method: 'get'
-      }
-      const { data: body } = await axios(req)
-      if (body.data.cid) return body.data.cid
-    }
-    // Download is not available, clients should display "processing"
-    return null
-  }
-
   /* -------------- */
 
   web3Manager: Nullable<Web3Manager>
@@ -1166,7 +1146,7 @@ export class CreatorNode {
   async _uploadFile(
     file: File,
     route: string,
-    onProgress: ProgressCB = () => {},
+    onProgress: ProgressCB = () => { },
     extraFormDataOptions: Record<string, unknown> = {},
     retries = 2,
     timeoutMs: number | null = null
@@ -1276,9 +1256,8 @@ export class CreatorNode {
     if ('response' in e && e.response?.data?.error) {
       const cnRequestID = e.response.headers['cn-request-id']
       // cnRequestID will be the same as requestId if it receives the X-Request-ID header
-      const errMessage = `Server returned error: [${e.response.status.toString()}] [${
-        e.response.data.error
-      }] for request: [${cnRequestID}, ${requestId}]`
+      const errMessage = `Server returned error: [${e.response.status.toString()}] [${e.response.data.error
+        }] for request: [${cnRequestID}, ${requestId}]`
 
       console.error(errMessage)
       throw new Error(errMessage)
@@ -1325,7 +1304,7 @@ export class CreatorNode {
   /**
    * Calls fn and then retries once after 500ms, again after 1500ms, and again after 4000ms
    */
-  async _retry3(fn: () => Promise<any>, onRetry = (_err: any) => {}) {
+  async _retry3(fn: () => Promise<any>, onRetry = (_err: any) => { }) {
     return await retry(fn, {
       minTimeout: 500,
       maxTimeout: 4000,

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -1146,7 +1146,7 @@ export class CreatorNode {
   async _uploadFile(
     file: File,
     route: string,
-    onProgress: ProgressCB = () => { },
+    onProgress: ProgressCB = () => {},
     extraFormDataOptions: Record<string, unknown> = {},
     retries = 2,
     timeoutMs: number | null = null
@@ -1256,8 +1256,9 @@ export class CreatorNode {
     if ('response' in e && e.response?.data?.error) {
       const cnRequestID = e.response.headers['cn-request-id']
       // cnRequestID will be the same as requestId if it receives the X-Request-ID header
-      const errMessage = `Server returned error: [${e.response.status.toString()}] [${e.response.data.error
-        }] for request: [${cnRequestID}, ${requestId}]`
+      const errMessage = `Server returned error: [${e.response.status.toString()}] [${
+        e.response.data.error
+      }] for request: [${cnRequestID}, ${requestId}]`
 
       console.error(errMessage)
       throw new Error(errMessage)
@@ -1304,7 +1305,7 @@ export class CreatorNode {
   /**
    * Calls fn and then retries once after 500ms, again after 1500ms, and again after 4000ms
    */
-  async _retry3(fn: () => Promise<any>, onRetry = (_err: any) => { }) {
+  async _retry3(fn: () => Promise<any>, onRetry = (_err: any) => {}) {
     return await retry(fn, {
       minTimeout: 500,
       maxTimeout: 4000,


### PR DESCRIPTION
### Description
- Removes the `/tracks/download_status` route because it depends on segments being present in db and I didn't see it used anywhere in protocol or client
- Removes enforcing track segments when creating or updating a track

### How Has This Been Tested?
None - passing off to @endline but it's only removing straightforward code so it should be pretty safe.