### PR TITLE
Make mediorum stop looking like it's erroring when it's not

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"gocloud.dev/gcerrors"
 	"golang.org/x/exp/slices"
 )
 
@@ -72,6 +73,10 @@ func (ss *MediorumServer) getBlobInfo(c echo.Context) error {
 	key := c.Param("cid")
 	attr, err := ss.bucket.Attributes(ctx, key)
 	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return c.String(404, "blob not found")
+		}
+		ss.logger.Warn("error getting blob attributes", "error", err)
 		return err
 	}
 	return c.JSON(200, attr)


### PR DESCRIPTION
### Description
- Makes `/internal/blobs/info/:cid` return just 404 when not found instead of 500 with a long message about stat
- Changes query for replication so it doesn't cause gorm's default logger to print "record not found" in obnoxious red and purple text


### How Has This Been Tested?
`make dev` and upload a file at localhost:1991. The logs look healthy now.