### PR TITLE
repair + replicate handle more edge cases

### DIFF
--- a/mediorum/bash_scripts/deploy_mediorum.sh
+++ b/mediorum/bash_scripts/deploy_mediorum.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-docker system prune -a --force
+# docker system prune -a --force
 
 cd audius-docker-compose/creator-node
 git fetch
-git checkout dev
+git checkout mediorum_tag_2
 git pull
 
 FILE='/home/ubuntu/audius-docker-compose/creator-node/.env'

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"golang.org/x/exp/slices"
+	"gorm.io/gorm"
 )
 
 func (ss *MediorumServer) replicateFile(fileName string, file io.ReadSeeker) ([]string, error) {
-	logger := ss.logger.With("key", fileName)
+	logger := ss.logger.With("task", "replicate", "cid", fileName)
 
 	healthyHostNames := ss.findHealthyHostNames("5 minutes")
 	success := []string{}
@@ -21,16 +22,18 @@ func (ss *MediorumServer) replicateFile(fileName string, file io.ReadSeeker) ([]
 		logger := logger.With("to", peer.Host)
 
 		if !slices.Contains(healthyHostNames, peer.Host) {
-			logger.Debug("skipping unhealthy host", "healthy", healthyHostNames)
+			logger.Info("skipping unhealthy host", "healthy", healthyHostNames)
 			continue
 		}
+
+		logger.Info("replicating")
 
 		file.Seek(0, 0)
 		err := ss.replicateFileToHost(peer, fileName, file)
 		if err != nil {
-			logger.Warn("replication failed", "err", err)
+			logger.Error("replication failed", err)
 		} else {
-			logger.Debug("replicated")
+			logger.Info("replicated")
 			success = append(success, peer.Host)
 			if len(success) == ss.Config.ReplicationFactor {
 				break
@@ -43,6 +46,8 @@ func (ss *MediorumServer) replicateFile(fileName string, file io.ReadSeeker) ([]
 
 func (ss *MediorumServer) replicateToMyBucket(fileName string, file io.Reader) error {
 	ctx := context.Background()
+	logger := ss.logger.With("task", "replicateToMyBucket", "cid", fileName)
+	logger.Info("replicateToMyBucket")
 
 	// already have?
 	alreadyHave, _ := ss.bucket.Exists(ctx, fileName)
@@ -61,28 +66,43 @@ func (ss *MediorumServer) replicateToMyBucket(fileName string, file io.Reader) e
 	}
 
 	// record that we "have" this key
-	return ss.crud.Create(&Blob{
-		Host:      ss.Config.Self.Host,
-		Key:       fileName,
-		CreatedAt: time.Now().UTC(),
-	})
+	var existingBlob *Blob
+	found := ss.crud.DB.Where("host = ? AND key = ?", ss.Config.Self.Host, fileName).First(&existingBlob)
+	if found.Error == gorm.ErrRecordNotFound {
+		logger.Info("creating blob record")
+		return ss.crud.Create(&Blob{
+			Host:      ss.Config.Self.Host,
+			Key:       fileName,
+			CreatedAt: time.Now().UTC(),
+		})
+	}
+
+	return nil
 }
 
 func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
+	logger := ss.logger.With("task", "dropFromMyBucket", "cid", fileName)
+
+	logger.Info("deleting blob")
 	ctx := context.Background()
 	err := ss.bucket.Delete(ctx, fileName)
 	if err != nil {
-		return err
+		logger.Error("failed to delete", err)
 	}
 
-	// record that we deleted this key
-	return ss.crud.Delete(&Blob{
-		Host: ss.Config.Self.Host,
-		Key:  fileName,
-	})
+	// if blob record exists... delete it
+	var existingBlob *Blob
+	found := ss.crud.DB.Where("host = ? AND key = ?", ss.Config.Self.Host, fileName).First(&existingBlob)
+	if found.Error == nil {
+		logger.Info("deleting blob record")
+		return ss.crud.Delete(existingBlob)
+	}
+
+	return nil
 }
 
 func (ss *MediorumServer) replicateFileToHost(peer Peer, fileName string, file io.Reader) error {
+	// logger := ss.logger.With()
 	if peer.Host == ss.Config.Self.Host {
 		return ss.replicateToMyBucket(fileName, file)
 	}
@@ -92,8 +112,8 @@ func (ss *MediorumServer) replicateFileToHost(peer Peer, fileName string, file i
 	}
 
 	// first check if target already has it...
-	if ss.hostHasBlob(peer.Host, fileName) {
-		ss.logger.Debug(peer.Host + " already has " + fileName)
+	if ss.hostHasBlob(peer.Host, fileName, true) {
+		ss.logger.Info(peer.Host + " already has " + fileName)
 		return nil
 	}
 
@@ -117,7 +137,7 @@ func (ss *MediorumServer) replicateFileToHost(peer Peer, fileName string, file i
 	}()
 
 	req := signature.SignedPost(
-		peer.ApiPath("internal/blobs"),
+		peer.ApiPath("internal/blobs")+"?cid="+fileName,
 		m.FormDataContentType(),
 		r,
 		ss.Config.privateKey)
@@ -136,11 +156,17 @@ func (ss *MediorumServer) replicateFileToHost(peer Peer, fileName string, file i
 	return <-errChan
 }
 
-func (ss *MediorumServer) hostHasBlob(host, key string) bool {
+// this is a "quick check" that a host has a blob
+// used for checking host has blob before redirecting to it
+func (ss *MediorumServer) hostHasBlob(host, key string, doubleCheck bool) bool {
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	u := apiPath(host, "internal/blobs/info", key)
+	checkMethod := "info"
+	if doubleCheck {
+		checkMethod = "double_check"
+	}
+	u := apiPath(host, "internal/blobs", checkMethod, key)
 	has, err := client.Get(u)
 	if err != nil {
 		return false

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -165,3 +165,14 @@ func computeFileCID(f io.ReadSeeker) (string, error) {
 	}
 	return cid.String(), nil
 }
+
+func validateCID(expectedCID string, f io.ReadSeeker) error {
+	computed, err := computeFileCID(f)
+	if err != nil {
+		return err
+	}
+	if computed != expectedCID {
+		return fmt.Errorf("expected cid: %s but contents hashed to %s", expectedCID, computed)
+	}
+	return nil
+}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -244,9 +244,11 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	internalApi.POST("/crud/push", ss.serveCrudPush, middleware.BasicAuth(ss.checkBasicAuth))
 
 	// internal: blobs
+	internalApi.GET("/blobs/broken", ss.getBlobBroken)
 	internalApi.GET("/blobs/problems", ss.getBlobProblems)
 	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation)
 	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo)
+	internalApi.GET("/blobs/double_check/:cid", ss.getBlobDoubleCheck)
 	internalApi.POST("/blobs", ss.postBlob, middleware.BasicAuth(ss.checkBasicAuth))
 
 	// WIP internal: metrics


### PR DESCRIPTION
### Description

When debugging problem blobs on staging, found a few edge cases which caused repair to not work:

* a node would have a blob on disk but no `blob` row in db.  In this case peers would think that node doesn't have the blob and attempt to replicate blob to it repeatedly.
* a blob would be corrupt and the contents would hash to a different CID.  In this case node would try to push blob to peers but CID wouldn't match up and it would reject it, and node would keep retrying.

So this PR addresses it by:
* adding a blob `double_check` endpoint that will only return 200 if: node has blob, CID validates, node has db record for blob.
* making the blob create + delete more like an upsert, where it will write the blob (if missing) and write the db record (if missing) and one or both of those can happen, so that the end state is that both the blob and db record will exist (or not in case of delete)
* delete a blob if the CID validation fails.  adios.
* also adds more consistent logs and a "broken blob" endpoint to help with debugging. 

We were talking about a background task to reconcile on-disk and db state (i.e. to handle someone just deleting files from the file system)... this PR should mostly achieve the same behavior lazily as part of the routine repair.go between servers.

### How Has This Been Tested?

Deployed to staging... problem blobs went from ~80 to 2... then added the code to delete invalid CIDs... went from 2 to zero, and there's no on-going re-replication attempts.