### PR TITLE
[C-2947] Don't default services (except logger)

### DIFF
--- a/libs/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/libs/src/sdk/api/albums/AlbumsApi.test.ts
@@ -110,7 +110,7 @@ describe('AlbumsApi', () => {
     albums = new AlbumsApi(
       new Configuration(),
       new Storage({ storageNodeSelector, logger: new Logger() }),
-      new EntityManager(),
+      new EntityManager({ discoveryNodeSelector: new DiscoveryNodeSelector() }),
       auth,
       logger
     )

--- a/libs/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/libs/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -110,7 +110,7 @@ describe('PlaylistsApi', () => {
     playlists = new PlaylistsApi(
       new Configuration(),
       new Storage({ storageNodeSelector, logger: new Logger() }),
-      new EntityManager(),
+      new EntityManager({ discoveryNodeSelector: new DiscoveryNodeSelector() }),
       auth,
       new Logger()
     )

--- a/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -84,7 +84,7 @@ describe('TracksApi', () => {
       new Configuration(),
       new DiscoveryNodeSelector(),
       new Storage({ storageNodeSelector, logger: new Logger() }),
-      new EntityManager(),
+      new EntityManager({ discoveryNodeSelector: new DiscoveryNodeSelector() }),
       auth,
       new Logger()
     )

--- a/libs/src/sdk/api/users/UsersApi.test.ts
+++ b/libs/src/sdk/api/users/UsersApi.test.ts
@@ -56,7 +56,7 @@ describe('UsersApi', () => {
     users = new UsersApi(
       new Configuration(),
       new Storage({ storageNodeSelector, logger: new Logger() }),
-      new EntityManager(),
+      new EntityManager({ discoveryNodeSelector: new DiscoveryNodeSelector() }),
       auth,
       new Logger()
     )

--- a/libs/src/sdk/services/EntityManager/EntityManager.ts
+++ b/libs/src/sdk/services/EntityManager/EntityManager.ts
@@ -24,6 +24,7 @@ import {
   ManageEntityOptions
 } from './types'
 import type { LoggerService } from '../Logger'
+import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 
 export class EntityManager implements EntityManagerService {
   /**
@@ -31,12 +32,15 @@ export class EntityManager implements EntityManagerService {
    */
   private readonly config: EntityManagerConfigInternal
 
+  private readonly discoveryNodeSelector: DiscoveryNodeSelectorService
+
   private readonly contract: Contract
   private readonly web3: Web3Type
   private readonly logger: LoggerService
 
-  constructor(config?: EntityManagerConfig) {
+  constructor(config: EntityManagerConfig) {
     this.config = mergeConfigWithDefaults(config, defaultEntityManagerConfig)
+    this.discoveryNodeSelector = config.discoveryNodeSelector
     this.web3 = new Web3(
       new Web3.providers.HttpProvider(this.config.web3ProviderUrl, {
         timeout: 10000
@@ -150,8 +154,7 @@ export class EntityManager implements EntityManagerService {
     confirmationPollingInterval?: number
   }) {
     const confirmBlock = async () => {
-      const endpoint =
-        await this.config.discoveryNodeSelector.getSelectedEndpoint()
+      const endpoint = await this.discoveryNodeSelector.getSelectedEndpoint()
       const {
         data: { block_passed }
       } = await (
@@ -196,7 +199,7 @@ export class EntityManager implements EntityManagerService {
       return this.config.identityServiceUrl
     }
     const discoveryEndpoint =
-      await this.config.discoveryNodeSelector.getSelectedEndpoint()
+      await this.discoveryNodeSelector.getSelectedEndpoint()
     if (discoveryEndpoint === null) {
       return this.config.identityServiceUrl
     }

--- a/libs/src/sdk/services/EntityManager/constants.ts
+++ b/libs/src/sdk/services/EntityManager/constants.ts
@@ -1,13 +1,11 @@
 import type { EntityManagerConfigInternal } from './types'
 import { productionConfig } from '../../config'
-import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import { Logger } from '../Logger'
 
 export const defaultEntityManagerConfig: EntityManagerConfigInternal = {
   contractAddress: productionConfig.entityManagerContractAddress,
   web3ProviderUrl: productionConfig.web3ProviderUrl,
   identityServiceUrl: productionConfig.identityServiceUrl,
-  discoveryNodeSelector: new DiscoveryNodeSelector(),
   useDiscoveryRelay: false,
   logger: new Logger()
 }

--- a/libs/src/sdk/services/EntityManager/types.ts
+++ b/libs/src/sdk/services/EntityManager/types.ts
@@ -17,10 +17,6 @@ export type EntityManagerConfigInternal = {
    */
   identityServiceUrl: string
   /**
-   * The DiscoveryNodeSelector service used to get a discovery node to confirm blocks
-   */
-  discoveryNodeSelector: DiscoveryNodeSelectorService
-  /**
    * Whether to use discovery for relay instead of identity
    */
   useDiscoveryRelay: boolean
@@ -29,7 +25,12 @@ export type EntityManagerConfigInternal = {
    */
   logger: LoggerService
 }
-export type EntityManagerConfig = Partial<EntityManagerConfigInternal>
+export type EntityManagerConfig = Partial<EntityManagerConfigInternal> & {
+  /**
+   * The DiscoveryNodeSelector service used to get a discovery node to confirm blocks
+   */
+  discoveryNodeSelector: DiscoveryNodeSelectorService
+}
 
 export type EntityManagerService = {
   manageEntity: (

--- a/libs/src/sdk/services/Storage/Storage.ts
+++ b/libs/src/sdk/services/Storage/Storage.ts
@@ -35,7 +35,7 @@ export class Storage implements StorageService {
 
   constructor(config: StorageServiceConfig) {
     this.config = mergeConfigWithDefaults(config, defaultStorageServiceConfig)
-    this.storageNodeSelector = this.config.storageNodeSelector
+    this.storageNodeSelector = config.storageNodeSelector
     this.logger = this.config.logger.createPrefixedLogger('[storage]')
   }
 

--- a/libs/src/sdk/services/Storage/constants.ts
+++ b/libs/src/sdk/services/Storage/constants.ts
@@ -1,12 +1,7 @@
 import { Logger } from '../Logger'
-import { StorageNodeSelector } from '../StorageNodeSelector'
-import { defaultStorageNodeSelectorConfig } from '../StorageNodeSelector/constants'
 import type { StorageServiceConfigInternal } from './types'
 
 export const defaultStorageServiceConfig: StorageServiceConfigInternal = {
-  storageNodeSelector: new StorageNodeSelector(
-    defaultStorageNodeSelectorConfig
-  ),
   logger: new Logger()
 }
 

--- a/libs/src/sdk/services/Storage/types.ts
+++ b/libs/src/sdk/services/Storage/types.ts
@@ -5,16 +5,15 @@ import type { LoggerService } from '../Logger'
 
 export type StorageServiceConfigInternal = {
   /**
-   * The StorageNodeSelector service used to get the relevant storage node for content
-   */
-  storageNodeSelector: StorageNodeSelectorService
-  /**
    * Logger service, defaults to console
    */
   logger: LoggerService
 }
 
 export type StorageServiceConfig = Partial<StorageServiceConfigInternal> & {
+  /**
+   * The StorageNodeSelector service used to get the relevant storage node for content
+   */
   storageNodeSelector: StorageNodeSelectorService
 }
 

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -32,12 +32,13 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
       config,
       defaultStorageNodeSelectorConfig
     )
-    this.auth = this.config.auth
+    this.discoveryNodeSelector = config.discoveryNodeSelector
+    this.auth = config.auth
+
     this.logger = this.config.logger.createPrefixedLogger(
       '[storage-node-selector]'
     )
     this.nodes = this.config.bootstrapNodes ?? []
-    this.discoveryNodeSelector = this.config.discoveryNodeSelector
 
     this.discoveryNodeSelector?.addEventListener(
       'change',

--- a/libs/src/sdk/services/StorageNodeSelector/constants.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/constants.ts
@@ -1,13 +1,9 @@
 import { productionConfig } from '../../config'
-import { Auth } from '../Auth/Auth'
-import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import { Logger } from '../Logger'
 import type { StorageNodeSelectorConfigInternal } from './types'
 
 export const defaultStorageNodeSelectorConfig: StorageNodeSelectorConfigInternal =
   {
     bootstrapNodes: productionConfig.storageNodes,
-    auth: new Auth(),
-    discoveryNodeSelector: new DiscoveryNodeSelector(),
     logger: new Logger()
   }

--- a/libs/src/sdk/services/StorageNodeSelector/types.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/types.ts
@@ -18,15 +18,6 @@ export type StorageNodeSelectorConfigInternal = {
    */
   bootstrapNodes: StorageNode[]
   /**
-   * The Authentication service, used to get the user's wallet for rendevous calculations
-   */
-  auth: Auth
-  /**
-   * DiscoveryNodeSelector instance being used, so that the node can listen for
-   * selection events and update its healthy storage node list
-   */
-  discoveryNodeSelector: DiscoveryNodeSelectorService
-  /**
    * Logger service, defaults to console logging
    */
   logger: LoggerService
@@ -34,6 +25,14 @@ export type StorageNodeSelectorConfigInternal = {
 
 export type StorageNodeSelectorConfig =
   Partial<StorageNodeSelectorConfigInternal> & {
+    /**
+     * The Authentication service, used to get the user's wallet for rendevous calculations
+     */
     auth: Auth
+
+    /**
+     * DiscoveryNodeSelector instance being used, so that the node can listen for
+     * selection events and update its healthy storage node list
+     */
     discoveryNodeSelector: DiscoveryNodeSelectorService
   }


### PR DESCRIPTION
### Description

On staging, we were seeing logs for health checks on production. This is because we create default services _before_ checking if they're needed. 

In `Storage`, we require `StorageNodeSelector`. Despite it not being needed, since we pass in our own `storageNodeSelector` via config, we initialize a new default `StorageNodeSelector` in our `defaultStorageConfig` and then use object spreading to override that default one with our defined one.

In `StorageNodeSelector`, we require a `DiscoveryNodeSelector`, and default to a prod `DiscoveryNodeSelector`, and in `StorageNodeSelector` we immediately invoke `getSelectedNode()`. Though we specified a `DiscoveryNodeSelector` in the SDK config, the _default_ `StorageNodeSelector` initializes a _default_ `DiscoveryNodeSelector`, so we get the production logs in staging despite us not using the default services.

We have two options:
1. This PR: Never default these services, and always require them to be passed in.
2. Alternatively: Don't use the object spreading/separate default object technique and manually check for each and every service, defaulting if necessary

I lean towards option 1. It helps make the dependencies explicit, and prevents user error by forgetting to inject a dependency and accidentally initializing prod services when they don't mean to. This does, however, introduce a few breaking type changes. That said, our third party users should not be using our services directly, but via the `sdk` root object.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
