### PR TITLE
[C-2695] Expose content-nodes in discovery-node health-check

### DIFF
--- a/discovery-provider/src/queries/confirm_indexing_transaction_error.py
+++ b/discovery-provider/src/queries/confirm_indexing_transaction_error.py
@@ -2,7 +2,7 @@ import logging
 
 import requests
 from src.queries.get_skipped_transactions import set_indexing_error
-from src.tasks.index_metrics import get_all_other_nodes
+from src.tasks.index_metrics import get_all_other_discovery_nodes
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def confirm_indexing_transaction_error(
     Gets all other discovery nodes and makes an api call to check the status of a transaction
     given a blocknumber, blockhash, and transactionhash
     """
-    all_other_nodes = get_all_other_nodes()[0]
+    all_other_nodes = get_all_other_discovery_nodes()[0]
     num_other_nodes = len(all_other_nodes)
     num_transaction_failures = 0
     for node in all_other_nodes:

--- a/discovery-provider/src/queries/get_attestation.py
+++ b/discovery-provider/src/queries/get_attestation.py
@@ -16,7 +16,7 @@ from src.tasks.index_oracles import (
     oracle_addresses_key,
 )
 from src.utils.config import shared_config
-from src.utils.get_all_other_nodes import get_all_other_nodes
+from src.utils.get_all_other_nodes import get_all_other_discovery_nodes
 from src.utils.redis_connection import get_redis
 from web3 import Web3
 
@@ -189,7 +189,7 @@ ADD_SENDER_MESSAGE_PREFIX = "add"
 
 
 def verify_discovery_node_exists_on_chain(new_sender_address: str) -> bool:
-    other_nodes_addresses = set(get_all_other_nodes()[1])
+    other_nodes_addresses = set(get_all_other_discovery_nodes()[1])
     return new_sender_address in other_nodes_addresses
 
 

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -330,7 +330,8 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     ) == "postgresql://postgres:postgres@db:5432/audius_discovery" or "localhost" in os.getenv(
         "audius_db_url", ""
     )
-    discovery_nodes = get_all_other_nodes.get_all_other_nodes_cached(redis)
+    discovery_nodes = get_all_other_nodes.get_all_other_discovery_nodes_cached(redis)
+    content_nodes = get_all_other_nodes.get_all_other_content_nodes_cached(redis)
     final_poa_block = get_final_poa_block()
     backfilled_cid_data = get_backfilled_cid_data(redis)
     health_results = {
@@ -371,7 +372,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "latest_block_num": latest_block_num,
         "latest_indexed_block_num": latest_indexed_block_num,
         "final_poa_block": final_poa_block,
-        "network": {"discovery_nodes": discovery_nodes},
+        "network": {"discovery_nodes": discovery_nodes, "content_nodes": content_nodes},
         "backfilled_cid_data": backfilled_cid_data,
     }
 

--- a/discovery-provider/src/queries/get_redirect_weights.py
+++ b/discovery-provider/src/queries/get_redirect_weights.py
@@ -3,7 +3,7 @@ import logging
 import requests
 from flask import Blueprint
 from src.api_helpers import success_response
-from src.utils.get_all_other_nodes import get_all_other_nodes
+from src.utils.get_all_other_nodes import get_all_other_discovery_nodes
 from src.utils.redis_cache import cache, internal_api_cache_prefix
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ bp = Blueprint("redirect_weights", __name__)
 @bp.route("/redirect_weights", methods=["GET"])
 @cache(ttl_sec=10 * 60, cache_prefix_override=internal_api_cache_prefix)
 def redirect_weights():
-    endpoints, _ = get_all_other_nodes()
+    endpoints, _ = get_all_other_discovery_nodes()
     loads = {}
     for endpoint in endpoints:
         try:

--- a/discovery-provider/src/tasks/cache_current_nodes.py
+++ b/discovery-provider/src/tasks/cache_current_nodes.py
@@ -30,23 +30,19 @@ def cache_current_nodes_task(self):
         have_lock = update_lock.acquire(blocking=False)
         if have_lock:
             logger.info("cache_current_nodes.py | fetching all other discovery nodes")
-            nodes = get_all_other_discovery_nodes()[0]
+            discovery_nodes = get_all_other_discovery_nodes()[0]
             current_node = get_node_endpoint()
             # add current node to list
             if current_node is not None:
-                nodes.append(current_node)
+                discovery_nodes.append(current_node)
 
-            set_json_cached_key(redis, ALL_DISCOVERY_NODES_CACHE_KEY, nodes)
+            set_json_cached_key(redis, ALL_DISCOVERY_NODES_CACHE_KEY, discovery_nodes)
             logger.info("cache_current_nodes.py | set current discovery nodes in redis")
 
             logger.info("cache_current_nodes.py | fetching all other content nodes")
-            nodes = get_all_other_content_nodes()[0]
-            current_node = get_node_endpoint()
-            # add current node to list
-            if current_node is not None:
-                nodes.append(current_node)
+            content_nodes = get_all_other_content_nodes()[0]
 
-            set_json_cached_key(redis, ALL_CONTENT_NODES_CACHE_KEY, nodes)
+            set_json_cached_key(redis, ALL_CONTENT_NODES_CACHE_KEY, content_nodes)
             logger.info("cache_current_nodes.py | set current content nodes in redis")
         else:
             logger.info("cache_current_nodes.py | Failed to acquire lock")

--- a/discovery-provider/src/tasks/cache_current_nodes.py
+++ b/discovery-provider/src/tasks/cache_current_nodes.py
@@ -2,8 +2,10 @@ import logging
 
 from src.tasks.celery_app import celery
 from src.utils.get_all_other_nodes import (
-    ALL_NODES_CACHE_KEY,
-    get_all_other_nodes,
+    ALL_CONTENT_NODES_CACHE_KEY,
+    ALL_DISCOVERY_NODES_CACHE_KEY,
+    get_all_other_content_nodes,
+    get_all_other_discovery_nodes,
     get_node_endpoint,
 )
 from src.utils.prometheus_metric import save_duration_metric
@@ -27,15 +29,25 @@ def cache_current_nodes_task(self):
     try:
         have_lock = update_lock.acquire(blocking=False)
         if have_lock:
-            logger.info("cache_current_nodes.py | fetching all other nodes")
-            nodes = get_all_other_nodes()[0]
+            logger.info("cache_current_nodes.py | fetching all other discovery nodes")
+            nodes = get_all_other_discovery_nodes()[0]
             current_node = get_node_endpoint()
             # add current node to list
             if current_node is not None:
                 nodes.append(current_node)
 
-            set_json_cached_key(redis, ALL_NODES_CACHE_KEY, nodes)
-            logger.info("cache_current_nodes.py | set current nodes in redis")
+            set_json_cached_key(redis, ALL_DISCOVERY_NODES_CACHE_KEY, nodes)
+            logger.info("cache_current_nodes.py | set current discovery nodes in redis")
+
+            logger.info("cache_current_nodes.py | fetching all other content nodes")
+            nodes = get_all_other_content_nodes()[0]
+            current_node = get_node_endpoint()
+            # add current node to list
+            if current_node is not None:
+                nodes.append(current_node)
+
+            set_json_cached_key(redis, ALL_CONTENT_NODES_CACHE_KEY, nodes)
+            logger.info("cache_current_nodes.py | set current content nodes in redis")
         else:
             logger.info("cache_current_nodes.py | Failed to acquire lock")
     except Exception as e:

--- a/discovery-provider/src/tasks/index_metrics.py
+++ b/discovery-provider/src/tasks/index_metrics.py
@@ -10,7 +10,7 @@ from src.queries.update_historical_metrics import (
     update_historical_monthly_route_metrics,
 )
 from src.tasks.celery_app import celery
-from src.utils.get_all_other_nodes import get_all_other_nodes
+from src.utils.get_all_other_nodes import get_all_other_discovery_nodes
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
@@ -75,7 +75,7 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
     and merge with this node's metrics so that this node will be aware
     of all the metrics across users hitting different providers
     """
-    all_other_nodes = get_all_other_nodes()[0]
+    all_other_nodes = get_all_other_discovery_nodes()[0]
 
     visited_node_timestamps_str = redis.get(metrics_visited_nodes)
     visited_node_timestamps = (
@@ -233,7 +233,7 @@ def synchronize_all_node_metrics(self, db):
     monthly_route_metrics = {}
     daily_app_metrics = {}
     monthly_app_metrics = {}
-    all_other_nodes = get_all_other_nodes()[0]
+    all_other_nodes = get_all_other_discovery_nodes()[0]
     for node in all_other_nodes:
         historical_metrics = get_historical_metrics(node)
         logger.debug(f"got historical metrics from {node}: {historical_metrics}")

--- a/discovery-provider/src/tasks/index_network_peers.py
+++ b/discovery-provider/src/tasks/index_network_peers.py
@@ -4,7 +4,7 @@ import os
 import requests
 from src.tasks.celery_app import celery
 from src.utils.eth_contracts_helpers import fetch_all_registered_content_nodes
-from src.utils.get_all_other_nodes import get_all_other_nodes
+from src.utils.get_all_other_nodes import get_all_other_discovery_nodes
 from src.utils.prometheus_metric import save_duration_metric
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,9 @@ def index_discovery_node_peers(self):
     # the maximum signers in addition to the registered static nodes
     max_signers = int(shared_config["discprov"]["max_signers"])
 
-    other_wallets = set([wallet.lower() for wallet in get_all_other_nodes()[1]])
+    other_wallets = set(
+        [wallet.lower() for wallet in get_all_other_discovery_nodes()[1]]
+    )
     logger.info(
         f"index_network_peers.py | Other registered discovery addresses: {other_wallets}"
     )


### PR DESCRIPTION
### Description

Adds content node endpoints in discovery-node health-check endpoint. this way, we wont need need to hit eth for the content nodes.

### How Has This Been Tested?

Ran locally and confirmed content nodes were present
