### PR TITLE
[PLAT-1087] Free up cycles when block not found for 500ms

### DIFF
--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -787,7 +787,8 @@ def index_nethermind(self):
                 # Nothing to index
                 logger.disable()
                 update_lock.release()
-                celery.send_task("index_nethermind")
+                # Send the task with a small amount of sleep to free up cycles
+                celery.send_task("index_nethermind", countdown=0.5)
                 return
 
             if in_valid_state:


### PR DESCRIPTION
### Description

Free up cycles when block not found. Hopefully reduces nominal CPU usage.

500ms was picked because, I observed "block not found" on stage discovery nodes between these timestamps.

2023-06-27 16:27:17,469

2023-06-27 16:27:18,106

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


