### PR TITLE
Fix file-type import

### DIFF
--- a/libs/src/sdk/types/File.ts
+++ b/libs/src/sdk/types/File.ts
@@ -2,9 +2,9 @@ import { z } from 'zod'
 
 let fileType: any
 if (typeof window !== 'undefined' && window) {
-  fileType = require('file-type')
-} else {
   fileType = require('file-type/browser')
+} else {
+  fileType = require('file-type')
 }
 
 /**


### PR DESCRIPTION
### Description

* `file-type/browser` was being imported in a node / mobile environment which is causing mobile builds to fail

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
