### PR TITLE
PLAT-1096: notifs heap fixes

### DIFF
--- a/discovery-provider/plugins/notifications/Dockerfile
+++ b/discovery-provider/plugins/notifications/Dockerfile
@@ -15,4 +15,4 @@ RUN npm run build
 ENV PATH="${PATH}:/notifications/node_modules/.bin"
 
 # Run the command on container startup
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "dev"]

--- a/discovery-provider/plugins/notifications/Dockerfile
+++ b/discovery-provider/plugins/notifications/Dockerfile
@@ -15,4 +15,4 @@ RUN npm run build
 ENV PATH="${PATH}:/notifications/node_modules/.bin"
 
 # Run the command on container startup
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "start"]

--- a/discovery-provider/plugins/notifications/package.json
+++ b/discovery-provider/plugins/notifications/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pretty": "prettier --write .",
     "sql-ts": "ts-node scripts/sql-ts.ts",
-    "start": "pm2-runtime build/src/main.js --restart-delay=3000",
+    "start": "pm2-runtime build/src/main.js --restart-delay=3000 --node-args=\"--max-old-space-size=512\"",
     "test:watch": "jest --watchAll",
     "test": "tsc && jest --runInBand --forceExit",
     "test-push": "ts-node scripts/test-push-notification.ts",

--- a/discovery-provider/plugins/notifications/scripts/create-announcement.ts
+++ b/discovery-provider/plugins/notifications/scripts/create-announcement.ts
@@ -79,7 +79,7 @@ export const main = async () => {
   await audiusInstance.init()
   const notification = {
     title: values.title,
-    description: values.description
+    description: values.body
   }
 
   try {
@@ -92,7 +92,7 @@ export const main = async () => {
         // @ts-ignore
         'Create', // EntityManagerClient.Action.CREATE,
         JSON.stringify(notification),
-        values.privateKey
+        values.pk
       )
     console.log({ res })
   } catch (e) {

--- a/discovery-provider/plugins/notifications/scripts/create-announcement.ts
+++ b/discovery-provider/plugins/notifications/scripts/create-announcement.ts
@@ -79,7 +79,7 @@ export const main = async () => {
   await audiusInstance.init()
   const notification = {
     title: values.title,
-    description: values.body
+    short_description: values.body
   }
 
   try {

--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -20,6 +20,7 @@ import {
 import { Server } from './server'
 import { configureWebPush } from './web'
 import { configureAnnouncement } from './processNotifications/mappers/announcement'
+import { logMemStats } from './utils/memStats'
 
 export class Processor {
   discoveryDB: Knex
@@ -59,6 +60,9 @@ export class Processor {
 
     // setup announcements
     configureAnnouncement()
+
+    // log memory stats on startup
+    logMemStats()
 
     // Comment out to prevent app notifications until complete
     this.listener = new Listener()

--- a/discovery-provider/plugins/notifications/src/server/index.ts
+++ b/discovery-provider/plugins/notifications/src/server/index.ts
@@ -2,6 +2,7 @@ import express, { Express } from 'express'
 
 import { Server as HttpServer } from 'http'
 import { router as healthCheckRouter } from './routes/healthCheck'
+import { router as memStatsRouter } from "./routes/memStats"
 
 const DEFAULT_PORT = 6000
 
@@ -17,6 +18,7 @@ export class Server {
 
   init = async () => {
     this.app.use('/health_check', healthCheckRouter)
+    this.app.use('/mem_stats', memStatsRouter)
 
     await new Promise((resolve) => {
       this.httpServer = this.app.listen(this.port, () => {

--- a/discovery-provider/plugins/notifications/src/server/routes/memStats.ts
+++ b/discovery-provider/plugins/notifications/src/server/routes/memStats.ts
@@ -1,0 +1,10 @@
+import { Router, Request, Response } from 'express'
+import { config } from '../../config'
+import { getMemStats } from '../../utils/memStats'
+
+const router = Router()
+
+// Mapped to the /mem_stats Endpoint
+ router.get("/", async (req: Request, res: Response) => res.json(getMemStats()))
+
+ export { router }

--- a/discovery-provider/plugins/notifications/src/utils/memStats.ts
+++ b/discovery-provider/plugins/notifications/src/utils/memStats.ts
@@ -4,7 +4,8 @@ export type MemoryStats = {
     heapTotal: string,
     heapUsed: string
     heapAvailable: string,
-    external: string
+    external: string,
+    rss: string,
 }
 
 export const logMemStats = () => {
@@ -14,6 +15,7 @@ export const logMemStats = () => {
     logFmt("Heap Used", stats.heapUsed)
     logFmt("Heap Available", stats.heapAvailable)
     logFmt("External", stats.external)
+    logFmt("RSS", stats.rss)
 }
 
 export const getMemStats = (): MemoryStats => {
@@ -24,7 +26,8 @@ export const getMemStats = (): MemoryStats => {
     const heapUsed = convert(memoryUsage.heapUsed)
     const heapAvailable = (parseFloat(heapTotal) - parseFloat(heapUsed)).toString()
     const external = convert(memoryUsage.external)
+    const rss = convert(memoryUsage.rss)
     return {
-        heapAvailable, heapTotal, heapUsed, external
+        heapAvailable, heapTotal, heapUsed, external, rss
     }
 }

--- a/discovery-provider/plugins/notifications/src/utils/memStats.ts
+++ b/discovery-provider/plugins/notifications/src/utils/memStats.ts
@@ -1,0 +1,30 @@
+import { logger } from "../logger"
+
+export type MemoryStats = {
+    heapTotal: string,
+    heapUsed: string
+    heapAvailable: string,
+    external: string
+}
+
+export const logMemStats = () => {
+    const stats = getMemStats()
+    const logFmt = (key: string, val: string) => logger.info(`${key}: ${val}MB`)
+    logFmt("Heap Total", stats.heapTotal)
+    logFmt("Heap Used", stats.heapUsed)
+    logFmt("Heap Available", stats.heapAvailable)
+    logFmt("External", stats.external)
+}
+
+export const getMemStats = (): MemoryStats => {
+    const memoryUsage = process.memoryUsage()
+    const bytesToMb = 1024 * 1024
+    const convert = (bytes: number): string => (bytes / bytesToMb).toFixed(2)
+    const heapTotal = convert(memoryUsage.heapTotal)
+    const heapUsed = convert(memoryUsage.heapUsed)
+    const heapAvailable = (parseFloat(heapTotal) - parseFloat(heapUsed)).toString()
+    const external = convert(memoryUsage.external)
+    return {
+        heapAvailable, heapTotal, heapUsed, external
+    }
+}


### PR DESCRIPTION
Dockerfile has been running `npm run dev` which is bloating the allocated heap size drastically. We should at least run `npm run start` and see if we get memory issues after that.

### How Has This Been Tested?
ran `npm run dev` and `npm run start` on stage and noticed heap total differences of 336mb to 61mb respectively.
