### PR TITLE
[PAY-1547] Add USDC related tables to DB

### DIFF
--- a/discovery-provider/ddl/migrations/0010_usdc_userbank_tables.sql
+++ b/discovery-provider/ddl/migrations/0010_usdc_userbank_tables.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+-- USDC user bank accounts
+CREATE TABLE IF NOT EXISTS usdc_user_bank_accounts (
+    "signature" varchar NOT NULL,
+    ethereum_address varchar NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    bank_account varchar NOT NULL,
+    PRIMARY KEY("signature")
+);
+CREATE INDEX IF NOT EXISTS idx_usdc_user_bank_accounts_eth_address ON usdc_user_bank_accounts USING btree (ethereum_address);
+
+-- USDC transactions history
+CREATE TABLE IF NOT EXISTS usdc_transactions_history (
+    user_bank varchar NOT NULL,
+    slot integer NOT NULL,
+    "signature" varchar NOT NULL,
+    transaction_type varchar NOT NULL,
+    method varchar NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    transaction_created_at timestamp NOT NULL,
+    change numeric NOT NULL,
+    balance numeric NOT NULL,
+    tx_metadata varchar,
+    PRIMARY KEY(user_bank, "signature")
+);
+CREATE INDEX IF NOT EXISTS idx_usdc_transactions_history_slot ON usdc_transactions_history USING btree (slot);
+CREATE INDEX IF NOT EXISTS idx_usdc_transactions_history_type ON usdc_transactions_history USING btree (transaction_type);
+
+-- USDC purchases table
+DO $$ BEGIN
+    CREATE TYPE usdc_purchase_content_type AS ENUM ('track', 'playlist', 'album');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS usdc_purchases (
+    slot integer NOT NULL,
+    "signature" varchar NOT NULL,
+    buyer_user_id integer NOT NULL,
+    seller_user_id integer NOT NULL,
+    amount numeric NOT NULL,
+    content_type usdc_purchase_content_type NOT NULL,
+    content_id integer NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(slot, "signature")
+);
+CREATE INDEX IF NOT EXISTS idx_usdc_purchases_buyer ON usdc_purchases USING btree (buyer_user_id);
+CREATE INDEX IF NOT EXISTS idx_usdc_purchases_seller ON usdc_purchases USING btree (seller_user_id);
+CREATE INDEX IF NOT EXISTS idx_usdc_purchases_type ON usdc_purchases USING btree (content_type);
+
+-- USDC tx indexing progress
+CREATE TABLE IF NOT EXISTS usdc_token_tx (
+    last_scanned_slot integer NOT NULL,
+    "signature" varchar NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMIT;

--- a/discovery-provider/ddl/migrations/0010_usdc_userbank_tables.sql
+++ b/discovery-provider/ddl/migrations/0010_usdc_userbank_tables.sql
@@ -22,7 +22,6 @@ CREATE TABLE IF NOT EXISTS usdc_transactions_history (
     transaction_created_at timestamp NOT NULL,
     change numeric NOT NULL,
     balance numeric NOT NULL,
-    tx_metadata varchar,
     PRIMARY KEY(user_bank, "signature")
 );
 CREATE INDEX IF NOT EXISTS idx_usdc_transactions_history_slot ON usdc_transactions_history USING btree (slot);
@@ -40,7 +39,7 @@ CREATE TABLE IF NOT EXISTS usdc_purchases (
     "signature" varchar NOT NULL,
     buyer_user_id integer NOT NULL,
     seller_user_id integer NOT NULL,
-    amount numeric NOT NULL,
+    amount bigint NOT NULL,
     content_type usdc_purchase_content_type NOT NULL,
     content_id integer NOT NULL,
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -50,13 +49,5 @@ CREATE TABLE IF NOT EXISTS usdc_purchases (
 CREATE INDEX IF NOT EXISTS idx_usdc_purchases_buyer ON usdc_purchases USING btree (buyer_user_id);
 CREATE INDEX IF NOT EXISTS idx_usdc_purchases_seller ON usdc_purchases USING btree (seller_user_id);
 CREATE INDEX IF NOT EXISTS idx_usdc_purchases_type ON usdc_purchases USING btree (content_type);
-
--- USDC tx indexing progress
-CREATE TABLE IF NOT EXISTS usdc_token_tx (
-    last_scanned_slot integer NOT NULL,
-    "signature" varchar NOT NULL,
-    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
 
 COMMIT;


### PR DESCRIPTION
### Description

Adds tables for USDC related things.

Open Qs:
- Do we want any improvements on existing userbank things? Eg any foreign keys/cascading deletes?
- Do we want `spl_token`-like indexing progress or put each tx in the table like former `user_bank_tx` table?

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested that migrations ran successfully by pointing DDL script at local db