### PR TITLE
Fix SDK storage upload header

### DIFF
--- a/libs/src/sdk/services/Storage/Storage.ts
+++ b/libs/src/sdk/services/Storage/Storage.ts
@@ -134,9 +134,11 @@ export class Storage implements StorageService {
       url: `${contentNodeEndpoint}/uploads`,
       maxContentLength: Infinity,
       data: formData,
-      headers: formData.getBoundary ?? {
-        'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`
-      },
+      headers: formData.getBoundary
+        ? {
+            'Content-Type': `multipart/form-data; boundary=${formData.getBoundary()}`
+          }
+        : undefined,
       onUploadProgress: (progressEvent) =>
         onProgress?.(progressEvent.loaded, progressEvent.total)
     })


### PR DESCRIPTION
### Description

I introduced a bug when adding browser upload support to the sdk. The content-type header only needs to get set server side, but it was being set to `formData.getBoundary`

### How Has This Been Tested?

Tested upload from server and browser