### PR TITLE
[CON-770] Turn off state machine

### DIFF
--- a/creator-node/src/config.js
+++ b/creator-node/src/config.js
@@ -506,7 +506,7 @@ const config = convict({
     doc: 'number of state monitoring jobs that can run in each interval (0 to pause queue)',
     format: 'nat',
     env: 'stateMonitoringQueueRateLimitJobsPerInterval',
-    default: 1
+    default: 0
   },
   recoverOrphanedDataQueueRateLimitInterval: {
     doc: 'interval (ms) during which at most recoverOrphanedDataQueueRateLimitJobsPerInterval recover-orphaned-data jobs will run',
@@ -518,7 +518,7 @@ const config = convict({
     doc: 'number of recover-orphaned-data jobs that can run in each interval (0 to pause queue)',
     format: 'nat',
     env: 'recoverOrphanedDataQueueRateLimitJobsPerInterval',
-    default: 1
+    default: 0
   },
   recoverOrphanedDataNumUsersPerBatch: {
     doc: 'number of users to fetch from redis and issue requests for (sequentially) in each batch',
@@ -596,13 +596,13 @@ const config = convict({
     doc: 'Max bull queue concurrency for recurring sync request jobs',
     format: 'nat',
     env: 'maxRecurringRequestSyncJobConcurrency',
-    default: 20
+    default: 0
   },
   maxUpdateReplicaSetJobConcurrency: {
     doc: 'Max bull queue concurrency for update replica set jobs',
     format: 'nat',
     env: 'maxUpdateReplicaSetJobConcurrency',
-    default: 10
+    default: 0
   },
   peerHealthCheckRequestTimeout: {
     doc: 'Timeout [ms] for checking health check route',

--- a/dev-tools/startup/creator-node-container.sh
+++ b/dev-tools/startup/creator-node-container.sh
@@ -47,7 +47,7 @@ export redisPort=6379
 
 # Sync / SnapbackSM configs
 export stateMonitoringQueueRateLimitInterval=60000
-export stateMonitoringQueueRateLimitJobsPerInterval=1
+export stateMonitoringQueueRateLimitJobsPerInterval=0
 export snapbackModuloBase=3
 export minimumDailySyncCount=5
 export minimumRollingSyncCount=10


### PR DESCRIPTION
### Description
Disables the queues that handle recurring syncs and replica set updates. Leaves manual syncs alone because v1 signups rely on these to sync metadata from primary->secondaries. Leaves the actual code alone so it's reversible in case of emergency.

### How Has This Been Tested?
I'll verify on staging that the `/health/bull` route is showing recurring sync and replica set update queues as not processing any jobs.