### PR TITLE
ignore collisions on notification inserts

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/notification.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/notification.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from psycopg2.errors import UniqueViolation
 from src.exceptions import IndexingValidationError
 from src.models.notifications.notification import (
     Notification,
@@ -81,7 +82,10 @@ def create_notification(params: ManageEntityParameters):
         user_ids=user_ids,
     )
     key = params.block_datetime
-    params.add_notification_record(key, notification)
+    try:
+        params.add_notification_record(key, notification)
+    except UniqueViolation as e:
+        logger.warn(f"received duplicate notification, ignoring {e}")
 
 
 def validate_view_playlist_tx(params: ManageEntityParameters):


### PR DESCRIPTION
### Description
There's an error where we are inserting a duplicate notification, this is halting indexing and should be ignored. Standard revert procedure (delete and reinsert) can't be done here because that'll trigger a duplicate notif on the plugin.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
