### PR TITLE
Add web push notifications for announcements

### DIFF
--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/announcement.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/announcement.test.ts
@@ -1,6 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 import { Processor } from '../../main'
 import * as sns from '../../sns'
+import * as web from '../../web'
 
 import {
   createUsers,
@@ -22,6 +23,10 @@ describe('Announcement Notification', () => {
   const sendPushNotificationSpy = jest
     .spyOn(sns, 'sendPushNotification')
     .mockImplementation(() => Promise.resolve({ endpointDisabled: false }))
+
+  const sendBrowserNotificationSpy = jest
+    .spyOn(web, 'sendBrowserNotification')
+    .mockImplementation(() => Promise.resolve(3))
 
   beforeEach(async () => {
     process.env.ANNOUNCEMENTS_DRY_RUN = 'false'
@@ -82,6 +87,13 @@ describe('Announcement Notification', () => {
           type: 'Announcement'
         }
       }
+    )
+    expect(sendBrowserNotificationSpy).toHaveBeenCalledWith(
+      true,
+      expect.any(Object),
+      1,
+      'This is an announcement',
+      'This is some information about the announcement we need to display'
     )
   })
 

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/announcement.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/announcement.ts
@@ -15,6 +15,7 @@ import {
 import { UserNotificationSettings } from './userNotificationSettings'
 import { logger } from '../../logger'
 import { disableDeviceArns } from '../../utils/disableArnEndpoint'
+import { sendBrowserNotification } from '../../web'
 
 const getEnv = (envVar: string | undefined, defaultVal?: boolean): boolean => {
   if (envVar === undefined && defaultVal === undefined) return true
@@ -99,7 +100,8 @@ export class Announcement extends BaseNotification<AnnouncementNotificationRow> 
       if (!isDryRun) {
         await this.broadcastAnnouncement(
           validReceiverUserIds,
-          isLiveEmailEnabled
+          isLiveEmailEnabled,
+          isBrowserPushEnabled
         )
       }
 
@@ -124,7 +126,11 @@ export class Announcement extends BaseNotification<AnnouncementNotificationRow> 
     }
   }
 
-  async broadcastAnnouncement(userIds: number[], isLiveEmailEnabled: boolean) {
+  async broadcastAnnouncement(
+    userIds: number[],
+    isLiveEmailEnabled: boolean,
+    isBrowserPushEnabled: boolean
+  ) {
     const userNotificationSettings = await buildUserNotificationSettings(
       this.identityDB,
       userIds
@@ -132,7 +138,8 @@ export class Announcement extends BaseNotification<AnnouncementNotificationRow> 
     for (const userId of userIds) {
       await this.broadcastPushNotificationAnnouncements(
         userId,
-        userNotificationSettings
+        userNotificationSettings,
+        isBrowserPushEnabled
       )
       await this.broadcastEmailAnnouncements(
         isLiveEmailEnabled,
@@ -144,16 +151,28 @@ export class Announcement extends BaseNotification<AnnouncementNotificationRow> 
 
   async broadcastPushNotificationAnnouncements(
     userId: number,
-    userNotificationSettings: UserNotificationSettings
+    userNotificationSettings: UserNotificationSettings,
+    isBrowserPushEnabled: boolean
   ) {
     if (
       userNotificationSettings.shouldSendPushNotification({
         receiverUserId: userId
       })
     ) {
+      const title = this.notification.data.title
+      const body = this.notification.data.short_description
+      // purposefully leaving this without await,
+      // so we don't have to wait for each user's to be sent
+      // before the next's.
+      sendBrowserNotification(
+        isBrowserPushEnabled,
+        userNotificationSettings,
+        userId,
+        title,
+        body
+      )
       const devices: Device[] = userNotificationSettings.getDevices(userId)
       // If the user's settings for the follow notification is set to true, proceed
-  
       const pushes = await Promise.all(
         devices.map((device) => {
           // this may get rate limited by AWS


### PR DESCRIPTION
### Description
Adds web push notifs to announcements. i think we finished web push before announcements were done, and we forgot to add them back into announcements. adding them back with a test. note its purposefully without an await so we don't block on sending tehm sequentially

### How Has This Been Tested?
added unit test

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
