### PR TITLE
[CON-817] Try cuckoo filter first for faster v2 lookup

### DIFF
--- a/mediorum/server/cuckoo.go
+++ b/mediorum/server/cuckoo.go
@@ -162,12 +162,11 @@ func (ss *MediorumServer) buildCuckoo() error {
 
 	cf := cuckoo.NewScalableCuckooFilter()
 
+	// TODO: blobs table would probably eventually change to something like: 1 table for all CIDs I have, and 1 table for all CIDs in the entire network (for repair.go)
 	rows, err := conn.Query(ctx, `
-	select distinct multihash from "Files" where type != 'track'
-	union all
-	select distinct "dirMultihash" from "Files" where "dirMultihash" is not null
+	select distinct key from blobs where host = $1
 	order by 1
-	`)
+	`, ss.Config.Self.Host)
 	if err != nil {
 		return err
 	}

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -166,7 +166,7 @@ func (ss *MediorumServer) hostHasBlob(host, key string) bool {
 	client := http.Client{
 		Timeout: time.Second,
 	}
-	u := apiPath(host, fmt.Sprintf("internal/blobs/%s/info", url.PathEscape(key)))
+	u := apiPath(host, fmt.Sprintf("internal/blobs/info/%s", url.PathEscape(key)))
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return false

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -288,17 +288,16 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	internalApi.GET("/cuckoo", ss.serveCuckoo)
 	internalApi.GET("/cuckoo/size", ss.serveCuckooSize)
-	internalApi.GET("/cuckoo/:cid", ss.serveCuckooLookup)
+	internalApi.GET("/cuckoo/:cid", ss.serveCuckooLookup, cidutil.UnescapeCidParam)
 
 	// internal: crud
 	internalApi.GET("/crud/sweep", ss.serveCrudSweep)
 	internalApi.POST("/crud/push", ss.serveCrudPush, middleware.BasicAuth(ss.checkBasicAuth))
 
-	// TODO: Remove these 2 old info routes
-	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation)
-	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo)
+	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation, cidutil.UnescapeCidParam)
+	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo, cidutil.UnescapeCidParam)
 
-	// new info routes
+	// TODO: remove
 	internalApi.GET("/blobs/:cid/location", ss.getBlobLocation, cidutil.UnescapeCidParam)
 	internalApi.GET("/blobs/:cid/info", ss.getBlobInfo, cidutil.UnescapeCidParam)
 


### PR DESCRIPTION
### Description
As we've migrated millions of Qm files to the v2 system, the blobs query on redirect is sometimes slow. This PR makes it so nodes use a cuckoo filter for fast lookup when redirecting for v2 files (or Qm files that were migrated into the v2 system). We still fall back to the existing blobs table query, and we use the same hostHasBlob check before redirecting to ensure we'll never redirect based on a cuckoo false positive.


Also:
- Removes expensive Files table query which briefly maxes out postgres CPU every hour
- Puts CID back at the end of the info route because some SPs' reverse proxies are url-unencoding slashes. Example: [figment8](https://audius-content-8.figment.io/internal/blobs/QmRirCtcym58PJv61nAy23zrcjqa6euT72aEcCN6VPa74t%2F150x150.jpg/location) and [audiusindex4](https://cn4.mainnet.audiusindex.org/internal/blobs/QmRirCtcym58PJv61nAy23zrcjqa6euT72aEcCN6VPa74t%2F150x150.jpg/location) are on the same version, but the CID check only works on the latter link


### How Has This Been Tested?
Will test querying on staging where a redirect is required.
