### PR TITLE
Use rendezvous for all streams

### DIFF
--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -166,9 +166,9 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 					}
 					err := ss.pullFileFromHost(host, cid)
 					if err != nil {
-						logger.Error("pull failed", "err", err, "host", host)
+						logger.Error("pull failed (blob I should have)", "err", err, "host", host)
 					} else {
-						logger.Info("pull OK", "host", host)
+						logger.Info("pull OK (blob I should have)", "host", host)
 						success = true
 						break
 					}
@@ -227,9 +227,9 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 					for _, host := range hasIt {
 						err := ss.pullFileFromHost(host, cid)
 						if err != nil {
-							logger.Error("pull failed", err, "host", host)
+							logger.Error("pull failed (under-replicated)", err, "host", host)
 						} else {
-							logger.Info("pull OK", "host", host)
+							logger.Info("pull OK (under-replicated)", "host", host)
 							success = true
 							break
 						}

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -62,14 +62,22 @@ type legacyHealth struct {
 }
 
 func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
+	healthy := ss.databaseSize > 0
+
+	// if we're in stage or prod, return healthy=false if we can't connect to the legacy CN
 	legacyHealth, err := ss.fetchCreatorNodeHealth()
+	if ss.Config.Env == "stage" || ss.Config.Env == "prod" {
+		if err != nil {
+			healthy = false
+		}
+	}
 
 	// since we're using peerHealth
 	ss.peerHealthMutex.RLock()
 	defer ss.peerHealthMutex.RUnlock()
 
 	data := healthCheckResponseData{
-		Healthy:                   err == nil && ss.databaseSize > 0,
+		Healthy:                   healthy,
 		Version:                   legacyHealth.Version,
 		Service:                   legacyHealth.Service,
 		BuiltAt:                   vcsBuildTime,
@@ -113,7 +121,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 	status := 200
 	if !ss.Config.WalletIsRegistered {
 		status = 506
-	} else if !data.Healthy {
+	} else if !healthy {
 		status = 500
 	}
 

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -113,6 +113,8 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 	status := 200
 	if !ss.Config.WalletIsRegistered {
 		status = 506
+	} else if !data.Healthy {
+		status = 500
 	}
 
 	signatureHex := fmt.Sprintf("0x%s", hex.EncodeToString(signature))

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -231,8 +231,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	routes.GET("/ipfs/:cid", ss.getBlob, ss.ensureNotDelisted)
 	routes.GET("/content/:cid", ss.getBlob, ss.ensureNotDelisted)
-	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.ensureNotDelisted)
-	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.ensureNotDelisted)
+	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant)
+	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant)
 	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.ensureNotDelisted, ss.requireSignature)
 	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.ensureNotDelisted, ss.requireSignature)
 	routes.GET("/contact", ss.serveContact)


### PR DESCRIPTION
### Description
- Makes Discovery track streaming use rendezvous for every request, only using Content Nodes that returned 200 for /health_check
- Makes sure CN returns 500 when unhealthy (including when it can't reach its db)

This fixes the `AttributeError: 'NoneType' object has no attribute 'split'` error when streaming tracks from v2 users. There will be more redirects until Qm CIDs are migrated, but this should effectively be the same latency as now because the extra request for the first byte is removed.

### How Has This Been Tested?
Tested mediorum health check locally and discovery streaming tracks from v2 and non-v2 users on staging.