### PR TITLE
[CON-823] Deprecate serving from non-CDK disk

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -68,6 +68,34 @@ func (ss *MediorumServer) ensureNotDelisted(next echo.HandlerFunc) echo.HandlerF
 	}
 }
 
+func (ss *MediorumServer) getBlobDeprecated(c echo.Context) error {
+	cid := c.Param("cid")
+
+	// the only keys we store with ".jpg" suffixes are of the format "<cid>/<size>.jpg", so remove the ".jpg" if it's just like "<cid>.jpg"
+	// this is to support clients that forget to leave off the .jpg for this legacy format
+	if strings.HasSuffix(cid, ".jpg") && !strings.Contains(cid, "/") {
+		cid = cid[:len(cid)-4]
+
+		// find and replace cid parameter for future calls
+		names := c.ParamNames()
+		values := c.ParamValues()
+		for i, name := range names {
+			if name == "cid" {
+				values[i] = cid
+			}
+		}
+
+		// set parameters back to the context
+		c.SetParamNames(names...)
+		c.SetParamValues(values...)
+	}
+
+	if cidutil.IsLegacyCID(cid) {
+		return ss.serveLegacyCid(c)
+	}
+	return c.String(404, "blob not found")
+}
+
 func (ss *MediorumServer) getBlob(c echo.Context) error {
 	ctx := c.Request().Context()
 	cid := c.Param("cid")
@@ -142,14 +170,17 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	host, err := ss.findNodeToServeBlob(cid)
 	if err == nil && host != "" {
 		dest := ss.replaceHost(c, host)
+		query := dest.Query()
+		query.Add("allow_unhealthy", "true") // we confirmed the node has it, so allow it to serve it even if unhealthy
+		dest.RawQuery = query.Encode()
 		return c.Redirect(302, dest.String())
 	}
 
 	// TODO: remove this legacy fallback once we've migrated all Qm keys to CDK buckets
-	if cidutil.IsLegacyCID(cid) {
-		logger.Debug("serving legacy cid")
-		return ss.serveLegacyCid(c)
-	}
+	// if cidutil.IsLegacyCID(cid) {
+	// 	logger.Debug("serving legacy cid")
+	// 	return ss.serveLegacyCid(c)
+	// }
 
 	if err != nil {
 		logger.Warn("error finding node to serve blob", "err", err)
@@ -180,7 +211,19 @@ func (ss *MediorumServer) findNodeToServeBlob(key string) (string, error) {
 		fallbackHealthyHosts = append(fallbackHealthyHosts, blob.Host)
 	}
 	fallbackHostWithBlob := ss.raceHostHasBlob(key, fallbackHealthyHosts)
-	return fallbackHostWithBlob, nil
+	if fallbackHostWithBlob != "" {
+		return fallbackHostWithBlob, nil
+	}
+
+	// try unhealthy hosts as a last resort
+	unhealthyHosts := []string{}
+	for _, peer := range ss.Config.Peers {
+		if peer.Host != ss.Config.Self.Host && !slices.Contains(healthyHosts, peer.Host) {
+			unhealthyHosts = append(unhealthyHosts, peer.Host)
+		}
+	}
+	unhealthyHostWithBlob := ss.raceHostHasBlob(key, unhealthyHosts)
+	return unhealthyHostWithBlob, nil
 }
 
 func (ss *MediorumServer) logTrackListen(c echo.Context) {

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -156,6 +156,11 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 
 func (ss *MediorumServer) requireHealthy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		allowUnhealthy, _ := strconv.ParseBool(c.QueryParam("allow_unhealthy"))
+		if allowUnhealthy {
+			return next(c)
+		}
+
 		if !ss.Config.WalletIsRegistered {
 			return c.JSON(506, "wallet not registered")
 		}

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -313,6 +313,15 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 	return c.JSON(200, uploads)
 }
 
+// TODO: remove after confirming files didn't start go missing
+func (ss *MediorumServer) getBlobByJobIDAndVariantDeprecated(c echo.Context) error {
+	jobID := c.Param("jobID")
+	variant := c.Param("variant")
+	c.SetParamNames("dirCid", "fileName")
+	c.SetParamValues(jobID, variant)
+	return ss.serveLegacyDirCid(c)
+}
+
 func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 	// if the client provided a filename, set it in the header to be auto-populated in download prompt
 	filenameForDownload := c.QueryParam("filename")
@@ -348,19 +357,24 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 		if err != nil {
 			c.Response().Header().Set("x-find-node-err", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			// TODO: remove this legacy fallback once we've migrated all Qm CIDs to CDK buckets. return `err` instead
-			c.SetParamNames("dirCid", "fileName")
-			c.SetParamValues(jobID, variant)
-			return ss.serveLegacyDirCid(c)
+			// c.SetParamNames("dirCid", "fileName")
+			// c.SetParamValues(jobID, variant)
+			// return ss.serveLegacyDirCid(c)
+			return err
 		} else if host != "" {
 			c.Response().Header().Set("x-find-node-success", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			dest := ss.replaceHost(c, host)
+			query := dest.Query()
+			query.Add("allow_unhealthy", "true") // we confirmed the node has it, so allow it to serve it even if unhealthy
+			dest.RawQuery = query.Encode()
 			return c.Redirect(302, dest.String())
 		} else {
 			c.Response().Header().Set("x-find-node-not-found", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			// TODO: remove this legacy fallback once we've migrated all Qm CIDs to CDK buckets
-			c.SetParamNames("dirCid", "fileName")
-			c.SetParamValues(jobID, variant)
-			return ss.serveLegacyDirCid(c)
+			// c.SetParamNames("dirCid", "fileName")
+			// c.SetParamValues(jobID, variant)
+			// return ss.serveLegacyDirCid(c)
+			return c.String(404, fmt.Sprintf("no host found for %s/%s", jobID, variant))
 		}
 	} else {
 		// TODO: remove cache once metadata has only CIDs and no jobIds/variants, so then we won't need a db lookup

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -259,7 +259,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/uploads/:id", ss.getUpload, ss.requireHealthy)
 	routes.POST("/uploads/:id", ss.updateUpload, ss.requireHealthy, ss.requireUserSignature)
 	routes.POST("/uploads", ss.postUpload, ss.requireHealthy)
-	// Workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
+	// workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
 	routes.OPTIONS("/uploads", func(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	})
@@ -281,6 +281,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 			"data": c.RealIP(), // client/requestor IP
 		})
 	})
+
+	// TODO: remove deprecated routes
+	routes.GET("/deprecated/:cid", ss.getBlobDeprecated, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.GET("/deprecated/:jobID/:variant", ss.getBlobByJobIDAndVariantDeprecated, ss.requireHealthy)
 
 	// -------------------
 	// internal


### PR DESCRIPTION
### Description
- Stops serving content from non-CDK disk, and adds deprecated route to test serving from non-CDK disk if needed
- Allows unhealthy nodes to serve content as a last resort when they're confirmed to have it and able to query their db (required to check for delist status)

### How Has This Been Tested?
Will soak on staging to confirm images and tracks continue to be served as expected.
