### PR TITLE
Use unique port for test db

### DIFF
--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -15,7 +15,7 @@ services:
     image: postgres
     restart: unless-stopped
     ports:
-      - 5454:5432
+      - 5455:5432
     environment:
       PGUSER: "postgres"
       POSTGRES_PASSWORD: "postgres"


### PR DESCRIPTION
Use 5455 for postgres in docker-compose.test.yml so that tests can be run even if the local stack is already up

### Description

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
