### PR TITLE
Check current block timestamp in delist task

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_update_delist_statuses.py
+++ b/discovery-provider/integration_tests/tasks/test_update_delist_statuses.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 from unittest import mock
 
@@ -11,7 +12,11 @@ from src.models.delisting.track_delist_status import (
 from src.models.delisting.user_delist_status import DelistUserReason, UserDelistStatus
 from src.models.tracks.track import Track
 from src.models.users.user import User
-from src.tasks.update_delist_statuses import DELIST_BATCH_SIZE, process_delist_statuses
+from src.tasks.update_delist_statuses import (
+    DATETIME_FORMAT_STRING,
+    DELIST_BATCH_SIZE,
+    process_delist_statuses,
+)
 from src.utils.db_session import get_db
 
 
@@ -88,7 +93,13 @@ def test_update_user_delist_statuses_missing_user(mock_requests, app):
             "endpoint": "http://mock-trusted-notifier.audius.co/",
             "wallet": "0x0",
         }
-        process_delist_statuses(session, trusted_notifier_manager)
+        # Have not indexed the block with the CREATE USER 300 tx
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 19:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
         # check user_delist_statuses persisted
         all_delist_statuses: List[UserDelistStatus] = (
             session.query(UserDelistStatus)
@@ -107,16 +118,80 @@ def test_update_user_delist_statuses_missing_user(mock_requests, app):
 
         # check users not updated
         users: List[User] = (
-            session.query(User)
-            .filter(
-                User.is_current,
-                User.user_id == 100
-            )
-            .all()
+            session.query(User).filter(User.is_current, User.user_id == 100).all()
         )
         assert len(users) == 1
         assert not users[0].is_deactivated
         assert users[0].is_available
+
+
+@mock.patch("src.utils.auth_helpers.requests")
+def test_update_user_delist_statuses_skip_missing_user(mock_requests, app):
+    with app.app_context():
+        db = get_db()
+    _seed_db(db)
+
+    mock_return = {
+        "result": {
+            # Note: real response will only have "users" or "tracks" according
+            # to the query param, not both. Include both here anyway for mocking simplicity
+            "tracks": [],
+            "users": [
+                {
+                    "createdAt": "2023-05-17 18:00:00.999999+00",
+                    "userId": 100,
+                    "delisted": True,
+                    "reason": "STRIKE_THRESHOLD",
+                },
+                {
+                    "createdAt": "2023-05-17 20:00:00.999999+00",
+                    "userId": 300,
+                    "delisted": True,
+                    "reason": "MANUAL",
+                },
+            ],
+        }
+    }
+    mock_requests.get.return_value = _mock_response(mock_return)
+
+    with db.scoped_session() as session:
+        trusted_notifier_manager = {
+            "endpoint": "http://mock-trusted-notifier.audius.co/",
+            "wallet": "0x0",
+        }
+        # Will never index CREATE USER 300 into db at this point in indexing.
+        # Should skip delist for user 300 and advance cursor.
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 21:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
+        # check user_delist_statuses persisted
+        all_delist_statuses: List[UserDelistStatus] = (
+            session.query(UserDelistStatus)
+            .order_by(asc(UserDelistStatus.created_at))
+            .all()
+        )
+        assert len(all_delist_statuses) == 2
+
+        # check cursor updated
+        user_delist_cursors: List[DelistStatusCursor] = (
+            session.query(DelistStatusCursor)
+            .filter(DelistStatusCursor.entity == DelistEntity.USERS)
+            .all()
+        )
+        assert len(user_delist_cursors) == 1
+        assert user_delist_cursors[0].host == trusted_notifier_manager["endpoint"]
+        assert user_delist_cursors[0].created_at == all_delist_statuses[1].created_at
+
+        # check user 100 updated
+        users: List[User] = (
+            session.query(User).filter(User.is_current, User.user_id == 100).all()
+        )
+        assert len(users) == 1
+        assert users[0].is_deactivated
+        assert not users[0].is_available
 
 
 @mock.patch("src.utils.auth_helpers.requests")
@@ -159,7 +234,12 @@ def test_update_user_delist_statuses(mock_requests, app):
             "endpoint": "http://mock-trusted-notifier.audius.co/",
             "wallet": "0x0",
         }
-        process_delist_statuses(session, trusted_notifier_manager)
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 20:00:01.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
         # check user_delist_statuses
         all_delist_statuses: List[UserDelistStatus] = (
             session.query(UserDelistStatus)
@@ -239,7 +319,13 @@ def test_update_track_delist_statuses_missing_track(mock_requests, app):
             "endpoint": "http://mock-trusted-notifier.audius.co/",
             "wallet": "0x0",
         }
-        process_delist_statuses(session, trusted_notifier_manager)
+        # Have not indexed the block with the CREATE TRACK 500 tx
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 21:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
         # check track_delist_statuses persisted
         all_delist_statuses: List[TrackDelistStatus] = (
             session.query(TrackDelistStatus)
@@ -258,16 +344,84 @@ def test_update_track_delist_statuses_missing_track(mock_requests, app):
 
         # check tracks not updated
         tracks: List[Track] = (
-            session.query(Track)
-            .filter(
-                Track.is_current,
-                Track.track_id == 300
-            )
-            .all()
+            session.query(Track).filter(Track.is_current, Track.track_id == 300).all()
         )
         assert len(tracks) == 1
         assert not tracks[0].is_delete
         assert tracks[0].is_available
+
+
+@mock.patch("src.utils.auth_helpers.requests")
+def test_update_track_delist_statuses_skip_missing_track(mock_requests, app):
+    with app.app_context():
+        db = get_db()
+    _seed_db(db)
+
+    mock_return = {
+        "result": {
+            # Note: real response will only have "users" or "tracks" according
+            # to the query param, not both. Include both here anyway for mocking simplicity
+            "users": [],
+            "tracks": [
+                {
+                    "createdAt": "2023-05-17 20:47:29.362983+00",
+                    "trackId": 300,
+                    "ownerId": 100,
+                    "trackCid": "1234",
+                    "delisted": True,
+                    "reason": "DMCA",
+                },
+                {
+                    "createdAt": "2023-05-17 21:47:29.362983+00",
+                    "trackId": 500,
+                    "ownerId": 200,
+                    "trackCid": "5678",
+                    "delisted": True,
+                    "reason": "ACR",
+                },
+            ],
+        }
+    }
+    mock_requests.get.return_value = _mock_response(mock_return)
+
+    with db.scoped_session() as session:
+        trusted_notifier_manager = {
+            "endpoint": "http://mock-trusted-notifier.audius.co/",
+            "wallet": "0x0",
+        }
+        # Will never index CREATE TRACK 500 into db at this point in indexing.
+        # Should skip delist for track 500 and advance cursor.
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 22:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
+        # check track_delist_statuses persisted
+        all_delist_statuses: List[TrackDelistStatus] = (
+            session.query(TrackDelistStatus)
+            .order_by(asc(TrackDelistStatus.created_at))
+            .all()
+        )
+        assert len(all_delist_statuses) == 2
+
+        # check cursor updated
+        track_delist_cursors: List[DelistStatusCursor] = (
+            session.query(DelistStatusCursor)
+            .filter(DelistStatusCursor.entity == DelistEntity.TRACKS)
+            .all()
+        )
+        assert len(track_delist_cursors) == 1
+        assert track_delist_cursors[0].host == trusted_notifier_manager["endpoint"]
+        assert track_delist_cursors[0].created_at == all_delist_statuses[1].created_at
+
+        # check track 300 updated
+        tracks: List[Track] = (
+            session.query(Track).filter(Track.is_current, Track.track_id == 300).all()
+        )
+        assert len(tracks) == 1
+        assert tracks[0].is_delete
+        assert not tracks[0].is_available
 
 
 @mock.patch("src.utils.auth_helpers.requests")
@@ -316,7 +470,12 @@ def test_update_track_delist_statuses(mock_requests, app):
             "endpoint": "http://mock-trusted-notifier.audius.co/",
             "wallet": "0x0",
         }
-        process_delist_statuses(session, trusted_notifier_manager)
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 23:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
         # check track_delist_statuses
         all_delist_statuses: List[TrackDelistStatus] = (
             session.query(TrackDelistStatus)
@@ -422,7 +581,12 @@ def test_format_poll_more_endpoint(app, mocker):
             side_effect=assert_signed_get,
             autospec=True,
         )
-        process_delist_statuses(session, trusted_notifier_manager)
+        current_block_timestamp = datetime.strptime(
+            "2023-05-17 19:00:00.999999+00", DATETIME_FORMAT_STRING
+        ).timestamp()
+        process_delist_statuses(
+            session, trusted_notifier_manager, current_block_timestamp
+        )
 
         # check cursor unchanged
         delist_cursors: List[DelistStatusCursor] = (

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -6,10 +6,8 @@ from operator import itemgetter, or_
 
 from hexbytes import HexBytes
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql import text
 from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.challenges.trending_challenge import should_trending_challenge_update
-from src.models.delisting.delist_status_cursor import DelistEntity, DelistStatusCursor
 from src.models.grants.developer_app import DeveloperApp
 from src.models.grants.grant import Grant
 from src.models.indexing.block import Block

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -474,7 +474,7 @@ def get_block(web3: Web3, blocknumber: int):
         return False
 
 
-def revert_delist_cursor(session: Session, revert_block_parent_hash: str):
+def revert_delist_cursors(session: Session, revert_block_parent_hash: str):
     parent_number_results = (
         session.query(Block.number)
         .filter(Block.blockhash == revert_block_parent_hash)
@@ -491,7 +491,7 @@ def revert_delist_cursor(session: Session, revert_block_parent_hash: str):
             tzinfo=timezone.utc
         )
         celery.send_task(
-            "revert_delist_cursor",
+            "revert_delist_status_cursors",
             kwargs={"reverted_cursor": parent_datetime},
         )
 
@@ -523,7 +523,7 @@ def revert_block(session: Session, revert_block: Block):
     )
 
     # set delist cursor back to parent block's timestamp
-    revert_delist_cursor(session, parent_hash)
+    revert_delist_cursors(session, parent_hash)
 
     # aggregate all transactions in current block
     revert_save_entries = (

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -448,7 +448,8 @@ def index_next_block(
             # Every 100 blocks, poll and apply delist statuses from trusted notifier
             if next_block.number % 100 == 0:
                 celery.send_task(
-                    "update_delist_statuses"
+                    "update_delist_statuses",
+                    args=(next_block.timestamp)
                 )
         except Exception as e:
             # Do not throw error, as this should not stop indexing

--- a/discovery-provider/src/tasks/index_nethermind.py
+++ b/discovery-provider/src/tasks/index_nethermind.py
@@ -449,7 +449,7 @@ def index_next_block(
             if next_block.number % 100 == 0:
                 celery.send_task(
                     "update_delist_statuses",
-                    args=(next_block.timestamp)
+                    kwargs={"current_block_timestamp": next_block.timestamp}
                 )
         except Exception as e:
             # Do not throw error, as this should not stop indexing

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -368,16 +368,15 @@ def process_delist_statuses(
 # ####### CELERY TASKS ####### #
 
 
-@celery.task(name="revert_delist_cursor", bind=True)
+@celery.task(name="revert_delist_status_cursors", bind=True)
 @save_duration_metric(metric_group="celery_task")
 @log_duration(logger)
-def revert_delist_cursor(self, reverted_cursor: datetime):
+def revert_delist_status_cursors(self, reverted_cursor: datetime):
     """Sets the cursors in delist_status_cursor back upon a block reversion"""
-    db = revert_delist_cursor.db
-    redis = revert_delist_cursor.redis
+    db = revert_delist_status_cursors.db
+    redis = revert_delist_status_cursors.redis
     have_lock = False
-    # Same lock as the update delist task to ensure the reverted cursor
-    # doesn't get overwritten
+    # Same lock as the update delist task to ensure the reverted cursor doesn't get overwritten
     update_lock = redis.lock(
         UPDATE_DELIST_STATUSES_LOCK,
         timeout=DEFAULT_LOCK_TIMEOUT_SECONDS,
@@ -402,12 +401,12 @@ def revert_delist_cursor(self, reverted_cursor: datetime):
                     {"cursor": reverted_cursor, "entity": DelistEntity.TRACKS},
                 )
                 logger.info(
-                    f"update_delist_statuses.py | revert_delist_cursor | Reverted delist cursors to {reverted_cursor}"
+                    f"update_delist_statuses.py | revert_delist_status_cursors | Reverted delist cursors to {reverted_cursor}"
                 )
 
         except Exception as e:
             logger.error(
-                "update_delist_statuses.py | revert_delist_cursor | Fatal error in main loop",
+                "update_delist_statuses.py | revert_delist_status_cursors | Fatal error in main loop",
                 exc_info=True,
             )
             raise e
@@ -416,7 +415,7 @@ def revert_delist_cursor(self, reverted_cursor: datetime):
                 update_lock.release()
     else:
         logger.warning(
-            "update_delist_statuses.py | revert_delist_cursor | Lock not acquired",
+            "update_delist_statuses.py | revert_delist_status_cursors | Lock not acquired",
             exc_info=True,
         )
 

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -153,7 +153,6 @@ def update_track_is_available_statuses(
         # going forward. If the track is missing on this node at this point, it'll never
         # be created. This is to keep delisting unblocked despite data inconsistencies.
 
-        # todo what about reverts
         def wait_for_track_to_be_indexed(track_id):
             return (
                 track_delist_map[track_id]["delist_created_at"]
@@ -377,6 +376,7 @@ def update_delist_statuses(self, current_block_timestamp: int) -> None:
     db = update_delist_statuses.db
     redis = update_delist_statuses.redis
     trusted_notifier_manager = update_delist_statuses.trusted_notifier_manager
+    logger.info(f"update_delist_statuses.py | MIHCHELLE | current_block_timestamp: {current_block_timestamp}")
     if not trusted_notifier_manager:
         logger.error(
             "update_delist_statuses.py | failed to get trusted notifier from chain. not polling delist statuses"

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict, List, Set
 from urllib.parse import quote
 
 from sqlalchemy.orm.session import Session
@@ -17,9 +18,10 @@ logger = StructuredLogger(__name__)
 UPDATE_DELIST_STATUSES_LOCK = "update_delist_statuses_lock"
 DEFAULT_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 DELIST_BATCH_SIZE = 5000
+DATETIME_FORMAT_STRING = "%Y-%m-%d %H:%M:%S.%f+00"
 
 
-def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[User]:
+def query_users_by_user_ids(session: Session, user_ids: Set[int]) -> List[User]:
     """Returns a list of User objects that has a user id in `user_ids`"""
     users = (
         session.query(User)
@@ -33,7 +35,7 @@ def query_users_by_user_ids(session: Session, user_ids: List[int]) -> List[User]
     return users
 
 
-def query_tracks_by_track_ids(session: Session, track_ids: List[int]) -> List[Track]:
+def query_tracks_by_track_ids(session: Session, track_ids: Set[int]) -> List[Track]:
     """Returns a list of Track objects that has a track id in `track_ids`"""
     tracks = (
         session.query(Track)
@@ -47,26 +49,59 @@ def query_tracks_by_track_ids(session: Session, track_ids: List[int]) -> List[Tr
     return tracks
 
 
-def update_user_is_available_statuses(session, users):
+def update_user_is_available_statuses(
+    session: Session, users: List[Dict], current_block_timestamp: int
+):
     """Update users table to reflect delist statuses"""
     # If there are duplicate user ids with different delist values in users,
     # only the most recent value is persisted because users is sorted by asc createdAt
-    user_id_to_delisted_map = {}
+    user_delist_map = {}
     for user in users:
         user_id = user["userId"]
         delisted = user["delisted"]
-        user_id_to_delisted_map[user_id] = delisted
+        delist_created_at = datetime.strptime(
+            user["createdAt"], DATETIME_FORMAT_STRING
+        ).timestamp()
+        user_delist_map[user_id] = {
+            "delisted": delisted,
+            "delist_created_at": delist_created_at,
+        }
 
-    user_ids = set(user_id_to_delisted_map.keys())
+    user_ids = set(user_delist_map.keys())
     users_to_update = query_users_by_user_ids(session, user_ids)
     user_ids_to_update = set(map(lambda user: user.user_id, users_to_update))
-    if len(user_id_to_delisted_map) != len(user_ids_to_update):
-        # halt processing until indexing is caught up and all users are created in db
+
+    if len(user_delist_map) != len(user_ids_to_update):
+        # Halt processing until indexing is caught up and all users are created in db
         missing_user_ids = user_ids - user_ids_to_update
-        logger.info(f"update_delist_statuses.py | missing user ids: {missing_user_ids}")
-        return False, []
+        # However, do not wait for missing users for which the delist was created before
+        # the current_block_timestamp. Since user created at < delist created at, if
+        # delist created at < current block timestamp, we know we've indexed past the point
+        # the CREATE USER was written to chain and we won't index the CREATE USER again
+        # going forward. If the user is missing on this node at this point, it'll never
+        # be created. This is to keep delisting unblocked despite data inconsistencies.
+        def wait_for_user_to_be_indexed(user_id):
+            return (
+                user_delist_map[user_id]["delist_created_at"] > current_block_timestamp
+            )
+
+        missing_user_ids_to_wait_for = set(
+            filter(
+                wait_for_user_to_be_indexed,
+                missing_user_ids,
+            )
+        )
+        if len(missing_user_ids_to_wait_for) > 0:
+            logger.info(
+                f"update_delist_statuses.py | waiting for missing user ids to be indexed: {missing_user_ids_to_wait_for}, current_block_timestamp: {current_block_timestamp}"
+            )
+            return False, []
+
+        logger.info(
+            f"update_delist_statuses.py | ignoring delists for missing user ids: {missing_user_ids}, current_block_timestamp: {current_block_timestamp}"
+        )
     for user in users_to_update:
-        delisted = user_id_to_delisted_map[user.user_id]
+        delisted = user_delist_map[user.user_id]["delisted"]
         if delisted:
             # Deactivate active users that have been delisted
             if user.is_available:
@@ -86,28 +121,63 @@ def update_user_is_available_statuses(session, users):
     return True, users_updated
 
 
-def update_track_is_available_statuses(session, tracks):
+def update_track_is_available_statuses(
+    session: Session, tracks: List[Dict], current_block_timestamp: int
+):
     """Update tracks table to reflect delist statuses"""
     # If there are duplicate track ids with different delist values in tracks,
     # only the most recent value is persisted because tracks is sorted by asc createdAt
-    track_id_to_delisted_map = {}
+    track_delist_map = {}
     for track in tracks:
         track_id = track["trackId"]
         delisted = track["delisted"]
-        track_id_to_delisted_map[track_id] = delisted
+        delist_created_at = datetime.strptime(
+            track["createdAt"], DATETIME_FORMAT_STRING
+        ).timestamp()
+        track_delist_map[track_id] = {
+            "delisted": delisted,
+            "delist_created_at": delist_created_at,
+        }
 
-    track_ids = set(track_id_to_delisted_map.keys())
+    track_ids = set(track_delist_map.keys())
     tracks_to_update = query_tracks_by_track_ids(session, track_ids)
     track_ids_to_update = set(map(lambda track: track.track_id, tracks_to_update))
-    if len(track_id_to_delisted_map) != len(track_ids_to_update):
-        # halt processing until indexing is caught up and all tracks are created in db
+
+    if len(track_delist_map) != len(track_ids_to_update):
+        # Halt processing until indexing is caught up and all tracks are created in db
         missing_track_ids = track_ids - track_ids_to_update
-        logger.info(
-            f"update_delist_statuses.py | missing track ids: {missing_track_ids}"
+        # However, do not wait for missing tracks for which the delist was created before
+        # the current_block_timestamp. Since track created at < delist created at, if
+        # delist created at < current block timestamp, we know we've indexed past the point
+        # the CREATE TRACK was written to chain and we won't index the CREATE TRACK again
+        # going forward. If the track is missing on this node at this point, it'll never
+        # be created. This is to keep delisting unblocked despite data inconsistencies.
+
+        # todo what about reverts
+        def wait_for_track_to_be_indexed(track_id):
+            return (
+                track_delist_map[track_id]["delist_created_at"]
+                > current_block_timestamp
+            )
+
+        missing_track_ids_to_wait_for = set(
+            filter(
+                wait_for_track_to_be_indexed,
+                missing_track_ids,
+            )
         )
-        return False, []
+        if len(missing_track_ids_to_wait_for) > 0:
+            logger.info(
+                f"update_delist_statuses.py | waiting for missing track ids to be indexed: {missing_track_ids_to_wait_for}, current block timestamp: {current_block_timestamp}"
+            )
+            return False, []
+
+        logger.info(
+            f"update_delist_statuses.py | ignoring delists for missing track ids: {missing_track_ids}, current_block_timestamp: {current_block_timestamp}"
+        )
+
     for track in tracks_to_update:
-        delisted = track_id_to_delisted_map[track.track_id]
+        delisted = track_delist_map[track.track_id]["delisted"]
         if delisted:
             # Deactivate active tracks that have been delisted
             if track.is_available:
@@ -130,7 +200,7 @@ def update_track_is_available_statuses(session, tracks):
     return True, tracks_updated
 
 
-def insert_user_delist_statuses(session, users):
+def insert_user_delist_statuses(session: Session, users: List[Dict]):
     sql = text(
         """
         INSERT INTO user_delist_statuses (created_at, user_id, delisted, reason)
@@ -156,7 +226,7 @@ def insert_user_delist_statuses(session, users):
     )
 
 
-def insert_track_delist_statuses(session, tracks):
+def insert_track_delist_statuses(session: Session, tracks: List[Dict]):
     sql = text(
         """
         INSERT INTO track_delist_statuses
@@ -187,7 +257,9 @@ def insert_track_delist_statuses(session, tracks):
     )
 
 
-def update_delist_status_cursor(session, cursor, endpoint, entity):
+def update_delist_status_cursor(
+    session: Session, cursor: str, endpoint: str, entity: str
+):
     sql = text(
         """
         INSERT INTO delist_status_cursor
@@ -207,20 +279,24 @@ def update_delist_status_cursor(session, cursor, endpoint, entity):
     )
 
 
-def process_user_delist_statuses(session, resp, endpoint):
+def process_user_delist_statuses(
+    session: Session, resp: Dict, endpoint: str, current_block_timestamp: int
+):
     # Expect users in resp to be sorted by createdAt asc
     users = resp["result"]["users"]
     if len(users) > 0:
         insert_user_delist_statuses(session, users)
         try:
-            success, users_updated = update_user_is_available_statuses(session, users)
+            success, users_updated = update_user_is_available_statuses(
+                session, users, current_block_timestamp
+            )
             if success:
                 cursor_after = users[-1]["createdAt"]
                 update_delist_status_cursor(
                     session, cursor_after, endpoint, DelistEntity.USERS
                 )
                 logger.info(
-                    f"update_delist_statuses.py | processed {len(users)} user delist statuses: {users_updated}"
+                    f"update_delist_statuses.py | processed {len(users_updated)} user delist statuses: {users_updated}"
                 )
         except Exception as e:
             logger.error(
@@ -228,14 +304,16 @@ def process_user_delist_statuses(session, resp, endpoint):
             )
 
 
-def process_track_delist_statuses(session, resp, endpoint):
+def process_track_delist_statuses(
+    session: Session, resp: Dict, endpoint: str, current_block_timestamp: int
+):
     # Expect tracks in resp to be sorted by createdAt asc
     tracks = resp["result"]["tracks"]
     if len(tracks) > 0:
         insert_track_delist_statuses(session, tracks)
         try:
             success, tracks_updated = update_track_is_available_statuses(
-                session, tracks
+                session, tracks, current_block_timestamp
             )
             if success:
                 cursor_after = tracks[-1]["createdAt"]
@@ -243,7 +321,7 @@ def process_track_delist_statuses(session, resp, endpoint):
                     session, cursor_after, endpoint, DelistEntity.TRACKS
                 )
                 logger.info(
-                    f"update_delist_statuses.py | processed {len(tracks)} track delist statuses: {tracks_updated}"
+                    f"update_delist_statuses.py | processed {len(tracks_updated)} track delist statuses: {tracks_updated}"
                 )
         except Exception as e:
             logger.error(
@@ -251,7 +329,9 @@ def process_track_delist_statuses(session, resp, endpoint):
             )
 
 
-def process_delist_statuses(session: Session, trusted_notifier_manager: Dict):
+def process_delist_statuses(
+    session: Session, trusted_notifier_manager: Dict, current_block_timestamp: int
+):
     endpoint = trusted_notifier_manager["endpoint"]
     if endpoint[-1] != "/":
         endpoint += "/"
@@ -278,16 +358,20 @@ def process_delist_statuses(session: Session, trusted_notifier_manager: Dict):
         resp.raise_for_status()
 
         if entity == DelistEntity.USERS:
-            process_user_delist_statuses(session, resp.json(), endpoint)
+            process_user_delist_statuses(
+                session, resp.json(), endpoint, current_block_timestamp
+            )
         elif entity == DelistEntity.TRACKS:
-            process_track_delist_statuses(session, resp.json(), endpoint)
+            process_track_delist_statuses(
+                session, resp.json(), endpoint, current_block_timestamp
+            )
 
 
 # ####### CELERY TASKS ####### #
 @celery.task(name="update_delist_statuses", bind=True)
 @save_duration_metric(metric_group="celery_task")
 @log_duration(logger)
-def update_delist_statuses(self) -> None:
+def update_delist_statuses(self, current_block_timestamp: int) -> None:
     """Recurring task that polls trusted notifier for delist statuses"""
 
     db = update_delist_statuses.db
@@ -312,7 +396,9 @@ def update_delist_statuses(self) -> None:
     if have_lock:
         try:
             with db.scoped_session() as session:
-                process_delist_statuses(session, trusted_notifier_manager)
+                process_delist_statuses(
+                    session, trusted_notifier_manager, current_block_timestamp
+                )
                 session.commit()
 
         except Exception as e:

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -376,7 +376,6 @@ def update_delist_statuses(self, current_block_timestamp: int) -> None:
     db = update_delist_statuses.db
     redis = update_delist_statuses.redis
     trusted_notifier_manager = update_delist_statuses.trusted_notifier_manager
-    logger.info(f"update_delist_statuses.py | MIHCHELLE | current_block_timestamp: {current_block_timestamp}")
     if not trusted_notifier_manager:
         logger.error(
             "update_delist_statuses.py | failed to get trusted notifier from chain. not polling delist statuses"

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -155,8 +155,7 @@ def update_track_is_available_statuses(
 
         def wait_for_track_to_be_indexed(track_id):
             return (
-                track_delist_map[track_id]["delist_timestamp"]
-                > current_block_timestamp
+                track_delist_map[track_id]["delist_timestamp"] > current_block_timestamp
             )
 
         missing_track_ids_to_wait_for = set(
@@ -368,6 +367,7 @@ def process_delist_statuses(
 
 # ####### CELERY TASKS ####### #
 
+
 @celery.task(name="revert_delist_cursor", bind=True)
 @save_duration_metric(metric_group="celery_task")
 @log_duration(logger)
@@ -394,16 +394,21 @@ def revert_delist_cursor(self, reverted_cursor: datetime):
                     """
                 )
                 session.execute(
-                    update_sql, {"cursor": reverted_cursor, "entity": DelistEntity.USERS}
+                    update_sql,
+                    {"cursor": reverted_cursor, "entity": DelistEntity.USERS},
                 )
                 session.execute(
-                    update_sql, {"cursor": reverted_cursor, "entity": DelistEntity.TRACKS}
+                    update_sql,
+                    {"cursor": reverted_cursor, "entity": DelistEntity.TRACKS},
                 )
-                logger.info(f"update_delist_statuses.py | revert_delist_cursor | Reverted delist cursors to {reverted_cursor}")
+                logger.info(
+                    f"update_delist_statuses.py | revert_delist_cursor | Reverted delist cursors to {reverted_cursor}"
+                )
 
         except Exception as e:
             logger.error(
-                "update_delist_statuses.py | revert_delist_cursor | Fatal error in main loop", exc_info=True
+                "update_delist_statuses.py | revert_delist_cursor | Fatal error in main loop",
+                exc_info=True,
             )
             raise e
         finally:

--- a/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/discovery-provider/src/tasks/update_delist_statuses.py
@@ -59,12 +59,12 @@ def update_user_is_available_statuses(
     for user in users:
         user_id = user["userId"]
         delisted = user["delisted"]
-        delist_created_at = datetime.strptime(
+        delist_timestamp = datetime.strptime(
             user["createdAt"], DATETIME_FORMAT_STRING
         ).timestamp()
         user_delist_map[user_id] = {
             "delisted": delisted,
-            "delist_created_at": delist_created_at,
+            "delist_timestamp": delist_timestamp,
         }
 
     user_ids = set(user_delist_map.keys())
@@ -82,7 +82,7 @@ def update_user_is_available_statuses(
         # be created. This is to keep delisting unblocked despite data inconsistencies.
         def wait_for_user_to_be_indexed(user_id):
             return (
-                user_delist_map[user_id]["delist_created_at"] > current_block_timestamp
+                user_delist_map[user_id]["delist_timestamp"] > current_block_timestamp
             )
 
         missing_user_ids_to_wait_for = set(
@@ -131,12 +131,12 @@ def update_track_is_available_statuses(
     for track in tracks:
         track_id = track["trackId"]
         delisted = track["delisted"]
-        delist_created_at = datetime.strptime(
+        delist_timestamp = datetime.strptime(
             track["createdAt"], DATETIME_FORMAT_STRING
         ).timestamp()
         track_delist_map[track_id] = {
             "delisted": delisted,
-            "delist_created_at": delist_created_at,
+            "delist_timestamp": delist_timestamp,
         }
 
     track_ids = set(track_delist_map.keys())
@@ -155,7 +155,7 @@ def update_track_is_available_statuses(
 
         def wait_for_track_to_be_indexed(track_id):
             return (
-                track_delist_map[track_id]["delist_created_at"]
+                track_delist_map[track_id]["delist_timestamp"]
                 > current_block_timestamp
             )
 


### PR DESCRIPTION
### Description
Skip tracks and users with delists created at <= current block's timestamp (task runs after indexing the block). 

This allows delisting to proceed despite missing entities in the db while also accounting for slow indexing. Ideally and theoretically, all nodes should have every one of these track and user in their dbs, as trusted notifier gets these IDs from discovery in the first place, but the reality of the system is there are slight data inconsistencies on every node. 

If the delist timestamp > the current block's timestamp, this node is just behind on indexing and still might index the CREATE USER/TRACK tx later, so don't advance the delist polling cursor. 

If the delist timestamp <= the current block's timestamp and the entity is still not in the node's db, the node has certainly indexed past the block on chain where the CREATE tx was and for some reason didn't successfully index it, and will never index it going forward. So don't block the delist task waiting for this id to be created, and advance the delist polling cursor.

Upon block reversions, set the delist cursor back to the reverted block's parent's timestamp so the recurring task doesn't miss any tracks/users in the new fork.

### How Has This Been Tested?
Integration tests, test on a stage node

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
