### PR TITLE
sdk and discovery: Fix full bulk tracks endpoint

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -311,7 +311,7 @@ class FullBulkTracks(Resource):
         description="""Gets a list of tracks using their IDs or permalinks""",
     )
     @full_ns.expect(full_track_route_parser)
-    @full_ns.marshal_with(full_track_response)
+    @full_ns.marshal_with(full_tracks_response)
     @cache(ttl_sec=5)
     def get(self):
         args = full_track_route_parser.parse_args()

--- a/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -214,7 +214,7 @@ export class TracksApi extends runtime.BaseAPI {
     /** @hidden
      * Gets a list of tracks using their IDs or permalinks
      */
-    async getBulkTracksRaw(requestParameters: GetBulkTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTrackResponse>> {
+    async getBulkTracksRaw(requestParameters: GetBulkTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
         const queryParameters: any = {};
 
         if (requestParameters.userId !== undefined) {
@@ -238,13 +238,13 @@ export class TracksApi extends runtime.BaseAPI {
             query: queryParameters,
         }, initOverrides);
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => FullTrackResponseFromJSON(jsonValue));
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksResponseFromJSON(jsonValue));
     }
 
     /**
      * Gets a list of tracks using their IDs or permalinks
      */
-    async getBulkTracks(requestParameters: GetBulkTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTrackResponse> {
+    async getBulkTracks(requestParameters: GetBulkTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
         const response = await this.getBulkTracksRaw(requestParameters, initOverrides);
         return await response.value();
     }


### PR DESCRIPTION
### Description

Tried this with locally linked libs:
`await audiusSdk.full.tracks.getBulkTracks({ permalink: ['handle3131/title-55f4'] })`

Got this error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at TrackFullFromJSONTyped (TrackFull.ts:437:1)
    at TrackFullFromJSON (TrackFull.ts:399:1)
    at FullTrackResponseFromJSONTyped (FullTrackResponse.ts:119:1)
    at FullTrackResponseFromJSON (FullTrackResponse.ts:103:1)
    at JSONApiResponse.transformer (TracksApi.ts:241:1)
    at JSONApiResponse._callee6$ (runtime.ts:389:1)
    at tryCatch (regeneratorRuntime.js:86:1)
    at Generator._invoke (regeneratorRuntime.js:66:1)
    at Generator.next (regeneratorRuntime.js:117:1)
    at asyncGeneratorStep$1 (transactionHandler.ts:413:1)
 ```
Offending line according to error:
`'followeeReposts': ((json['followee_reposts'] as Array<any>).map(RepostFromJSON)),`
Network request has that data as an empty array:
`"followee_reposts": [],`

Putting a breakpoint shows that the json is an array, not object.

Looks like a problem with the swagger.json of that endpoint. Sure enough, it has `@full_ns.marshal_with(full_track_response)`  (non-plural) instead of `@full_ns.marshal_with(full_tracks_response)`

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
