### PR TITLE
[PLAT-608][PLAT-1129] Add dual playlist route writes and fix private fetches

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.yml
@@ -9,6 +9,8 @@ services:
       args:
         app_name: app-template
     restart: always
+    profiles:
+      - pedalboard
 
   trending-challenge-rewards:
     container_name: trending-challenge-rewards
@@ -18,3 +20,5 @@ services:
       args:
         app_name: trending-challenge-rewards
     restart: always
+    profiles:
+      - pedalboard

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -55,13 +55,6 @@ services:
       interval: 10s
       timeout: 5s
 
-  autoheal:
-    # Restarts containers when they become unhealthy
-    extends:
-      file: docker-compose.dev.yml
-      service: autoheal
-    <<: *common
-
   build-audius-libs:
     extends:
       file: docker-compose.dev.yml

--- a/discovery-provider/integration_tests/queries/test_get_playlists.py
+++ b/discovery-provider/integration_tests/queries/test_get_playlists.py
@@ -165,7 +165,7 @@ def test_get_private_playlist_with_playlist_ids(app, test_entities):
                 ),
             )
 
-            assert len(playlist) == 0
+            assert len(playlist) == 1
 
 
 def test_get_playlist_with_permalink(app, test_entities):

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 from typing import List
 
@@ -16,6 +17,8 @@ from src.tasks.entity_manager.utils import (
 from src.utils.db_session import get_db
 from web3 import Web3
 from web3.datastructures import AttributeDict
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
@@ -345,15 +348,13 @@ def tx_receipts_update_routes():
     }
 
 
-def assert_playlist_route(
-    route, slug, title_slug, collision_id, owner_id, playlist_id, is_current
-):
-    assert route.slug == slug
-    assert route.title_slug == title_slug
-    assert route.collision_id == collision_id
-    assert route.owner_id == owner_id
-    assert route.playlist_id == playlist_id
-    assert route.is_current == is_current
+def assert_playlist_route(route, route2):
+    assert route.slug == route2.slug
+    assert route.title_slug == route2.title_slug
+    assert route.collision_id == route2.collision_id
+    assert route.owner_id == route2.owner_id
+    assert route.playlist_id == route2.playlist_id
+    assert route.is_current == route2.is_current
 
 
 def test_index_valid_playlists_updates_routes(app, mocker, tx_receipts_update_routes):
@@ -402,111 +403,106 @@ def test_index_valid_playlists_updates_routes(app, mocker, tx_receipts_update_ro
 
         # validate db records
         playlist_routes = session.query(PlaylistRoute).all()
-        assert len(playlist_routes) == 6
-        playlist_1_route_current = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET and route.is_current
+        assert len(playlist_routes) == 11
+
+        expected_routes = [
+            PlaylistRoute(
+                slug="my-playlist",
+                title_slug="my-playlist",
+                collision_id=0,
+                owner_id=1,
+                playlist_id=400000,
+                is_current=False,
             ),
-            None,
-        )
-        playlist_1_route_not_current = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET and not route.is_current
+            PlaylistRoute(
+                slug="my-playlist-400000",
+                title_slug="my-playlist-400000",
+                collision_id=0,
+                owner_id=1,
+                playlist_id=400000,
+                is_current=True,
             ),
-            None,
-        )
-        playlist_2_route = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET + 1
+            PlaylistRoute(
+                slug="my-playlist-1-w-new-name",
+                title_slug="my-playlist-1-w-new-name",
+                collision_id=0,
+                owner_id=1,
+                playlist_id=400000,
+                is_current=True,
             ),
-            None,
-        )
-        playlist_3_route = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET + 4
+            PlaylistRoute(
+                slug="my-playlist-2",
+                title_slug="my-playlist-2",
+                collision_id=0,
+                owner_id=1,
+                playlist_id=400001,
+                is_current=True,
             ),
-            None,
-        )
-        playlist_4_route = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET + 5
+            PlaylistRoute(
+                slug="my-playlist-2-400001",
+                title_slug="my-playlist-2-400001",
+                collision_id=0,
+                owner_id=1,
+                playlist_id=400001,
+                is_current=True,
             ),
-            None,
-        )
-        playlist_diff_owner_route = next(
-            (
-                route
-                for route in playlist_routes
-                if route.playlist_id == PLAYLIST_ID_OFFSET + 6
+            PlaylistRoute(
+                slug="my-playlist-1",
+                title_slug="my-playlist",
+                collision_id=1,
+                owner_id=1,
+                playlist_id=400004,
+                is_current=True,
             ),
-            None,
-        )
-        # Though we updated the playlist 3 times,
-        # we only updated the name to have a diff slug two times
-        assert_playlist_route(
-            route=playlist_1_route_current,
-            slug="my-playlist-1-w-new-name",
-            title_slug="my-playlist-1-w-new-name",
-            collision_id=0,
-            owner_id=1,
-            playlist_id=PLAYLIST_ID_OFFSET,
-            is_current=True,
-        )
-        assert_playlist_route(
-            route=playlist_1_route_not_current,
-            slug="my-playlist",
-            title_slug="my-playlist",
-            collision_id=0,
-            owner_id=1,
-            playlist_id=PLAYLIST_ID_OFFSET,
-            is_current=False,
-        )
-        assert_playlist_route(
-            route=playlist_2_route,
-            slug="my-playlist-2",
-            title_slug="my-playlist-2",
-            collision_id=0,
-            owner_id=1,
-            playlist_id=PLAYLIST_ID_OFFSET + 1,
-            is_current=True,
-        )
-        assert_playlist_route(
-            route=playlist_3_route,
-            slug="my-playlist-1",
-            title_slug="my-playlist",
-            collision_id=1,
-            owner_id=1,
-            is_current=True,
-            playlist_id=PLAYLIST_ID_OFFSET + 4,
-        )
-        assert_playlist_route(
-            route=playlist_4_route,
-            slug="my-playlist-3",
-            title_slug="my-playlist",
-            collision_id=3,
-            playlist_id=PLAYLIST_ID_OFFSET + 5,
-            owner_id=1,
-            is_current=True,
-        )
-        assert_playlist_route(
-            route=playlist_diff_owner_route,
-            slug="my-playlist",
-            title_slug="my-playlist",
-            collision_id=0,
-            playlist_id=PLAYLIST_ID_OFFSET + 6,
-            owner_id=2,
-            is_current=True,
-        )
+            PlaylistRoute(
+                slug="my-playlist-400004",
+                title_slug="my-playlist-400004",
+                collision_id=1,
+                owner_id=1,
+                playlist_id=400004,
+                is_current=True,
+            ),
+            PlaylistRoute(
+                slug="my-playlist-3",
+                title_slug="my-playlist",
+                collision_id=3,
+                owner_id=1,
+                playlist_id=400005,
+                is_current=True,
+            ),
+            PlaylistRoute(
+                slug="my-playlist-400005",
+                title_slug="my-playlist-400005",
+                collision_id=3,
+                owner_id=1,
+                playlist_id=400005,
+                is_current=True,
+            ),
+            PlaylistRoute(
+                slug="my-playlist",
+                title_slug="my-playlist",
+                collision_id=0,
+                owner_id=2,
+                playlist_id=400006,
+                is_current=True,
+            ),
+            PlaylistRoute(
+                slug="my-playlist-400006",
+                title_slug="my-playlist-400006",
+                collision_id=0,
+                owner_id=2,
+                playlist_id=400006,
+                is_current=True,
+            ),
+        ]
+
+        def sort_key(route):
+            return (route.playlist_id, route.slug)
+
+        sorted_routes = sorted(playlist_routes, key=sort_key)
+        sorted_expected_routes = sorted(expected_routes, key=sort_key)
+        for i in range(len(sorted_routes)):
+            assert_playlist_route(sorted_routes[i], sorted_expected_routes[i])
 
 
 def test_index_valid_playlists(app, mocker, tx_receipts):

--- a/discovery-provider/src/queries/get_playlists.py
+++ b/discovery-provider/src/queries/get_playlists.py
@@ -88,10 +88,6 @@ def _get_unpopulated_playlists(session, args):
         # user id filter if the optional query param is passed in
         playlist_query = playlist_query.filter(Playlist.playlist_owner_id == user_id)
 
-    # If no current_user_id and no direct route was passed in, never show hidden playlists
-    if not current_user_id and not routes:
-        playlist_query = playlist_query.filter(Playlist.is_private == False)
-
     # Filter out deletes unless we're fetching explicitly by id or route
     if "playlist_ids" not in args and not routes:
         playlist_query = playlist_query.filter(Playlist.is_delete == False)
@@ -101,16 +97,16 @@ def _get_unpopulated_playlists(session, args):
     playlists = helpers.query_result_to_list(playlists)
 
     # if we passed in a current_user_id and no direct route was passed in,
-    # filter out all privte playlists where
-    # the owner_id doesn't match the current_user_id
-    if current_user_id and not routes:
-        playlists = list(
-            filter(
-                lambda playlist: (not playlist["is_private"])
-                or playlist["playlist_owner_id"] == current_user_id,
-                playlists,
+    # filter out all private playlists where the owner_id doesn't match the current_user_id
+    if "playlist_ids" not in args and not routes:
+        if current_user_id:
+            playlists = list(
+                filter(
+                    lambda playlist: (not playlist["is_private"])
+                    or playlist["playlist_owner_id"] == current_user_id,
+                    playlists,
+                )
             )
-        )
 
     # retrieve playlist ids list
     playlist_ids = list(map(lambda playlist: playlist["playlist_id"], playlists))

--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -21,7 +21,9 @@ from src.tasks.task_helpers import generate_slug_and_collision_id
 from src.utils import helpers
 
 
-def update_playlist_routes_table(params: ManageEntityParameters, playlist_record):
+def update_playlist_routes_table(
+    params: ManageEntityParameters, playlist_record: Playlist, is_create: bool
+):
     pending_playlist_routes = params.pending_playlist_routes
     session = params.session
 
@@ -89,6 +91,27 @@ def update_playlist_routes_table(params: ManageEntityParameters, playlist_record
     new_playlist_route.txhash = playlist_record.txhash
     session.add(new_playlist_route)
 
+    if is_create:
+        # playlist-name-<id>
+        migration_playlist_slug_title = helpers.sanitize_slug(
+            playlist_record.playlist_name,
+            playlist_record.playlist_id,
+            playlist_record.playlist_id,
+        )
+        migration_playlist_slug = migration_playlist_slug_title
+
+        migration_playlist_route = PlaylistRoute()
+        migration_playlist_route.slug = migration_playlist_slug
+        migration_playlist_route.title_slug = migration_playlist_slug_title
+        migration_playlist_route.collision_id = new_collision_id
+        migration_playlist_route.owner_id = playlist_record.playlist_owner_id
+        migration_playlist_route.playlist_id = playlist_record.playlist_id
+        migration_playlist_route.is_current = True
+        migration_playlist_route.blockhash = playlist_record.blockhash
+        migration_playlist_route.blocknumber = playlist_record.blocknumber
+        migration_playlist_route.txhash = playlist_record.txhash
+        session.add(migration_playlist_route)
+
     # Add to pending playlist routes so we don't add the same route twice
     pending_playlist_routes.append(new_playlist_route)
 
@@ -110,7 +133,9 @@ def validate_playlist_tx(params: ManageEntityParameters):
     validate_signer(params)
 
     if params.entity_type != EntityType.PLAYLIST:
-        raise IndexingValidationError(f"Entity type {params.entity_type} is not a playlist")
+        raise IndexingValidationError(
+            f"Entity type {params.entity_type} is not a playlist"
+        )
 
     premium_tracks = list(
         filter(
@@ -123,12 +148,18 @@ def validate_playlist_tx(params: ManageEntityParameters):
 
     if params.action == Action.CREATE:
         if playlist_id in params.existing_records[EntityType.PLAYLIST]:
-            raise IndexingValidationError(f"Cannot create playlist {playlist_id} that already exists")
+            raise IndexingValidationError(
+                f"Cannot create playlist {playlist_id} that already exists"
+            )
         if playlist_id < PLAYLIST_ID_OFFSET:
-            raise IndexingValidationError(f"Cannot create playlist {playlist_id} below the offset")
+            raise IndexingValidationError(
+                f"Cannot create playlist {playlist_id} below the offset"
+            )
     else:
         if playlist_id not in params.existing_records[EntityType.PLAYLIST]:
-            raise IndexingValidationError(f"Cannot update playlist {playlist_id} that does not exist")
+            raise IndexingValidationError(
+                f"Cannot update playlist {playlist_id} that does not exist"
+            )
         existing_playlist: Playlist = params.existing_records[EntityType.PLAYLIST][
             playlist_id
         ]
@@ -196,9 +227,7 @@ def create_playlist(params: ManageEntityParameters):
         is_delete=False,
     )
 
-    update_playlist_routes_table(
-        params, create_playlist_record
-    )
+    update_playlist_routes_table(params, create_playlist_record, True)
 
     params.add_playlist_record(playlist_id, create_playlist_record)
 
@@ -235,14 +264,9 @@ def update_playlist(params: ManageEntityParameters):
         params.txhash,
         params.block_datetime,
     )
-    process_playlist_data_event(
-        params,
-        updated_playlist
-    )
+    process_playlist_data_event(params, updated_playlist)
 
-    update_playlist_routes_table(
-        params, updated_playlist
-    )
+    update_playlist_routes_table(params, updated_playlist, False)
 
     params.add_playlist_record(playlist_id, updated_playlist)
 


### PR DESCRIPTION
### Description

* Dual writes to playlist_routes for the interim so fetching by old and new styles will work. Unblocks client.
* Allows for fetches of private playlists via playlist id in API

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audius-compose up
audius-cmd create-playlist "857866038" --private --from ray
```

Confirmed that 
private playlist shows http://audius-protocol-discovery-provider-1/v1/full/playlists/11jkz

Confirmed that fetches work by old and new slug
http://audius-protocol-discovery-provider-1/v1/full/playlists/by_permalink/ray/playlist-d418-30620257
http://audius-protocol-discovery-provider-1/v1/full/playlists/by_permalink/ray/playlist-d418