### PR TITLE
Don't only check patch in version check

### DIFF
--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -216,7 +216,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
       return false
     }
 
-    // If this service is behind by patches, add it as a backup and reject
+    // If this service is behind, add it as a backup and reject
     if (semver.lt(version, this.currentVersion)) {
       this.addBackup(urlMap[response.config.url as string] as string, data.data)
       return false

--- a/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
+++ b/libs/src/services/discoveryProvider/DiscoveryProviderSelection.ts
@@ -217,7 +217,7 @@ export class DiscoveryProviderSelection extends ServiceSelection {
     }
 
     // If this service is behind by patches, add it as a backup and reject
-    if (semver.patch(version) < semver.patch(this.currentVersion)) {
+    if (semver.lt(version, this.currentVersion)) {
       this.addBackup(urlMap[response.config.url as string] as string, data.data)
       return false
     }


### PR DESCRIPTION
### Description

This code still lives on as part of the quorum fetching for RewardsAttester. Since we bumped to `0.4.1` but the on-chain version is still `0.3.98`, the patch version of the latter is _more_ than the patch version of the former, yet the former is newer and should still be used.

Thus, since only a single node is still on `0.3.98`, RewardsAttester cannot find 3 uniquely owned DiscoveryNodes and claiming rewards fails.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Not tested