### PR TITLE
[C-2737] Add collection upload to write sdk

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -1,4 +1,3 @@
-import logging
 from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Set
@@ -16,15 +15,17 @@ from src.tasks.entity_manager.utils import (
     EntityType,
     ManageEntityParameters,
     copy_record,
+    validate_signer,
 )
 from src.tasks.task_helpers import generate_slug_and_collision_id
 from src.utils import helpers
 
-logger = logging.getLogger(__name__)
 
+def update_playlist_routes_table(params: ManageEntityParameters, playlist_record):
+    pending_playlist_routes = params.pending_playlist_routes
+    session = params.session
 
-def update_playlist_routes_table(session, playlist_record, pending_playlist_routes):
-    logger.info(
+    params.logger.info(
         f"index.py | playlists.py | Updating playlist routes for {playlist_record.playlist_id}"
     )
     # Get the title slug, and set the new slug to that
@@ -59,7 +60,7 @@ def update_playlist_routes_table(session, playlist_record, pending_playlist_rout
     if prev_playlist_route_record:
         if prev_playlist_route_record.title_slug == new_playlist_slug_title:
             # If the title slug hasn't changed, we have no work to do
-            logger.info(f"not changing for {playlist_record.playlist_id}")
+            params.logger.info(f"not changing for {playlist_record.playlist_id}")
             return
         # The new route will be current
         prev_playlist_route_record.is_current = False
@@ -91,7 +92,7 @@ def update_playlist_routes_table(session, playlist_record, pending_playlist_rout
     # Add to pending playlist routes so we don't add the same route twice
     pending_playlist_routes.append(new_playlist_route)
 
-    logger.info(
+    params.logger.info(
         f"index.py | playlists.py | Updated playlist routes for {playlist_record.playlist_id} with slug {new_playlist_slug} and owner_id {new_playlist_route.owner_id}"
     )
 
@@ -108,9 +109,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
     if user_id not in params.existing_records[EntityType.USER]:
         raise IndexingValidationError(f"User {user_id} does not exist")
 
-    wallet = params.existing_records[EntityType.USER][user_id].wallet
-    if wallet and wallet.lower() != params.signer.lower():
-        raise IndexingValidationError(f"User {user_id} does not match signer")
+    validate_signer(params)
 
     if params.entity_type != EntityType.PLAYLIST:
         raise IndexingValidationError(f"Entity type {params.entity_type} is not a playlist")
@@ -200,7 +199,7 @@ def create_playlist(params: ManageEntityParameters):
     )
 
     update_playlist_routes_table(
-        params.session, create_playlist_record, params.pending_playlist_routes
+        params, create_playlist_record
     )
 
     params.add_playlist_record(playlist_id, create_playlist_record)
@@ -239,15 +238,12 @@ def update_playlist(params: ManageEntityParameters):
         params.block_datetime,
     )
     process_playlist_data_event(
-        updated_playlist,
-        params.metadata,
-        params.block_integer_time,
-        params.block_datetime,
-        params.metadata_cid,
+        params,
+        updated_playlist
     )
 
     update_playlist_routes_table(
-        params.session, updated_playlist, params.pending_playlist_routes
+        params, updated_playlist
     )
 
     params.add_playlist_record(playlist_id, updated_playlist)
@@ -343,14 +339,16 @@ def process_playlist_contents(playlist_record, playlist_metadata, block_integer_
 
 
 def process_playlist_data_event(
+    params: ManageEntityParameters,
     playlist_record,
-    playlist_metadata,
-    block_integer_time,
-    block_datetime,
-    metadata_cid,
 ):
+    playlist_metadata = params.playlist_metadata
+    block_integer_time = params.block_integer_time
+    block_datetime = params.block_datetime
+    metadata_cid = params.metadata_cid
+
     playlist_record.is_album = (
-        playlist_metadata["is_album"] if "is_album" in playlist_metadata else False
+        params.playlist_metadata["is_album"] if "is_album" in playlist_metadata else False
     )
     playlist_record.description = playlist_metadata["description"]
     playlist_record.playlist_image_multihash = playlist_metadata[
@@ -385,6 +383,6 @@ def process_playlist_data_event(
     playlist_record.updated_at = block_datetime
     playlist_record.metadata_multihash = metadata_cid
 
-    logger.info(
+    params.logger.info(
         f"playlist.py | EntityManager | Updated playlist record {playlist_record}"
     )

--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -348,7 +348,7 @@ def process_playlist_data_event(
     metadata_cid = params.metadata_cid
 
     playlist_record.is_album = (
-        params.playlist_metadata["is_album"] if "is_album" in playlist_metadata else False
+        playlist_metadata["is_album"] if "is_album" in playlist_metadata else False
     )
     playlist_record.description = playlist_metadata["description"]
     playlist_record.playlist_image_multihash = playlist_metadata[

--- a/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict
 
 from sqlalchemy.sql import null

--- a/libs/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/libs/src/sdk/api/playlists/PlaylistsApi.ts
@@ -1,4 +1,4 @@
-import type { AuthService } from '../../services'
+import type { AuthService, StorageService } from '../../services'
 import snakecaseKeys from 'snakecase-keys'
 import {
   Action,
@@ -12,22 +12,182 @@ import {
   PlaylistsApi as GeneratedPlaylistsApi
 } from '../generated/default'
 import {
+  createUploadPlaylistSchema,
+  PlaylistMetadata,
   RepostPlaylistRequest,
   RepostPlaylistSchema,
   SavePlaylistRequest,
   SavePlaylistSchema,
   UnrepostPlaylistSchema,
   UnsavePlaylistRequest,
-  UnsavePlaylistSchema
+  UnsavePlaylistSchema,
+  UploadPlaylistRequest
 } from './types'
+import { retry3 } from '../../utils/retry'
+import { generateMetadataCidV1 } from '../../utils/cid'
+import { TracksUploader } from '../tracks/TracksUploader'
+import type { TrackMetadataType } from '../tracks/types'
 
 export class PlaylistsApi extends GeneratedPlaylistsApi {
+  private readonly tracksUploader: TracksUploader
+
   constructor(
     configuration: Configuration,
+    private readonly storage: StorageService,
     private readonly entityManager: EntityManagerService,
     private readonly auth: AuthService
   ) {
     super(configuration)
+    this.tracksUploader = new TracksUploader(configuration)
+  }
+
+  /**
+   * Upload a playlist or album
+   */
+  async uploadPlaylist(
+    requestParameters: UploadPlaylistRequest,
+    writeOptions?: WriteOptions
+  ) {
+    // Parse inputs
+    const {
+      userId,
+      trackFiles,
+      coverArtFile,
+      metadata: parsedMetadata,
+      trackMetadatas: parsedTrackMetadatas,
+      onProgress
+    } = parseRequestParameters(
+      'uploadPlaylist',
+      createUploadPlaylistSchema()
+    )(requestParameters)
+
+    // Transform track metadata
+    const metadata = this.tracksUploader.transformTrackUploadMetadata(
+      parsedMetadata,
+      userId
+    )
+
+    // Upload track audio and cover art to storage node
+    const [coverArtResponse, ...audioResponses] = await Promise.all([
+      retry3(
+        async () =>
+          await this.storage.uploadFile({
+            file: coverArtFile,
+            onProgress,
+            template: 'img_square'
+          }),
+        (e) => {
+          console.log('Retrying uploadTrackCoverArt', e)
+        }
+      ),
+      ...trackFiles.map((trackFile) =>
+        retry3(
+          async () =>
+            await this.storage.uploadFile({
+              file: trackFile,
+              onProgress,
+              template: 'audio'
+            }),
+          (e) => {
+            console.log('Retrying uploadTrackAudio', e)
+          }
+        )
+      )
+    ])
+
+    // Combine track metadata with playlist metadata
+    const trackMetadatas = parsedTrackMetadatas.map((tm) =>
+      this.combineMetadata(tm, {
+        ...metadata,
+        coverArtSizes: coverArtResponse.id
+      })
+    )
+
+    // Write tracks to chain
+    const trackIds = await Promise.all(
+      trackMetadatas.map(async (trackMetadata, i) => {
+        // Update metadata to include uploaded CIDs
+        const audioResponse = audioResponses[i]
+
+        if (!audioResponse) {
+          throw new Error(`Failed to upload track: ${trackMetadata}`)
+        }
+
+        // TODO: generalize this?
+        const updatedMetadata = {
+          ...trackMetadata,
+          trackSegments: [],
+          trackCid: audioResponse.results['320'],
+          download: trackMetadata.download?.isDownloadable
+            ? {
+                ...trackMetadata.download,
+                cid: audioResponse.results['320']
+              }
+            : trackMetadata.download,
+          coverArtSizes: coverArtResponse.id,
+          duration: parseInt(audioResponse.probe.format.duration, 10)
+        }
+
+        const metadataCid = await generateMetadataCidV1(updatedMetadata)
+        const trackId = await this.tracksUploader.generateId('track')
+        await this.entityManager.manageEntity({
+          userId,
+          entityType: EntityType.TRACK,
+          // Should the trackId also be in the metadata?
+          entityId: trackId,
+          action: Action.CREATE,
+          metadata: JSON.stringify({
+            cid: metadataCid.toString(),
+            data: snakecaseKeys(updatedMetadata)
+          }),
+          auth: this.auth,
+          ...writeOptions
+        })
+
+        return trackId
+      })
+    )
+
+    const playlistId = await this.tracksUploader.generateId('playlist')
+
+    // Update metadata to include uploaded CIDs
+    const updatedMetadata = {
+      ...metadata,
+      isPrivate: false,
+      playlistContents: {
+        trackIds: trackIds.map((trackId) => ({
+          track: trackId,
+          metadataTime: Date.now()
+        }))
+      },
+      coverArtSizes: coverArtResponse.id
+    }
+
+    // TODO: handle error and delete playlist
+    // TODO: duration?
+
+    // Write playlist metadata to chain
+    const metadataCid = await generateMetadataCidV1(updatedMetadata)
+
+    const response = await this.entityManager.manageEntity({
+      userId,
+      entityType: EntityType.PLAYLIST,
+      entityId: playlistId,
+      action: Action.CREATE,
+      metadata: JSON.stringify({
+        cid: metadataCid,
+        data: snakecaseKeys(updatedMetadata)
+      }),
+      auth: this.auth,
+      ...writeOptions
+    })
+    const txReceipt = response.txReceipt
+
+    return {
+      blockHash: txReceipt.blockHash,
+      blockNumber: txReceipt.blockNumber,
+      playlistId
+    }
   }
 
   /**
@@ -134,5 +294,37 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     const txReceipt = response.txReceipt
 
     return txReceipt
+  }
+
+  /**
+   * Combines the metadata for a track and a collection (playlist or album),
+   * taking the metadata from the playlist when the track is missing it.
+   */
+  private combineMetadata(
+    trackMetadata: TrackMetadataType & { coverArtSizes?: string },
+    playlistMetadata: PlaylistMetadata & { coverArtSizes?: string }
+  ) {
+    const metadata = trackMetadata
+
+    metadata.coverArtSizes = playlistMetadata.coverArtSizes
+
+    if (!metadata.genre) metadata.genre = playlistMetadata.genre
+    if (!metadata.mood) metadata.mood = playlistMetadata.mood
+
+    if (playlistMetadata.tags) {
+      if (!metadata.tags) {
+        // Take playlist tags
+        metadata.tags = playlistMetadata.tags
+      } else {
+        // Combine tags and dedupe
+        metadata.tags = [
+          ...new Set([
+            ...metadata.tags.split(','),
+            ...playlistMetadata.tags.split(',')
+          ])
+        ].join(',')
+      }
+    }
+    return trackMetadata
   }
 }

--- a/libs/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/libs/src/sdk/api/playlists/PlaylistsApi.ts
@@ -14,6 +14,7 @@ import {
 import {
   createUploadPlaylistSchema,
   PlaylistMetadata,
+  PlaylistTrackMetadata,
   RepostPlaylistRequest,
   RepostPlaylistSchema,
   SavePlaylistRequest,
@@ -26,7 +27,6 @@ import {
 import { retry3 } from '../../utils/retry'
 import { generateMetadataCidV1 } from '../../utils/cid'
 import { TrackUploadHelper } from '../tracks/TrackUploadHelper'
-import type { TrackMetadata } from '../tracks/types'
 
 export class PlaylistsApi extends GeneratedPlaylistsApi {
   private readonly trackUploadHelper: TrackUploadHelper
@@ -284,7 +284,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
    * taking the metadata from the playlist when the track is missing it.
    */
   private combineMetadata(
-    trackMetadata: TrackMetadata & { coverArtSizes?: string },
+    trackMetadata: PlaylistTrackMetadata & { coverArtSizes?: string },
     playlistMetadata: PlaylistMetadata & { coverArtSizes?: string }
   ) {
     const metadata = trackMetadata

--- a/libs/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/libs/src/sdk/api/playlists/PlaylistsApi.ts
@@ -49,9 +49,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     writeOptions?: WriteOptions
   ) {
     // TODO: handle error and delete playlist
-    // TODO: duration?
-    // TODO: Progress callback
-    // TODO: collection image not working
+    // TODO: Progress callback, granular to each track?
     // TODO: delegated playlist writes
 
     // Parse inputs
@@ -104,10 +102,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
             parsedTrackMetadata,
             userId
           ),
-          {
-            ...metadata,
-            coverArtSizes: coverArtResponse.id
-          }
+          metadata
         )
 
         // Update metadata to include uploaded CIDs
@@ -164,7 +159,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           time: Date.now()
         }))
       },
-      coverArtSizes: coverArtResponse.id
+      playlistImageSizesMultihash: coverArtResponse.id
     }
 
     // Write playlist metadata to chain
@@ -306,8 +301,6 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     playlistMetadata: PlaylistMetadata & { coverArtSizes?: string }
   ) {
     const metadata = trackMetadata
-
-    metadata.coverArtSizes = playlistMetadata.coverArtSizes
 
     if (!metadata.genre) metadata.genre = playlistMetadata.genre
     if (!metadata.mood) metadata.mood = playlistMetadata.mood

--- a/libs/src/sdk/api/playlists/types.ts
+++ b/libs/src/sdk/api/playlists/types.ts
@@ -15,7 +15,6 @@ const createUploadPlaylistMetadataSchema = () =>
        * Is this playlist an album?
        */
       isAlbum: z.optional(z.boolean()),
-      //   isPrivate: z.optional(z.boolean()),
       isrc: z.optional(z.string()),
       iswc: z.optional(z.string()),
       license: z.optional(z.string()),

--- a/libs/src/sdk/api/playlists/types.ts
+++ b/libs/src/sdk/api/playlists/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { CrossPlatformFile } from '../../types/File'
+import type { CrossPlatformFile as File } from '../../types/File'
 import { Genre } from '../../types/Genre'
 import { HashId } from '../../types/HashId'
 import { Mood } from '../../types/Mood'
@@ -20,7 +20,7 @@ const createUploadPlaylistMetadataSchema = () =>
       iswc: z.optional(z.string()),
       license: z.optional(z.string()),
       mood: z.optional(z.enum(Object.values(Mood) as [Mood, ...Mood[]])),
-      playlist_name: z.string(),
+      playlistName: z.string(),
       releaseDate: z.optional(
         z.date().max(new Date(), { message: 'should not be in the future' })
       ),
@@ -38,15 +38,13 @@ export const createUploadPlaylistSchema = () =>
     .object({
       userId: HashId,
       coverArtFile: z.custom<File>((data: unknown) =>
-        isFileValid(data as CrossPlatformFile)
+        isFileValid(data as File)
       ),
       metadata: createUploadPlaylistMetadataSchema(),
       onProgress: z.optional(z.function().args(z.number())),
       trackMetadatas: z.array(createUploadTrackMetadataSchema()),
       trackFiles: z.array(
-        z.custom<File>((data: unknown) =>
-          isFileValid(data as CrossPlatformFile)
-        )
+        z.custom<File>((data: unknown) => isFileValid(data as File))
       )
     })
     .strict()

--- a/libs/src/sdk/api/playlists/types.ts
+++ b/libs/src/sdk/api/playlists/types.ts
@@ -32,6 +32,19 @@ export type PlaylistMetadata = z.input<
   ReturnType<typeof createUploadPlaylistMetadataSchema>
 >
 
+const createPlaylistTrackMetadataSchema = () =>
+  createUploadTrackMetadataSchema().partial({
+    genre: true,
+    mood: true,
+    tags: true
+  })
+
+// PlaylistTrackMetadata is less strict than TrackMetadata because
+// `genre`, `mood`, and `tags` are optional
+export type PlaylistTrackMetadata = z.infer<
+  ReturnType<typeof createPlaylistTrackMetadataSchema>
+>
+
 export const createUploadPlaylistSchema = () =>
   z
     .object({
@@ -41,7 +54,10 @@ export const createUploadPlaylistSchema = () =>
       ),
       metadata: createUploadPlaylistMetadataSchema(),
       onProgress: z.optional(z.function().args(z.number())),
-      trackMetadatas: z.array(createUploadTrackMetadataSchema()),
+      /**
+       * Track metadata is populated from the playlist if fields are missing
+       */
+      trackMetadatas: z.array(createPlaylistTrackMetadataSchema()),
       trackFiles: z.array(
         z.custom<File>((data: unknown) => isFileValid(data as File))
       )

--- a/libs/src/sdk/api/playlists/types.ts
+++ b/libs/src/sdk/api/playlists/types.ts
@@ -1,5 +1,59 @@
 import { z } from 'zod'
+import type { CrossPlatformFile } from '../../types/File'
+import { Genre } from '../../types/Genre'
 import { HashId } from '../../types/HashId'
+import { Mood } from '../../types/Mood'
+import { isFileValid } from '../../utils/file'
+import { createUploadTrackMetadataSchema } from '../tracks/types'
+
+const createUploadPlaylistMetadataSchema = () =>
+  z
+    .object({
+      description: z.optional(z.string().max(1000)),
+      genre: z.enum(Object.values(Genre) as [Genre, ...Genre[]]),
+      /**
+       * Is this playlist an album?
+       */
+      isAlbum: z.optional(z.boolean()),
+      //   isPrivate: z.optional(z.boolean()),
+      isrc: z.optional(z.string()),
+      iswc: z.optional(z.string()),
+      license: z.optional(z.string()),
+      mood: z.optional(z.enum(Object.values(Mood) as [Mood, ...Mood[]])),
+      playlist_name: z.string(),
+      releaseDate: z.optional(
+        z.date().max(new Date(), { message: 'should not be in the future' })
+      ),
+      tags: z.optional(z.string()),
+      upc: z.optional(z.string())
+    })
+    .strict()
+
+export type PlaylistMetadata = z.input<
+  ReturnType<typeof createUploadPlaylistMetadataSchema>
+>
+
+export const createUploadPlaylistSchema = () =>
+  z
+    .object({
+      userId: HashId,
+      coverArtFile: z.custom<File>((data: unknown) =>
+        isFileValid(data as CrossPlatformFile)
+      ),
+      metadata: createUploadPlaylistMetadataSchema(),
+      onProgress: z.optional(z.function().args(z.number())),
+      trackMetadatas: z.array(createUploadTrackMetadataSchema()),
+      trackFiles: z.array(
+        z.custom<File>((data: unknown) =>
+          isFileValid(data as CrossPlatformFile)
+        )
+      )
+    })
+    .strict()
+
+export type UploadPlaylistRequest = z.input<
+  ReturnType<typeof createUploadPlaylistSchema>
+>
 
 export const SavePlaylistSchema = z
   .object({

--- a/libs/src/sdk/api/tracks/TrackUploadHelper.ts
+++ b/libs/src/sdk/api/tracks/TrackUploadHelper.ts
@@ -1,8 +1,7 @@
-import type { z } from 'zod'
 import type { UploadResponse } from '../../services/Storage/types'
 import { decodeHashId } from '../../utils/hashId'
 import { BaseAPI } from '../generated/default'
-import type { createUploadTrackSchema, TrackMetadata } from './types'
+import type { PlaylistTrackMetadata } from '../playlists/types'
 
 export class TrackUploadHelper extends BaseAPI {
   public async generateId(type: 'track' | 'playlist') {
@@ -22,9 +21,9 @@ export class TrackUploadHelper extends BaseAPI {
   }
 
   public transformTrackUploadMetadata(
-    inputMetadata: z.output<
-      ReturnType<typeof createUploadTrackSchema>
-    >['metadata'],
+    // PlaylistTrackMetadata is less strict than TrackMetadata because
+    // `genre`, `mood`, and `tags` are optional
+    inputMetadata: PlaylistTrackMetadata,
     userId: number
   ) {
     const metadata = {
@@ -55,7 +54,7 @@ export class TrackUploadHelper extends BaseAPI {
   }
 
   public populateTrackMetadataWithUploadResponse(
-    trackMetadata: TrackMetadata,
+    trackMetadata: PlaylistTrackMetadata,
     audioResponse: UploadResponse,
     coverArtResponse: UploadResponse
   ) {

--- a/libs/src/sdk/api/tracks/TrackUploadHelper.ts
+++ b/libs/src/sdk/api/tracks/TrackUploadHelper.ts
@@ -1,9 +1,10 @@
 import type { z } from 'zod'
+import type { UploadResponse } from '../../services/Storage/types'
 import { decodeHashId } from '../../utils/hashId'
 import { BaseAPI } from '../generated/default'
-import type { createUploadTrackSchema } from './types'
+import type { createUploadTrackSchema, TrackMetadata } from './types'
 
-export class TracksUploader extends BaseAPI {
+export class TrackUploadHelper extends BaseAPI {
   public async generateId(type: 'track' | 'playlist') {
     const response = await this.request({
       path: `/${type}s/unclaimed_id`,
@@ -51,5 +52,25 @@ export class TracksUploader extends BaseAPI {
       }
     }
     return metadata
+  }
+
+  public populateTrackMetadataWithUploadResponse(
+    trackMetadata: TrackMetadata,
+    audioResponse: UploadResponse,
+    coverArtResponse: UploadResponse
+  ) {
+    return {
+      ...trackMetadata,
+      trackSegments: [],
+      trackCid: audioResponse.results['320'],
+      download: trackMetadata.download?.isDownloadable
+        ? {
+            ...trackMetadata.download,
+            cid: audioResponse.results['320']
+          }
+        : trackMetadata.download,
+      coverArtSizes: coverArtResponse.id,
+      duration: parseInt(audioResponse.probe.format.duration, 10)
+    }
   }
 }

--- a/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -8,11 +8,13 @@ import { EntityManager } from '../../services/EntityManager'
 import { DiscoveryNodeSelector } from '../../services/DiscoveryNodeSelector'
 import { StorageNodeSelector } from '../../services/StorageNodeSelector'
 import { Storage } from '../../services/Storage'
+import { TrackUploadHelper } from './TrackUploadHelper'
 
 jest.mock('../../services/EntityManager')
 jest.mock('../../services/DiscoveryNodeSelector')
 jest.mock('../../services/StorageNodeSelector')
 jest.mock('../../services/Storage')
+jest.mock('./TrackUploadHelper')
 
 jest.spyOn(Storage.prototype, 'uploadFile').mockImplementation(async () => {
   return {
@@ -30,10 +32,17 @@ jest.spyOn(Storage.prototype, 'uploadFile').mockImplementation(async () => {
 })
 
 jest
-  .spyOn(TracksApi.prototype, 'generateId' as any)
+  .spyOn(TrackUploadHelper.prototype, 'generateId' as any)
   .mockImplementation(async () => {
     return 1
   })
+
+jest
+  .spyOn(
+    TrackUploadHelper.prototype,
+    'populateTrackMetadataWithUploadResponse' as any
+  )
+  .mockImplementation(async () => ({}))
 
 jest
   .spyOn(EntityManager.prototype, 'manageEntity')

--- a/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -30,7 +30,7 @@ jest.spyOn(Storage.prototype, 'uploadFile').mockImplementation(async () => {
 })
 
 jest
-  .spyOn(TracksApi.prototype, 'generateTrackId' as any)
+  .spyOn(TracksApi.prototype, 'generateId' as any)
   .mockImplementation(async () => {
     return 1
   })

--- a/libs/src/sdk/api/tracks/TracksApi.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.ts
@@ -1,4 +1,3 @@
-import type { z } from 'zod'
 import snakecaseKeys from 'snakecase-keys'
 import { BaseAPI, BASE_PATH, RequiredError } from '../generated/default/runtime'
 
@@ -195,7 +194,10 @@ export class TracksApi extends TracksApiWithoutStream {
     )(requestParameters)
 
     // Transform metadata
-    const metadata = this.transformTrackUploadMetadata(parsedMetadata, userId)
+    const metadata = this.tracksUploader.transformTrackUploadMetadata(
+      parsedMetadata,
+      userId
+    )
 
     // Upload track cover art to storage node
     const coverArtResp = await retry3(

--- a/libs/src/sdk/api/tracks/TracksUploader.ts
+++ b/libs/src/sdk/api/tracks/TracksUploader.ts
@@ -1,3 +1,4 @@
+import type { z } from 'zod'
 import { decodeHashId } from '../../utils/hashId'
 import { BaseAPI } from '../generated/default'
 import type { createUploadTrackSchema } from './types'

--- a/libs/src/sdk/api/tracks/TracksUploader.ts
+++ b/libs/src/sdk/api/tracks/TracksUploader.ts
@@ -1,0 +1,54 @@
+import { decodeHashId } from '../../utils/hashId'
+import { BaseAPI } from '../generated/default'
+import type { createUploadTrackSchema } from './types'
+
+export class TracksUploader extends BaseAPI {
+  public async generateId(type: 'track' | 'playlist') {
+    const response = await this.request({
+      path: `/${type}s/unclaimed_id`,
+      method: 'GET',
+      headers: {},
+      query: { noCache: Math.floor(Math.random() * 1000).toString() }
+    })
+
+    const { data } = await response.json()
+    const id = decodeHashId(data)
+    if (id === null) {
+      throw new Error(`Could not generate ${type} id`)
+    }
+    return id
+  }
+
+  public transformTrackUploadMetadata(
+    inputMetadata: z.output<
+      ReturnType<typeof createUploadTrackSchema>
+    >['metadata'],
+    userId: number
+  ) {
+    const metadata = {
+      ...inputMetadata,
+      ownerId: userId
+    }
+
+    const isPremium = metadata.isPremium
+    const isUnlisted = metadata.isUnlisted
+
+    // If track is premium, set remixes to false
+    if (isPremium && metadata.fieldVisibility) {
+      metadata.fieldVisibility.remixes = false
+    }
+
+    // If track is public, set required visibility fields to true
+    if (!isUnlisted) {
+      metadata.fieldVisibility = {
+        ...metadata.fieldVisibility,
+        genre: true,
+        mood: true,
+        tags: true,
+        share: true,
+        playCount: true
+      }
+    }
+    return metadata
+  }
+}

--- a/libs/src/sdk/api/tracks/types.ts
+++ b/libs/src/sdk/api/tracks/types.ts
@@ -91,7 +91,7 @@ export const createUploadTrackMetadataSchema = () =>
     })
     .strict()
 
-export type TrackMetadataType = z.input<
+export type TrackMetadata = z.input<
   ReturnType<typeof createUploadTrackMetadataSchema>
 >
 

--- a/libs/src/sdk/api/tracks/types.ts
+++ b/libs/src/sdk/api/tracks/types.ts
@@ -1,8 +1,5 @@
 import { z } from 'zod'
-import type {
-  CrossPlatformFile,
-  CrossPlatformFile as File
-} from '../../types/File'
+import type { CrossPlatformFile as File } from '../../types/File'
 import { Genre } from '../../types/Genre'
 import { HashId } from '../../types/HashId'
 import { Mood } from '../../types/Mood'
@@ -103,13 +100,11 @@ export const createUploadTrackSchema = () =>
     .object({
       userId: HashId,
       coverArtFile: z.custom<File>((data: unknown) =>
-        isFileValid(data as CrossPlatformFile)
+        isFileValid(data as File)
       ),
       metadata: createUploadTrackMetadataSchema(),
       onProgress: z.optional(z.function().args(z.number())),
-      trackFile: z.custom<File>((data: unknown) =>
-        isFileValid(data as CrossPlatformFile)
-      )
+      trackFile: z.custom<File>((data: unknown) => isFileValid(data as File))
     })
     .strict()
 

--- a/libs/src/sdk/api/tracks/types.ts
+++ b/libs/src/sdk/api/tracks/types.ts
@@ -51,12 +51,6 @@ export const createUploadTrackMetadataSchema = () =>
           requiresFollow: z.boolean()
         })
       ),
-      isPremium: z.optional(z.boolean()),
-      isrc: z.optional(z.string()),
-      isUnlisted: z.optional(z.boolean()),
-      iswc: z.optional(z.string()),
-      license: z.optional(z.string()),
-      mood: z.optional(z.enum(Object.values(Mood) as [Mood, ...Mood[]])),
       fieldVisibility: z.optional(
         z.object({
           mood: z.optional(z.boolean()),
@@ -68,6 +62,12 @@ export const createUploadTrackMetadataSchema = () =>
         })
       ),
       genre: z.enum(Object.values(Genre) as [Genre, ...Genre[]]),
+      isPremium: z.optional(z.boolean()),
+      isrc: z.optional(z.string()),
+      isUnlisted: z.optional(z.boolean()),
+      iswc: z.optional(z.string()),
+      license: z.optional(z.string()),
+      mood: z.optional(z.enum(Object.values(Mood) as [Mood, ...Mood[]])),
       premiumConditions: z.optional(
         z.union([
           PremiumConditionsNFTCollection,

--- a/libs/src/sdk/sdk.ts
+++ b/libs/src/sdk/sdk.ts
@@ -182,6 +182,7 @@ const initializeApis = ({
   )
   const playlists = new PlaylistsApi(
     generatedApiClientConfig,
+    services.storage,
     services.entityManager,
     services.auth
   )


### PR DESCRIPTION
### Description

* Add `audiusSdk.playlists.uploadPlaylist`, this is used for both playlists and albums
* Add delegated writes for playlists in entity manager
  *  Update `logger` references to `params.logger` for better logging context
* Add `TrackUploadHelper` to generalize shared logic between `TracksApi` and `PlaylistsApi`

* TODO: add tests

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested against local audius-protocol, confirmed both playlists and albums upload properly and resulting entities are correct
