### PR TITLE
comms derives wallet address from private key

### DIFF
--- a/comms/discovery/config/constants.go
+++ b/comms/discovery/config/constants.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 var (
 
 	// Rate limit config
@@ -15,4 +17,22 @@ var (
 		RateLimitMaxNumMessagesPerRecipient: 1000,
 		RateLimitMaxNumNewChats:             100,
 	}
+
+	// honorary nodes used to create db snapshots
+	// are allowed read access.
+	honoraryNodes = []string{
+		// stage-discovery-4
+		"0xb1C931A9ac123866372CEbb6bbAF50FfD18dd5DF",
+		// prod-discovery-4
+		"0x32bF5092890bb03A45bd03AaeFAd11d4afC9a851",
+	}
 )
+
+func IsHonoraryNode(wallet string) bool {
+	for _, hon := range honoraryNodes {
+		if strings.EqualFold(wallet, hon) {
+			return true
+		}
+	}
+	return false
+}

--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -44,12 +44,18 @@ func DiscoveryMain() {
 			// correct hostname if configured incorrectly
 			for _, peer := range peers {
 				if strings.EqualFold(peer.Wallet, discoveryConfig.MyWallet) {
+					discoveryConfig.IsRegisteredWallet = true
 					if discoveryConfig.MyHost != peer.Host {
 						slog.Warn("incorrect hostname", "incorrect", discoveryConfig.MyHost, "correct", peer.Host)
 						discoveryConfig.MyHost = peer.Host
 					}
 					break
 				}
+			}
+
+			// special case read only nodes
+			if config.IsHonoraryNode(discoveryConfig.MyWallet) {
+				discoveryConfig.IsRegisteredWallet = true
 			}
 
 			// fix any relayed_by records that have (incorrect) trailing slash
@@ -72,8 +78,10 @@ func DiscoveryMain() {
 			return err
 		}
 
-		// start sweepers
-		proc.StartPeerClients()
+		// only start sweepers if registered...
+		if discoveryConfig.IsRegisteredWallet {
+			proc.StartPeerClients()
+		}
 
 		err = pubkeystore.Dial(discoveryConfig)
 		if err != nil {

--- a/comms/discovery/server/basic_auth.go
+++ b/comms/discovery/server/basic_auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"comms.audius.co/discovery/config"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/labstack/echo/v4"
 )
@@ -42,7 +43,7 @@ func (ss *ChatServer) checkRegisteredNodeBasicAuth(user, pass string, c echo.Con
 	wallet := crypto.PubkeyToAddress(*pubkey).Hex()
 
 	// add discovery 4 as an "honorary" peer
-	if strings.EqualFold(wallet, "0x32bF5092890bb03A45bd03AaeFAd11d4afC9a851") {
+	if config.IsHonoraryNode(wallet) {
 		return true, nil
 	}
 

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -103,14 +103,15 @@ type ChatServer struct {
 func (s *ChatServer) getStatus(c echo.Context) error {
 	errors := s.proc.SweeperErrors()
 	return c.JSON(http.StatusOK, map[string]any{
-		"host":            s.config.MyHost,
-		"wallet":          s.config.MyWallet,
-		"commit":          vcsRevision,
-		"built":           vcsBuildTime,
-		"booted":          bootTime,
-		"healthy":         s.websocketError == nil, // && len(errors) == 0,
-		"errors":          errors,
-		"websocket_error": s.websocketError,
+		"host":                 s.config.MyHost,
+		"wallet":               s.config.MyWallet,
+		"is_registered_wallet": s.config.IsRegisteredWallet,
+		"commit":               vcsRevision,
+		"built":                vcsBuildTime,
+		"booted":               bootTime,
+		"healthy":              s.config.IsRegisteredWallet && s.websocketError == nil, // && len(errors) == 0,
+		"errors":               errors,
+		"websocket_error":      s.websocketError,
 	})
 }
 


### PR DESCRIPTION
### Description

* computes wallet from private key
* only reads `audius_delegate_private_key` to print warning if it doesn't match
* marks node unhealthy if computed wallet not in registered list
* doesn't start peer client if not registered (cuts down on log spam from sandbox nodes)
* better special case of DN4