### PR TITLE
Dedupe notifications grouped by action

### DIFF
--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -23,14 +23,6 @@ WITH user_seen as (
     user_id = :user_id
   ORDER BY
     seen_at desc
-), user_created_at as (
-  SELECT
-    created_at
-  FROM
-    users
-  WHERE
-    user_id =  :user_id
-  AND is_current
 )
 SELECT
     n.type,
@@ -57,7 +49,7 @@ FROM
 LEFT JOIN user_seen on
   user_seen.seen_at >= n.timestamp and user_seen.prev_seen_at < n.timestamp
 WHERE
-  ((ARRAY[:user_id] && n.user_ids) OR (n.type = 'announcement' AND n.timestamp > (SELECT created_at FROM user_created_at))) AND
+  (ARRAY[:user_id] && n.user_ids OR n.type = 'announcement') AND
   (:valid_types is NOT NULL AND n.type in :valid_types) AND
   (
     (:timestamp_offset is NULL AND :group_id_offset is NULL) OR
@@ -84,15 +76,6 @@ notification_groups_sql = notification_groups_sql.bindparams(
 unread_notification_count_sql = text(
     """
 --- Create Intervals of user seen
-WITH user_created_at as (
-  SELECT
-    created_at
-  FROM
-    users
-  WHERE
-    user_id = :user_id
-  AND is_current
-)
 SELECT
     count(*)
 FROM (
@@ -100,7 +83,7 @@ FROM (
    from
        notification n
   WHERE
-    ((ARRAY[:user_id] && n.user_ids) OR (n.type = 'announcement' AND n.timestamp > (SELECT created_at FROM user_created_at))) AND
+    (ARRAY[:user_id] && n.user_ids OR n.type = 'announcement') AND
     (:valid_types is NOT NULL AND n.type in :valid_types) AND
     n.timestamp > COALESCE((
         SELECT
@@ -479,9 +462,10 @@ def get_notifications(session: Session, args: GetNotificationArgs):
     notifications_and_actions = [
         {
             **notification,
-            "actions": [
-                notification_id_data[id] for id in notification["notification_ids"]
-            ],
+            "actions": sorted(
+                [notification_id_data[id] for id in notification["notification_ids"]],
+                key=lambda x: x["specifier"],
+            ),
         }
         for notification in notifications
     ]


### PR DESCRIPTION
### Description
Follow notifications were duped if they were grouped together.

![Screenshot 2023-06-07 at 10 38 08 AM](https://github.com/AudiusProject/audius-protocol/assets/6413636/dec453c1-7c48-4242-a1da-e71c32b62891)

This is because the ordering would change and trigger a different rendering. This enforces an order on grouped notifications so it's deterministic and doesn't insert additional rows.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Tested on sandbox.