### PR TITLE
Nerf crudr sweep and pg_beam

### DIFF
--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -82,7 +82,7 @@ func (p *PeerClient) startSweeper() {
 		if err != nil {
 			p.logger.Warn("sweep failed", "err", err)
 		}
-		time.Sleep(time.Minute)
+		time.Sleep(time.Second * 30)
 	}
 }
 

--- a/mediorum/server/cid_log_server.go
+++ b/mediorum/server/cid_log_server.go
@@ -20,7 +20,7 @@ func (ss *MediorumServer) servePgBeam(c echo.Context) error {
 		from cid_log
 		where updated_at > '%s'
 		order by updated_at
-		limit 100000
+		limit 1000
 		`,
 		after.Format(time.RFC3339Nano))
 	copySql := fmt.Sprintf("COPY (%s) TO STDOUT", query)

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -7,11 +7,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const PullLimit = 10000
+
 func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
 	ss.crud.DB.
 		Where("host = ? AND ulid >= ?", ss.Config.Self.Host, after).
+		Limit(PullLimit).
 		Find(&ops)
 	return c.JSON(200, ops)
 }


### PR DESCRIPTION
### Description
- Crudr sweep (from every node): unlimited rows every minute -> 10k rows every 30s
- cid_lookup beam (from every node until table is built up): 100k rows every 60-90s -> 1k rows every 60-90s

### How Has This Been Tested?
Testing on prod user-metadata, where flare-181 has been most noticeable
