### PR TITLE
[C-2529] Add confirmer to EntityManager in sdk

### DIFF
--- a/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -47,7 +47,11 @@ describe('TracksApi', () => {
   let tracks: TracksApi
 
   const auth = new Auth()
-  const storageNodeSelector = new StorageNodeSelector({ auth })
+  const discoveryNodeSelector = new DiscoveryNodeSelector()
+  const storageNodeSelector = new StorageNodeSelector({
+    auth,
+    discoveryNodeSelector
+  })
 
   beforeAll(() => {
     tracks = new TracksApi(

--- a/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -61,6 +61,10 @@ describe('TracksApi', () => {
       new EntityManager(),
       auth
     )
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'info').mockImplementation(() => {})
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   describe('uploadTrack', () => {

--- a/libs/src/sdk/config/development.ts
+++ b/libs/src/sdk/config/development.ts
@@ -11,5 +11,5 @@ export const servicesConfig: ServicesConfig = {
   ],
   "entityManagerContractAddress": "0x5b9b42d6e4B2e4Bf8d42Eba32D46918e10899B66",
   "web3ProviderUrl": "http://audius-protocol-poa-ganache-1",
-  "identityServiceEndpoint": "http://audius-protocol-identity-service-1"
+  "identityServiceUrl": "http://audius-protocol-identity-service-1"
 }

--- a/libs/src/sdk/config/production.ts
+++ b/libs/src/sdk/config/production.ts
@@ -70,5 +70,5 @@ export const servicesConfig: ServicesConfig = {
   ],
   "web3ProviderUrl": "https://poa-gateway.audius.co",
   "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
-  "identityServiceEndpoint": "https://identityservice.audius.co"
+  "identityServiceUrl": "https://identityservice.audius.co"
 }

--- a/libs/src/sdk/config/staging.ts
+++ b/libs/src/sdk/config/staging.ts
@@ -14,5 +14,5 @@ export const servicesConfig: ServicesConfig = {
   ],
   "web3ProviderUrl": "https://poa-gateway.staging.audius.co",
   "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
-  "identityServiceEndpoint": "https://identityservice.staging.audius.co"
+  "identityServiceUrl": "https://identityservice.staging.audius.co"
 }

--- a/libs/src/sdk/config/types.ts
+++ b/libs/src/sdk/config/types.ts
@@ -3,5 +3,5 @@ export type ServicesConfig = {
   discoveryNodes: string[]
   entityManagerContractAddress: string
   web3ProviderUrl: string
-  identityServiceEndpoint: string
+  identityServiceUrl: string
 }

--- a/libs/src/sdk/scripts/generateServicesConfig.ts
+++ b/libs/src/sdk/scripts/generateServicesConfig.ts
@@ -11,7 +11,7 @@ type EnvironmentConfig = {
   ETH_PROVIDER_URL: string
   ETH_REGISTRY_ADDRESS: string
   ETH_TOKEN_ADDRESS: string
-  IDENTITY_SERVICE_ENDPOINT: string
+  IDENTITY_SERVICE_URL: string
   WORMHOLE_ADDRESS: string
   ENTITY_MANAGER_CONTRACT_ADDRESS: string
   WEB3_PROVIDER_URL: string
@@ -25,7 +25,7 @@ const envConfigs: Record<'staging' | 'production', EnvironmentConfig> = {
     ETH_PROVIDER_URL: 'https://eth.audius.co',
     ETH_REGISTRY_ADDRESS: '0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C',
     ETH_TOKEN_ADDRESS: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998',
-    IDENTITY_SERVICE_ENDPOINT: 'https://identityservice.audius.co',
+    IDENTITY_SERVICE_URL: 'https://identityservice.audius.co',
     WORMHOLE_ADDRESS: '0x6E7a1F7339bbB62b23D44797b63e4258d283E095',
     WEB3_PROVIDER_URL: 'https://poa-gateway.audius.co',
     ENTITY_MANAGER_CONTRACT_ADDRESS:
@@ -38,7 +38,7 @@ const envConfigs: Record<'staging' | 'production', EnvironmentConfig> = {
     ETH_PROVIDER_URL: 'https://eth.staging.audius.co',
     ETH_REGISTRY_ADDRESS: '0xF27A9c44d7d5DDdA29bC1eeaD94718EeAC1775e3',
     ETH_TOKEN_ADDRESS: '0x5375BE4c52fA29b26077B0F15ee5254D779676A6',
-    IDENTITY_SERVICE_ENDPOINT: 'https://identityservice.staging.audius.co',
+    IDENTITY_SERVICE_URL: 'https://identityservice.staging.audius.co',
     WORMHOLE_ADDRESS: '0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7',
     WEB3_PROVIDER_URL: 'https://poa-gateway.staging.audius.co',
     ENTITY_MANAGER_CONTRACT_ADDRESS:
@@ -51,7 +51,7 @@ const devConfig: ServicesConfig = {
   discoveryNodes: ['http://audius-protocol-discovery-provider-1'],
   entityManagerContractAddress: '0x5b9b42d6e4B2e4Bf8d42Eba32D46918e10899B66',
   web3ProviderUrl: 'http://audius-protocol-poa-ganache-1',
-  identityServiceEndpoint: 'http://audius-protocol-identity-service-1'
+  identityServiceUrl: 'http://audius-protocol-identity-service-1'
 }
 
 const generateServicesConfig = async (
@@ -60,7 +60,7 @@ const generateServicesConfig = async (
   const contracts = new EthContracts({
     ethWeb3Manager: new EthWeb3Manager({
       identityService: new IdentityService({
-        identityServiceEndpoint: config.IDENTITY_SERVICE_ENDPOINT
+        identityServiceEndpoint: config.IDENTITY_SERVICE_URL
       }),
       web3Config: {
         ownerWallet: config.ETH_OWNER_WALLET,
@@ -92,7 +92,7 @@ const generateServicesConfig = async (
     discoveryNodes: discoveryNodes.map((node) => node.endpoint),
     web3ProviderUrl: config.WEB3_PROVIDER_URL,
     entityManagerContractAddress: config.ENTITY_MANAGER_CONTRACT_ADDRESS,
-    identityServiceEndpoint: config.IDENTITY_SERVICE_ENDPOINT
+    identityServiceUrl: config.IDENTITY_SERVICE_URL
   }
 }
 

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -141,11 +141,15 @@ const initializeServices = (config: SdkConfig) => {
       config.services?.discoveryNodeSelector ?? defaultDiscoveryNodeSelector
   })
 
+  const defaultStorage = new Storage({
+    storageNodeSelector: defaultStorageNodeSelector
+  })
+
   const defaultServices: ServicesContainer = {
     storageNodeSelector: defaultStorageNodeSelector,
     discoveryNodeSelector: defaultDiscoveryNodeSelector,
     entityManager: defaultEntityManager,
-    storage: new Storage({ storageNodeSelector: defaultStorageNodeSelector }),
+    storage: defaultStorage,
     auth: defaultAuthService
   }
   return { ...defaultServices, ...config.services }

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -38,6 +38,7 @@ import {
   StorageNodeSelector,
   StorageNodeSelectorService
 } from './services/StorageNodeSelector'
+import { defaultEntityManagerConfig } from './services/EntityManager/constants'
 
 type ServicesContainer = {
   /**
@@ -126,15 +127,25 @@ const initializeServices = (config: SdkConfig) => {
       ? new AppAuth(config.apiKey, config.apiSecret)
       : new Auth()
 
-  const storageNodeSelector = new StorageNodeSelector({
-    auth: config.services?.auth ?? defaultAuthService
+  const defaultDiscoveryNodeSelector = new DiscoveryNodeSelector()
+
+  const defaultStorageNodeSelector = new StorageNodeSelector({
+    auth: config.services?.auth ?? defaultAuthService,
+    discoveryNodeSelector:
+      config.services?.discoveryNodeSelector ?? defaultDiscoveryNodeSelector
+  })
+
+  const defaultEntityManager = new EntityManager({
+    ...defaultEntityManagerConfig,
+    discoveryNodeSelector:
+      config.services?.discoveryNodeSelector ?? defaultDiscoveryNodeSelector
   })
 
   const defaultServices: ServicesContainer = {
-    discoveryNodeSelector: new DiscoveryNodeSelector(),
-    storageNodeSelector,
-    entityManager: new EntityManager(),
-    storage: new Storage({ storageNodeSelector }),
+    storageNodeSelector: defaultStorageNodeSelector,
+    discoveryNodeSelector: defaultDiscoveryNodeSelector,
+    entityManager: defaultEntityManager,
+    storage: new Storage({ storageNodeSelector: defaultStorageNodeSelector }),
     auth: defaultAuthService
   }
   return { ...defaultServices, ...config.services }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/healthCheckTypes.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/healthCheckTypes.ts
@@ -39,7 +39,7 @@ export type HealthCheckResponseData = DeepPartial<{
   maximum_healthy_block_difference: number
   meets_min_requirements: boolean
   network: {
-    content_nodes: Array<{ endpoint: string; ownerDelegateWallet: string }>
+    content_nodes: Array<{ endpoint: string; delegateOwnerWallet: string }>
     discovery_nodes: string[]
   }
   num_users_in_immediate_balance_refresh_queue: number

--- a/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -12,6 +12,12 @@ const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'
 
 const discoveryNode = 'https://discovery-provider.audius.co'
 
+jest.mock('../DiscoveryNodeSelector')
+
+jest
+  .spyOn(DiscoveryNodeSelector.prototype, 'getSelectedEndpoint')
+  .mockImplementation(async () => discoveryNode)
+
 class MockAuth implements AuthService {
   getSharedSecret = async () => new Uint8Array()
   signTransaction: (data: EIP712TypedData) => Promise<string> = async () =>

--- a/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -75,6 +75,13 @@ const mswHandlers = [
 ]
 
 const server = setupServer(...mswHandlers)
+
+jest
+  .spyOn(EntityManager.prototype, 'contractMethod', 'get')
+  .mockImplementation(() => () => ({
+    encodeABI: () => ''
+  }))
+
 const entityManager = new EntityManager({
   discoveryNodeSelector,
   web3ProviderUrl: developmentConfig.web3ProviderUrl,

--- a/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -7,12 +7,34 @@ import type { EIP712TypedData } from 'eth-sig-util'
 import { EntityManager } from './EntityManager'
 import { developmentConfig } from '../../config'
 import { Action, EntityType } from './types'
+import Web3 from '../../utils/web3'
 
 const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'
 
 const discoveryNode = 'https://discovery-provider.audius.co'
 
 jest.mock('../DiscoveryNodeSelector')
+jest.mock('../../utils/web3', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      eth: {
+        net: {
+          getId: () => ''
+        },
+        Contract: jest.fn().mockImplementation(() => ({
+          methods: {
+            manageEntity: () => ({
+              encodeABI: () => ''
+            })
+          }
+        }))
+      }
+    }
+  })
+})
+;(Web3 as any).providers = {
+  HttpProvider: jest.fn().mockImplementation(() => {})
+}
 
 jest
   .spyOn(DiscoveryNodeSelector.prototype, 'getSelectedEndpoint')

--- a/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -76,15 +76,9 @@ const mswHandlers = [
 
 const server = setupServer(...mswHandlers)
 
-jest
-  .spyOn(EntityManager.prototype, 'contractMethod', 'get')
-  .mockImplementation(() => () => ({
-    encodeABI: () => ''
-  }))
-
 const entityManager = new EntityManager({
   discoveryNodeSelector,
-  web3ProviderUrl: developmentConfig.web3ProviderUrl,
+  web3ProviderUrl: '',
   contractAddress: developmentConfig.entityManagerContractAddress,
   identityServiceUrl: developmentConfig.identityServiceUrl
 })

--- a/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -1,0 +1,133 @@
+import { rest } from 'msw'
+import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
+import { setupServer } from 'msw/node'
+
+import type { AuthService } from '../Auth/types'
+import type { EIP712TypedData } from 'eth-sig-util'
+import { EntityManager } from './EntityManager'
+import { developmentConfig } from '../../config'
+import { Action, EntityType } from './types'
+
+const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'
+
+const discoveryNode = 'https://discovery-provider.audius.co'
+
+class MockAuth implements AuthService {
+  getSharedSecret = async () => new Uint8Array()
+  signTransaction: (data: EIP712TypedData) => Promise<string> = async () =>
+    '0xcfe7a6974bd1691c0a298e119318337c54bf58175f8a9a6aeeaf3b0346c6105265c83de64ab81da28266c4b5b4ff68d81d9e266f9163d7ebd5b2a52d46e275941c'
+  sign: (data: string) => Promise<[Uint8Array, number]> = async () => [
+    new Uint8Array(),
+    0
+  ]
+
+  getAddress = async () => {
+    return userWallet
+  }
+}
+
+const auth = new MockAuth()
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  initialSelectedNode: discoveryNode
+})
+
+const mswHandlers = [
+  rest.post(
+    `${developmentConfig.identityServiceUrl}/relay`,
+    (_req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          receipt: {
+            blockHash: '',
+            blockNumber: 1
+          }
+        })
+      )
+    }
+  ),
+
+  rest.get(`${discoveryNode}/block_confirmation`, (req, res, ctx) => {
+    const blockNumber = req.url.searchParams.get('blocknumber')
+
+    const data = {
+      0: {
+        block_passed: false
+      },
+      1: {
+        block_passed: true
+      }
+    }[Number(blockNumber)!]
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        data
+      })
+    )
+  })
+]
+
+const server = setupServer(...mswHandlers)
+const entityManager = new EntityManager({
+  discoveryNodeSelector,
+  web3ProviderUrl: developmentConfig.web3ProviderUrl,
+  contractAddress: developmentConfig.entityManagerContractAddress,
+  identityServiceUrl: developmentConfig.identityServiceUrl
+})
+
+describe('EntityManager', () => {
+  beforeAll(() => {
+    server.listen()
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  describe('manageEntity', () => {
+    it('calls relay and confirms the transaction', async () => {
+      const confirmWriteSpy = jest.spyOn(entityManager, 'confirmWrite')
+
+      await entityManager.manageEntity({
+        userId: 1,
+        entityType: EntityType.TRACK,
+        entityId: 1,
+        action: Action.CREATE,
+        metadata: JSON.stringify({}),
+        auth
+      })
+
+      expect(confirmWriteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockHash: '',
+          blockNumber: 1
+        })
+      )
+    })
+  })
+
+  describe('confirmWrite', () => {
+    it('confirms a write', async () => {
+      const result = await entityManager.confirmWrite({
+        blockHash: '',
+        blockNumber: 1
+      })
+      expect(result).toBe(true)
+    })
+
+    it("throws when a write can't be confirmed", async () => {
+      await expect(async () => {
+        await entityManager.confirmWrite({
+          blockHash: '',
+          blockNumber: 0,
+          confirmationTimeout: 1000
+        })
+      }).rejects.toThrow()
+    })
+  })
+})

--- a/libs/src/sdk/services/EntityManager/EntityManager.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.ts
@@ -45,10 +45,6 @@ export class EntityManager implements EntityManagerService {
     )
   }
 
-  public get contractMethod() {
-    return this.contract.methods.manageEntity
-  }
-
   /**
    * Calls the manage entity method on chain to update some data
    */
@@ -78,7 +74,7 @@ export class EntityManager implements EntityManagerService {
     const senderAddress = await auth.getAddress()
     const signature = await auth.signTransaction(signatureData)
 
-    const method = await this.contractMethod(
+    const method = await this.contract.methods.manageEntity(
       userId,
       entityType,
       entityId,

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -10,5 +10,5 @@ export const defaultEntityManagerConfig: EntityManagerConfig = {
 }
 
 export const DEFAULT_GAS_LIMIT = 2000000
-export const POLLING_FREQUENCY_MILLIS = 2000
+export const CONFIRMATION_POLLING_INTERVAL = 2000
 export const CONFIRMATION_TIMEOUT = 30000

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -1,10 +1,12 @@
 import type { EntityManagerConfig } from './types'
 import { productionConfig } from '../../config'
+import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 
 export const defaultEntityManagerConfig: EntityManagerConfig = {
   contractAddress: productionConfig.entityManagerContractAddress,
   web3ProviderUrl: productionConfig.web3ProviderUrl,
-  identityServiceUrl: productionConfig.identityServiceEndpoint
+  identityServiceUrl: productionConfig.identityServiceEndpoint,
+  discoveryNodeSelector: new DiscoveryNodeSelector()
 }
 
 export const DEFAULT_GAS_LIMIT = 2000000

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -5,7 +5,7 @@ import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 export const defaultEntityManagerConfig: EntityManagerConfig = {
   contractAddress: productionConfig.entityManagerContractAddress,
   web3ProviderUrl: productionConfig.web3ProviderUrl,
-  identityServiceUrl: productionConfig.identityServiceEndpoint,
+  identityServiceUrl: productionConfig.identityServiceUrl,
   discoveryNodeSelector: new DiscoveryNodeSelector()
 }
 

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -10,3 +10,5 @@ export const defaultEntityManagerConfig: EntityManagerConfig = {
 }
 
 export const DEFAULT_GAS_LIMIT = 2000000
+export const POLLING_FREQUENCY_MILLIS = 2000
+export const CONFIRMATION_TIMEOUT = 30000

--- a/libs/src/sdk/services/EntityManager/types.ts
+++ b/libs/src/sdk/services/EntityManager/types.ts
@@ -1,10 +1,12 @@
 import type { AuthService } from '../Auth'
 import type { TransactionReceipt } from 'web3-core'
+import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 
 export type EntityManagerConfig = {
   contractAddress: string
   web3ProviderUrl: string
   identityServiceUrl: string
+  discoveryNodeSelector: DiscoveryNodeSelectorService
 }
 
 export enum Action {

--- a/libs/src/sdk/services/EntityManager/types.ts
+++ b/libs/src/sdk/services/EntityManager/types.ts
@@ -9,6 +9,12 @@ export type EntityManagerConfig = {
   discoveryNodeSelector: DiscoveryNodeSelectorService
 }
 
+export type EntityManagerService = {
+  manageEntity: (
+    options: ManageEntityOptions
+  ) => Promise<{ txReceipt: TransactionReceipt }>
+}
+
 export enum Action {
   CREATE = 'Create',
   UPDATE = 'Update',
@@ -36,13 +42,47 @@ export enum EntityType {
   DELEGATION = 'Delegation'
 }
 
-export type EntityManagerService = {
-  manageEntity: (options: {
-    userId: number
-    entityType: EntityType
-    entityId: number
-    action: Action
-    metadata: string
-    auth: AuthService
-  }) => Promise<{ txReceipt: TransactionReceipt }>
+export type ManageEntityOptions = {
+  /**
+   * The numeric user id
+   */
+  userId: number
+  /**
+   * The type of entity being modified
+   */
+  entityType: EntityType
+  /**
+   * The id of the entity
+   */
+  entityId: number
+  /**
+   * Action being performed on the entity
+   */
+  action: Action
+  /**
+   * Metadata associated with the action
+   */
+  metadata: string
+  /**
+   * An instance of AuthService
+   */
+  auth: AuthService
+  /**
+   * Timeout confirmation of the write
+   */
+  confirmationTimeout?: number
+  /**
+   * Skip confirmation of the write
+   */
+  skipConfirmation?: boolean
+}
+
+export enum BlockConfirmation {
+  CONFIRMED = 'CONFIRMED',
+  DENIED = 'DENIED',
+  UNKNOWN = 'UNKNOWN'
+}
+
+export type WriteOptions = {
+  confirmationTimeout?: number
 }

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -12,11 +12,11 @@ jest.mock('../DiscoveryNodeSelector')
 
 const storageNodeA = {
   endpoint: 'https://node-a.audius.co',
-  ownerDelegateWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54971'
+  delegateOwnerWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54971'
 }
 const storageNodeB = {
   endpoint: 'https://node-b.audius.co',
-  ownerDelegateWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54972'
+  delegateOwnerWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54972'
 }
 
 const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -8,6 +8,8 @@ import { setupServer } from 'msw/node'
 import type { AuthService } from '../Auth/types'
 import type { EIP712TypedData } from 'eth-sig-util'
 
+jest.mock('../DiscoveryNodeSelector')
+
 const storageNodeA = {
   endpoint: 'https://node-a.audius.co',
   ownerDelegateWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54971'
@@ -35,6 +37,7 @@ class MockAuth implements AuthService {
 }
 
 const auth = new MockAuth()
+const discoveryNodeSelector = new DiscoveryNodeSelector()
 
 const mswHandlers = [
   rest.get(`${discoveryNode}/health_check`, (_req, res, ctx) => {
@@ -90,7 +93,8 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      auth
+      auth,
+      discoveryNodeSelector
     })
 
     expect(await storageNodeSelector.getSelectedNode()).toEqual(
@@ -108,7 +112,8 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      auth
+      auth,
+      discoveryNodeSelector
     })
 
     expect(await storageNodeSelector.getSelectedNode()).toEqual(

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -8,8 +8,6 @@ import { setupServer } from 'msw/node'
 import type { AuthService } from '../Auth/types'
 import type { EIP712TypedData } from 'eth-sig-util'
 
-jest.mock('../DiscoveryNodeSelector')
-
 const storageNodeA = {
   endpoint: 'https://node-a.audius.co',
   delegateOwnerWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54971'
@@ -37,7 +35,9 @@ class MockAuth implements AuthService {
 }
 
 const auth = new MockAuth()
-const discoveryNodeSelector = new DiscoveryNodeSelector()
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  initialSelectedNode: discoveryNode
+})
 
 const mswHandlers = [
   rest.get(`${discoveryNode}/health_check`, (_req, res, ctx) => {

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -2,7 +2,7 @@ import { Maybe, RendezvousHash, isNodeHealthy } from '../../../utils'
 import fetch from 'cross-fetch'
 import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { HealthCheckResponseData } from '../DiscoveryNodeSelector/healthCheckTypes'
-import type { Auth } from '../Auth'
+import type { AuthService } from '../Auth'
 import type {
   StorageNode,
   StorageNodeSelectorConfig,
@@ -13,7 +13,7 @@ import { defaultStorageNodeSelectorConfig } from './contants'
 
 export class StorageNodeSelector implements StorageNodeSelectorService {
   private readonly config: StorageNodeSelectorConfig
-  private readonly auth: Auth
+  private readonly auth: AuthService
   private nodes: StorageNode[]
   private orderedNodes?: StorageNode[]
   private selectedNode?: string | null
@@ -121,10 +121,6 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
     return orderedNodes
   }
 
-  private debug(...args: any[]) {
-    console.debug('[audius-sdk][storage-node-selector]', ...args)
-  }
-
   /** console.info proxy utility to add a prefix */
   private info(...args: any[]) {
     console.info('[audius-sdk][storage-node-selector]', ...args)
@@ -132,11 +128,6 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
 
   /** console.warn proxy utility to add a prefix */
   private warn(...args: any[]) {
-    console.warn('[audius-sdk][storage-node-selector]', ...args)
-  }
-
-  /** console.error proxy utility to add a prefix */
-  private error(...args: any[]) {
     console.warn('[audius-sdk][storage-node-selector]', ...args)
   }
 }

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -1,20 +1,15 @@
 import { Maybe, RendezvousHash, isNodeHealthy } from '../../../utils'
 import fetch from 'cross-fetch'
-import type { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
+import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { HealthCheckResponseData } from '../DiscoveryNodeSelector/healthCheckTypes'
 import type { Auth } from '../Auth'
-import type { StorageNodeSelectorService } from './types'
-
-type StorageNode = {
-  endpoint: string
-  ownerDelegateWallet: string
-}
-
-export type StorageNodeSelectorConfig = {
-  bootstrapNodes?: StorageNode[]
-  auth: Auth
-  discoveryNodeSelector?: DiscoveryNodeSelector
-}
+import type {
+  StorageNode,
+  StorageNodeSelectorConfig,
+  StorageNodeSelectorService
+} from './types'
+import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
+import { defaultStorageNodeSelectorConfig } from './contants'
 
 export class StorageNodeSelector implements StorageNodeSelectorService {
   private readonly config: StorageNodeSelectorConfig
@@ -23,10 +18,13 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
   private orderedNodes?: StorageNode[]
   private selectedNode?: string | null
   private selectedDiscoveryNode?: string | null
-  private readonly discoveryNodeSelector?: DiscoveryNodeSelector
+  private readonly discoveryNodeSelector?: DiscoveryNodeSelectorService
 
   constructor(config: StorageNodeSelectorConfig) {
-    this.config = config
+    this.config = mergeConfigWithDefaults(
+      config,
+      defaultStorageNodeSelectorConfig
+    )
     this.auth = this.config.auth
     this.nodes = this.config.bootstrapNodes ?? []
     this.discoveryNodeSelector = this.config.discoveryNodeSelector

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -9,7 +9,7 @@ import type {
   StorageNodeSelectorService
 } from './types'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
-import { defaultStorageNodeSelectorConfig } from './contants'
+import { defaultStorageNodeSelectorConfig } from './constants'
 
 export class StorageNodeSelector implements StorageNodeSelectorService {
   private readonly config: StorageNodeSelectorConfig

--- a/libs/src/sdk/services/StorageNodeSelector/constants.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/constants.ts
@@ -1,4 +1,4 @@
-import { Auth } from '../Auth'
+import { Auth } from '../Auth/Auth'
 import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import type { StorageNodeSelectorConfig } from './types'
 

--- a/libs/src/sdk/services/StorageNodeSelector/contants.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/contants.ts
@@ -1,0 +1,9 @@
+import { Auth } from '../Auth'
+import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
+import type { StorageNodeSelectorConfig } from './types'
+
+export const defaultStorageNodeSelectorConfig: StorageNodeSelectorConfig = {
+  bootstrapNodes: [],
+  auth: new Auth(),
+  discoveryNodeSelector: new DiscoveryNodeSelector()
+}

--- a/libs/src/sdk/services/StorageNodeSelector/types.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/types.ts
@@ -7,7 +7,7 @@ export type StorageNodeSelectorService = {
 
 export type StorageNode = {
   endpoint: string
-  ownerDelegateWallet: string
+  delegateOwnerWallet: string
 }
 
 export type StorageNodeSelectorConfig = {

--- a/libs/src/sdk/services/StorageNodeSelector/types.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/types.ts
@@ -1,3 +1,17 @@
+import type { Auth } from '../Auth'
+import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
+
 export type StorageNodeSelectorService = {
   getSelectedNode: () => Promise<string | null>
+}
+
+export type StorageNode = {
+  endpoint: string
+  ownerDelegateWallet: string
+}
+
+export type StorageNodeSelectorConfig = {
+  bootstrapNodes?: StorageNode[]
+  auth: Auth
+  discoveryNodeSelector: DiscoveryNodeSelectorService
 }

--- a/sdk-consumer/index.ts
+++ b/sdk-consumer/index.ts
@@ -1,5 +1,5 @@
-import { DiscoveryNodeSelector, sdk } from "@audius/sdk";
-import { UploadTrackRequest } from "@audius/sdk";
+import { DiscoveryNodeSelector, EntityManager, sdk } from "@audius/sdk";
+import { UploadTrackRequest, developmentConfig } from "@audius/sdk";
 import express from "express";
 import multer from "multer";
 
@@ -13,11 +13,19 @@ const port = 3000;
 
 // Test/develop sdk functionality here
 
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  initialSelectedNode: "http://audius-protocol-discovery-provider-1",
+});
+
 const audiusSdk = sdk({
   appName: "sdk-consumer",
   services: {
-    discoveryNodeSelector: new DiscoveryNodeSelector({
-      initialSelectedNode: "http://audius-protocol-discovery-provider-1",
+    discoveryNodeSelector,
+    entityManager: new EntityManager({
+      discoveryNodeSelector,
+      web3ProviderUrl: developmentConfig.web3ProviderUrl,
+      contractAddress: developmentConfig.entityManagerContractAddress,
+      identityServiceUrl: developmentConfig.identityServiceUrl,
     }),
   },
   apiKey: "",


### PR DESCRIPTION
### Description

* Add `confirmWrite` to EntityManager
  This is simply polling discovery node for the block to be passed, the orchestration and sequencing of writes will have to be done in userland
* Add tests for EntityManager
* Pass `discoveryNodeSelector` to `StorageNodeSelector`
* Rename `identityServiceEndpoint` -> `identityServiceUrl` in config (we were already using Url in sdk, Endpoint is old nomenclature from libs)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
