### PR TITLE
[PAY-1666] Update identity stripe endpoint to support usdc

### DIFF
--- a/identity-service/src/routes/stripe.js
+++ b/identity-service/src/routes/stripe.js
@@ -23,10 +23,10 @@ module.exports = function (app) {
   app.post(
     '/stripe/session',
     handleResponse(async (req) => {
-      const { destinationWallet, amount } = req.body
+      const { destinationWallet, amount, destinationCurrency } = req.body
 
-      if (!destinationWallet || !amount) {
-        return errorResponseBadRequest('Missing destinationWallet or amount')
+      if (!destinationWallet || !amount || !destinationCurrency) {
+        return errorResponseBadRequest('Missing input param')
       }
 
       const urlEncodedData = new URLSearchParams({
@@ -35,10 +35,14 @@ module.exports = function (app) {
         'transaction_details[supported_destination_networks][]': 'solana',
         'transaction_details[supported_destination_currencies][]': 'sol',
         'transaction_details[destination_network]': 'solana',
-        'transaction_details[destination_currency]': 'sol',
+        'transaction_details[destination_currency]': destinationCurrency,
         'transaction_details[destination_exchange_amount]': amount,
         customer_ip_address: getIP(req)
       })
+      urlEncodedData.append(
+        'transaction_details[supported_destination_networks][]',
+        'usdc'
+      )
 
       try {
         const req = {

--- a/identity-service/src/routes/stripe.js
+++ b/identity-service/src/routes/stripe.js
@@ -28,6 +28,11 @@ module.exports = function (app) {
       if (!destinationWallet || !amount || !destinationCurrency) {
         return errorResponseBadRequest('Missing input param')
       }
+      if (destinationCurrency !== 'sol' && destinationCurrency !== 'usdc') {
+        return errorResponseBadRequest(
+          'Invalid destination currency: only support sol and usdc'
+        )
+      }
 
       const urlEncodedData = new URLSearchParams({
         customer_wallet_address: destinationWallet,
@@ -40,7 +45,7 @@ module.exports = function (app) {
         customer_ip_address: getIP(req)
       })
       urlEncodedData.append(
-        'transaction_details[supported_destination_networks][]',
+        'transaction_details[supported_destination_currencies[]',
         'usdc'
       )
 

--- a/libs/src/services/identity/IdentityService.ts
+++ b/libs/src/services/identity/IdentityService.ts
@@ -79,6 +79,7 @@ type InAppAudioPurchaseMetadata = {
 type CreateStripeSessionRequest = {
   destinationWallet: string
   amount: string
+  destinationCurrency: 'audio' | 'usdc'
 }
 
 type CreateStripeSessionResponse = {


### PR DESCRIPTION
### Description
Updates `/stripe/session` endpoint on identity to support creating usdc sessions in addition to sol.

### How Has This Been Tested?

Have not been able to test locally - all requests to stripe are hitting 500. Would like to merge and test on stage.