### PR TITLE
Hotfix mediorum /contact, blacklist v2 tracks, and fix hanging on stream

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -56,7 +56,7 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	}
 
 	// v1 feature parity
-	// go ss.logTrackListen(c)
+	go ss.logTrackListen(c)
 
 	if isLegacyCID(key) {
 		ss.logger.Debug("serving legacy cid", "cid", key)

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -44,6 +44,10 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	ctx := c.Request().Context()
 	key := c.Param("cid")
 
+	if ss.isCidBlacklisted(ctx, key) {
+		return c.String(403, "cid is blacklisted by this node")
+	}
+
 	// If the client provided a filename, set it in the header to be auto-populated in download prompt
 	filenameForDownload := c.QueryParam("filename")
 	if filenameForDownload != "" {
@@ -112,7 +116,7 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 
 	sig, err := signature.ParseFromQueryString(c.QueryParam("signature"))
 	if err != nil {
-		ss.logger.Warn("unable to parse signature for request", c.QueryParam("signature"))
+		ss.logger.Warn("unable to parse signature for request", "signature", c.QueryParam("signature"))
 		return
 	}
 
@@ -155,8 +159,6 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 		resBody, _ := io.ReadAll(res.Body)
 		ss.logger.Warn(fmt.Sprintf("unsuccessful POST [%d] %s", res.StatusCode, resBody))
 	}
-
-	return
 }
 
 // checks signature from discovery node for cidstream endpoint + premium content.

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -56,7 +56,7 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	}
 
 	// v1 feature parity
-	go ss.logTrackListen(c)
+	// go ss.logTrackListen(c)
 
 	if isLegacyCID(key) {
 		ss.logger.Debug("serving legacy cid", "cid", key)

--- a/mediorum/server/serve_contact.go
+++ b/mediorum/server/serve_contact.go
@@ -6,10 +6,18 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type ContactResponse struct {
+	Email string `json:"email"`
+}
+
 func (ss *MediorumServer) serveContact(c echo.Context) error {
+	if ss.trustedNotifier != nil {
+		return c.JSON(200, ContactResponse{Email: ss.trustedNotifier.Email})
+	}
+
 	email := os.Getenv("nodeOperatorEmailAddress")
 	if email == "" {
 		return c.String(200, "Email address unavailable at the moment")
 	}
-	return c.String(200, email)
+	return c.JSON(200, ContactResponse{Email: email})
 }

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -19,11 +19,6 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 	cid := c.Param("cid")
 	sql := `select "storagePath" from "Files" where "multihash" = $1 limit 1`
 
-	// check blacklist
-	if ss.isCidBlacklisted(ctx, cid) {
-		return c.String(403, "cid is blacklisted by this node")
-	}
-
 	// lookup on-disk storage path
 	var storagePath string
 	err := ss.pgPool.QueryRow(ctx, sql, cid).Scan(&storagePath)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -5,11 +5,13 @@ import (
 	"crypto/ecdsa"
 	"log"
 	"mediorum/crudr"
+	"mediorum/ethcontracts"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -57,13 +59,14 @@ type MediorumConfig struct {
 }
 
 type MediorumServer struct {
-	echo      *echo.Echo
-	bucket    *blob.Bucket
-	placement *placement
-	logger    *slog.Logger
-	crud      *crudr.Crudr
-	pgPool    *pgxpool.Pool
-	quit      chan os.Signal
+	echo            *echo.Echo
+	bucket          *blob.Bucket
+	placement       *placement
+	logger          *slog.Logger
+	crud            *crudr.Crudr
+	pgPool          *pgxpool.Pool
+	quit            chan os.Signal
+	trustedNotifier *ethcontracts.NotifierInfo
 
 	StartedAt time.Time
 	Config    MediorumConfig
@@ -138,6 +141,19 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	crud := crudr.New(config.Self.Host, config.privateKey, peerHosts, db)
 	dbMigrate(crud)
 
+	// Read trusted notifier endpoint from chain
+	var trustedNotifier ethcontracts.NotifierInfo
+	if config.TrustedNotifierID > 0 {
+		trustedNotifier, err := ethcontracts.GetNotifierForID(strconv.Itoa(config.TrustedNotifierID))
+		if err == nil {
+			slog.Info("got trusted notifier from chain", "endpoint", trustedNotifier.Endpoint, "wallet", trustedNotifier.Wallet)
+		} else {
+			slog.Error("failed to get trusted notifier from chain, not polling delist statuses", err)
+		}
+	} else {
+		slog.Warn("trusted notifier id not set, not polling delist statuses or serving /contact route")
+	}
+
 	// echoServer server
 	echoServer := echo.New()
 	echoServer.HideBanner = true
@@ -151,13 +167,14 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	echoServer.Use(middleware.Logger())
 
 	ss := &MediorumServer{
-		echo:      echoServer,
-		bucket:    bucket,
-		placement: newPlacement(config),
-		crud:      crud,
-		pgPool:    pgPool,
-		logger:    logger,
-		quit:      make(chan os.Signal, 1),
+		echo:            echoServer,
+		bucket:          bucket,
+		placement:       newPlacement(config),
+		crud:            crud,
+		pgPool:          pgPool,
+		logger:          logger,
+		quit:            make(chan os.Signal, 1),
+		trustedNotifier: &trustedNotifier,
 
 		StartedAt: time.Now().UTC(),
 		Config:    config,
@@ -194,7 +211,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/content/:cid", ss.getBlob)
 	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant)
 	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant)
-	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireSignature) // TODO: Log listen, check delisted status, respect cache in payload, and use `signature` queryparam for premium content
+	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireSignature)
 	routes.GET("/contact", ss.serveContact)
 
 	// status + debug:
@@ -203,11 +220,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/debug/uploads", ss.dumpUploads)
 	routes.GET("/debug/ls", ss.getLs)
 	routes.GET("/debug/peers", ss.debugPeers)
-
-	// legacy:
-	routes.GET("/cid/:cid", ss.serveLegacyCid)
-	routes.GET("/cid/:dirCid/:fileName", ss.serveLegacyDirCid)
-	routes.GET("/metadata", ss.serveCidMetadata)
 
 	// -------------------
 	// internal

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -144,7 +144,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// Read trusted notifier endpoint from chain
 	var trustedNotifier ethcontracts.NotifierInfo
 	if config.TrustedNotifierID > 0 {
-		trustedNotifier, err := ethcontracts.GetNotifierForID(strconv.Itoa(config.TrustedNotifierID))
+		trustedNotifier, err = ethcontracts.GetNotifierForID(strconv.Itoa(config.TrustedNotifierID))
 		if err == nil {
 			slog.Info("got trusted notifier from chain", "endpoint", trustedNotifier.Endpoint, "wallet", trustedNotifier.Wallet)
 		} else {


### PR DESCRIPTION
### Description
- Makes blacklist check happen for v2 uploads and prior to `logTrackListen()`
- Fixes mediorum /contact route not using trusted notifier email from chain (JS route uses it so it should stay the same for parity)

### How Has This Been Tested?
`/contact` now shows an email, and tracks are now streamable (or return 403 when blacklisted) on prod user-metadata
