### PR TITLE
Follow on fix social feature type

### DIFF
--- a/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -991,7 +991,7 @@ def test_index_social_feature_playlist_type(app, mocker):
         album_save: List[Save] = (
             session.query(Save).filter(Save.save_item_id == 2).first()
         )
-        assert album_save.save_type == "album"
+        assert album_save.save_type == "playlist"
 
         # Verify repost
         playlist_repost: List[Repost] = (
@@ -1002,7 +1002,7 @@ def test_index_social_feature_playlist_type(app, mocker):
         album_repost: List[Repost] = (
             session.query(Repost).filter(Repost.repost_item_id == 2).first()
         )
-        assert album_repost.repost_type == "album"
+        assert album_repost.repost_type == "playlist"
 
         aggregate_playlist: List[AggregatePlaylist] = (
             session.query(AggregatePlaylist)

--- a/discovery-provider/src/tasks/entity_manager/entities/social_features.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/social_features.py
@@ -123,15 +123,6 @@ def get_attribute_from_record_metadata(params, attribute):
     return None
 
 
-def get_social_feature_type(params):
-    save_type = params.entity_type.lower()
-    if params.entity_type == EntityType.PLAYLIST:
-        # discern playlists and albums
-        existing_entity = params.existing_records[params.entity_type][params.entity_id]
-        save_type = "album" if existing_entity.is_album else "playlist"
-    return save_type
-
-
 def create_save(params):
     is_save_of_repost = get_attribute_from_record_metadata(params, "is_save_of_repost")
 
@@ -142,7 +133,7 @@ def create_save(params):
         txhash=params.txhash,
         user_id=params.user_id,
         save_item_id=params.entity_id,
-        save_type=get_social_feature_type(params),
+        save_type=params.entity_type.lower(),
         is_current=True,
         is_delete=False,
         is_save_of_repost=bool(is_save_of_repost),
@@ -161,7 +152,7 @@ def create_repost(params):
         txhash=params.txhash,
         user_id=params.user_id,
         repost_item_id=params.entity_id,
-        repost_type=get_social_feature_type(params),
+        repost_type=params.entity_type.lower(),
         is_repost_of_repost=bool(is_repost_of_repost),
         is_current=True,
         is_delete=False,


### PR DESCRIPTION
### Description
Following up 
https://github.com/AudiusProject/audius-protocol/pull/5767/files#diff-ef86d71348b6d07b1d29a5a8f6cb09baa689e87f656e41bfc60b798edd1ccea0

Forgot to make EM always use playlist type instead of album type when indexing repost / saves.

### How Has This Been Tested?
Tested on stage. Confirmed repost/save worked and aggregates, icons looked right. 
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
