### PR TITLE
[PAY-1341] Add optional currentUserId to every chats request

### DIFF
--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -270,11 +270,14 @@ export class ChatsApi
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
-    const { userIds } = parseRequestParameters(
+    const { userIds, currentUserId } = parseRequestParameters(
       'getPermissions',
       ChatGetPermissionRequestSchema
     )(requestParameters)
     query['id'] = userIds
+    if (currentUserId) {
+      query['current_user_id'] = currentUserId
+    }
 
     const res = await this.signAndSendRequest({
       method: 'GET',

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -27,12 +27,16 @@ import {
   ChatEvents,
   ChatGetAllRequest,
   ChatGetAllRequestSchema,
+  ChatGetBlockersRequest,
+  ChatGetBlockersRequestSchema,
   ChatGetMessagesRequest,
   ChatGetMessagesRequestSchema,
   ChatGetPermissionRequest,
   ChatGetPermissionRequestSchema,
   ChatGetRequest,
   ChatGetRequestSchema,
+  ChatGetUnreadCountRequest,
+  ChatGetUnreadCountRequestSchema,
   ChatInviteRequest,
   ChatInviteRequestSchema,
   ChatListenRequest,
@@ -246,10 +250,10 @@ export class ChatsApi
    * @param requestParameters.currentUserId the user to act on behalf of
    * @returns the unread count response
    */
-  public async getUnreadCount(requestParameters: ChatUnreadCountRequest) {
+  public async getUnreadCount(requestParameters: ChatGetUnreadCountRequest) {
     const { currentUserId } = parseRequestParameters(
       'getUnreadCount',
-      ChatUnreadCountRequestSchema
+      ChatGetUnreadCountRequestSchema
     )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
@@ -288,9 +292,21 @@ export class ChatsApi
     return (await res.json()) as TypedCommsResponse<ValidatedChatPermissions[]>
   }
 
-  public async getBlockers() {
+  /**
+   * Gets the user ids that have blocked the current user
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the blockers response
+   */
+  public async getBlockers(requestParameters: ChatGetBlockersRequest) {
+    const { currentUserId } = parseRequestParameters(
+      'getBlockers',
+      ChatGetBlockersRequestSchema
+    )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
+    }
+    if (currentUserId) {
+      query['current_user_id'] = currentUserId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',
@@ -301,9 +317,21 @@ export class ChatsApi
     return (await response.json()) as TypedCommsResponse<string[]>
   }
 
-  public async getBlockees() {
+  /**
+   * Gets the user ids the current user has blocked
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns
+   */
+  public async getBlockees(requestParameters: ChatGetBlockersRequest) {
+    const { currentUserId } = parseRequestParameters(
+      'getBlockees',
+      ChatGetBlockersRequestSchema
+    )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
+    }
+    if (currentUserId) {
+      query['current_user_id'] = currentUserId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -62,8 +62,17 @@ export class ChatsApi
   extends BaseAPI
   implements EventEmitterTarget<ChatEvents>
 {
+  /**
+   * A map of chatId => chatSecret so we don't have to repeatedly fetch it
+   */
   private chatSecrets: Record<string, Uint8Array> = {}
+  /**
+   * An event emitter that's used for consumers to listen for chat events
+   */
   private readonly eventEmitter: TypedEmitter<ChatEvents>
+  /**
+   * The websocket currently in use
+   */
   private websocket: WebSocket | undefined
   /**
    * The current user ID to use when connecting/reconnecting the websocket

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -138,6 +138,12 @@ export class ChatsApi
     }
   }
 
+  /**
+   * Gets a single chat
+   * @param requestParameters.chatId the chat to get
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the chat response
+   */
   public async get(requestParameters: ChatGetRequest) {
     const { chatId, currentUserId } = parseRequestParameters(
       'get',
@@ -152,6 +158,14 @@ export class ChatsApi
     }
   }
 
+  /**
+   * Gets a list of chats
+   * @param requestParameters.limit the max number of chats to get
+   * @param requestParameters.before a timestamp cursor for pagination
+   * @param requestParameters.after a timestamp cursor for pagination
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the chat list response
+   */
   public async getAll(requestParameters?: ChatGetAllRequest) {
     const { currentUserId, limit, before, after } = parseRequestParameters(
       'getAll',
@@ -190,6 +204,14 @@ export class ChatsApi
     }
   }
 
+  /**
+   * Gets a list of messages
+   * @param requestParameters.chatId the chat to get messages for
+   * @param requestParameters.before a timestamp cursor for pagination
+   * @param requestParameters.after a timestamp cursor for pagination
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the messages list response
+   */
   public async getMessages(
     requestParameters: ChatGetMessagesRequest
   ): Promise<TypedCommsResponse<ChatMessage[]>> {
@@ -270,6 +292,12 @@ export class ChatsApi
     return (await res.json()) as TypedCommsResponse<number>
   }
 
+  /**
+   * Gets the permission settings of the given users
+   * @param requestParameters.userIds the users to fetch permissions of
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the permissions response
+   */
   public async getPermissions(requestParameters: ChatGetPermissionRequest) {
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
@@ -342,6 +370,11 @@ export class ChatsApi
     return (await response.json()) as TypedCommsResponse<string[]>
   }
 
+  /**
+   * Gets URL metadata useful for link previews
+   * @param requestParameters.content the urls to get metadata for
+   * @returns the unfurl response
+   */
   public async unfurl(requestParameters: ChatUnfurlRequest) {
     const { urls } = parseRequestParameters(
       'unfurl',
@@ -363,6 +396,13 @@ export class ChatsApi
 
   // #region MUTATE
 
+  /**
+   * Creates a chat between users
+   * @param requestParameters.userId the user id who is creating the chat
+   * @param requestParameters.invitedUserIds the user ids to add to the chat
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async create(requestParameters: ChatCreateRequest) {
     const { currentUserId, userId, invitedUserIds } = parseRequestParameters(
       'create',
@@ -384,6 +424,14 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Invites other users to an existing chat
+   * @param requestParameters.chatId the chat id of the chat to invite to
+   * @param requestParameters.userId the user id who is creating the chat
+   * @param requestParameters.invitedUserIds the user ids to add to the chat
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async invite(requestParameters: ChatInviteRequest) {
     const { currentUserId, chatId, userId, invitedUserIds } =
       parseRequestParameters(
@@ -403,6 +451,14 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Sends a message to a user in a chat
+   * @param requestParameters.message the message
+   * @param requestParameters.chatId the chat to send a message in
+   * @param requestParameters.messageId the id of the message
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async message(requestParameters: ChatMessageRequest) {
     const { currentUserId, chatId, message, messageId } =
       parseRequestParameters(
@@ -424,6 +480,14 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Reacts to a message
+   * @param requestParameters.reaction the reaction
+   * @param requestParameters.chatId the chat to send a reaction in
+   * @param requestParameters.messageId the id of the message to react to
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async react(requestParameters: ChatReactRequest) {
     const { currentUserId, chatId, messageId, reaction } =
       parseRequestParameters('react', ChatReactRequestSchema)(requestParameters)
@@ -438,6 +502,12 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Marks a chat as read
+   * @param requestParameters.chatId the chat to mark as read
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async read(requestParameters: ChatReadRequest) {
     const { currentUserId, chatId } = parseRequestParameters(
       'read',
@@ -452,6 +522,12 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Blocks a user from sending messages to the current user
+   * @param requestParameters.userId the user to block
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async block(requestParameters: ChatBlockRequest) {
     const { currentUserId, userId } = parseRequestParameters(
       'block',
@@ -466,6 +542,12 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Unblocks a user from sending messages to the current user
+   * @param requestParameters.userId the user to unblock
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async unblock(requestParameters: ChatBlockRequest) {
     const { currentUserId, userId } = parseRequestParameters(
       'unblock',
@@ -480,6 +562,12 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Clears a chat's history for the current user
+   * @param requestParameters.chatId the chat to clear
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async delete(requestParameters: ChatDeleteRequest) {
     const { currentUserId, chatId } = parseRequestParameters(
       'delete',
@@ -494,6 +582,12 @@ export class ChatsApi
     })
   }
 
+  /**
+   * Sets the inbox settings permissions of the current user
+   * @param requestParameters.permit the permission to set
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the rpc object
+   */
   public async permit(requestParameters: ChatPermitRequest) {
     const { currentUserId, permit } = parseRequestParameters(
       'permit',

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -241,9 +241,21 @@ export class ChatsApi
     }
   }
 
-  public async getUnreadCount() {
+  /**
+   * Gets the total unread message count for a user
+   * @param requestParameters.currentUserId the user to act on behalf of
+   * @returns the unread count response
+   */
+  public async getUnreadCount(requestParameters: ChatUnreadCountRequest) {
+    const { currentUserId } = parseRequestParameters(
+      'getUnreadCount',
+      ChatUnreadCountRequestSchema
+    )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
+    }
+    if (currentUserId) {
+      query['current_user_id'] = currentUserId
     }
     const res = await this.signAndSendRequest({
       method: 'GET',

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -135,11 +135,11 @@ export class ChatsApi
   }
 
   public async get(requestParameters: ChatGetRequest) {
-    const { chatId } = parseRequestParameters(
+    const { chatId, currentUserId } = parseRequestParameters(
       'get',
       ChatGetRequestSchema
     )(requestParameters)
-    const response = await this.getRaw(chatId)
+    const response = await this.getRaw(chatId, currentUserId)
     return {
       ...response,
       data: response.data
@@ -551,10 +551,13 @@ export class ChatsApi
     }
   }
 
-  private async getRaw(chatId: string) {
+  private async getRaw(chatId: string, currentUserId?: string) {
     const path = `/comms/chats/${chatId}`
     const queryParameters: HTTPQuery = {
       timestamp: new Date().getTime()
+    }
+    if (currentUserId) {
+      queryParameters['current_user_id'] = currentUserId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',

--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -273,15 +273,15 @@ export class ChatsApi
    * @returns the unread count response
    */
   public async getUnreadCount(requestParameters: ChatGetUnreadCountRequest) {
-    const { currentUserId } = parseRequestParameters(
+    const parsedArgs = parseRequestParameters(
       'getUnreadCount',
       ChatGetUnreadCountRequestSchema
     )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
-    if (currentUserId) {
-      query['current_user_id'] = currentUserId
+    if (parsedArgs?.currentUserId) {
+      query['current_user_id'] = parsedArgs.currentUserId
     }
     const res = await this.signAndSendRequest({
       method: 'GET',
@@ -325,16 +325,16 @@ export class ChatsApi
    * @param requestParameters.currentUserId the user to act on behalf of
    * @returns the blockers response
    */
-  public async getBlockers(requestParameters: ChatGetBlockersRequest) {
-    const { currentUserId } = parseRequestParameters(
+  public async getBlockers(requestParameters?: ChatGetBlockersRequest) {
+    const parsedArgs = parseRequestParameters(
       'getBlockers',
       ChatGetBlockersRequestSchema
     )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
-    if (currentUserId) {
-      query['current_user_id'] = currentUserId
+    if (parsedArgs?.currentUserId) {
+      query['current_user_id'] = parsedArgs.currentUserId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',
@@ -350,16 +350,16 @@ export class ChatsApi
    * @param requestParameters.currentUserId the user to act on behalf of
    * @returns
    */
-  public async getBlockees(requestParameters: ChatGetBlockersRequest) {
-    const { currentUserId } = parseRequestParameters(
+  public async getBlockees(requestParameters?: ChatGetBlockersRequest) {
+    const parsedArgs = parseRequestParameters(
       'getBlockees',
       ChatGetBlockersRequestSchema
     )(requestParameters)
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
-    if (currentUserId) {
-      query['current_user_id'] = currentUserId
+    if (parsedArgs?.currentUserId) {
+      query['current_user_id'] = parsedArgs.currentUserId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -43,6 +43,22 @@ export type ChatGetMessagesRequest = z.infer<
   typeof ChatGetMessagesRequestSchema
 >
 
+export const ChatGetUnreadCountRequestSchema = z.object({
+  currentUserId: z.optional(z.string())
+})
+
+export type ChatGetUnreadCountRequest = z.infer<
+  typeof ChatGetUnreadCountRequestSchema
+>
+
+export const ChatGetBlockersRequestSchema = z.object({
+  currentUserId: z.optional(z.string())
+})
+
+export type ChatGetBlockersRequest = z.infer<
+  typeof ChatGetBlockersRequestSchema
+>
+
 export const ChatCreateRequestSchema = z.object({
   currentUserId: z.optional(z.string()),
   userId: z.string(),

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -43,17 +43,21 @@ export type ChatGetMessagesRequest = z.infer<
   typeof ChatGetMessagesRequestSchema
 >
 
-export const ChatGetUnreadCountRequestSchema = z.object({
-  currentUserId: z.optional(z.string())
-})
+export const ChatGetUnreadCountRequestSchema = z.optional(
+  z.object({
+    currentUserId: z.optional(z.string())
+  })
+)
 
 export type ChatGetUnreadCountRequest = z.infer<
   typeof ChatGetUnreadCountRequestSchema
 >
 
-export const ChatGetBlockersRequestSchema = z.object({
-  currentUserId: z.optional(z.string())
-})
+export const ChatGetBlockersRequestSchema = z.optional(
+  z.object({
+    currentUserId: z.optional(z.string())
+  })
+)
 
 export type ChatGetBlockersRequest = z.infer<
   typeof ChatGetBlockersRequestSchema

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -25,6 +25,7 @@ export const ChatGetAllRequestSchema = z.object({
 export type ChatGetAllRequest = z.infer<typeof ChatGetAllRequestSchema>
 
 export const ChatGetRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   chatId: z.string()
 })
 

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -9,6 +9,12 @@ import {
 
 // REQUEST PARAMETERS
 
+export const ChatListenRequestSchema = z.object({
+  currentUserId: z.optional(z.string())
+})
+
+export type ChatListenRequest = z.infer<typeof ChatListenRequestSchema>
+
 export const ChatGetAllRequestSchema = z.object({
   currentUserId: z.optional(z.string()),
   limit: z.optional(z.number()),

--- a/libs/src/sdk/api/chats/clientTypes.ts
+++ b/libs/src/sdk/api/chats/clientTypes.ts
@@ -10,6 +10,7 @@ import {
 // REQUEST PARAMETERS
 
 export const ChatGetAllRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   limit: z.optional(z.number()),
   before: z.optional(z.string()),
   after: z.optional(z.string())
@@ -24,6 +25,7 @@ export const ChatGetRequestSchema = z.object({
 export type ChatGetRequest = z.infer<typeof ChatGetRequestSchema>
 
 export const ChatGetMessagesRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   chatId: z.string(),
   limit: z.optional(z.number()),
   before: z.optional(z.string()),
@@ -35,6 +37,7 @@ export type ChatGetMessagesRequest = z.infer<
 >
 
 export const ChatCreateRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   userId: z.string(),
   invitedUserIds: z.array(z.string()).min(1)
 })
@@ -42,6 +45,7 @@ export const ChatCreateRequestSchema = z.object({
 export type ChatCreateRequest = z.infer<typeof ChatCreateRequestSchema>
 
 export const ChatInviteRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   chatId: z.string(),
   userId: z.string(),
   invitedUserIds: z.array(z.string()).min(1)
@@ -50,6 +54,7 @@ export const ChatInviteRequestSchema = z.object({
 export type ChatInviteRequest = z.infer<typeof ChatInviteRequestSchema>
 
 export const ChatMessageRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   chatId: z.string(),
   messageId: z.optional(z.string()),
   message: z.string()
@@ -58,6 +63,7 @@ export const ChatMessageRequestSchema = z.object({
 export type ChatMessageRequest = z.infer<typeof ChatMessageRequestSchema>
 
 export const ChatReactRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   chatId: z.string(),
   messageId: z.string(),
   reaction: z.nullable(z.string())
@@ -65,27 +71,36 @@ export const ChatReactRequestSchema = z.object({
 
 export type ChatReactRequest = z.infer<typeof ChatReactRequestSchema>
 
-export const ChatReadRequestSchema = z.object({ chatId: z.string() })
+export const ChatReadRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
+  chatId: z.string()
+})
 
 export type ChatReadRequest = z.infer<typeof ChatReadRequestSchema>
 
 export const ChatBlockRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   userId: z.string()
 })
 
 export type ChatBlockRequest = z.infer<typeof ChatBlockRequestSchema>
 
-export const ChatDeleteRequestSchema = z.object({ chatId: z.string() })
+export const ChatDeleteRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
+  chatId: z.string()
+})
 
 export type ChatDeleteRequest = z.infer<typeof ChatDeleteRequestSchema>
 
 export const ChatPermitRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   permit: z.nativeEnum(ChatPermission)
 })
 
 export type ChatPermitRequest = z.infer<typeof ChatPermitRequestSchema>
 
 export const ChatValidateCanCreateRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   userIds: z.array(z.string()).min(1)
 })
 
@@ -94,6 +109,7 @@ export type ChatValidateCanCreateRequest = z.infer<
 >
 
 export const ChatGetPermissionRequestSchema = z.object({
+  currentUserId: z.optional(z.string()),
   userIds: z.array(z.string()).min(1)
 })
 

--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -29,11 +29,11 @@ import { AbortController as AbortControllerPolyfill } from 'node-abort-controlle
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
 
 const getPathFromUrl = (url: string) => {
-  const pathRegex = /^([a-z]+:\/\/)?(?:www\.)?([^\/]+)?(.*)$/
+  const pathRegex = /^([a-z]+:\/\/)?(?:www\.)?([^/]+)?(.*)$/
 
   const match = url.match(pathRegex)
 
-  if (match && match[3]) {
+  if (match?.[3]) {
     const path = match[3]
     return path
   } else {
@@ -374,10 +374,10 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
         attemptedServicesCount
       })
       this.isBehind = false
+      return this.selectedNode
     } finally {
       this.reselectLock = false
       this.eventEmitter.emit('reselectAttemptComplete')
-      return this.selectedNode
     }
   }
 

--- a/libs/src/sdk/utils/parseRequestParameters.ts
+++ b/libs/src/sdk/utils/parseRequestParameters.ts
@@ -13,7 +13,10 @@ export class ParseRequestError extends Error {
  * @returns The parsed data or throws an error
  */
 export const parseRequestParameters =
-  <T extends z.AnyZodObject>(name: string, schema: T) =>
+  <T extends z.AnyZodObject | z.ZodOptional<z.AnyZodObject>>(
+    name: string,
+    schema: T
+  ) =>
   <J>(requestParameters: J): z.infer<T> => {
     const result = schema.safeParse(requestParameters)
     if (!result.success) {


### PR DESCRIPTION
### Description

In order to disambiguate since wallets are potentially linked to multiple accounts, we added a `currentUserId` field to each request that the SDK makes in `chats`. Prior to this, we were inferring user ID from signature. Given the bugs in signup, and given delegation coming in the future, we should support explicitly setting a user id to act on behalf of for each request.

Pending changes from @stereosteve for the read endpoints piece of this

Also includes some ESLint cleanup and some doc comments

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

TBD
