### PR TITLE
Gate user-facing routes with health check so client knows to retry another node

### DIFF
--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -18,7 +18,7 @@ func (ss *MediorumServer) monitorCidCursors() {
 		if err := pgxscan.Select(ctx, ss.pgPool, &cidCursors, `select * from cid_cursor order by host`); err == nil {
 			ss.cachedCidCursors = cidCursors
 
-			if getPercentNodesSeededLegacy(cidCursors, ss.logger) > 50 {
+			if ss.isSeedingLegacy && getPercentNodesSeededLegacy(cidCursors, ss.logger) > 50 {
 				ss.isSeedingLegacy = false
 				ss.logger.Info("seeding legacy complete")
 			}

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -172,3 +172,23 @@ func (ss *MediorumServer) fetchCreatorNodeHealth() (legacyHealth, error) {
 	err = json.Unmarshal(body, &legacyHealth)
 	return legacyHealth, err
 }
+
+func (ss *MediorumServer) requireHealthy(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if !ss.Config.WalletIsRegistered {
+			return c.JSON(506, "wallet not registered")
+		}
+		dbHealthy := ss.databaseSize > 0
+		if !dbHealthy {
+			return c.JSON(500, "database not healthy")
+		}
+		if ss.isSeeding {
+			return c.JSON(503, "seeding")
+		}
+		if ss.isSeedingLegacy {
+			return c.JSON(503, "seeding legacy")
+		}
+
+		return next(c)
+	}
+}

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -126,11 +126,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 	if !ss.Config.WalletIsRegistered {
 		status = 506
 	} else if !healthy {
-		if ss.isSeeding {
-			status = 503
-		} else {
-			status = 500
-		}
+		status = 503
 	}
 
 	signatureHex := fmt.Sprintf("0x%s", hex.EncodeToString(signature))
@@ -180,7 +176,7 @@ func (ss *MediorumServer) requireHealthy(next echo.HandlerFunc) echo.HandlerFunc
 		}
 		dbHealthy := ss.databaseSize > 0
 		if !dbHealthy {
-			return c.JSON(500, "database not healthy")
+			return c.JSON(503, "database not healthy")
 		}
 		if ss.isSeeding {
 			return c.JSON(503, "seeding")


### PR DESCRIPTION
### Description
Adds health check middleware so user-facing routes return 5xx when they're unhealthy. This is important to fix a race condition where the client uses the bootstrap list of all nodes, so it isn't aware that the node is unhealthy yet.

What's currently happening:
1. Page loads and client requests image from unhealthy node
2. Unhealthy node 404s
3. Client doesn't retry

What will happen after this PR is merged:
1. Page loads and client requests image from unhealthy node
2. Unhealthy node 5xxs
3. Client refreshes list of healthy nodes from Discovery and retries a different node

### How Has This Been Tested?
Fetching images on staging. No staging nodes are unhealthy currently, but it's the same logic as before - just moved to a middleware and put in front of more routes. Should also test an upload.