### PR TITLE
[CON-818] Race mediorum redirects 5 at a time

### DIFF
--- a/mediorum/server/cuckoo.go
+++ b/mediorum/server/cuckoo.go
@@ -81,6 +81,22 @@ func (ss *MediorumServer) cuckooLookup(cid string) []string {
 	return hosts
 }
 
+func (ss *MediorumServer) cuckooLookupSubset(cid string, hostSubset []string) []string {
+	hosts := []string{}
+	cidBytes := []byte(cid)
+	cuckooMu.RLock()
+	for _, host := range hostSubset {
+		filter, ok := cuckooMap[host]
+		if ok && filter.Lookup(cidBytes) {
+			hosts = append(hosts, host)
+		} else if !ok {
+			ss.logger.Warn("cuckoo lookup subset: host not found", "host", host)
+		}
+	}
+	cuckooMu.RUnlock()
+	return hosts
+}
+
 func (ss *MediorumServer) startCuckooFetcher() error {
 	for {
 		for _, peer := range ss.Config.Peers {

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func (ss *MediorumServer) replicateFile(fileName string, file io.ReadSeeker) ([]string, error) {
@@ -160,8 +162,7 @@ func (ss *MediorumServer) replicateFileToHost(peer string, fileName string, file
 	return <-errChan
 }
 
-// this is a "quick check" that a host has a blob
-// used for checking host has blob before redirecting to it
+// hostHasBlob is a "quick check" that a host has a blob (used for checking host has blob before redirecting to it).
 func (ss *MediorumServer) hostHasBlob(host, key string) bool {
 	client := http.Client{
 		Timeout: time.Second,
@@ -178,6 +179,34 @@ func (ss *MediorumServer) hostHasBlob(host, key string) bool {
 	}
 	defer has.Body.Close()
 	return has.StatusCode == 200
+}
+
+// raceHostHasBlob tries batches of 5 hosts concurrently to find the first healthy host with the key instead of sequentially waiting for a 1s timeout from each host.
+func (ss *MediorumServer) raceHostHasBlob(key string, hostsWithKey []string) string {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+	hostWithKeyCh := make(chan string, 1)
+
+	for _, host := range hostsWithKey {
+		h := host
+		g.Go(func() error {
+			if ss.hostHasBlob(h, key) {
+				hostWithKeyCh <- h
+				cancel() // cancel the context on the first success
+			}
+			return nil
+		})
+	}
+
+	g.Wait()
+	select {
+	case host := <-hostWithKeyCh:
+		return host
+	default:
+		return ""
+	}
 }
 
 func (ss *MediorumServer) pullFileFromHost(host, cid string) error {


### PR DESCRIPTION
### Description
Redirects are still slow in many cases because they wait for a 1 second timeout when checking a node that's supposed to have the CID (but the node doesn't have it because of a cuckoo false-positive or because it's unhealthy but thinks it's healthy). This PR races 3 of these `hostHasBlob` checks at once to avoid this second of added latency from some redirects.

### How Has This Been Tested?
I'll test redirects like I did for https://github.com/AudiusProject/audius-protocol/pull/5764 on staging with CN9 and CN10 before merging.