### PR TITLE
Fix activity sub-types for library endpoints PAY-1679

### DIFF
--- a/discovery-provider/src/api/v1/models/activities.py
+++ b/discovery-provider/src/api/v1/models/activities.py
@@ -3,7 +3,11 @@ from flask_restx.fields import MarshallingError
 from flask_restx.marshalling import marshal
 
 from .common import ns
-from .playlists import full_playlist_model, playlist_model
+from .playlists import (
+    full_playlist_model,
+    full_playlist_without_tracks_model,
+    playlist_model,
+)
 from .tracks import track, track_full
 
 
@@ -56,14 +60,17 @@ activity_model_full = ns.model(
     },
 )
 
-track_activity_model_full = ns.clone(
+library_track_activity_model_full = ns.clone(
     "track_activity_full",
     activity_model_full,
-    {"item": fields.Nested(track_full)},
+    {"item_type": fields.FormattedString("track"), "item": fields.Nested(track_full)},
 )
 
-collection_activity_model_full = ns.clone(
+library_collection_activity_model_full = ns.clone(
     "collection_activity_full",
     activity_model_full,
-    {"item": fields.Nested(full_playlist_model)},
+    {
+        "item_type": fields.FormattedString("playlist"),
+        "item": fields.Nested(full_playlist_without_tracks_model),
+    },
 )

--- a/discovery-provider/src/api/v1/models/playlists.py
+++ b/discovery-provider/src/api/v1/models/playlists.py
@@ -41,8 +41,9 @@ playlist_model = ns.model(
     },
 )
 
-full_playlist_model = ns.clone(
-    "playlist_full",
+
+full_playlist_without_tracks_model = ns.clone(
+    "playlist_full_without_tracks",
     playlist_model,
     {
         "blocknumber": fields.Integer(required=True),
@@ -59,9 +60,17 @@ full_playlist_model = ns.clone(
         ),
         "user_id": fields.String(required=True),
         "user": fields.Nested(user_model_full, required=True),
-        "tracks": fields.List(fields.Nested(track_full), required=True),
+        "tracks": fields.List(fields.Nested(track_full), required=False),
         "cover_art": fields.String,
         "cover_art_sizes": fields.String,
         "track_count": fields.Integer(required=True),
+    },
+)
+
+full_playlist_model = ns.clone(
+    "playlist_full",
+    full_playlist_without_tracks_model,
+    {
+        "tracks": fields.List(fields.Nested(track_full), required=True),
     },
 )

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Optional, Union
+from typing import Optional
 
 from eth_account.messages import encode_defunct
 from flask import request
@@ -46,8 +46,8 @@ from src.api.v1.helpers import (
 from src.api.v1.models.activities import (
     activity_model,
     activity_model_full,
-    collection_activity_model_full,
-    track_activity_model_full,
+    library_collection_activity_model_full,
+    library_track_activity_model_full,
 )
 from src.api.v1.models.common import favorite
 from src.api.v1.models.developer_apps import authorized_app, developer_app
@@ -741,13 +741,13 @@ favorites_response = make_response(
 track_library_full_response = make_full_response(
     "track_library_response_full",
     full_ns,
-    fields.List(fields.Nested(track_activity_model_full)),
+    fields.List(fields.Nested(library_track_activity_model_full)),
 )
 
 collection_library_full_response = make_full_response(
     "collection_library_response_full",
     full_ns,
-    fields.List(fields.Nested(collection_activity_model_full)),
+    fields.List(fields.Nested(library_collection_activity_model_full)),
 )
 
 


### PR DESCRIPTION
### Description
Generated types were not correct for new library endpoints
-ItemType was `object` instead of 'track' or 'playlist'
-CollectionActivity had `tracks` as required but endpoints were returning them as null so the generated SDK methods would fail due to a type error

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
