### PR TITLE
make wallet user_id lookup deterministic

### DIFF
--- a/comms/discovery/db/queries/get_users.go
+++ b/comms/discovery/db/queries/get_users.go
@@ -7,7 +7,14 @@ import (
 )
 
 const getUserIDFromWallet = `
-select user_id from users where is_current = TRUE and wallet = LOWER($1)
+select user_id
+from users
+where is_current = TRUE
+  and handle IS NOT NULL
+  and is_available = TRUE
+  and is_deactivated = FALSE
+  and wallet = LOWER($1)
+order by user_id asc
 `
 
 func GetUserIDFromWallet(q db.Queryable, ctx context.Context, walletAddress string) (int32, error) {

--- a/comms/discovery/server/mutate_test.go
+++ b/comms/discovery/server/mutate_test.go
@@ -38,7 +38,7 @@ func TestMutateEndpoint(t *testing.T) {
 	user2IdEncoded, _ := misc.EncodeHashId(int(user2Id))
 
 	// Create 2 users
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true)", user1Id, wallet1, user2Id, wallet2)
+	_, err = tx.Exec("insert into users (user_id, handle, wallet, is_current) values ($1, $2::text, lower($2), true), ($3, $4::text, lower($4), true)", user1Id, wallet1, user2Id, wallet2)
 	assert.NoError(t, err)
 
 	err = tx.Commit()

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -76,7 +76,7 @@ func TestGetChats(t *testing.T) {
 	user4Id := seededRand.Int31()
 
 	// Create 1 user with wallet
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true)", user1Id, wallet1)
+	_, err = tx.Exec("insert into users (user_id, handle, wallet, is_current) values ($1, $2::text, lower($2), true)", user1Id, wallet1)
 	assert.NoError(t, err)
 
 	// Create 3 chats
@@ -320,7 +320,7 @@ func TestGetMessages(t *testing.T) {
 	user2Id := seededRand.Int31()
 
 	// Create 1 user with wallet
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true)", user1Id, wallet1)
+	_, err = tx.Exec("insert into users (user_id, handle, wallet, is_current) values ($1, $2::text, lower($2), true)", user1Id, wallet1)
 	assert.NoError(t, err)
 
 	// Create a chat
@@ -531,7 +531,7 @@ func TestGetPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create 2 users with wallets
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true)", user1Id, wallet1, user2Id, wallet2)
+	_, err = tx.Exec("insert into users (user_id, handle, wallet, is_current) values ($1, $2::text, lower($2), true), ($3, $4::text, lower($4), true)", user1Id, wallet1, user2Id, wallet2)
 	assert.NoError(t, err)
 
 	// user 2 follows user 1
@@ -765,7 +765,7 @@ func TestGetBlockersAndBlockees(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create 3 users
-	_, err = tx.Exec("insert into users (user_id, wallet, is_current) values ($1, lower($2), true), ($3, lower($4), true), ($5, lower($6), true)", user1Id, wallet1, user2Id, wallet2, user3Id, wallet3)
+	_, err = tx.Exec("insert into users (user_id, handle, wallet, is_current) values ($1, $2::text, lower($2), true), ($3, $4::text, lower($4), true), ($5, $6::text, lower($6), true)", user1Id, wallet1, user2Id, wallet2, user3Id, wallet3)
 	assert.NoError(t, err)
 
 	// Set blocks:
@@ -773,6 +773,7 @@ func TestGetBlockersAndBlockees(t *testing.T) {
 	// - user 2 blocks no one
 	// - user 3 blocks user 2
 	_, err = tx.Exec("insert into chat_blocked_users (blocker_user_id, blockee_user_id, created_at) values ($1, $2, $3), ($4, $5, $3)", user1Id, user3Id, time.Now(), user3Id, user2Id)
+	assert.NoError(t, err)
 
 	err = tx.Commit()
 	assert.NoError(t, err)


### PR DESCRIPTION
avoids selecting a errant is_current user row that has null handle... 
as a last resort if there are duplicate valid users with same wallet, sorts by user_id asc to make deterministic.
