### PR TITLE
[Discovery API] Check if developer app was found before trying to format it

### DIFF
--- a/discovery-provider/src/api/v1/developer_apps.py
+++ b/discovery-provider/src/api/v1/developer_apps.py
@@ -36,7 +36,7 @@ class GetDeveloperApp(Resource):
         raw_developer_app = get_developer_app_by_address(
             get_prefixed_eth_address(address)
         )
-        developer_app = format_developer_app(raw_developer_app)
-        if not developer_app:
+        if not raw_developer_app:
             abort_not_found(address, ns)
+        developer_app = format_developer_app(raw_developer_app)
         return success_response(developer_app)


### PR DESCRIPTION
### Description

The check was done out of order with the formatting, so endpoint was returning 500 instead of 404 if developer app with matching address was not found.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
