### PR TITLE
Move warn debug about unhealthy/aborted DN request to debug

### DIFF
--- a/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
+++ b/libs/src/sdk/services/DiscoveryNodeSelector/DiscoveryNodeSelector.ts
@@ -420,7 +420,7 @@ export class DiscoveryNodeSelector implements DiscoveryNodeSelectorService {
           this.logger.debug('health_check', endpoint, health, reason)
         } else if (health === HealthCheckStatus.UNHEALTHY) {
           this.unhealthyServices.add(endpoint)
-          this.logger.warn('health_check', endpoint, health, reason)
+          this.logger.debug('health_check', endpoint, health, reason)
         } else if (health === HealthCheckStatus.BEHIND) {
           this.unhealthyServices.add(endpoint)
           if (data) {


### PR DESCRIPTION
### Description

Makes basic app look pretty rough 

```
import { sdk } from "@audius/sdk";

const audiusSdk = sdk({
  apiKey: "xxx",
  apiSecret: "xxx",
});

const main = async () => {
  console.log('test')
}

main()
```

```
~/audius-dapp-demo node index.js
test
[audius-sdk][discovery-node-selector] health_check https://audius-discovery-15.cultur3stake.com unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://discovery-au-02.audius.openplayer.org unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://audius-metadata-4.figment.io unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://blockdaemon-audius-discovery-04.bdnodes.net unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://blockdaemon-audius-discovery-06.bdnodes.net unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://blockchange-audius-discovery-01.bdnodes.net unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://audius-discovery-15.cultur3stake.com unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://audius-discovery-11.cultur3stake.com unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://blockdaemon-audius-discovery-08.bdnodes.net unhealthy The user aborted a request.
[audius-sdk][discovery-node-selector] health_check https://audius.w3coins.io unhealthy The user aborted a request.
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
