### PR TITLE
Use cuckoo filter for Files table contents

### DIFF
--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/panmari/cuckoofilter v1.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/mediorum/go.sum
+++ b/mediorum/go.sum
@@ -771,6 +771,9 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 h1:y7y0Oa6UawqTFPCDw9JG6pdKt4F9pAhHv0B7FMGaGD0=
+github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.78.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
@@ -1537,6 +1540,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/panmari/cuckoofilter v1.0.3 h1:MgTxXG2aP0YPWFyY1sKt1caWidUFREk9BaOnakDKZOU=
+github.com/panmari/cuckoofilter v1.0.3/go.mod h1:O7+ZOHxwlADJ1So2/ZsKBExDwILNPZsyt77zN0ZTBLg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/mediorum/server/cuckoo.go
+++ b/mediorum/server/cuckoo.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	cuckoo "github.com/panmari/cuckoofilter"
+)
+
+var (
+	myCuckooKeyName = "my_cuckoo"
+	cuckooMap       = map[string]*cuckoo.Filter{}
+	cuckooMu        = sync.RWMutex{}
+)
+
+func (ss *MediorumServer) serveCuckooLookup(c echo.Context) error {
+	cid := c.Param("cid")
+	hosts := ss.cuckooLookup(cid)
+	return c.JSON(200, hosts)
+}
+
+func (ss *MediorumServer) serveCuckooSize(c echo.Context) error {
+	sizes := map[string]any{}
+	cuckooMu.RLock()
+	for host, filter := range cuckooMap {
+		sizes[host] = map[string]any{
+			"size":        filter.Count(),
+			"load_factor": filter.LoadFactor(),
+		}
+	}
+	cuckooMu.RUnlock()
+	return c.JSON(200, sizes)
+}
+
+func (ss *MediorumServer) serveCuckoo(c echo.Context) error {
+	ctx := c.Request().Context()
+	r, err := ss.bucket.NewReader(ctx, myCuckooKeyName, nil)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// would be nice to do some Last-Modified stuff here
+	return c.Stream(200, "", r)
+}
+
+func (ss *MediorumServer) cuckooLookup(cid string) []string {
+	hosts := []string{}
+	cidBytes := []byte(cid)
+	cuckooMu.RLock()
+	for host, filter := range cuckooMap {
+		if filter.Lookup(cidBytes) {
+			hosts = append(hosts, host)
+		}
+	}
+	cuckooMu.RUnlock()
+	return hosts
+}
+
+func (ss *MediorumServer) startCuckooFetcher() error {
+	for {
+		for _, peer := range ss.Config.Peers {
+			if peer.Host == ss.Config.Self.Host {
+				continue
+			}
+
+			err := ss.fetchPeerCuckoo(peer.Host)
+			if err != nil {
+				ss.logger.Warn("failed to fetch peer cuckoo", "peer", peer.Host, "err", err)
+			}
+		}
+		time.Sleep(time.Minute * 10)
+	}
+}
+
+func (ss *MediorumServer) fetchPeerCuckoo(host string) error {
+	client := http.Client{
+		Timeout: time.Minute,
+	}
+
+	endpoint := host + "/internal/cuckoo"
+	r, err := client.Get(endpoint)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return fmt.Errorf("bad status: %s: %s", endpoint, r.Status)
+	}
+
+	f, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	filter, err := cuckoo.Decode(f)
+	if err != nil {
+		return err
+	}
+
+	cuckooMu.Lock()
+	cuckooMap[host] = filter
+	cuckooMu.Unlock()
+	return nil
+}
+
+func (ss *MediorumServer) startCuckooBuilder() error {
+	for {
+		startTime := time.Now()
+		err := ss.buildCuckoo()
+		took := time.Since(startTime)
+		ss.logger.Info("built cuckoo", "took", took.String(), "err", err)
+		time.Sleep(time.Hour)
+	}
+}
+
+func (ss *MediorumServer) buildCuckoo() error {
+	ctx := context.Background()
+
+	conn, err := ss.pgPool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+
+	count := 0
+	err = conn.QueryRow(ctx, `select count(*) from "Files" where type != 'track'`).Scan(&count)
+	if err != nil {
+		return err
+	}
+
+	cf := cuckoo.NewFilter(uint(count))
+
+	rows, err := conn.Query(ctx, `
+	select multihash from "Files" where type != 'track'
+	union all
+	select "dirMultihash" from "Files" where "dirMultihash" is not null`)
+	if err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var cid []byte
+
+		err := rows.Scan(&cid)
+		if err != nil {
+			return err
+		}
+		cf.Insert(cid)
+	}
+
+	return ss.bucket.WriteAll(ctx, myCuckooKeyName, cf.Encode(), nil)
+}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -266,6 +266,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	internalApi.GET("/beam/files", ss.servePgBeam)
 
+	internalApi.GET("/cuckoo", ss.serveCuckoo)
+	internalApi.GET("/cuckoo/size", ss.serveCuckooSize)
+	internalApi.GET("/cuckoo/:cid", ss.serveCuckooLookup)
+
 	// internal: crud
 	internalApi.GET("/crud/sweep", ss.serveCrudSweep)
 	internalApi.POST("/crud/push", ss.serveCrudPush, middleware.BasicAuth(ss.checkBasicAuth))
@@ -311,6 +315,9 @@ func (ss *MediorumServer) MustStart() {
 	}()
 
 	go ss.startTranscoder()
+
+	go ss.startCuckooBuilder()
+	go ss.startCuckooFetcher()
 
 	// for any background task that make authenticated peer requests
 	// only start if we have a valid registered wallet


### PR DESCRIPTION
### Description

Builds a cuckoo filter for CIDs in Files table.

* goroutine to rebuild cuckoo filter from scratch every hour.  Cuckoo does support add + delete, but for now we'll just build from scratch every time for simplicity.  On our prod node the resulting filter is 16MB in size.
* goroutine to pull filters from peers every 10 minutes.  In general each filter will be 8 or 16MB, so memory consumption is like `16MB * PeerCount`
* debug endpoint to get size + do lookup

atm it doesn't use the filters in the actual request path... thought is to deploy this so it is everywhere and then in subsequent deploy can update request path to use this instead of `cid_lookup`

### How Has This Been Tested?

will deploy to two staging nodes