### PR TITLE
DMs: gossip

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -77,8 +77,9 @@ func (proc *RPCProcessor) SweeperErrors() []string {
 
 func (proc *RPCProcessor) StartPeerClients() {
 	for _, p := range proc.peerClients {
-		p.Start()
+		go p.startSender()
 	}
+	go proc.startSweeper()
 }
 
 func (proc *RPCProcessor) Validate(userId int32, rawRpc schema.RawRPC) error {

--- a/comms/discovery/rpcz/peer_client.go
+++ b/comms/discovery/rpcz/peer_client.go
@@ -2,16 +2,10 @@ package rpcz
 
 import (
 	"bytes"
-	"database/sql"
-	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"time"
 
-	"comms.audius.co/discovery/db"
-	"comms.audius.co/discovery/schema"
 	"comms.audius.co/shared/signing"
 	"golang.org/x/exp/slog"
 )
@@ -37,12 +31,6 @@ func NewPeerClient(host string, proc *RPCProcessor) *PeerClient {
 		outbox: make(chan []byte, outboxBufferSize),
 		logger: slog.With("peer", host),
 	}
-}
-
-func (p *PeerClient) Start() {
-	// todo: should be able to stop these
-	go p.startSender()
-	go p.startSweeper()
 }
 
 func (p *PeerClient) Send(data []byte) bool {
@@ -80,137 +68,4 @@ func (p *PeerClient) startSender() {
 
 		resp.Body.Close()
 	}
-}
-
-// sweeper goroutine will pull messages on interval
-func (c *PeerClient) startSweeper() {
-	// for now we reset cursor on boot every time...
-	// this is to try to resolve any prior bad state...
-	// if everything works we can remove this step
-	db.Conn.MustExec(`delete from rpc_cursor where relayed_by=$1`, c.Host)
-
-	for {
-		c.err = c.doSweep()
-		if c.err != nil {
-			c.logger.Error("sweep error", c.err)
-		}
-		time.Sleep(time.Second * 30)
-	}
-}
-
-func (c *PeerClient) doSweep() error {
-	host := c.Host
-	bulkEndpoint := "/comms/rpc/bulk"
-
-	// get cursor
-
-	var after time.Time
-	err := db.Conn.Get(&after, "SELECT relayed_at FROM rpc_cursor WHERE relayed_by=$1", host)
-	if err != nil && err != sql.ErrNoRows {
-		c.logger.Error("backfill failed to get cursor: ", "err", err)
-	}
-
-	endpoint := host + bulkEndpoint + "?after=" + url.QueryEscape(after.Format(time.RFC3339Nano))
-	started := time.Now()
-
-	req, err := http.NewRequest("GET", endpoint, nil)
-	if err != nil {
-		return err
-	}
-
-	// add header for signed nonce
-	req.Header.Add("Authorization", signing.BasicAuthNonce(c.proc.discoveryConfig.MyPrivateKey))
-
-	client := &http.Client{
-		Timeout: time.Minute,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("bad status: %d", resp.StatusCode)
-	}
-
-	var ops []*schema.RpcLog
-	dec := json.NewDecoder(resp.Body)
-	err = dec.Decode(&ops)
-	if err != nil {
-		return err
-	}
-
-	// add any prior rpc_error rows to the end for retry
-	err = c.appendRpcErrorRows(&ops)
-	if err != nil {
-		c.logger.Error("failed to query rpc_error rows", err)
-	}
-
-	var cursor time.Time
-	for _, op := range ops {
-		logger := c.logger.With("sig", op.Sig)
-		err = c.proc.Apply(op)
-
-		if err != nil {
-			// if apply error, record in rpc_error table
-			logger.Error("sweep apply error", "err", err, "sig", op.Sig)
-			if err := c.insertRpcError(op, err); err != nil {
-				logger.Error("failed to insert rpc_error row", err)
-			}
-		} else {
-			// if ok, clear any prior error
-			if ok, err := db.Conn.Exec(`delete from rpc_error where sig = $1`, op.Sig); err != nil {
-				logger.Error("failed to clear rpc_error rows", err)
-			} else if c, _ := ok.RowsAffected(); c > 0 {
-				logger.Info("rpc_error resolved")
-			}
-		}
-
-		cursor = op.RelayedAt
-	}
-
-	if !cursor.IsZero() {
-		c.logger.Info("sweep done", "took", time.Since(started).String(), "count", len(ops), "cursor", cursor)
-		q := `insert into rpc_cursor values ($1, $2) on conflict (relayed_by) do update set relayed_at = $2;`
-		_, err = db.Conn.Exec(q, host, cursor)
-		return err
-	}
-
-	return err
-}
-
-func (c *PeerClient) insertRpcError(op *schema.RpcLog, applyError error) error {
-	opJson, err := json.Marshal(op)
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Conn.Exec(`
-	insert into rpc_error
-		(sig, rpc_log_json, error_text, error_count, last_attempt)
-	values
-		($1, $2, $3, 1, now())
-	on conflict (sig) do update set error_text = $3, error_count = rpc_error.error_count + 1, last_attempt = now()
-	`, op.Sig, opJson, applyError.Error())
-
-	return err
-}
-
-func (c *PeerClient) appendRpcErrorRows(ops *[]*schema.RpcLog) error {
-	var js []string
-	err := db.Conn.Select(&js, `select rpc_log_json from rpc_error where rpc_log_json->>'relayed_by' = $1 and error_count < 30 order by last_attempt asc`, c.Host)
-	if err != nil {
-		return err
-	}
-	for _, j := range js {
-		var op *schema.RpcLog
-		err := json.Unmarshal([]byte(j), &op)
-		if err == nil {
-			*ops = append(*ops, op)
-		}
-	}
-
-	return nil
 }

--- a/comms/discovery/rpcz/peer_sweeper.go
+++ b/comms/discovery/rpcz/peer_sweeper.go
@@ -1,0 +1,166 @@
+package rpcz
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"comms.audius.co/discovery/db"
+	"comms.audius.co/discovery/schema"
+	"comms.audius.co/shared/signing"
+	"golang.org/x/exp/slog"
+)
+
+// sweeper goroutine will pull messages on interval
+func (proc *RPCProcessor) startSweeper() {
+	// for now we reset cursor on boot every time...
+	// this is to try to resolve any prior bad state...
+	// if everything works we can remove this step
+	db.Conn.MustExec(`truncate rpc_cursor`)
+
+	for {
+		// visit each host in turn
+		for _, peer := range proc.discoveryConfig.Peers() {
+			logger := slog.With("host", peer.Host)
+			if err := proc.sweepHost(peer.Host); err != nil {
+				logger.Error("sweepHost failed", "err", err)
+			}
+		}
+
+		// visit any failed rpc rows for retry
+		proc.sweepFailed()
+
+		time.Sleep(time.Second * 10)
+	}
+
+}
+
+func (proc *RPCProcessor) sweepHost(host string) error {
+	logger := slog.With("sweep_host", host)
+	bulkEndpoint := "/comms/rpc/bulk"
+
+	// get cursor
+	var after time.Time
+	err := db.Conn.Get(&after, "SELECT relayed_at FROM rpc_cursor WHERE relayed_by=$1", host)
+	if err != nil && err != sql.ErrNoRows {
+		logger.Error("backfill failed to get cursor: ", "err", err)
+	}
+
+	endpoint := host + bulkEndpoint + "?after=" + url.QueryEscape(after.Format(time.RFC3339Nano))
+	started := time.Now()
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	// add header for signed nonce
+	req.Header.Add("Authorization", signing.BasicAuthNonce(proc.discoveryConfig.MyPrivateKey))
+
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("bad status: %d", resp.StatusCode)
+	}
+
+	var ops []*schema.RpcLog
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&ops)
+	if err != nil {
+		return err
+	}
+
+	var cursor time.Time
+	for _, op := range ops {
+		proc.sweeperApply(op)
+		cursor = op.AppliedAt
+	}
+
+	if !cursor.IsZero() {
+		logger.Info("sweep done", "took", time.Since(started).String(), "count", len(ops), "cursor", cursor)
+		q := `insert into rpc_cursor values ($1, $2) on conflict (relayed_by) do update set relayed_at = $2;`
+		_, err = db.Conn.Exec(q, host, cursor)
+		return err
+	}
+
+	return err
+}
+
+func (proc *RPCProcessor) sweepFailed() {
+	ops, err := getRpcErrorRows()
+	if err != nil {
+		slog.Error("getRpcErrorRows failed", "err", err)
+		return
+	}
+	for _, op := range ops {
+		proc.sweeperApply(op)
+	}
+}
+
+func (proc *RPCProcessor) sweeperApply(op *schema.RpcLog) {
+	logger := logger.With("sig", op.Sig)
+
+	err := proc.Apply(op)
+
+	if err != nil {
+		// if apply error, record in rpc_error table
+		logger.Error("sweep apply error", "err", err, "sig", op.Sig)
+		if err := insertRpcError(op, err); err != nil {
+			logger.Error("failed to insert rpc_error row", err)
+		}
+	} else {
+		// if ok, clear any prior error
+		if ok, err := db.Conn.Exec(`delete from rpc_error where sig = $1`, op.Sig); err != nil {
+			logger.Error("failed to clear rpc_error rows", err)
+		} else if c, _ := ok.RowsAffected(); c > 0 {
+			logger.Info("rpc_error resolved")
+		}
+	}
+}
+
+func insertRpcError(op *schema.RpcLog, applyError error) error {
+	opJson, err := json.Marshal(op)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Conn.Exec(`
+	insert into rpc_error
+		(sig, rpc_log_json, error_text, error_count, last_attempt)
+	values
+		($1, $2, $3, 1, now())
+	on conflict (sig) do update set error_text = $3, error_count = rpc_error.error_count + 1, last_attempt = now()
+	`, op.Sig, opJson, applyError.Error())
+
+	return err
+}
+
+func getRpcErrorRows() ([]*schema.RpcLog, error) {
+	var js []string
+	err := db.Conn.Select(&js, `select rpc_log_json from rpc_error where error_count < 30 order by last_attempt asc`)
+	if err != nil {
+		return nil, err
+	}
+
+	var ops []*schema.RpcLog
+	for _, j := range js {
+		var op *schema.RpcLog
+		err := json.Unmarshal([]byte(j), &op)
+		if err == nil {
+			ops = append(ops, op)
+		}
+	}
+
+	return ops, nil
+}

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -746,8 +746,8 @@ func (ss *ChatServer) getRpcBulk(c echo.Context) error {
 		fmt.Println("failed to parse time", err, c.QueryParam("after"), c.QueryString())
 	}
 
-	query := `select * from rpc_log where relayed_by = $1 and relayed_at > $2 order by relayed_at asc limit 10000`
-	err := db.Conn.Select(&rpcs, query, ss.config.MyHost, after.Truncate(time.Microsecond))
+	query := `select * from rpc_log where applied_at > $1 order by applied_at asc limit 10000`
+	err := db.Conn.Select(&rpcs, query, after.Truncate(time.Microsecond))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Currently on `main` we start a goroutine per peer and sweep only the messages that were relayed by that peer.  This non-gossip style replication has these downsides:

* if there is "no route" between two hosts (due to DNS config) they don't get each other's messages
* if a host re-seeds and the db has an incomplete history... the host's own history will change and become incomplete
* if a host is down, messages it relayed are unavailable while down

This PR makes it more gossip style... it will scroll all messages in `rpc_log` in `applied_at` order instead of using `(relayed_by, relayed_at)`.

This means there is more write amplification, but also ensures all hosts get all messages and `rpc_log` acts like a more reliable grow only set.  Skipping a message you have already seen is cheap, so the write amplification is ok.

### How Has This Been Tested?

deployed to staging