### PR TITLE
Add mediorum container to axiom logs

### DIFF
--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -12,7 +12,8 @@
     "redis",
     "comms",
     "notifications",
-    "chain"
+    "chain",
+    "mediorum"
   ]
   exclude_containers = [
     # System containers


### PR DESCRIPTION
### Description

Add `mediorum` to axiom log aggregation.

Built docker artifact here
https://hub.docker.com/layers/audius/vector/0.28.1-alpine/images/sha256-03b88a6684632d7e6f0720214815a9a90e99d7d49c33d9b7f5b599c7250a472d?context=repo

### How Has This Been Tested?

Updated stage nodes to use new image. Logs can be seen here

https://app.axiom.co/audius-Lu52/stream/stage-content?ig=&q=%7B%22op%22%3A%22and%22%2C%22field%22%3A%22%22%2C%22children%22%3A%5B%7B%22field%22%3A%22container_name%22%2C%22op%22%3A%22%3D%3D%22%2C%22value%22%3A%22mediorum%22%7D%5D%7D
