### PR TITLE
[INF-437] Upgrade ci jobs to node 18.17

### DIFF
--- a/.circleci/src/jobs/release-audius-sdk.yml
+++ b/.circleci/src/jobs/release-audius-sdk.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
 resource_class: large
 docker:
-  - image: cimg/node:14.16
+  - image: cimg/node:18.17
 steps:
   - checkout
 

--- a/.circleci/src/jobs/release-governance.yml
+++ b/.circleci/src/jobs/release-governance.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/node:14.16
+  - image: cimg/node:18.17
 steps:
   - checkout
 


### PR DESCRIPTION
### Description

* Upgrade `release-audius-sdk` and `release-governance` to node 18.17

### How Has This Been Tested?

This one is kinda hard to test, will see if sdk beta releases are successful on main

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
