### PR TITLE
Fix relay rate limits

### DIFF
--- a/identity-service/relay-rate-limit.json
+++ b/identity-service/relay-rate-limit.json
@@ -110,13 +110,13 @@
     "whitelist": 1000
   },
   "CreateNotification": {
-    "owner": 0,
-    "app": 0,
+    "owner": -1,
+    "app": -1,
     "whitelist": 1000
   },
   "ViewNotification": {
     "owner": 100,
-    "app": 0,
+    "app": -1,
     "whitelist": 1000
   },
   "ViewPlaylistNotification": {
@@ -126,22 +126,22 @@
   },
   "CreateDeveloperApp": {
     "owner": 3,
-    "app": 0,
+    "app": -1,
     "whitelist": 1000
   },
   "DeleteDeveloperApp": {
     "owner": 3,
-    "app": 0,
+    "app": -1,
     "whitelist": 1000
   },
   "CreateGrant": {
     "owner": 5,
-    "app": 0,
+    "app": -1,
     "whitelist": 1000
   },
   "DeleteGrant": {
     "owner": 5,
-    "app": 0,
+    "app": -1,
     "whitelist": 1000
   }
 }


### PR DESCRIPTION
### Description

Some relay rate limits were set to 0 with the intention of blocking all requests, but this causes the rate limit to no-op. -1 is what we want

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
