### PR TITLE
Fix cid_lookup schema and stay unhealthy while seeding

### DIFF
--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-const CidLookupBatchSize = 1000
+const CidLookupBatchSize = 2000
 
 func (ss *MediorumServer) startCidBeamClient() {
 	for {

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -17,6 +17,10 @@ func (ss *MediorumServer) monitorCidCursors() {
 		ctx := context.Background()
 		if err := pgxscan.Select(ctx, ss.pgPool, &cidCursors, `select * from cid_cursor order by host`); err == nil {
 			ss.cachedCidCursors = cidCursors
+
+			if getPercentNodesSeededLegacy(cidCursors, ss.logger) > 50 {
+				ss.isSeedingLegacy = false
+			}
 		}
 	}
 }
@@ -68,4 +72,23 @@ func getDatabaseSize(p *pgxpool.Pool) (uint64, error) {
 	}
 
 	return size, nil
+}
+
+func getPercentNodesSeededLegacy(cidCursors []cidCursor, logger *slog.Logger) float64 {
+	// we're still seeding from each node until its cursor is after 2023-06-01
+	cutoff, err := time.Parse(time.RFC3339, "2023-06-01T00:00:00Z00:00")
+	if err != nil {
+		logger.Error("error parsing seeding cutoff", "err", err)
+		return 0
+	}
+
+	nCaughtUp := 0
+	nPeers := len(cidCursors)
+	for _, cursor := range cidCursors {
+		if cursor.UpdatedAt.After(cutoff) {
+			nCaughtUp++
+		}
+	}
+
+	return (float64(nCaughtUp) / float64(nPeers)) * 100
 }

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -20,6 +20,7 @@ func (ss *MediorumServer) monitorCidCursors() {
 
 			if getPercentNodesSeededLegacy(cidCursors, ss.logger) > 50 {
 				ss.isSeedingLegacy = false
+				ss.logger.Info("seeding legacy complete")
 			}
 		}
 	}
@@ -76,7 +77,7 @@ func getDatabaseSize(p *pgxpool.Pool) (uint64, error) {
 
 func getPercentNodesSeededLegacy(cidCursors []cidCursor, logger *slog.Logger) float64 {
 	// we're still seeding from each node until its cursor is after 2023-06-01
-	cutoff, err := time.Parse(time.RFC3339, "2023-06-01T00:00:00Z00:00")
+	cutoff, err := time.Parse(time.RFC3339, "2023-06-01T00:00:00Z")
 	if err != nil {
 		logger.Error("error parsing seeding cutoff", "err", err)
 		return 0

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -31,6 +31,7 @@ type healthCheckResponseData struct {
 	Version                   string                     `json:"version"`
 	Service                   string                     `json:"service"` // used by registerWithDelegate()
 	IsSeeding                 bool                       `json:"isSeeding"`
+	IsSeedingLegacy           bool                       `json:"isSeedingLegacy"`
 	BuiltAt                   string                     `json:"builtAt"`
 	StartedAt                 time.Time                  `json:"startedAt"`
 	SPID                      int                        `json:"spID"`
@@ -63,7 +64,7 @@ type legacyHealth struct {
 }
 
 func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
-	healthy := ss.databaseSize > 0 && !ss.isSeeding
+	healthy := ss.databaseSize > 0 && !ss.isSeeding && !ss.isSeedingLegacy
 
 	// if we're in stage or prod, return healthy=false if we can't connect to the legacy CN
 	legacyHealth, err := ss.fetchCreatorNodeHealth()
@@ -82,6 +83,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		Version:                   legacyHealth.Version,
 		Service:                   legacyHealth.Service,
 		IsSeeding:                 ss.isSeeding,
+		IsSeedingLegacy:           ss.isSeedingLegacy,
 		BuiltAt:                   vcsBuildTime,
 		StartedAt:                 ss.StartedAt,
 		SelectedDiscoveryProvider: legacyHealth.SelectedDiscoveryProvider,

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -37,7 +37,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"isSeedingLegacy":false,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -145,7 +145,7 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
 
 func (ss *MediorumServer) findHostsWithCid(ctx context.Context, cid string) ([]string, error) {
 	var hosts []string
-	sql := `select "host" from cid_lookup where "multihash" = $1 order by random()`
+	sql := `select "host" from cid_lookup where "multihash" = $1 and "host" is not null order by random()`
 	err := pgxscan.Select(ctx, ss.pgPool, &hosts, sql, cid)
 	return hosts, err
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -77,6 +78,7 @@ type MediorumServer struct {
 	storagePathSize uint64
 	databaseSize    uint64
 	isSeeding       bool
+	isSeedingLegacy bool
 
 	peerHealthMutex  sync.RWMutex
 	peerHealth       map[string]time.Time
@@ -151,7 +153,42 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	pgConfig, _ := pgxpool.ParseConfig(config.PostgresDSN)
 	pgPool, err := pgxpool.NewWithConfig(context.Background(), pgConfig)
 	if err != nil {
-		log.Println("dial postgres failed", err)
+		logger.Error("dial postgres failed", "err", err)
+	}
+
+	// clean up incompatible schema (probably from an earlier version)
+	// if cid_lookup has wrong schema, do tx to drop and truncate
+	var columnNames []string
+	sql := `
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name = 'cid_lookup' AND column_name NOT IN ('multihash', 'host')
+`
+	err = pgxscan.Select(context.Background(), pgPool, &columnNames, sql)
+	if err != nil {
+		logger.Error("Failed to execute query to check for invalid cid_lookup schema", "err", err)
+	} else {
+		if len(columnNames) > 0 {
+			logger.Warn("Found invalid cid_lookup schema, dropping and truncating table")
+			sql = `begin; truncate mediorum_migrations; drop table cid_lookup; drop table cid_cursor; drop table cid_log; commit;`
+			_, err = pgPool.Exec(context.Background(), sql)
+			if err != nil {
+				logger.Error("Failed to drop and truncate tables related to invalid schema for cid_lookup", "err", err)
+				os.Exit(1)
+			} else {
+				logger.Info("Successfully dropped and truncated tables related to invalid schema for cid_lookup. Restarting...")
+				os.Exit(0)
+			}
+		}
+	}
+
+	// if cid_lookup has null hosts, log warning
+	var nullHostExists bool
+	err = pgPool.QueryRow(context.Background(), `SELECT EXISTS(SELECT 1 FROM cid_lookup WHERE host IS NULL)`).Scan(&nullHostExists)
+	if err != nil {
+		logger.Error("Failed to execute query to check for null hosts in cid_lookup", "err", err)
+	} else if nullHostExists {
+		logger.Warn("Found null host(s) in cid_lookup")
 	}
 
 	// crud
@@ -170,12 +207,12 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	if config.TrustedNotifierID > 0 {
 		trustedNotifier, err = ethcontracts.GetNotifierForID(strconv.Itoa(config.TrustedNotifierID), config.Self.Wallet)
 		if err == nil {
-			slog.Info("got trusted notifier from chain", "endpoint", trustedNotifier.Endpoint, "wallet", trustedNotifier.Wallet)
+			logger.Info("got trusted notifier from chain", "endpoint", trustedNotifier.Endpoint, "wallet", trustedNotifier.Wallet)
 		} else {
-			slog.Error("failed to get trusted notifier from chain, not polling delist statuses", "err", err)
+			logger.Error("failed to get trusted notifier from chain, not polling delist statuses", "err", err)
 		}
 	} else {
-		slog.Warn("trusted notifier id not set, not polling delist statuses or serving /contact route")
+		logger.Warn("trusted notifier id not set, not polling delist statuses or serving /contact route")
 	}
 
 	// echoServer server
@@ -199,6 +236,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		quit:            make(chan os.Signal, 1),
 		trustedNotifier: &trustedNotifier,
 		isSeeding:       config.Env == "stage" || config.Env == "prod",
+		isSeedingLegacy: config.Env == "stage" || config.Env == "prod",
 
 		peerHealth: map[string]time.Time{},
 
@@ -247,6 +285,24 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// internal
 	internalApi := routes.Group("/internal")
 
+	// TODO: remove after all nodes upgrade to v0.3.98
+	routes.GET("/status", func(c echo.Context) error {
+		if !ss.Config.WalletIsRegistered {
+			return c.JSON(506, "wallet not registered")
+		}
+		dbHealthy := ss.databaseSize > 0
+		if !dbHealthy {
+			return c.JSON(500, "database not healthy")
+		}
+		if ss.isSeeding {
+			return c.JSON(503, "seeding")
+		}
+		if ss.isSeedingLegacy {
+			return c.JSON(503, "seeding legacy")
+		}
+		return c.String(200, "OK")
+	})
+
 	// responds to polling requests in peer_health
 	// should do no real work
 	internalApi.GET("/ok", func(c echo.Context) error {
@@ -259,6 +315,9 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		}
 		if ss.isSeeding {
 			return c.JSON(503, "seeding")
+		}
+		if ss.isSeedingLegacy {
+			return c.JSON(503, "seeding legacy")
 		}
 		return c.String(200, "OK")
 	})


### PR DESCRIPTION
### Description

- Drops `cid_lookup` and related tables if schema is wrong, and restarts so they'll be re-created correctly
- Logs `Found null host(s) in cid_lookup` when `cid_lookup` has a null host, which should never happen
- Marks node as seeding/unhealthy until it has a cid_cursor to >2023-06-01 for >50% of nodes. This prevents a node from receiving a request and 404ing because it incorrectly thinks there's no other node with the file to redirect to
- Adds back simple `/status` route that was removed too early

### How Has This Been Tested?
Before deploying, I'll test on staging and then a prod node to make sure files are served and nothing is dropped when it's not supposed to.

Search in axiom for `msg` containing:

- `Found null host(s) in cid_lookup`
- `Found invalid cid_lookup schema, dropping and truncating table`
- `Failed to execute query to check for invalid cid_lookup schema`
- `Failed to execute query to check for null hosts in cid_lookup`