### PR TITLE
Raise rate limits for social features

### DIFF
--- a/identity-service/relay-rate-limit.json
+++ b/identity-service/relay-rate-limit.json
@@ -50,62 +50,62 @@
     "whitelist": 1000
   },
   "FollowUser": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnfollowUser": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "SubscribeUser": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnsubscribeUser": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "SaveTrack": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnsaveTrack": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "RepostTrack": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnrepostTrack": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "SavePlaylist": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnsavePlaylist": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "RepostPlaylist": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },
   "UnrepostPlaylist": {
-    "owner": 100,
+    "owner": 2000,
     "app": 10,
     "whitelist": 1000
   },


### PR DESCRIPTION
### Description
Raise rate limits for social features based on current usage. The owner rate limit is for users taking action with their own wallet.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
