### PR TITLE
[PAY-1693] SDK: Don't cache chat secrets on create, make client refetch them

### DIFF
--- a/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/libs/src/sdk/api/chats/ChatsApi.ts
@@ -422,7 +422,6 @@ export class ChatsApi
 
     const chatId = [userId, ...invitedUserIds].sort().join(':')
     const chatSecret = secp.utils.randomPrivateKey()
-    this.chatSecrets[chatId] = chatSecret
     const invites = await this.createInvites(userId, invitedUserIds, chatSecret)
 
     return await this.sendRpc({


### PR DESCRIPTION
### Description

By not setting the chat secret in the memory cache here, the user will have to refetch the chat to get the secret when sending the first message. This ensures the creation of the chat was successful before setting the private key in memory cache

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Have not tested. Will need to test with client