### PR TITLE
[PLAT-1086] Log cleanup

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -51,8 +51,8 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
         # Clear the celerybeat artifacts
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
-        audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
-        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        audius_service=beat celery -A src.worker.celery beat --loglevel WARNING --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
+        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel WARNING 2>&1 | tee >(logger -t worker) &
     fi
 else
     if [[ "$audius_no_server" != "true" ]] && [[ "$audius_no_server" != "1" ]]; then
@@ -63,8 +63,8 @@ else
         # Clear the celerybeat artifacts
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
-        audius_service=beat celery -A src.worker.celery beat --loglevel $audius_discprov_loglevel --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        audius_service=beat celery -A src.worker.celery beat --loglevel WARNING --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
+        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel WARNING 2>&1 | tee >(logger -t worker) &
     fi
 fi
 

--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -52,7 +52,7 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel WARNING --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
-        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel WARNING 2>&1 | tee >(logger -t worker) &
+        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
 else
     if [[ "$audius_no_server" != "true" ]] && [[ "$audius_no_server" != "1" ]]; then
@@ -64,7 +64,7 @@ else
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --loglevel WARNING --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid 2>&1 | tee >(logger -t beat) &
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel WARNING 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
 fi
 

--- a/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/discovery-provider/src/challenges/challenge_event_bus.py
@@ -115,9 +115,10 @@ class ChallengeEventBus:
 
     def flush(self):
         """Flushes the in-memory queue of events and enqueues them to Redis"""
-        logger.info(
-            f"ChallengeEventBus: Flushing {len(self._in_memory_queue)} events from in-memory queue"
-        )
+        if len(self._in_memory_queue) != 0:
+            logger.info(
+                f"ChallengeEventBus: Flushing {len(self._in_memory_queue)} events from in-memory queue"
+            )
         for event in self._in_memory_queue:
             try:
                 event_json = self._event_to_json(

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -610,7 +610,8 @@ def process_solana_rewards_manager(
         get_tx_in_db,
         MIN_SLOT,
     )
-    logger.info(f"index_rewards_manager.py | {transaction_signatures}")
+    if transaction_signatures:
+        logger.info(f"index_rewards_manager.py | {transaction_signatures}")
 
     last_tx = process_transaction_signatures(
         solana_client_manager, db, redis, transaction_signatures

--- a/discovery-provider/src/tasks/index_solana_plays.py
+++ b/discovery-provider/src/tasks/index_solana_plays.py
@@ -591,10 +591,6 @@ def process_solana_plays(solana_client_manager: SolanaClientManager, redis: Redi
             TRACK_LISTEN_PROGRAM, before=last_tx_signature, limit=fetch_size
         )
         is_initial_fetch = False
-
-        logger.info(
-            f"index_solana_plays.py | Retrieved transactions before {last_tx_signature}"
-        )
         transactions_array = transactions_history["result"]
         if not transactions_array:
             # This is considered an 'intersection' since there are no further transactions to process but


### PR DESCRIPTION
### Description

* Remove extremely noisy 0 event challenge bus logs: https://app.axiom.co/audius-Lu52/explorer?did=stage-discovery&qid=PeLgQsmAJmx-rwxa9z
* Set beat logs coming from celery itself to >= WARNING, which will removes logs around "Sending due task" (contributing ~50% of our log volume)
* Early return and cleanup in solana indexers

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

sandbox