### PR TITLE
Re-seed cid_lookup instead of falling back to every node

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -6,6 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"math/rand"
+	"os"
+	"time"
 
 	_ "embed"
 )
@@ -27,10 +30,26 @@ func Migrate(db *sql.DB) {
 	mustExec(db, mediorumMigrationTable)
 	runMigration(db, cidLookupDDL)
 	runMigration(db, delistStatusesDDL)
-	runMigration(db, `drop table if exists server_healths;`)
 
-	// delete legacy blobs
-	shouldExec(db, `delete from blobs where key not like 'ba%'`)
+	// stagger re-seeding between 1-3hrs. TODO: safe to remove after everyone runs it once
+	min := time.Duration(60)
+	max := time.Duration(180)
+	diff := max.Minutes() - min.Minutes()
+	randomTime := min + time.Duration(rand.Float64()*diff)*time.Minute
+	time.AfterFunc(randomTime, func() {
+		ddl := `begin; truncate mediorum_migrations; drop table cid_lookup; drop table cid_cursor; drop table cid_log; commit;`
+		h := md5string(ddl)
+		var alreadyRan bool
+		db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, h).Scan(&alreadyRan)
+		if alreadyRan {
+			fmt.Printf("hash %s exists skipping ddl \n", h)
+			return
+		}
+
+		mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, h)
+		mustExec(db, ddl)
+		os.Exit(0)
+	})
 }
 
 func runMigration(db *sql.DB, ddl string) {
@@ -52,13 +71,6 @@ func mustExec(db *sql.DB, ddl string, va ...interface{}) {
 	if err != nil {
 		fmt.Println(ddl)
 		log.Fatal(err)
-	}
-}
-
-func shouldExec(db *sql.DB, ddl string, va ...interface{}) {
-	_, err := db.Exec(ddl, va...)
-	if err != nil {
-		fmt.Println("ddl shouldExec failed", ddl, err)
 	}
 }
 

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -32,8 +32,8 @@ func Migrate(db *sql.DB) {
 	runMigration(db, delistStatusesDDL)
 
 	// stagger re-seeding between 1-3hrs. TODO: safe to remove after everyone runs it once
-	min := time.Duration(60)
-	max := time.Duration(180)
+	min := time.Duration(2)
+	max := time.Duration(5)
 	diff := max.Minutes() - min.Minutes()
 	randomTime := min + time.Duration(rand.Float64()*diff)*time.Minute
 	time.AfterFunc(randomTime, func() {

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-const CidLookupBatchSize = 2000
+const CidLookupBatchSize = 4000
 
 func (ss *MediorumServer) startCidBeamClient() {
 	for {

--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,30 +172,30 @@ func (ss *MediorumServer) redirectToCid(c echo.Context, cid string, checkAllNode
 		return c.Redirect(302, dest.String())
 	}
 
-	// check all healthy hosts via HEAD request to see if they have the cid but aren't in cid_lookup
-	if checkAllNodes {
-		for _, host := range healthyHosts {
-			if host == ss.Config.Self.Host {
-				continue
-			}
-			dest := replaceHost(*c.Request().URL, host)
-			req, err := http.NewRequest("HEAD", "https:"+dest.String(), nil)
-			if err != nil {
-				logger.Error("error creating HEAD request", "err", err)
-				continue
-			}
-			req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				logger.Error("error sending HEAD request", "err", err)
-				continue
-			}
-			if resp.StatusCode == 200 || resp.StatusCode == 204 || resp.StatusCode == 206 || resp.StatusCode == 302 || resp.StatusCode == 304 {
-				dest.Query().Add("localOnly", "true")
-				return c.Redirect(302, dest.String())
-			}
-		}
-	}
+	// // check all healthy hosts via HEAD request to see if they have the cid but aren't in cid_lookup
+	// if checkAllNodes {
+	// 	for _, host := range healthyHosts {
+	// 		if host == ss.Config.Self.Host {
+	// 			continue
+	// 		}
+	// 		dest := replaceHost(*c.Request().URL, host)
+	// 		req, err := http.NewRequest("HEAD", "https:"+dest.String(), nil)
+	// 		if err != nil {
+	// 			logger.Error("error creating HEAD request", "err", err)
+	// 			continue
+	// 		}
+	// 		req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
+	// 		resp, err := http.DefaultClient.Do(req)
+	// 		if err != nil {
+	// 			logger.Error("error sending HEAD request", "err", err)
+	// 			continue
+	// 		}
+	// 		if resp.StatusCode == 200 || resp.StatusCode == 204 || resp.StatusCode == 206 || resp.StatusCode == 302 || resp.StatusCode == 304 {
+	// 			dest.Query().Add("localOnly", "true")
+	// 			return c.Redirect(302, dest.String())
+	// 		}
+	// 	}
+	// }
 
 	logger.Info("no healthy host found with cid")
 	return c.String(404, "no healthy host found with cid: "+cid)

--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -8,7 +8,6 @@
   include_containers = [
     "server",
     "indexer",
-    "postgres",
     "redis",
     "comms",
     "notifications",
@@ -21,6 +20,7 @@
     "logspout",
     "autoheal",
     "exporter",  # Exclude all containers beginning with exporter
+    "postgres", # Temporary to stop spam from one SP. TODO: Move back to include_containers
   ]
 
 [transforms.parse]


### PR DESCRIPTION
### Description
- Reverts checking every node for Qm CIDs on 404 because this is causing spam that's making nodes go offline (fyi @stereosteve if you have any ideas on how to make this more precise so it doesn't cause too much spam)
- Re-seeds the cid_lookup table for Qm CIDs on every node
- Stops logging from postgres container so we stop killing our logs from culturestake16 (I pushed the vector image already, so it should go out in the next audius-docker-compose update)

### How Has This Been Tested?
- The ways to test this aren't very expedient given the ongoing issue. Will look through it synchronously on staging
- Monitor healthz and the Axiom dashboard to see log spam and 404 HEADs decrease