### PR TITLE
Disallow non-cidstream mp3s, and fix filename download

### DIFF
--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -3,8 +3,8 @@ package server
 import (
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
-	"net/url"
 	"sync"
 	"time"
 
@@ -116,11 +116,11 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 }
 
 func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
-	// If the client provided a filename, set it in the header to be auto-populated in download prompt
+	// if the client provided a filename, set it in the header to be auto-populated in download prompt
 	filenameForDownload := c.QueryParam("filename")
 	if filenameForDownload != "" {
-		contentDisposition := url.QueryEscape(filenameForDownload)
-		c.Response().Header().Set("Content-Disposition", "attachment; filename="+contentDisposition)
+		contentDisposition := mime.QEncoding.Encode("utf-8", filenameForDownload)
+		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
 	}
 
 	jobID := c.Param("jobID")


### PR DESCRIPTION
### Description
- Blocks mp3 streaming from /ipfs and /content routes, and removes the corresponding log and x-would-block header
- Fixes file names replacing space chars with plus chars when downloading tracks or stems

### How Has This Been Tested?
Deployed to stage CN6 and tested downloading from it - it doesn't replace spaces with pluses anymore.

Example: https://discoveryprovider.staging.audius.co/v1/tracks/LjNAZ/stream?user_data=Premium%20content%20user%20signature%20at%201689018506695&user_signature=0x204ebcc22352f7003d127c7ffd93fc29057cf770e9e3f111c50a687ff7f35ebe127fac5f30d3d79027036f9f6ac3770b6e704b268965ed5b9fb036c2da9f9fbf1b&filename=birds%20-%20Instrumental%20%20-%20Theo%20(Audius).mp3