### PR TITLE
[CON-744] Update mediorum health_check and healthz

### DIFF
--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -2,7 +2,10 @@ version: "3.9"
 
 services:
   storagev2:
-    build: ${PROJECT_ROOT}/mediorum
+    build:
+      context: ${PROJECT_ROOT}/mediorum
+      args:
+        git_sha: "${GIT_COMMIT}"
     restart: unless-stopped
     entrypoint: /bin/sh
     command: /tmp/dev-tools/startup/storagev2.sh 3 # Change 3 to number of nodes if you want more or fewer (up to 5)
@@ -14,7 +17,6 @@ services:
       - web3EthProviderUrl=http://eth-ganache:8545 # Used only in register script
       - ethProviderUrl=http://eth-ganache:8545
       - ethRegistryAddress=${ETH_REGISTRY_ADDRESS}
-      - GIT_SHA=${GIT_COMMIT}
     env_file: .env # Used in register script to get wallets
     ports:
       - 1991:1991

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -261,3 +261,11 @@ func (c *Crudr) ApplyOp(op *Op) error {
 
 	return nil
 }
+
+func (c *Crudr) GetOutboxSizes() map[string]int {
+	sizes := make(map[string]int)
+	for _, p := range c.peerClients {
+		sizes[p.Host] = len(p.outbox)
+	}
+	return sizes
+}

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -5,9 +5,21 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/exp/slog"
 )
+
+func (ss *MediorumServer) monitorCidCursors() {
+	ticker := time.NewTicker(10 * time.Second)
+	for range ticker.C {
+		cidCursors := []cidCursor{}
+		ctx := context.Background()
+		if err := pgxscan.Select(ctx, ss.pgPool, &cidCursors, `select * from cid_cursor order by host`); err == nil {
+			ss.cachedCidCursors = cidCursors
+		}
+	}
+}
 
 func (ss *MediorumServer) monitorDiskAndDbStatus() {
 	ss.updateDiskAndDbStatus()

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -29,7 +29,6 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifier:   &ethcontracts.NotifierInfo{Wallet: "0xnotifier", Endpoint: "http://notifier.com", Email: "dmca@notifier.com"},
 		Env:               "DEV",
 		Self:              Peer{Host: "test1.com", Wallet: "0xtest1"},
-		Peers:             []Peer{{Host: "test2.com", Wallet: "0xtest2"}},
 		Signers:           []Peer{{Host: "test2.com", Wallet: "0xtest2"}},
 		ReplicationFactor: 3,
 		Dir:               "/dir",
@@ -38,7 +37,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"listenPort":"1991","peerHealths":null,"peers":[{"host":"test2.com","wallet":"0xtest2"}],"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0"}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0"}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -5,9 +5,10 @@ import (
 )
 
 type Metrics struct {
-	Host         string `json:"host"`
-	Uploads      int64  `json:"uploads"`
-	ProblemBlobs int64  `json:"problem_blobs"`
+	Host         string         `json:"host"`
+	Uploads      int64          `json:"uploads"`
+	ProblemBlobs int64          `json:"problem_blobs"`
+	OutboxSizes  map[string]int `json:"outbox_sizes"`
 }
 
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
@@ -23,6 +24,8 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	uploads := []*Upload{}
 	ss.crud.DB.Order("created_at desc").Find(&uploads).Count(&ucount)
 	m.Uploads = ucount
+
+	m.OutboxSizes = ss.crud.GetOutboxSizes()
 
 	return c.JSON(200, m)
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -76,8 +76,9 @@ type MediorumServer struct {
 	storagePathSize uint64
 	databaseSize    uint64
 
-	peerHealthMutex sync.RWMutex
-	peerHealth      map[string]time.Time
+	peerHealthMutex  sync.RWMutex
+	peerHealth       map[string]time.Time
+	cachedCidCursors []cidCursor
 
 	StartedAt time.Time
 	Config    MediorumConfig
@@ -307,6 +308,8 @@ func (ss *MediorumServer) MustStart() {
 	go ss.startPollingDelistStatuses()
 
 	go ss.monitorDiskAndDbStatus()
+
+	go ss.monitorCidCursors()
 
 	// signals
 	signal.Notify(ss.quit, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
### Description

- Healthz: adds peer health and makes "started at" compatible with latest health check consolidation commit (currently foundation nodes show empty values in this column)
- Mediorum health check: fixes empty git field and caches cid cursors for 10 seconds to avoid unbounded db requests
- Exposes outbox sizes via `/internal/metrics`

### How Has This Been Tested?

Checked healthz after running locally, and deployed to stage CN6 to confirm view on healthz and /health_check git sha.