### PR TITLE
Make mediorum only redirect if db is reachable

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -79,6 +79,13 @@ func (ss *MediorumServer) getBlobInfo(c echo.Context) error {
 		ss.logger.Warn("error getting blob attributes", "error", err)
 		return err
 	}
+
+	// since this is called before redirecting, make sure this node can actually serve the blob (it needs to check db for delisted status)
+	dbHealthy := ss.databaseSize > 0
+	if !dbHealthy {
+		return c.String(500, "database connection issue")
+	}
+
 	return c.JSON(200, attr)
 }
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -244,6 +244,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		if !ss.Config.WalletIsRegistered {
 			status = 506
 		}
+		dbHealthy := ss.databaseSize > 0
+		if !dbHealthy {
+			status = 500
+		}
 		return c.JSON(status, map[string]any{
 			"host":                 ss.Config.Self.Host,
 			"wallet":               ss.Config.Self.Wallet,
@@ -258,6 +262,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// responds to polling requests in peer_health
 	// should do no real work
 	internalApi.GET("/ok", func(c echo.Context) error {
+		dbHealthy := ss.databaseSize > 0
+		if !dbHealthy {
+			c.JSON(500, "database not healthy")
+		}
 		return c.String(200, "OK")
 	})
 


### PR DESCRIPTION
### Description
Fixes oncall issue where Discovery correctly ignores the node with an unreachable db, but mediorum still redirects to it.

### How Has This Been Tested?
We'd have to take the db offline to test. I think it's safer to just monitor on staging for a while and then release to SPs since the SP with an unreachable db is on auto-upgrade.