### PR TITLE
Change DM notifs back to default on

### DIFF
--- a/identity-service/sequelize/migrations/20230626231334-default-messages-on-mobile-notification-settings.js
+++ b/identity-service/sequelize/migrations/20230626231334-default-messages-on-mobile-notification-settings.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn('UserNotificationMobileSettings', 'messages')
+      .then(() =>
+        queryInterface.addColumn('UserNotificationMobileSettings', 'messages', {
+          type: Sequelize.BOOLEAN,
+          allowNull: false,
+          defaultValue: true
+        })
+      )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn('UserNotificationMobileSettings', 'messages')
+      .then(() =>
+        queryInterface.addColumn('UserNotificationMobileSettings', 'messages', {
+          type: Sequelize.BOOLEAN,
+          allowNull: false,
+          defaultValue: false
+        })
+      )
+  }
+}

--- a/identity-service/sequelize/migrations/20230626231346-default-messages-on-browser-notification-settings.js
+++ b/identity-service/sequelize/migrations/20230626231346-default-messages-on-browser-notification-settings.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn('UserNotificationBrowserSettings', 'messages')
+      .then(() =>
+        queryInterface.addColumn(
+          'UserNotificationBrowserSettings',
+          'messages',
+          {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: true
+          }
+        )
+      )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn('UserNotificationBrowserSettings', 'messages')
+      .then(() =>
+        queryInterface.addColumn(
+          'UserNotificationBrowserSettings',
+          'messages',
+          {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+          }
+        )
+      )
+  }
+}

--- a/identity-service/src/models/userNotificationBrowserSettings.js
+++ b/identity-service/src/models/userNotificationBrowserSettings.js
@@ -36,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
       messages: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: false
+        defaultValue: true
       }
     },
     {}

--- a/identity-service/src/models/userNotificationMobileSettings.js
+++ b/identity-service/src/models/userNotificationMobileSettings.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
       messages: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
-        defaultValue: false
+        defaultValue: true
       }
     },
     {}


### PR DESCRIPTION
### Description
In preparation for DMs launch on 7/11, this should go out in the release the week before (week of 7/3).

DM notifs were set to default off during the testing period on prod these past few months out of an abundance of caution.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
