### PR TITLE
Switch acdc version to latest working

### DIFF
--- a/discovery-provider/chain/Dockerfile.acdc
+++ b/discovery-provider/chain/Dockerfile.acdc
@@ -1,3 +1,3 @@
-FROM nethermind/nethermind:1.18.0
+FROM nethermind/nethermind:1.17.4
 
 RUN apt-get update && apt-get -y install curl jq


### PR DESCRIPTION
### Description

1.18 is not usable by us, image is built for 1.17.4 using README
Compose change: https://github.com/AudiusProject/audius-docker-compose/pull/299

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Sandbox, but will soak on stage before production deployment 