### PR TITLE
Do not destroy mobile settings when deregistering device token

### DIFF
--- a/identity-service/src/routes/push_notifications.js
+++ b/identity-service/src/routes/push_notifications.js
@@ -201,7 +201,6 @@ module.exports = function (app) {
       }
 
       let tokenDeleted = false
-      let settingsDeleted = false
       try {
         // delete device token
         const tokenObj = await models.NotificationDeviceToken.findOne({
@@ -211,9 +210,6 @@ module.exports = function (app) {
           }
         })
 
-        const deleteUserNotificationSettings =
-          tokenObj.deviceType !== DEVICE_TYPES.SAFARI
-
         if (tokenObj) {
           // delete the endpoint from AWS SNS
           if (tokenObj.awsARN)
@@ -222,21 +218,7 @@ module.exports = function (app) {
           tokenDeleted = true
         }
 
-        // Delete user mobile notification settings if device type is mobile (android or ios)
-        if (deleteUserNotificationSettings) {
-          const settingsObj =
-            await models.UserNotificationMobileSettings.findOne({
-              where: {
-                userId
-              }
-            })
-          if (settingsObj) {
-            await settingsObj.destroy()
-            settingsDeleted = true
-          }
-        }
-
-        return successResponse({ tokenDeleted, settingsDeleted })
+        return successResponse({ tokenDeleted })
       } catch (e) {
         req.logger.error(
           `Unable to deregister device token for deviceToken: ${deviceToken}`,


### PR DESCRIPTION
### Description
Client posts to this endpoint on signout; we don't want to nuke their notif settings - just want to deregister the token so that we are not sending the device notifications anymore.

This endpoint is hit in 2 places in the client: when disabling all notifs in app settings, and when logging out. When the client handles disabling notifs, it updates mobile settings to false accordingly separately so this change is safe.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
