### PR TITLE
creatorNodeVersionOverride env var

### DIFF
--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -4,6 +4,7 @@ const { Keypair } = require('@solana/web3.js')
 
 // allow foundation nodes to specify creatorNodeVersionOverride via ENV
 if (process.env.creatorNodeVersionOverride) {
+  versionInfo.version_real = versionInfo.version
   versionInfo.version = process.env.creatorNodeVersionOverride
 }
 

--- a/creator-node/src/components/healthCheck/healthCheckComponentService.js
+++ b/creator-node/src/components/healthCheck/healthCheckComponentService.js
@@ -2,6 +2,11 @@ const path = require('path')
 const versionInfo = require(path.join(process.cwd(), '.version.json'))
 const { Keypair } = require('@solana/web3.js')
 
+// allow foundation nodes to specify creatorNodeVersionOverride via ENV
+if (process.env.creatorNodeVersionOverride) {
+  versionInfo.version = process.env.creatorNodeVersionOverride
+}
+
 const config = require('../../config')
 const utils = require('../../utils')
 const { MONITORS } = require('../../monitors/monitors')


### PR DESCRIPTION
### Description

specify `creatorNodeVersionOverride` in `override.env` instead of maintaining foundation release branch.

### How Has This Been Tested?

will deploy to a stage node and verify works