### PR TITLE
Use tmp file key without slash

### DIFF
--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -234,12 +234,12 @@ const (
 )
 
 func (ss *MediorumServer) getKeyToTempFile(fileHash string) (*os.File, error) {
-	key := cidutil.ShardCID(fileHash)
-	temp, err := os.CreateTemp("", key)
+	temp, err := os.CreateTemp("", fileHash)
 	if err != nil {
 		return nil, err
 	}
 
+	key := cidutil.ShardCID(fileHash)
 	blob, err := ss.bucket.NewReader(context.Background(), key, nil)
 	if err != nil {
 		return nil, err

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -489,6 +489,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 		return onError(err, upload.Status, "getting file")
 	}
 	defer temp.Close()
+	defer os.Remove(temp.Name())
 
 	switch JobTemplate(upload.Template) {
 	case JobTemplateImgSquare:


### PR DESCRIPTION
### Description
Fix using a key with the shard because the path separator isn't allowed in os.CreateTemp.