### PR TITLE
DMs: better retry mechanism

### DIFF
--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -47,10 +47,9 @@ func DiscoveryMain() {
 			return err
 		}
 
-		// only start sweepers if registered...
-		if discoveryConfig.IsRegisteredWallet {
-			proc.StartPeerClients()
-		}
+		// start peer clients
+		// todo: would be nice to only start sweepers if registered...
+		proc.StartPeerClients()
 
 		err = pubkeystore.Dial(discoveryConfig)
 		if err != nil {

--- a/comms/discovery/rpcz/chat_create_test.go
+++ b/comms/discovery/rpcz/chat_create_test.go
@@ -65,13 +65,17 @@ func TestChatCreate(t *testing.T) {
 	// send a message in this earlier chat
 	chatSendMessage(tx, 1, chatId, "good_message", tsLate, "this message is blessed")
 	tx.QueryRow(`select count(*) from chat_message where chat_id = $1`, chatId).Scan(&count)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 2, count)
 
 	err = tx.QueryRow(`select count(*) from chat_member where invite_code = 'earlier'`).Scan(&count)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
 
 	err = tx.QueryRow(`select count(*) from chat_member where invite_code = 'later'`).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	err = tx.QueryRow(`select count(*) from chat_member where invite_code = 'even_later'`).Scan(&count)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count)
 

--- a/comms/discovery/rpcz/peer_client.go
+++ b/comms/discovery/rpcz/peer_client.go
@@ -161,8 +161,10 @@ func (c *PeerClient) doSweep() error {
 			}
 		} else {
 			// if ok, clear any prior error
-			if _, err := db.Conn.Exec(`delete from rpc_error where sig = $1`, op.Sig); err != nil {
+			if ok, err := db.Conn.Exec(`delete from rpc_error where sig = $1`, op.Sig); err != nil {
 				logger.Error("failed to clear rpc_error rows", err)
+			} else if c, _ := ok.RowsAffected(); c > 0 {
+				logger.Info("rpc_error resolved")
 			}
 		}
 

--- a/comms/discovery/rpcz/peer_client_test.go
+++ b/comms/discovery/rpcz/peer_client_test.go
@@ -1,0 +1,94 @@
+package rpcz
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+
+	"comms.audius.co/discovery/config"
+	"comms.audius.co/discovery/db"
+	"comms.audius.co/discovery/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerClient(t *testing.T) {
+	db.Conn.MustExec(`truncate rpc_error`)
+
+	discoveryConfig := config.Parse()
+
+	proc, err := NewProcessor(discoveryConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pc := NewPeerClient("https://example.com", proc)
+
+	op := &schema.RpcLog{
+		Sig:       "sig1",
+		Rpc:       []byte(`{"fun": true}`),
+		RelayedBy: "https://example.com",
+	}
+	err = pc.insertRpcError(op, errors.New("error1"))
+	assert.NoError(t, err)
+
+	var errorCount int
+	var errorText string
+	err = db.Conn.QueryRow(`select error_count, error_text from rpc_error where sig = 'sig1'`).Scan(&errorCount, &errorText)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, errorCount)
+	assert.Equal(t, "error1", errorText)
+
+	// second attempt
+	err = pc.insertRpcError(op, errors.New("error2"))
+	assert.NoError(t, err)
+
+	err = db.Conn.QueryRow(`select error_count, error_text from rpc_error where sig = 'sig1'`).Scan(&errorCount, &errorText)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, errorCount)
+	assert.Equal(t, "error2", errorText)
+
+	// add a second error
+	{
+		op := &schema.RpcLog{
+			Sig:       "sig2",
+			Rpc:       []byte(`{"fun": true}`),
+			RelayedBy: "https://example.com",
+		}
+		err = pc.insertRpcError(op, errors.New("error2"))
+		assert.NoError(t, err)
+	}
+
+	// add a third error but from an unrelated host
+	// this peer client should only consider (https://example.com)
+	{
+		op := &schema.RpcLog{
+			Sig:       "sig3",
+			Rpc:       []byte(`{"fun": true}`),
+			RelayedBy: "https://google.com",
+		}
+		err = pc.insertRpcError(op, errors.New("error3"))
+		assert.NoError(t, err)
+	}
+
+	{
+		var myFailed []*schema.RpcLog
+		err := pc.appendRpcErrorRows(&myFailed)
+		assert.NoError(t, err)
+		assert.Len(t, myFailed, 2)
+	}
+
+	// increment retry above threshold
+	for i := 0; i < 100; i++ {
+		pc.insertRpcError(op, fmt.Errorf("error%d", i))
+	}
+
+	// should ignore error that is over threshold
+	{
+		var myFailed []*schema.RpcLog
+		err := pc.appendRpcErrorRows(&myFailed)
+		assert.NoError(t, err)
+		assert.Len(t, myFailed, 1)
+	}
+
+}

--- a/comms/discovery/rpcz/rate_limit_test.go
+++ b/comms/discovery/rpcz/rate_limit_test.go
@@ -59,7 +59,7 @@ func TestRateLimit(t *testing.T) {
 	chatTs := time.Now().UTC().Add(-time.Hour * time.Duration(48))
 	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2)", chatId1, chatTs)
 	assert.NoError(t, err)
-	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3)", chatId1, user1Id, user2Id)
+	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id, created_at) values ($1, $2, $1, $2, $4), ($1, $2, $1, $3, $4)", chatId1, user1Id, user2Id, chatTs)
 	assert.NoError(t, err)
 
 	// user1Id messaged user2Id 48 hours ago

--- a/comms/discovery/rpcz/test_utils.go
+++ b/comms/discovery/rpcz/test_utils.go
@@ -11,12 +11,14 @@ import (
 func SetupChatWithMembers(t *testing.T, tx *sqlx.Tx, chatId string, user1 int32, user2 int32) {
 	var err error
 
+	ts := time.Now().UTC()
+
 	// create chat
 	// - should create chat and initial self invite in one tx
-	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2)", chatId, time.Now().UTC())
+	_, err = tx.Exec("insert into chat (chat_id, created_at, last_message_at) values ($1, $2, $2)", chatId, ts)
 	assert.NoError(t, err)
 
 	// insert two members
-	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3)", chatId, user1, user2)
+	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id, created_at) values ($1, $2, $1, $2, $4), ($1, $2, $1, $3, $4)", chatId, user1, user2, ts)
 	assert.NoError(t, err)
 }

--- a/comms/discovery/server/server_test.go
+++ b/comms/discovery/server/server_test.go
@@ -90,7 +90,7 @@ func TestGetChats(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Insert members into chats (1 and 2, 1 and 3, 1 and 4)
-	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3), ($4, $2, $4, $2), ($4, $2, $4, $5), ($6, $2, $6, $2), ($6, $2, $6, $7)", chatId1, user1Id, user2Id, chatId2, user3Id, chatId3, user4Id)
+	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id, created_at) values ($1, $2, $1, $2, now()), ($1, $2, $1, $3, now()), ($4, $2, $4, $2, now()), ($4, $2, $4, $5, now()), ($6, $2, $6, $2, now()), ($6, $2, $6, $7, now())", chatId1, user1Id, user2Id, chatId2, user3Id, chatId3, user4Id)
 	assert.NoError(t, err)
 
 	// Insert 2 messages into chat 1
@@ -330,7 +330,7 @@ func TestGetMessages(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Insert members 1 and 2 into chat
-	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id) values ($1, $2, $1, $2), ($1, $2, $1, $3)", chatId, user1Id, user2Id)
+	_, err = tx.Exec("insert into chat_member (chat_id, invited_by_user_id, invite_code, user_id, created_at) values ($1, $2, $1, $2, now()), ($1, $2, $1, $3, now())", chatId, user1Id, user2Id)
 	assert.NoError(t, err)
 
 	// Insert chat messages

--- a/discovery-provider/ddl/migrations/0007_dm_chat_member_created_at.sql
+++ b/discovery-provider/ddl/migrations/0007_dm_chat_member_created_at.sql
@@ -1,0 +1,16 @@
+begin;
+
+-- add column
+alter table chat_member add column if not exists created_at timestamp without time zone;
+
+-- backfill from chat row
+update chat_member m
+set created_at = c.created_at
+from chat c
+where m.chat_id = c.chat_id
+  and m.created_at is null;
+
+-- make not null
+alter table chat_member alter column created_at set not null;
+
+commit;

--- a/discovery-provider/ddl/migrations/0008_rpc_log_error.sql
+++ b/discovery-provider/ddl/migrations/0008_rpc_log_error.sql
@@ -1,0 +1,11 @@
+begin;
+
+create table if not exists rpc_error (
+  sig text primary key,
+  rpc_log_json jsonb not null,
+  error_text text not null,
+  error_count int not null default 0,
+  last_attempt timestamp without time zone not null
+);
+
+commit;


### PR DESCRIPTION
### Description

Might want to review commits independently.

* First one: don't delete chats on conflict, simply update `chat_member` rows to resolve `invite_code` conflict
* Second one: if sweeper hits apply error, captures rpc into `rpc_error` table and moves on... will retry on subsequent runs up to 30 times.  Also adds endpoint to dump contents of rpc_error table

### How Has This Been Tested?

Deployed to stage DN1... no `rpc_error` rows, but confirmed works.