### PR TITLE
Add track_price_history fkey

### DIFF
--- a/discovery-provider/ddl/migrations/0025_add_track_price_history_fkey.sql
+++ b/discovery-provider/ddl/migrations/0025_add_track_price_history_fkey.sql
@@ -1,0 +1,4 @@
+-- add this fkey constraint to cascade delete track_price_history on revert
+begin;
+alter table track_price_history add constraint track_price_history_blocknumber_fkey foreign key (blocknumber) references blocks (number) on delete cascade;
+commit;


### PR DESCRIPTION
### Description

Just add a fkey constraint so we don't have to manually delete from track_price_history on revert. No other change is needed because track_price_history does not maintain is_current.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Existing tests pass. Ran migration on sandbox.