### PR TITLE
DN trusted notifier polling: handle slow indexing. add monitor for cursor being behind

### DIFF
--- a/discovery-provider/ddl/migrations/0009_nuke_tn_delist_tables.sql
+++ b/discovery-provider/ddl/migrations/0009_nuke_tn_delist_tables.sql
@@ -1,0 +1,3 @@
+begin;
+  truncate delist_status_cursor;
+commit;

--- a/discovery-provider/ddl/migrations/0009_nuke_tn_delist_tables.sql
+++ b/discovery-provider/ddl/migrations/0009_nuke_tn_delist_tables.sql
@@ -1,3 +1,3 @@
 begin;
-  truncate delist_status_cursor;
+  truncate table delist_status_cursor;
 commit;

--- a/discovery-provider/integration_tests/tasks/test_update_delist_statuses.py
+++ b/discovery-provider/integration_tests/tasks/test_update_delist_statuses.py
@@ -55,7 +55,7 @@ def _mock_response(json_data, raise_for_status=None):
 
 
 @mock.patch("src.utils.auth_helpers.requests")
-def test_update_track_delist_statuses_missing_user(mock_requests, app):
+def test_update_user_delist_statuses_missing_user(mock_requests, app):
     with app.app_context():
         db = get_db()
     _seed_db(db)

--- a/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
+++ b/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
@@ -33,7 +33,7 @@ def check_user_delist_status_cursor(redis: Redis):
                 float(user_cursor_check_timestamp.decode())
             ).replace(tzinfo=timezone.utc)
             # Only run query every 12h
-            if latest_check > datetime.now(timezone.utc) - timedelta(hours=4):
+            if latest_check > datetime.now(timezone.utc) - timedelta(hours=12):
                 user_delist_cursor_check = redis.get(
                     USER_DELIST_STATUS_CURSOR_CHECK_KEY
                 ).decode()
@@ -83,7 +83,7 @@ def check_track_delist_status_cursor(redis: Redis):
                 float(track_cursor_check_timestamp.decode())
             ).replace(tzinfo=timezone.utc)
             # Only run query every 12h
-            if latest_check > datetime.now(timezone.utc) - timedelta(hours=4):
+            if latest_check > datetime.now(timezone.utc) - timedelta(hours=12):
                 track_delist_cursor_check = redis.get(
                     TRACK_DELIST_STATUS_CURSOR_CHECK_KEY
                 ).decode()

--- a/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
+++ b/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
@@ -38,7 +38,7 @@ def check_user_delist_status_cursor(redis: Redis):
                     USER_DELIST_STATUS_CURSOR_CHECK_KEY
                 ).decode()
                 if user_delist_cursor_check != "ok":
-                    # If discrepancies, re-run query every 5 min to quickly suppress errors
+                    # If not ok, re-run query every 5 min to quickly suppress errors
                     # once resolved
                     if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
                         return user_delist_cursor_check
@@ -88,7 +88,7 @@ def check_track_delist_status_cursor(redis: Redis):
                     TRACK_DELIST_STATUS_CURSOR_CHECK_KEY
                 ).decode()
                 if track_delist_cursor_check != "ok":
-                    # If discrepancies, re-run query every 5 min to quickly suppress errors
+                    # If not ok, re-run query every 5 min to quickly suppress errors
                     # once resolved
                     if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
                         return track_delist_cursor_check

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -16,7 +16,7 @@ logger = StructuredLogger(__name__)
 
 UPDATE_DELIST_STATUSES_LOCK = "update_delist_statuses_lock"
 DEFAULT_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
-DELIST_BATCH_SIZE = 500
+DELIST_BATCH_SIZE = 5000
 
 
 def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[User]:
@@ -56,25 +56,28 @@ def update_user_is_available_statuses(session, users):
         user_id = user["userId"]
         delisted = user["delisted"]
         user_id_to_delisted_map[user_id] = delisted
-    user_ids = list(user_id_to_delisted_map.keys())
-    try:
-        users_to_update = query_users_by_user_ids(session, user_ids)
-        for user in users_to_update:
-            delisted = user_id_to_delisted_map[user.user_id]
-            if delisted:
-                # Deactivate active users that have been delisted
-                if user.is_available:
-                    user.is_available = False
-                    user.is_deactivated = True
-            else:
-                # Re-activate deactivated users that have been un-delisted
-                if not user.is_available:
-                    user.is_available = True
-                    user.is_deactivated = False
-    except Exception as e:
-        logger.error(
-            f"update_delist_statuses.py | Could not process user id batch {user_ids}: {e}\nContinuing..."
-        )
+
+    user_ids = set(user_id_to_delisted_map.keys())
+    users_to_update = query_users_by_user_ids(session, user_ids)
+    user_ids_to_update = set(map(lambda user: user.user_id, users_to_update))
+    if len(user_id_to_delisted_map) != len(user_ids_to_update):
+        # halt processing until indexing is caught up and all users are created in db
+        missing_user_ids = user_ids - user_ids_to_update
+        logger.info(f"update_delist_statuses.py | missing user ids: {missing_user_ids}")
+        return False
+    for user in users_to_update:
+        delisted = user_id_to_delisted_map[user.user_id]
+        if delisted:
+            # Deactivate active users that have been delisted
+            if user.is_available:
+                user.is_available = False
+                user.is_deactivated = True
+        else:
+            # Re-activate deactivated users that have been un-delisted
+            if not user.is_available:
+                user.is_available = True
+                user.is_deactivated = False
+    return True
 
 
 def update_track_is_available_statuses(session, tracks):
@@ -86,25 +89,28 @@ def update_track_is_available_statuses(session, tracks):
         track_id = track["trackId"]
         delisted = track["delisted"]
         track_id_to_delisted_map[track_id] = delisted
-    track_ids = list(track_id_to_delisted_map.keys())
-    try:
-        tracks_to_update = query_tracks_by_track_ids(session, track_ids)
-        for track in tracks_to_update:
-            delisted = track_id_to_delisted_map[track.track_id]
-            if delisted:
-                # Deactivate active tracks that have been delisted
-                if track.is_available:
-                    track.is_available = False
-                    track.is_delete = True
-            else:
-                # Re-activate deactivated tracks that have been un-delisted
-                if not track.is_available:
-                    track.is_available = True
-                    track.is_delete = False
-    except Exception as e:
-        logger.error(
-            f"update_delist_statuses.py | Could not process track id batch {track_ids}: {e}\nContinuing..."
-        )
+
+    track_ids = set(track_id_to_delisted_map.keys())
+    tracks_to_update = query_tracks_by_track_ids(session, track_ids)
+    track_ids_to_update = set(map(lambda track: track.track_id, tracks_to_update))
+    if len(track_id_to_delisted_map) != len(track_ids_to_update):
+        # halt processing until indexing is caught up and all tracks are created in db
+        missing_track_ids = track_ids - track_ids_to_update
+        logger.info(f"update_delist_statuses.py | missing track ids: {missing_track_ids}")
+        return False
+    for track in tracks_to_update:
+        delisted = track_id_to_delisted_map[track.track_id]
+        if delisted:
+            # Deactivate active tracks that have been delisted
+            if track.is_available:
+                track.is_available = False
+                track.is_delete = True
+        else:
+            # Re-activate deactivated tracks that have been un-delisted
+            if not track.is_available:
+                track.is_available = True
+                track.is_delete = False
+    return True
 
 
 def insert_user_delist_statuses(session, users):
@@ -189,12 +195,16 @@ def process_user_delist_statuses(session, resp, endpoint):
     users = resp["result"]["users"]
     if len(users) > 0:
         insert_user_delist_statuses(session, users)
-        update_user_is_available_statuses(session, users)
-        cursor_after = users[-1]["createdAt"]
-        update_delist_status_cursor(session, cursor_after, endpoint, DelistEntity.USERS)
-    logger.info(
-        f"update_delist_statuses.py | processed {len(users)} user delist statuses"
-    )
+        try:
+            success = update_user_is_available_statuses(session, users)
+            if success:
+                cursor_after = users[-1]["createdAt"]
+                update_delist_status_cursor(session, cursor_after, endpoint, DelistEntity.USERS)
+                logger.info(
+                    f"update_delist_statuses.py | processed {len(users)} user delist statuses"
+                )
+        except Exception as e:
+            logger.error(f"update_delist_statuses.py | exception while processing user delists: {e}")
 
 
 def process_track_delist_statuses(session, resp, endpoint):
@@ -202,14 +212,18 @@ def process_track_delist_statuses(session, resp, endpoint):
     tracks = resp["result"]["tracks"]
     if len(tracks) > 0:
         insert_track_delist_statuses(session, tracks)
-        update_track_is_available_statuses(session, tracks)
-        cursor_after = tracks[-1]["createdAt"]
-        update_delist_status_cursor(
-            session, cursor_after, endpoint, DelistEntity.TRACKS
-        )
-    logger.info(
-        f"update_delist_statuses.py | processed {len(tracks)} track delist statuses"
-    )
+        try:
+            success = update_track_is_available_statuses(session, tracks)
+            if success:
+                cursor_after = tracks[-1]["createdAt"]
+                update_delist_status_cursor(
+                    session, cursor_after, endpoint, DelistEntity.TRACKS
+                )
+                logger.info(
+                    f"update_delist_statuses.py | processed {len(tracks)} track delist statuses"
+                )
+        except Exception as e:
+            logger.error(f"update_delist_statuses.py | exception while processing track delists: {e}")
 
 
 def process_delist_statuses(session: Session, trusted_notifier_manager: Dict):

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -61,7 +61,7 @@ latest_sol_rewards_manager_backfill_slot_key = (
 LAST_REACTIONS_INDEX_TIME_KEY = "reactions_last_index_time"
 LAST_SEEN_NEW_REACTION_TIME_KEY = "reactions_last_new_reaction_time"
 
-# Delist status cursor monitoring key
+# Delist status cursor monitoring keys
 USER_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY = "user_delist_status_cursor_check_timestamp_key"
 USER_DELIST_STATUS_CURSOR_CHECK_KEY = "user_delist_status_cursor_check_key"
 TRACK_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY = "track_delist_status_cursor_check_timestamp_key"

--- a/discovery-provider/src/utils/redis_constants.py
+++ b/discovery-provider/src/utils/redis_constants.py
@@ -61,6 +61,12 @@ latest_sol_rewards_manager_backfill_slot_key = (
 LAST_REACTIONS_INDEX_TIME_KEY = "reactions_last_index_time"
 LAST_SEEN_NEW_REACTION_TIME_KEY = "reactions_last_new_reaction_time"
 
+# Delist status cursor monitoring key
+USER_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY = "user_delist_status_cursor_check_timestamp_key"
+USER_DELIST_STATUS_CURSOR_CHECK_KEY = "user_delist_status_cursor_check_key"
+TRACK_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY = "track_delist_status_cursor_check_timestamp_key"
+TRACK_DELIST_STATUS_CURSOR_CHECK_KEY = "track_delist_status_cursor_check_key"
+
 # User delist discrepancy keys
 USER_DELIST_DISCREPANCIES_TIMESTAMP_KEY = "user_delist_discrepancies_timestamp"
 USER_DELIST_DISCREPANCIES_KEY = "user_delist_discrepancies"


### PR DESCRIPTION
### Description
Do not update the delist status cursor if there are missing tracks or users in the discovery db that should be updated, so that discovery retries the delist until indexing is caught up. This is what was causing discrepancies in prod DN3, which is slower than the other nodes.

Also check the cursor every 12h to make sure it's caught up.

Nuke the cursors table to make all nodes including SPs go through the delists again. No need to truncate user_delist_statuses and track_delist_statuses, those have an ON CONFLICT DO NOTHING clause on the insert.

### How Has This Been Tested?
Written tests, checked health endpoint on local

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
