### PR TITLE
[PAY-1409] DMs: Include chat_id in push notification

### DIFF
--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -72,7 +72,10 @@ describe('Push Notifications', () => {
       {
         title: 'Message',
         body: `New message from ${user1.name}`,
-        data: {}
+        data: {
+          type: 'Message',
+          chatId
+        }
       }
     )
 
@@ -101,6 +104,7 @@ describe('Push Notifications', () => {
         title: 'Reaction',
         body: `${user2.name} reacted ${reaction} to your message`,
         data: {
+          type: 'MessageReaction',
           chatId,
           messageId
         }
@@ -156,6 +160,7 @@ describe('Push Notifications', () => {
         title: 'Message',
         body: `New message from ${user1.name}`,
         data: {
+          type: 'Message',
           chatId
         }
       }

--- a/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -100,7 +100,10 @@ describe('Push Notifications', () => {
       {
         title: 'Reaction',
         body: `${user2.name} reacted ${reaction} to your message`,
-        data: {}
+        data: {
+          chatId,
+          messageId
+        }
       }
     )
   }, 40000)
@@ -152,7 +155,9 @@ describe('Push Notifications', () => {
       {
         title: 'Message',
         body: `New message from ${user1.name}`,
-        data: {}
+        data: {
+          chatId
+        }
       }
     )
 

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
@@ -98,7 +98,8 @@ export class Message extends BaseNotification<DMNotification> {
               title,
               body,
               data: {
-                chat_id: this.notification.chat_id
+                type: 'Message',
+                chatId: this.notification.chat_id
               }
             }
           )

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/message.ts
@@ -97,7 +97,9 @@ export class Message extends BaseNotification<DMNotification> {
             {
               title,
               body,
-              data: {}
+              data: {
+                chat_id: this.notification.chat_id
+              }
             }
           )
         })

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/messageReaction.ts
@@ -103,7 +103,11 @@ export class MessageReaction extends BaseNotification<DMReactionNotification> {
             {
               title,
               body,
-              data: {}
+              data: {
+                type: 'MessageReaction',
+                chatId: this.notification.chat_id,
+                messageId: this.notification.message_id
+              }
             }
           )
         })

--- a/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -88,6 +88,7 @@ async function getUnreadReactions(
   return await discoveryDB
     .select(
       'chat_member.chat_id as chat_id',
+      'chat_message.message_id',
       'chat_message_reactions.user_id as sender_user_id',
       'chat_message.user_id as receiver_user_id',
       'chat_message_reactions.reaction as reaction',

--- a/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -62,6 +62,7 @@ async function getUnreadMessages(
 ): Promise<DMNotification[]> {
   return await discoveryDB
     .select(
+      'chat_member.chat_id as chat_id',
       'chat_message.user_id as sender_user_id',
       'chat_member.user_id as receiver_user_id',
       'chat_message.created_at as timestamp'
@@ -86,6 +87,7 @@ async function getUnreadReactions(
 ): Promise<DMReactionNotification[]> {
   return await discoveryDB
     .select(
+      'chat_member.chat_id as chat_id',
       'chat_message_reactions.user_id as sender_user_id',
       'chat_message.user_id as receiver_user_id',
       'chat_message_reactions.reaction as reaction',

--- a/discovery-provider/plugins/notifications/src/types/notifications.ts
+++ b/discovery-provider/plugins/notifications/src/types/notifications.ts
@@ -14,6 +14,7 @@ export type DMNotification = {
 
 export type DMReactionNotification = {
   chat_id: string
+  message_id: string
   sender_user_id: number
   receiver_user_id: number
   reaction: string

--- a/discovery-provider/plugins/notifications/src/types/notifications.ts
+++ b/discovery-provider/plugins/notifications/src/types/notifications.ts
@@ -6,12 +6,14 @@ import {
 import { NotificationRow } from './dn'
 
 export type DMNotification = {
+  chat_id: string
   sender_user_id: number
   receiver_user_id: number
   timestamp: Date
 }
 
 export type DMReactionNotification = {
+  chat_id: string
   sender_user_id: number
   receiver_user_id: number
   reaction: string


### PR DESCRIPTION
### Description

Send `chat_id` in push notifications so we can deep-link in the app to that chat

Related: https://github.com/AudiusProject/audius-client/pull/3549

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

It hasn't