### PR TITLE
DM: validate host + wallet pair

### DIFF
--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -40,15 +40,10 @@ func DiscoveryMain() {
 				return err
 			}
 
-			// find self in peer list
-			// correct hostname if configured incorrectly
+			// validate host + wallet pair
 			for _, peer := range peers {
-				if strings.EqualFold(peer.Wallet, discoveryConfig.MyWallet) {
+				if strings.EqualFold(peer.Wallet, discoveryConfig.MyWallet) && strings.EqualFold(peer.Host, discoveryConfig.MyHost) {
 					discoveryConfig.IsRegisteredWallet = true
-					if discoveryConfig.MyHost != peer.Host {
-						slog.Warn("incorrect hostname", "incorrect", discoveryConfig.MyHost, "correct", peer.Host)
-						discoveryConfig.MyHost = peer.Host
-					}
 					break
 				}
 			}


### PR DESCRIPTION
### Description

Removes code that tries to infer host name from wallet... since some hosts re-use wallet, this causes problems.
Both host + wallet must be correct for `comms.healthy` to be true.

Also refreshes registered peer list on interval.