### PR TITLE
Add album routes to playlist permalinks project

### DIFF
--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -215,7 +215,8 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
     row.repost_count = row.reposted_by.length
     row.save_count = row.saved_by.length
     const slug = row.routes[row.routes.length - 1]
-    row.permalink = `/${row.user.handle}/playlist/${slug}`
+    const collection_type = row.is_album ? 'album' : 'playlist'
+    row.permalink = `/${row.user.handle}/${collection_type}/${slug}`
   }
 
   private async getTracks(trackIds: number[]) {

--- a/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/discovery-provider/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -215,8 +215,8 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
     row.repost_count = row.reposted_by.length
     row.save_count = row.saved_by.length
     const slug = row.routes[row.routes.length - 1]
-    const collection_type = row.is_album ? 'album' : 'playlist'
-    row.permalink = `/${row.user.handle}/${collection_type}/${slug}`
+    const collectionType = row.is_album ? 'album' : 'playlist'
+    row.permalink = `/${row.user.handle}/${collectionType}/${slug}`
   }
 
   private async getTracks(trackIds: number[]) {

--- a/discovery-provider/src/models/playlists/playlist.py
+++ b/discovery-provider/src/models/playlists/playlist.py
@@ -75,7 +75,8 @@ class Playlist(Base, RepresentableMixin):
     @property
     def permalink(self):
         if self.user and self.user[0].handle and self._slug:
-            return f"/{self.user[0].handle}/playlist/{self._slug}"
+            collection_type = 'album' if self.is_album else 'playlist'
+            return f"/{self.user[0].handle}/{collection_type}/{self._slug}"
         return ""
 
     # unpacking args into @validates


### PR DESCRIPTION
### Description
albums were not properly accounted for in the permalink returned from the backend, updating to return the proper permalink for albums

### How Has This Been Tested?
checking the playlist endpoint returns the correct permalink for an album

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
