### PR TITLE
[CON-811] Self-mark unhealthy when unable to query upload count

### DIFF
--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"errors"
 	"syscall"
 	"time"
 
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/exp/slog"
+	"gorm.io/gorm"
 )
 
 func (ss *MediorumServer) monitorCidCursors() {
@@ -38,13 +40,13 @@ func (ss *MediorumServer) updateDiskAndDbStatus() {
 		slog.Error("Error getting disk status", "err", err)
 	}
 
-	dbSize, err := getDatabaseSize(ss.pgPool)
-	if err == nil {
-		ss.databaseSize = dbSize
-	} else {
-		ss.databaseSize = 0
-		slog.Error("Error getting database size", "err", err)
-	}
+	dbSize, errStr := getDatabaseSize(ss.pgPool)
+	ss.databaseSize = dbSize
+	ss.dbSizeErr = errStr
+
+	uploadsCount, errStr := getUploadsCount(ss.crud.DB)
+	ss.uploadsCount = uploadsCount
+	ss.uploadsCountErr = errStr
 }
 
 func getDiskStatus(path string) (total uint64, free uint64, err error) {
@@ -59,13 +61,32 @@ func getDiskStatus(path string) (total uint64, free uint64, err error) {
 	return
 }
 
-func getDatabaseSize(p *pgxpool.Pool) (uint64, error) {
-	var size uint64
-	err := p.QueryRow(context.Background(), `SELECT pg_database_size(current_database())`).Scan(&size)
+func getDatabaseSize(p *pgxpool.Pool) (size uint64, errStr string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 
-	if err != nil {
-		return 0, err
+	if err := p.QueryRow(ctx, `SELECT pg_database_size(current_database())`).Scan(&size); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			errStr = "timeout getting database size within 1s: " + err.Error()
+		} else {
+			errStr = "error getting database size: " + err.Error()
+		}
 	}
 
-	return size, nil
+	return
+}
+
+func getUploadsCount(db *gorm.DB) (count int64, errStr string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := db.WithContext(ctx).Model(&Upload{}).Count(&count).Error; err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			errStr = "timeout getting uploads count within 2s: " + err.Error()
+		} else {
+			errStr = "error getting uploads count: " + err.Error()
+		}
+	}
+
+	return
 }

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -25,7 +25,7 @@ func (ss *MediorumServer) monitorCidCursors() {
 
 func (ss *MediorumServer) monitorDiskAndDbStatus() {
 	ss.updateDiskAndDbStatus()
-	ticker := time.NewTicker(2 * time.Minute)
+	ticker := time.NewTicker(3 * time.Minute)
 	for range ticker.C {
 		ss.updateDiskAndDbStatus()
 	}
@@ -77,12 +77,12 @@ func getDatabaseSize(p *pgxpool.Pool) (size uint64, errStr string) {
 }
 
 func getUploadsCount(db *gorm.DB) (count int64, errStr string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := db.WithContext(ctx).Model(&Upload{}).Count(&count).Error; err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			errStr = "timeout getting uploads count within 2s: " + err.Error()
+			errStr = "timeout getting uploads count within 30s: " + err.Error()
 		} else {
 			errStr = "error getting uploads count: " + err.Error()
 		}

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -45,7 +45,7 @@ func (ss *MediorumServer) getBlobInfo(c echo.Context) error {
 	}
 
 	// since this is called before redirecting, make sure this node can actually serve the blob (it needs to check db for delisted status)
-	dbHealthy := ss.databaseSize > 0
+	dbHealthy := ss.databaseSize > 0 && ss.dbSizeErr == "" && ss.uploadsCountErr == ""
 	if !dbHealthy {
 		return c.String(500, "database connection issue")
 	}

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -37,7 +37,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","cidCursors":null,"databaseSize":99999,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","cidCursors":null,"databaseSize":99999,"dbSizeErr":"","dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -5,10 +5,9 @@ import (
 )
 
 type Metrics struct {
-	Host         string         `json:"host"`
-	Uploads      int64          `json:"uploads"`
-	ProblemBlobs int64          `json:"problem_blobs"`
-	OutboxSizes  map[string]int `json:"outbox_sizes"`
+	Host        string         `json:"host"`
+	Uploads     int64          `json:"uploads"`
+	OutboxSizes map[string]int `json:"outbox_sizes"`
 }
 
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
@@ -17,7 +16,7 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 
 	var ucount int64
 	ss.crud.DB.Model(&Upload{}).Count(&ucount)
-	m.Uploads = ucount
+	m.Uploads = ss.uploadsCount
 
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
 

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -13,11 +13,7 @@ type Metrics struct {
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m := Metrics{}
 	m.Host = ss.Config.Self.Host
-
-	var ucount int64
-	ss.crud.DB.Model(&Upload{}).Count(&ucount)
 	m.Uploads = ss.uploadsCount
-
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
 
 	return c.JSON(200, m)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -85,8 +85,14 @@ type MediorumServer struct {
 	trustedNotifier *ethcontracts.NotifierInfo
 	storagePathUsed uint64
 	storagePathSize uint64
-	databaseSize    uint64
-	isSeeding       bool
+
+	databaseSize uint64
+	dbSizeErr    string
+
+	uploadsCount    int64
+	uploadsCountErr string
+
+	isSeeding bool
 
 	peerHealthMutex  sync.RWMutex
 	peerHealth       map[string]time.Time


### PR DESCRIPTION
### Description
Makes nodes self-mark as unhealthy when they're unable to count the # of upload records in db. Healthz shows that this is a proxy for general db health.

### How Has This Been Tested?
Deployed to stage cn9 and verified that the node was healthy and showed empty upload count errors.