### PR TITLE
Add documentation to StorageNodeSelector config, make logger optional

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/types.ts
@@ -76,6 +76,9 @@ export type DiscoveryNodeSelectorServiceConfigInternal = {
    */
   bootstrapServices: string[]
 
+  /**
+   * Logger service, defaults to console logging
+   */
   logger: LoggerService
 }
 

--- a/libs/src/sdk/services/EntityManager/EntityManager.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.ts
@@ -19,6 +19,7 @@ import {
 import {
   BlockConfirmation,
   EntityManagerConfig,
+  EntityManagerConfigInternal,
   EntityManagerService,
   ManageEntityOptions
 } from './types'
@@ -28,7 +29,7 @@ export class EntityManager implements EntityManagerService {
   /**
    * Configuration passed in by consumer (with defaults)
    */
-  private readonly config: EntityManagerConfig
+  private readonly config: EntityManagerConfigInternal
 
   private readonly contract: Contract
   private readonly web3: Web3Type

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -1,13 +1,14 @@
-import type { EntityManagerConfig } from './types'
+import type { EntityManagerConfigInternal } from './types'
 import { productionConfig } from '../../config'
 import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import { Logger } from '../Logger'
 
-export const defaultEntityManagerConfig: EntityManagerConfig = {
+export const defaultEntityManagerConfig: EntityManagerConfigInternal = {
   contractAddress: productionConfig.entityManagerContractAddress,
   web3ProviderUrl: productionConfig.web3ProviderUrl,
   identityServiceUrl: productionConfig.identityServiceUrl,
   discoveryNodeSelector: new DiscoveryNodeSelector(),
+  useDiscoveryRelay: false,
   logger: new Logger()
 }
 

--- a/libs/src/sdk/services/EntityManager/types.ts
+++ b/libs/src/sdk/services/EntityManager/types.ts
@@ -3,14 +3,33 @@ import type { TransactionReceipt } from 'web3-core'
 import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { LoggerService } from '../Logger'
 
-export type EntityManagerConfig = {
+export type EntityManagerConfigInternal = {
+  /**
+   * Address of the EntityManager contract
+   */
   contractAddress: string
+  /**
+   * The URL of the Web3 provider service
+   */
   web3ProviderUrl: string
+  /**
+   * The URL of the Audius Identity Service, used for relays
+   */
   identityServiceUrl: string
+  /**
+   * The DiscoveryNodeSelector service used to get a discovery node to confirm blocks
+   */
   discoveryNodeSelector: DiscoveryNodeSelectorService
-  useDiscoveryRelay?: boolean
+  /**
+   * Whether to use discovery for relay instead of identity
+   */
+  useDiscoveryRelay: boolean
+  /**
+   * Logger service, defaults to console
+   */
   logger: LoggerService
 }
+export type EntityManagerConfig = Partial<EntityManagerConfigInternal>
 
 export type EntityManagerService = {
   manageEntity: (

--- a/libs/src/sdk/services/Storage/Storage.ts
+++ b/libs/src/sdk/services/Storage/Storage.ts
@@ -8,6 +8,7 @@ import type {
   ProgressCB,
   StorageService,
   StorageServiceConfig,
+  StorageServiceConfigInternal,
   UploadResponse
 } from './types'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
@@ -28,7 +29,7 @@ export class Storage implements StorageService {
   /**
    * Configuration passed in by consumer (with defaults)
    */
-  private readonly config: StorageServiceConfig
+  private readonly config: StorageServiceConfigInternal
   private readonly storageNodeSelector: StorageNodeSelectorService
   private readonly logger: LoggerService
 

--- a/libs/src/sdk/services/Storage/constants.ts
+++ b/libs/src/sdk/services/Storage/constants.ts
@@ -1,7 +1,12 @@
 import { Logger } from '../Logger'
-import type { StorageServiceConfig } from './types'
+import { StorageNodeSelector } from '../StorageNodeSelector'
+import { defaultStorageNodeSelectorConfig } from '../StorageNodeSelector/constants'
+import type { StorageServiceConfigInternal } from './types'
 
-export const defaultStorageServiceConfig: Partial<StorageServiceConfig> = {
+export const defaultStorageServiceConfig: StorageServiceConfigInternal = {
+  storageNodeSelector: new StorageNodeSelector(
+    defaultStorageNodeSelectorConfig
+  ),
   logger: new Logger()
 }
 

--- a/libs/src/sdk/services/Storage/types.ts
+++ b/libs/src/sdk/services/Storage/types.ts
@@ -3,9 +3,19 @@ import type { StorageNodeSelectorService } from '../StorageNodeSelector'
 import type { AuthService } from '../Auth'
 import type { LoggerService } from '../Logger'
 
-export type StorageServiceConfig = {
+export type StorageServiceConfigInternal = {
+  /**
+   * The StorageNodeSelector service used to get the relevant storage node for content
+   */
   storageNodeSelector: StorageNodeSelectorService
+  /**
+   * Logger service, defaults to console
+   */
   logger: LoggerService
+}
+
+export type StorageServiceConfig = Partial<StorageServiceConfigInternal> & {
+  storageNodeSelector: StorageNodeSelectorService
 }
 
 export type ProgressCB = (loaded: number, total: number) => void

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -6,6 +6,7 @@ import type { AuthService } from '../Auth'
 import type {
   StorageNode,
   StorageNodeSelectorConfig,
+  StorageNodeSelectorConfigInternal,
   StorageNodeSelectorService
 } from './types'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
@@ -15,7 +16,7 @@ import type { LoggerService } from '../Logger'
 const DISCOVERY_RESPONSE_TIMEOUT = 15000
 
 export class StorageNodeSelector implements StorageNodeSelectorService {
-  private readonly config: StorageNodeSelectorConfig
+  private readonly config: StorageNodeSelectorConfigInternal
   private readonly auth: AuthService
   private readonly logger: LoggerService
   private nodes: StorageNode[]

--- a/libs/src/sdk/services/StorageNodeSelector/constants.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/constants.ts
@@ -2,11 +2,12 @@ import { productionConfig } from '../../config'
 import { Auth } from '../Auth/Auth'
 import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import { Logger } from '../Logger'
-import type { StorageNodeSelectorConfig } from './types'
+import type { StorageNodeSelectorConfigInternal } from './types'
 
-export const defaultStorageNodeSelectorConfig: StorageNodeSelectorConfig = {
-  bootstrapNodes: productionConfig.storageNodes,
-  auth: new Auth(),
-  discoveryNodeSelector: new DiscoveryNodeSelector(),
-  logger: new Logger()
-}
+export const defaultStorageNodeSelectorConfig: StorageNodeSelectorConfigInternal =
+  {
+    bootstrapNodes: productionConfig.storageNodes,
+    auth: new Auth(),
+    discoveryNodeSelector: new DiscoveryNodeSelector(),
+    logger: new Logger()
+  }

--- a/libs/src/sdk/services/StorageNodeSelector/types.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/types.ts
@@ -12,9 +12,28 @@ export type StorageNode = {
   delegateOwnerWallet: string
 }
 
-export type StorageNodeSelectorConfig = {
-  bootstrapNodes?: StorageNode[]
+export type StorageNodeSelectorConfigInternal = {
+  /**
+   * Starting list of healthy storage nodes to use before a discovery node is selected
+   */
+  bootstrapNodes: StorageNode[]
+  /**
+   * The Authentication service, used to get the user's wallet for rendevous calculations
+   */
   auth: Auth
+  /**
+   * DiscoveryNodeSelector instance being used, so that the node can listen for
+   * selection events and update its healthy storage node list
+   */
   discoveryNodeSelector: DiscoveryNodeSelectorService
+  /**
+   * Logger service, defaults to console logging
+   */
   logger: LoggerService
 }
+
+export type StorageNodeSelectorConfig =
+  Partial<StorageNodeSelectorConfigInternal> & {
+    auth: Auth
+    discoveryNodeSelector: DiscoveryNodeSelectorService
+  }


### PR DESCRIPTION
### Description

Makes it optional to specify logger for StorageNodeSelector, and adds some nice comments for the config

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
