### PR TITLE
DMs make internal rpcs idempotent

### DIFF
--- a/comms/discovery/config/config.go
+++ b/comms/discovery/config/config.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"log"
 	"os"
-	"strings"
 	"sync"
 
+	"comms.audius.co/discovery/misc"
 	"comms.audius.co/discovery/the_graph"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/exp/slog"
@@ -40,7 +40,7 @@ func (c *DiscoveryConfig) Peers() []the_graph.Peer {
 func Parse() *DiscoveryConfig {
 	c := &DiscoveryConfig{}
 
-	c.MyHost = strings.TrimRight(strings.TrimSpace(os.Getenv("audius_discprov_url")), "/") // trim any trailing /
+	c.MyHost = misc.TrimTrailingSlash(os.Getenv("audius_discprov_url"))
 	c.IsStaging = os.Getenv("AUDIUS_IS_STAGING") == "true"
 
 	pk, err := parsePrivateKey(os.Getenv("audius_delegate_private_key"))

--- a/comms/discovery/misc/trim.go
+++ b/comms/discovery/misc/trim.go
@@ -1,0 +1,9 @@
+package misc
+
+import (
+	"strings"
+)
+
+func TrimTrailingSlash(h string) string {
+	return strings.TrimRight(strings.TrimSpace(h), "/")
+}

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -382,14 +382,14 @@ func (proc *RPCProcessor) applyInternalMessage(rpcLog *schema.RpcLog, rawRpc *sc
 	switch rawRpc.Method {
 	case "internal.chat.ban":
 		for _, userId := range params.UserIDs {
-			_, err := tx.Exec(`insert into chat_ban values ($1) on conflict do nothing`, userId)
+			err := upsertUserBan(tx, userId, true, rpcLog.RelayedAt)
 			if err != nil {
 				logger.Error("failed", "err", err)
 			}
 		}
 	case "internal.chat.unban":
 		for _, userId := range params.UserIDs {
-			_, err := tx.Exec(`delete from chat_ban where user_id = $1`, userId)
+			err := upsertUserBan(tx, userId, false, rpcLog.RelayedAt)
 			if err != nil {
 				logger.Error("failed", "err", err)
 			}

--- a/comms/discovery/rpcz/chat_test.go
+++ b/comms/discovery/rpcz/chat_test.go
@@ -133,10 +133,5 @@ func TestChat(t *testing.T) {
 	assert.NoError(t, err)
 	assertReaction(user1Id, replyMessageId, nil)
 
-	// user1 is banned
-	tx.MustExec(`insert into chat_ban values ($1)`, user1Id)
-
-	assert.True(t, testValidator.isBanned(tx, user1Id))
-
 	tx.Rollback()
 }

--- a/comms/discovery/rpcz/internal_rpc.go
+++ b/comms/discovery/rpcz/internal_rpc.go
@@ -1,0 +1,22 @@
+package rpcz
+
+import (
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func upsertUserBan(tx *sqlx.Tx, userId string, isBanned bool, ts time.Time) error {
+	banUpsertSql := `
+	insert into chat_ban
+		(user_id, is_banned, updated_at)
+	values
+		($1, $2, $3)
+	on conflict (user_id) do update
+	set is_banned = $2, updated_at = $3
+	where chat_ban.updated_at < $3
+	`
+
+	_, err := tx.Exec(banUpsertSql, userId, isBanned, ts)
+	return err
+}

--- a/comms/discovery/rpcz/internal_rpc_test.go
+++ b/comms/discovery/rpcz/internal_rpc_test.go
@@ -1,0 +1,34 @@
+package rpcz
+
+import (
+	"testing"
+	"time"
+
+	"comms.audius.co/discovery/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBan(t *testing.T) {
+	time1 := time.Now().Add(-time.Minute * 3)
+	time2 := time.Now().Add(-time.Minute * 2)
+	time3 := time.Now().Add(-time.Minute * 1)
+
+	tx := db.Conn.MustBegin()
+	defer tx.Rollback()
+
+	// ban
+	err := upsertUserBan(tx, "1", true, time1)
+	assert.NoError(t, err)
+	assert.True(t, testValidator.isBanned(tx, 1))
+
+	// unban
+	err = upsertUserBan(tx, "1", false, time3)
+	assert.NoError(t, err)
+	assert.False(t, testValidator.isBanned(tx, 1))
+
+	// ban rpc arrives late... should be ignored
+	err = upsertUserBan(tx, "1", true, time2)
+	assert.NoError(t, err)
+	assert.False(t, testValidator.isBanned(tx, 1))
+
+}

--- a/comms/discovery/rpcz/main_test.go
+++ b/comms/discovery/rpcz/main_test.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"testing"
 
+	"comms.audius.co/discovery/config"
 	"comms.audius.co/discovery/db"
 )
 
 var (
 	testValidator *Validator
+	testProcessor *RPCProcessor
 )
 
 // this runs before all tests (not a per-test setup / teardown)
@@ -30,6 +32,10 @@ func TestMain(m *testing.M) {
 		db:      db.Conn,
 		limiter: limiter,
 	}
+
+	// setup test processor
+	discoveryConfig := config.Parse()
+	testProcessor, err = NewProcessor(discoveryConfig)
 
 	// run tests
 	code := m.Run()

--- a/comms/discovery/rpcz/validator.go
+++ b/comms/discovery/rpcz/validator.go
@@ -74,7 +74,7 @@ func (vtor *Validator) Validate(userId int32, rawRpc schema.RawRPC) error {
 func (vtor *Validator) isBanned(tx *sqlx.Tx, userId int32) bool {
 	q := vtor.getQ(tx)
 	isBanned := false
-	q.Get(&isBanned, `select count(user_id) = 1 from chat_ban where user_id = $1`, userId)
+	q.Get(&isBanned, `select count(user_id) = 1 from chat_ban where user_id = $1 and is_banned = true`, userId)
 	return isBanned
 }
 

--- a/discovery-provider/ddl/migrations/0011_chat_ban_timestamps.sql
+++ b/discovery-provider/ddl/migrations/0011_chat_ban_timestamps.sql
@@ -1,0 +1,8 @@
+begin;
+
+truncate table chat_ban;
+alter table chat_ban add column if not exists is_banned boolean not null;
+alter table chat_ban add column if not exists updated_at timestamp without time zone not null;
+
+commit;
+

--- a/discovery-provider/ddl/migrations/0012_rpc_log_applied_at_idx.sql
+++ b/discovery-provider/ddl/migrations/0012_rpc_log_applied_at_idx.sql
@@ -1,0 +1,1 @@
+create index if not exists rpc_log_applied_at_idx on rpc_log using brin(applied_at);


### PR DESCRIPTION
* updates chat_ban table to correctly handle out of order RPCs
* adds brin index to `rpc_log.applied_at`
* infers hostname when safe to do so