### PR TITLE
PLAT-1161: skip push on playlist update and if track already existed

### DIFF
--- a/discovery-provider/es-indexer/src/indexNames.ts
+++ b/discovery-provider/es-indexer/src/indexNames.ts
@@ -1,5 +1,5 @@
 export const indexNames = {
-  playlists: 'playlists14',
+  playlists: 'playlists15',
   reposts: 'reposts13',
   saves: 'saves13',
   tracks: 'tracks14',

--- a/discovery-provider/integration_tests/notifications/test_playlist.py
+++ b/discovery-provider/integration_tests/notifications/test_playlist.py
@@ -53,7 +53,7 @@ def test_playlist_track_added_notification(app):
         assert len(notifications) == 2
         assert (
             notifications[0].group_id
-            == "track_added_to_playlist:playlist_id:0:track_id:20:blocknumber:0"
+            == "track_added_to_playlist:playlist_id:0:track_id:20"
         )
         assert notifications[0].specifier == "1"
         assert notifications[0].type == "track_added_to_playlist"

--- a/discovery-provider/integration_tests/notifications/test_playlist.py
+++ b/discovery-provider/integration_tests/notifications/test_playlist.py
@@ -68,7 +68,7 @@ def test_playlist_track_added_notification(app):
 
         assert (
             notifications[1].group_id
-            == "track_added_to_playlist:playlist_id:0:track_id:30:blocknumber:0"
+            == "track_added_to_playlist:playlist_id:0:track_id:30"
         )
         assert notifications[1].specifier == "15"
         assert notifications[1].type == "track_added_to_playlist"

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
@@ -75,7 +75,7 @@ describe('Add track to playlist notification', () => {
         title: 'Your track got on a playlist! 💿',
         body: `user_2 added title_track to their playlist title_of_playlist`,
         data: {
-          id: 'timestamp:1589373217:group_id:track_added_to_playlist:playlist_id:55:track_id:10:blocknumber:1',
+          id: 'timestamp:1589373217:group_id:track_added_to_playlist:playlist_id:55:track_id:10',
           playlistId: 55,
           type: 'AddTrackToPlaylist'
         }

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
@@ -71,7 +71,6 @@ export class AddTrackToPlaylist extends BaseNotification<AddTrackToPlaylistNotif
     }> = await this.dnDB
       .select('playlist_id', 'playlist_name', 'playlist_owner_id', 'playlist_contents')
       .from<PlaylistRow>('playlists')
-      .whereIn("is_current", ["true", "false"])
       .orderBy("blocknumber", "desc")
       .limit(2)
       .whereIn('playlist_id', [this.playlistId])

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
@@ -14,10 +14,21 @@ import {
 } from './userNotificationSettings'
 import { sendBrowserNotification } from '../../web'
 import { disableDeviceArns } from '../../utils/disableArnEndpoint'
+import { logger } from '../../logger'
 
 type AddTrackToPlaylistNotificationRow = Omit<NotificationRow, 'data'> & {
   data: AddTrackToPlaylistNotification
 }
+
+type Track = {
+  time: number;
+  track: number;
+};
+
+type PlaylistContents = {
+  track_ids: Track[];
+};
+
 export class AddTrackToPlaylist extends BaseNotification<AddTrackToPlaylistNotificationRow> {
   trackId: number
   playlistId: number
@@ -55,13 +66,16 @@ export class AddTrackToPlaylist extends BaseNotification<AddTrackToPlaylistNotif
     const playlistRes: Array<{
       playlist_id: number
       playlist_name: string
-      playlist_owner_id: number
+      playlist_owner_id: number,
+      playlist_contents: PlaylistContents,
     }> = await this.dnDB
-      .select('playlist_id', 'playlist_name', 'playlist_owner_id')
+      .select('playlist_id', 'playlist_name', 'playlist_owner_id', 'playlist_contents')
       .from<PlaylistRow>('playlists')
-      .where('is_current', true)
+      .whereIn("is_current", ["true", "false"])
+      .orderBy("blocknumber", "desc")
+      .limit(2)
       .whereIn('playlist_id', [this.playlistId])
-    const playlist = playlistRes[0]
+    const [playlist, old_playlist] = playlistRes
 
     const res: Array<{
       user_id: number
@@ -82,6 +96,16 @@ export class AddTrackToPlaylist extends BaseNotification<AddTrackToPlaylistNotif
 
     if (users?.[track.owner_id]?.isDeactivated) {
       return
+    }
+
+    if (old_playlist !== undefined) {
+      // playlist update happened, not create
+      const old_track_ids = old_playlist.playlist_contents.track_ids.map((track) => track.track)
+      if (old_track_ids.includes(track.track_id)) {
+        logger.info(`playlist update, skipping push ${track} ${playlist.playlist_name}`)
+        // track was already present on playlist
+        return
+      }
     }
 
     // Get the user's notification setting from identity service

--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -308,65 +308,27 @@ def delete_playlist(params: ManageEntityParameters):
 
 
 def process_playlist_contents(playlist_record, playlist_metadata, block_integer_time):
-    if playlist_record.metadata_multihash:
-        # playlist already has metadata
-        metadata_index_time_dict: Dict[int, Dict[int, int]] = defaultdict(dict)
-        playlist_tracks = playlist_record.playlist_contents["track_ids"]
-        for track in playlist_tracks:
-            track_id = track["track"]
-            if "metadata_time" in track:
-                metadata_time = track["metadata_time"]
-                metadata_index_time_dict[track_id][metadata_time] = track["time"]
+    updated_tracks = []
+    for track in playlist_metadata["playlist_contents"]["track_ids"]:
+        track_id = track["track"]
+        metadata_time = track["time"]
+        index_time = block_integer_time  # default to current block for new tracks
 
-        updated_tracks = []
-        for track in playlist_metadata["playlist_contents"]["track_ids"]:
-            track_id = track["track"]
-            metadata_time = track["time"]
-            index_time = block_integer_time  # default to current block for new tracks
+        # { track_id: 89027834, time: 802934023 }
+        previous_playlist_tracks = playlist_record["playlist_contents"]["track_ids"]
+        for previous_track in previous_playlist_tracks:
+            previous_track_id = previous_track["track"]
+            previous_track_time = previous_track["time"]
+            if previous_track_id == track_id and previous_track_time == metadata_time:
+                index_time = previous_track_time
 
-            # { track_id: 89027834, time: 802934023 }
-            previous_playlist_tracks = playlist_record["playlist_contents"]["track_ids"]
-            for previous_track in previous_playlist_tracks:
-                previous_track_id = previous_track["track"]
-                previous_track_time = previous_track["time"]
-                if previous_track_id == track_id:
-                    index_time = previous_track_time
-
-            updated_tracks.append(
-                {
-                    "track": track_id,
-                    "time": index_time,
-                    "metadata_time": metadata_time,
-                }
-            )
-    else:
-        # upgrade legacy playlist to include metadata
-        # assume metadata and indexing timestamp is the same
-        track_id_index_times: Set = set()
-        playlist_tracks = playlist_record.playlist_contents["track_ids"]
-        for track in playlist_tracks:
-            track_id = track["track"]
-            index_time = track["time"]
-            track_id_index_times.add((track_id, index_time))
-
-        updated_tracks = []
-        for track in playlist_metadata["playlist_contents"]["track_ids"]:
-            track_id = track["track"]
-            metadata_time = track["time"]
-
-            # use track["time"] if present in previous record else this is a new track
-            index_time = (
-                track["time"]
-                if (track_id, metadata_time) in track_id_index_times
-                else block_integer_time
-            )
-            updated_tracks.append(
-                {
-                    "track": track_id,
-                    "time": index_time,
-                    "metadata_time": metadata_time,
-                }
-            )
+        updated_tracks.append(
+            {
+                "track": track_id,
+                "time": index_time,
+                "metadata_time": metadata_time,
+            }
+        )
 
     return {"track_ids": updated_tracks}
 

--- a/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -324,12 +324,13 @@ def process_playlist_contents(playlist_record, playlist_metadata, block_integer_
             metadata_time = track["time"]
             index_time = block_integer_time  # default to current block for new tracks
 
-            if (
-                track_id in metadata_index_time_dict
-                and metadata_time in metadata_index_time_dict[track_id]
-            ):
-                # track exists in prev record (reorder / delete)
-                index_time = metadata_index_time_dict[track_id][metadata_time]
+            # { track_id: 89027834, time: 802934023 }
+            previous_playlist_tracks = playlist_record["playlist_contents"]["track_ids"]
+            for previous_track in previous_playlist_tracks:
+                previous_track_id = previous_track["track"]
+                previous_track_time = previous_track["time"]
+                if previous_track_id == track_id:
+                    index_time = previous_track_time
 
             updated_tracks.append(
                 {


### PR DESCRIPTION
### Description
adds a check against old current row for a playlist that if a track exists in the old instance, don't send a push because it was already there

### How Has This Been Tested?
Tested on stage but stage has a bug where playlist rearrangements are not working. Works on production.
