### PR TITLE
PLAT-1096: use for loop instead of callbacks

### DIFF
--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -322,17 +322,17 @@ export async function processEmailNotifications(
 
     while (true) {
       const now = Date.now()
-      if (now > timeout) break
+      if (now > timeout) return
       logger.info(`processEmailNotifications | gathering users for ${frequency} query ${startOffset} ${pageCount}`)
       const userRows: { blockchainUserId: number; email: string }[] = await getUsersCanNotifyQuery(identityDb, startOffset, frequency, pageCount, lastUser)
       pageOffset = pageOffset + pageCount
-      if (userRows.length === 0) break // once we've reached the end of users for this query
+      if (userRows.length === 0) return // once we've reached the end of users for this query
       lastUser = userRows[userRows.length - 1].blockchainUserId
       if (lastUser === undefined) {
         logger.info("no last user found")
-        break
+        return
       }
-      if (userRows.length === 0) break
+      if (userRows.length === 0) return
       const emailUsers = userRows.reduce((acc, user) => {
         acc[user.blockchainUserId] = user.email
         return acc

--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -323,6 +323,7 @@ export async function processEmailNotifications(
     while (true) {
       const now = Date.now()
       if (now > timeout) break
+      logger.info(`processEmailNotifications | gathering users for ${frequency} query ${startOffset} ${pageCount}`)
       const userRows: { blockchainUserId: number; email: string }[] = await getUsersCanNotifyQuery(identityDb, startOffset, frequency, pageCount, lastUser)
       pageOffset = pageOffset + pageCount
       if (userRows.length === 0) break // once we've reached the end of users for this query

--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -332,7 +332,6 @@ export async function processEmailNotifications(
         logger.info("no last user found")
         return
       }
-      if (userRows.length === 0) return
       const emailUsers = userRows.reduce((acc, user) => {
         acc[user.blockchainUserId] = user.email
         return acc

--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -143,6 +143,7 @@ export class Processor {
         )
         this.lastWeeklyEmailSent = moment.utc()
       }
+      logger.info('Completed processing scheduled emails')
       // free up event loop + batch queries to postgres
       await new Promise((r) => setTimeout(r, config.pollInterval))
     }

--- a/discovery-provider/plugins/notifications/src/remoteConfig.ts
+++ b/discovery-provider/plugins/notifications/src/remoteConfig.ts
@@ -37,6 +37,11 @@ export const EmailPluginMappings = {
   Scheduled: 'scheduled'
 }
 
+export const NotificationsScheduledEmails = "notification_scheduled_emails"
+export const ScheduledEmailPluginMappings = {
+  PageCount: 'page_count'
+}
+
 const defaultMappingVariable = {
   [MappingVariable.PushRepost]: false,
   [MappingVariable.PushSave]: false,
@@ -112,5 +117,18 @@ export class RemoteConfig {
       }
     }
     return optimizelyValue
+  }
+
+  getFeatureVariableValue<T>(featureName: string, variable: string, defaultValue: T): T {
+    const optimizelyValue = this.optimizelyClient.getFeatureVariable(
+      featureName,
+      variable,
+      ''
+    )
+
+    if (optimizelyValue === null) {
+      return defaultValue
+    }
+    return optimizelyValue as T
   }
 }


### PR DESCRIPTION
### Description
I think the heap error is caused by values being passed to the callbacks during this large loop. This includes long lived values like the db connection which may be confusing the garbage collector. Announcements works with a for loop and not callbacks so adjusting this to work the same way. 

### How Has This Been Tested?
Will run on stage.
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
