### PR TITLE
[CON-734] Add discovery rendezvous and use it in /tracks/:encodedId/stream

### DIFF
--- a/discovery-provider/requirements.txt
+++ b/discovery-provider/requirements.txt
@@ -50,6 +50,7 @@ opentelemetry-sdk==1.12.0
 opentelemetry-semantic-conventions==0.33b0
 opentelemetry-util-http==0.33b0
 lxml==4.9.1
+crc32c==2.3.post0
 
 # Solana support
 base58==2.1.0

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import random
 import urllib.parse
 from typing import List
 from urllib.parse import urljoin
@@ -65,15 +64,16 @@ from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unclaimed_id import get_unclaimed_id
 from src.queries.get_underground_trending import get_underground_trending
 from src.queries.search_queries import SearchKind, search
-from src.tasks.index_network_peers import CONTENT_PEERS_REDIS_KEY
 from src.trending_strategies.trending_strategy_factory import (
     DEFAULT_TRENDING_VERSIONS,
     TrendingStrategyFactory,
 )
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils import redis_connection
+from src.utils.get_all_other_nodes import get_all_other_content_nodes_cached
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
+from src.utils.rendezvous import RendezvousHash
 
 from .models.tracks import remixes_response as remixes_response_model
 from .models.tracks import stem_full, track, track_full
@@ -447,10 +447,26 @@ class TrackStream(Resource):
         is_storage_v2 = not (len(track_cid) == 46 and track_cid.startswith("Qm"))
         if is_storage_v2:
             redis = redis_connection.get_redis()
-            content_nodes = (
-                redis.get(CONTENT_PEERS_REDIS_KEY).decode("utf-8").split(",")
+            # TODO (theo): make celery task use /health/peers endpoint to save only healthy CNs to a separate redis key
+            content_nodes = get_all_other_content_nodes_cached(redis)
+            if not content_nodes:
+                logger.error(
+                    f"tracks.py | stream | No healthy Content Nodes found when streaming track ID {track_id}. Please investigate."
+                )
+                abort_not_found(track_id, ns)
+
+            rendezvous = RendezvousHash(
+                *[cn["delegateOwnerWallet"] for cn in content_nodes]
             )
-            content_node = random.choice(content_nodes)
+            content_node_wallet = rendezvous.get(track_cid)
+            content_node = next(
+                (
+                    cn["endpoint"]
+                    for cn in content_nodes
+                    if cn["delegateOwnerWallet"] == content_node_wallet
+                ),
+                content_nodes[0]["endpoint"],
+            )
         elif info["creator_nodes"]:
             content_nodes = info["creator_nodes"].split(",")
             content_node = content_nodes[0]

--- a/discovery-provider/src/utils/eth_contracts_helpers.py
+++ b/discovery-provider/src/utils/eth_contracts_helpers.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 import logging
 
-import requests
 from src.utils.helpers import is_fqdn
 from src.utils.redis_cache import (
     get_cn_sp_id_key,
@@ -81,12 +80,3 @@ def fetch_all_registered_content_nodes(
                     f"eth_contract_helpers.py | ERROR in fetch_cnode_futures {cn_spID} generated {exc}"
                 )
     return eth_cn_endpoints_set
-
-
-def isCNodeHealthy(endpoint: str) -> bool:
-    try:
-        response = requests.get(f"{endpoint}/status", timeout=5)
-        return response.status_code == 200
-    except Exception as e:
-        logger.warning(f"Failed to check health for content node '{endpoint}': {e}")
-        return False

--- a/discovery-provider/src/utils/get_all_other_nodes.py
+++ b/discovery-provider/src/utils/get_all_other_nodes.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from src.utils import web3_provider
 from src.utils.config import shared_config
@@ -44,7 +44,7 @@ async def get_async_node(sp_id, sp_factory_instance, service_type):
     return result
 
 
-def get_all_nodes(service_type: str) -> Tuple[List[str], List[str]]:
+def get_all_nodes(service_type: bytes) -> Tuple[List[str], List[str]]:
     eth_web3 = web3_provider.get_eth_web3()
 
     eth_registry_address = eth_web3.toChecksumAddress(
@@ -113,7 +113,7 @@ def get_all_other_discovery_nodes_cached(redis) -> List[str]:
     return get_json_cached_key(redis, ALL_DISCOVERY_NODES_CACHE_KEY)
 
 
-def get_all_other_content_nodes_cached(redis) -> List[str]:
+def get_all_other_content_nodes_cached(redis) -> List[Dict[str, str]]:
     """
     Attempts to get the number of content nodes from redis.
     """

--- a/discovery-provider/src/utils/rendezvous.py
+++ b/discovery-provider/src/utils/rendezvous.py
@@ -1,0 +1,35 @@
+from typing import List
+
+import crc32c
+
+
+# Python equivalent of https://github.com/tysonmote/rendezvous/blob/be0258dbbd3d/rendezvous.go
+class RendezvousHash:
+    def __init__(self, *nodes: str):
+        self.nodes: List[bytes] = [bytes(node, "utf-8") for node in nodes]
+
+    def add(self, *nodes: str) -> None:
+        for node in nodes:
+            self.nodes.append(bytes(node, "utf-8"))
+
+    def get(self, key: str) -> str:
+        max_node = max(
+            (node for node in self.nodes),
+            default=None,
+            key=lambda node: self.hash(node, bytes(key, "utf-8")),
+        )
+        return max_node.decode("utf-8") if max_node is not None else ""
+
+    def get_n(self, n: int, key: str) -> List[str]:
+        scores = [(self.hash(node, bytes(key, "utf-8")), node) for node in self.nodes]
+        scores.sort(key=lambda x: (-x[0], x[1]))
+        return [node.decode("utf-8") for _, node in scores[:n]]
+
+    def get_nodes(self) -> List[str]:
+        return [node.decode("utf-8") for node in self.nodes]
+
+    @staticmethod
+    def hash(node: bytes, key: bytes) -> int:
+        combined = key + node
+        # Convert to unsigned 32-bit integer to match golang uint32 here: https://github.com/tysonmote/rendezvous/blob/be0258dbbd3d/rendezvous.go#L92
+        return crc32c.crc32c(combined) & 0xFFFFFFFF

--- a/discovery-provider/src/utils/rendezvous_unit_test.py
+++ b/discovery-provider/src/utils/rendezvous_unit_test.py
@@ -1,0 +1,68 @@
+import pytest
+from src.utils.rendezvous import RendezvousHash
+
+
+def test_create_new_hash():
+    nodes = ["node1", "node2", "node3"]
+    hash_obj = RendezvousHash(*nodes)
+    assert hash_obj.get_nodes() == nodes
+
+
+def test_add_additional_nodes():
+    nodes = ["node1", "node2", "node3"]
+    hash_obj = RendezvousHash(*nodes)
+    new_nodes = ["node4", "node5"]
+    hash_obj.add(*new_nodes)
+    assert hash_obj.get_nodes() == nodes + new_nodes
+
+
+def test_return_highest_scoring_node():
+    nodes = ["node1", "node2", "node3"]
+    hash_obj = RendezvousHash(*nodes)
+    key = "test-key"
+    highest_node = hash_obj.get(key)
+    assert highest_node in nodes
+
+
+def test_return_top_n_nodes():
+    nodes = ["node1", "node2", "node3"]
+    hash_obj = RendezvousHash(*nodes)
+    key = "test-key"
+    top2_nodes = hash_obj.get_n(2, key)
+    assert len(top2_nodes) == 2
+    assert all(node in nodes for node in top2_nodes)
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("", "d"),
+        ("foo", "e"),
+        ("bar", "c"),
+    ],
+)
+def test_hash_get(key, expected):
+    hash_obj = RendezvousHash()
+    hash_obj.add("a", "b", "c", "d", "e")
+    got_node = hash_obj.get(key)
+    assert got_node == expected
+
+
+# Ensures the hash results match the results of the equivalent Go code.
+# See https://github.com/tysonmote/rendezvous/blob/be0258dbbd3d0df637b328d951067124541e7b6a/rendezvous_test.go
+@pytest.mark.parametrize(
+    "n,key,expected",
+    [
+        (1, "foo", ["e"]),
+        (2, "bar", ["c", "e"]),
+        (3, "baz", ["d", "a", "b"]),
+        (2, "biz", ["b", "a"]),
+        (0, "boz", []),
+        (100, "floo", ["d", "a", "b", "c", "e"]),
+    ],
+)
+def test_hash_get_n(n, key, expected):
+    hash_obj = RendezvousHash()
+    hash_obj.add("a", "b", "c", "d", "e")
+    got_nodes = hash_obj.get_n(n, key)
+    assert got_nodes == expected


### PR DESCRIPTION
### Description
- Adds rendezvous.py and unit tests to make sure it matches the [Go](https://github.com/tysonmote/rendezvous/blob/be0258dbbd3d/rendezvous.go) and [TS](https://github.com/AudiusProject/audius-protocol/blob/main/libs/src/utils/rendezvous.ts) implementations
- Makes Discovery track streaming route use rendezvous instead of `random` to find the Content Node to redirect to

### How Has This Been Tested?
```
audius-compose up -c 3
audius-cmd create-user
audius-cmd upload-track -f <user handle>
hashids encode <track id>
```
Play the encoded ID via audius-protocol-discovery-provider-1/v1/tracks/:encodedId/stream. Do this a few times and make sure the same track gets redirected to the same CN each time.
