### PR TITLE
PLAT-1020: add better signer comparison

### DIFF
--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -89,8 +89,14 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     return (!str.includes("The node stopped producing blocks.")).toString()
   }
   // currently discprov does not expose the address of its internal chain instance
-  const isSigner = (str: string | undefined) => getProducing(str)
+  const isSigner = (nodeAddr?: string, signerAddrs?: string[]) => {
+    if (nodeAddr === undefined) return "node address not found"
+    if (signerAddrs === undefined) return "clique signers not found"
+    return signerAddrs.includes(nodeAddr).toString()
+  }
   const chainDescription: string = health.chain_health?.entries["node-health"].description
+
+  console.log(JSON.stringify(data?.signer))
 
   return (
     <tr>
@@ -140,7 +146,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
       </td>
       <td>{`${dbSize} GB`}</td>
       <td>{health.chain_health?.status}</td>
-      <td>{isSigner(chainDescription)}</td>
+      <td>{isSigner(data?.signer, health.chain_health?.signers)}</td>
       <td>{getPeers(chainDescription)}</td>
       <td>{getProducing(chainDescription)}</td>
       <td>{health.chain_health?.block_number}</td>

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -96,8 +96,6 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   }
   const chainDescription: string = health.chain_health?.entries["node-health"].description
 
-  console.log(JSON.stringify(data?.signer))
-
   return (
     <tr>
       <td>


### PR DESCRIPTION
### Description
adds signer comparison to healthz

### How Has This Been Tested?
- run healthz against prod or stage
- the is signer column is now using the correct logic instead of inferring from block production
