### PR TITLE
Fix migration route for playlists

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -106,7 +106,7 @@ def update_playlist_routes_table(
         migration_playlist_route.collision_id = new_collision_id
         migration_playlist_route.owner_id = playlist_record.playlist_owner_id
         migration_playlist_route.playlist_id = playlist_record.playlist_id
-        migration_playlist_route.is_current = True
+        migration_playlist_route.is_current = False
         migration_playlist_route.blockhash = playlist_record.blockhash
         migration_playlist_route.blocknumber = playlist_record.blocknumber
         migration_playlist_route.txhash = playlist_record.txhash


### PR DESCRIPTION
### Description

https://github.com/AudiusProject/audius-protocol/blob/31b70d294425aa45a03dc794d5a2387966aa7885/discovery-provider/src/queries/get_playlists.py#L64

We are allowed to query by is current is fault, so the dual written migration record should be set to false.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will test updates thoroughly on stage after