### PR TITLE
Fix is_unlisted on track create

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -177,10 +177,7 @@ def populate_track_record_metadata(track_record, track_metadata, handle):
     if track_metadata["cover_art_sizes"]:
         track_record.cover_art = track_metadata["cover_art_sizes"]
 
-    # Only update `is_unlisted` if the track is unlisted. Once public, track cannot be
-    # made unlisted again
-    if track_record.is_unlisted:
-        track_record.is_unlisted = track_metadata["is_unlisted"]
+    track_record.is_unlisted = track_metadata["is_unlisted"]
 
     # Only update `duration` if it's provided,
     # otherwise fall back to the original value. This will allow for replacing


### PR DESCRIPTION
### Description

Revert change enforcing one-way update of `is_unlisted` in entity manager. This change broke the initial setting of `is_unlisted` on track create

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
