### PR TITLE
Fix album repost triggers

### DIFF
--- a/discovery-provider/ddl/functions/handle_repost.sql
+++ b/discovery-provider/ddl/functions/handle_repost.sql
@@ -17,6 +17,7 @@ begin
 
     entity_type := 'track';
   else
+    raise notice 'inserting';
     insert into aggregate_playlist (playlist_id, is_album)
     select p.playlist_id, p.is_album
     from playlists p

--- a/discovery-provider/ddl/functions/handle_repost.sql
+++ b/discovery-provider/ddl/functions/handle_repost.sql
@@ -17,7 +17,11 @@ begin
 
     entity_type := 'track';
   else
-    insert into aggregate_playlist (playlist_id, is_album) values (new.repost_item_id, new.repost_type = 'album') on conflict do nothing;
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.repost_item_id
+    on conflict do nothing;
 
     entity_type := 'playlist';
   end if;

--- a/discovery-provider/ddl/functions/handle_repost.sql
+++ b/discovery-provider/ddl/functions/handle_repost.sql
@@ -21,6 +21,7 @@ begin
     select p.playlist_id, p.is_album
     from playlists p
     where p.playlist_id = new.repost_item_id
+    and p.is_current
     on conflict do nothing;
 
     entity_type := 'playlist';

--- a/discovery-provider/ddl/functions/handle_repost.sql
+++ b/discovery-provider/ddl/functions/handle_repost.sql
@@ -17,7 +17,6 @@ begin
 
     entity_type := 'track';
   else
-    raise notice 'inserting';
     insert into aggregate_playlist (playlist_id, is_album)
     select p.playlist_id, p.is_album
     from playlists p

--- a/discovery-provider/ddl/functions/handle_save.sql
+++ b/discovery-provider/ddl/functions/handle_save.sql
@@ -17,7 +17,11 @@ begin
 
     entity_type := 'track';
   else
-    insert into aggregate_playlist (playlist_id, is_album) values (new.save_item_id, new.save_type = 'album') on conflict do nothing;
+    insert into aggregate_playlist (playlist_id, is_album)
+    select p.playlist_id, p.is_album
+    from playlists p
+    where p.playlist_id = new.repost_item_id
+    on conflict do nothing;
     
     entity_type := 'playlist';
   end if;

--- a/discovery-provider/ddl/functions/handle_save.sql
+++ b/discovery-provider/ddl/functions/handle_save.sql
@@ -20,7 +20,7 @@ begin
     insert into aggregate_playlist (playlist_id, is_album)
     select p.playlist_id, p.is_album
     from playlists p
-    where p.playlist_id = new.repost_item_id
+    where p.playlist_id = new.save_item_id
     and p.is_current
     on conflict do nothing;
     

--- a/discovery-provider/ddl/functions/handle_save.sql
+++ b/discovery-provider/ddl/functions/handle_save.sql
@@ -21,6 +21,7 @@ begin
     select p.playlist_id, p.is_album
     from playlists p
     where p.playlist_id = new.repost_item_id
+    and p.is_current
     on conflict do nothing;
     
     entity_type := 'playlist';

--- a/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
+++ b/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
@@ -5,7 +5,7 @@ update saves
 set
     save_type = 'playlist'
 where
-    save_type = 'album';
+    save_type = 'album'
     and (
         is_current = false
         or is_current = true
@@ -15,8 +15,11 @@ update reposts
 set
     repost_type = 'playlist'
 where
-    repost_type = 'album';
-
+    repost_type = 'album'
+    and (
+        is_current = false
+        or is_current = true
+    );
 -- remove dupes
 -- pick most recent row with is_current and delete others 
 with

--- a/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
+++ b/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
@@ -1,0 +1,85 @@
+begin;
+
+-- only use repost type playlist / track
+update saves
+set
+    save_type = 'playlist'
+where
+    save_type = 'album';
+    and (
+        is_current = false
+        or is_current = true
+    );
+
+update reposts
+set
+    repost_type = 'playlist'
+where
+    repost_type = 'album';
+
+-- remove dupes
+-- pick most recent row with is_current and delete others 
+with
+    max_blocknumbers as (
+        select
+            *
+        from
+            (
+                select
+                    repost_item_id,
+                    user_id,
+                    repost_type,
+                    max(blocknumber) as max_blocknumber,
+                    count(*) as current_count
+                from
+                    reposts
+                where
+                    is_current = true
+                group by
+                    repost_item_id,
+                    user_id,
+                    repost_type
+            ) a
+        where
+            a.current_count > 1
+    )
+delete from reposts using max_blocknumbers
+where
+    reposts.repost_item_id = max_blocknumbers.repost_item_id
+    and reposts.user_id = max_blocknumbers.user_id
+    and reposts.repost_type = max_blocknumbers.repost_type
+    and reposts.blocknumber < max_blocknumbers.max_blocknumber;
+
+with
+    max_blocknumbers as (
+        select
+            *
+        from
+            (
+                select
+                    save_item_id,
+                    user_id,
+                    save_type,
+                    max(blocknumber) as max_blocknumber,
+                    count(*) as current_count
+                from
+                    saves
+                where
+                    is_current = true
+                group by
+                    save_item_id,
+                    user_id,
+                    save_type
+            ) a
+        where
+            a.current_count > 1
+    )
+delete from saves using max_blocknumbers
+where
+    saves.save_item_id = max_blocknumbers.save_item_id
+    and saves.user_id = max_blocknumbers.user_id
+    and saves.save_type = max_blocknumbers.save_type
+    and saves.blocknumber < max_blocknumbers.max_blocknumber;
+
+
+commit;

--- a/discovery-provider/integration_tests/models/test_aggregate_counters.py
+++ b/discovery-provider/integration_tests/models/test_aggregate_counters.py
@@ -56,6 +56,8 @@ basic_entities = {
             },
         },
     ],
+}
+test_social_feature_entities = {
     "follows": [
         {
             "follower_user_id": 1,
@@ -79,6 +81,7 @@ def test_aggregate_counters(app):
         db = get_db()
 
     populate_mock_db(db, basic_entities)
+    populate_mock_db(db, test_social_feature_entities)
 
     with db.scoped_session() as session:
         agg_users: List[AggregateUser] = (

--- a/discovery-provider/integration_tests/queries/test_get_collections_library.py
+++ b/discovery-provider/integration_tests/queries/test_get_collections_library.py
@@ -45,6 +45,14 @@ def populate_entries(db):
                 "playlist_name": "xyz",
             },
         ],
+        "users": [
+            {"user_id": 1},
+            {"user_id": 2, "name": "testhandle123"},
+            {"user_id": 3},
+            {"user_id": 4},
+        ],
+    }
+    test_social_feature_entities = {
         "reposts": [
             {
                 "repost_item_id": 3,
@@ -61,14 +69,9 @@ def populate_entries(db):
                 "created_at": datetime(2019, 6, 16),
             }
         ],
-        "users": [
-            {"user_id": 1},
-            {"user_id": 2, "name": "testhandle123"},
-            {"user_id": 3},
-            {"user_id": 4},
-        ],
     }
     populate_mock_db(db, test_entities)
+    populate_mock_db(db, test_social_feature_entities)
 
 
 def with_collection_library_setup(test_fn):

--- a/discovery-provider/integration_tests/queries/test_populate_playlist_metadata.py
+++ b/discovery-provider/integration_tests/queries/test_populate_playlist_metadata.py
@@ -28,6 +28,8 @@ def test_populate_playlist_metadata(app):
             {"user_id": 3, "handle": "user3"},
             {"user_id": 4, "handle": "user4"},
         ],
+    }
+    test_social_feature_entities = {
         "reposts": [
             {"repost_item_id": 1, "repost_type": "playlist", "user_id": 2},
             {"repost_item_id": 1, "repost_type": "playlist", "user_id": 3},
@@ -46,6 +48,7 @@ def test_populate_playlist_metadata(app):
     }
 
     populate_mock_db(db, test_entities)
+    populate_mock_db(db, test_social_feature_entities)
 
     with db.scoped_session() as session:
         playlist_ids = [1, 2, 3, 4]

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -223,11 +223,8 @@ def test_index_valid_social_features(app, mocker):
             {"user_id": 2, "handle": "user-2", "wallet": "user2wallet"},
             {"user_id": 3, "handle": "user-3", "wallet": "user3wallet"},
         ],
-        "follows": [{"follower_user_id": 1, "followee_user_id": 3}],
-        "tracks": [{"track_id": 1, "owner_id": 11}],
-        "reposts": [{"repost_item_id": 1, "repost_type": "playlist", "user_id": 1}],
         "playlists": [{"playlist_id": 1, "playlist_owner_id": 11}],
-        "subscriptions": [{"subscriber_id": 3, "user_id": 2}],
+        "tracks": [{"track_id": 1, "owner_id": 11}],
         "developer_apps": [
             {
                 "user_id": 1,
@@ -243,7 +240,14 @@ def test_index_valid_social_features(app, mocker):
         ],
     }
 
+    test_social_feature_entities = {
+        "reposts": [{"repost_item_id": 1, "repost_type": "playlist", "user_id": 1}],
+        "subscriptions": [{"subscriber_id": 3, "user_id": 2}],
+        "follows": [{"follower_user_id": 1, "followee_user_id": 3}],
+    }
+
     populate_mock_db(db, entities)
+    populate_mock_db(db, test_social_feature_entities)
 
     with db.scoped_session() as session:
         # index transactions

--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -654,12 +654,15 @@ def test_index_entity_update_and_social_feature(app, mocker):
             for i in range(1, 13)
         ],
         "playlists": [{"playlist_id": 1, "playlist_owner_id": 10}],
+    }
+    social_feature_entities = {
         "reposts": [
             {"repost_item_id": 1, "repost_type": "playlist", "user_id": i}
             for i in range(1, 10)
         ],
     }
     populate_mock_db(db, entities)
+    populate_mock_db(db, social_feature_entities)
 
     with db.scoped_session() as session:
         # index transactions

--- a/discovery-provider/integration_tests/tasks/test_update_aggregates.py
+++ b/discovery-provider/integration_tests/tasks/test_update_aggregates.py
@@ -5,7 +5,6 @@ from integration_tests.utils import populate_mock_db
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.users.aggregate_user import AggregateUser
-from src.models.social.repost import Repost
 
 from src.tasks.update_aggregates import _update_aggregates
 from src.utils.db_session import get_db
@@ -111,8 +110,6 @@ def test_update_aggregate_playlist(app):
         aggregate_playlist = (
             session.query(AggregatePlaylist).filter_by(playlist_id=1).first()
         )
-        print(f"asdf reposts {session.query(Repost).all()}")
-        print(f"asdf aggregate_playlist {aggregate_playlist}")
         assert aggregate_playlist.playlist_id == 1
         assert aggregate_playlist.repost_count == 1
         assert aggregate_playlist.save_count == 1
@@ -126,7 +123,6 @@ def test_update_aggregate_playlist(app):
         aggregate_playlist = (
             session.query(AggregatePlaylist).filter_by(playlist_id=1).first()
         )
-        print(f"asdf aggregate_playlist {aggregate_playlist}")
         assert aggregate_playlist.playlist_id == 1
         assert aggregate_playlist.repost_count == 1
         assert aggregate_playlist.save_count == 1

--- a/discovery-provider/integration_tests/tasks/test_update_aggregates.py
+++ b/discovery-provider/integration_tests/tasks/test_update_aggregates.py
@@ -5,6 +5,8 @@ from integration_tests.utils import populate_mock_db
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.tracks.aggregate_track import AggregateTrack
 from src.models.users.aggregate_user import AggregateUser
+from src.models.social.repost import Repost
+
 from src.tasks.update_aggregates import _update_aggregates
 from src.utils.db_session import get_db
 
@@ -68,6 +70,8 @@ def test_update_aggregate_playlist(app):
             },
         ],
         "user": [{"user_id": 1}, {"user_id": 2}],
+    }
+    social_feature_entities = {
         "saves": [{"user_id": 2, "save_item_id": 1, "save_type": "playlist"}],
         "reposts": [
             {
@@ -93,6 +97,7 @@ def test_update_aggregate_playlist(app):
     }
 
     populate_mock_db(db, entities)
+    populate_mock_db(db, social_feature_entities)
 
     with db.scoped_session() as session:
         # verify triggers work
@@ -106,6 +111,8 @@ def test_update_aggregate_playlist(app):
         aggregate_playlist = (
             session.query(AggregatePlaylist).filter_by(playlist_id=1).first()
         )
+        print(f"asdf reposts {session.query(Repost).all()}")
+        print(f"asdf aggregate_playlist {aggregate_playlist}")
         assert aggregate_playlist.playlist_id == 1
         assert aggregate_playlist.repost_count == 1
         assert aggregate_playlist.save_count == 1
@@ -119,6 +126,7 @@ def test_update_aggregate_playlist(app):
         aggregate_playlist = (
             session.query(AggregatePlaylist).filter_by(playlist_id=1).first()
         )
+        print(f"asdf aggregate_playlist {aggregate_playlist}")
         assert aggregate_playlist.playlist_id == 1
         assert aggregate_playlist.repost_count == 1
         assert aggregate_playlist.save_count == 1

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -229,8 +229,8 @@ def configure_flask_app_logging(app, loglevel_str):
         request_user_id = request.headers.get("X-User-ID")
         if request_user_id:
             log_params["request_user_id"] = request_user_id
-        
-        request_app_name = request.args.get('app_name')
+
+        request_app_name = request.args.get("app_name")
         if request_app_name:
             log_params["appName"] = request_app_name
             logger.info("handle read via developer app", extra=log_params)


### PR DESCRIPTION
### Description
My fix https://github.com/AudiusProject/audius-protocol/pull/5467/files wasn't complete. That fix was intended to use album repost_type so the handle_repost trigger would recognize an album vs playlist.

The client still sends playlist entity type so existing reposts wouldn't be found https://github.com/AudiusProject/audius-protocol/blob/main/discovery-provider/src/tasks/entity_manager/entity_manager.py#L736-L737. This allows users to repost multiple times, bypassing the duplicate check.

This change modifies the trigger to just check the playlist table and use that to determine is_album instead of the repost_type. It also cleans up duplicate reposts and ensures we only use playlist repost_type.


### How Has This Been Tested?
Tested on sandbox. Migration took a while but worked ~ 5-10 mins.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
