### PR TITLE
Default init config objects for userbanks functions

### DIFF
--- a/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -237,7 +237,7 @@ export class SolanaWeb3Manager {
   }: {
     ethAddress?: string
     mint?: MintName
-  }) {
+  } = {}) {
     const userbank = await this.deriveUserBank({ ethAddress, mint })
     const tokenAccount = await this.getTokenAccountInfo(userbank.toString())
     return !!tokenAccount
@@ -353,7 +353,7 @@ export class SolanaWeb3Manager {
   }: {
     ethAddress?: string
     mint?: MintName
-  }) {
+  } = {}) {
     if (!this.web3Manager) {
       throw new Error(
         'A web3Manager is required for this solanaWeb3Manager method'


### PR DESCRIPTION
### Description
For functions where all objects in the config are optional, we should default init them to empty objects to avoid throwing errors when no config is passed.
