### PR TITLE
[plat-1109] Add db trigger to create usdc purchase notifications

### DIFF
--- a/discovery-provider/ddl/functions/handle_usdc_purchase.sql
+++ b/discovery-provider/ddl/functions/handle_usdc_purchase.sql
@@ -1,0 +1,54 @@
+create or replace function handle_usdc_purchase() returns trigger as $$
+begin
+
+  -- insert seller/artist notification
+  INSERT INTO notification
+          (slot, user_ids, timestamp, type, specifier, group_id, data)
+        VALUES
+          (
+            new.slot,
+            ARRAY [new.seller_user_id],
+            new.created_at,
+            'usdc_purchase_seller',
+            new.buyer_user_id,
+            'usdc_purchase_seller:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'content_id', new.content_id
+              )
+          ),
+          (
+            new.slot,
+            ARRAY [new.buyer_user_id],
+            new.created_at,
+            'usdc_purchase_buyer',
+            new.buyer_user_id,
+            'usdc_purchase_buyer:' || 'seller_user_id:' || new.seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+            json_build_object(
+                'content_type', new.content_type,
+                'buyer_user_id', new.buyer_user_id,
+                'seller_user_id', new.seller_user_id,
+                'amount', new.amount,
+                'content_id', new.content_id
+            )
+          )
+        on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end; 
+$$ language plpgsql;
+
+do $$ begin
+  create trigger on_usdc_purchase
+  after insert on usdc_purchases
+  for each row execute procedure handle_usdc_purchase();
+exception
+  when others then null;
+end $$;

--- a/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
+++ b/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
@@ -1,0 +1,60 @@
+import logging
+from typing import List
+
+from integration_tests.utils import populate_mock_db
+from src.models.notifications.notification import Notification
+from src.models.users.usdc_purchase import UsdcPurchaseContentType
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+# ========================================== Start Tests ==========================================
+def test_usdc_purchase_notification(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "users": [{"user_id": 1}, {"user_id": 2}],
+        "tracks": [{"track_id": 100, "owner_id": 2}],
+    }
+    populate_mock_db(db, entities)
+    entities = {
+        "usdc_purchases": [
+            {
+                "buyer_user_id": 1,
+                "seller_user_id": 2,
+                "amount": 1000,
+                "content_type": UsdcPurchaseContentType.track,
+                "content_id": 100
+            }
+        ]
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        seller_notifications: List[Notification] = session.query(Notification).filter(Notification.type == 'usdc_purchase_seller').all()
+        buyer_notifications: List[Notification] = session.query(Notification).filter(Notification.type == 'usdc_purchase_buyer').all()
+        print('seller notifs ', seller_notifications)
+        assert len(seller_notifications) == 1
+        assert len(buyer_notifications) == 1
+        assert seller_notifications[0].user_ids == [2]
+        assert seller_notifications[0].specifier == '1'
+        assert seller_notifications[0].group_id == "usdc_purchase_seller:seller_user_id:2:buyer_user_id:1:content_id:100:content_type:track"
+        assert seller_notifications[0].data == {
+            "content_type": "track",
+            "buyer_user_id": 1,
+            "seller_user_id": 2,
+            "amount": 1000,
+            "content_id": 100
+        }
+        assert buyer_notifications[0].user_ids == [1]
+        assert buyer_notifications[0].specifier == '1'
+        assert buyer_notifications[0].group_id == "usdc_purchase_buyer:seller_user_id:2:buyer_user_id:1:content_id:100:content_type:track"
+        assert buyer_notifications[0].data == {
+            "content_type": "track",
+            "buyer_user_id": 1,
+            "seller_user_id": 2,
+            "amount": 1000,
+            "content_id": 100
+        }

--- a/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
+++ b/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
@@ -22,6 +22,7 @@ def test_usdc_purchase_notification(app):
     entities = {
         "usdc_purchases": [
             {
+                "slot": 4,
                 "buyer_user_id": 1,
                 "seller_user_id": 2,
                 "amount": 1000,
@@ -35,7 +36,6 @@ def test_usdc_purchase_notification(app):
     with db.scoped_session() as session:
         seller_notifications: List[Notification] = session.query(Notification).filter(Notification.type == 'usdc_purchase_seller').all()
         buyer_notifications: List[Notification] = session.query(Notification).filter(Notification.type == 'usdc_purchase_buyer').all()
-        print('seller notifs ', seller_notifications)
         assert len(seller_notifications) == 1
         assert len(buyer_notifications) == 1
         assert seller_notifications[0].user_ids == [2]
@@ -48,6 +48,7 @@ def test_usdc_purchase_notification(app):
             "amount": 1000,
             "content_id": 100
         }
+        assert seller_notifications[0].slot == 4
         assert buyer_notifications[0].user_ids == [1]
         assert buyer_notifications[0].specifier == '1'
         assert buyer_notifications[0].group_id == "usdc_purchase_buyer:seller_user_id:2:buyer_user_id:1:content_id:100:content_type:track"
@@ -58,3 +59,4 @@ def test_usdc_purchase_notification(app):
             "amount": 1000,
             "content_id": 100
         }
+        assert buyer_notifications[0].slot == 4

--- a/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
+++ b/discovery-provider/integration_tests/notifications/test_usdc_purchase.py
@@ -3,7 +3,7 @@ from typing import List
 
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
-from src.models.users.usdc_purchase import UsdcPurchaseContentType
+from src.models.users.usdc_purchase import PurchaseType
 from src.utils.db_session import get_db
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def test_usdc_purchase_notification(app):
                 "buyer_user_id": 1,
                 "seller_user_id": 2,
                 "amount": 1000,
-                "content_type": UsdcPurchaseContentType.track,
+                "content_type": PurchaseType.track,
                 "content_id": 100
             }
         ]

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -33,6 +33,7 @@ from src.models.tracks.track_route import TrackRoute
 from src.models.users.aggregate_user import AggregateUser
 from src.models.users.associated_wallet import AssociatedWallet, WalletChain
 from src.models.users.supporter_rank_up import SupporterRankUp
+from src.models.users.usdc_purchase import UsdcPurchase
 from src.models.users.user import User
 from src.models.users.user_balance_change import UserBalanceChange
 from src.models.users.user_bank import UserBankAccount, UserBankTx
@@ -144,6 +145,7 @@ def populate_mock_db(db, entities, block_offset=None):
         notifications = entities.get("notification", [])
         playlist_seens = entities.get("playlist_seens", [])
         user_balance_changes = entities.get("user_balance_changes", [])
+        usdc_purchases = entities.get("usdc_purchases", [])
 
         num_blocks = max(
             len(tracks),
@@ -649,6 +651,19 @@ def populate_mock_db(db, entities, block_offset=None):
                 previous_balance=balance_change.get("previous_balance", 0),
                 created_at=balance_change.get("created_at", datetime.now()),
                 updated_at=balance_change.get("updated_at", datetime.now()),
+            )
+            session.add(ns)
+        for i, usdc_purchase in enumerate(usdc_purchases):
+            ns = UsdcPurchase(
+                slot=usdc_purchase.get("slot", i),
+                signature=usdc_purchase.get("signature", 'fake_signature'),
+                buyer_user_id=usdc_purchase.get("buyer_user_id", 1),
+                seller_user_id=usdc_purchase.get("seller_user_id", 2),
+                amount=usdc_purchase.get("amount", 100),
+                content_type=usdc_purchase.get("content_type", "track"),
+                content_id=usdc_purchase.get("content_id", 3),
+                created_at=usdc_purchase.get("created_at", datetime.now()),
+                updated_at=usdc_purchase.get("updated_at", datetime.now()),
             )
             session.add(ns)
 

--- a/discovery-provider/integration_tests/utils.py
+++ b/discovery-provider/integration_tests/utils.py
@@ -33,7 +33,7 @@ from src.models.tracks.track_route import TrackRoute
 from src.models.users.aggregate_user import AggregateUser
 from src.models.users.associated_wallet import AssociatedWallet, WalletChain
 from src.models.users.supporter_rank_up import SupporterRankUp
-from src.models.users.usdc_purchase import UsdcPurchase
+from src.models.users.usdc_purchase import USDCPurchase
 from src.models.users.user import User
 from src.models.users.user_balance_change import UserBalanceChange
 from src.models.users.user_bank import UserBankAccount, UserBankTx
@@ -654,7 +654,7 @@ def populate_mock_db(db, entities, block_offset=None):
             )
             session.add(ns)
         for i, usdc_purchase in enumerate(usdc_purchases):
-            ns = UsdcPurchase(
+            ns = USDCPurchase(
                 slot=usdc_purchase.get("slot", i),
                 signature=usdc_purchase.get("signature", 'fake_signature'),
                 buyer_user_id=usdc_purchase.get("buyer_user_id", 1),

--- a/discovery-provider/src/models/users/usdc_purchase.py
+++ b/discovery-provider/src/models/users/usdc_purchase.py
@@ -1,11 +1,11 @@
 import enum
 
-from sqlalchemy import Column, DateTime, Enum, Integer, Numeric, String, text
+from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String, text
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin
 
 
-class UsdcPurchaseContentType(str, enum.Enum):
+class PurchaseType(str, enum.Enum):
     track = "track"
     playlist = "playlist"
     album = "album"
@@ -14,12 +14,12 @@ class UsdcPurchaseContentType(str, enum.Enum):
 class UsdcPurchase(Base, RepresentableMixin):
     __tablename__ = "usdc_purchases"
 
-    slot = Column(Integer, nullable=False, index=True)
+    slot = Column(Integer, primary_key=True, nullable=False, index=True)
     signature = Column(String, primary_key=True, nullable=False)
-    buyer_user_id = Column(String, nullable=False, index=True)
-    seller_user_id = Column(String, nullable=False, index=True)
-    amount = Column(Numeric, nullable=False)
-    content_type = Column(Enum(UsdcPurchaseContentType), nullable=False)
+    seller_user_id = Column(Integer, nullable=False, index=True)
+    buyer_user_id = Column(Integer, nullable=False, index=True)
+    amount = Column(BigInteger, nullable=False)
+    content_type = Column(Enum(PurchaseType), nullable=False, index=True)
     content_id = Column(Integer, nullable=False)
 
     created_at = Column(

--- a/discovery-provider/src/models/users/usdc_purchase.py
+++ b/discovery-provider/src/models/users/usdc_purchase.py
@@ -11,7 +11,7 @@ class PurchaseType(str, enum.Enum):
     album = "album"
 
 
-class UsdcPurchase(Base, RepresentableMixin):
+class USDCPurchase(Base, RepresentableMixin):
     __tablename__ = "usdc_purchases"
 
     slot = Column(Integer, primary_key=True, nullable=False, index=True)

--- a/discovery-provider/src/models/users/usdc_purchase.py
+++ b/discovery-provider/src/models/users/usdc_purchase.py
@@ -1,0 +1,30 @@
+import enum
+
+from sqlalchemy import Column, DateTime, Enum, Integer, Numeric, String, text
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class UsdcPurchaseContentType(str, enum.Enum):
+    track = "track"
+    playlist = "playlist"
+    album = "album"
+
+
+class UsdcPurchase(Base, RepresentableMixin):
+    __tablename__ = "usdc_purchases"
+
+    slot = Column(Integer, nullable=False, index=True)
+    signature = Column(String, primary_key=True, nullable=False)
+    buyer_user_id = Column(String, nullable=False, index=True)
+    seller_user_id = Column(String, nullable=False, index=True)
+    amount = Column(Numeric, nullable=False)
+    content_type = Column(Enum(UsdcPurchaseContentType), nullable=False)
+    content_id = Column(Integer, nullable=False)
+
+    created_at = Column(
+        DateTime, nullable=False, index=True, server_default=text("CURRENT_TIMESTAMP")
+    )
+    updated_at = Column(
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
+    )


### PR DESCRIPTION
### Description
- adds python models for usdc purchases
- includes usdc purchases in the populate_entities db utils function
- add db trigger handle_usdc_purchase that creates two notifs, one for the person buying the music and another for the person selling the music

### How Has This Been Tested?
added unit test

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
