### PR TITLE
Remove and fix 2 slow mediorum sql queries

### DIFF
--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -21,8 +21,7 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	}
 	m.ProblemBlobs = count
 	var ucount int64
-	uploads := []*Upload{}
-	ss.crud.DB.Order("created_at desc").Find(&uploads).Count(&ucount)
+	ss.crud.DB.Model(&Upload{}).Count(&ucount)
 	m.Uploads = ucount
 
 	m.OutboxSizes = ss.crud.GetOutboxSizes()

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -182,15 +182,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		}
 	}
 
-	// if cid_lookup has null hosts, log warning
-	var nullHostExists bool
-	err = pgPool.QueryRow(context.Background(), `SELECT EXISTS(SELECT 1 FROM cid_lookup WHERE host IS NULL)`).Scan(&nullHostExists)
-	if err != nil {
-		logger.Error("Failed to execute query to check for null hosts in cid_lookup", "err", err)
-	} else if nullHostExists {
-		logger.Warn("Found null host(s) in cid_lookup")
-	}
-
 	// crud
 	peerHosts := []string{}
 	for _, peer := range config.Peers {


### PR DESCRIPTION
### Description
https://github.com/AudiusProject/audius-protocol/pull/5616 mostly works when testing on prod, but the SQL query for null hosts is too slow and times out because the index on the table first sorts by multihash and then by host (`create unique index if not exists "idx_multihash" on cid_lookup("multihash", "host");`). So this removes that query and fixes an unrelated query that I also noticed "slow sql" logs for on prod.

### How Has This Been Tested?
Deploying prod hotfix.