### PR TITLE
[plat-1110] return usdc purchase notifs in get notifications query

### DIFF
--- a/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime, timedelta
+
+from integration_tests.utils import populate_mock_db
+from src.models.users.usdc_purchase import PurchaseType
+from src.queries.get_notifications import get_notifications
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+t1 = datetime(2020, 10, 10, 10, 35, 0)
+t2 = t1 - timedelta(hours=1)
+t3 = t1 - timedelta(hours=2)
+t4 = t1 - timedelta(hours=3)
+
+
+def test_get_repost_notifications(app):
+    with app.app_context():
+        db_mock = get_db()
+
+        test_entities = {
+            "users": [{"user_id": i + 1} for i in range(20)],
+            "tracks": [{"track_id": 1, "owner_id": 1}],
+        }
+        populate_mock_db(db_mock, test_entities)
+
+        test_actions = {
+            "usdc_purchases": [
+              {
+                "buyer_user_id": 2,
+                "seller_user_id": 1,
+                "amount": 1000,
+                "content_type": PurchaseType.track,
+                "content_id": 100
+              }
+            ]
+        }
+        populate_mock_db(db_mock, test_actions)
+
+        with db_mock.scoped_session() as session:
+            args = {"limit": 10, "user_id": 1}
+            u1_seller_notifications = get_notifications(session, args)
+            assert len(u1_seller_notifications) == 1
+            assert u1_seller_notifications[0]["group_id"] == "usdc_purchase_seller:seller_user_id:1:buyer_user_id:2:content_id:100:content_type:track"
+            assert u1_seller_notifications[0]["is_seen"] == False
+            assert len(u1_seller_notifications[0]["actions"]) == 1
+            assert u1_seller_notifications[0]["actions"][0]["data"] == {
+                "content_type": "track",
+                "buyer_user_id": 1,
+                "seller_user_id": 2,
+                "amount": 1000,
+                "content_id": 100
+            }

--- a/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
@@ -2,8 +2,9 @@ import logging
 from datetime import datetime, timedelta
 
 from integration_tests.utils import populate_mock_db
+from src.api.v1.utils.extend_notification import extend_notification
 from src.models.users.usdc_purchase import PurchaseType
-from src.queries.get_notifications import get_notifications
+from src.queries.get_notifications import NotificationType, get_notifications
 from src.utils.db_session import get_db
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ def test_get_repost_notifications(app):
         db_mock = get_db()
 
         test_entities = {
-            "users": [{"user_id": i + 1} for i in range(20)],
+            "users": [{"user_id": i + 1} for i in range(4)],
             "tracks": [{"track_id": 1, "owner_id": 1}],
         }
         populate_mock_db(db_mock, test_entities)
@@ -27,27 +28,114 @@ def test_get_repost_notifications(app):
         test_actions = {
             "usdc_purchases": [
               {
+                "slot": 4,
                 "buyer_user_id": 2,
                 "seller_user_id": 1,
                 "amount": 1000,
                 "content_type": PurchaseType.track,
-                "content_id": 100
+                "content_id": 1
               }
             ]
         }
         populate_mock_db(db_mock, test_actions)
 
         with db_mock.scoped_session() as session:
-            args = {"limit": 10, "user_id": 1}
+            args = {
+                "limit": 10,
+                "user_id": 1,
+                "valid_types": [NotificationType.USDC_PURCHASE_SELLER],
+            }
             u1_seller_notifications = get_notifications(session, args)
             assert len(u1_seller_notifications) == 1
-            assert u1_seller_notifications[0]["group_id"] == "usdc_purchase_seller:seller_user_id:1:buyer_user_id:2:content_id:100:content_type:track"
+            assert u1_seller_notifications[0]["group_id"] == "usdc_purchase_seller:seller_user_id:1:buyer_user_id:2:content_id:1:content_type:track"
             assert u1_seller_notifications[0]["is_seen"] == False
             assert len(u1_seller_notifications[0]["actions"]) == 1
             assert u1_seller_notifications[0]["actions"][0]["data"] == {
                 "content_type": "track",
-                "buyer_user_id": 1,
-                "seller_user_id": 2,
+                "buyer_user_id": 2,
+                "seller_user_id": 1,
                 "amount": 1000,
-                "content_id": 100
+                "content_id": 1
+            }
+
+            args = {
+                "limit": 10,
+                "user_id": 2,
+                "valid_types": [NotificationType.USDC_PURCHASE_BUYER],
+            }
+            u2_buyer_notifications = get_notifications(session, args)
+            assert len(u2_buyer_notifications) == 1
+            assert u2_buyer_notifications[0]["group_id"] == "usdc_purchase_buyer:seller_user_id:1:buyer_user_id:2:content_id:1:content_type:track"
+            assert u2_buyer_notifications[0]["is_seen"] == False
+            assert len(u2_buyer_notifications[0]["actions"]) == 1
+            assert u2_buyer_notifications[0]["actions"][0]["data"] == {
+                "content_type": "track",
+                "buyer_user_id": 2,
+                "seller_user_id": 1,
+                "amount": 1000,
+                "content_id": 1
+            }
+
+
+def test_extended_usdc_purchase_notification(app):
+    with app.app_context():
+        db_mock = get_db()
+
+        test_entities = {
+            "users": [{"user_id": i + 1} for i in range(4)],
+            "tracks": [{"track_id": 1, "owner_id": 1}],
+        }
+        populate_mock_db(db_mock, test_entities)
+
+        test_actions = {
+            "usdc_purchases": [
+              {
+                "slot": 4,
+                "buyer_user_id": 2,
+                "seller_user_id": 1,
+                "amount": 1000,
+                "content_type": PurchaseType.track,
+                "content_id": 1
+              }
+            ]
+        }
+        populate_mock_db(db_mock, test_actions)
+
+        with db_mock.scoped_session() as session:
+            args = {
+                "limit": 10,
+                "user_id": 1,
+                "valid_types": [NotificationType.USDC_PURCHASE_SELLER],
+            }
+            u1_seller_notifications = get_notifications(session, args)
+            extended_buyer_notif = extend_notification(u1_seller_notifications[0])
+            assert extended_buyer_notif["type"] == "usdc_purchase_seller"
+            assert extended_buyer_notif["group_id"] == "usdc_purchase_seller:seller_user_id:1:buyer_user_id:2:content_id:1:content_type:track"
+            assert extended_buyer_notif["actions"][0]["specifier"] == "ML51L"
+            assert extended_buyer_notif["actions"][0]["type"] == "usdc_purchase_seller"
+            assert extended_buyer_notif["actions"][0]["data"] == {
+                "content_type": "track",
+                "buyer_user_id": "ML51L",
+                "seller_user_id": "7eP5n",
+                "amount": "10000000000000",
+                "content_id": "7eP5n"
+            }
+
+            args = {
+                "limit": 10,
+                "user_id": 2,
+                "valid_types": [NotificationType.USDC_PURCHASE_BUYER],
+            }
+            u2_buyer_notifications = get_notifications(session, args)
+            extended_buyer_notif = extend_notification(u2_buyer_notifications[0])
+            assert extended_buyer_notif["type"] == "usdc_purchase_buyer"
+            assert extended_buyer_notif["group_id"] == "usdc_purchase_buyer:seller_user_id:1:buyer_user_id:2:content_id:1:content_type:track"
+            assert extended_buyer_notif["actions"][0]["specifier"] == "ML51L"
+            assert extended_buyer_notif["actions"][0]["type"] == "usdc_purchase_buyer"
+            assert extended_buyer_notif["actions"][0]["data"] == {
+                "content_type": "track",
+                "buyer_user_id": "ML51L",
+                "seller_user_id": "7eP5n",
+                "amount": "10000000000000",
+                "content_id": "7eP5n"
             }

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -32,6 +32,8 @@ from src.queries.get_notifications import (
     TrendingNotification,
     TrendingPlaylistNotification,
     TrendingUndergroundNotification,
+    UsdcPurchaseBuyerNotification,
+    UsdcPurchaseSellerNotification,
 )
 from src.utils.helpers import encode_int_id
 from src.utils.spl_audio import to_wei_string
@@ -442,6 +444,25 @@ def extend_trending_playlist(action: NotificationAction):
             "genre": data["genre"],
             "playlist_id": encode_int_id(data["playlist_id"]),
             "time_range": data["time_range"],
+        },
+    }
+    return notification
+
+
+def extend_usdc_purchase_seller(action: NotificationAction):
+    data: UsdcPurchaseSellerNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "content_type": data["content_type"],
+            "buyer_user_id": encode_int_id(data["buyer_user_id"]),
+            "seller_user_id": encode_int_id(data["seller_user_id"]),
+            "amount": to_wei_string(data["amount"]),
+            "content_id": encode_int_id(data["content_id"]),
         },
     }
     return notification

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -468,6 +468,25 @@ def extend_usdc_purchase_seller(action: NotificationAction):
     return notification
 
 
+def extend_usdc_purchase_buyer(action: NotificationAction):
+    data: UsdcPurchaseBuyerNotification = action["data"]  # type: ignore
+    notification = {
+        "specifier": encode_int_id(int(action["specifier"])),
+        "type": action["type"],
+        "timestamp": datetime.timestamp(action["timestamp"])
+        if action["timestamp"]
+        else action["timestamp"],
+        "data": {
+            "content_type": data["content_type"],
+            "buyer_user_id": encode_int_id(data["buyer_user_id"]),
+            "seller_user_id": encode_int_id(data["seller_user_id"]),
+            "amount": to_wei_string(data["amount"]),
+            "content_id": encode_int_id(data["content_id"]),
+        },
+    }
+    return notification
+
+
 def extend_trending_underground(action: NotificationAction):
     data: TrendingUndergroundNotification = action["data"]  # type: ignore
     notification = {
@@ -522,5 +541,7 @@ notification_action_handler = {
     "trending": extend_trending,
     "trending_playlist": extend_trending_playlist,
     "trending_underground": extend_trending_underground,
+    "usdc_purchase_buyer": extend_usdc_purchase_buyer,
+    "usdc_purchase_seller": extend_usdc_purchase_seller,
     "announcement": extend_announcement,
 }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -162,6 +162,8 @@ class NotificationType(str, Enum):
     TRENDING = "trending"
     TRENDING_PLAYLIST = "trending_playlist"
     TRENDING_UNDERGROUND = "trending_underground"
+    USDC_PURCHASE_BUYER = "usdc_purchase_buyer"
+    USDC_PURCHASE_SELLER = "usdc_purchase_seller"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -390,6 +392,22 @@ class TrendingUndergroundNotification(TypedDict):
     time_range: str
 
 
+class UsdcPurchaseSellerNotification(TypedDict):
+    content_type: str
+    content_id: int
+    buyer_user_id: int
+    seller_user_id: int
+    amount: int
+
+
+class UsdcPurchaseBuyerNotification(TypedDict):
+    content_type: str
+    content_id: int
+    buyer_user_id: int
+    seller_user_id: int
+    amount: int
+
+
 class AnnouncementNotification(TypedDict):
     title: str
     short_description: str
@@ -421,6 +439,8 @@ NotificationData = Union[
     PlaylistMilestoneNotification,
     TierChangeNotification,
     TrendingNotification,
+    UsdcPurchaseBuyerNotification,
+    UsdcPurchaseSellerNotification
 ]
 
 


### PR DESCRIPTION
### Description
Adds the usdc notifications to the get notifications query so they can be returned to the front end on request. note they are not considered default types so they do not get automatically returned unless specifically specified

### How Has This Been Tested?
added unit tests

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
