### PR TITLE
[CON-746] Improve content node usage of eth rpc

### DIFF
--- a/creator-node/src/services/ContentNodeInfoManager.ts
+++ b/creator-node/src/services/ContentNodeInfoManager.ts
@@ -19,7 +19,6 @@ import { createChildLogger } from '../logging'
 import defaultRedisClient from '../redis'
 import { timeout } from '../utils'
 import { asyncRetry } from '../utils/asyncRetry'
-import config from '../config'
 
 const SP_ID_TO_CHAIN_INFO_MAP_KEY = 'contentNodeInfoManagerSpIdMap'
 

--- a/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
+++ b/creator-node/src/services/stateMachineManager/stateReconciliation/updateReplicaSet.jobProcessor.ts
@@ -147,7 +147,9 @@ const updateReplicaSetJobProcessor = async function ({
           performSyncCheck: false,
           whitelist: reconfigNodeWhitelist,
           blacklist: reconfigNodeBlacklist,
-          log: true
+          log: true,
+          getServices: () =>
+            Array.from(spInfoMap.values()).map((c) => c.endpoint)
         })
 
       healthyNodes = Object.keys(healthyServicesMap || {})

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -12,7 +12,7 @@ const {
 const { hasEnoughStorageSpace } = require('../fileManager')
 const {
   getMapOfCNodeEndpointToSpId
-} = require('services/ContentNodeInfoManager')
+} = require('../services/ContentNodeInfoManager')
 
 const PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS = config.get(
   'peerHealthCheckRequestTimeout'

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -10,6 +10,9 @@ const {
   GET_NODE_USERS_DEFAULT_PAGE_SIZE
 } = require('./StateMachineConstants')
 const { hasEnoughStorageSpace } = require('../fileManager')
+const {
+  getMapOfCNodeEndpointToSpId
+} = require('services/ContentNodeInfoManager')
 
 const PEER_HEALTH_CHECK_REQUEST_TIMEOUT_MS = config.get(
   'peerHealthCheckRequestTimeout'
@@ -170,8 +173,7 @@ class PeerSetManager {
         logger.error(`getNodeUsers request canceled: ${e.message}`)
       }
       throw new Error(
-        `getNodeUsers() Error: ${e.toString()} - connected discprov [${
-          this.discoveryProviderEndpoint
+        `getNodeUsers() Error: ${e.toString()} - connected discprov [${this.discoveryProviderEndpoint
         }]`
       )
     } finally {
@@ -267,8 +269,7 @@ class PeerSetManager {
       })
     ) {
       throw new Error(
-        `Almost out of storage=${
-          storagePathSize - storagePathUsed
+        `Almost out of storage=${storagePathSize - storagePathUsed
         }bytes remaining out of ${storagePathSize}. Requires less than ${MAX_STORAGE_USED_PERCENT}% used`
       )
     }
@@ -281,8 +282,7 @@ class PeerSetManager {
       totalMemory - usedMemory <= MINIMUM_MEMORY_AVAILABLE
     ) {
       throw new Error(
-        `Running low on memory=${
-          totalMemory - usedMemory
+        `Running low on memory=${totalMemory - usedMemory
         }bytes remaining. Minimum memory required=${MINIMUM_MEMORY_AVAILABLE}bytes`
       )
     }
@@ -294,13 +294,11 @@ class PeerSetManager {
       allocatedFileDescriptors &&
       maxFileDescriptors &&
       allocatedFileDescriptors / maxFileDescriptors >=
-        MAX_FILE_DESCRIPTORS_ALLOCATED_PERCENTAGE
+      MAX_FILE_DESCRIPTORS_ALLOCATED_PERCENTAGE
     ) {
       throw new Error(
-        `Running low on file descriptors availability=${
-          (allocatedFileDescriptors / maxFileDescriptors) * 100
-        }% used. Max file descriptors allocated percentage allowed=${
-          MAX_FILE_DESCRIPTORS_ALLOCATED_PERCENTAGE * 100
+        `Running low on file descriptors availability=${(allocatedFileDescriptors / maxFileDescriptors) * 100
+        }% used. Max file descriptors allocated percentage allowed=${MAX_FILE_DESCRIPTORS_ALLOCATED_PERCENTAGE * 100
         }%`
       )
     }
@@ -312,11 +310,10 @@ class PeerSetManager {
       dailySyncFailCount &&
       dailySyncSuccessCount + dailySyncFailCount > MINIMUM_DAILY_SYNC_COUNT &&
       dailySyncSuccessCount / (dailySyncFailCount + dailySyncSuccessCount) <
-        MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE
+      MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE
     ) {
       throw new Error(
-        `Latest daily sync data shows that this node fails at a high rate of syncs. Successful syncs=${dailySyncSuccessCount} || Failed syncs=${dailySyncFailCount}. Minimum successful sync percentage=${
-          MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE * 100
+        `Latest daily sync data shows that this node fails at a high rate of syncs. Successful syncs=${dailySyncSuccessCount} || Failed syncs=${dailySyncFailCount}. Minimum successful sync percentage=${MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE * 100
         }%`
       )
     }
@@ -328,14 +325,13 @@ class PeerSetManager {
       thirtyDayRollingSyncSuccessCount &&
       thirtyDayRollingSyncFailCount &&
       thirtyDayRollingSyncSuccessCount + thirtyDayRollingSyncFailCount >
-        MINIMUM_ROLLING_SYNC_COUNT &&
+      MINIMUM_ROLLING_SYNC_COUNT &&
       thirtyDayRollingSyncSuccessCount /
-        (thirtyDayRollingSyncFailCount + thirtyDayRollingSyncSuccessCount) <
-        MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE
+      (thirtyDayRollingSyncFailCount + thirtyDayRollingSyncSuccessCount) <
+      MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE
     ) {
       throw new Error(
-        `Rolling sync data shows that this node fails at a high rate of syncs. Successful syncs=${thirtyDayRollingSyncSuccessCount} || Failed syncs=${thirtyDayRollingSyncFailCount}. Minimum successful sync percentage=${
-          MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE * 100
+        `Rolling sync data shows that this node fails at a high rate of syncs. Successful syncs=${thirtyDayRollingSyncSuccessCount} || Failed syncs=${thirtyDayRollingSyncFailCount}. Minimum successful sync percentage=${MINIMUM_SUCCESSFUL_SYNC_COUNT_PERCENTAGE * 100
         }%`
       )
     }
@@ -346,27 +342,9 @@ class PeerSetManager {
    * `this.endpointToSPIdMap` value. If the existing map is empty, throw error as we need this map to issue reconfigs.
    * @param {Object} ethContracts audiusLibs.ethContracts instance; has helper fn to get service provider info
    */
-  async updateEndpointToSpIdMap(ethContracts) {
-    const endpointToSPIdMap = {}
-    try {
-      const contentNodes = await ethContracts.getServiceProviderList(
-        'content-node'
-      )
-      contentNodes.forEach((cn) => {
-        endpointToSPIdMap[cn.endpoint] = cn.spID
-      })
-    } catch (e) {
-      this.logError(`[updateEndpointToSpIdMap]: ${e.message}`)
-    }
-
-    if (Object.keys(endpointToSPIdMap).length > 0)
-      this.endpointToSPIdMap = endpointToSPIdMap
-    if (Object.keys(this.endpointToSPIdMap).length === 0) {
-      const errorMsg =
-        '[updateEndpointToSpIdMap]: Unable to initialize this.endpointToSPIdMap'
-      this.logError(errorMsg)
-      throw new Error(errorMsg)
-    }
+  async updateEndpointToSpIdMap() {
+    const cNodeEndpointToSpIdMap = await getMapOfCNodeEndpointToSpId()
+    return cNodeEndpointToSpIdMap
   }
 
   /**
@@ -418,7 +396,7 @@ class PeerSetManager {
         const failedTimestampPlusThreshold = new Date(failedTimestamp)
         failedTimestampPlusThreshold.setSeconds(
           failedTimestamp.getSeconds() +
-            this.maxNumberSecondsPrimaryRemainsUnhealthy
+          this.maxNumberSecondsPrimaryRemainsUnhealthy
         )
 
         // Determine if the failed timestamp + max hours threshold surpasses our allowed time threshold

--- a/creator-node/src/snapbackSM/peerSetManager.js
+++ b/creator-node/src/snapbackSM/peerSetManager.js
@@ -340,11 +340,9 @@ class PeerSetManager {
   /**
    * Updates `this.endpointToSPIdMap` to the mapping of <endpoint : spId>. If the fetch fails, rely on the previous
    * `this.endpointToSPIdMap` value. If the existing map is empty, throw error as we need this map to issue reconfigs.
-   * @param {Object} ethContracts audiusLibs.ethContracts instance; has helper fn to get service provider info
    */
   async updateEndpointToSpIdMap() {
-    const cNodeEndpointToSpIdMap = await getMapOfCNodeEndpointToSpId()
-    return cNodeEndpointToSpIdMap
+    this.endpointToSPIdMap = await getMapOfCNodeEndpointToSpId()
   }
 
   /**

--- a/libs/src/api/ServiceProvider.ts
+++ b/libs/src/api/ServiceProvider.ts
@@ -32,6 +32,8 @@ type AutoSelectCreatorNodesConfig = {
   preferHigherPatchForPrimary?: boolean
   preferHigherPatchForSecondaries?: boolean
   log?: boolean
+  // override going to chain to generate a list of all service endpoints
+  getServices?: () => Promise<string[]>
 }
 
 /**
@@ -121,7 +123,8 @@ export class ServiceProvider extends Base {
     equivalencyDelta = CONTENT_NODE_SELECTION_EQUIVALENCY_DELTA,
     preferHigherPatchForPrimary = true,
     preferHigherPatchForSecondaries = true,
-    log = true
+    log = true,
+    getServices
   }: AutoSelectCreatorNodesConfig) {
     const creatorNodeSelection = new CreatorNodeSelection({
       creatorNode: this.creatorNode,
@@ -133,7 +136,8 @@ export class ServiceProvider extends Base {
       timeout,
       equivalencyDelta,
       preferHigherPatchForPrimary,
-      preferHigherPatchForSecondaries
+      preferHigherPatchForSecondaries,
+      getServices
     })
 
     const { primary, secondaries, services } =

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -55,6 +55,7 @@ type CreatorNodeSelectionConfig = Omit<
   preferHigherPatchForPrimary?: boolean
   preferHigherPatchForSecondaries?: boolean
   logger?: Logger
+  getServices?: () => Promise<string[]>
 }
 
 interface Decision {
@@ -89,21 +90,24 @@ export class CreatorNodeSelection extends ServiceSelection {
     timeout = null,
     equivalencyDelta = null,
     preferHigherPatchForPrimary = true,
-    preferHigherPatchForSecondaries = true
+    preferHigherPatchForSecondaries = true,
+    getServices
   }: CreatorNodeSelectionConfig) {
     super({
-      getServices: async () => {
-        this.currentVersion = await ethContracts.getCurrentVersion(
-          CREATOR_NODE_SERVICE_NAME
-        )
-        const services = await this.ethContracts.getServiceProviderList(
-          CREATOR_NODE_SERVICE_NAME
-        )
-        return services.map((e) => {
-          setSpIDForEndpoint(e.endpoint, e.spID)
-          return e.endpoint
-        })
-      },
+      getServices: getServices
+        ? getServices
+        : async () => {
+            this.currentVersion = await ethContracts.getCurrentVersion(
+              CREATOR_NODE_SERVICE_NAME
+            )
+            const services = await this.ethContracts.getServiceProviderList(
+              CREATOR_NODE_SERVICE_NAME
+            )
+            return services.map((e) => {
+              setSpIDForEndpoint(e.endpoint, e.spID)
+              return e.endpoint
+            })
+          },
       // Use the content node's configured whitelist if not provided
       whitelist: whitelist ?? creatorNode?.passList,
       blacklist: blacklist ?? creatorNode?.blockList


### PR DESCRIPTION
### Description

There's a content node <> libs dependency here, but the code should be safe to merge as is and just require a follow up PR to upgrade sdk in content node.

The gist of changes here are to reduce calling to chain *every time* job processors run (which is a lot) and instead try to rely on the unified sp-id mapping that gets refreshed every 10 min.
https://github.com/AudiusProject/audius-protocol/blob/2176ebd90d57e61d4ceeff2017580ca2857c6369/creator-node/src/config.js#L493

This comes at some disadvantages of course, but I think it's safe enough to do, especially given that we are moving off of the system entirely ~soon. From taking a look, it doesn't seem that mediorum drives a ton of eth RPC traffic. As a compromise, down to change the sp-id mapping interval to 1-2 minutes or so.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Not really sure the best way. Tests passing is something.