### PR TITLE
Make redirect err more informative

### DIFF
--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -109,7 +109,7 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
 
 	hosts, err := ss.findHostsWithCid(ctx, cid)
 	if err != nil {
-		return err
+		return c.String(500, "error redirecting:"+err.Error())
 	}
 
 	logger := ss.logger.With("cid", cid)


### PR DESCRIPTION
### Description
This makes it easier to track down vague errors like:
```
{
"error": "scanning all: scanning: scanning: doing scan: scanFn: scany: scan row value into a primitive type: can't scan into dest[0]: cannot scan NULL into *string",
"message": "Internal Server Error"
}
```

### How Has This Been Tested?
Just an error line.