### PR TITLE
Cleanup subgenre db migration

### DIFF
--- a/discovery-provider/ddl/migrations/0018_clean_up_subgenre.sql
+++ b/discovery-provider/ddl/migrations/0018_clean_up_subgenre.sql
@@ -1,0 +1,11 @@
+-- clean up subgenres 
+alter table tracks disable trigger on_track;
+alter table tracks disable trigger trg_tracks;
+
+update tracks
+set genre = substring(genre from position(' - ' in genre) + 3)
+where (is_current = true or is_current = false)
+and genre like 'Electronic - %';
+
+alter table tracks enable trigger on_track;
+alter table tracks enable trigger trg_tracks;


### PR DESCRIPTION
### Description
Mobile uploads were using genre - subgenre. So they'd fail EM indexing genre validation.
Make `Electronic - Tech House` -> `Tech House`.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Tested on sandbox.