### PR TITLE
[CON-733] Implement "full" content node (STORE_ALL)

### DIFF
--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -238,6 +238,8 @@ func startDevCluster() {
 			AudiusDockerCompose: os.Getenv("AUDIUS_DOCKER_COMPOSE_GIT_SHA"),
 			AutoUpgradeEnabled:  os.Getenv("autoUpgradeEnabled") == "true",
 			LegacyFSRoot:        "/file_storage",
+			IsV2Only:            os.Getenv("IS_V2_ONLY") == "true",
+			VersionJson:         GetVersionJson(),
 		}
 		privKeyEnvVar := fmt.Sprintf("CN%d_SP_OWNER_PRIVATE_KEY", idx+1)
 		if privateKey, found := os.LookupEnv(privKeyEnvVar); found {

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -129,6 +129,7 @@ func startStagingOrProd(isProd bool) {
 		AudiusDockerCompose: os.Getenv("AUDIUS_DOCKER_COMPOSE_GIT_SHA"),
 		AutoUpgradeEnabled:  os.Getenv("autoUpgradeEnabled") == "true",
 		IsV2Only:            os.Getenv("IS_V2_ONLY") == "true",
+		StoreAll:            os.Getenv("STORE_ALL") == "true",
 		VersionJson:         GetVersionJson(),
 	}
 

--- a/mediorum/server/placement.go
+++ b/mediorum/server/placement.go
@@ -11,6 +11,12 @@ func (ss *MediorumServer) rendezvous(h string) ([]string, bool) {
 	hosts := ss.findHealthyPeers(5 * time.Minute)
 	hashRing := rendezvous.New(hosts...)
 	orderedHosts := hashRing.GetN(len(hosts), h)
-	isMine := slices.Index(orderedHosts, ss.Config.Self.Host) < ss.Config.ReplicationFactor // || ss.Config.FullNode
+	isMine := slices.Index(orderedHosts, ss.Config.Self.Host) < ss.Config.ReplicationFactor
+	if ss.Config.StoreAll {
+		isMine = true
+	} else if isLegacyCID(h) {
+		// TODO(theo): Don't store Qm CIDs for now unless STORE_ALL is true. Remove this once all nodes have enough space to store Qm CIDs
+		isMine = false
+	}
 	return orderedHosts, isMine
 }

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -49,13 +49,12 @@ func (ss *MediorumServer) replicateToMyBucket(fileName string, file io.Reader) e
 		if err != nil {
 			return err
 		}
+		defer w.Close()
 
 		_, err = io.Copy(w, file)
 		if err != nil {
 			return err
 		}
-
-		w.Close()
 	}
 
 	// record that we "have" this key

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -141,9 +141,13 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 	if err != nil {
 		return c.JSON(500, map[string]string{"error": "Failed to sort health check data: " + err.Error()})
 	}
-	signature, err := signature.SignBytes(dataBytesSorted, ss.Config.privateKey)
-	if err != nil {
-		return c.JSON(500, map[string]string{"error": "Failed to sign health check response: " + err.Error()})
+	signatureHex := "private key not set (should only happen on local dev)!"
+	if ss.Config.privateKey != nil {
+		signature, err := signature.SignBytes(dataBytesSorted, ss.Config.privateKey)
+		if err != nil {
+			return c.JSON(500, map[string]string{"error": "Failed to sign health check response: " + err.Error()})
+		}
+		signatureHex = fmt.Sprintf("0x%s", hex.EncodeToString(signature))
 	}
 
 	status := 200
@@ -151,7 +155,6 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		status = 503
 	}
 
-	signatureHex := fmt.Sprintf("0x%s", hex.EncodeToString(signature))
 	return c.JSON(status, healthCheckResponse{
 		Data:      data,
 		Signer:    ss.Config.Self.Wallet,

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -57,6 +57,7 @@ type healthCheckResponseData struct {
 	CidCursors                []cidCursor                `json:"cidCursors"`
 	PeerHealths               map[string]time.Time       `json:"peerHealths"`
 	IsV2Only                  bool                       `json:"isV2Only"`
+	StoreAll                  bool                       `json:"storeAll"`
 }
 
 type legacyHealth struct {
@@ -129,6 +130,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		PeerHealths:               ss.peerHealth,
 		Signers:                   ss.Config.Signers,
 		IsV2Only:                  ss.Config.IsV2Only,
+		StoreAll:                  ss.Config.StoreAll,
 	}
 
 	dataBytes, err := json.Marshal(data)

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -38,7 +38,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStoreDSN":"files:///temp/blobs","builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"isSeedingLegacy":false,"isV2Only":false,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStoreDSN":"files:///temp/blobs","builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"isSeedingLegacy":false,"isV2Only":false,"listenPort":"1991","peerHealths":null,"replicationFactor":3,"selectedDiscoveryProvider":"","self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"upstreamCN":"4001","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -279,6 +279,7 @@ func computeFileCID(f io.ReadSeeker) (string, error) {
 	return cid.String(), nil
 }
 
+// note: any Qm CID will be invalid because its hash won't match the contents
 func validateCID(expectedCID string, f io.ReadSeeker) error {
 	computed, err := computeFileCID(f)
 	if err != nil {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -65,12 +65,11 @@ type MediorumConfig struct {
 	AutoUpgradeEnabled  bool
 	WalletIsRegistered  bool
 	IsV2Only            bool
+	StoreAll            bool
 	VersionJson         VersionJson
 
 	// should have a basedir type of thing
 	// by default will put db + blobs there
-
-	// StoreAll          bool   // todo: set this to true for "full node"
 
 	privateKey *ecdsa.PrivateKey
 }
@@ -298,7 +297,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// TODO: remove
 	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation)
 	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo)
-	internalApi.GET("/blobs/double_check/:cid", ss.getBlobDoubleCheck)
 
 	// new info routes
 	internalApi.GET("/blobs/:cid/location", ss.getBlobLocation)

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -34,6 +34,11 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 			ReplicationFactor: replicationFactor,
 			Dir:               fmt.Sprintf("/tmp/mediorum_test/%s", peer.Wallet),
 			PostgresDSN:       fmt.Sprintf("postgres://postgres:example@localhost:5454/m%d", idx+1),
+			IsV2Only:          true,
+			VersionJson: VersionJson{
+				Version: "0.0.0",
+				Service: "content-node",
+			},
 		}
 		server, err := New(config)
 		if err != nil {


### PR DESCRIPTION
### Description
- Adds `STORE_ALL` env var to make node store all files, including legacy/Qm CIDs, regardless of rendezvous ordering
- Removes unused `/blobs/double_check/:cid` route

### How Has This Been Tested?
Verified that stage CN12 now has all (non-Qm) CIDs in its S3 bucket. Other nodes should still only be storing CIDs when they're in the top 3 by rendezvous score.