### PR TITLE
Fix DM browser notifs

### DIFF
--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
@@ -60,7 +60,8 @@ export class Message extends BaseNotification<DMNotification> {
       userNotificationSettings.isNotificationTypeBrowserEnabled(
         this.receiverUserId,
         'messages'
-      )) {
+      )
+    ) {
       await sendBrowserNotification(
         isBrowserPushEnabled,
         userNotificationSettings,
@@ -81,7 +82,9 @@ export class Message extends BaseNotification<DMNotification> {
         'messages'
       )
     ) {
-      const devices = userNotificationSettings.getDevices(this.receiverUserId)
+      const devices: Device[] = userNotificationSettings.getDevices(
+        this.receiverUserId
+      )
       await Promise.all(
         devices.map((device) => {
           return sendPushNotification(

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
@@ -23,7 +23,7 @@ export class Message extends BaseNotification<DMNotification> {
     isLiveEmailEnabled,
     isBrowserPushEnabled
   }: {
-    isLiveEmailEnabled: boolean,
+    isLiveEmailEnabled: boolean
     isBrowserPushEnabled: boolean
   }) {
     const res: Array<{
@@ -56,8 +56,18 @@ export class Message extends BaseNotification<DMNotification> {
     const title = 'Message'
     const body = `New message from ${users[this.senderUserId].name}`
 
-    if (userNotificationSettings.isNotificationTypeBrowserEnabled(this.receiverUserId, 'messages')) {
-      await sendBrowserNotification(isBrowserPushEnabled, userNotificationSettings, this.receiverUserId, title, body)
+    if (
+      userNotificationSettings.isNotificationTypeBrowserEnabled(
+        this.receiverUserId,
+        'messages'
+      )) {
+      await sendBrowserNotification(
+        isBrowserPushEnabled,
+        userNotificationSettings,
+        this.receiverUserId,
+        title,
+        body
+      )
     }
 
     // If the user has devices to the notification to, proceed
@@ -90,16 +100,6 @@ export class Message extends BaseNotification<DMNotification> {
         })
       )
       await this.incrementBadgeCount(this.receiverUserId)
-    }
-    if (
-      isLiveEmailEnabled &&
-      userNotificationSettings.shouldSendEmailAtFrequency({
-        initiatorUserId: this.senderUserId,
-        receiverUserId: this.receiverUserId,
-        frequency: 'live'
-      })
-    ) {
-      // TODO: send out email
     }
   }
 }

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
@@ -27,7 +27,7 @@ export class MessageReaction extends BaseNotification<DMReactionNotification> {
     isLiveEmailEnabled,
     isBrowserPushEnabled
   }: {
-    isLiveEmailEnabled: boolean,
+    isLiveEmailEnabled: boolean
     isBrowserPushEnabled: boolean
   }) {
     const res: Array<{
@@ -58,13 +58,16 @@ export class MessageReaction extends BaseNotification<DMReactionNotification> {
     )
 
     const title = 'Reaction'
-    const body = `${users[this.senderUserId].name} reacted ${this.notification.reaction} to your message`
+    const body = `${users[this.senderUserId].name} reacted ${
+      this.notification.reaction
+    } to your message`
 
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
         this.receiverUserId,
         'messages'
-      )) {
+      )
+    ) {
       await sendBrowserNotification(
         isBrowserPushEnabled,
         userNotificationSettings,

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
@@ -7,6 +7,7 @@ import {
   buildUserNotificationSettings,
   Device
 } from './userNotificationSettings'
+import { sendBrowserNotification } from '../../web'
 
 export class MessageReaction extends BaseNotification<DMReactionNotification> {
   receiverUserId: number
@@ -56,6 +57,23 @@ export class MessageReaction extends BaseNotification<DMReactionNotification> {
       [this.receiverUserId, this.senderUserId]
     )
 
+    const title = 'Reaction'
+    const body = `${users[this.senderUserId].name} reacted ${this.notification.reaction} to your message`
+
+    if (
+      userNotificationSettings.isNotificationTypeBrowserEnabled(
+        this.receiverUserId,
+        'messages'
+      )) {
+      await sendBrowserNotification(
+        isBrowserPushEnabled,
+        userNotificationSettings,
+        this.receiverUserId,
+        title,
+        body
+      )
+    }
+
     // If the user has devices to the notification to, proceed
     if (
       userNotificationSettings.shouldSendPushNotification({
@@ -80,27 +98,14 @@ export class MessageReaction extends BaseNotification<DMReactionNotification> {
               targetARN: device.awsARN
             },
             {
-              title: 'Reaction',
-              body: `${users[this.senderUserId].name} reacted ${
-                this.notification.reaction
-              } to your message`,
+              title,
+              body,
               data: {}
             }
           )
         })
       )
       await this.incrementBadgeCount(this.receiverUserId)
-    }
-
-    if (
-      isLiveEmailEnabled &&
-      userNotificationSettings.shouldSendEmailAtFrequency({
-        initiatorUserId: this.senderUserId,
-        receiverUserId: this.receiverUserId,
-        frequency: 'live'
-      })
-    ) {
-      // TODO: Send out email
     }
   }
 }

--- a/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -198,7 +198,10 @@ export async function sendDMNotifications(discoveryDB: Knex, identityDB: Knex) {
 
     // Send push notifications
     for (const notification of notifications) {
-      await notification.pushNotification({ isLiveEmailEnabled: false, isBrowserPushEnabled: false })
+      await notification.pushNotification({
+        isLiveEmailEnabled: false,
+        isBrowserPushEnabled: false
+      })
     }
 
     // Set last indexed timestamps in redis


### PR DESCRIPTION
### Description
Send browser notifs for DM reactions + clean up unused live email clause (DM emails are sent once a day for live-freq users rather than live)
Should, in addition to https://github.com/AudiusProject/audius-protocol/pull/5332, fix DM browser notifs.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
