### PR TITLE
Add RWMutex to legacy path counts, and block segments+metadata

### DIFF
--- a/mediorum/server/serve_legacy.go
+++ b/mediorum/server/serve_legacy.go
@@ -27,9 +27,11 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 		logger.Error("error querying cid storage path", "err", err)
 	}
 
+	ss.legacyServesMu.Lock()
 	if !slices.Contains(ss.attemptedLegacyServes, cid) && len(ss.attemptedLegacyServes) < 100000 {
 		ss.attemptedLegacyServes = append(ss.attemptedLegacyServes, cid)
 	}
+	ss.legacyServesMu.Unlock()
 
 	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", cid)
 	if diskPath == "" {
@@ -50,9 +52,11 @@ func (ss *MediorumServer) serveLegacyCid(c echo.Context) error {
 		logger.Error("error serving cid", "err", err, "storagePath", diskPath)
 		return ss.redirectToCid(c, cid)
 	}
+	ss.legacyServesMu.Lock()
 	if !slices.Contains(ss.successfulLegacyServes, cid) && len(ss.successfulLegacyServes) < 100000 {
 		ss.successfulLegacyServes = append(ss.successfulLegacyServes, cid)
 	}
+	ss.legacyServesMu.Unlock()
 
 	// v1 file listen
 	if isAudioFile {
@@ -76,9 +80,11 @@ func (ss *MediorumServer) serveLegacyDirCid(c echo.Context) error {
 	}
 
 	key := dirCid + "/" + fileName
+	ss.legacyServesMu.Lock()
 	if !slices.Contains(ss.attemptedLegacyServes, key) && len(ss.attemptedLegacyServes) < 100000 {
 		ss.attemptedLegacyServes = append(ss.attemptedLegacyServes, key)
 	}
+	ss.legacyServesMu.Unlock()
 
 	// dirCid is actually the CID, and fileName is a size like "150x150.jpg"
 	diskPath := getDiskPathOnlyIfFileExists(storagePath, "", dirCid)
@@ -100,9 +106,11 @@ func (ss *MediorumServer) serveLegacyDirCid(c echo.Context) error {
 		logger.Error("error serving dirCid", "err", err, "storagePath", diskPath)
 		return ss.redirectToCid(c, dirCid)
 	}
+	ss.legacyServesMu.Lock()
 	if !slices.Contains(ss.successfulLegacyServes, key) && len(ss.successfulLegacyServes) < 100000 {
 		ss.successfulLegacyServes = append(ss.successfulLegacyServes, key)
 	}
+	ss.legacyServesMu.Unlock()
 
 	return nil
 }

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -17,6 +17,9 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m.Host = ss.Config.Self.Host
 	m.Uploads = ss.uploadsCount
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
+
+	ss.legacyServesMu.RLock()
+	defer ss.legacyServesMu.RUnlock()
 	m.AttemptedLegacyServes = ss.attemptedLegacyServes
 	m.SuccessfulLegacyServes = ss.successfulLegacyServes
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -94,6 +94,7 @@ type MediorumServer struct {
 
 	attemptedLegacyServes  []string
 	successfulLegacyServes []string
+	legacyServesMu         sync.RWMutex
 
 	isSeeding bool
 


### PR DESCRIPTION
### Description
- There's a low amount of concurrent reads/writes for tracking legacy serves, which could cause an unexpected panic. Although the foundation nodes haven't had this happen yet, I'm adding this just to be safe.
- Blocks serving segments and metadata through the legacy path. This is pretty safe because these are both supposed to have been stopped being supported a long time ago and because this is only on the fallback legacy path that which we're also aiming to stop supporting.

### How Has This Been Tested?
Re-tested the legacy tracking on stage CN10, and verified the following links:
- (metadata) https://creatornode10.staging.audius.co/content/QmT2SUjUsmbJ4Y1kpbFpjMepTkR3AHrM5231Tn1eoPoTXZ
- (segment) https://creatornode10.staging.audius.co/content/QmXUbQuv5yG7HjK6WBFducdYkX2kabZ6TgUAZYVZb2c7wL
- (mp3 - still streams) https://creatornode10.staging.audius.co/tracks/cidstream/QmPyLkcNfwyS8LF9Rg87WjEu5fiYoLjMSgvJVZwV8pZM7p?signature=%7B%22data%22%3A%20%22%7B%5C%22trackId%5C%22%3A%2087067299%2C%20%5C%22cid%5C%22%3A%20%5C%22QmPyLkcNfwyS8LF9Rg87WjEu5fiYoLjMSgvJVZwV8pZM7p%5C%22%2C%20%5C%22timestamp%5C%22%3A%201692306712106%2C%20%5C%22userId%5C%22%3A%20127559427%2C%20%5C%22shouldCache%5C%22%3A%201%7D%22%2C%20%22signature%22%3A%20%220xcb706b081419abd5acb1f7bd70d7f502427d455d722e51f622b0f1b41570373e1ec21dfd09631592cedbc25d00638a440fa9c98a4690c5dfed18ee7f85ff08811b%22%7D