### PR TITLE
[CON-819] Cache image lookup and add timing headers

### DIFF
--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -330,6 +330,7 @@ func (ss *MediorumServer) MustStart() {
 
 	go ss.startCuckooBuilder()
 	go ss.startCuckooFetcher()
+	go ss.buildUploadsCache()
 
 	// for any background task that make authenticated peer requests
 	// only start if we have a valid registered wallet

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -330,6 +330,7 @@ func (ss *MediorumServer) MustStart() {
 
 	go ss.startCuckooBuilder()
 	go ss.startCuckooFetcher()
+	createUploadsCache()
 	go ss.buildUploadsCache()
 
 	// for any background task that make authenticated peer requests

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -65,6 +65,7 @@ func (ss *MediorumServer) startTranscoder() {
 			return
 		}
 		for _, upload := range *uploads {
+			uploadsCache.Set(upload.ID, upload.TranscodeResults)
 			// only the first mirror transcodes
 			if upload.Status == JobStatusNew && slices.Index(upload.Mirrors, myHost) == 0 {
 				ss.logger.Info("got transcode job", "id", upload.ID)
@@ -85,6 +86,7 @@ func (ss *MediorumServer) startTranscoder() {
 			return
 		}
 		for _, upload := range *uploads {
+			uploadsCache.Set(upload.ID, upload.TranscodeResults)
 			if upload.Status == JobStatusRetranscode {
 				if upload.TranscodedMirrors == nil {
 					ss.logger.Warn("missing full transcoded mp3 data in retranscode job. skipping", "id", upload.ID)
@@ -466,6 +468,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 	if upload.Status == JobStatusBusyRetranscode {
 		// Re-transcode previews off the 320kbps downsample
 		fileHash = upload.TranscodeResults["320"]
+		uploadsCache.Set(upload.ID, upload.TranscodeResults)
 	}
 
 	logger := ss.logger.With("template", upload.Template, "cid", fileHash)
@@ -510,6 +513,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 
 			variantName := fmt.Sprintf("%dx%[1]d.jpg", targetBox)
 			upload.TranscodeResults[variantName] = resultHash
+			uploadsCache.Set(upload.ID, upload.TranscodeResults)
 		}
 
 	case JobTemplateImgBackdrop:
@@ -530,6 +534,7 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 
 			variantName := fmt.Sprintf("%dx.jpg", targetWidth)
 			upload.TranscodeResults[variantName] = resultHash
+			uploadsCache.Set(upload.ID, upload.TranscodeResults)
 		}
 
 	case JobTemplateAudio, "":

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -468,7 +468,6 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 	if upload.Status == JobStatusBusyRetranscode {
 		// Re-transcode previews off the 320kbps downsample
 		fileHash = upload.TranscodeResults["320"]
-		uploadsCache.Set(upload.ID, upload.TranscodeResults)
 	}
 
 	logger := ss.logger.With("template", upload.Template, "cid", fileHash)


### PR DESCRIPTION
### Description
- Adds cache to avoid hitting the db for every image (only caches the uploads `:jobId/:variant` mapping, not responses)
- Adds timing headers to image requests to expose slow steps. Examples (may need to add queryparam to bypass Cloudflare cache when testing):
  - [this](https://usermetadata.audius.co/content/QmWX4bbsPoSikz129PsUu9i6oqqMfZ3Tv1pABjMVY7qiqF/150x150.jpg) has plenty of healthy hosts in the fast, in-memory cuckoo lookup, but it still takes 1.5s to redirect even from a beefy node
  - [this](https://audius-content-8.cultur3stake.com/content/01H7DM30TZWPBBTDWJJ614AEYH/150x150.jpg) is extremely slow (8 seconds) because culturestake isn't aware of the upload because another culturestake node did the transcoding and has a messed up DNS or reverse proxy

### How Has This Been Tested?
Check the headers where this is running on stage CN9:
* https://creatornode9.staging.audius.co/content/QmehGdgb1UoRk69WZsiN34Yt4i3uPPQcwMyyucGmXMDj3Q/150x150.jpg
* https://creatornode9.staging.audius.co/content/SHU36LPYMA3RPFYQJTJEWHEIZSYAD4W3/150x150.jpg

After merging to staging it wouldn't hurt to test an upload while watching the Network tab.