### PR TITLE
Fix: Don't break existing bulk get tracks endpoint for slug + handle

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -7,15 +7,7 @@ from urllib.parse import urljoin
 
 from flask import redirect
 from flask.globals import request
-from flask_restx import (
-    Namespace,
-    Resource,
-    fields,
-    inputs,
-    marshal,
-    marshal_with,
-    reqparse,
-)
+from flask_restx import Namespace, Resource, fields, inputs, marshal, reqparse
 from src.api.v1.helpers import (
     DescriptiveArgument,
     abort_bad_path_param,
@@ -253,9 +245,7 @@ class BulkTracks(Resource):
         200, "Success", tracks_response
     )  # Manually set the expected response to be a list of tracks using using @ns.response
     @ns.expect(track_slug_parser)
-    @marshal_with(
-        track_response
-    )  # Don't document using the marshaller - required for backwards compat supporting non-list responses
+    @ns.response(200, "Success", tracks_response)
     @cache(ttl_sec=5)
     def get(self):
         args = track_slug_parser.parse_args()
@@ -304,11 +294,16 @@ class BulkTracks(Resource):
                 abort_not_found(ids, ns)
 
         # For backwards compatibility, the old handle/slug route returned an object, not an array
+        # Manually handle marshalling to accomodate while also allowing new SDK to have array as return type
         if handle and slug:
             tracks = extend_track(tracks[0])
+            response, status = success_response(tracks)
+            return marshal(response, track_response), status
         else:
             tracks = [extend_track(track) for track in tracks]
-        return success_response(tracks)
+            response, status = success_response(tracks)
+            return marshal(response, tracks_response), status
+
 
 
 @full_ns.route("")
@@ -319,7 +314,7 @@ class FullBulkTracks(Resource):
         description="""Gets a list of tracks using their IDs or permalinks""",
     )
     @full_ns.expect(full_track_route_parser)
-    @full_ns.response(200, 'Success', full_tracks_response)
+    @full_ns.response(200, "Success", full_tracks_response)
     @cache(ttl_sec=5)
     def get(self):
         args = full_track_route_parser.parse_args()
@@ -369,11 +364,15 @@ class FullBulkTracks(Resource):
                 abort_not_found(ids, full_ns)
 
         # For backwards compatibility, the old handle/slug route returned an object, not an array
+        # Manually handle marshalling to accomodate while also allowing new SDK to have array as return type
         if handle and slug:
             tracks = extend_track(tracks[0])
+            response, status = success_response(tracks)
+            return marshal(response, full_track_response), status
         else:
             tracks = [extend_track(track) for track in tracks]
-        return success_response(marshal(tracks, track_full, None, False, None, False))
+            response, status = success_response(tracks)
+            return marshal(response, full_tracks_response), status
 
 
 # Stream

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -7,7 +7,15 @@ from urllib.parse import urljoin
 
 from flask import redirect
 from flask.globals import request
-from flask_restx import Namespace, Resource, fields, inputs, marshal_with, reqparse
+from flask_restx import (
+    Namespace,
+    Resource,
+    fields,
+    inputs,
+    marshal,
+    marshal_with,
+    reqparse,
+)
 from src.api.v1.helpers import (
     DescriptiveArgument,
     abort_bad_path_param,
@@ -311,7 +319,7 @@ class FullBulkTracks(Resource):
         description="""Gets a list of tracks using their IDs or permalinks""",
     )
     @full_ns.expect(full_track_route_parser)
-    @full_ns.marshal_with(full_tracks_response)
+    @full_ns.response(200, 'Success', full_tracks_response)
     @cache(ttl_sec=5)
     def get(self):
         args = full_track_route_parser.parse_args()
@@ -365,7 +373,7 @@ class FullBulkTracks(Resource):
             tracks = extend_track(tracks[0])
         else:
             tracks = [extend_track(track) for track in tracks]
-        return success_response(tracks)
+        return success_response(marshal(tracks, track_full, None, False, None, False))
 
 
 # Stream


### PR DESCRIPTION
### Description

#5693 introduced a breaking change to DN API by making _every_ type of request to the bulk tracks endpoint return an array. Unfortunately, several clients are already using the bulk tracks endpoint with the deprecated slug+handle approach that only returns a single track. Thus, to keep backwards compatibility, this change changes the documentation of the endpoint to show that it returns an array _without_ marshalling the response into an array format, and instead conditionally use the correct marshallers manually.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed locally that using slug + handle = object in data field, and using id or permalink = array in data field, and that JSON schema has array as the return type