### PR TITLE
Check host health before redirect for legacy path

### DIFF
--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
+	"golang.org/x/exp/slices"
 )
 
 func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
@@ -103,19 +105,22 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
 		return err
 	}
 
-	// here we would want to check that host in question is up
-	// (perhaps using healthy hosts convetion from elsewhere)
-	// for now just use first host
 	logger := ss.logger.With("cid", cid)
 	logger.Info("potential hosts for cid", "hosts", hosts)
+	healthyHosts := ss.findHealthyPeers(2 * time.Minute)
+
 	for _, host := range hosts {
+		if !slices.Contains(healthyHosts, host) {
+			logger.Info("host not healthy; skipping", "host", host)
+			continue
+		}
 		dest := replaceHost(*c.Request().URL, host)
 		logger.Info("redirecting to: " + dest.String())
 		return c.Redirect(302, dest.String())
 	}
 
-	logger.Info("no host found with cid")
-	return c.String(404, "no host found with cid: "+cid)
+	logger.Info("no healthy host found with cid")
+	return c.String(404, "no healthy host found with cid: "+cid)
 }
 
 func (ss *MediorumServer) findHostsWithCid(ctx context.Context, cid string) ([]string, error) {


### PR DESCRIPTION
### Description
Adds a check for node health before redirecting on the legacy path. This is already done for the v2 path. Note that in the legacy path we can't use `hostHasBlob` because that checks the CDK bucket.

### How Has This Been Tested?
This is small enough to just test on staging by fetching a track or image. The example I ran into in prod was https://creatornode.audius.co/content/QmapqPuNu4foZCAj1o2igjJKDQmpJLFxcd2zgpBThUpjga/480x480.jpg redirecting to https://audius-creator-2.theblueprint.xyz/content/QmapqPuNu4foZCAj1o2igjJKDQmpJLFxcd2zgpBThUpjga/480x480.jpg when the latter was down for 3 hours.