### PR TITLE
[CON-778] Mediorum: Check all healthy nodes on 404 and use GA

### DIFF
--- a/mediorum/cmd/main.go
+++ b/mediorum/cmd/main.go
@@ -24,13 +24,13 @@ func initClient() *loadtest.TestClient {
 
 	switch env := os.Getenv("MEDIORUM_ENV"); env {
 	case "prod":
-		g := registrar.NewGraphProd()
+		g := registrar.NewAudiusApiGatewayProd()
 		registeredPeers, err = g.Peers()
 		if err != nil {
 			panic(err)
 		}
 	case "stage":
-		g := registrar.NewGraphStaging()
+		g := registrar.NewAudiusApiGatewayStaging()
 		registeredPeers, err = g.Peers()
 		if err != nil {
 			panic(err)

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -41,9 +41,9 @@ func main() {
 
 func startStagingOrProd(isProd bool) {
 	logger := slog.With("creatorNodeEndpoint", os.Getenv("creatorNodeEndpoint"))
-	g := registrar.NewGraphStaging()
+	g := registrar.NewAudiusApiGatewayStaging()
 	if isProd {
-		g = registrar.NewGraphProd()
+		g = registrar.NewAudiusApiGatewayProd()
 	}
 
 	var peers, signers []server.Peer

--- a/mediorum/registrar/audius_api_gateway.go
+++ b/mediorum/registrar/audius_api_gateway.go
@@ -1,0 +1,74 @@
+package registrar
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"mediorum/server"
+)
+
+type NodeResponse struct {
+	Data []Node `json:"data"`
+}
+
+type Node struct {
+	Owner               string `json:"owner"`
+	Endpoint            string `json:"endpoint"`
+	SpID                int    `json:"spID"`
+	Type                string `json:"type"`
+	BlockNumber         int    `json:"blockNumber"`
+	DelegateOwnerWallet string `json:"delegateOwnerWallet"`
+}
+
+func NewAudiusApiGatewayStaging() PeerProvider {
+	endpoint := `https://api.staging.audius.co`
+	return &audiusApiGatewayProvider{endpoint}
+}
+
+func NewAudiusApiGatewayProd() PeerProvider {
+	endpoint := `https://api.audius.co`
+	return &audiusApiGatewayProvider{endpoint}
+}
+
+type audiusApiGatewayProvider struct {
+	endpoint string
+}
+
+func (p *audiusApiGatewayProvider) Peers() ([]server.Peer, error) {
+	return p.getNodes("/content/verbose")
+}
+
+func (p *audiusApiGatewayProvider) Signers() ([]server.Peer, error) {
+	return p.getNodes("/discovery/verbose")
+}
+
+func (p *audiusApiGatewayProvider) getNodes(path string) ([]server.Peer, error) {
+	endpoint := p.endpoint + path
+
+	resp, err := httpClient.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodeResponse NodeResponse
+	err = json.Unmarshal(body, &nodeResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	var peers []server.Peer
+	for _, node := range nodeResponse.Data {
+		peer := server.Peer{
+			Host:   node.Endpoint,
+			Wallet: node.DelegateOwnerWallet,
+		}
+		peers = append(peers, peer)
+	}
+
+	return peers, nil
+}

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +28,7 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 
 	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", cid)
 	if diskPath == "" {
-		return ss.redirectToCid(c, cid)
+		return ss.redirectToCid(c, cid, true)
 	}
 
 	// detect mime type and block mp3 streaming outside of the /tracks/cidstream route
@@ -38,7 +39,7 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 
 	if err = c.File(diskPath); err != nil {
 		logger.Error("error serving cid", "err", err, "storagePath", diskPath)
-		return ss.redirectToCid(c, cid)
+		return ss.redirectToCid(c, cid, true)
 	}
 
 	// v1 file listen
@@ -63,7 +64,7 @@ func (ss *MediorumServer) headLegacyCid(c echo.Context) error {
 
 	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", cid)
 	if diskPath == "" {
-		return ss.redirectToCid(c, cid)
+		return ss.redirectToCid(c, cid, false)
 	}
 
 	// detect mime type and block mp3 streaming outside of the /tracks/cidstream route
@@ -73,7 +74,7 @@ func (ss *MediorumServer) headLegacyCid(c echo.Context) error {
 	}
 
 	if _, err := os.Stat(diskPath); os.IsNotExist(err) {
-		return ss.redirectToCid(c, cid)
+		return ss.redirectToCid(c, cid, false)
 	}
 
 	return c.NoContent(200)
@@ -95,7 +96,7 @@ func (ss *MediorumServer) serveLegacyDirCid(c echo.Context) error {
 	// dirCid is actually the CID, and fileName is a size like "150x150.jpg"
 	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", dirCid)
 	if diskPath == "" {
-		return ss.redirectToCid(c, dirCid)
+		return ss.redirectToCid(c, dirCid, true)
 	}
 
 	// detect mime type and block mp3 streaming outside of the /tracks/cidstream route
@@ -106,13 +107,45 @@ func (ss *MediorumServer) serveLegacyDirCid(c echo.Context) error {
 
 	if err = c.File(diskPath); err != nil {
 		logger.Error("error serving dirCid", "err", err, "storagePath", diskPath)
-		return ss.redirectToCid(c, dirCid)
+		return ss.redirectToCid(c, dirCid, true)
 	}
 
 	return nil
 }
 
-func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
+func (ss *MediorumServer) headLegacyDirCid(c echo.Context) error {
+	ctx := c.Request().Context()
+	dirCid := c.Param("dirCid")
+	fileName := c.Param("fileName")
+	logger := ss.logger.With("dirCid", dirCid)
+
+	sql := `select "storagePath" from "Files" where "dirMultihash" = $1 and "fileName" = $2`
+	var storagePath string
+	err := ss.pgPool.QueryRow(ctx, sql, dirCid, fileName).Scan(&storagePath)
+	if err != nil && err != pgx.ErrNoRows {
+		logger.Error("error querying dirCid storage path", "err", err)
+	}
+
+	// dirCid is actually the CID, and fileName is a size like "150x150.jpg"
+	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", dirCid)
+	if diskPath == "" {
+		return ss.redirectToCid(c, dirCid, false)
+	}
+
+	// detect mime type and block mp3 streaming outside of the /tracks/cidstream route
+	isAudioFile := isAudioFile(diskPath)
+	if isAudioFile {
+		return c.String(401, "mp3 streaming is blocked. Please use Discovery /v1/tracks/:encodedId/stream")
+	}
+
+	if _, err := os.Stat(diskPath); os.IsNotExist(err) {
+		return ss.redirectToCid(c, dirCid, false)
+	}
+
+	return c.NoContent(200)
+}
+
+func (ss *MediorumServer) redirectToCid(c echo.Context, cid string, checkAllNodes bool) error {
 	ctx := c.Request().Context()
 
 	// don't redirect if the legacy "localOnly" query parameter is set
@@ -129,6 +162,7 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
 	logger.Info("potential hosts for cid", "hosts", hosts)
 	healthyHosts := ss.findHealthyPeers(2 * time.Minute)
 
+	// redirect to the first healthy host that we know has the cid (thanks to our cid_lookup table)
 	for _, host := range hosts {
 		if !slices.Contains(healthyHosts, host) {
 			logger.Info("host not healthy; skipping", "host", host)
@@ -137,6 +171,27 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string) error {
 		dest := replaceHost(*c.Request().URL, host)
 		logger.Info("redirecting to: " + dest.String())
 		return c.Redirect(302, dest.String())
+	}
+
+	// check all healthy hosts via HEAD request to see if they have the cid but aren't in cid_lookup
+	if checkAllNodes {
+		for _, host := range healthyHosts {
+			dest := replaceHost(*c.Request().URL, host)
+			req, err := http.NewRequest("HEAD", dest.String(), nil)
+			if err != nil {
+				logger.Error("error creating HEAD request", "err", err)
+				continue
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				logger.Error("error sending HEAD request", "err", err)
+				continue
+			}
+			if resp.StatusCode == 200 || resp.StatusCode == 204 || resp.StatusCode == 206 || resp.StatusCode == 302 || resp.StatusCode == 304 {
+				dest.Query().Add("localOnly", "true")
+				return c.Redirect(302, dest.String())
+			}
+		}
 	}
 
 	logger.Info("no healthy host found with cid")

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -177,7 +177,7 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string, checkAllNode
 	if checkAllNodes {
 		for _, host := range healthyHosts {
 			dest := replaceHost(*c.Request().URL, host)
-			req, err := http.NewRequest("HEAD", dest.String(), nil)
+			req, err := http.NewRequest("HEAD", "https:"+dest.String(), nil)
 			if err != nil {
 				logger.Error("error creating HEAD request", "err", err)
 				continue

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -176,12 +176,16 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string, checkAllNode
 	// check all healthy hosts via HEAD request to see if they have the cid but aren't in cid_lookup
 	if checkAllNodes {
 		for _, host := range healthyHosts {
+			if host == ss.Config.Self.Host {
+				continue
+			}
 			dest := replaceHost(*c.Request().URL, host)
 			req, err := http.NewRequest("HEAD", "https:"+dest.String(), nil)
 			if err != nil {
 				logger.Error("error creating HEAD request", "err", err)
 				continue
 			}
+			req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				logger.Error("error sending HEAD request", "err", err)

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -234,6 +234,31 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 	}
 }
 
+func (ss *MediorumServer) headBlobByJobIDAndVariant(c echo.Context) error {
+	jobID := c.Param("jobID")
+	variant := c.Param("variant")
+
+	if isLegacyCID(jobID) {
+		c.SetParamNames("dirCid", "fileName")
+		c.SetParamValues(jobID, variant)
+		return ss.headLegacyDirCid(c)
+	} else {
+		var upload *Upload
+		err := ss.crud.DB.First(&upload, "id = ?", jobID).Error
+		if err != nil {
+			return err
+		}
+		cid, ok := upload.TranscodeResults[variant]
+		if !ok {
+			msg := fmt.Sprintf("variant %s not found for upload %s", variant, jobID)
+			return c.String(400, msg)
+		}
+		c.SetParamNames("cid")
+		c.SetParamValues(cid)
+		return ss.headBlob(c)
+	}
+}
+
 func computeFileHeaderCID(fh *multipart.FileHeader) (string, error) {
 	f, err := fh.Open()
 	if err != nil {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -263,9 +263,13 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		return c.NoContent(http.StatusNoContent)
 	})
 
+	routes.HEAD("/ipfs/:cid", ss.headBlob, ss.requireHealthy, ss.ensureNotDelisted)
 	routes.GET("/ipfs/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.HEAD("/content/:cid", ss.headBlob, ss.requireHealthy, ss.ensureNotDelisted)
 	routes.GET("/content/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.HEAD("/ipfs/:jobID/:variant", ss.headBlobByJobIDAndVariant, ss.requireHealthy)
 	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
+	routes.HEAD("/content/:jobID/:variant", ss.headBlobByJobIDAndVariant, ss.requireHealthy)
 	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
 	routes.HEAD("/tracks/cidstream/:cid", ss.headBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
 	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)


### PR DESCRIPTION
### Description
When a Qm CID can't be found in the cid_lookup table, this PR makes it send a HEAD request to every healthy node to see if anyone else has the file on disk or in their cid_lookup table. In order to avoid an infinite spam loop, these HEAD requests don't do this extra check - they only look at their disk and cid_lookup table.

This is to fix an issue where some nodes have an incomplete cid_lookup table. Their cursor has moved past some CID, so it will never be aware that another node has it.

### How Has This Been Tested?
Confirmed on 2 staging nodes that they send the HEAD requests for track playback and image fetching of only Qm CIDs and that it doesn't cause an infinite loop when it's a fake/missing CID.