### PR TITLE
Fix skip ci on libs/*

### DIFF
--- a/libs/scripts/release.sh
+++ b/libs/scripts/release.sh
@@ -37,6 +37,7 @@ function git-changelog () {
 function commit-message () {
     echo "${STUB}: ${VERSION}
 
+[skip ci]
 ## Changelog
 
 ${CHANGE_LOG}"
@@ -89,7 +90,7 @@ function bump-version () {
         # Commit to a new branch
         git checkout -b ${STUB}-${VERSION}
         git add .
-        git commit -m "$(commit-message)" -m "[skip ci]"
+        git commit -m "$(commit-message)"
 
         # Push branch to remote
         git push -u origin ${STUB}-${VERSION}
@@ -106,7 +107,7 @@ function merge-bump () {
 
         # squash branch commit
         git merge --squash ${STUB}-${VERSION} || exit 1
-        git commit -m "$(commit-message)" -m "[skip ci]" || exit 1
+        git commit -m "$(commit-message)" || exit 1
 
         # tag release
         git tag -a @audius/${STUB}@${VERSION} -m "$(commit-message)" || exit 1


### PR DESCRIPTION
### Description

`[skip ci]` only works in the first 250 chars:
https://circleci.com/docs/skip-build/?utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--uscan-en-dsa-tROAS-auth-brand&utm_term=g_-_c__dsa_&utm_content=&gclid=CjwKCAjwvdajBhBEEiwAeMh1U-cpXyrug3PVM23J1EZdn1m_XgvaVRW1bl4HXbbAzFYzYgv7QRca8hoCquMQAvD_BwE

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

A good guess...