### PR TITLE
[C-2942] Improve logs around developer app rate limits and reads

### DIFF
--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -227,6 +227,11 @@ def configure_flask_app_logging(app, loglevel_str):
         request_user_id = request.headers.get("X-User-ID")
         if request_user_id:
             log_params["request_user_id"] = request_user_id
+        
+        request_app_name = request.args.get('app_name')
+        if request_app_name:
+            log_params["appName"] = request_app_name
+            logger.info("handle read via developer app", extra=log_params)
 
         parts = []
         for name, value in log_params.items():

--- a/identity-service/src/rateLimiter.js
+++ b/identity-service/src/rateLimiter.js
@@ -275,7 +275,10 @@ const getRelayRateLimiterMiddleware = () => {
       try {
         const key = getEntityManagerActionKey(req.body.encodedABI)
         const signer = recoverSigner(req.body.encodedABI)
-        req.logger.error(`Rate limited sender ${signer} performing ${key}`)
+        req.logger.error(
+          { _signer: signer, isApp: req.isFromApp },
+          `Rate limited sender ${signer} performing ${key}`
+        )
       } catch (error) {
         req.logger.error(`Cannot relay without sender address`)
       }


### PR DESCRIPTION
### Description

* Add log for flask requests containing `app_name` param. This will be used to create an axiom chart for top apps sorted by read counts
  This could be a pretty big log volume increase, is this ok?
* Add log for rate limiting on developer apps. This will be used to create an axiom chart for apps exceeding rate limits



### How Has This Been Tested?
Checked logs locally
