### PR TITLE
Fix resolve to use slug/handle for collections

### DIFF
--- a/discovery-provider/integration_tests/api/v1/utils/resolve_url_test.py
+++ b/discovery-provider/integration_tests/api/v1/utils/resolve_url_test.py
@@ -25,10 +25,13 @@ def test_resolve_playlist_url(app):
     with app.test_request_context():
         db = get_db()
         with db.scoped_session() as session:
-            url = "https://audius.co/urbanbankai/playlist/up-next-atl-august-2020-9801"
+            url = "https://audius.co/urbanbankai/playlist/up-next-atl-august-2020"
             resolved_url = resolve_url(session, url)
 
-            assert resolved_url == "/v1/playlists/ePkW0"
+            assert (
+                resolved_url
+                == "/v1/playlists/by_permalink/urbanbankai/up-next-atl-august-2020"
+            )
 
 
 def test_resolve_non_fully_qualified_url(app):

--- a/discovery-provider/src/api/v1/playlists.py
+++ b/discovery-provider/src/api/v1/playlists.py
@@ -176,6 +176,35 @@ class FullPlaylist(Resource):
         return response
 
 
+@ns.route("/by_permalink/<string:handle>/<string:slug>")
+class PlaylistByHandleAndSlug(Resource):
+    @ns.doc(
+        id="""Get Playlist By Handle and Slug""",
+        description="""Get a playlist by handle and slug""",
+        params={"handle": "playlist owner handle", "slug": "playlist slug"},
+    )
+    @ns.expect(current_user_parser)
+    @ns.marshal_with(playlists_response)
+    @cache(ttl_sec=5)
+    def get(self, handle, slug):
+        args = current_user_parser.parse_args()
+        current_user_id = get_current_user_id(args)
+
+        route = {
+            "handle": handle,
+            "slug": slug,
+        }
+
+        playlist = get_playlist(current_user_id=current_user_id, route=route)
+        return_response = []
+        if playlist:
+            tracks = get_tracks_for_playlist(playlist["playlist_id"], current_user_id)
+            playlist["tracks"] = tracks
+            return_response = [playlist]
+
+        return success_response(return_response)
+
+
 @full_ns.route("/by_permalink/<string:handle>/<string:slug>")
 class FullPlaylistByHandleAndSlug(Resource):
     @ns.doc(

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -6,7 +6,6 @@ from typing import List
 from urllib.parse import urljoin
 
 import requests
-
 from flask import redirect
 from flask.globals import request
 from flask_restx import Namespace, Resource, fields, inputs, marshal, reqparse
@@ -509,7 +508,9 @@ class TrackStream(Resource):
             stream_url = urljoin(content_node, path)
             headers = {"Range": "bytes=0-1"}
             try:
-                response = requests.get(stream_url + "&skip_play_count=True", headers=headers, timeout=.5)
+                response = requests.get(
+                    stream_url + "&skip_play_count=True", headers=headers, timeout=0.5
+                )
                 if response.status_code == 206:
                     return stream_url
             except:

--- a/discovery-provider/src/api/v1/utils/resolve_url.py
+++ b/discovery-provider/src/api/v1/utils/resolve_url.py
@@ -39,7 +39,7 @@ def resolve_url(session, url):
         slug = match.group("slug")
         handle = match.group("handle")
         return ns_url_for(
-            playlists_ns, "full_playlist_by_handle_and_slug", slug=slug, handle=handle
+            playlists_ns, "playlist_by_handle_and_slug", slug=slug, handle=handle
         )
 
     match = user_url_regex.match(path)

--- a/discovery-provider/src/api/v1/utils/resolve_url.py
+++ b/discovery-provider/src/api/v1/utils/resolve_url.py
@@ -11,9 +11,7 @@ from src.models.users.user import User
 from src.utils.helpers import encode_int_id
 
 track_url_regex = re.compile(r"^/(?P<handle>[^/]*)/(?P<slug>[^/]*)$")
-playlist_url_regex = re.compile(
-    r"/(?P<handle>[^/]*)/(playlist|album)/(?P<track>[^/]*)(?=-)-(?P<id>[0-9]*)$"
-)
+playlist_url_regex = re.compile(r"/(?P<handle>[^/]*)/(playlist|album)/(?P<slug>[^/]*)$")
 user_url_regex = re.compile(r"^/(?P<handle>[^/]*)$")
 
 
@@ -38,9 +36,11 @@ def resolve_url(session, url):
 
     match = playlist_url_regex.match(path)
     if match:
-        playlist_id = match.group("id")
-        hashed_id = encode_int_id(int(playlist_id))
-        return ns_url_for(playlists_ns, "playlist", playlist_id=hashed_id)
+        slug = match.group("slug")
+        handle = match.group("handle")
+        return ns_url_for(
+            playlists_ns, "full_playlist_by_handle_and_slug", slug=slug, handle=handle
+        )
 
     match = user_url_regex.match(path)
     if match:


### PR DESCRIPTION
### Description

Resolve currently not working because slug/handle route isn't being used.
Probably should go out before client changes, but after/with migration to fix the special characters.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audius-compose up
audius-cmd create-user freddie_mercury
audius-cmd upload-track --from freddie_mercury --title "Bohemian Rhapsody"
audius-cmd create-playlist 961132438 --from freddie_mercury

curl http://audius-protocol-discovery-provider-1/v1/playlists/by_permalink/freddie_mercury/playlist-7123
curl http://audius-protocol-discovery-provider-1/v1/resolve?url=/freddie_mercury/playlist/playlist-7123
```
