### PR TITLE
[INF-423] Fix sdk gen with audius-compose

### DIFF
--- a/libs/src/sdk/api/generator/gen.js
+++ b/libs/src/sdk/api/generator/gen.js
@@ -5,7 +5,7 @@ const program = new commander.Command()
 
 const spawnOpenAPIGenerator = (openApiGeneratorArgs) => {
   console.log('Running OpenAPI Generator:')
-  const fullCmd = `docker run --rm -v "${
+  const fullCmd = `docker run --add-host=audius-protocol-discovery-provider-1:host-gateway --rm -v "${
     process.env.PWD
   }:/local" openapitools/openapi-generator-cli ${openApiGeneratorArgs.join(
     ' '
@@ -30,7 +30,7 @@ const generate = ({ env, apiVersion, apiFlavor, generator }) => {
   // Setup args
   let baseURL = ''
   if (env === 'dev') {
-    baseURL = 'http://host.docker.internal:5000'
+    baseURL = 'http://audius-protocol-discovery-provider-1'
   } else if (env === 'stage') {
     // Hardcode a stage DN, it doesn't matter
     baseURL = 'https://discoveryprovider.staging.audius.co'


### PR DESCRIPTION
### Description

* `npm run gen:dev` was failing because openapigenerator couldn't connect to `audius-protocol-discovery-provider-1`. Adding an additional host to the docker command fixes it, thanks @theoilie !

The additional host should have no effect on CI, in stage or prod environments

### How Has This Been Tested?

Generated sdk locally
