### PR TITLE
Fix userbank lookup for USDC

### DIFF
--- a/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -239,7 +239,7 @@ export class SolanaWeb3Manager {
     mint?: MintName
   } = {}) {
     const userbank = await this.deriveUserBank({ ethAddress, mint })
-    const tokenAccount = await this.getTokenAccountInfo(userbank.toString())
+    const tokenAccount = await this.getTokenAccountInfo(userbank.toString(), mint)
     return !!tokenAccount
   }
 


### PR DESCRIPTION
### Description
We aren't passing the mint to `getTokenAccountInfo`, so attempt to look up a userbank for USDC will fail due to using the wrong key.

### How Has This Been Tested?
Tested locally against client
