### PR TITLE
Dedupe log messages in vector config

### DIFF
--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -34,7 +34,7 @@
     if exists(.log) {
       . = parse_json(string!(.log)) ?? .log
     }
-    if !exists(.message) && !exists(.log) && !exists(.msg){
+    if !exists(.message) && !exists(.log) && !exists(.msg) {
       .message = .
     }
 

--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -34,7 +34,7 @@
     if exists(.log) {
       . = parse_json(string!(.log)) ?? .log
     }
-    if !exists(.message) && !exists(.log) {
+    if !exists(.message) && !exists(.log) && !exists(.msg){
       .message = .
     }
 


### PR DESCRIPTION
### Description
Dedupe this


```

message:{"level":30,"listen":true,"msg":"booting","name":"es-indexer","time":"2023-05-31T19:03:49.095Z"}msg:bootingcontainer_name:indexerlisten:truename:es-indexernode:dn1.stuffisup.comtime:2023-05-31T19:03:49.095Z

```

so there's not a message and msg field

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
