### PR TITLE
[PLAT-861] allow empty string for user bios in em indexing

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -254,7 +254,7 @@ def update_user_metadata(
     if "cover_photo" in metadata and metadata["cover_photo"]:
         user_record.cover_photo = metadata["cover_photo"]
 
-    if "bio" in metadata and metadata["bio"]:
+    if "bio" in metadata:
         user_record.bio = metadata["bio"]
 
     if "name" in metadata and metadata["name"]:


### PR DESCRIPTION
### Description
Removes the null check for user bios so if a user deletes their bio, we can set the bio to that empty string. 

Confirmed this is already the behavior for playlist and track descriptions (we can set empty strings). and checked any other fields that would want this behavior but might not have it but didn't find any

### How Has This Been Tested?
testing end to end on stage, verified results in discovery look correct. added unit test as well

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
