### PR TITLE
Fix noisy metadata deserialization error

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -57,16 +57,22 @@ def validate_user_tx(params: ManageEntityParameters):
 
     if params.action == Action.CREATE or params.action == Action.UPDATE:
         user_bio = None
-        try:
-            user_metadata, _ = parse_metadata(
-                params.metadata, Action.UPDATE, EntityType.USER
-            )
-            if user_metadata:
-                user_bio = user_metadata.get("bio")
-        except Exception:
-            # enforce json metadata after single transaction sign up
-            # dont want to raise here, only check bio IF it exists
-            pass
+        # TODO remove this clause for non-dict param.metadata after single
+        # transaction sign up is fully rolled out
+        if not isinstance(params.metadata, dict):
+            try:
+                user_metadata, _ = parse_metadata(
+                    params.metadata, Action.UPDATE, EntityType.USER
+                )
+                if user_metadata:
+                    user_bio = user_metadata.get("bio")
+            except Exception:
+                # enforce json metadata after single transaction sign up
+                # dont want to raise here, only check bio IF it exists
+                pass
+        else:
+            user_bio = user_metadata.get("bio")
+
         if user_bio and len(user_bio) > CHARACTER_LIMIT_USER_BIO:
             raise IndexingValidationError(
                 f"Playlist {user_id} bio exceeds character limit {CHARACTER_LIMIT_USER_BIO}"

--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -58,8 +58,6 @@ def validate_user_tx(params: ManageEntityParameters):
     if params.action == Action.CREATE or params.action == Action.UPDATE:
         user_bio = None
         try:
-            # TODO(michelle) validate metadata for notification, developer app
-            # pass in UPDATE until this is fixed
             user_metadata, _ = parse_metadata(
                 params.metadata, Action.UPDATE, EntityType.USER
             )

--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -57,8 +57,9 @@ def validate_user_tx(params: ManageEntityParameters):
 
     if params.action == Action.CREATE or params.action == Action.UPDATE:
         user_bio = None
-        # TODO remove this clause for non-dict param.metadata after single
-        # transaction sign up is fully rolled out
+        # TODO remove this clause for non-dict params.metadata after single
+        # transaction sign up is fully rolled out, as all metadata for CREATEs
+        # or UPDATEs should have been deserialized into dicts at this point.
         if not isinstance(params.metadata, dict):
             try:
                 user_metadata, _ = parse_metadata(

--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -71,7 +71,7 @@ def validate_user_tx(params: ManageEntityParameters):
                 # dont want to raise here, only check bio IF it exists
                 pass
         else:
-            user_bio = user_metadata.get("bio")
+            user_bio = params.metadata.get("bio")
 
         if user_bio and len(user_bio) > CHARACTER_LIMIT_USER_BIO:
             raise IndexingValidationError(

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -236,7 +236,8 @@ class ManageEntityParameters:
 
 # Whether to expect valid metadata json based on the action and entity type
 def expect_cid_metadata_json(metadata, action, entity_type):
-    # TODO after single tx signup, expect metadata for CREATE USER txs, so remove this clause
+    # TODO after single tx sign up is fully rolled out, expect metadata
+    # for CREATE USER txs, so remove this clause
     if action == Action.CREATE and entity_type == EntityType.USER:
         return False
     # TODO(michelle) validate metadata for notification, developer app,
@@ -299,7 +300,7 @@ def sanitize_json(json_resp):
 
 
 # Returns metadata, cid
-def parse_metadata(metadata, action, entity_type):
+def parse_metadata(metadata: str, action: str, entity_type: str):
     if not expect_cid_metadata_json(metadata, action, entity_type):
         return metadata, None
     try:

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -303,11 +303,7 @@ def parse_metadata(metadata, action, entity_type):
     if not expect_cid_metadata_json(metadata, action, entity_type):
         return metadata, None
     try:
-        if isinstance(metadata, dict):
-            metadata_dict = metadata
-        else:
-            metadata_dict = json.loads(metadata)
-        data = sanitize_json(metadata_dict)
+        data = sanitize_json(json.loads(metadata))
 
         if "cid" not in data.keys() or "data" not in data.keys():
             raise IndexingValidationError("required keys missing in metadata")

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -302,7 +302,11 @@ def parse_metadata(metadata, action, entity_type):
     if not expect_cid_metadata_json(metadata, action, entity_type):
         return metadata, None
     try:
-        data = sanitize_json(json.loads(metadata))
+        if isinstance(metadata, dict):
+            metadata_dict = metadata
+        else:
+            metadata_dict = json.loads(metadata)
+        data = sanitize_json(metadata_dict)
 
         if "cid" not in data.keys() or "data" not in data.keys():
             raise IndexingValidationError("required keys missing in metadata")

--- a/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/discovery-provider/src/tasks/entity_manager/utils.py
@@ -236,6 +236,7 @@ class ManageEntityParameters:
 
 # Whether to expect valid metadata json based on the action and entity type
 def expect_cid_metadata_json(metadata, action, entity_type):
+    # TODO after single tx signup, expect metadata for CREATE USER txs, so remove this clause
     if action == Action.CREATE and entity_type == EntityType.USER:
         return False
     # TODO(michelle) validate metadata for notification, developer app,


### PR DESCRIPTION
### Description
seeing a lot of `error deserializing metadata` errors recently in the [logs](https://app.axiom.co/audius-Lu52/stream/stage-discovery?ig=&q=%7B%22op%22%3A%22and%22%2C%22field%22%3A%22%22%2C%22children%22%3A%5B%7B%22field%22%3A%22msg%22%2C%22op%22%3A%22contains%22%2C%22value%22%3A%22error%20deserializing%20metadata%22%7D%5D%7D) (no impact on write functionality). this was from this [change](https://github.com/AudiusProject/audius-protocol/pull/5406/files#diff-5f2036d31b9e5c951ef78b6688b2a253dff55168fad03a59c7bc76b9ffb992e2).

`parse_metadata` expects the metadata param to be a string and will throw an error if it is a dict. in `validate_user_tx`, `params.metadata` was already deserialized into a dict when building the params for UPDATE USER events, but not for CREATE USER events. this will be the case until we fully roll out single tx signups and remove this clause: https://github.com/AudiusProject/audius-protocol/blob/df59882dc34a936b4925c08d81e43790cfa79196/discovery-provider/src/tasks/entity_manager/utils.py#L239

this pr handles this mid-migration case correctly. after single tx signups are fully rolled out, we can remove the `parse_metadata` logic in `validate_user_tx` and leave it to be parsed upstream as usual, as is currently the case for UPDATE USER.

thanks @sliptype for point out the noise

### How Has This Been Tested?
test on stage, make sure no more errors when updating users

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
