### PR TITLE
[CON-829] Add legacy paths counter & expose in healthz

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -177,10 +177,9 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 	}
 
 	// TODO: remove this legacy fallback once we've migrated all Qm keys to CDK buckets
-	// if cidutil.IsLegacyCID(cid) {
-	// 	logger.Debug("serving legacy cid")
-	// 	return ss.serveLegacyCid(c)
-	// }
+	if cidutil.IsLegacyCID(cid) {
+		return ss.serveLegacyCid(c)
+	}
 
 	if err != nil {
 		logger.Warn("error finding node to serve blob", "err", err)

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -5,9 +5,11 @@ import (
 )
 
 type Metrics struct {
-	Host        string         `json:"host"`
-	Uploads     int64          `json:"uploads"`
-	OutboxSizes map[string]int `json:"outbox_sizes"`
+	Host                   string         `json:"host"`
+	Uploads                int64          `json:"uploads"`
+	OutboxSizes            map[string]int `json:"outbox_sizes"`
+	AttemptedLegacyServes  []string       `json:"attempted_legacy_serves"`
+	SuccessfulLegacyServes []string       `json:"successful_legacy_serves"`
 }
 
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
@@ -15,6 +17,8 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m.Host = ss.Config.Self.Host
 	m.Uploads = ss.uploadsCount
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
+	m.AttemptedLegacyServes = ss.attemptedLegacyServes
+	m.SuccessfulLegacyServes = ss.successfulLegacyServes
 
 	return c.JSON(200, m)
 }

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -357,10 +357,10 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 		if err != nil {
 			c.Response().Header().Set("x-find-node-err", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			// TODO: remove this legacy fallback once we've migrated all Qm CIDs to CDK buckets. return `err` instead
-			// c.SetParamNames("dirCid", "fileName")
-			// c.SetParamValues(jobID, variant)
-			// return ss.serveLegacyDirCid(c)
-			return err
+			c.SetParamNames("dirCid", "fileName")
+			c.SetParamValues(jobID, variant)
+			return ss.serveLegacyDirCid(c)
+			// return err
 		} else if host != "" {
 			c.Response().Header().Set("x-find-node-success", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			dest := ss.replaceHost(c, host)
@@ -371,10 +371,10 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 		} else {
 			c.Response().Header().Set("x-find-node-not-found", fmt.Sprintf("%.2fs", time.Since(startFindNode).Seconds()))
 			// TODO: remove this legacy fallback once we've migrated all Qm CIDs to CDK buckets
-			// c.SetParamNames("dirCid", "fileName")
-			// c.SetParamValues(jobID, variant)
-			// return ss.serveLegacyDirCid(c)
-			return c.String(404, fmt.Sprintf("no host found for %s/%s", jobID, variant))
+			c.SetParamNames("dirCid", "fileName")
+			c.SetParamValues(jobID, variant)
+			return ss.serveLegacyDirCid(c)
+			// return c.String(404, fmt.Sprintf("no host found for %s/%s", jobID, variant))
 		}
 	} else {
 		// TODO: remove cache once metadata has only CIDs and no jobIds/variants, so then we won't need a db lookup

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -92,6 +92,9 @@ type MediorumServer struct {
 	uploadsCount    int64
 	uploadsCountErr string
 
+	attemptedLegacyServes  []string
+	successfulLegacyServes []string
+
 	isSeeding bool
 
 	peerHealthMutex  sync.RWMutex

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -1,6 +1,5 @@
 import useSWR from 'swr'
 import {
-  EnvironmentSelector,
   useEnvironmentSelection,
 } from './components/EnvironmentSelector'
 import { SP, useServiceProviders } from './useServiceProviders'
@@ -43,6 +42,7 @@ export function DiscoveryHealth() {
             {isContent && <th>Started</th>}
             {isContent && <th>Uploads</th>}
             {isContent && <th>Healthy Peers {'<'}2m</th>}
+            {isContent && <th>Legacy Served</th>}
             <th>Registered Wallet</th>
           </tr>
         </thead>
@@ -178,6 +178,13 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
       </td>)}
       {isContent && <td>{metrics?.uploads}</td>}
       {isContent && <td>{healthyPeers2m}</td>}
+      {isContent && (
+        <td>
+          <a href={sp.endpoint + '/internal/metrics'} target="_blank">
+            {metrics?.attempted_legacy_serves?.length || 0} | {metrics?.successful_legacy_serves?.length || 0}
+          </a>
+        </td>
+      )}
       <td>
         <pre>{sp.delegateOwnerWallet}</pre>
       </td>


### PR DESCRIPTION
### Description
- Adds to `/internal/metrics` route a list of CIDs (capped at 100K) that were attempted and successfully returned from a legacy (non-CDK disk) path
- Exposes this new metrics in healthz "Legacy Served" column of format "<attempted> | <successful>"

### How Has This Been Tested?
Deployed to CN10, queried a legacy CID that doesn't exist, and verified that the counter increased on healthz
<img width="1702" alt="Screenshot 2023-08-17 at 10 52 21 AM" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/a3f3d497-1a26-47ad-86f9-4be8422e77b7">

You can click the link in healthz to easily jump to /internal/metrics:
<hr />

<img width="660" alt="Screenshot 2023-08-17 at 10 53 06 AM" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/23a6c383-0a37-4b3f-a5f8-70e298cf983b">

