### PR TITLE
Separate health check for registration

### DIFF
--- a/libs/src/services/ethContracts/ServiceProviderFactoryClient.ts
+++ b/libs/src/services/ethContracts/ServiceProviderFactoryClient.ts
@@ -74,7 +74,10 @@ export class ServiceProviderFactoryClient extends GovernedContractClient {
       const axiosRequestObj: AxiosRequestConfig = {
         url: requestUrl,
         method: 'get',
-        timeout: 1000
+        timeout: 1000,
+        params: {
+          'allow_unregistered': 'true'
+        }
       }
       const resp = await axios(axiosRequestObj)
       const endpointServiceType = resp.data.data.service

--- a/libs/tests/governanceTest.js
+++ b/libs/tests/governanceTest.js
@@ -46,7 +46,7 @@ const setupAccounts = async () => {
   for (const lib of inittedLibs) {
     const testEndpoint = getRandomLocalhost()
     nock(testEndpoint)
-      .get('/health_check')
+      .get('/health_check?allow_unregistered=true')
       .reply(200, {
         data: {
           service: testServiceType,

--- a/libs/tests/helpers.js
+++ b/libs/tests/helpers.js
@@ -96,7 +96,7 @@ const deregisterSPEndpoint = async (libs, account, type) => {
   }
 
   if (type === 'discovery-provider') {
-    path = '/health_check'
+    path = '/health_check?allow_unregistered=true'
     response = { data: { ...response } }
   }
 

--- a/libs/tests/stakingTest.js
+++ b/libs/tests/stakingTest.js
@@ -140,7 +140,7 @@ describe('Staking tests', () => {
       }
 
       if (testServiceType === 'discovery-provider') {
-        path = '/health_check'
+        path = '/health_check?allow_unregistered=true'
         response = { data: { ...response } }
       }
 
@@ -267,7 +267,7 @@ describe('Staking tests', () => {
       }
 
       if (testServiceType === 'discovery-provider') {
-        path = '/health_check'
+        path = '/health_check?allow_unregistered=true'
         response = { data: { ...response } }
       }
 


### PR DESCRIPTION
### Description
506 for unregistered nodes on health check, and make registration pass `allow_unregistered` query param to bypass.

### How Has This Been Tested?
Deployed to stage CN12 and confirmed that when using an unregistered wallet it returns 200 with `?allow_registered=true` in the `/health_check` and 506 otherwise.