### PR TITLE
Ignore non-CID Qm keys in repair.go

### DIFF
--- a/mediorum/cidutil/cidutil.go
+++ b/mediorum/cidutil/cidutil.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"mime/multipart"
 	"path/filepath"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
@@ -45,18 +46,28 @@ func ValidateCID(expectedCID string, f io.ReadSeeker) error {
 	return nil
 }
 
+// Returns true both for "Qm" CIDs AND for for keys like "Qmwhatever/150x150.jpg" to support legacy migrated keys
 func IsLegacyCID(cid string) bool {
-	return len(cid) == 46 && cid[:2] == "Qm"
+	return strings.HasPrefix(cid, "Qm")
+}
+
+// Only returns true for exact v0 CIDs (46 chars and start with "Qm")
+func IsLegacyCIDStrict(cid string) bool {
+	return IsLegacyCID(cid) && len(cid) == 46
 }
 
 // Returns a sharded filepath/key for CID based on CID version.
 // V0: last 3 chars, offset by 1
 // V1: last 5 chars
+// Fallback: unchanged (for legacy migrated keys like "Qm.../150x150.jpg")
 func ShardCID(cidStr string) string {
-	if IsLegacyCID(cidStr) {
+	if IsLegacyCIDStrict(cidStr) {
 		return shardLegacyCID(cidStr)
 	}
-	return shardCIDV1(cidStr)
+	if strings.HasPrefix(cidStr, "ba") {
+		return shardCIDV1(cidStr)
+	}
+	return cidStr
 }
 
 // Returns sharded filepath for CID V0. Ex: returns "QuP/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU" for "QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU"

--- a/mediorum/cidutil/cidutil_test.go
+++ b/mediorum/cidutil/cidutil_test.go
@@ -7,14 +7,27 @@ import (
 )
 
 var (
-	v0CID = "QmP8Wuu1kN9iHBoBptB4UrTN3orna3Z6ZW2xevNkoE2y22"
-	v1CID = "baeaaaiqsecffzabbj7utfkkmywbhlls46twtaq3fbvpbozvugl4bqszfru7u2"
-	uuid  = "FKFFJMUVC2JJKRZLS64KM5M7AI3HJCWJ"
+	v0CID         = "QmP8Wuu1kN9iHBoBptB4UrTN3orna3Z6ZW2xevNkoE2y22"
+	v0CIDMigrated = "QmP8Wuu1kN9iHBoBptB4UrTN3orna3Z6ZW2xevNkoE2y22/150x150.jpg"
+	v1CID         = "baeaaaiqsecffzabbj7utfkkmywbhlls46twtaq3fbvpbozvugl4bqszfru7u2"
+	uuid          = "FKFFJMUVC2JJKRZLS64KM5M7AI3HJCWJ"
 )
 
 func TestIsLegacyCID(t *testing.T) {
 	if !IsLegacyCID(v0CID) {
 		t.Errorf("IsLegacyCID failed for v0 CID")
+	}
+
+	if !IsLegacyCIDStrict(v0CID) {
+		t.Errorf("IsLegacyCIDStrict failed for v0 CID")
+	}
+
+	if !IsLegacyCID(v0CIDMigrated) {
+		t.Errorf("IsLegacyCID failed for migrated v0 CID")
+	}
+
+	if IsLegacyCIDStrict(v0CIDMigrated) {
+		t.Errorf("IsLegacyCIDStrict failed for migrated v0 CID")
 	}
 
 	if IsLegacyCID(v1CID) {

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -84,7 +84,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 			preferredHosts, isMine := ss.rendezvous(cid)
 			myRank := slices.Index(preferredHosts, ss.Config.Self.Host)
 
-			// TODO(theo): Don't repair Qm CIDs for now (isMine will still be true). Remove this once all nodes have enough space to store Qm CIDs
+			// TODO(theo): Don't repair Qm keys for now (isMine will still be true). Remove this once all nodes have enough space to store Qm keys
 			if cidutil.IsLegacyCID(cid) {
 				myRank = 999
 			}
@@ -103,7 +103,7 @@ func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 			}
 
 			// in cleanup mode do some extra checks:
-			// - validate CID, delete if invalid (doesn't apply to Qm CIDs because their hash is not the CID)
+			// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
 			if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
 				if r, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
 					err := cidutil.ValidateCID(cid, r)


### PR DESCRIPTION
### Description
Before rolling out the migration of Qm files to the v2 buckets, repair.go should ignore _all_ Qm keys rather than just ones that are exact CIDs. Otherwise, when repair.go sees a key like "Qmwhatever/150x150.jpg" it will try to replicate it and possibly run out of disk space.

### How Has This Been Tested?
Ran the Qm migration on stage cn9 and and stage usermetadata, and used this PR to confirm that it makes other nodes ignore the migrated files in repair.go (to avoid over replicating and running out of disk space).