### PR TITLE
[CON-771] Short circuit when transcode fails

### DIFF
--- a/libs/src/sdk/services/Storage/Storage.ts
+++ b/libs/src/sdk/services/Storage/Storage.ts
@@ -100,7 +100,15 @@ export class Storage implements StorageService {
             `Upload failed: id=${id}, resp=${JSON.stringify(resp)}`
           )
         }
-      } catch (e) {
+      } catch (e: any) {
+        // Rethrow if error is "Upload failed" or if status code is 422 (Unprocessable Entity)
+        if (
+          e.message?.startsWith('Upload failed') ||
+          (e.response && e.response?.status === 422)
+        ) {
+          throw e
+        }
+
         // Swallow errors caused by failure to establish connection to node so we can retry polling
         console.error(`Failed to poll for processing status, ${e}`)
       }

--- a/libs/src/services/creatorNode/CreatorNode.ts
+++ b/libs/src/services/creatorNode/CreatorNode.ts
@@ -427,7 +427,15 @@ export class CreatorNode {
             `Upload failed: id=${id}, resp=${JSON.stringify(resp)}`
           )
         }
-      } catch (e) {
+      } catch (e: any) {
+        // Rethrow if error is "Upload failed" or if status code is 422 (Unprocessable Entity)
+        if (
+          e.message?.startsWith('Upload failed') ||
+          (e.response && e.response?.status === 422)
+        ) {
+          throw e
+        }
+
         // Swallow errors caused by failure to establish connection to node so we can retry polling
         console.error(`Failed to poll for processing status, ${e}`)
       }

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -30,6 +30,9 @@ func (ss *MediorumServer) getUpload(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	if upload.Status == JobStatusError {
+		return c.JSON(422, upload)
+	}
 	return c.JSON(200, upload)
 }
 


### PR DESCRIPTION
### Description
- Makes `/uploads/:id` return 422 Unprocessable Entity on error status. Technically this could be a 500 since any server-side error could cause a transcode to fail. However, in practice we've only ever seen transcode errors due to a file that would never succeed no matter how many retries it gets, so I'd call it unprocessable
- Makes client/libs/sdk fail fast if it gets this 422

### How Has This Been Tested?
This is low risk, so I'll test on staging by renaming a random file to have a .mp3 extension and then uploading it.