### PR TITLE
[PAY-1643] Re-add support for track library filter query

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_track_library.py
+++ b/discovery-provider/integration_tests/queries/test_get_track_library.py
@@ -418,15 +418,15 @@ def test_all_filter(session):
 def test_tracks_query(session):
     # Test it with all query path
     # TODO: [PAY-1643] Enable this test again
-    # args = GetTrackLibraryArgs(
-    #     user_id=1287290,
-    #     current_user_id=1287290,
-    #     limit=10,
-    #     offset=0,
-    #     filter_type=LibraryFilterType.all,
-    #     filter_deleted=False,
-    #     query="some_title",
-    # )
+    args = GetTrackLibraryArgs(
+        user_id=1287290,
+        current_user_id=1287290,
+        limit=10,
+        offset=0,
+        filter_type=LibraryFilterType.all,
+        filter_deleted=False,
+        query="some_title",
+    )
 
     # track_library = _get_track_library(args, session)
     # assert len(track_library) == 1, "should return 1 track"

--- a/discovery-provider/src/queries/get_track_library.py
+++ b/discovery-provider/src/queries/get_track_library.py
@@ -1,7 +1,6 @@
 from typing import Optional, TypedDict, cast
 
 from sqlalchemy import asc, desc, func, or_
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.functions import coalesce, max
@@ -24,9 +23,6 @@ from src.queries.query_helpers import (
 )
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
-from src.utils.structured_logger import StructuredLogger
-
-logger = StructuredLogger(__name__)
 
 
 class GetTrackLibraryArgs(TypedDict):

--- a/discovery-provider/src/queries/get_track_library.py
+++ b/discovery-provider/src/queries/get_track_library.py
@@ -1,8 +1,7 @@
-from typing import Optional, TypedDict, cast
+from typing import Optional, TypedDict
 
 from sqlalchemy import asc, desc, func, or_
 from sqlalchemy.orm import contains_eager
-from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.functions import coalesce, max
 
 from src.models.social.aggregate_plays import AggregatePlay
@@ -159,9 +158,7 @@ def _get_track_library(args: GetTrackLibraryArgs, session):
             .options(contains_eager(TrackWithAggregates.user))
             .filter(
                 or_(
-                    cast(ColumnElement, TrackWithAggregates.title).ilike(
-                        f"%{query.lower()}%"
-                    ),
+                    TrackWithAggregates.title.ilike(f"%{query.lower()}%"),
                     User.name.ilike(f"%{query.lower()}%"),
                 )
             )
@@ -169,9 +166,7 @@ def _get_track_library(args: GetTrackLibraryArgs, session):
 
     # Set sort methods
     if sort_method == SortMethod.title:
-        base_query = base_query.order_by(
-            sort_fn(cast(ColumnElement, TrackWithAggregates.title))
-        )
+        base_query = base_query.order_by(sort_fn(TrackWithAggregates.title))
     elif sort_method == SortMethod.artist_name:
         base_query = base_query.join(TrackWithAggregates.user, aliased=True).order_by(
             sort_fn(User.name)

--- a/discovery-provider/src/queries/get_track_library.py
+++ b/discovery-provider/src/queries/get_track_library.py
@@ -1,9 +1,10 @@
-from typing import Optional, Type, TypedDict, cast
+from typing import Optional, TypedDict, cast
 
-from sqlalchemy import asc, desc, func, or_, text
-from sqlalchemy.orm import aliased
+from sqlalchemy import asc, desc, func, or_
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import contains_eager
 from sqlalchemy.sql.expression import ColumnElement
-from sqlalchemy.sql.functions import coalesce
+from sqlalchemy.sql.functions import coalesce, max
 
 from src.models.social.aggregate_plays import AggregatePlay
 from src.models.social.repost import Repost, RepostType
@@ -23,6 +24,9 @@ from src.queries.query_helpers import (
 )
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
+from src.utils.structured_logger import StructuredLogger
+
+logger = StructuredLogger(__name__)
 
 
 class GetTrackLibraryArgs(TypedDict):
@@ -86,106 +90,94 @@ def _get_track_library(args: GetTrackLibraryArgs, session):
     # union them together and remove duplicate track IDs.
     #
     # It's a straight forward approach with a few SQLALchemy gotchas - namely
-    # that in the case of querying 'all', we need to alias the TrackWithAggregates table
-    # to avoid accidentally joining on TrackWithAggregates, and in subsequent query building logic
-    # conditionally refer to either the aliased TrackWithAggregatesAlias table or the raw TrackWithAggregates table
-    # to avoid an accidental join.
+    # we have to use contains_eager when including the user for the query filter so that it doesn't get joined twice
 
-    favorites_base = (
-        session.query(TrackWithAggregates, Save.created_at.label("item_created_at"))
-        .join(Save, Save.save_item_id == TrackWithAggregates.track_id)
-        .filter(
-            TrackWithAggregates.is_current == True,
-            Save.user_id == user_id,
-            Save.is_current == True,
-            Save.is_delete == False,
-            Save.save_type == SaveType.track,
-        )
+    favorites_base = session.query(
+        Save.save_item_id.label("item_id"), Save.created_at.label("item_created_at")
+    ).filter(
+        Save.user_id == user_id,
+        Save.is_current == True,
+        Save.is_delete == False,
+        Save.save_type == SaveType.track,
     )
-    reposts_base = (
-        session.query(TrackWithAggregates, Repost.created_at.label("item_created_at"))
-        .join(Repost, Repost.repost_item_id == TrackWithAggregates.track_id)
-        .filter(
-            TrackWithAggregates.is_current == True,
-            Repost.user_id == user_id,
-            Repost.is_current == True,
-            Repost.is_delete == False,
-            Repost.repost_type == RepostType.track,
-        )
+    reposts_base = session.query(
+        Repost.repost_item_id.label("item_id"),
+        Repost.created_at.label("item_created_at"),
+    ).filter(
+        Repost.user_id == user_id,
+        Repost.is_current == True,
+        Repost.is_delete == False,
+        Repost.repost_type == RepostType.track,
     )
-    purchase_base = (
-        session.query(
-            TrackWithAggregates, USDCPurchase.created_at.label("item_created_at")
-        )
-        .join(
-            USDCPurchase,
-            USDCPurchase.content_id == TrackWithAggregates.track_id,
-        )
-        .filter(
-            TrackWithAggregates.is_current == True,
-            USDCPurchase.content_type == "track",
-            USDCPurchase.buyer_user_id == user_id,
-        )
+    purchase_base = session.query(
+        USDCPurchase.content_id.label("item_id"),
+        USDCPurchase.created_at.label("item_created_at"),
+    ).filter(
+        USDCPurchase.content_type == "track",
+        USDCPurchase.buyer_user_id == user_id,
     )
 
     # Construct all query
     # Union the three base queries together, and remove duplicate track IDs,
     # select from union as a subquery.
-    subquery = (
-        (favorites_base.union_all(reposts_base, purchase_base))
-        .distinct(TrackWithAggregates.track_id)
-        .order_by(TrackWithAggregates.track_id)
-    ).subquery()
-
-    # Alias needs a type hint
-    TrackWithAggregatesAlias = cast(
-        Type[TrackWithAggregates], aliased(TrackWithAggregates, subquery)
+    union_subquery = favorites_base.union_all(reposts_base, purchase_base).subquery(
+        name="union_subquery"
+    )
+    all_base = (
+        session.query(
+            union_subquery.c.item_id,
+            max(union_subquery.c.item_created_at).label("item_created_at"),
+        )
+        .select_from(union_subquery)
+        .group_by(union_subquery.c.item_id)
     )
 
-    all_base = session.query(
-        TrackWithAggregatesAlias,
-        subquery.c.item_created_at.label("item_created_at"),
-    )
-
-    # Set the base query
-    base_query = {
-        LibraryFilterType.all: all_base,
-        LibraryFilterType.favorite: favorites_base,
-        LibraryFilterType.repost: reposts_base,
-        LibraryFilterType.purchase: purchase_base,
+    # Set the base subquery
+    subquery = {
+        LibraryFilterType.all: all_base.subquery(name="library"),
+        LibraryFilterType.favorite: favorites_base.subquery(name="favorites"),
+        LibraryFilterType.repost: reposts_base.subquery(name="reposts"),
+        LibraryFilterType.purchase: purchase_base.subquery(name="purchases"),
     }[filter_type]
 
-    # Depending on whether this is 'all' or not,
-    # subsequent query building either needs to reference TrackWithAggregates or the aliased TrackWithAggregatesAlias
-    # to avoid accidental join.
-    TracksTable: Type[TrackWithAggregates] = (
-        TrackWithAggregatesAlias
-        if filter_type == LibraryFilterType.all
-        else TrackWithAggregates
+    # Set the base query of tracks by joining on the subquery
+    base_query = (
+        session.query(TrackWithAggregates, subquery.c.item_created_at)
+        .select_from(subquery)
+        .join(
+            TrackWithAggregates,
+            TrackWithAggregates.track_id == subquery.c.item_id,
+        )
+        .filter(TrackWithAggregates.is_current == True)
     )
 
     # Allow filtering of deletes
     if filter_deleted:
-        base_query = base_query.filter(TracksTable.is_delete == False)
+        base_query = base_query.filter(TrackWithAggregates.is_delete == False)
 
+    # Filter results based on user's filter query
+    # Use contains_eager to load user without duplicating it
     if query:
-        #  TODO: [PAY-1643] Implement all query for library
-        if filter_type == LibraryFilterType.all:
-            raise ValueError("Library filter type 'all' does not support query yet")
-        base_query = base_query.join(TracksTable.user, aliased=True).filter(
-            or_(
-                cast(ColumnElement, TracksTable.title).ilike(f"%{query.lower()}%"),
-                User.name.ilike(f"%{query.lower()}%"),
+        base_query = (
+            base_query.join(TrackWithAggregates.user.of_type(User))
+            .options(contains_eager(TrackWithAggregates.user))
+            .filter(
+                or_(
+                    cast(ColumnElement, TrackWithAggregates.title).ilike(
+                        f"%{query.lower()}%"
+                    ),
+                    User.name.ilike(f"%{query.lower()}%"),
+                )
             )
         )
 
     # Set sort methods
     if sort_method == SortMethod.title:
         base_query = base_query.order_by(
-            sort_fn(cast(ColumnElement, TracksTable.title))
+            sort_fn(cast(ColumnElement, TrackWithAggregates.title))
         )
     elif sort_method == SortMethod.artist_name:
-        base_query = base_query.join(TracksTable.user, aliased=True).order_by(
+        base_query = base_query.join(TrackWithAggregates.user, aliased=True).order_by(
             sort_fn(User.name)
         )
     elif sort_method == SortMethod.release_date:
@@ -193,49 +185,43 @@ def _get_track_library(args: GetTrackLibraryArgs, session):
             sort_fn(
                 coalesce(
                     func.to_date_safe(
-                        TracksTable.release_date,
+                        TrackWithAggregates.release_date,
                         "Dy Mon DD YYYY HH24:MI:SS",
                     ),
-                    TracksTable.created_at,
+                    TrackWithAggregates.created_at,
                 )
             )
         )
     elif sort_method == SortMethod.plays:
-        base_query = base_query.join(TracksTable.aggregate_play).order_by(
+        base_query = base_query.join(TrackWithAggregates.aggregate_play).order_by(
             sort_fn(AggregatePlay.count)
         )
     elif sort_method == SortMethod.reposts:
-        base_query = base_query.join(TracksTable.aggregate_track).order_by(
+        base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
             sort_fn(AggregateTrack.repost_count)
         )
     elif sort_method == SortMethod.saves:
-        base_query = base_query.join(TracksTable.aggregate_track).order_by(
+        base_query = base_query.join(TrackWithAggregates.aggregate_track).order_by(
             sort_fn(AggregateTrack.save_count)
         )
     else:
         # This branch covers added_date, or any other sort method
-        if filter_type == LibraryFilterType.favorite:
-            base_query = base_query.order_by(
-                sort_fn(Save.created_at),
-                desc(TracksTable.track_id),
-            )
-        elif filter_type == LibraryFilterType.repost:
-            base_query = base_query.order_by(
-                sort_fn(Repost.created_at),
-                desc(TracksTable.track_id),
-            )
-        elif filter_type == LibraryFilterType.purchase:
-            base_query = base_query.order_by(
-                sort_fn(USDCPurchase.created_at),
-                desc(TracksTable.track_id),
-            )
-        elif filter_type == LibraryFilterType.all:
-            base_query = base_query.order_by(
-                sort_fn(cast(ColumnElement, text("item_created_at"))),
-                desc(TracksTable.track_id),
-            )
+        base_query = base_query.order_by(
+            sort_fn(subquery.c.item_created_at),
+            desc(TrackWithAggregates.track_id),
+        )
 
-    query_results = add_query_pagination(base_query, limit, offset).all()
+    final_query = add_query_pagination(base_query, limit, offset)
+
+    logger.info(
+        str(
+            final_query.statement.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+    )
+
+    query_results = final_query.all()
 
     if not query_results:
         return []

--- a/discovery-provider/src/queries/get_track_library.py
+++ b/discovery-provider/src/queries/get_track_library.py
@@ -211,17 +211,7 @@ def _get_track_library(args: GetTrackLibraryArgs, session):
             desc(TrackWithAggregates.track_id),
         )
 
-    final_query = add_query_pagination(base_query, limit, offset)
-
-    logger.info(
-        str(
-            final_query.statement.compile(
-                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-            )
-        )
-    )
-
-    query_results = final_query.all()
+    query_results = add_query_pagination(base_query, limit, offset).all()
 
     if not query_results:
         return []


### PR DESCRIPTION
### Description

Reimplements the track library query to not fetch tracks until the end, greatly improving perf allowing us to filter again. Also simplifies the query a bit in my opinion, at the cost of losing some typehints

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

tested with prod clone locally

### Example SQL Output

```sql
SELECT
    anon_1.blockhash,
    anon_1.blocknumber,
    anon_1.user_id,
    anon_1.is_current,
    anon_1.handle,
    anon_1.wallet,
    anon_1.name,
    anon_1.profile_picture,
    anon_1.cover_photo,
    anon_1.bio,
    anon_1.location,
    anon_1.is_storage_v2,
    anon_1.metadata_multihash,
    anon_1.creator_node_endpoint,
    anon_1.is_verified,
    anon_1.artist_pick_track_id,
    anon_1.created_at,
    anon_1.updated_at,
    anon_1.handle_lc,
    anon_1.cover_photo_sizes,
    anon_1.profile_picture_sizes,
    anon_1.primary_id,
    anon_1.secondary_ids,
    anon_1.replica_set_update_signer,
    anon_1.has_collectibles,
    anon_1.txhash,
    anon_1.playlist_library,
    anon_1.is_deactivated,
    anon_1.is_available,
    anon_1.slot,
    anon_1.user_storage_account,
    anon_1.user_authority_account,
    anon_1.allow_ai_attribution,
    anon_1.track_id,
    anon_1.is_delete,
    anon_1.owner_id,
    anon_1.audio_upload_id,
    anon_1.preview_cid,
    anon_1.track_cid,
    anon_1.title,
    anon_1.duration,
    anon_1.preview_start_seconds,
    anon_1.cover_art,
    anon_1.tags,
    anon_1.genre,
    anon_1.mood,
    anon_1.credits_splits,
    anon_1.create_date,
    anon_1.release_date,
    anon_1.file_type,
    anon_1.track_segments,
    anon_1.description,
    anon_1.isrc,
    anon_1.iswc,
    anon_1.license,
    anon_1.cover_art_sizes,
    anon_1.download,
    anon_1.is_unlisted,
    anon_1.field_visibility,
    anon_1.route_id,
    anon_1.stem_of,
    anon_1.remix_of,
    anon_1.is_premium,
    anon_1.premium_conditions,
    anon_1.is_playlist_upload,
    anon_1.ai_attribution_user_id,
    anon_1.item_created_at,
    aggregate_track_1.track_id,
    aggregate_track_1.repost_count,
    aggregate_track_1.save_count,
    aggregate_plays_1.play_item_id,
    aggregate_plays_1.count,
    track_routes_1.slug,
    track_routes_1.title_slug,
    track_routes_1.collision_id,
    track_routes_1.owner_id,
    track_routes_1.track_id,
    track_routes_1.is_current,
    track_routes_1.blockhash,
    track_routes_1.blocknumber,
    track_routes_1.txhash
FROM
    (
        SELECT
            users.blockhash AS blockhash,
            users.blocknumber AS blocknumber,
            users.user_id AS user_id,
            users.is_current AS is_current,
            users.handle AS handle,
            users.wallet AS wallet,
            users.name AS name,
            users.profile_picture AS profile_picture,
            users.cover_photo AS cover_photo,
            users.bio AS bio,
            users.location AS location,
            users.is_storage_v2 AS is_storage_v2,
            users.metadata_multihash AS metadata_multihash,
            users.creator_node_endpoint AS creator_node_endpoint,
            users.is_verified AS is_verified,
            users.artist_pick_track_id AS artist_pick_track_id,
            users.created_at AS created_at,
            users.updated_at AS updated_at,
            users.handle_lc AS handle_lc,
            users.cover_photo_sizes AS cover_photo_sizes,
            users.profile_picture_sizes AS profile_picture_sizes,
            users.primary_id AS primary_id,
            users.secondary_ids AS secondary_ids,
            users.replica_set_update_signer AS replica_set_update_signer,
            users.has_collectibles AS has_collectibles,
            users.txhash AS txhash,
            users.playlist_library AS playlist_library,
            users.is_deactivated AS is_deactivated,
            users.is_available AS is_available,
            users.slot AS slot,
            users.user_storage_account AS user_storage_account,
            users.user_authority_account AS user_authority_account,
            users.allow_ai_attribution AS allow_ai_attribution,
            tracks.blockhash AS blockhash,
            tracks.blocknumber AS blocknumber,
            tracks.track_id AS track_id,
            tracks.is_current AS is_current,
            tracks.is_delete AS is_delete,
            tracks.owner_id AS owner_id,
            tracks.audio_upload_id AS audio_upload_id,
            tracks.preview_cid AS preview_cid,
            tracks.track_cid AS track_cid,
            tracks.title AS title,
            tracks.duration AS duration,
            tracks.preview_start_seconds AS preview_start_seconds,
            tracks.cover_art AS cover_art,
            tracks.tags AS tags,
            tracks.genre AS genre,
            tracks.mood AS mood,
            tracks.credits_splits AS credits_splits,
            tracks.create_date AS create_date,
            tracks.release_date AS release_date,
            tracks.file_type AS file_type,
            tracks.metadata_multihash AS metadata_multihash,
            tracks.track_segments AS track_segments,
            tracks.created_at AS created_at,
            tracks.description AS description,
            tracks.isrc AS isrc,
            tracks.iswc AS iswc,
            tracks.license AS license,
            tracks.updated_at AS updated_at,
            tracks.cover_art_sizes AS cover_art_sizes,
            tracks.download AS download,
            tracks.is_unlisted AS is_unlisted,
            tracks.field_visibility AS field_visibility,
            tracks.route_id AS route_id,
            tracks.stem_of AS stem_of,
            tracks.remix_of AS remix_of,
            tracks.txhash AS txhash,
            tracks.slot AS slot,
            tracks.is_available AS is_available,
            tracks.is_premium AS is_premium,
            tracks.premium_conditions AS premium_conditions,
            tracks.is_playlist_upload AS is_playlist_upload,
            tracks.ai_attribution_user_id AS ai_attribution_user_id,
            library.item_created_at AS item_created_at
        FROM
            (
                SELECT
                    union_subquery.item_id AS item_id,
                    max(union_subquery.item_created_at) AS item_created_at
                FROM
                    (
                        SELECT
                            anon_2.item_id AS item_id,
                            anon_2.item_created_at AS item_created_at
                        FROM
                            (
                                SELECT
                                    saves.save_item_id AS item_id,
                                    saves.created_at AS item_created_at
                                FROM
                                    saves
                                WHERE
                                    saves.user_id = 1
                                    AND saves.is_current = true
                                    AND saves.is_delete = false
                                    AND saves.save_type = 'track'
                                UNION
                                ALL
                                SELECT
                                    reposts.repost_item_id AS item_id,
                                    reposts.created_at AS item_created_at
                                FROM
                                    reposts
                                WHERE
                                    reposts.user_id = 1
                                    AND reposts.is_current = true
                                    AND reposts.is_delete = false
                                    AND reposts.repost_type = 'track'
                                UNION
                                ALL
                                SELECT
                                    usdc_purchases.content_id AS item_id,
                                    usdc_purchases.created_at AS item_created_at
                                FROM
                                    usdc_purchases
                                WHERE
                                    usdc_purchases.content_type = 'track'
                                    AND usdc_purchases.buyer_user_id = 1
                            ) AS anon_2
                    ) AS union_subquery
                GROUP BY
                    union_subquery.item_id
            ) AS library
            JOIN tracks ON tracks.track_id = library.item_id
            JOIN users ON tracks.owner_id = users.user_id
            AND users.is_current
        WHERE
            tracks.is_current = true
            AND (
                tracks.title ILIKE '%%ricky%%'
                OR users.name ILIKE '%%ricky%%'
            )
        ORDER BY
            library.item_created_at DESC,
            tracks.track_id DESC
        LIMIT
            100 OFFSET 0
    ) AS anon_1
    LEFT OUTER JOIN aggregate_track AS aggregate_track_1 ON anon_1.track_id = aggregate_track_1.track_id
    LEFT OUTER JOIN aggregate_plays AS aggregate_plays_1 ON anon_1.track_id = aggregate_plays_1.play_item_id
    LEFT OUTER JOIN track_routes AS track_routes_1 ON anon_1.track_id = track_routes_1.track_id
    AND track_routes_1.is_current
ORDER BY
    anon_1.item_created_at DESC,
    anon_1.track_id DESC
 ```
 
 
### Explain Analyze

https://explain.depesz.com/s/2DvS#html