### PR TITLE
populate relayed_by and relayed_at (if missing)

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -91,6 +91,13 @@ func (proc *RPCProcessor) Validate(userId int32, rawRpc schema.RawRPC) error {
 //   - pushes to peers.
 func (proc *RPCProcessor) ApplyAndPublish(rpcLog *schema.RpcLog) (*schema.RpcLog, error) {
 
+	if rpcLog.RelayedBy == "" {
+		rpcLog.RelayedBy = proc.discoveryConfig.MyHost
+	}
+	if rpcLog.RelayedAt.IsZero() {
+		rpcLog.RelayedAt = time.Now()
+	}
+
 	// apply
 	err := proc.Apply(rpcLog)
 	if err != nil {

--- a/comms/discovery/rpcz/chat_test.go
+++ b/comms/discovery/rpcz/chat_test.go
@@ -133,5 +133,10 @@ func TestChat(t *testing.T) {
 	assert.NoError(t, err)
 	assertReaction(user1Id, replyMessageId, nil)
 
+	// user1 is banned
+	tx.MustExec(`insert into chat_ban values ($1)`, user1Id)
+
+	assert.True(t, testValidator.isBanned(tx, user1Id))
+
 	tx.Rollback()
 }


### PR DESCRIPTION
### Description

fixes internal rpc cli

### How Has This Been Tested?

tested on stage discovery 1... verified stage 2 gets the message.

note that it is not "pushed" so is subject to the ~1m polling interval.

