### PR TITLE
SDK: Don't check comms API response health

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
@@ -110,9 +110,10 @@ export const parseApiHealthStatusReason = ({
       return { health: HealthCheckStatus.BEHIND, reason: 'slot diff' }
     }
   } else if (isCommsResponse(data)) {
-    if (!isApiCommsHealthy({ data })) {
-      return { health: HealthCheckStatus.UNHEALTHY, reason: 'comms' }
-    }
+    // TODO: Re-enable once is
+    // if (!isApiCommsHealthy({ data })) {
+    //   return { health: HealthCheckStatus.UNHEALTHY, reason: 'comms' }
+    // }
   }
 
   return { health: HealthCheckStatus.HEALTHY }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
@@ -110,7 +110,7 @@ export const parseApiHealthStatusReason = ({
       return { health: HealthCheckStatus.BEHIND, reason: 'slot diff' }
     }
   } else if (isCommsResponse(data)) {
-    // TODO: Re-enable once is
+    // TODO: Re-enable once is_healthy is correctly reporting
     // if (!isApiCommsHealthy({ data })) {
     //   return { health: HealthCheckStatus.UNHEALTHY, reason: 'comms' }
     // }

--- a/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/healthChecks.ts
@@ -76,9 +76,9 @@ const isApiSolanaIndexerHealthy = ({
   data.latest_chain_slot_plays - data.latest_indexed_slot_plays <=
     maxSlotDiffPlays
 
-const isApiCommsHealthy = ({ data }: { data: CommsResponse }) => {
-  return data.health?.is_healthy
-}
+// const isApiCommsHealthy = ({ data }: { data: CommsResponse }) => {
+//   return data.health?.is_healthy
+// }
 
 export const parseApiHealthStatusReason = ({
   data,


### PR DESCRIPTION
### Description

The API response `is_healthy` field is not properly updated to match the `health_check` health response. Until it is, ignore it.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
