### PR TITLE
Fix discovery selector usage of latest_chain_block

### DIFF
--- a/discovery-provider/src/api_helpers.py
+++ b/discovery-provider/src/api_helpers.py
@@ -13,6 +13,7 @@ from src.queries.get_sol_plays import get_sol_play_health_info
 # pylint: disable=R0401
 from src.utils import helpers, web3_provider
 from src.utils.config import shared_config
+from src.utils.helpers import get_final_poa_block
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 from web3 import Web3
 from web3.auto import w3
@@ -60,11 +61,12 @@ def response_dict_with_metadata(response_dictionary, sign_response):
     latest_chain_block, _ = get_latest_chain_block_set_if_nx(
         redis_conn, web3_connection
     )
+    final_poa_block = get_final_poa_block()
     response_dictionary["latest_indexed_block"] = (
         int(latest_indexed_block) if latest_indexed_block else None
     )
     response_dictionary["latest_chain_block"] = (
-        int(latest_chain_block) if latest_chain_block else None
+        int(latest_chain_block) + final_poa_block if latest_chain_block else None
     )
 
     # Include plays slot difference information

--- a/discovery-provider/src/api_helpers.py
+++ b/discovery-provider/src/api_helpers.py
@@ -13,7 +13,6 @@ from src.queries.get_sol_plays import get_sol_play_health_info
 # pylint: disable=R0401
 from src.utils import helpers, web3_provider
 from src.utils.config import shared_config
-from src.utils.helpers import get_final_poa_block
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 from web3 import Web3
 from web3.auto import w3
@@ -61,12 +60,11 @@ def response_dict_with_metadata(response_dictionary, sign_response):
     latest_chain_block, _ = get_latest_chain_block_set_if_nx(
         redis_conn, web3_connection
     )
-    final_poa_block = get_final_poa_block()
     response_dictionary["latest_indexed_block"] = (
         int(latest_indexed_block) if latest_indexed_block else None
     )
     response_dictionary["latest_chain_block"] = (
-        int(latest_chain_block) + final_poa_block if latest_chain_block else None
+        int(latest_chain_block) if latest_chain_block else None
     )
 
     # Include plays slot difference information

--- a/discovery-provider/src/queries/get_health.py
+++ b/discovery-provider/src/queries/get_health.py
@@ -213,7 +213,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
             latest_block = web3.eth.get_block("latest", True)
             latest_block_num = latest_block.number + (final_poa_block or 0)
             latest_block_hash = latest_block.hash.hex()
-            print("raymont", latest_block.number, final_poa_block)
         except Exception as e:
             logger.error(f"Could not get latest block from chain: {e}")
 

--- a/discovery-provider/src/queries/get_health_unit_test.py
+++ b/discovery-provider/src/queries/get_health_unit_test.py
@@ -300,7 +300,7 @@ def test_get_health_with_invalid_db_state(web3_mock, redis_mock, db_mock):
 
 
 def test_get_health_skip_redis(web3_mock, redis_mock, db_mock):
-    """Tests that the health check takes note of the latest chain block correctly"""
+    """Tests that the health check skips returning redis data first if explicitly disabled"""
 
     # Set up web3 eth
     def get_block(_u1, _u2):  # unused
@@ -348,7 +348,7 @@ def test_get_health_skip_redis(web3_mock, redis_mock, db_mock):
 
 @patch("src.utils.helpers.get_final_poa_block", return_value=5)
 def test_get_health_skip_redis_with_final_poa_block(_, web3_mock, redis_mock, db_mock):
-    """Tests that the health check skips returning redis data first if explicitly disabled"""
+    """Tests that the health check takes note of the latest chain block correctly"""
 
     # Set up web3 eth
     def get_block(_u1, _u2):  # unused
@@ -359,12 +359,6 @@ def test_get_health_skip_redis_with_final_poa_block(_, web3_mock, redis_mock, db
 
     cache_play_health_vars(redis_mock)
     web3_mock.eth.get_block = get_block
-
-    # Set up redis state
-    redis_mock.set(latest_block_redis_key, "3")
-    redis_mock.set(latest_block_hash_redis_key, "0x3")
-    redis_mock.set(most_recent_indexed_block_redis_key, "2")
-    redis_mock.set(most_recent_indexed_block_hash_redis_key, "0x02")
 
     # Set up db state
     with db_mock.scoped_session() as session:
@@ -388,10 +382,6 @@ def test_get_health_skip_redis_with_final_poa_block(_, web3_mock, redis_mock, db
     assert health_results["db"]["number"] == 6
     assert health_results["db"]["blockhash"] == "0x06"
     assert health_results["block_difference"] == 1
-
-    assert "maximum_healthy_block_difference" in health_results
-    assert "version" in health_results
-    assert "service" in health_results
 
 
 def test_get_health_unhealthy_block_difference(web3_mock, redis_mock, db_mock):

--- a/discovery-provider/src/queries/get_health_unit_test.py
+++ b/discovery-provider/src/queries/get_health_unit_test.py
@@ -300,7 +300,7 @@ def test_get_health_with_invalid_db_state(web3_mock, redis_mock, db_mock):
 
 
 def test_get_health_skip_redis(web3_mock, redis_mock, db_mock):
-    """Tests that the health check skips returnning redis data first if explicitly disabled"""
+    """Tests that the health check takes note of the latest chain block correctly"""
 
     # Set up web3 eth
     def get_block(_u1, _u2):  # unused
@@ -348,7 +348,7 @@ def test_get_health_skip_redis(web3_mock, redis_mock, db_mock):
 
 @patch("src.utils.helpers.get_final_poa_block", return_value=5)
 def test_get_health_skip_redis_with_final_poa_block(_, web3_mock, redis_mock, db_mock):
-    """Tests that the health check skips returnning redis data first if explicitly disabled"""
+    """Tests that the health check skips returning redis data first if explicitly disabled"""
 
     # Set up web3 eth
     def get_block(_u1, _u2):  # unused


### PR DESCRIPTION
### Description

I believe discovery node selection does not work entirely because of our POA offset.
See 
https://discoveryprovider.audius.co/health_check
```
latest_chain_block: 6680664,
latest_indexed_block: 38093662,
```

And sdk/libs code (which we have many flavors of): https://github.com/AudiusProject/audius-protocol/blob/ba8bb1a65a813cf1712842ba132c5c2157a1006f/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts#L49

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
pytest src/queries/get_health_unit_test.py
```

Tested on sandbox machine too and verified correct values in health check