### PR TITLE
Add timeout to mediorum sql, and make batch a queryparam

### DIFF
--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+const CidLookupBatchSize = 1000
+
 func (ss *MediorumServer) startBeamClients() {
 	for _, peer := range ss.Config.Peers {
 		if peer.Host == ss.Config.Self.Host {
@@ -47,15 +49,16 @@ type beamResult struct {
 }
 
 func (ss *MediorumServer) beamFromPeer(peer Peer) (*beamResult, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 	client := http.Client{
-		Timeout: 5 * time.Minute,
+		Timeout: time.Minute,
 	}
 
 	var cursorBefore time.Time
 	ss.pgPool.QueryRow(ctx, `select updated_at from cid_cursor where host = $1`, peer.Host).Scan(&cursorBefore)
 
-	endpoint := fmt.Sprintf("%s?after=%s", peer.ApiPath("internal/beam/files"), url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
+	endpoint := fmt.Sprintf("%s?batchSize=%d&after=%s", peer.ApiPath("internal/beam/files"), CidLookupBatchSize, url.QueryEscape(cursorBefore.Format(time.RFC3339Nano)))
 	startedAt := time.Now()
 	logger := slog.With("beam_client", peer.Host)
 	resp, err := client.Get(endpoint)

--- a/mediorum/server/cid_log_server.go
+++ b/mediorum/server/cid_log_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -15,14 +16,19 @@ func (ss *MediorumServer) servePgBeam(c echo.Context) error {
 		after = t
 	}
 
+	batchSize := CidLookupBatchSize
+	if param, err := strconv.Atoi(c.QueryParam("batchSize")); err == nil && param > 0 {
+		batchSize = param
+	}
+
 	query := fmt.Sprintf(`
 		select *
 		from cid_log
 		where updated_at > '%s'
 		order by updated_at
-		limit 1000
+		limit %d
 		`,
-		after.Format(time.RFC3339Nano))
+		after.Format(time.RFC3339Nano), batchSize)
 	copySql := fmt.Sprintf("COPY (%s) TO STDOUT", query)
 
 	// pg COPY TO

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -153,9 +153,9 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 		ss.logger.Error("unable to POST to identity service", err)
 		return
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		defer res.Body.Close()
 		resBody, _ := io.ReadAll(res.Body)
 		ss.logger.Warn(fmt.Sprintf("unsuccessful POST [%d] %s", res.StatusCode, resBody))
 	}


### PR DESCRIPTION
### Description
- Beaming now allows clients to choose their own batchSize so we can more easily hotfix on prod user-metadata, for example, without having to wait for the whole network to upgrade
- Adds 2m timeout to sql query that @stereosteve had to manually kill otherwise

### How Has This Been Tested?
Testing on prod user-metadata