### PR TITLE
Make mediorum case insensitive again

### DIFF
--- a/mediorum/registrar/audius_api_gateway.go
+++ b/mediorum/registrar/audius_api_gateway.go
@@ -3,7 +3,9 @@ package registrar
 import (
 	"encoding/json"
 	"io/ioutil"
+	"mediorum/httputil"
 	"mediorum/server"
+	"strings"
 )
 
 type NodeResponse struct {
@@ -64,8 +66,8 @@ func (p *audiusApiGatewayProvider) getNodes(path string) ([]server.Peer, error) 
 	var peers []server.Peer
 	for _, node := range nodeResponse.Data {
 		peer := server.Peer{
-			Host:   node.Endpoint,
-			Wallet: node.DelegateOwnerWallet,
+			Host:   httputil.RemoveTrailingSlash(strings.ToLower(node.Endpoint)),
+			Wallet: strings.ToLower(node.DelegateOwnerWallet),
 		}
 		peers = append(peers, peer)
 	}


### PR DESCRIPTION
### Description
I forgot to handle case sensitivity and endpoint normalization when switching the node from The Graph to API Gateway, which I think might've caused a page.

### How Has This Been Tested?
Very simple change - doesn't really need big testing.