### PR TITLE
[CON-749] Update mediorum slog and user-agent

### DIFF
--- a/mediorum/cmd/loadtest/client.go
+++ b/mediorum/cmd/loadtest/client.go
@@ -50,12 +50,18 @@ func (tc *TestClient) pingPeer(wg *sync.WaitGroup, peer server.Peer) {
 	defer wg.Done()
 
 	client := &http.Client{Timeout: 1000 * time.Millisecond} // fail fast for heath check
-	res, err := client.Get(fmt.Sprintf("%s%s", peer.Host, "/health_check"))
-
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", peer.Host, "/health_check"), nil)
 	if err != nil {
 		fmt.Printf("e")
 		return
 	}
+	req.Header.Set("User-Agent", "mediorum-load-test")
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("e")
+		return
+	}
+
 	if res.StatusCode == http.StatusOK {
 		fmt.Printf(".")
 		tc.UpPeers = append(tc.UpPeers, peer)

--- a/mediorum/cmd/loadtest/upload.go
+++ b/mediorum/cmd/loadtest/upload.go
@@ -63,6 +63,7 @@ func (tc *TestClient) upload(data []byte, filename string) error {
 	}
 
 	req.Header.Add("Content-Type", m.FormDataContentType())
+	req.Header.Set("User-Agent", "mediorum-load-test")
 
 	resp, err := tc.HttpClient.Do(req)
 	if err != nil {

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -45,8 +45,8 @@ type Crudr struct {
 	callbacks []func(op *Op, records interface{})
 }
 
-func New(host string, myPrivateKey *ecdsa.PrivateKey, peerHosts []string, db *gorm.DB) *Crudr {
-	host = httputil.RemoveTrailingSlash(strings.ToLower(host))
+func New(selfHost string, myPrivateKey *ecdsa.PrivateKey, peerHosts []string, db *gorm.DB) *Crudr {
+	selfHost = httputil.RemoveTrailingSlash(strings.ToLower(selfHost))
 
 	opDDL := `
 	create table if not exists ops (
@@ -73,15 +73,15 @@ func New(host string, myPrivateKey *ecdsa.PrivateKey, peerHosts []string, db *go
 		DB:           db,
 		myPrivateKey: myPrivateKey,
 
-		host:    host,
-		logger:  slog.With("module", "crud", "from", host),
+		host:    selfHost,
+		logger:  slog.With("module", "crud", "from", selfHost),
 		typeMap: map[string]reflect.Type{},
 
 		peerClients: make([]*PeerClient, len(peerHosts)),
 	}
 
-	for idx, host := range peerHosts {
-		c.peerClients[idx] = NewPeerClient(host, c)
+	for idx, peerHost := range peerHosts {
+		c.peerClients[idx] = NewPeerClient(peerHost, c, selfHost)
 	}
 
 	return c

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -110,7 +110,7 @@ func startStagingOrProd(isProd bool) {
 
 	ss, err := server.New(config)
 	if err != nil {
-		logger.Error("failed to create server", err)
+		logger.Error("failed to create server", "err", err)
 		log.Fatal(err)
 	}
 
@@ -191,7 +191,7 @@ func startDevCluster() {
 		peer := peer
 		spID, err := ethcontracts.GetServiceProviderIdFromEndpoint(peer.Host, peer.Wallet)
 		if err != nil || spID == 0 {
-			slog.Error(fmt.Sprintf("failed to recover spID for %s, %s (this is expected if running locally without eth-ganache)", peer.Host, peer.Wallet), err)
+			slog.Error(fmt.Sprintf("failed to recover spID for %s, %s (this is expected if running locally without eth-ganache)", peer.Host, peer.Wallet), "err", err)
 			spID = idx + 1
 		}
 		config := server.MediorumConfig{

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -35,14 +35,14 @@ func (ss *MediorumServer) updateDiskAndDbStatus() {
 		ss.storagePathUsed = total - free
 		ss.storagePathSize = total
 	} else {
-		slog.Error("Error getting disk status", err)
+		slog.Error("Error getting disk status", "err", err)
 	}
 
 	dbSize, err := getDatabaseSize(ss.pgPool)
 	if err == nil {
 		ss.databaseSize = dbSize
 	} else {
-		slog.Error("Error getting database size", err)
+		slog.Error("Error getting database size", "err", err)
 	}
 }
 

--- a/mediorum/server/peer_health.go
+++ b/mediorum/server/peer_health.go
@@ -21,7 +21,15 @@ func (ss *MediorumServer) startHealthPoller() {
 		for _, peer := range ss.Config.Peers {
 			peer := peer
 			go func() {
-				resp, err := httpClient.Get(peer.ApiPath("/status")) // todo: switch to /internal/ok later
+				req, err := http.NewRequest("GET", peer.ApiPath("/status"), nil) // todo: switch to /internal/ok later
+				if err != nil {
+					return
+				}
+				req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
+				resp, err := httpClient.Do(req)
+				if err != nil {
+					return
+				}
 				if err == nil {
 					if resp.StatusCode == 200 {
 						// mark healthy

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -30,7 +30,7 @@ func (ss *MediorumServer) startRepairer() {
 		err := ss.runRepair(cleanupMode)
 		took := time.Since(repairStart)
 		if err != nil {
-			logger.Error("repair failed", err, "took", took)
+			logger.Error("repair failed", "err", err, "took", took)
 		} else {
 			logger.Info("repair OK", "took", took)
 		}
@@ -131,7 +131,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 
 			isOnDisk, err := ss.bucket.Exists(ctx, cid)
 			if err != nil {
-				logger.Error("exist check failed", err)
+				logger.Error("exist check failed", "err", err)
 				continue
 			}
 
@@ -142,7 +142,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 					err := validateCID(cid, r)
 					r.Close()
 					if err != nil {
-						logger.Error("deleting invalid CID", err)
+						logger.Error("deleting invalid CID", "err", err)
 						ss.bucket.Delete(ctx, cid)
 						isOnDisk = false
 					}
@@ -158,7 +158,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 					}
 					err := ss.pullFileFromHost(host, cid)
 					if err != nil {
-						logger.Error("pull failed", err, "host", host)
+						logger.Error("pull failed", "err", err, "host", host)
 					} else {
 						logger.Info("pull OK", "host", host)
 						success = true
@@ -187,7 +187,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 					logger.Info("deleting", "depth", depth, "hosts", preferredHosts)
 					err = ss.dropFromMyBucket(cid)
 					if err != nil {
-						logger.Error("delete failed", err)
+						logger.Error("delete failed", "err", err)
 					} else {
 						logger.Info("delete OK")
 					}

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -81,9 +81,13 @@ func (ss *MediorumServer) getBlobDoubleCheck(c echo.Context) error {
 	ctx := c.Request().Context()
 	key := c.Param("cid")
 
-	// verify blob exists
 	r, err := ss.bucket.NewReader(ctx, key, nil)
 	if err != nil {
+		// Check if the error is a blob not found error
+		// If it is, return a 404
+		if strings.Contains(err.Error(), "not found") {
+			return c.String(404, "blob not found")
+		}
 		return err
 	}
 	defer r.Close()
@@ -230,7 +234,7 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 	endpoint := fmt.Sprintf("%s/tracks/%d/listen", os.Getenv("identityService"), sig.Data.TrackId)
 	signatureData, err := signature.GenerateListenTimestampAndSignature(ss.Config.privateKey)
 	if err != nil {
-		ss.logger.Error("unable to build request", err)
+		ss.logger.Error("unable to build request", "err", err)
 		return
 	}
 
@@ -243,21 +247,22 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 
 	buf, err := json.Marshal(body)
 	if err != nil {
-		ss.logger.Error("unable to build request", err)
+		ss.logger.Error("unable to build request", "err", err)
 		return
 	}
 
 	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(buf))
 	if err != nil {
-		ss.logger.Error("unable to build request", err)
+		ss.logger.Error("unable to build request", "err", err)
 		return
 	}
 	req.Header.Set("content-type", "application/json")
 	req.Header.Add("x-forwarded-for", c.RealIP())
+	req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
 
 	res, err := httpClient.Do(req)
 	if err != nil {
-		ss.logger.Error("unable to POST to identity service", err)
+		ss.logger.Error("unable to POST to identity service", "err", err)
 		return
 	}
 	defer res.Body.Close()

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -134,27 +134,33 @@ func (ss *MediorumServer) getPeerHealth(c echo.Context) error {
 	})
 }
 
-func (ss *MediorumServer) fetchCreatorNodeHealth() (legacyHealth legacyHealth, err error) {
+func (ss *MediorumServer) fetchCreatorNodeHealth() (legacyHealth, error) {
+	legacyHealth := legacyHealth{}
 	upstream, err := url.Parse(ss.Config.UpstreamCN)
 	if err != nil {
-		return
+		return legacyHealth, err
 	}
 
 	httpClient := http.Client{
 		Timeout: time.Second,
 	}
 
-	resp, err := httpClient.Get(upstream.JoinPath("/health_check").String())
+	req, err := http.NewRequest("GET", upstream.JoinPath("/health_check").String(), nil)
 	if err != nil {
-		return
+		return legacyHealth, err
+	}
+	req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return legacyHealth, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return
+		return legacyHealth, err
 	}
 
 	err = json.Unmarshal(body, &legacyHealth)
-	return
+	return legacyHealth, err
 }

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -22,7 +22,7 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 	if err == pgx.ErrNoRows {
 		return ss.redirectToCid(c, cid)
 	} else if err != nil {
-		logger.Error("error querying cid storage path", err)
+		logger.Error("error querying cid storage path", "err", err)
 		return err
 	}
 
@@ -34,7 +34,7 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 	}
 
 	if err = c.File(storagePath); err != nil {
-		logger.Error("error serving cid", err, "storagePath", storagePath)
+		logger.Error("error serving cid", "err", err, "storagePath", storagePath)
 		return ss.redirectToCid(c, cid)
 	}
 
@@ -55,7 +55,7 @@ func (ss *MediorumServer) headLegacyCid(c echo.Context) error {
 	if err == pgx.ErrNoRows {
 		return ss.redirectToCid(c, cid)
 	} else if err != nil {
-		logger.Error("error querying cid storage path", err)
+		logger.Error("error querying cid storage path", "err", err)
 		return err
 	}
 
@@ -78,12 +78,12 @@ func (ss *MediorumServer) serveLegacyDirCid(c echo.Context) error {
 	if err == pgx.ErrNoRows {
 		return ss.redirectToCid(c, dirCid)
 	} else if err != nil {
-		logger.Error("error querying dirCid storage path", err)
+		logger.Error("error querying dirCid storage path", "err", err)
 		return err
 	}
 
 	if err = c.File(storagePath); err != nil {
-		logger.Error("error serving dirCid", err, "storagePath", storagePath)
+		logger.Error("error serving dirCid", "err", err, "storagePath", storagePath)
 		return ss.redirectToCid(c, dirCid)
 	}
 
@@ -136,7 +136,7 @@ func (ss *MediorumServer) isCidBlacklisted(ctx context.Context, cid string) bool
 	            false)`
 	err := ss.pgPool.QueryRow(ctx, sql, cid).Scan(&blacklisted)
 	if err != nil {
-		ss.logger.Error("isCidBlacklisted error", err, "cid", cid)
+		ss.logger.Error("isCidBlacklisted error", "err", err, "cid", cid)
 	}
 	return blacklisted
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -169,7 +169,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		if err == nil {
 			slog.Info("got trusted notifier from chain", "endpoint", trustedNotifier.Endpoint, "wallet", trustedNotifier.Wallet)
 		} else {
-			slog.Error("failed to get trusted notifier from chain, not polling delist statuses", err)
+			slog.Error("failed to get trusted notifier from chain, not polling delist statuses", "err", err)
 		}
 	} else {
 		slog.Warn("trusted notifier id not set, not polling delist statuses or serving /contact route")
@@ -350,12 +350,12 @@ func (ss *MediorumServer) Stop() {
 	defer cancel()
 
 	if err := ss.echo.Shutdown(ctx); err != nil {
-		ss.logger.Error("echo shutdown", err)
+		ss.logger.Error("echo shutdown", "err", err)
 	}
 
 	if db, err := ss.crud.DB.DB(); err == nil {
 		if err := db.Close(); err != nil {
-			ss.logger.Error("db shutdown", err)
+			ss.logger.Error("db shutdown", "err", err)
 		}
 	}
 

--- a/mediorum/server/signature/basic_auth.go
+++ b/mediorum/server/signature/basic_auth.go
@@ -28,18 +28,19 @@ func basicAuthNonce(privateKey *ecdsa.PrivateKey) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(basic))
 }
 
-func SignedGet(endpoint string, privateKey *ecdsa.PrivateKey) (*http.Request, error) {
+func SignedGet(endpoint string, privateKey *ecdsa.PrivateKey, selfHost string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Add("Authorization", basicAuthNonce(privateKey))
+	req.Header.Set("User-Agent", "mediorum "+selfHost)
 
 	return req, nil
 }
 
-func SignedPost(endpoint string, contentType string, r io.Reader, privateKey *ecdsa.PrivateKey) *http.Request {
+func SignedPost(endpoint string, contentType string, r io.Reader, privateKey *ecdsa.PrivateKey, selfHost string) *http.Request {
 	req, err := http.NewRequest("POST", endpoint, r)
 	if err != nil {
 		panic(err)
@@ -47,6 +48,7 @@ func SignedPost(endpoint string, contentType string, r io.Reader, privateKey *ec
 
 	req.Header.Add("Content-Type", contentType)
 	req.Header.Add("Authorization", basicAuthNonce(privateKey))
+	req.Header.Set("User-Agent", "mediorum "+selfHost)
 
 	return req
 }

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -134,7 +134,7 @@ func (ss *MediorumServer) startTranscodeWorker(n int, work chan *Upload) {
 		ss.logger.Debug("transcoding", "upload", upload.ID)
 		err := ss.transcode(upload)
 		if err != nil {
-			ss.logger.Warn("transocde failed", "upload", upload, "err", err)
+			ss.logger.Warn("transcode failed", "upload", upload, "err", err)
 		}
 	}
 }
@@ -189,7 +189,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 		upload.Error = errMsg.Error()
 		upload.Status = JobStatusError
 		ss.crud.Update(upload)
-		logger.Error("transcode error", err)
+		logger.Error("transcode error", "err", err)
 		return errMsg
 	}
 
@@ -265,7 +265,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 		// read ffmpeg progress
 		stderr, err := cmd.StderrPipe()
 		if err != nil {
-			fmt.Println("progress err", err)
+			logger.Error("progress err", "err", err)
 		} else if upload.FFProbe != nil {
 			durationSeconds := cast.ToFloat64(upload.FFProbe.Format.Duration)
 			durationUs := durationSeconds * 1000 * 1000


### PR DESCRIPTION
### Description
- Updates our usage of `slog.Error` to match the updated spec – it no longer accepts `error` type as the second parameter (see then https://pkg.go.dev/golang.org/x/exp@v0.0.0-20230129154200-a960b3787bd2/slog#Logger.Error vs now https://pkg.go.dev/golang.org/x/exp/slog#Logger.Error). This will fix some of the `!BADKEY` fields we see in Axiom
- Changes the User-Agent header from the default “Go-http-client/2.0” to the SP’s hostname for outgoing requests so that some logs are more helpful
- Makes the cid double_check route return 404 instead of 500 when it doesn't have a file (I guess we're removing this route soon anyway @stereosteve)


### How Has This Been Tested?
Testing on staging