### PR TITLE
PLAT-1022: web push DMs

### DIFF
--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -11,6 +11,8 @@ import { sendDMNotifications } from './tasks/dmNotifications'
 import { processEmailNotifications } from './email/notifications/index'
 import { sendAppNotifications } from './tasks/appNotifications'
 import {
+  BrowserPluginMappings,
+  BrowserPushPlugin,
   EmailPluginMappings,
   NotificationsEmailPlugin,
   RemoteConfig
@@ -93,6 +95,14 @@ export class Processor {
     return Boolean(isEnabled)
   }
 
+  getIsBrowserPushEnabled(): boolean {
+    const isEnabled = this.remoteConfig.getFeatureVariableEnabled(
+      BrowserPushPlugin,
+      BrowserPluginMappings.Enabled
+    )
+    return Boolean(isEnabled)
+  }
+
   /**
    * Starts the app push notifications
    */
@@ -102,7 +112,7 @@ export class Processor {
     this.isRunning = true
     while (this.isRunning) {
       await sendAppNotifications(this.listener, this.appNotificationsProcessor)
-      await sendDMNotifications(this.discoveryDB, this.identityDB)
+      await sendDMNotifications(this.discoveryDB, this.identityDB, this.getIsBrowserPushEnabled())
 
       if (
         this.getIsScheduledEmailEnabled() &&

--- a/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -142,7 +142,7 @@ enum DMPhase {
   FINSH = 'FINSH'
 }
 
-export async function sendDMNotifications(discoveryDB: Knex, identityDB: Knex) {
+export async function sendDMNotifications(discoveryDB: Knex, identityDB: Knex, isBrowserPushEnabled?: boolean) {
   const timer = new Timer('dm')
   try {
     // Query DN for unread messages and reactions between min and max cursors
@@ -198,7 +198,7 @@ export async function sendDMNotifications(discoveryDB: Knex, identityDB: Knex) {
 
     // Send push notifications
     for (const notification of notifications) {
-      await notification.pushNotification({ isLiveEmailEnabled: false, isBrowserPushEnabled: false })
+      await notification.pushNotification({ isLiveEmailEnabled: false, isBrowserPushEnabled })
     }
 
     // Set last indexed timestamps in redis


### PR DESCRIPTION
### Description
passes web push flag to dms handler when previously it was hardcoded to false

### How Has This Been Tested?
will test on stage

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
- enable web push for your users
- send dms from one user to the other and the user that received a message should see a web push notification related to the new DM
