### PR TITLE
Fix broken trending playlist test

### DIFF
--- a/discovery-provider/integration_tests/challenges/test_trending_challenge.py
+++ b/discovery-provider/integration_tests/challenges/test_trending_challenge.py
@@ -327,4 +327,4 @@ def test_trending_challenge_job(app):
             .filter(TrendingResult.type == str(TrendingType.PLAYLISTS))
             .all()
         )
-        assert len(trending_playlists) == 4
+        assert len(trending_playlists) == 2


### PR DESCRIPTION
### Description

Test was broken in https://github.com/AudiusProject/audius-protocol/commit/b70e97308e43bc85f04df2f17ea1e00b80d52715

Two of the test case playlists are no longer valid because they do not container >= 3 tracks from other artists besides themselves.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tests pass