### PR TITLE
Remove expensive cid_lookup backfill and slow down beaming

### DIFF
--- a/mediorum/ddl/cid_lookup.sql
+++ b/mediorum/ddl/cid_lookup.sql
@@ -1,3 +1,4 @@
+-- DEPRECATED. Soon we'll drop the Files table and cid_lookup completely.
 begin;
 
 
@@ -51,51 +52,51 @@ create table if not exists cid_cursor (
 -- initial backfill
 
 -- backfill multihash
-insert into cid_log (multihash, updated_at)
-  select "multihash", "createdAt" from "Files"
-    where "type" != 'track'
-      on conflict do nothing;
+-- insert into cid_log (multihash, updated_at)
+--   select "multihash", "createdAt" from "Files"
+--     where "type" != 'track'
+--       on conflict do nothing;
 
 -- backfill dirMultihash
-insert into cid_log (multihash, updated_at)
-  select "dirMultihash", "createdAt" from "Files" where "dirMultihash" is not null
-    on conflict do nothing;
+-- insert into cid_log (multihash, updated_at)
+--   select "dirMultihash", "createdAt" from "Files" where "dirMultihash" is not null
+--     on conflict do nothing;
 
 
 create index if not exists idx_cid_log_updated_at on cid_log(updated_at);
 
--- trigger code: creates a cid_log entry when a File is created or deleted
-create or replace function handle_cid_change() returns trigger as $$
-declare
-begin
+-- (NO LONGER NEEDED BECAUSE FILES TABLE NEVER CHANGES) trigger code: creates a cid_log entry when a File is created or deleted
+-- create or replace function handle_cid_change() returns trigger as $$
+-- declare
+-- begin
 
-    case tg_op
-    when 'DELETE' then
-        if old."type" = 'track' then
-          return null;
-        end if;
-        update cid_log set is_deleted = true, updated_at = now() where multihash = old.multihash;
-        update cid_log set is_deleted = true, updated_at = now() where multihash = old."dirMultihash";
-    else
-        if new."type" = 'track' then
-          return null;
-        end if;
-        insert into cid_log (multihash, updated_at) values (new.multihash, new."createdAt")
-          on conflict do nothing;
-        if new."dirMultihash" is not null then
-          insert into cid_log (multihash, updated_at) values (new."dirMultihash", new."createdAt")
-            on conflict do nothing;
-        end if;
-    end case;
-    return null;
+--     case tg_op
+--     when 'DELETE' then
+--         if old."type" = 'track' then
+--           return null;
+--         end if;
+--         update cid_log set is_deleted = true, updated_at = now() where multihash = old.multihash;
+--         update cid_log set is_deleted = true, updated_at = now() where multihash = old."dirMultihash";
+--     else
+--         if new."type" = 'track' then
+--           return null;
+--         end if;
+--         insert into cid_log (multihash, updated_at) values (new.multihash, new."createdAt")
+--           on conflict do nothing;
+--         if new."dirMultihash" is not null then
+--           insert into cid_log (multihash, updated_at) values (new."dirMultihash", new."createdAt")
+--             on conflict do nothing;
+--         end if;
+--     end case;
+--     return null;
 
-end;
-$$ language plpgsql;
+-- end;
+-- $$ language plpgsql;
 
 -- trigger trigger
 drop trigger if exists handle_cid_change on "Files";
-create trigger handle_cid_change
-    after insert or delete on "Files"
-    for each row execute procedure handle_cid_change();
+-- create trigger handle_cid_change
+--     after insert or delete on "Files"
+--     for each row execute procedure handle_cid_change();
 
 commit;

--- a/mediorum/server/cid_log_client.go
+++ b/mediorum/server/cid_log_client.go
@@ -26,7 +26,7 @@ func (ss *MediorumServer) startCidBeamClient() {
 				slog.Info("beam OK", "result", result)
 			}
 		}
-		time.Sleep(time.Minute)
+		time.Sleep(time.Minute * 10)
 	}
 }
 


### PR DESCRIPTION
### Description
Just removes the backfill instead of the whole migration because this is needed as a hotfix. We can also remove the whole thing soon, though.

### How Has This Been Tested?
~~I'll deploy to prod CN3 before merging. This migration recently ran there and got stuck on the backfill.~~ Works on CN3.