### PR TITLE
Fix name collision with developer_app schema

### DIFF
--- a/discovery-provider/src/api/v1/developer_apps.py
+++ b/discovery-provider/src/api/v1/developer_apps.py
@@ -13,7 +13,7 @@ from src.utils.redis_metrics import record_metrics
 ns = Namespace("developer_apps", description="Developer app related operations")
 
 developer_app_response = make_response(
-    "developer_app", ns, fields.Nested(developer_app)
+    "developer_app_response", ns, fields.Nested(developer_app)
 )
 
 


### PR DESCRIPTION
### Description

Fixes issue where "developer_app" was being used as a model and as an endpoint