### PR TITLE
[PLAT-1125] Tolerate higher minor/major versions in selection

### DIFF
--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
@@ -800,6 +800,7 @@ describe('test CreatorNodeSelection', () => {
     }
     // Make sure there is some variance
     assert(!primaries.every((val) => val === primaries[0]))
+    // @ts-ignore mocha is typed incorrectly
   }).timeout(10000)
 
   describe('Test preferHigherPatchForPrimary and preferHigherPatchForSecondaries', () => {

--- a/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
 import assert from 'assert'
-import semver from 'semver'
 
 import { CREATOR_NODE_SERVICE_NAME } from './constants'
 import { CreatorNodeSelection } from './CreatorNodeSelection'
@@ -21,12 +20,6 @@ const mockEthContracts = (
       return ['1.2.2', '1.2.3'][queryIndex] as string
     },
     getServiceProviderList: async () => urls.map((u) => ({ endpoint: u })),
-    hasSameMajorAndMinorVersion: (version1: string, version2: string) => {
-      return (
-        semver.major(version1) === semver.major(version2) &&
-        semver.minor(version1) === semver.minor(version2)
-      )
-    },
     isInRegressedMode: () => {
       return false
     }
@@ -807,7 +800,7 @@ describe('test CreatorNodeSelection', () => {
     }
     // Make sure there is some variance
     assert(!primaries.every((val) => val === primaries[0]))
-  }, 10000)
+  }).timeout(10000)
 
   describe('Test preferHigherPatchForPrimary and preferHigherPatchForSecondaries', () => {
     it('Selects highest version nodes when preferHigherPatchForPrimary and preferHigherPatchForSecondaries are enabled', async () => {

--- a/libs/src/services/creatorNode/CreatorNodeSelection.ts
+++ b/libs/src/services/creatorNode/CreatorNodeSelection.ts
@@ -1,6 +1,6 @@
 import type { AxiosResponse } from 'axios'
 import _ from 'lodash'
-import type { EthContracts } from '../ethContracts'
+import { EthContracts, isVersionAtLeastSameMajorMinor } from '../ethContracts'
 
 import {
   ServiceSelection,
@@ -387,7 +387,7 @@ export class CreatorNodeSelection extends ServiceSelection {
       //      use existing value from `this.maxStorageUsedPercent`
       if (resp.response) {
         const isUp = resp.response.status === 200
-        const versionIsUpToDate = this.ethContracts.hasSameMajorAndMinorVersion(
+        const versionIsUpToDate = isVersionAtLeastSameMajorMinor(
           this.currentVersion as string,
           resp.response.data.data.version
         )

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
 import assert from 'assert'
-import semver from 'semver'
 import { DiscoveryProviderSelection } from './DiscoveryProviderSelection'
 import { DISCOVERY_PROVIDER_TIMESTAMP } from './constants'
 import type { EthContracts } from '../ethContracts'
@@ -21,12 +20,6 @@ const mockEthContracts = (
       return ['1.2.2', '1.2.3'][queryIndex] as string
     },
     getServiceProviderList: async () => urls.map((u) => ({ endpoint: u })),
-    hasSameMajorAndMinorVersion: (version1: string, version2: string) => {
-      return (
-        semver.major(version1) === semver.major(version2) &&
-        semver.minor(version1) === semver.minor(version2)
-      )
-    },
     isInRegressedMode: () => {
       return false
     }

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -12,7 +12,7 @@ import {
   REGRESSED_MODE_TIMEOUT
 } from './constants'
 import semver from 'semver'
-import type { EthContracts } from '../ethContracts'
+import { EthContracts, isVersionAtLeastSameMajorMinor } from '../ethContracts'
 import type { AxiosResponse } from 'axios'
 import type { Maybe, Nullable } from '../../utils'
 import type { LocalStorage } from '../../utils/localStorage'
@@ -211,13 +211,8 @@ export class DiscoveryProviderSelection extends ServiceSelection {
     if (service !== DISCOVERY_SERVICE_NAME) return false
     if (!semver.valid(version)) return false
 
-    // If this service is not the same major/minor as what's on chain, reject
-    if (
-      !this.ethContracts.hasSameMajorAndMinorVersion(
-        this.currentVersion,
-        version
-      )
-    ) {
+    // If this service is not at least the version on chain, reject
+    if (!isVersionAtLeastSameMajorMinor(this.currentVersion, version)) {
       return false
     }
 
@@ -319,7 +314,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
       let isVersionOk = false
       for (let i = 0; i < (this.validVersions as string[]).length; ++i) {
         if (
-          this.ethContracts.hasSameMajorAndMinorVersion(
+          isVersionAtLeastSameMajorMinor(
             this.validVersions?.[i] as string,
             version
           )

--- a/libs/src/services/ethContracts/EthContracts.ts
+++ b/libs/src/services/ethContracts/EthContracts.ts
@@ -317,18 +317,6 @@ export class EthContracts {
     )
   }
 
-  /**
-   * Determines whether the major and minor versions are equal
-   * @param version1 string 1
-   * @param version2 string 2
-   */
-  hasSameMajorAndMinorVersion(version1: string, version2: string) {
-    return (
-      semver.major(version1) === semver.major(version2) &&
-      semver.minor(version1) === semver.minor(version2)
-    )
-  }
-
   async getServiceProviderList(spType: string) {
     return await this.ServiceProviderFactoryClient.getServiceProviderList(
       spType
@@ -346,4 +334,23 @@ export class EthContracts {
   async getServiceTypeInfo(spType: string) {
     return await this.ServiceTypeManagerClient.getServiceTypeInfo(spType)
   }
+}
+
+/**
+ * Determines whether version2's major/minor versions are greater than or
+ * equal to version1's major/minor.
+ * @param version1 string 1
+ * @param version2 string 2
+ */
+export const isVersionAtLeastSameMajorMinor = (
+  version1: string,
+  version2: string
+) => {
+  const version1MajorMinor = `${semver.major(version1)}.${semver.minor(
+    version1
+  )}.0`
+  const version2MajorMinor = `${semver.major(version2)}.${semver.minor(
+    version2
+  )}.0`
+  return semver.gte(version2MajorMinor, version1MajorMinor)
 }


### PR DESCRIPTION
### Description

Anything use old "libs" style selection won't pick a service with a minor version higher than what's registered on chain. This makes it so we accept any service with a major/minor version ahead of what's on chain.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Unit
