### PR TITLE
Make grant creation faster on EM indexing C-2803

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
@@ -12,18 +12,11 @@ from web3.datastructures import AttributeDict
 new_grants_data = [
     {
         "user_id": 1,
-        "grantee_address": "user3wallet",
-        "is_user_grant": True,
-    },
-    {
-        "user_id": 1,
         "grantee_address": "0x3a388671bb4D6E1Ea08D79Ee191b40FB45A8F4C4",
-        "is_user_grant": False,
     },
     {
         "user_id": 1,
         "grantee_address": "0x04c9fc3784120f50932436f84c59aebebb12e0d",
-        "is_user_grant": False,
     },
 ]
 
@@ -62,20 +55,6 @@ def test_index_grant(app, mocker):
                         "_metadata": f"""{{"grantee_address": "{new_grants_data[1]["grantee_address"]}"}}""",
                         "_action": Action.CREATE,
                         "_signer": f"user{new_grants_data[1]['user_id']}wallet",
-                    }
-                )
-            },
-        ],
-        "CreateGrantTx3": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": 0,
-                        "_entityType": EntityType.GRANT,
-                        "_userId": new_grants_data[2]["user_id"],
-                        "_metadata": f"""{{"grantee_address": "{new_grants_data[2]["grantee_address"]}"}}""",
-                        "_action": Action.CREATE,
-                        "_signer": f"user{new_grants_data[2]['user_id']}wallet",
                     }
                 )
             },
@@ -135,7 +114,7 @@ def test_index_grant(app, mocker):
 
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
-        assert len(all_grants) == 4
+        assert len(all_grants) == 3
 
         for expected_grant in new_grants_data:
             found_matches = [
@@ -147,10 +126,6 @@ def test_index_grant(app, mocker):
             assert len(found_matches) == 1
             res = found_matches[0]
             assert res.is_current == True
-            if expected_grant["is_user_grant"]:
-                assert res.is_approved == False
-            else:
-                assert res.is_approved == True
             assert res.blocknumber == 0
 
     # Test invalid create grant txs
@@ -236,7 +211,7 @@ def test_index_grant(app, mocker):
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
         # make sure no new rows were added
-        assert len(all_grants) == 4
+        assert len(all_grants) == 3
 
     tx_receipts = {
         "InvalidDeleteGrantTx1": [
@@ -305,7 +280,7 @@ def test_index_grant(app, mocker):
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
         # make sure no new rows were added
-        assert len(all_grants) == 4
+        assert len(all_grants) == 3
 
     # Valid deletes
     tx_receipts = {
@@ -337,20 +312,6 @@ def test_index_grant(app, mocker):
                 )
             },
         ],
-        "DeleteGrantTx3": [
-            {
-                "args": AttributeDict(
-                    {
-                        "_entityId": 0,
-                        "_entityType": EntityType.GRANT,
-                        "_userId": new_grants_data[2]["user_id"],
-                        "_metadata": f"""{{"grantee_address": "{new_grants_data[2]["grantee_address"]}"}}""",
-                        "_action": Action.DELETE,
-                        "_signer": f"user{new_grants_data[2]['user_id']}wallet",
-                    }
-                )
-            },
-        ],
     }
 
     entity_manager_txs = [
@@ -371,7 +332,7 @@ def test_index_grant(app, mocker):
 
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
-        assert len(all_grants) == 7
+        assert len(all_grants) == 5
 
         for expected_grant in new_grants_data:
             found_matches = [
@@ -386,10 +347,6 @@ def test_index_grant(app, mocker):
             assert res.user_id == expected_grant["user_id"]
             assert res.is_current == True
             assert res.grantee_address == expected_grant["grantee_address"].lower()
-            if expected_grant["is_user_grant"]:
-                assert res.is_approved == False
-            else:
-                assert res.is_approved == True
             assert res.is_revoked == True
             assert res.blocknumber == 0
 
@@ -430,7 +387,7 @@ def test_index_grant(app, mocker):
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
         # No change
-        assert len(all_grants) == 7
+        assert len(all_grants) == 5
 
     # Reactivate a revoked grant
     tx_receipts = {
@@ -468,7 +425,7 @@ def test_index_grant(app, mocker):
 
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
-        assert len(all_grants) == 8
+        assert len(all_grants) == 6
         expected_grant = new_grants_data[1]
         found_matches = [
             item
@@ -482,6 +439,5 @@ def test_index_grant(app, mocker):
         assert res.user_id == expected_grant["user_id"]
         assert res.is_current == True
         assert res.grantee_address == expected_grant["grantee_address"].lower()
-        assert res.is_approved == True
         assert res.is_revoked == False
         assert res.blocknumber == 0

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -150,7 +150,7 @@ def entity_manager_update(
                         block_number,
                         event_blockhash,
                         txhash,
-                        logger
+                        logger,
                     )
 
                     # update logger context with this tx event
@@ -271,9 +271,7 @@ def entity_manager_update(
                     logger.info("process transaction")  # log event context
                 except IndexingValidationError as e:
                     # swallow exception to keep indexing
-                    logger.info(
-                        f"failed to process transaction error {e}"
-                    )
+                    logger.info(f"failed to process transaction error {e}")
         # compile records_to_save
         records_to_save = []
         for record_type, record_dict in new_records.items():
@@ -416,9 +414,6 @@ def collect_entities_to_fetch(update_task, entity_manager_txs):
                     entities_to_fetch[EntityType.DEVELOPER_APP].add(
                         raw_grantee_address.lower()
                     )
-                    entities_to_fetch[EntityType.USER_WALLET].add(
-                        raw_grantee_address.lower()
-                    )
                 else:
                     logger.error(
                         "tasks | entity_manager.py | Missing grantee address in metadata required for add grant tx"
@@ -494,20 +489,6 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
             .all()
         )
         existing_entities[EntityType.USER] = {user.user_id: user for user in users}
-
-    # USERS BY WALLET
-    if entities_to_fetch[EntityType.USER_WALLET]:
-        users_by_wallet: List[User] = (
-            session.query(User)
-            .filter(
-                func.lower(User.wallet).in_(entities_to_fetch[EntityType.USER_WALLET]),
-                User.is_current == True,
-            )
-            .all()
-        )
-        existing_entities[EntityType.USER_WALLET] = {
-            (cast(str, user.wallet)).lower(): user.user_id for user in users_by_wallet
-        }
 
     # FOLLOWS
     if entities_to_fetch[EntityType.FOLLOW]:

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -1,8 +1,7 @@
 import json
-import logging
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Set, Tuple, cast
+from typing import Any, Dict, List, Set, Tuple
 
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm.session import Session

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -72,7 +72,6 @@ class EntityType(str, Enum):
     TRACK = "Track"
     USER = "User"
     USER_REPLICA_SET = "UserReplicaSet"
-    USER_WALLET = "UserWallet"
     FOLLOW = "Follow"
     SAVE = "Save"
     REPOST = "Repost"
@@ -146,7 +145,7 @@ class ManageEntityParameters:
         block_number: int,
         event_blockhash: str,
         txhash: str,
-        logger: StructuredLogger
+        logger: StructuredLogger,
     ):
         self.user_id = helpers.get_tx_arg(event, "_userId")
         self.entity_id = helpers.get_tx_arg(event, "_entityId")

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -102,7 +102,6 @@ class RecordDict(TypedDict):
 class ExistingRecordDict(TypedDict):
     Playlist: Dict[int, Playlist]
     Track: Dict[int, Track]
-    UserByWallet: Dict[str, User]
     User: Dict[int, User]
     Follow: Dict[Tuple, Follow]
     Save: Dict[Tuple, Save]
@@ -122,7 +121,6 @@ class EntitiesToFetchDict(TypedDict):
     PlaylistSeen: Set[Tuple]
     Grant: Set[Tuple]
     DeveloperApp: Set[str]
-    UserByWallet: Set[str]
 
 
 MANAGE_ENTITY_EVENT_TYPE = "ManageEntity"


### PR DESCRIPTION
### Description
Get rid of the query for users by wallet address, since we don't need it anymore. Hopefully this makes the grant creation faster since anecdotally it has been taking longer than other txs. With this deleted, there's no other reason it should be slower than other tx processing times.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
