### PR TITLE
Return unhealthy mediorum if no db connection

### DIFF
--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -42,6 +42,7 @@ func (ss *MediorumServer) updateDiskAndDbStatus() {
 	if err == nil {
 		ss.databaseSize = dbSize
 	} else {
+		ss.databaseSize = 0
 		slog.Error("Error getting database size", "err", err)
 	}
 }

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -69,7 +69,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 	defer ss.peerHealthMutex.RUnlock()
 
 	data := healthCheckResponseData{
-		Healthy:                   err == nil,
+		Healthy:                   err == nil && ss.databaseSize > 0,
 		Version:                   legacyHealth.Version,
 		Service:                   legacyHealth.Service,
 		BuiltAt:                   vcsBuildTime,


### PR DESCRIPTION
### Description
Returns healthy=false in health check if the db size check fails to connect or is empty. It will never be empty as long as there's even a single table (even if it has no rows yet).

### How Has This Been Tested?
Very small change. We can test on staging.