### PR TITLE
[CON-773] support new nodes better

### DIFF
--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -277,3 +277,15 @@ func (c *Crudr) GetOutboxSizes() map[string]int {
 	}
 	return sizes
 }
+
+func (c *Crudr) GetPercentNodesSeeded() float64 {
+	var nCaughtUp int
+	var nPeers int = len(c.peerClients)
+	for _, p := range c.peerClients {
+		if p.Seeded {
+			nCaughtUp++
+		}
+	}
+
+	return (float64(nCaughtUp) / float64(nPeers)) * 100
+}

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -332,7 +332,7 @@ func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider)
 		slices.Sort(combined)
 		slices.Sort(configCombined)
 		if !slices.Equal(combined, configCombined) {
-			logger.Info("peers or signers changed on chain. restarting...", "peers", len(peers), "signers", len(signers))
+			logger.Info("peers or signers changed on chain. restarting...", "peers", len(peers), "signers", len(signers), "combined", combined, "configCombined", configCombined)
 			os.Exit(0) // restarting from inside the app is too error-prone so we'll let docker compose autoheal handle it
 		}
 	}

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -343,8 +343,6 @@ func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider)
 		}
 
 		if peersChanged || signersChanged {
-			ss.Config.Peers = peers
-			ss.Config.Signers = signers
 			logger.Info("peers or signers changed on chain. restarting...", "peers", len(peers), "signers", len(signers))
 			os.Exit(0) // restarting from inside the app is too error-prone so we'll let docker compose autoheal handle it
 		}

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -299,7 +299,7 @@ func getenvWithDefault(key string, fallback string) string {
 // fetch registered nodes from chain every 30 minutes and restart if they've changed
 func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider) {
 	logger := slog.With("creatorNodeEndpoint", os.Getenv("creatorNodeEndpoint"))
-	ticker := time.NewTicker(1 * time.Minute) // TODO: Change to 30
+	ticker := time.NewTicker(30 * time.Minute)
 	for range ticker.C {
 		var peers, signers []server.Peer
 		var err error
@@ -342,7 +342,7 @@ func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider)
 			}
 		}
 
-		if peersChanged || signersChanged || true { // TODO: Remove || true
+		if peersChanged || signersChanged {
 			ss.Config.Peers = peers
 			ss.Config.Signers = signers
 			logger.Info("peers or signers changed on chain. restarting...", "peers", len(peers), "signers", len(signers))

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -114,6 +114,8 @@ func startStagingOrProd(isProd bool) {
 		log.Fatal(err)
 	}
 
+	go refreshPeersAndSigners(ss, g)
+
 	ss.MustStart()
 }
 
@@ -312,7 +314,8 @@ func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider)
 			return err
 		})
 		if err := eg.Wait(); err != nil {
-			panic(err)
+			logger.Error("failed to fetch registered nodes", "err", err)
+			continue
 		}
 
 		peersChanged := false

--- a/mediorum/server/peer_health.go
+++ b/mediorum/server/peer_health.go
@@ -22,7 +22,7 @@ func (ss *MediorumServer) startHealthPoller() {
 			peer := peer
 			go func() {
 				defer wg.Done()
-				req, err := http.NewRequest("GET", peer.ApiPath("/status"), nil) // todo: switch to /internal/ok later
+				req, err := http.NewRequest("GET", peer.ApiPath("/internal/ok"), nil)
 				if err != nil {
 					return
 				}

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -13,7 +13,7 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
 	ss.crud.DB.
-		Where("host = ? AND ulid >= ?", ss.Config.Self.Host, after).
+		Where("host = ? AND ulid > ?", ss.Config.Self.Host, after).
 		Limit(PullLimit).
 		Order("ulid asc").
 		Find(&ops)

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -37,7 +37,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -363,12 +363,7 @@ func (ss *MediorumServer) Stop() {
 }
 
 func (ss *MediorumServer) pollForSeedingCompletion() {
-	if ss.crud.GetPercentNodesSeeded() > PercentSeededThreshold {
-		ss.isSeeding = false
-		return
-	}
-
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(10 * time.Second)
 	for range ticker.C {
 		if ss.crud.GetPercentNodesSeeded() > PercentSeededThreshold {
 			ss.isSeeding = false

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -198,7 +198,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		logger:          logger,
 		quit:            make(chan os.Signal, 1),
 		trustedNotifier: &trustedNotifier,
-		isSeeding:       true,
+		isSeeding:       config.Env == "stage" || config.Env == "prod",
 
 		peerHealth: map[string]time.Time{},
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -76,6 +76,7 @@ type MediorumServer struct {
 	storagePathUsed uint64
 	storagePathSize uint64
 	databaseSize    uint64
+	isSeeding       bool
 
 	peerHealthMutex  sync.RWMutex
 	peerHealth       map[string]time.Time
@@ -88,6 +89,8 @@ type MediorumServer struct {
 var (
 	apiBasePath = ""
 )
+
+const PercentSeededThreshold = 50
 
 func New(config MediorumConfig) (*MediorumServer, error) {
 	if env := os.Getenv("MEDIORUM_ENV"); env != "" {
@@ -195,6 +198,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		logger:          logger,
 		quit:            make(chan os.Signal, 1),
 		trustedNotifier: &trustedNotifier,
+		isSeeding:       true,
 
 		peerHealth: map[string]time.Time{},
 
@@ -238,23 +242,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
 
-	// todo: use `/internal/ok` instead... this is just needed for transition
-	routes.GET("/status", func(c echo.Context) error {
-		status := 200
-		if !ss.Config.WalletIsRegistered {
-			status = 506
-		}
-		dbHealthy := ss.databaseSize > 0
-		if !dbHealthy {
-			status = 500
-		}
-		return c.JSON(status, map[string]any{
-			"host":                 ss.Config.Self.Host,
-			"wallet":               ss.Config.Self.Wallet,
-			"wallet_is_registered": ss.Config.WalletIsRegistered,
-		})
-	})
-
 	// -------------------
 	// internal
 	internalApi := routes.Group("/internal")
@@ -262,9 +249,15 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// responds to polling requests in peer_health
 	// should do no real work
 	internalApi.GET("/ok", func(c echo.Context) error {
+		if !ss.Config.WalletIsRegistered {
+			return c.JSON(506, "wallet not registered")
+		}
 		dbHealthy := ss.databaseSize > 0
 		if !dbHealthy {
-			c.JSON(500, "database not healthy")
+			return c.JSON(500, "database not healthy")
+		}
+		if ss.isSeeding {
+			return c.JSON(503, "seeding")
 		}
 		return c.String(200, "OK")
 	})
@@ -331,6 +324,8 @@ func (ss *MediorumServer) MustStart() {
 
 		go ss.startPollingDelistStatuses()
 
+		go ss.pollForSeedingCompletion()
+
 	}
 
 	go ss.monitorDiskAndDbStatus()
@@ -365,4 +360,19 @@ func (ss *MediorumServer) Stop() {
 
 	ss.logger.Debug("bye")
 
+}
+
+func (ss *MediorumServer) pollForSeedingCompletion() {
+	if ss.crud.GetPercentNodesSeeded() > PercentSeededThreshold {
+		ss.isSeeding = false
+		return
+	}
+
+	ticker := time.NewTicker(time.Minute)
+	for range ticker.C {
+		if ss.crud.GetPercentNodesSeeded() > PercentSeededThreshold {
+			ss.isSeeding = false
+			return
+		}
+	}
 }


### PR DESCRIPTION
### Description
- Makes nodes poll The Graph every 30m to allow signature-gated communication with recently registered nodes. Restarts the server when these change (the alternative would be updating peers and signers variables and worrying about every usage of them now and forever in the future)
- Adds "seeding" phase so new nodes are unhealthy and don't receive requests for files they don't yet have. Seeding is flexible and considered complete when for >50% of nodes there are either no more ulids to sweep or the last ulid swept has a timestamp from the past hour
  - Ignores the cid_lookup table because it will be removed soonish and would just cause issues now and later after no new v1 uploads are coming in. Staging cid_cursors are currently days old so would look like they're still "seeding," but that's probably just because there aren't new rows in their Files tables
  - Ignores delist cursors because that pagination moves faster and has less data to seed


### How Has This Been Tested?
I confirmed on stage CN9 that the node gets past the "seeding" stage and that docker autoheal detects the `os.Exit(0)` and restarts the mediorum container when chain updates (fake update when testing).