### PR TITLE
PLAT-1173: move db initializers around

### DIFF
--- a/discovery-provider/plugins/pedalboard/packages/basekit/src/app.ts
+++ b/discovery-provider/plugins/pedalboard/packages/basekit/src/app.ts
@@ -3,8 +3,14 @@ import duration from "dayjs/plugin/duration";
 import { Knex, knex } from "knex";
 import { setIntervalAsync } from "set-interval-async";
 import { Table } from "storage/src/index";
+import { initializeDiscoveryDb, initializeIdentityDb } from "./db";
 
 dayjs.extend(duration);
+
+export interface AppParams {
+  discoveryDb: string,
+  identityDb: string
+}
 
 export default class App<AppData> {
   // database connections
@@ -28,23 +34,10 @@ export default class App<AppData> {
 
   private appData: AppData;
 
-  constructor(appData: AppData) {
-    this.discoveryDb = knex({
-      client: "pg",
-      connection: {
-        connectionString:
-          process.env.discoveryDb ||
-          "postgresql://postgres:postgres@localhost:5432/audius_discovery",
-      },
-    });
-    if (process.env.identityDb !== undefined) {
-      this.identityDb = knex({
-        client: "pg",
-        connection: {
-          connectionString: process.env.identityDb,
-        },
-      });
-    }
+  constructor(appData: AppData, params: Partial<AppParams>) {
+    const { discoveryDb, identityDb } = params
+    this.discoveryDb = initializeDiscoveryDb(discoveryDb);
+    this.identityDb = initializeIdentityDb(identityDb)
     this.listeners = new Map();
     this.scans = new Map();
     this.tickers = [];

--- a/discovery-provider/plugins/pedalboard/packages/basekit/src/db.ts
+++ b/discovery-provider/plugins/pedalboard/packages/basekit/src/db.ts
@@ -1,0 +1,49 @@
+/**
+ * Collection of database initialization utilities. Can be used in the app module or standalone.
+ */
+
+import knex, { Knex } from "knex";
+
+/**
+ * Establishes a connection to the discovery database. Starts out using the passed in connection string,
+ * then attempts to use `audius_db_url` env var, and lastly defaults to 'postgresql://postgres:postgres@db:5432/audius_discovery'.
+ * @param connectionString optional param to pass in a specific database url
+ * @returns knex object that's connected to the configured url
+ */
+export const initializeDiscoveryDb = (connectionString?: string): Knex => {
+    // will first use connection string, next try env var, third default to local pg string
+    const connection = connectionString || process.env.audius_db_url || "postgresql://postgres:postgres@db:5432/audius_discovery"
+    return knex({
+        client: "pg",
+        connection,
+    })
+}
+
+/**
+ * Establishes a connection to the discovery database. Starts out using the passed in connection string,
+ * then attempts to use `identity_db_url` env var, and lastly defaults to 'postgresql://postgres:postgres@db:5432/audius_identity_service'.
+ * @param connectionString optional param to pass in a specific database url
+ * @returns knex object that's connected to the configured url
+ */
+export const initializeIdentityDb = (connectionString?: string): Knex => {
+    // will first use connection string, next try env var, third default to local pg string
+    const connection = connectionString || process.env.identity_db_url || "postgresql://postgres:postgres@db:5432/audius_identity_service"
+    return knex({
+        client: "pg",
+        connection,
+    })
+}
+
+/**
+ * Creates a listener on a pg_notify topic and sends messages back to an async callback for any usage the implementor may need.
+ * @param db A knex connection to a postgres db.
+ * @param onMessage Callback that takes an async function and passes the typed message to it.
+ */
+export const listenOn = async <T>(db: Knex, onMessage: (db: Knex, msg: T) => Promise<void>): Promise<void> => {
+    const conn = await db.client.acquireConnection()
+    conn.on("notification", async (msg: any) => {
+        console.log(JSON.stringify(msg));
+        const { payload } = msg;
+        await onMessage(db, JSON.parse(payload))
+    });
+}

--- a/discovery-provider/plugins/pedalboard/packages/basekit/src/index.ts
+++ b/discovery-provider/plugins/pedalboard/packages/basekit/src/index.ts
@@ -1,1 +1,2 @@
 export { default as App } from "./app";
+export * from "./db"


### PR DESCRIPTION
### Description
moves db initializers to a place where they can be initialized in either app or on their own with ease
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
