### PR TITLE
Handle track preview in POST /uploads

### DIFF
--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -3,6 +3,7 @@ begin;
 ALTER TABLE uploads
 ADD COLUMN IF NOT EXISTS user_id integer,
 ADD COLUMN IF NOT EXISTS preview_start_seconds integer,
-ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone;
+ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone,
+ADD COLUMN IF NOT EXISTS transcoded_mirrors text[];
 
 commit;

--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -1,8 +1,8 @@
 begin;
 
 ALTER TABLE uploads
-ADD COLUMN IF NOT EXISTS user_id integer,
-ADD COLUMN IF NOT EXISTS selected_preview string,
+ADD COLUMN IF NOT EXISTS user_wallet text,
+ADD COLUMN IF NOT EXISTS selected_preview text,
 ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone,
 ADD COLUMN IF NOT EXISTS transcoded_mirrors text[];
 

--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -2,6 +2,7 @@ begin;
 
 ALTER TABLE uploads
 ADD COLUMN IF NOT EXISTS user_id integer,
-ADD COLUMN IF NOT EXISTS preview_start_seconds integer;
+ADD COLUMN IF NOT EXISTS preview_start_seconds integer,
+ADD COLUMN IF NOT EXISTS updated_at timestamp without timezone;
 
 commit;

--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -1,0 +1,7 @@
+begin;
+
+ALTER TABLE uploads
+ADD COLUMN IF NOT EXISTS user_id integer,
+ADD COLUMN IF NOT EXISTS preview_start_seconds integer;
+
+commit;

--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -3,6 +3,6 @@ begin;
 ALTER TABLE uploads
 ADD COLUMN IF NOT EXISTS user_id integer,
 ADD COLUMN IF NOT EXISTS preview_start_seconds integer,
-ADD COLUMN IF NOT EXISTS updated_at timestamp without timezone;
+ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone;
 
 commit;

--- a/mediorum/ddl/add_fields_to_uploads.sql
+++ b/mediorum/ddl/add_fields_to_uploads.sql
@@ -2,7 +2,7 @@ begin;
 
 ALTER TABLE uploads
 ADD COLUMN IF NOT EXISTS user_id integer,
-ADD COLUMN IF NOT EXISTS preview_start_seconds integer,
+ADD COLUMN IF NOT EXISTS selected_preview string,
 ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone,
 ADD COLUMN IF NOT EXISTS transcoded_mirrors text[];
 

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -20,17 +20,17 @@ type Blob struct {
 type Upload struct {
 	ID string `json:"id"` // base32 file hash
 
-	UserID              sql.NullInt64  `json:"user_id"`
-	Template            JobTemplate    `json:"template"`
-	OrigFileName        string         `json:"orig_filename"`
-	OrigFileCID         string         `json:"orig_file_cid" gorm:"column:orig_file_cid;index:idx_uploads_orig_file_cid"` //
-	PreviewStartSeconds sql.NullInt64  `json:"preview_start_seconds"`
-	FFProbe             *FFProbeResult `json:"probe" gorm:"serializer:json"`
-	Error               string         `json:"error,omitempty"`
-	ErrorCount          int            `json:"error_count,omitempty"`
-	Mirrors             []string       `json:"mirrors" gorm:"serializer:json"`
-	TranscodedMirrors   []string       `json:"transcoded_mirrors" gorm:"serializer:json"`
-	Status              string         `json:"status" gorm:"index"`
+	UserID            sql.NullInt64  `json:"user_id"`
+	Template          JobTemplate    `json:"template"`
+	OrigFileName      string         `json:"orig_filename"`
+	OrigFileCID       string         `json:"orig_file_cid" gorm:"column:orig_file_cid;index:idx_uploads_orig_file_cid"` //
+	SelectedPreview   sql.NullString `json:"selected_preview"`
+	FFProbe           *FFProbeResult `json:"probe" gorm:"serializer:json"`
+	Error             string         `json:"error,omitempty"`
+	ErrorCount        int            `json:"error_count,omitempty"`
+	Mirrors           []string       `json:"mirrors" gorm:"serializer:json"`
+	TranscodedMirrors []string       `json:"transcoded_mirrors" gorm:"serializer:json"`
+	Status            string         `json:"status" gorm:"index"`
 
 	CreatedBy string    `json:"created_by" `
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime:false"`

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"mediorum/crudr"
 	"mediorum/ddl"
 	"time"
@@ -19,14 +20,16 @@ type Blob struct {
 type Upload struct {
 	ID string `json:"id"` // base32 file hash
 
-	Template     JobTemplate    `json:"template"`
-	OrigFileName string         `json:"orig_filename"`
-	OrigFileCID  string         `json:"orig_file_cid" gorm:"column:orig_file_cid;index:idx_uploads_orig_file_cid"` //
-	FFProbe      *FFProbeResult `json:"probe" gorm:"serializer:json"`
-	Error        string         `json:"error,omitempty"`
-	ErrorCount   int            `json:"error_count,omitempty"`
-	Mirrors      []string       `json:"mirrors" gorm:"serializer:json"`
-	Status       string         `json:"status" gorm:"index"`
+	UserID              sql.NullInt64  `json:"user_id"`
+	Template            JobTemplate    `json:"template"`
+	OrigFileName        string         `json:"orig_filename"`
+	OrigFileCID         string         `json:"orig_file_cid" gorm:"column:orig_file_cid;index:idx_uploads_orig_file_cid"` //
+	PreviewStartSeconds sql.NullInt64  `json:"preview_start_seconds"`
+	FFProbe             *FFProbeResult `json:"probe" gorm:"serializer:json"`
+	Error               string         `json:"error,omitempty"`
+	ErrorCount          int            `json:"error_count,omitempty"`
+	Mirrors             []string       `json:"mirrors" gorm:"serializer:json"`
+	Status              string         `json:"status" gorm:"index"`
 
 	CreatedBy string    `json:"created_by" `
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime:false"`

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -29,6 +29,7 @@ type Upload struct {
 	Error               string         `json:"error,omitempty"`
 	ErrorCount          int            `json:"error_count,omitempty"`
 	Mirrors             []string       `json:"mirrors" gorm:"serializer:json"`
+	TranscodedMirrors   []string       `json:"transcoded_mirrors" gorm:"serializer:json"`
 	Status              string         `json:"status" gorm:"index"`
 
 	CreatedBy string    `json:"created_by" `

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -20,7 +20,7 @@ type Blob struct {
 type Upload struct {
 	ID string `json:"id"` // base32 file hash
 
-	UserID            sql.NullInt64  `json:"user_id"`
+	UserWallet        sql.NullString `json:"user_wallet"`
 	Template          JobTemplate    `json:"template"`
 	OrigFileName      string         `json:"orig_filename"`
 	OrigFileCID       string         `json:"orig_file_cid" gorm:"column:orig_file_cid;index:idx_uploads_orig_file_cid"` //

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -33,6 +33,7 @@ type Upload struct {
 
 	CreatedBy string    `json:"created_by" `
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime:false"`
+	UpdatedAt time.Time `json:"updated_at" gorm:"autoCreateTime:false"`
 
 	TranscodedBy      string    `json:"transcoded_by"`
 	TranscodeProgress float64   `json:"transcode_progress"`

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -328,6 +328,7 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 func (s *MediorumServer) requireSignature(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		cid := c.Param("cid")
+		id := c.Param("id")
 		sig, err := signature.ParseFromQueryString(c.QueryParam("signature"))
 		if err != nil {
 			return c.JSON(401, map[string]string{
@@ -356,11 +357,17 @@ func (s *MediorumServer) requireSignature(next echo.HandlerFunc) echo.HandlerFun
 				})
 			}
 
-			// check it is for this cid
-			if sig.Data.Cid != cid {
+			// check it is for this cid or id
+			if cid != "" && sig.Data.Cid != cid {
 				return c.JSON(401, map[string]string{
 					"error":  "signature contains incorrect CID",
 					"detail": fmt.Sprintf("url: %s, signature %s", cid, sig.Data.Cid),
+				})
+			}
+			if id != "" && sig.Data.ID != id {
+				return c.JSON(401, map[string]string{
+					"error":  "signature contains incorrect ID",
+					"detail": fmt.Sprintf("url: %s, signature %s", id, sig.Data.ID),
 				})
 			}
 

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -357,13 +357,14 @@ func (s *MediorumServer) requireSignature(next echo.HandlerFunc) echo.HandlerFun
 				})
 			}
 
-			// check it is for this cid or id
+			// check it is for this cid or job id
 			if cid != "" && sig.Data.Cid != cid {
 				return c.JSON(401, map[string]string{
 					"error":  "signature contains incorrect CID",
 					"detail": fmt.Sprintf("url: %s, signature %s", cid, sig.Data.Cid),
 				})
 			}
+			// note: id is the upload ID, which is persisted in discovery as part of a track's metadata
 			if id != "" && sig.Data.ID != id {
 				return c.JSON(401, map[string]string{
 					"error":  "signature contains incorrect ID",

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -325,10 +325,9 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 
 // checks signature from discovery node for cidstream endpoint + premium content.
 // based on: https://github.com/AudiusProject/audius-protocol/blob/main/creator-node/src/middlewares/contentAccess/contentAccessMiddleware.ts
-func (s *MediorumServer) requireSignature(next echo.HandlerFunc) echo.HandlerFunc {
+func (s *MediorumServer) requireRegisteredSignature(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		cid := c.Param("cid")
-		id := c.Param("id")
 		sig, err := signature.ParseFromQueryString(c.QueryParam("signature"))
 		if err != nil {
 			return c.JSON(401, map[string]string{
@@ -357,18 +356,11 @@ func (s *MediorumServer) requireSignature(next echo.HandlerFunc) echo.HandlerFun
 				})
 			}
 
-			// check it is for this cid or job id
-			if cid != "" && sig.Data.Cid != cid {
+			// check it is for this cid
+			if sig.Data.Cid != cid {
 				return c.JSON(401, map[string]string{
 					"error":  "signature contains incorrect CID",
 					"detail": fmt.Sprintf("url: %s, signature %s", cid, sig.Data.Cid),
-				})
-			}
-			// note: id is the upload ID, which is persisted in discovery as part of a track's metadata
-			if id != "" && sig.Data.ID != id {
-				return c.JSON(401, map[string]string{
-					"error":  "signature contains incorrect ID",
-					"detail": fmt.Sprintf("url: %s, signature %s", id, sig.Data.ID),
 				})
 			}
 

--- a/mediorum/server/serve_blob_test.go
+++ b/mediorum/server/serve_blob_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRequireSignatureWithUnregisteredNode(t *testing.T) {
+func TestRequireRegisteredSignatureWithUnregisteredNode(t *testing.T) {
 	ss := testNetwork[0]
 
 	// Empty list of signers means no node's signature will be valid
@@ -32,7 +32,7 @@ func TestRequireSignatureWithUnregisteredNode(t *testing.T) {
 	c.SetParamValues(cid)
 
 	// Handle the request
-	h := ss.requireSignature(func(c echo.Context) error {
+	h := ss.requireRegisteredSignature(func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 	h(c)
@@ -42,7 +42,7 @@ func TestRequireSignatureWithUnregisteredNode(t *testing.T) {
 	assert.Contains(t, body, "signer not in list of registered nodes")
 }
 
-func TestRequireSignatureWithOldTimestamp(t *testing.T) {
+func TestRequireRegisteredSignatureWithOldTimestamp(t *testing.T) {
 	ss := testNetwork[0]
 
 	// Make sure the wallet is registered as a signer
@@ -63,7 +63,7 @@ func TestRequireSignatureWithOldTimestamp(t *testing.T) {
 	c.SetParamValues(cid)
 
 	// Handle the request
-	h := ss.requireSignature(func(c echo.Context) error {
+	h := ss.requireRegisteredSignature(func(c echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 	h(c)

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -71,9 +71,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 	if previewStartSecondsString != "" {
 		previewStartSecondsInt, err := strconv.Atoi(previewStartSecondsString)
 		if err != nil {
-			errMsg := "error parsing previewStartSeconds"
-			ss.logger.Error(errMsg, err)
-			return c.String(400, errMsg+": "+err.Error())
+			return c.String(400, "error parsing previewStartSeconds: "+err.Error())
 		}
 
 		previewStartSeconds = sql.NullInt64{
@@ -127,9 +125,7 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 	if previewStartSecondsString != "" {
 		previewStartSecondsInt, err := strconv.Atoi(previewStartSecondsString)
 		if err != nil {
-			errMsg := "error parsing previewStartSeconds"
-			ss.logger.Error(errMsg, err)
-			return c.String(400, errMsg+": "+err.Error())
+			return c.String(400, "error parsing previewStartSeconds: "+err.Error())
 		}
 
 		previewStartSeconds = sql.NullInt64{

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -87,7 +87,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 	if previewStartSeconds != upload.PreviewStartSeconds {
 		upload.PreviewStartSeconds = previewStartSeconds
 		upload.UpdatedAt = time.Now().UTC()
-		upload.Status = JobStatusNewRetranscode
+		upload.Status = JobStatusRetranscode
 
 		err = ss.crud.Update(upload)
 		if err != nil {
@@ -153,6 +153,7 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 		go func() {
 			defer wg.Done()
 
+			now := time.Now().UTC()
 			upload := &Upload{
 				ID:                  ulid.Make().String(),
 				UserID:              userId,
@@ -160,7 +161,8 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 				Template:            template,
 				PreviewStartSeconds: previewStartSeconds,
 				CreatedBy:           ss.Config.Self.Host,
-				CreatedAt:           time.Now().UTC(),
+				CreatedAt:           now,
+				UpdatedAt:           now,
 				OrigFileName:        formFile.Filename,
 				TranscodeResults:    map[string]string{},
 			}

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -61,8 +61,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 		if err != nil {
 			return c.String(http.StatusBadRequest, "error parsing previewStartSeconds: "+err.Error())
 		}
-		previewEndSeconds := previewStartSeconds + audioPreviewDuration
-		selectedPreviewString := fmt.Sprintf("320_preview|%g|%g", previewStartSeconds, previewEndSeconds)
+		selectedPreviewString := fmt.Sprintf("320_preview|%g", previewStartSeconds)
 		selectedPreview = sql.NullString{
 			Valid:  true,
 			String: selectedPreviewString,
@@ -115,8 +114,7 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 		if err != nil {
 			return c.String(http.StatusBadRequest, "error parsing previewStartSeconds: "+err.Error())
 		}
-		previewEndSeconds := previewStartSeconds + audioPreviewDuration
-		selectedPreviewString := fmt.Sprintf("320_preview|%g|%g", previewStartSeconds, previewEndSeconds)
+		selectedPreviewString := fmt.Sprintf("320_preview|%g", previewStartSeconds)
 		selectedPreview = sql.NullString{
 			Valid:  true,
 			String: selectedPreviewString,

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -67,6 +67,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 	}
 	previewStartSeconds := sql.NullInt64{Valid: false}
 	previewStartSecondsString := c.FormValue("previewStartSeconds")
+
 	if previewStartSecondsString != "" {
 		previewStartSecondsInt, err := strconv.Atoi(previewStartSecondsString)
 		if err != nil {
@@ -83,8 +84,9 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 	defer form.RemoveAll()
 
 	// Update supported editable fields
-	// TODO support removing track preview?
-	if previewStartSeconds != upload.PreviewStartSeconds {
+
+	// Do not support deleting previews
+	if previewStartSeconds.Valid && previewStartSeconds != upload.PreviewStartSeconds {
 		upload.PreviewStartSeconds = previewStartSeconds
 		upload.UpdatedAt = time.Now().UTC()
 		upload.Status = JobStatusRetranscode

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -99,7 +99,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 
 func (ss *MediorumServer) postUpload(c echo.Context) error {
 	// Parse X-User-Wallet header
-	userWalletHeader := c.Request().Header.Get("X-User-Wallet")
+	userWalletHeader := c.Request().Header.Get("X-User-Wallet-Addr")
 	userWallet := sql.NullString{Valid: false}
 	if userWalletHeader != "" {
 		userWallet = sql.NullString{

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -223,7 +223,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// public: uploads
 	routes.GET("/uploads", ss.getUploads)
 	routes.GET("/uploads/:id", ss.getUpload)
-	routes.POST("/uploads/:id", ss.updateUpload, ss.requireSignature)
+	routes.POST("/uploads/:id", ss.updateUpload, ss.requireUserSignature)
 	routes.POST("/uploads", ss.postUpload)
 	// Workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
 	routes.OPTIONS("/uploads", func(c echo.Context) error {
@@ -234,8 +234,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/content/:cid", ss.getBlob, ss.ensureNotDelisted)
 	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant)
 	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant)
-	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.ensureNotDelisted, ss.requireSignature)
-	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.ensureNotDelisted, ss.requireSignature)
+	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.ensureNotDelisted, ss.requireRegisteredSignature)
+	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.ensureNotDelisted, ss.requireRegisteredSignature)
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -223,6 +223,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// public: uploads
 	routes.GET("/uploads", ss.getUploads)
 	routes.GET("/uploads/:id", ss.getUpload)
+	routes.POST("/uplaods/:id", ss.updateUpload)
 	routes.POST("/uploads", ss.postUpload)
 	// Workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
 	routes.OPTIONS("/uploads", func(c echo.Context) error {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -223,7 +223,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// public: uploads
 	routes.GET("/uploads", ss.getUploads)
 	routes.GET("/uploads/:id", ss.getUpload)
-	routes.POST("/uploads/:id", ss.updateUpload)
+	routes.POST("/uploads/:id", ss.updateUpload, ss.requireSignature)
 	routes.POST("/uploads", ss.postUpload)
 	// Workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
 	routes.OPTIONS("/uploads", func(c echo.Context) error {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -223,7 +223,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// public: uploads
 	routes.GET("/uploads", ss.getUploads)
 	routes.GET("/uploads/:id", ss.getUpload)
-	routes.POST("/uplaods/:id", ss.updateUpload)
+	routes.POST("/uploads/:id", ss.updateUpload)
 	routes.POST("/uploads", ss.postUpload)
 	// Workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
 	routes.OPTIONS("/uploads", func(c echo.Context) error {

--- a/mediorum/server/server_basic_auth_test.go
+++ b/mediorum/server/server_basic_auth_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequireUserSignatureWithIncorrectID(t *testing.T) {
+	ss := testNetwork[0]
+
+	id := "RNB53QS3EMQCJDWG6PKA66OB3UT7XKXI"
+	signature := "%7B%22data%22%3A%20%22%7B%5C%22upload_id%5C%22%3A%20%5C%22INCORRECTUPLOADID%5C%22%2C%20%5C%22timestamp%5C%22%3A%201596159123000%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220x5ad47b4605f08c14bca58631d3311b8f722a7037a3700666a509895ad011dffb6ae00a3144c03a9f077d746739ab63c205dab23ec7bd67288d337e5d27fdba8c1b%22%7D"
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/uploads/%s?signature=%s", id, signature), nil)
+
+	rec := httptest.NewRecorder()
+	c := ss.echo.NewContext(req, rec)
+	c.SetPath("/uploads/:id")
+	c.SetParamNames("id")
+	c.SetParamValues(id)
+
+	// Handle the request
+	h := ss.requireUserSignature(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+	h(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "signature contains incorrect ID")
+}
+
+func TestRequireUserSignatureWithOldTimestamp(t *testing.T) {
+	ss := testNetwork[0]
+
+	id := "RNB53QS3EMQCJDWG6PKA66OB3UT7XKXI"
+	signature := "%7B%22data%22%3A%20%22%7B%5C%22upload_id%5C%22%3A%20%5C%22RNB53QS3EMQCJDWG6PKA66OB3UT7XKXI%5C%22%2C%20%5C%22timestamp%5C%22%3A%201596159123000%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xc5dbec14490cee5c8d10cc8247291b2f4f906e5d4d27e276b0c2bb94ed576ec745fc5abd932871274a13d31eafe86493eac7ca44d12c2b4b3aa60ccb0e7c4bdf1b%22%7D"
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/uploads/%s?signature=%s", id, signature), nil)
+
+	rec := httptest.NewRecorder()
+	c := ss.echo.NewContext(req, rec)
+	c.SetPath("/uploads/:id")
+	c.SetParamNames("id")
+	c.SetParamValues(id)
+
+	// Handle the request
+	h := ss.requireUserSignature(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+	h(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "signature too old")
+}

--- a/mediorum/server/signature/signature.go
+++ b/mediorum/server/signature/signature.go
@@ -20,7 +20,7 @@ type SignatureEnvelope struct {
 }
 
 type SignatureData struct {
-	ID          string `json:"id"`
+	UploadID    string `json:"upload_id"`
 	Cid         string `json:"cid"`
 	ShouldCache int    `json:"shouldCache"`
 	Timestamp   int64  `json:"timestamp"`

--- a/mediorum/server/signature/signature.go
+++ b/mediorum/server/signature/signature.go
@@ -20,6 +20,7 @@ type SignatureEnvelope struct {
 }
 
 type SignatureData struct {
+	ID          string `json:"id"`
 	Cid         string `json:"cid"`
 	ShouldCache int    `json:"shouldCache"`
 	Timestamp   int64  `json:"timestamp"`

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -450,7 +450,7 @@ func (ss *MediorumServer) transcodeAudioPreview(upload *Upload, temp *os.File, l
 func (ss *MediorumServer) transcode(upload *Upload) error {
 	upload.TranscodedBy = ss.Config.Self.Host
 	upload.TranscodedAt = time.Now().UTC()
-	if upload.Status == JobStatusRetranscode {
+	if upload.Status == JobStatusRetranscode || upload.Status == JobStatusBusyRetranscode {
 		upload.Status = JobStatusBusyRetranscode
 	} else {
 		upload.Status = JobStatusBusy

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -81,7 +81,7 @@ func (ss *MediorumServer) startTranscoder() {
 		}
 		for _, upload := range *uploads {
 			// only the first mirror transcodes
-			if upload.Status == JobStatusNewRetranscode && slices.Index(upload.Mirrors, myHost) == 0 {
+			if upload.Status == JobStatusRetranscode && slices.Index(upload.Mirrors, myHost) == 0 {
 				ss.logger.Info("got retranscode job", "id", upload.ID)
 				work <- upload
 			}
@@ -188,11 +188,11 @@ const (
 )
 
 const (
-	JobStatusNew            = "new"
-	JobStatusNewRetranscode = "new_retranscode_preview"
-	JobStatusBusy           = "busy"
-	JobStatusDone           = "done"
-	JobStatusError          = "error"
+	JobStatusNew         = "new"
+	JobStatusRetranscode = "retranscode_preview"
+	JobStatusBusy        = "busy"
+	JobStatusDone        = "done"
+	JobStatusError       = "error"
 )
 
 func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {
@@ -427,7 +427,7 @@ func (ss *MediorumServer) transcodeAudioPreview(upload *Upload, temp *os.File, l
 }
 
 func (ss *MediorumServer) transcode(upload *Upload) error {
-	reTranscodePreview := upload.Status == JobStatusNewRetranscode
+	reTranscodePreview := upload.Status == JobStatusRetranscode
 
 	upload.TranscodedBy = ss.Config.Self.Host
 	upload.TranscodedAt = time.Now().UTC()

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -118,7 +118,6 @@ func (ss *MediorumServer) findMissedJobs(work chan *Upload, myHost string, retra
 	busyStatus := JobStatusBusy
 	errorStatus := JobStatusError
 	if retranscode {
-		// only look for retranscode jobs
 		newStatus = JobStatusRetranscode
 		busyStatus = JobStatusBusyRetranscode
 		errorStatus = JobStatusErrorRetranscode

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -16,7 +16,6 @@ import (
 	"mime/multipart"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +27,7 @@ import (
 )
 
 var (
-	audioPreviewDuration = 30.0 // seconds
+	audioPreviewDuration = "30" // seconds
 )
 
 func (ss *MediorumServer) startTranscoder() {
@@ -402,22 +401,12 @@ func (ss *MediorumServer) transcodeAudioPreview(upload *Upload, temp *os.File, l
 
 	splitPreview := strings.Split(upload.SelectedPreview.String, "|")
 	previewStart := splitPreview[1]
-	previewEnd := splitPreview[2]
-	previewStartSeconds, err := strconv.ParseFloat(previewStart, 64)
-	if err != nil {
-		return onError(err, "parsing selected preview start")
-	}
-	previewEndSeconds, err := strconv.ParseFloat(previewEnd, 64)
-	if err != nil {
-		return onError(err, "parsing selected preview end")
-	}
-	previewDuration := previewEndSeconds - previewStartSeconds
 
 	cmd := exec.Command("ffmpeg",
 		"-y",
 		"-i", srcPath,
 		"-ss", previewStart, // set preview start time
-		"-t", fmt.Sprint(previewDuration), // set preview duration
+		"-t", audioPreviewDuration, // set preview duration
 		"-b:a", "320k", // set bitrate to 320k
 		"-ar", "48000", // set sample rate to 48000 Hz
 		"-f", "mp3", // force output to mp3
@@ -427,7 +416,7 @@ func (ss *MediorumServer) transcodeAudioPreview(upload *Upload, temp *os.File, l
 		"-progress", "pipe:2",
 		destPath)
 
-	err = ss.transcodeAudio(upload, destPath, cmd, logger)
+	err := ss.transcodeAudio(upload, destPath, cmd, logger)
 	if err != nil {
 		return onError(err, "transcoding audio")
 	}

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -163,10 +163,11 @@ const (
 )
 
 const (
-	JobStatusNew   = "new"
-	JobStatusBusy  = "busy"
-	JobStatusDone  = "done"
-	JobStatusError = "error"
+	JobStatusNew         = "new"
+	JobStatusBusy        = "busy"
+	JobStatusRetranscode = "retranscode"
+	JobStatusDone        = "done"
+	JobStatusError       = "error"
 )
 
 func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {


### PR DESCRIPTION
### Description
1. Transcode preview if a `previewStartSeconds` field is set in the POST multipart from when uploading a track
2. Edit preview via `POST /uploads/:id` with a `previewStartSeconds` field in the POST body. sig from a registered DN required to edit. This sets the upload job status to `retranscode_preview`, which kicks off a retranscode job. Discovery will persist the upload job id for each track to use for this endpoint.

Notes
- Opted to put the preview cid in the upload's `transcode_results` and to not create a new `audio_preview` template. So normal full audio transcodes and audio previews share the same `uploads` record, they're just different entries in `transcode_results`. This made more sense to me from a schema perspective - both the 320kbps downsample and the 30s clip of the downsample are just different transcodings of the same master. Additionally this would mean we could persist the track's audio upload's job ID in discovery for reference when editing the upload to trigger a retranscode rather than just the audio preview's job ID... more extensible in case there are future features like this.
- The audio preview is transcoded off the full 320kbps downsample, not the master, in both the upload and edit upload paths.
- The edit endpoint will not do anything if an empty `previewStartSeconds` is passed in. We don't want to delete the transcoded preview even if in discovery/the client the user has un-gated the track.
- added a `transcoded_mirrors` col to `uploads`... this is like `mirrors` but for the full 320k audio transcode file. not used for image templates.

Question: what happens if the 1st node in the rendezvous hashring for the 320k downsample doesn't have the file for some reason? the transcode job status will be set to `error` when the file isn't found on the node's disk (consistent with the existing flow), but I don't see anywhere those jobs actually get cleaned up - do we depend on the client to retry?


### How Has This Been Tested?
- audius-cmd upload-track with hardcoded preview param in POST req, check db for correct state
- stream both full and preview transcodes directly from content nodes via /ipfs, make sure both sound correct and are correct lengths
- stream track from discovery endpoint to make sure update to signature struct is backwards compatible
- curl the edit endpoint (both to set a fresh preview and to change an existing start time) and make sure file is transcoded + job metadata updated
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/c66ae72f-b298-4dfd-a0a9-12e267320da1)
