### PR TITLE
Handle chat secret decryption failure cases more gracefully

### DIFF
--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -223,7 +223,13 @@ export class ChatsApi
         ChatGetMessagesRequestSchema
       )(requestParameters)
 
-    const sharedSecret = await this.getChatSecret(chatId)
+    let sharedSecret: Uint8Array
+    try {
+      sharedSecret = await this.getChatSecret(chatId)
+    } catch (e) {
+      console.error("[audius-sdk] Couldn't get chat secret", e)
+      throw new Error("[audius-sdk] Couldn't get chat secret")
+    }
     const path = `/comms/chats/${chatId}/messages`
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
@@ -667,22 +673,22 @@ export class ChatsApi
   }
 
   private async decryptLastChatMessage(c: UserChat): Promise<UserChat> {
-    const sharedSecret = await this.getChatSecret(c.chat_id)
     let lastMessage = ''
-    if (c.last_message && c.last_message.length > 0) {
-      try {
+    try {
+      const sharedSecret = await this.getChatSecret(c.chat_id)
+      if (c.last_message && c.last_message.length > 0) {
         lastMessage = await this.decryptString(
           sharedSecret,
           base64.decode(c.last_message)
         )
-      } catch (e) {
-        console.error(
-          "[audius-sdk]: Error: Couldn't decrypt last chat message",
-          c,
-          e
-        )
-        lastMessage = GENERIC_MESSAGE_ERROR
       }
+    } catch (e) {
+      console.error(
+        "[audius-sdk]: Error: Couldn't decrypt last chat message",
+        c,
+        e
+      )
+      lastMessage = GENERIC_MESSAGE_ERROR
     }
     return {
       ...c,


### PR DESCRIPTION
### Description

Not that this should ever happen... 

This change at least will make the chats list load, and isolate the brokenness to a single chat

### How Has This Been Tested?

Linked SDK against broken account

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
