### PR TITLE
Add image cid caching to v0 api

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -31,6 +31,11 @@ redis = get_redis()
 logger = logging.getLogger(__name__)
 
 
+PROFILE_PICTURE_SIZES = ["150x150", "480x480", "1000x1000"]
+PROFILE_COVER_PHOTO_SIZES = ["640x", "2000x"]
+COVER_ART_SIZES = ["150x150", "480x480", "1000x1000"]
+
+
 def make_image(endpoint, cid, width="", height=""):
     return f"{endpoint}/content/{cid}/{width}x{height}.jpg"
 
@@ -68,14 +73,11 @@ def add_track_artwork(track):
     if "user" not in track:
         return track
     cid = track["cover_art_sizes"]
-    endpoint = get_primary_endpoint(track["user"], cid)
-    if not endpoint:
-        return track
-
-    cover_cids = get_image_cids(track["user"], cid, ["150x150", "480x480", "1000x1000"])
+    cover_cids = get_image_cids(track["user"], cid, COVER_ART_SIZES)
     track["cover_art_cids"] = cover_cids
+    endpoint = get_primary_endpoint(track["user"], cid)
     artwork = get_image_urls(track["user"], cover_cids)
-    if not artwork:
+    if endpoint and not artwork:
         # Fallback to legacy image url format with dumb endpoint
         artwork = {
             "150x150": make_image(endpoint, cid, 150, 150),
@@ -89,17 +91,15 @@ def add_track_artwork(track):
 def add_playlist_artwork(playlist):
     if "user" not in playlist:
         return playlist
-    cid = playlist["playlist_image_sizes_multihash"]
-    endpoint = get_primary_endpoint(playlist["user"], cid)
-    if not endpoint:
-        return playlist
 
+    cid = playlist["playlist_image_sizes_multihash"]
     cover_cids = get_image_cids(
-        playlist["user"], cid, ["150x150", "480x480", "1000x1000"]
+        playlist["user"], cid, COVER_ART_SIZES
     )
     playlist["cover_art_cids"] = cover_cids
+    endpoint = get_primary_endpoint(playlist["user"], cid)
     artwork = get_image_urls(playlist["user"], cover_cids)
-    if not artwork:
+    if endpoint and not artwork:
         # Fallback to legacy image url format with dumb endpoint
         artwork = {
             "150x150": make_image(endpoint, cid, 150, 150),
@@ -132,15 +132,13 @@ def add_user_artwork(user):
 
     profile_cid = user.get("profile_picture_sizes")
     profile_endpoint = get_primary_endpoint(user, profile_cid)
-    cover_cid = user.get("cover_photo_sizes")
-    cover_endpoint = get_primary_endpoint(user, cover_cid)
-    if profile_endpoint and profile_cid:
+    if profile_cid:
         profile_cids = get_image_cids(
-            user, profile_cid, ["150x150", "480x480", "1000x1000"]
+            user, profile_cid, PROFILE_PICTURE_SIZES
         )
         user["profile_picture_cids"] = profile_cids
         profile = get_image_urls(user, profile_cids)
-        if not profile:
+        if profile_endpoint and not profile:
             # Fallback to legacy image url format with dumb endpoint
             profile = {
                 "150x150": make_image(profile_endpoint, profile_cid, 150, 150),
@@ -148,17 +146,20 @@ def add_user_artwork(user):
                 "1000x1000": make_image(profile_endpoint, profile_cid, 1000, 1000),
             }
         user["profile_picture"] = profile
-    if cover_endpoint and cover_cid:
-        cover_cids = get_image_cids(user, cover_cid, ["640x", "2000x"])
+    cover_cid = user.get("cover_photo_sizes")
+    cover_endpoint = get_primary_endpoint(user, cover_cid)
+    if cover_cid:
+        cover_cids = get_image_cids(user, cover_cid, PROFILE_COVER_PHOTO_SIZES)
         user["cover_photo_cids"] = cover_cids
         cover = get_image_urls(user, cover_cids)
-        if not cover:
+        if cover_endpoint and not cover:
             # Fallback to legacy image url format with dumb endpoint
             cover = {
                 "640x": make_image(cover_endpoint, cover_cid, 640),
                 "2000x": make_image(cover_endpoint, cover_cid, 2000),
             }
         user["cover_photo"] = cover
+
     return user
 
 

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import or_
 
 from src import exceptions
+from src.api.v1 import helpers as v1Helpers
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.playlists.playlist import Playlist
 from src.models.social.follow import Follow
@@ -275,6 +276,21 @@ def populate_user_metadata(
 
     for user in users:
         user_id = user["user_id"]
+
+        # Convert image cid to cids for each image size variant
+        profile_cid = user.get("profile_picture_sizes")
+        if profile_cid:
+            profile_cids = v1Helpers.get_image_cids(
+                user, profile_cid, v1Helpers.PROFILE_PICTURE_SIZES
+            )
+            user["profile_picture_cids"] = profile_cids
+        cover_cid = user.get("cover_photo_sizes")
+        if cover_cid:
+            cover_cids = v1Helpers.get_image_cids(
+                user, cover_cid, v1Helpers.PROFILE_COVER_PHOTO_SIZES
+            )
+            user["cover_photo_cids"] = cover_cids
+
         user_balance = balance_dict.get(user_id, {})
         user[response_name_constants.track_count] = count_dict.get(user_id, {}).get(
             response_name_constants.track_count, 0

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -866,7 +866,7 @@ def populate_playlist_metadata(
         playlist_id = playlist["playlist_id"]
 
         # Convert cover art cid to cids for each image size variant
-        cover_cid = playlist.get("cover_art_sizes")
+        cover_cid = playlist.get("playlist_image_sizes_multihash")
         if cover_cid:
             cover_cids = v1Helpers.get_image_cids(
                 playlist["user"], cover_cid, v1Helpers.COVER_ART_SIZES

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -486,6 +486,14 @@ def populate_track_metadata(
     for track in tracks:
         track_id = track["track_id"]
 
+        # Convert cover art cid to cids for each image size variant
+        cover_cid = track.get("cover_art_sizes")
+        if cover_cid:
+            cover_cids = v1Helpers.get_image_cids(
+                track["user"], cover_cid, v1Helpers.COVER_ART_SIZES
+            )
+            track["cover_art_cids"] = cover_cids
+
         if track_has_aggregates:
             aggregate_track = track.get("aggregate_track")
             track[response_name_constants.repost_count] = (
@@ -856,6 +864,15 @@ def populate_playlist_metadata(
 
     for playlist in playlists:
         playlist_id = playlist["playlist_id"]
+
+        # Convert cover art cid to cids for each image size variant
+        cover_cid = playlist.get("cover_art_sizes")
+        if cover_cid:
+            cover_cids = v1Helpers.get_image_cids(
+                playlist["user"], cover_cid, v1Helpers.COVER_ART_SIZES
+            )
+            playlist["cover_art_cids"] = cover_cids
+
         playlist[response_name_constants.repost_count] = count_dict.get(
             playlist_id, {}
         ).get(response_name_constants.repost_count, 0)


### PR DESCRIPTION
### Description
Client still uses the v0 API in some places, including initial caching of the user, so add cached image cid fields to the v0 endpoints. Also clean up v1.

v1 done in https://github.com/AudiusProject/audius-protocol/pull/5783

### How Has This Been Tested?
Deploy to stage, test against client changes with breakpoints to make sure correct direct links are used

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
