### PR TITLE
[CON-769] Return delisted before bad sig

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -108,12 +108,27 @@ func (ss *MediorumServer) getBlobDoubleCheck(c echo.Context) error {
 	return c.JSON(200, existingBlob)
 }
 
+func (ss *MediorumServer) ensureNotDelisted(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		ctx := c.Request().Context()
+		key := c.Param("cid")
+
+		if ss.isCidBlacklisted(ctx, key) {
+			ss.logger.Info("cid is blacklisted", "cid", key)
+			return c.String(403, "cid is blacklisted by this node")
+		}
+
+		c.Set("checkedDelistStatus", true)
+		return next(c)
+	}
+}
+
 func (ss *MediorumServer) getBlob(c echo.Context) error {
 	ctx := c.Request().Context()
 	key := c.Param("cid")
 	logger := ss.logger.With("cid", key)
 
-	if ss.isCidBlacklisted(ctx, key) {
+	if !c.Get("checkedDelistStatus").(bool) && ss.isCidBlacklisted(ctx, key) {
 		logger.Info("cid is blacklisted")
 		return c.String(403, "cid is blacklisted by this node")
 	}
@@ -176,7 +191,7 @@ func (ss *MediorumServer) headBlob(c echo.Context) error {
 	key := c.Param("cid")
 	logger := ss.logger.With("cid", key)
 
-	if ss.isCidBlacklisted(ctx, key) {
+	if !c.Get("checkedDelistStatus").(bool) && ss.isCidBlacklisted(ctx, key) {
 		logger.Info("cid is blacklisted")
 		return c.String(403, "cid is blacklisted by this node")
 	}

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -128,7 +128,11 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	key := c.Param("cid")
 	logger := ss.logger.With("cid", key)
 
-	if !c.Get("checkedDelistStatus").(bool) && ss.isCidBlacklisted(ctx, key) {
+	shouldCheckDelistStatus := true
+	if checkedDelistStatus, exists := c.Get("checkedDelistStatus").(bool); exists && checkedDelistStatus {
+		shouldCheckDelistStatus = false
+	}
+	if shouldCheckDelistStatus && ss.isCidBlacklisted(ctx, key) {
 		logger.Info("cid is blacklisted")
 		return c.String(403, "cid is blacklisted by this node")
 	}
@@ -191,7 +195,11 @@ func (ss *MediorumServer) headBlob(c echo.Context) error {
 	key := c.Param("cid")
 	logger := ss.logger.With("cid", key)
 
-	if !c.Get("checkedDelistStatus").(bool) && ss.isCidBlacklisted(ctx, key) {
+	shouldCheckDelistStatus := true
+	if checkedDelistStatus, exists := c.Get("checkedDelistStatus").(bool); exists && checkedDelistStatus {
+		shouldCheckDelistStatus = false
+	}
+	if shouldCheckDelistStatus && ss.isCidBlacklisted(ctx, key) {
 		logger.Info("cid is blacklisted")
 		return c.String(403, "cid is blacklisted by this node")
 	}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -229,12 +229,12 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		return c.NoContent(http.StatusNoContent)
 	})
 
-	routes.GET("/ipfs/:cid", ss.getBlob)
-	routes.GET("/content/:cid", ss.getBlob)
-	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant)
-	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant)
-	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.requireSignature)
-	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireSignature)
+	routes.GET("/ipfs/:cid", ss.getBlob, ss.ensureNotDelisted)
+	routes.GET("/content/:cid", ss.getBlob, ss.ensureNotDelisted)
+	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.ensureNotDelisted)
+	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.ensureNotDelisted)
+	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.ensureNotDelisted, ss.requireSignature)
+	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.ensureNotDelisted, ss.requireSignature)
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
 


### PR DESCRIPTION
### Description
Adds middleware *before* requireSignature so delisted statuses are surfaced instead of invalid signatures. This is a request from non-technical folks to be able to tell if a track is delisted or just a bad signature.

### How Has This Been Tested?
Got a signature and then delisted it. On the node where I'm testing this (stage CN6) it says the track is delisted. On other nodes, it says the signature expired.

Example track that has an expired signature and is delisted: [CN5](https://creatornode5.staging.audius.co/tracks/cidstream/QmUxV2feEgW7nEMMfw9MEStcjHzoQQNqrS1a63v3ztVfZ1?signature=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%201009765850%2C%20%5C%22cid%5C%22%3A%20%5C%22QmUxV2feEgW7nEMMfw9MEStcjHzoQQNqrS1a63v3ztVfZ1%5C%22%2C%20%5C%22timestamp%5C%22%3A%201684364028490%2C%20%5C%22userId%5C%22%3A%20700980330%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xcfed67fb043a5bea15766b121a0a8db02d3deaacb71a8f3a3d1fe6a72264cfef50683f0a68e141164c5d7155dc17f3a9bce6d388ce9049da4338e7fdd960e3e81b%22%7D) (old code - says invalid signature) vs [CN6](https://creatornode6.staging.audius.co/tracks/cidstream/QmUxV2feEgW7nEMMfw9MEStcjHzoQQNqrS1a63v3ztVfZ1?signature=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%201009765850%2C%20%5C%22cid%5C%22%3A%20%5C%22QmUxV2feEgW7nEMMfw9MEStcjHzoQQNqrS1a63v3ztVfZ1%5C%22%2C%20%5C%22timestamp%5C%22%3A%201684364028490%2C%20%5C%22userId%5C%22%3A%20700980330%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xcfed67fb043a5bea15766b121a0a8db02d3deaacb71a8f3a3d1fe6a72264cfef50683f0a68e141164c5d7155dc17f3a9bce6d388ce9049da4338e7fdd960e3e81b%22%7D) (new code - says track is delisted)