### PR TITLE
Add Write OAuth helpers to SDK C-2784

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/sdk",
-  "version": "2.0.3-beta.53",
+  "version": "3.0.3-beta.53",
   "audius": {
     "releaseSHA": "1b19b6001940e0a9764d5b8e3fb52e93c4917f14"
   },

--- a/libs/src/sdk/api/developer-apps/types.ts
+++ b/libs/src/sdk/api/developer-apps/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { HashId } from '../../types/HashId'
-import { isApiKeyValid } from '../../utils/file'
+import { isApiKeyValid } from '../../utils/apiKey'
 
 export const CreateDeveloperAppSchema = z.object({
   name: z.string(),

--- a/libs/src/sdk/api/grants/types.ts
+++ b/libs/src/sdk/api/grants/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { HashId } from '../../types/HashId'
-import { isApiKeyValid } from '../../utils/file'
+import { isApiKeyValid } from '../../utils/apiKey'
 
 export const CreateGrantSchema = z.object({
   userId: HashId,

--- a/libs/src/sdk/oauth/index.ts
+++ b/libs/src/sdk/oauth/index.ts
@@ -1,1 +1,2 @@
 export * from './OAuth'
+export * from './types'

--- a/libs/src/sdk/oauth/types.ts
+++ b/libs/src/sdk/oauth/types.ts
@@ -14,4 +14,7 @@ export type IsWriteAccessGrantedRequest = z.input<
   typeof IsWriteAccessGrantedSchema
 >
 
-export type OAuthScope = 'read' | 'write'
+export const OAUTH_SCOPE_OPTIONS = ['read', 'write'] as const
+type OAuthScopesTuple = typeof OAUTH_SCOPE_OPTIONS
+export type OAuthScopeOption = OAuthScopesTuple[number]
+export type OAuthScope = OAuthScopeOption | OAuthScopeOption[]

--- a/libs/src/sdk/oauth/types.ts
+++ b/libs/src/sdk/oauth/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { isApiKeyValid } from '../utils/file'
+import { isApiKeyValid } from '../utils/apiKey'
 
 export const IsWriteAccessGrantedSchema = z.object({
   userId: z.string(),

--- a/libs/src/sdk/oauth/types.ts
+++ b/libs/src/sdk/oauth/types.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { isApiKeyValid } from '../utils/file'
+
+export const IsWriteAccessGrantedSchema = z.object({
+  userId: z.string(),
+  apiKey: z.optional(
+    z.custom<string>((data: unknown) => {
+      return isApiKeyValid(data as string)
+    })
+  )
+})
+
+export type IsWriteAccessGrantedRequest = z.input<
+  typeof IsWriteAccessGrantedSchema
+>
+
+export type OAuthScope = 'read' | 'write'

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -92,7 +92,7 @@ type SdkConfig = {
  * The Audius SDK
  */
 export const sdk = (config: SdkConfig) => {
-  const { appName } = config
+  const { appName, apiKey } = config
 
   // Initialize services
   const services = initializeServices(config)
@@ -106,7 +106,7 @@ export const sdk = (config: SdkConfig) => {
   // Initialize OAuth
   const oauth =
     typeof window !== 'undefined'
-      ? new OAuth({ appName, usersApi: apis.users })
+      ? new OAuth({ appName, apiKey, usersApi: apis.users })
       : undefined
 
   return {

--- a/libs/src/sdk/utils/apiKey.ts
+++ b/libs/src/sdk/utils/apiKey.ts
@@ -1,0 +1,11 @@
+export const isApiKeyValid = (apiKey: string) => {
+  try {
+    if (apiKey.length !== 40) {
+      return false
+    }
+    const hexadecimalRegex = /^[0-9a-fA-F]+$/
+    return hexadecimalRegex.test(apiKey)
+  } catch (_e) {
+    return false
+  }
+}

--- a/libs/src/sdk/utils/file.ts
+++ b/libs/src/sdk/utils/file.ts
@@ -16,15 +16,3 @@ export const isFileValid = (file: CrossPlatformFile) => {
   // If in a browser environment
   return file && typeof file === 'object'
 }
-
-export const isApiKeyValid = (apiKey: string) => {
-  try {
-    if (apiKey.length !== 40) {
-      return false
-    }
-    const hexadecimalRegex = /^[0-9a-fA-F]+$/
-    return hexadecimalRegex.test(apiKey)
-  } catch (_e) {
-    return false
-  }
-}

--- a/libs/src/sdk/utils/oauthScope.ts
+++ b/libs/src/sdk/utils/oauthScope.ts
@@ -1,0 +1,6 @@
+import { OAUTH_SCOPE_OPTIONS } from '../oauth'
+
+export const isOAuthScopeValid = (scope: string[]) => {
+  const validScopes = new Set(OAUTH_SCOPE_OPTIONS)
+  return scope.findIndex((s) => !validScopes.has(s as any)) === -1
+}


### PR DESCRIPTION
### Description

Adds to existing OAuth helpers, documented here:
https://docs.audius.org/developers/log-in-with-audius

Now you can pass in scope to oauth.renderButton() or oauth.login() to do an OAuth write authorization using your api key.

This is a BREAKING change for existing OAuth users due to method signature changes

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
