### PR TITLE
Build solana-test-validator for linux

### DIFF
--- a/.circleci/src/workflows/integration.yml
+++ b/.circleci/src/workflows/integration.yml
@@ -1,10 +1,5 @@
 when: << pipeline.parameters.run-integration-workflow >>
 jobs:
-  - push-docker-image:
-      name: push-solana-test-validator
-      context: [GCP, dockerhub]
-      instance-name: circleci-push-solana-test-validator-$CIRCLE_BUILD_NUM
-      service: solana-test-validator
   - test-audius-cmd:
       context: GCP
       instance-name: circleci-test-audius-cmd-$CIRCLE_BUILD_NUM

--- a/dev-tools/compose/docker-compose.blockchain.yml
+++ b/dev-tools/compose/docker-compose.blockchain.yml
@@ -111,9 +111,29 @@ services:
   # solana-programs
 
   solana-test-validator:
-    # image: audius/solana-programs:latest # Default tag is "latest." Change tag to "m1-slow" to have very slow block times that use less CPU
     # NOTE: Building solana program can take a lot of time especially on m1 (upto 30 mins) so we used pre-built images
+    image: audius/solana-programs:latest # Default tag is "latest." Change tag to "m1-slow" to have very slow block times that use less CPU
+    volumes:
+      - solana-programs-idl:/usr/src/app/anchor/audius-data/idl
+    ports:
+      - "8899:8899"
+    deploy:
+      mode: global
+      resources:
+        limits:
+          memory: 3G
+    profiles:
+      - solana
+
+  # for infrequent solana builds
+  # see audius-protocol/solana-programs/README.md
+  solana-test-validator-build:
+    image: audius/solana-programs:latest-arm64 # build on mac
+    # image: audius/solana-programs:latest-amd64 # build on linux
     build:
+      # platform flags seem to have no effect?
+      # platform: linux/arm64
+      # platform: linux/amd64
       context: ${PROJECT_ROOT}/solana-programs
       dockerfile: Dockerfile.dev
       args:
@@ -133,14 +153,5 @@ services:
         reward_manager_token_pda_private_key: "${SOLANA_REWARD_MANAGER_TOKEN_PDA_SECRET_KEY}"
         valid_signer_eth_address: "${ETH_VALID_SIGNER_ADDRESS}"
         fake_usdc_token_private_key: "${SOLANA_USDC_TOKEN_MINT_SECRET_KEY}"
-    volumes:
-      - solana-programs-idl:/usr/src/app/anchor/audius-data/idl
-    ports:
-      - "8899:8899"
-    deploy:
-      mode: global
-      resources:
-        limits:
-          memory: 3G
     profiles:
-      - solana
+      - solana-build

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -217,6 +217,12 @@ services:
       file: docker-compose.blockchain.yml
       service: solana-test-validator
     <<: *common
+  
+  solana-test-validator-build:
+    extends:
+      file: docker-compose.blockchain.yml
+      service: solana-test-validator-build
+    <<: *common
 
 volumes:
   poa-contracts-abis:

--- a/solana-programs/README.md
+++ b/solana-programs/README.md
@@ -4,16 +4,47 @@
 
 ## Build
 
+> There are probably better ways to do this..
+
 If you are changing solana-programs and require a rebuild:
-- uncomment the build block in [audius-protocol/dev-tools/compose/docker-compose.blockchain.yml](audius-protocol/dev-tools/compose/docker-compose.blockchain.yml)
-- comment out the `image: audius/solana-programs:latest` line
 
-This will:
-- On local, promote `audius-compose up` to build the solana image for arm64
-- On CI, build and push images for amd64
+**Step 1**
 
-Once you have confirmed the build as working:
-- comment out the build step
-- uncomment the `image: audius/solana-programs:latest` line
+Builds performed locally will only run on arm processors (m1 mac).
 
-This will keep subsequent local dev and CI runs fast and up to date.
+```
+cd dev-tools/compose
+DOCKER_BUILDKIT=1 docker compose --profile=solana-build build solana-test-validator-build
+docker push audius/solana-programs:latest-arm64
+```
+
+**Step 2**
+
+Image must be built on a linux machine and pushed.
+Modify the image directive in `docker-compose.blockchain.yml:solana-test-validator-build` to look like
+
+```
+# image: audius/solana-programs:latest-arm64 # build on mac
+image: audius/solana-programs:latest-amd64 # build on linux
+```
+
+Then run build and push
+```
+DOCKER_BUILDKIT=1 docker compose --profile=solana-build build solana-test-validator-build
+docker push audius/solana-programs:latest-amd64
+```
+
+**Step 3**
+
+Publish a docker manifest that will allow both architectures to be tagged with `latest`
+
+```
+docker manifest create audius/solana-programs:latest --amend audius/solana-programs:latest-arm64 --amend audius/solana-programs:latest-amd64
+docker manifest push audius/solana-programs:latest
+```
+
+Now if you visit the solana-programs [dockerhub](https://hub.docker.com/repository/docker/audius/solana-programs/tags?page=1&ordering=last_updated) you should see a `latest` tag that references two architectures.
+
+Docker will pull the correct image for the host at runtime.
+
+> Again, theres probably a better way to do this.


### PR DESCRIPTION
### Description

Add documentation for multi arch building of `solana-test-validator` image.

Im going to pass on adding this to CI for now, as its rather complicated with our setup and dont know how much we actually need that rn.

**TEST**

on local m1 the below should run with no issues

```
docker run --rm -ti audius/solana-programs:latest
```

on linux box i.e. some ec2 machine the below should also run with no issues

```
docker run --rm -ti audius/solana-programs:latest
```