### PR TITLE
Fix urllib parse

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -482,7 +482,7 @@ class TrackStream(Resource):
             params["filename"] = filename
 
         base_path = f"tracks/cidstream/{track_cid}"
-        query_string = urllib.parse.urlencode(params)
+        query_string = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
         path = f"{base_path}?{query_string}"
         stream_url = urljoin(content_node, path)
 


### PR DESCRIPTION
### Description

One does not simply replace urllib.parse.quote with urllib.parse.urlencode in https://github.com/AudiusProject/audius-protocol/pull/5271/files because of course those do different encodings.

```
Note that the urlencode method includes the functionality of the quote function, so you probably rarely need to call quote on its own. Also note that urlencode uses the plus sign to encode a space character in a URL…which is basically as valid as using %20. Again, the confusing rules and standards are yet another reason to delegate this string parsing to the proper Python libraries.
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Deployed to stage node and verified + is back to being %20
- streaming works
- notifier works
