### PR TITLE
[PAY-1696][PAY-1697] - Update implementation and add rust unit tests

### DIFF
--- a/solana-programs/payment-router/Anchor.toml
+++ b/solana-programs/payment-router/Anchor.toml
@@ -14,4 +14,5 @@ wallet = "id.json"
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-create-payment-router-balance-pda= "yarn run ts-mocha -g 'pda' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test-create-payment-router-balance-ata= "yarn run ts-mocha -g 'associated' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-route= "yarn run ts-mocha -g 'routes' -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/solana-programs/payment-router/Anchor.toml
+++ b/solana-programs/payment-router/Anchor.toml
@@ -14,5 +14,4 @@ wallet = "id.json"
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-create-payment-router-balance-pda= "yarn run ts-mocha -g 'pda' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-test-create-payment-router-balance-ata= "yarn run ts-mocha -g 'associated' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-route= "yarn run ts-mocha -g 'routes' -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/solana-programs/payment-router/README.md
+++ b/solana-programs/payment-router/README.md
@@ -21,6 +21,25 @@ Anchor uses Yarn, so please sure you have it installed, and run
 yarn install
 ```
 
+## Running the unit tests
+Use Solana 1.16.1
+```
+solana-install init 1.16.1
+solana -V
+```
+
+and rustc 1.70.0
+```
+rustup install 1.70.0
+rustup default 1.70.0
+rustc -V
+```
+
+Run the tests
+```
+cargo test-bpf
+```
+
 ## Setting up your Solana cluster and environment
 We are going to be invoking programs on the Solana mainnet.
 So, for convenience, you can configure your cluster to use the Solana mainnet by default, and also use your chosen keypair file as the default Solana account by running:

--- a/solana-programs/payment-router/README.md
+++ b/solana-programs/payment-router/README.md
@@ -1,9 +1,8 @@
 # Payment Router
 
-This program transfer SOL AUDIO or SOL USDC from its PDA token account to given recipients.
+This program transfers SOL AUDIO or SOL USDC from its PDA token account to given recipients.
 
 The program has a PDA (Program Derived Address) account that will own the tokens.
-The program methods are permissionless, meaning that anyone can interact with them as long as they're willing to pay for the transactions.
 
 Please note that this program and its Anchor tests are set up to only work with the Solana mainnet cluster at the moment.
 

--- a/solana-programs/payment-router/programs/payment-router/Cargo.toml
+++ b/solana-programs/payment-router/programs/payment-router/Cargo.toml
@@ -14,6 +14,7 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+test-bpf = []
 
 [dependencies]
 anchor-lang = "0.28.0"

--- a/solana-programs/payment-router/programs/payment-router/Cargo.toml
+++ b/solana-programs/payment-router/programs/payment-router/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "payment-router"
 version = "0.1.0"
-description = "This program transfer SOL AUDIO or SOL USDC from its PDA token account to given recipients."
+description = "This program transfers SOL AUDIO or SOL USDC from its PDA token account to given recipients."
 edition = "2021"
 
 [lib]

--- a/solana-programs/payment-router/programs/payment-router/src/lib.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/lib.rs
@@ -3,7 +3,7 @@ use anchor_lang::{
     AnchorDeserialize,
     AnchorSerialize,
 };
-use anchor_spl::token::Token;
+use anchor_spl::token::{Token, TokenAccount};
 
 pub mod error;
 pub mod router;
@@ -81,7 +81,7 @@ pub struct CreatePaymentRouterBalancePDA<'info> {
 pub struct Route<'info> {
     #[account(mut)]
     /// CHECK: This is the token account owned by the PDA.
-    pub sender: UncheckedAccount<'info>,
+    pub sender: Account<'info, TokenAccount>,
     #[account(
         seeds = [b"payment_router".as_ref()],
         bump = payment_router_pda_bump

--- a/solana-programs/payment-router/programs/payment-router/src/lib.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/lib.rs
@@ -3,21 +3,12 @@ use anchor_lang::{
     AnchorDeserialize,
     AnchorSerialize,
 };
-use anchor_spl::{
-    associated_token::AssociatedToken,
-    token::
-    {
-        TokenAccount,
-        Mint,
-        Token
-    }
-};
+use anchor_spl::token::Token;
 
 pub mod error;
 pub mod router;
 
 use crate::router::{
-    SOL_AUDIO_TOKEN_ADDRESS,
     check_recipient_amounts,
     check_sender,
     execute_transfers
@@ -30,13 +21,6 @@ pub mod payment_router {
     use super::*;
 
     pub fn create_payment_router_balance_pda(_ctx: Context<CreatePaymentRouterBalancePDA>) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn create_payment_router_balance_ata(
-        _ctx: Context<CreatePaymentRouterBalanceAta>,
-        _payment_router_pda_bump: u8
-    ) -> Result<()> {
         Ok(())
     }
 
@@ -85,31 +69,6 @@ pub struct CreatePaymentRouterBalancePDA<'info> {
     pub payment_router_pda: UncheckedAccount<'info>,
     #[account(mut)]
     pub payer: Signer<'info>,
-    pub system_program: Program<'info, System>,
-}
-
-#[derive(Accounts)]
-#[instruction(payment_router_pda_bump: u8)]
-pub struct CreatePaymentRouterBalanceAta<'info> {
-    #[account(
-        seeds = [b"payment_router".as_ref()],
-        bump = payment_router_pda_bump,
-    )]
-    /// CHECK: This is the PDA owned by this program. This account holds both SOL USDC and SOL AUDIO. It is used to swap between the two tokens. This PDA is also used to transfer SOL AUDIO to ETH AUDIO via the wormhole.
-    pub payment_router_pda: UncheckedAccount<'info>,
-    #[account(
-        init,
-        payer = payer,
-        associated_token::mint = audio_mint,
-        associated_token::authority = payment_router_pda,
-    )]
-    pub audio_token_account: Account<'info, TokenAccount>,
-    #[account(address = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap())]
-    pub audio_mint: Account<'info, Mint>,
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    pub token_program: Program<'info, Token>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/solana-programs/payment-router/programs/payment-router/src/lib.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/lib.rs
@@ -3,12 +3,21 @@ use anchor_lang::{
     AnchorDeserialize,
     AnchorSerialize,
 };
-use anchor_spl::token::Token;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::
+    {
+        TokenAccount,
+        Mint,
+        Token
+    }
+};
 
 pub mod error;
 pub mod router;
 
 use crate::router::{
+    SOL_AUDIO_TOKEN_ADDRESS,
     check_recipient_amounts,
     check_sender,
     execute_transfers
@@ -21,6 +30,13 @@ pub mod payment_router {
     use super::*;
 
     pub fn create_payment_router_balance_pda(_ctx: Context<CreatePaymentRouterBalancePDA>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn create_payment_router_balance_ata(
+        _ctx: Context<CreatePaymentRouterBalanceAta>,
+        _payment_router_pda_bump: u8
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -69,6 +85,31 @@ pub struct CreatePaymentRouterBalancePDA<'info> {
     pub payment_router_pda: UncheckedAccount<'info>,
     #[account(mut)]
     pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(payment_router_pda_bump: u8)]
+pub struct CreatePaymentRouterBalanceAta<'info> {
+    #[account(
+        seeds = [b"payment_router".as_ref()],
+        bump = payment_router_pda_bump,
+    )]
+    /// CHECK: This is the PDA owned by this program. This account holds both SOL USDC and SOL AUDIO. It is used to swap between the two tokens. This PDA is also used to transfer SOL AUDIO to ETH AUDIO via the wormhole.
+    pub payment_router_pda: UncheckedAccount<'info>,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = audio_mint,
+        associated_token::authority = payment_router_pda,
+    )]
+    pub audio_token_account: Account<'info, TokenAccount>,
+    #[account(address = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap())]
+    pub audio_mint: Account<'info, Mint>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/solana-programs/payment-router/programs/payment-router/src/router.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/router.rs
@@ -17,7 +17,7 @@ pub fn check_sender(
     // i.e. that the owner of the sender account is owned by the program.
     // This is because we use the account macro with seeds and bump for the 'sender_owner'.
     let sender_data = sender.data.borrow();
-    let sender_account_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let sender_account_owner = <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
         ::unpack_account_owner(&sender_data)
         .unwrap();
     if sender_account_owner != sender_owner.key {

--- a/solana-programs/payment-router/programs/payment-router/src/router.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/router.rs
@@ -7,9 +7,6 @@ use anchor_spl::token::spl_token;
 
 use crate::error::PaymentRouterErrorCode;
 
-// https://explorer.solana.com/address/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
-pub const SOL_AUDIO_TOKEN_ADDRESS: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";
-
 // Verify PDA ownership of the sender token account.
 pub fn check_sender(
   sender: AccountInfo,

--- a/solana-programs/payment-router/programs/payment-router/src/router.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/router.rs
@@ -7,6 +7,9 @@ use anchor_spl::token::spl_token;
 
 use crate::error::PaymentRouterErrorCode;
 
+// https://explorer.solana.com/address/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
+pub const SOL_AUDIO_TOKEN_ADDRESS: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";
+
 // Verify PDA ownership of the sender token account.
 pub fn check_sender(
   sender: AccountInfo,

--- a/solana-programs/payment-router/programs/payment-router/tests/tests.rs
+++ b/solana-programs/payment-router/programs/payment-router/tests/tests.rs
@@ -1,0 +1,185 @@
+#![cfg(feature = "test-bpf")]
+
+use anchor_lang::prelude::{
+  AccountInfo,
+  Pubkey,
+  Error,
+};
+use anchor_lang::solana_program::pubkey::PUBKEY_BYTES;
+use anchor_spl::token::{
+  TokenAccount,
+  spl_token::state::ACCOUNT_INITIALIZED_INDEX
+};
+
+use payment_router::error::PaymentRouterErrorCode;
+use payment_router::router::{
+  check_sender,
+  check_recipient_amounts,
+};
+
+#[test]
+fn test_sender() {
+    let sender_key = Pubkey::new_unique();
+    let sender_owner_key = Pubkey::new_unique();
+    let other_key = Pubkey::new_unique();
+
+    let (sender_lamports, sender_data) = (&mut 0, &mut vec![]);
+    let sender_account_info = &get_initialized_token_account_info(
+      &sender_key,
+      sender_lamports,
+      sender_data,
+      &other_key,
+      &sender_owner_key
+    );
+
+    let (sender_owner_lamports, sender_owner_data) = (&mut 0, &mut vec![]);
+    let sender_owner_account_info = &get_initialized_token_account_info(
+      &sender_owner_key,
+      sender_owner_lamports,
+      sender_owner_data,
+      &other_key,
+      &other_key
+    );
+
+    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
+    let bad_account_info = &get_initialized_token_account_info(
+      &other_key,
+      bad_lamports,
+      bad_data,
+      &other_key,
+      &other_key
+    );
+
+    let bad_sender_result = check_sender(
+      bad_account_info.clone(),
+      sender_owner_account_info.clone(),
+    );
+    assert_error(bad_sender_result, PaymentRouterErrorCode::SenderTokenAccountNotOwnedByPDA);
+
+    let bad_sender_owner_result = check_sender(
+      sender_account_info.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_sender_owner_result, PaymentRouterErrorCode::SenderTokenAccountNotOwnedByPDA);
+
+    let result = check_sender(
+      sender_account_info.clone(),
+      sender_owner_account_info.clone(),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn test_recipient_amounts() {
+    let key = Pubkey::new_unique();
+
+    let (first_recipient_lamports, first_recipient_data) = (&mut 0, &mut vec![]);
+    let first_recipient_account_info = &get_initialized_token_account_info(
+        &key,
+        first_recipient_lamports,
+        first_recipient_data,
+        &key,
+        &key
+    );
+    let (second_recipient_lamports, second_recipient_data) = (&mut 0, &mut vec![]);
+    let second_recipient_account_info = &get_initialized_token_account_info(
+        &key,
+        second_recipient_lamports,
+        second_recipient_data,
+        &key,
+        &key
+    );
+
+    let remaining_accounts = vec![
+        first_recipient_account_info.clone(),
+        second_recipient_account_info.clone()
+    ];
+    let amounts = [1, 2];
+    let total_amount = 3;
+
+    let bad_accounts_result = check_recipient_amounts(
+        &vec![first_recipient_account_info.clone()],
+        amounts.to_vec(),
+        total_amount
+    );
+    assert_error(bad_accounts_result, PaymentRouterErrorCode::RecipientAmountMismatch);
+
+    let bad_amounts_result = check_recipient_amounts(
+        &remaining_accounts,
+        vec![1, 2, 3],
+        total_amount
+    );
+    assert_error(bad_amounts_result, PaymentRouterErrorCode::RecipientAmountMismatch);
+
+    let bad_total_result = check_recipient_amounts(
+        &remaining_accounts,
+        amounts.to_vec(),
+        4
+    );
+    assert_error(bad_total_result, PaymentRouterErrorCode::TotalAmountMismatch);
+
+    let result = check_recipient_amounts(
+        &remaining_accounts,
+        amounts.to_vec(),
+        total_amount
+    );
+    assert_eq!(result, Ok(()));
+}
+
+fn get_initialized_token_account_info<'a>(
+  key: &'a Pubkey,
+  lamports: &'a mut u64,
+  data: &'a mut Vec<u8>,
+  mint: &'a Pubkey,
+  owner: &'a Pubkey
+) -> AccountInfo<'a> {
+  // Set the mint and owner of the account.
+  // Note that the mint offset is 0 and the owner offset is 32.
+  data.extend_from_slice(&mint.to_bytes());
+  data.extend_from_slice(&owner.to_bytes());
+  let mint_and_owner_offset = 2 * PUBKEY_BYTES;
+  let repeat_count = TokenAccount::LEN - mint_and_owner_offset;
+  let mut repeated_bytes: Vec<u8> = vec![0; repeat_count];
+  let initialize_offset = ACCOUNT_INITIALIZED_INDEX - mint_and_owner_offset;
+  // Set the initialize byte to 1 which represents AccountState::Initialized
+  // and the rest of the bytes to 0.
+  repeated_bytes[initialize_offset] = 1;
+  data.extend_from_slice(&repeated_bytes);
+  make_readonly_account_info(
+      key,
+      lamports,
+      data,
+      owner
+  )
+}
+
+fn make_readonly_account_info<'a>(
+    key: &'a Pubkey,
+    lamports: &'a mut u64,
+    data: &'a mut [u8],
+    owner: &'a Pubkey,
+) -> AccountInfo<'a> {
+    let is_signer = false;
+    let is_writable = false;
+    let executable = false;
+    let rent_epoch = 0;
+    AccountInfo::new(
+        key,
+        is_signer,
+        is_writable,
+        lamports,
+        data,
+        owner,
+        executable,
+        rent_epoch,
+    )
+}
+
+fn assert_error(
+    res: Result<(), Error>,
+    error: PaymentRouterErrorCode,
+) {
+    if res != Err(error.into()) {
+        panic!("Expected {:?}, but got {:?}", error, res.unwrap_err());
+    }
+}

--- a/solana-programs/payment-router/scripts/testCreatePaymentRouterBalanceAta.sh
+++ b/solana-programs/payment-router/scripts/testCreatePaymentRouterBalanceAta.sh
@@ -1,9 +1,0 @@
-solana_config=$(solana config get)
-keypair_path=$(echo "$solana_config" | grep "Keypair Path" | awk '{print $3}')
-
-if [ -z "$keypair_path" ]; then
-  echo "Error: fee payer keypair path not found"
-  exit 1
-fi
-
-feePayerSecret=$(cat $keypair_path) anchor run test-create-payment-router-balance-ata -- --skip-deploy

--- a/solana-programs/payment-router/scripts/testCreatePaymentRouterBalanceAta.sh
+++ b/solana-programs/payment-router/scripts/testCreatePaymentRouterBalanceAta.sh
@@ -1,0 +1,9 @@
+solana_config=$(solana config get)
+keypair_path=$(echo "$solana_config" | grep "Keypair Path" | awk '{print $3}')
+
+if [ -z "$keypair_path" ]; then
+  echo "Error: fee payer keypair path not found"
+  exit 1
+fi
+
+feePayerSecret=$(cat $keypair_path) anchor run test-create-payment-router-balance-ata -- --skip-deploy

--- a/solana-programs/payment-router/tests/payment-router.ts
+++ b/solana-programs/payment-router/tests/payment-router.ts
@@ -3,9 +3,7 @@ import { Program } from '@coral-xyz/anchor'
 import { PaymentRouter } from '../target/types/payment_router'
 import { SOL_AUDIO_DECIMALS, SOL_AUDIO_TOKEN_ADDRESS } from './constants'
 import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
-  getAssociatedTokenAddressSync,
   getOrCreateAssociatedTokenAccount,
 } from '@solana/spl-token'
 import { assert } from 'chai'
@@ -77,39 +75,6 @@ describe('payment-router', () => {
       assert.ok(e.toString().includes(error), `Error message not expected: ${e}`)
       console.log('Payment Router balance PDA already exists')
     }
-  })
-
-  it('creates the payment router balance audio associated token account', async () => {
-    const audioTokenAccount = getAssociatedTokenAddressSync(
-      SOL_AUDIO_TOKEN_ADDRESS_KEY,
-      paymentRouterPda,
-      true // allowOwnerOffCurve: we need this since the owner is a program
-    )
-
-    try {
-      const tx = await program.methods
-        .createPaymentRouterBalanceAta(paymentRouterPdaBump)
-        .accounts({
-          paymentRouterPda,
-          audioTokenAccount,
-          audioMint: SOL_AUDIO_TOKEN_ADDRESS_KEY,
-          payer: feePayerPublicKey,
-          tokenProgram: TOKEN_PROGRAM_ID,
-          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-          systemProgram: SystemProgram.programId,
-        })
-        .signers([feePayerKeypair])
-        .rpc()
-      console.log('Your transaction signature', tx)
-    } catch (e) {
-      const timeoutError = 'TransactionExpiredTimeoutError'
-      if (e.toString().includes(timeoutError)) {
-        assert.fail(`The transaction timed out, but the ATAs may have been created.\nError: ${e}`)
-      }
-    }
-
-    const audioAtaAccount = await connection.getAccountInfo(audioTokenAccount)
-    assert.ok(audioAtaAccount, 'Payment Router AUDIO ATA account not found')
   })
 
   it('routes the amounts to the recipients', async () => {

--- a/solana-programs/staking-bridge/Anchor.toml
+++ b/solana-programs/staking-bridge/Anchor.toml
@@ -14,5 +14,6 @@ wallet = "id.json"
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-create-staking-bridge-balance-pda= "yarn run ts-mocha -g 'pda' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test-create-staking-bridge-balance-atas= "yarn run ts-mocha -g 'associated' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-raydium-swap= "yarn run ts-mocha -g 'swap' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-wormhole-transfer= "yarn run ts-mocha -g 'wormhole' -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/solana-programs/staking-bridge/Cargo.lock
+++ b/solana-programs/staking-bridge/Cargo.lock
@@ -1646,9 +1646,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1776,9 +1776,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2b96d4150d9ebf55e903014bc332ac64c642837d7f1e6f7b911d709331380"
+checksum = "d89ed0a4ba426c461866700f082a00d490e4bde6d27d2d88e129acb3fde79054"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -1809,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942534eb972f955ed186175495654cabece6261a8ac3211e5791440d40a1ed96"
+checksum = "b69dd83d2d675cad4ed0f0086a7d0c669dc407213b4bc916555ed329ea93f531"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1339e1a179e2465e97fd89c2f70d5f00c5644f36c0e547b8ecda414c748dfc2c"
+checksum = "9a2d34ee6f40d1be05852e9e442b7b3ead2c2ec6fef567079c1c0a4b3d3b8eb3"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1832,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f81c59ed0b65b403cc5db459dd1214dfab89ccd3ce20aadf98102b072d08562"
+checksum = "c38a798723409541aae8ddc9b69c4c78b798e6c219e3e526b5bd4280974a5f29"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23dbf6da55a2d191956c693d8490dc809799822536aceb11309043e9b622079"
+checksum = "ce456629674fdba5556ab109baac6ef5fc4caf5d42e375a1e3c4413807f3e81c"
 dependencies = [
  "assert_matches",
  "base64 0.21.2",
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7d686e405694cd6510cd77bb87d0eeda64ad3df08d3293278ba47ca78b8e5e"
+checksum = "e3e5a8c7e9e91c7d35f24ffd47a04221f76edb9aba968d79ee10e1cb26f16d2f"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.7"
+version = "1.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d04eecf3a7438c95db28b57437e94f09a1e60377183d9bea0c9db84506f504"
+checksum = "de66fbc7bd6cc3177270cb6c157722fb33f8f2cd2c5c3ad555c6f558705678c4"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.2",

--- a/solana-programs/staking-bridge/README.md
+++ b/solana-programs/staking-bridge/README.md
@@ -24,6 +24,25 @@ Anchor uses Yarn, so please sure you have it installed, and run
 yarn install
 ```
 
+## Running the unit tests
+Use Solana 1.16.1
+```
+solana-install init 1.16.1
+solana -V
+```
+
+and rustc 1.70.0
+```
+rustup install 1.70.0
+rustup default 1.70.0
+rustc -V
+```
+
+Run the tests
+```
+cargo test-bpf
+```
+
 ## Setting up your Solana cluster and environment
 We are going to be invoking programs on the Solana mainnet.
 So, for convenience, you can configure your cluster to use the Solana mainnet by default, and also use your chosen keypair file as the default Solana account by running:

--- a/solana-programs/staking-bridge/programs/staking-bridge/Cargo.toml
+++ b/solana-programs/staking-bridge/programs/staking-bridge/Cargo.toml
@@ -14,6 +14,7 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+test-bpf = []
 
 [dependencies]
 anchor-lang = "0.28.0"

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
@@ -4,8 +4,6 @@ pub const ETH_RECIPIENT_ADDRESS_PADDED_32_BYTES: &str = "00000000000000000000000
 pub const RAYDIUM_AMM_PROGRAM_ADDRESS: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";
 // https://github.com/project-serum/serum-dex/blob/master/README.md#program-deployments
 pub const SERUM_DEX_PROGRAM_ADDRESS: &str = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
-// https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-pub const SOL_USDC_TOKEN_ADDRESS: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 // https://explorer.solana.com/address/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
 pub const SOL_AUDIO_TOKEN_ADDRESS: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";
 // https://etherscan.io/token/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/error.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/error.rs
@@ -6,18 +6,8 @@ pub enum StakingBridgeErrorCode {
     NotCallingRaydiumAmmProgram,
     #[msg("Invalid serum DEX program.")]
     InvalidSerumDexProgram,
-    #[msg("Invalid source token mint.")]
-    InvalidSourceTokenMint,
-    #[msg("Invalid destination token mint.")]
-    InvalidDestinationTokenMint,
-    #[msg("Source token account not owned by PDA.")]
-    SourceTokenAccountNotOwnedByPDA,
-    #[msg("Destination token account not owned by PDA.")]
-    DestinationTokenAccountNotOwnedByPDA,
     #[msg("Not calling Wormhole Token Bridge program.")]
     NotCallingWormholeTokenBridgeProgram,
     #[msg("Invalid Wormhole Core Bridge program.")]
     InvalidWormholeCoreBridgeProgram,
-    #[msg("Wormhole token account not owned by PDA.")]
-    WormholeTokenAccountNotOwnedByPDA,
 }

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -18,13 +18,11 @@ pub mod wormhole;
 use crate::constant::SOL_AUDIO_TOKEN_ADDRESS;
 use crate::raydium::{
     check_swap_programs,
-    check_swap_token_accounts,
     check_swap_pdas,
     swap
 };
 use crate::wormhole::{
     check_wormhole_programs,
-    check_wormhole_token_accounts,
     check_wormhole_pdas,
     approve_wormhole_transfer,
     execute_wormhole_transfer
@@ -61,18 +59,10 @@ pub mod staking_bridge {
         let accounts = ctx.accounts;
         let program_id = &accounts.program_id;
         let serum_program = &accounts.serum_program;
-        let user_source_token_account = &accounts.user_source_token_account;
-        let user_destination_token_account = &accounts.user_destination_token_account;
-        let user_source_owner = &accounts.user_source_owner;
 
         check_swap_programs(
             program_id.to_account_info(),
             serum_program.to_account_info()
-        )?;
-        check_swap_token_accounts(
-            user_source_token_account.to_account_info(),
-            user_destination_token_account.to_account_info(),
-            user_source_owner.to_account_info()
         )?;
         check_swap_pdas(
             accounts,
@@ -104,16 +94,10 @@ pub mod staking_bridge {
         let accounts = ctx.accounts;
         let program_id = &accounts.program_id;
         let bridge_id = &accounts.bridge_id;
-        let from = &accounts.from;
-        let from_owner = &accounts.from_owner;
 
         check_wormhole_programs(
             program_id.to_account_info(),
             bridge_id.to_account_info()
-        )?;
-        check_wormhole_token_accounts(
-            from.to_account_info(),
-            from_owner.to_account_info()
         )?;
         check_wormhole_pdas(
             accounts,

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -1,11 +1,21 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::Token;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    mint,
+    token::
+    {
+        TokenAccount,
+        Mint,
+        Token
+    }
+};
 
 pub mod constant;
 pub mod error;
 pub mod raydium;
 pub mod wormhole;
 
+use crate::constant::SOL_AUDIO_TOKEN_ADDRESS;
 use crate::raydium::{
     check_swap_programs,
     check_swap_token_accounts,
@@ -26,13 +36,14 @@ declare_id!("HEDM7Zg7wNVSCWpV4TF7zp6rgj44C43CXnLtpY68V7bV");
 pub mod staking_bridge {
     use super::*;
 
-    /**
-     * Creates the PDA.
-     * This instruction can be called by anyone.
-     * Immediately returns successfully because Anchor handles
-     * the PDA creation via the CreateStakingBridgeBalancePda struct account macros.
-     */
     pub fn create_staking_bridge_balance_pda(_ctx: Context<CreateStakingBridgeBalancePda>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn create_staking_bridge_balance_atas(
+        _ctx: Context<CreateStakingBridgeBalanceAtas>,
+        _staking_bridge_pda_bump: u8
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -143,6 +154,40 @@ pub struct CreateStakingBridgeBalancePda<'info> {
     pub staking_bridge_pda: UncheckedAccount<'info>,
     #[account(mut)]
     pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(staking_bridge_pda_bump: u8)]
+pub struct CreateStakingBridgeBalanceAtas<'info> {
+    #[account(
+        seeds = [b"staking_bridge".as_ref()],
+        bump = staking_bridge_pda_bump,
+    )]
+    /// CHECK: This is the PDA owned by this program. This account holds both SOL USDC and SOL AUDIO. It is used to swap between the two tokens. This PDA is also used to transfer SOL AUDIO to ETH AUDIO via the wormhole.
+    pub staking_bridge_pda: UncheckedAccount<'info>,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = usdc_mint,
+        associated_token::authority = staking_bridge_pda,
+    )]
+    pub usdc_token_account: Account<'info, TokenAccount>,
+    #[account(address = mint::USDC)]
+    pub usdc_mint: Account<'info, Mint>,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = audio_mint,
+        associated_token::authority = staking_bridge_pda,
+    )]
+    pub audio_token_account: Account<'info, TokenAccount>,
+    #[account(address = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap())]
+    pub audio_mint: Account<'info, Mint>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -249,18 +249,28 @@ pub struct RaydiumSwap<'info> {
     #[account()]
     /// CHECK: This is the vault signer for the serum market. No check necessary.
     pub serum_vault_signer: UncheckedAccount<'info>,
-    #[account(mut)]
-    /// CHECK: This is the SOL USDC token account for the PDA, which is checked by the implementation of this method.
-    pub user_source_token_account: UncheckedAccount<'info>,
-    #[account(mut)]
-    /// CHECK: This is the SOL AUDIO token account for the PDA, which is checked by the implementation of this method.
-    pub user_destination_token_account: UncheckedAccount<'info>,
+    #[account(
+        mut,
+        associated_token::mint = usdc_mint,
+        associated_token::authority = user_source_owner,
+    )]
+    pub user_source_token_account: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        associated_token::mint = audio_mint,
+        associated_token::authority = user_source_owner,
+    )]
+    pub user_destination_token_account: Account<'info, TokenAccount>,
     #[account(
         seeds = [b"staking_bridge".as_ref()],
         bump = staking_bridge_pda_bump
     )]
     /// CHECK: This is the PDA initialized in the CreateStakingBridgeBalancePda instruction.
     pub user_source_owner: UncheckedAccount<'info>,
+    #[account(address = mint::USDC)]
+    pub usdc_mint: Account<'info, Mint>,
+    #[account(address = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap())]
+    pub audio_mint: Account<'info, Mint>,
     pub spl_token_program: Program<'info, Token>,
 }
 
@@ -327,9 +337,14 @@ pub struct PostWormholeMessage<'info> {
     )]
     /// CHECK: This is the PDA initialized in the CreateStakingBridgeBalancePda instruction.
     pub from_owner: UncheckedAccount<'info>,
-    #[account(mut)]
-    /// CHECK: This is the associated token account of the PDA, from which the tokens will be transferred
-    pub from: UncheckedAccount<'info>,
+    #[account(
+        mut,
+        associated_token::mint = audio_mint,
+        associated_token::authority = from_owner,
+    )]
+    pub from: Account<'info, TokenAccount>,
+    #[account(address = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap())]
+    pub audio_mint: Account<'info, Mint>,
     pub clock: Sysvar<'info, Clock>,
     pub rent: Sysvar<'info, Rent>,
     pub spl_token: Program<'info, Token>,

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -91,8 +91,19 @@ pub mod staking_bridge {
         staking_bridge_pda_bump: u8,
     ) -> Result<()> {
         let accounts = ctx.accounts;
-        check_wormhole_programs(accounts)?;
-        check_wormhole_token_accounts(accounts)?;
+        let program_id = &accounts.program_id;
+        let bridge_id = &accounts.bridge_id;
+        let from = &accounts.from;
+        let from_owner = &accounts.from_owner;
+
+        check_wormhole_programs(
+            program_id.to_account_info(),
+            bridge_id.to_account_info()
+        )?;
+        check_wormhole_token_accounts(
+            from.to_account_info(),
+            from_owner.to_account_info()
+        )?;
         check_wormhole_pdas(
             accounts,
             config_bump,

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -7,9 +7,9 @@ pub mod raydium;
 pub mod wormhole;
 
 use crate::raydium::{
-    check_raydium_programs,
-    check_raydium_token_accounts,
-    check_raydium_pdas,
+    check_swap_programs,
+    check_swap_token_accounts,
+    check_swap_pdas,
     swap
 };
 use crate::wormhole::{
@@ -48,9 +48,22 @@ pub mod staking_bridge {
         staking_bridge_pda_bump: u8
     ) -> Result<()> {
         let accounts = ctx.accounts;
-        check_raydium_programs(accounts)?;
-        check_raydium_token_accounts(accounts)?;
-        check_raydium_pdas(
+        let program_id = &accounts.program_id;
+        let serum_program = &accounts.serum_program;
+        let user_source_token_account = &accounts.user_source_token_account;
+        let user_destination_token_account = &accounts.user_destination_token_account;
+        let user_source_owner = &accounts.user_source_owner;
+
+        check_swap_programs(
+            program_id.to_account_info(),
+            serum_program.to_account_info()
+        )?;
+        check_swap_token_accounts(
+            user_source_token_account.to_account_info(),
+            user_destination_token_account.to_account_info(),
+            user_source_owner.to_account_info()
+        )?;
+        check_swap_pdas(
             accounts,
             vault_nonce
         )?;

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -7,16 +7,10 @@ use anchor_lang::solana_program::{
     },
 };
 use anchor_spl::token::spl_token;
-use anchor_spl::token::spl_token::state::{
-    Account,
-    GenericTokenAccount
-};
 
 use crate::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
-    SOL_USDC_TOKEN_ADDRESS,
-    SOL_AUDIO_TOKEN_ADDRESS
 };
 use crate::error::StakingBridgeErrorCode;
 use crate::{
@@ -39,55 +33,6 @@ pub fn check_swap_programs(
     // 2. Verify that the correct Serum DEX program was passed in.
     if serum_program.key().to_string() != SERUM_DEX_PROGRAM_ADDRESS.to_string() {
         return Err(StakingBridgeErrorCode::InvalidSerumDexProgram.into());
-    }
-
-    Ok(())
-}
-
-/**
- * 1. Verify PDA ownership of the token accounts.
- * 2. Verify that the source token account is of the USDC mint.
- * 3. Verify that the destination token account is of the AUDIO mint.
- */
-pub fn check_swap_token_accounts(
-    user_source_token_account: AccountInfo,
-    user_destination_token_account: AccountInfo,
-    user_source_owner: AccountInfo,
-) -> Result<()> {
-    // 1. Verify PDA ownership of the token accounts.
-    // Note that anchor checks for the program ownership of the 'user_source_owner' account,
-    // i.e. that the owner of the token accounts is owned by the program.
-    // This is because we use the account macro with seeds and bump for the 'user_source_owner'.
-    let source_token_data = user_source_token_account.data.borrow();
-    let source_token_owner= <Account as GenericTokenAccount>
-        ::unpack_account_owner(&source_token_data)
-        .unwrap();
-    if source_token_owner != user_source_owner.key {
-        return Err(StakingBridgeErrorCode::SourceTokenAccountNotOwnedByPDA.into());
-    }
-
-    let destination_token_data = user_destination_token_account.data.borrow();
-    let destination_token_owner= <Account as GenericTokenAccount>
-        ::unpack_account_owner(&destination_token_data)
-        .unwrap();
-    if destination_token_owner != user_source_owner.key {
-        return Err(StakingBridgeErrorCode::DestinationTokenAccountNotOwnedByPDA.into());
-    }
-
-    // 2. Verify that the source token account is of the USDC mint.
-    let source_token_mint= <Account as GenericTokenAccount>
-        ::unpack_account_mint(&source_token_data)
-        .unwrap();
-    if source_token_mint.key().to_string() != SOL_USDC_TOKEN_ADDRESS.to_string() {
-        return Err(StakingBridgeErrorCode::InvalidSourceTokenMint.into());
-    }
-
-    // 3. Verify that the destination token account is of the AUDIO mint.
-    let destination_token_mint= <Account as GenericTokenAccount>
-        ::unpack_account_mint(&destination_token_data)
-        .unwrap();
-    if destination_token_mint.key().to_string() != SOL_AUDIO_TOKEN_ADDRESS.to_string() {
-        return Err(StakingBridgeErrorCode::InvalidDestinationTokenMint.into());
     }
 
     Ok(())

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -24,10 +24,10 @@ use crate::{
  * 1. Verify that we are calling the Raydium AMM program.
  * 2. Verify that the correct Serum DEX program was passed in.
  */
-pub fn check_raydium_programs(accounts: &mut RaydiumSwap) -> Result<()> {
-    let program_id = &accounts.program_id;
-    let serum_program = &accounts.serum_program;
-
+pub fn check_swap_programs(
+    program_id: AccountInfo,
+    serum_program: AccountInfo,
+) -> Result<()> {
     // 1. Verify that we are calling the Raydium AMM program.
     if program_id.key().to_string() != RAYDIUM_AMM_PROGRAM_ADDRESS.to_string() {
         return Err(StakingBridgeErrorCode::NotCallingRaydiumAmmProgram.into());
@@ -45,16 +45,17 @@ pub fn check_raydium_programs(accounts: &mut RaydiumSwap) -> Result<()> {
  * 2. Verify that the source token account is of the USDC mint.
  * 3. Verify that the destination token account is of the AUDIO mint.
  */
-pub fn check_raydium_token_accounts(accounts: &mut RaydiumSwap) -> Result<()> {
-    let user_source_token_account = &accounts.user_source_token_account;
-    let user_destination_token_account = &accounts.user_destination_token_account;
-    let user_source_owner = &accounts.user_source_owner;
-
+pub fn check_swap_token_accounts(
+    user_source_token_account: AccountInfo,
+    user_destination_token_account: AccountInfo,
+    user_source_owner: AccountInfo,
+) -> Result<()> {
     // 1. Verify PDA ownership of the token accounts.
     // Note that anchor checks for the program ownership of the 'user_source_owner' account,
     // i.e. that the owner of the token accounts is owned by the program.
     // This is because we use the account macro with seeds and bump for the 'user_source_owner'.
     let source_token_data = user_source_token_account.data.borrow();
+    // msg!("source_token_data: {:?}", source_token_data);
     let source_token_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
         ::unpack_account_owner(&source_token_data)
         .unwrap();
@@ -92,7 +93,7 @@ pub fn check_raydium_token_accounts(accounts: &mut RaydiumSwap) -> Result<()> {
 /**
  * Verify that the correct PDAs are passed in.
  */
-pub fn check_raydium_pdas(
+pub fn check_swap_pdas(
     accounts: &mut RaydiumSwap,
     vault_nonce: u64
 ) -> Result<()> {

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -7,6 +7,10 @@ use anchor_lang::solana_program::{
     },
 };
 use anchor_spl::token::spl_token;
+use anchor_spl::token::spl_token::state::{
+    Account,
+    GenericTokenAccount
+};
 
 use crate::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
@@ -56,7 +60,7 @@ pub fn check_swap_token_accounts(
     // This is because we use the account macro with seeds and bump for the 'user_source_owner'.
     let source_token_data = user_source_token_account.data.borrow();
     // msg!("source_token_data: {:?}", source_token_data);
-    let source_token_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let source_token_owner= <Account as GenericTokenAccount>
         ::unpack_account_owner(&source_token_data)
         .unwrap();
     if source_token_owner != user_source_owner.key {
@@ -64,7 +68,7 @@ pub fn check_swap_token_accounts(
     }
 
     let destination_token_data = user_destination_token_account.data.borrow();
-    let destination_token_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let destination_token_owner= <Account as GenericTokenAccount>
         ::unpack_account_owner(&destination_token_data)
         .unwrap();
     if destination_token_owner != user_source_owner.key {
@@ -72,7 +76,7 @@ pub fn check_swap_token_accounts(
     }
 
     // 2. Verify that the source token account is of the USDC mint.
-    let source_token_mint= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let source_token_mint= <Account as GenericTokenAccount>
         ::unpack_account_mint(&source_token_data)
         .unwrap();
     if source_token_mint.key().to_string() != SOL_USDC_TOKEN_ADDRESS.to_string() {
@@ -80,7 +84,7 @@ pub fn check_swap_token_accounts(
     }
 
     // 3. Verify that the destination token account is of the AUDIO mint.
-    let destination_token_mint= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let destination_token_mint= <Account as GenericTokenAccount>
         ::unpack_account_mint(&destination_token_data)
         .unwrap();
     if destination_token_mint.key().to_string() != SOL_AUDIO_TOKEN_ADDRESS.to_string() {

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -59,7 +59,6 @@ pub fn check_swap_token_accounts(
     // i.e. that the owner of the token accounts is owned by the program.
     // This is because we use the account macro with seeds and bump for the 'user_source_owner'.
     let source_token_data = user_source_token_account.data.borrow();
-    // msg!("source_token_data: {:?}", source_token_data);
     let source_token_owner= <Account as GenericTokenAccount>
         ::unpack_account_owner(&source_token_data)
         .unwrap();

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
@@ -9,10 +9,6 @@ use anchor_lang::{
     },
 }};
 use anchor_spl::token::spl_token;
-use anchor_spl::token::spl_token::state::{
-    Account,
-    GenericTokenAccount
-};
 
 use crate::constant::{
     ETH_CHAIN_ID,
@@ -42,26 +38,6 @@ pub fn check_wormhole_programs(
     // 2. Verify that we are using the Wormhole Core Bridge program.
     if bridge_id.key().to_string() != WORMHOLE_CORE_BRIDGE_ID.to_string() {
         return Err(StakingBridgeErrorCode::InvalidWormholeCoreBridgeProgram.into());
-    }
-    Ok(())
-}
-
-/**
- * Verify PDA ownership of the 'from' token account.
- * Note that anchor checks for the program ownership of the 'from_owner' account,
- * i.e. that the owner of the 'from' token account is owned by the program.
- * This is because we use the account macro with seeds and bump for 'from_owner'.
- */
-pub fn check_wormhole_token_accounts(
-    from: AccountInfo,
-    from_owner: AccountInfo,
-) -> Result<()> {
-    let from_account_data = from.data.borrow();
-    let from_account_owner= <Account as GenericTokenAccount>
-        ::unpack_account_owner(&from_account_data)
-        .unwrap();
-    if from_account_owner != from_owner.key {
-        return Err(StakingBridgeErrorCode::WormholeTokenAccountNotOwnedByPDA.into());
     }
     Ok(())
 }

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
@@ -28,11 +28,9 @@ use crate::{
  * 2. Verify that we are using the Wormhole Core Bridge program.
  */
 pub fn check_wormhole_programs(
-    accounts: &mut PostWormholeMessage,
+    program_id: AccountInfo,
+    bridge_id: AccountInfo,
 ) -> Result<()> {
-    let program_id = &accounts.program_id;
-    let bridge_id = &accounts.bridge_id;
-
     // 1. Verify that we are calling the Wormhole Token Bridge program.
     if program_id.key().to_string() != WORMHOLE_TOKEN_BRIDGE_ID.to_string() {
         return Err(StakingBridgeErrorCode::NotCallingWormholeTokenBridgeProgram.into());
@@ -51,10 +49,9 @@ pub fn check_wormhole_programs(
  * This is because we use the account macro with seeds and bump for 'from_owner'.
  */
 pub fn check_wormhole_token_accounts(
-    accounts: &mut PostWormholeMessage,
+    from: AccountInfo,
+    from_owner: AccountInfo,
 ) -> Result<()> {
-    let from = &accounts.from;
-    let from_owner = &accounts.from_owner;
     let from_account_data = from.data.borrow();
     let from_account_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
         ::unpack_account_owner(&from_account_data)

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/wormhole.rs
@@ -9,6 +9,10 @@ use anchor_lang::{
     },
 }};
 use anchor_spl::token::spl_token;
+use anchor_spl::token::spl_token::state::{
+    Account,
+    GenericTokenAccount
+};
 
 use crate::constant::{
     ETH_CHAIN_ID,
@@ -53,7 +57,7 @@ pub fn check_wormhole_token_accounts(
     from_owner: AccountInfo,
 ) -> Result<()> {
     let from_account_data = from.data.borrow();
-    let from_account_owner= <anchor_spl::token::spl_token::state::Account as anchor_spl::token::spl_token::state::GenericTokenAccount>
+    let from_account_owner= <Account as GenericTokenAccount>
         ::unpack_account_owner(&from_account_data)
         .unwrap();
     if from_account_owner != from_owner.key {

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
@@ -1,0 +1,227 @@
+#![cfg(feature = "test-bpf")]
+
+use anchor_lang::prelude::{
+  AccountInfo,
+  Pubkey,
+  Error,
+};
+use anchor_lang::solana_program::pubkey::PUBKEY_BYTES;
+use anchor_spl::token::{
+    TokenAccount,
+    spl_token::state::ACCOUNT_INITIALIZED_INDEX
+};
+
+use staking_bridge::error::StakingBridgeErrorCode;
+use staking_bridge::raydium::{
+    check_swap_programs,
+    check_swap_token_accounts,
+};
+use staking_bridge::constant::{
+    RAYDIUM_AMM_PROGRAM_ADDRESS,
+    SERUM_DEX_PROGRAM_ADDRESS,
+    SOL_USDC_TOKEN_ADDRESS,
+    SOL_AUDIO_TOKEN_ADDRESS,
+};
+
+#[test]
+fn test_swap_programs() {
+    let raydium_key = &RAYDIUM_AMM_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
+    let serum_key = &SERUM_DEX_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
+    let other_key = &Pubkey::new_unique();
+
+    let (raydium_lamports, raydium_data) = (&mut 0, &mut vec![]);
+    let (serum_lamports, serum_data) = (&mut 0, &mut vec![]);
+    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
+    let raydium_program = &make_readonly_account_info(
+        raydium_key,
+        raydium_lamports,
+        raydium_data,
+        other_key
+    );
+    let serum_program = &make_readonly_account_info(
+        serum_key,
+        serum_lamports,
+        serum_data,
+        other_key
+    );
+    let bad_account_info = &make_readonly_account_info(
+        other_key,
+        bad_lamports,
+        bad_data,
+        other_key
+    );
+
+    let bad_raydium_program_result = check_swap_programs(
+      bad_account_info.clone(),
+      serum_program.clone(),
+    );
+    assert_error(bad_raydium_program_result, StakingBridgeErrorCode::NotCallingRaydiumAmmProgram);
+
+    let bad_serum_program_result = check_swap_programs(
+      raydium_program.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_serum_program_result, StakingBridgeErrorCode::InvalidSerumDexProgram);
+
+    let result = check_swap_programs(
+      raydium_program.clone(),
+      serum_program.clone(),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn test_swap_token_accounts() {
+    let usdc_mint_key = SOL_USDC_TOKEN_ADDRESS.parse::<Pubkey>().unwrap();
+    let audio_mint_key = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap();
+
+    let source_key = Pubkey::new_unique();
+    let destination_key = Pubkey::new_unique();
+    let owner_key = Pubkey::new_unique();
+    let other_key = Pubkey::new_unique();
+
+    let (source_lamports, source_data) = (&mut 0, &mut vec![]);
+    let source_account_info = &get_initialized_token_account_info(
+      &source_key,
+      source_lamports,
+      source_data,
+      &usdc_mint_key,
+      &owner_key
+    );
+
+    let (destination_lamports, destination_data) = (&mut 0, &mut vec![]);
+    let destination_account_info = &get_initialized_token_account_info(
+      &destination_key,
+      destination_lamports,
+      destination_data,
+      &audio_mint_key,
+      &owner_key
+    );
+
+    let (owner_lamports, owner_data) = (&mut 0, &mut vec![]);
+    let owner_account_info = &get_initialized_token_account_info(
+      &owner_key,
+      owner_lamports,
+      owner_data,
+      &other_key,
+      &other_key
+    );
+
+    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
+    let bad_account_info = &get_initialized_token_account_info(
+      &other_key,
+      bad_lamports,
+      bad_data,
+      &other_key,
+      &other_key
+    );
+
+    let (bad_mint_lamports, bad_mint_data) = (&mut 0, &mut vec![]);
+    let bad_mint_account_info = &get_initialized_token_account_info(
+      &other_key,
+      bad_mint_lamports,
+      bad_mint_data,
+      &other_key,
+      &owner_key
+    );
+
+    let bad_source_result = check_swap_token_accounts(
+      bad_account_info.clone(),
+      destination_account_info.clone(),
+      owner_account_info.clone(),
+    );
+    assert_error(bad_source_result, StakingBridgeErrorCode::SourceTokenAccountNotOwnedByPDA);
+
+    let bad_destination_result = check_swap_token_accounts(
+      source_account_info.clone(),
+      bad_account_info.clone(),
+      owner_account_info.clone(),
+    );
+    assert_error(bad_destination_result, StakingBridgeErrorCode::DestinationTokenAccountNotOwnedByPDA);
+
+    let bad_owner_result = check_swap_token_accounts(
+      source_account_info.clone(),
+      destination_account_info.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_owner_result, StakingBridgeErrorCode::SourceTokenAccountNotOwnedByPDA);
+
+    let bad_source_mint_result = check_swap_token_accounts(
+      bad_mint_account_info.clone(),
+      destination_account_info.clone(),
+      owner_account_info.clone(),
+    );
+    assert_error(bad_source_mint_result, StakingBridgeErrorCode::InvalidSourceTokenMint);
+
+    let bad_destination_mint_result = check_swap_token_accounts(
+      source_account_info.clone(),
+      bad_mint_account_info.clone(),
+      owner_account_info.clone(),
+    );
+    assert_error(bad_destination_mint_result, StakingBridgeErrorCode::InvalidDestinationTokenMint);
+
+    let result = check_swap_token_accounts(
+      source_account_info.clone(),
+      destination_account_info.clone(),
+      owner_account_info.clone(),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+fn get_initialized_token_account_info<'a>(
+  key: &'a Pubkey,
+  lamports: &'a mut u64,
+  data: &'a mut Vec<u8>,
+  mint: &'a Pubkey,
+  owner: &'a Pubkey
+) -> AccountInfo<'a> {
+  // Set the mint and owner of the account.
+  // Note that the mint offset is 0 and the owner offset is 32.
+  data.extend_from_slice(&mint.to_bytes());
+  data.extend_from_slice(&owner.to_bytes());
+  let mint_and_owner_offset = 2 * PUBKEY_BYTES;
+  let repeat_count = TokenAccount::LEN - mint_and_owner_offset;
+  let mut repeated_bytes: Vec<u8> = vec![0; repeat_count];
+  let initialize_offset = ACCOUNT_INITIALIZED_INDEX - mint_and_owner_offset;
+  // Set the initialize byte to 1 which represents AccountState::Initialized
+  // and the rest of the bytes to 0.
+  repeated_bytes[initialize_offset] = 1;
+  data.extend_from_slice(&repeated_bytes);
+  make_readonly_account_info(
+      key,
+      lamports,
+      data,
+      owner
+  )
+}
+
+fn make_readonly_account_info<'a>(
+    key: &'a Pubkey,
+    lamports: &'a mut u64,
+    data: &'a mut [u8],
+    owner: &'a Pubkey,
+) -> AccountInfo<'a> {
+    let is_signer = false;
+    let is_writable = false;
+    let executable = false;
+    let rent_epoch = 0;
+    AccountInfo::new(
+        key,
+        is_signer,
+        is_writable,
+        lamports,
+        data,
+        owner,
+        executable,
+        rent_epoch,
+    )
+}
+
+fn assert_error(
+    res: Result<(), Error>,
+    error: StakingBridgeErrorCode,
+) {
+  if res != Err(error.into()) {
+      panic!("Expected {:?}, but got {:?}", error, res.unwrap_err());
+  }
+}

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
@@ -3,18 +3,14 @@
 use anchor_lang::prelude::Pubkey;
 
 use staking_bridge::error::StakingBridgeErrorCode;
-use staking_bridge::raydium::{
-    check_swap_programs,
-    check_swap_token_accounts,
-};
+use staking_bridge::raydium::check_swap_programs;
 use staking_bridge::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
-    SOL_USDC_TOKEN_ADDRESS,
-    SOL_AUDIO_TOKEN_ADDRESS,
 };
 
 mod utils;
+mod wormhole_tests;
 use utils::{
   get_initialized_token_account_info,
   make_readonly_account_info,
@@ -64,104 +60,6 @@ fn test_swap_programs() {
     let result = check_swap_programs(
       raydium_program.clone(),
       serum_program.clone(),
-    );
-    assert_eq!(result, Ok(()));
-}
-
-#[test]
-fn test_swap_token_accounts() {
-    let usdc_mint_key = SOL_USDC_TOKEN_ADDRESS.parse::<Pubkey>().unwrap();
-    let audio_mint_key = SOL_AUDIO_TOKEN_ADDRESS.parse::<Pubkey>().unwrap();
-
-    let source_key = Pubkey::new_unique();
-    let destination_key = Pubkey::new_unique();
-    let owner_key = Pubkey::new_unique();
-    let other_key = Pubkey::new_unique();
-
-    let (source_lamports, source_data) = (&mut 0, &mut vec![]);
-    let source_account_info = &get_initialized_token_account_info(
-      &source_key,
-      source_lamports,
-      source_data,
-      &usdc_mint_key,
-      &owner_key
-    );
-
-    let (destination_lamports, destination_data) = (&mut 0, &mut vec![]);
-    let destination_account_info = &get_initialized_token_account_info(
-      &destination_key,
-      destination_lamports,
-      destination_data,
-      &audio_mint_key,
-      &owner_key
-    );
-
-    let (owner_lamports, owner_data) = (&mut 0, &mut vec![]);
-    let owner_account_info = &get_initialized_token_account_info(
-      &owner_key,
-      owner_lamports,
-      owner_data,
-      &other_key,
-      &other_key
-    );
-
-    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
-    let bad_account_info = &get_initialized_token_account_info(
-      &other_key,
-      bad_lamports,
-      bad_data,
-      &other_key,
-      &other_key
-    );
-
-    let (bad_mint_lamports, bad_mint_data) = (&mut 0, &mut vec![]);
-    let bad_mint_account_info = &get_initialized_token_account_info(
-      &other_key,
-      bad_mint_lamports,
-      bad_mint_data,
-      &other_key,
-      &owner_key
-    );
-
-    let bad_source_result = check_swap_token_accounts(
-      bad_account_info.clone(),
-      destination_account_info.clone(),
-      owner_account_info.clone(),
-    );
-    assert_error(bad_source_result, StakingBridgeErrorCode::SourceTokenAccountNotOwnedByPDA);
-
-    let bad_destination_result = check_swap_token_accounts(
-      source_account_info.clone(),
-      bad_account_info.clone(),
-      owner_account_info.clone(),
-    );
-    assert_error(bad_destination_result, StakingBridgeErrorCode::DestinationTokenAccountNotOwnedByPDA);
-
-    let bad_owner_result = check_swap_token_accounts(
-      source_account_info.clone(),
-      destination_account_info.clone(),
-      bad_account_info.clone(),
-    );
-    assert_error(bad_owner_result, StakingBridgeErrorCode::SourceTokenAccountNotOwnedByPDA);
-
-    let bad_source_mint_result = check_swap_token_accounts(
-      bad_mint_account_info.clone(),
-      destination_account_info.clone(),
-      owner_account_info.clone(),
-    );
-    assert_error(bad_source_mint_result, StakingBridgeErrorCode::InvalidSourceTokenMint);
-
-    let bad_destination_mint_result = check_swap_token_accounts(
-      source_account_info.clone(),
-      bad_mint_account_info.clone(),
-      owner_account_info.clone(),
-    );
-    assert_error(bad_destination_mint_result, StakingBridgeErrorCode::InvalidDestinationTokenMint);
-
-    let result = check_swap_token_accounts(
-      source_account_info.clone(),
-      destination_account_info.clone(),
-      owner_account_info.clone(),
     );
     assert_eq!(result, Ok(()));
 }

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
@@ -1,15 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
-use anchor_lang::prelude::{
-  AccountInfo,
-  Pubkey,
-  Error,
-};
-use anchor_lang::solana_program::pubkey::PUBKEY_BYTES;
-use anchor_spl::token::{
-    TokenAccount,
-    spl_token::state::ACCOUNT_INITIALIZED_INDEX
-};
+use anchor_lang::prelude::Pubkey;
 
 use staking_bridge::error::StakingBridgeErrorCode;
 use staking_bridge::raydium::{
@@ -21,6 +12,13 @@ use staking_bridge::constant::{
     SERUM_DEX_PROGRAM_ADDRESS,
     SOL_USDC_TOKEN_ADDRESS,
     SOL_AUDIO_TOKEN_ADDRESS,
+};
+
+mod utils;
+use utils::{
+  get_initialized_token_account_info,
+  make_readonly_account_info,
+  assert_error
 };
 
 #[test]
@@ -166,62 +164,4 @@ fn test_swap_token_accounts() {
       owner_account_info.clone(),
     );
     assert_eq!(result, Ok(()));
-}
-
-fn get_initialized_token_account_info<'a>(
-  key: &'a Pubkey,
-  lamports: &'a mut u64,
-  data: &'a mut Vec<u8>,
-  mint: &'a Pubkey,
-  owner: &'a Pubkey
-) -> AccountInfo<'a> {
-  // Set the mint and owner of the account.
-  // Note that the mint offset is 0 and the owner offset is 32.
-  data.extend_from_slice(&mint.to_bytes());
-  data.extend_from_slice(&owner.to_bytes());
-  let mint_and_owner_offset = 2 * PUBKEY_BYTES;
-  let repeat_count = TokenAccount::LEN - mint_and_owner_offset;
-  let mut repeated_bytes: Vec<u8> = vec![0; repeat_count];
-  let initialize_offset = ACCOUNT_INITIALIZED_INDEX - mint_and_owner_offset;
-  // Set the initialize byte to 1 which represents AccountState::Initialized
-  // and the rest of the bytes to 0.
-  repeated_bytes[initialize_offset] = 1;
-  data.extend_from_slice(&repeated_bytes);
-  make_readonly_account_info(
-      key,
-      lamports,
-      data,
-      owner
-  )
-}
-
-fn make_readonly_account_info<'a>(
-    key: &'a Pubkey,
-    lamports: &'a mut u64,
-    data: &'a mut [u8],
-    owner: &'a Pubkey,
-) -> AccountInfo<'a> {
-    let is_signer = false;
-    let is_writable = false;
-    let executable = false;
-    let rent_epoch = 0;
-    AccountInfo::new(
-        key,
-        is_signer,
-        is_writable,
-        lamports,
-        data,
-        owner,
-        executable,
-        rent_epoch,
-    )
-}
-
-fn assert_error(
-    res: Result<(), Error>,
-    error: StakingBridgeErrorCode,
-) {
-  if res != Err(error.into()) {
-      panic!("Expected {:?}, but got {:?}", error, res.unwrap_err());
-  }
 }

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/utils.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/utils.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-bpf")]
+
 use anchor_lang::prelude::{
   AccountInfo,
   Pubkey,

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/utils.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/utils.rs
@@ -1,0 +1,70 @@
+use anchor_lang::prelude::{
+  AccountInfo,
+  Pubkey,
+  Error,
+};
+use anchor_lang::solana_program::pubkey::PUBKEY_BYTES;
+use anchor_spl::token::{
+  TokenAccount,
+  spl_token::state::ACCOUNT_INITIALIZED_INDEX
+};
+
+use staking_bridge::error::StakingBridgeErrorCode;
+
+pub fn get_initialized_token_account_info<'a>(
+  key: &'a Pubkey,
+  lamports: &'a mut u64,
+  data: &'a mut Vec<u8>,
+  mint: &'a Pubkey,
+  owner: &'a Pubkey
+) -> AccountInfo<'a> {
+  // Set the mint and owner of the account.
+  // Note that the mint offset is 0 and the owner offset is 32.
+  data.extend_from_slice(&mint.to_bytes());
+  data.extend_from_slice(&owner.to_bytes());
+  let mint_and_owner_offset = 2 * PUBKEY_BYTES;
+  let repeat_count = TokenAccount::LEN - mint_and_owner_offset;
+  let mut repeated_bytes: Vec<u8> = vec![0; repeat_count];
+  let initialize_offset = ACCOUNT_INITIALIZED_INDEX - mint_and_owner_offset;
+  // Set the initialize byte to 1 which represents AccountState::Initialized
+  // and the rest of the bytes to 0.
+  repeated_bytes[initialize_offset] = 1;
+  data.extend_from_slice(&repeated_bytes);
+  make_readonly_account_info(
+      key,
+      lamports,
+      data,
+      owner
+  )
+}
+
+pub fn make_readonly_account_info<'a>(
+    key: &'a Pubkey,
+    lamports: &'a mut u64,
+    data: &'a mut [u8],
+    owner: &'a Pubkey,
+) -> AccountInfo<'a> {
+    let is_signer = false;
+    let is_writable = false;
+    let executable = false;
+    let rent_epoch = 0;
+    AccountInfo::new(
+        key,
+        is_signer,
+        is_writable,
+        lamports,
+        data,
+        owner,
+        executable,
+        rent_epoch,
+    )
+}
+
+pub fn assert_error(
+    res: Result<(), Error>,
+    error: StakingBridgeErrorCode,
+) {
+    if res != Err(error.into()) {
+        panic!("Expected {:?}, but got {:?}", error, res.unwrap_err());
+    }
+}

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/wormhole_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/wormhole_tests.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "test-bpf")]
+
+use anchor_lang::prelude::Pubkey;
+
+use staking_bridge::error::StakingBridgeErrorCode;
+use staking_bridge::wormhole::{
+    check_wormhole_programs,
+    check_wormhole_token_accounts,
+};
+use staking_bridge::constant::{
+  WORMHOLE_CORE_BRIDGE_ID,
+  WORMHOLE_TOKEN_BRIDGE_ID
+};
+
+mod utils;
+use utils::{
+  get_initialized_token_account_info,
+  make_readonly_account_info,
+  assert_error
+};
+
+#[test]
+fn test_wormhole_programs() {
+    let token_bridge_key = &WORMHOLE_TOKEN_BRIDGE_ID.parse::<Pubkey>().unwrap();
+    let core_bridge_key = &WORMHOLE_CORE_BRIDGE_ID.parse::<Pubkey>().unwrap();
+    let other_key = &Pubkey::new_unique();
+
+    let (token_bridge_lamports, token_bridge_data) = (&mut 0, &mut vec![]);
+    let token_bridge_program = &make_readonly_account_info(
+        token_bridge_key,
+        token_bridge_lamports,
+        token_bridge_data,
+        other_key
+    );
+    let (core_bridge_lamports, core_bridge_data) = (&mut 0, &mut vec![]);
+    let core_bridge_program = &make_readonly_account_info(
+        core_bridge_key,
+        core_bridge_lamports,
+        core_bridge_data,
+        other_key
+    );
+    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
+    let bad_account_info = &make_readonly_account_info(
+        other_key,
+        bad_lamports,
+        bad_data,
+        other_key
+    );
+
+    let bad_token_bridge_program_result = check_wormhole_programs(
+      bad_account_info.clone(),
+      core_bridge_program.clone(),
+    );
+    assert_error(bad_token_bridge_program_result, StakingBridgeErrorCode::NotCallingWormholeTokenBridgeProgram);
+
+    let bad_core_bridge_program_result = check_wormhole_programs(
+      token_bridge_program.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_core_bridge_program_result, StakingBridgeErrorCode::InvalidWormholeCoreBridgeProgram);
+
+    let result = check_wormhole_programs(
+      token_bridge_program.clone(),
+      core_bridge_program.clone(),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn test_wormhole_token_accounts() {
+    let from_key = Pubkey::new_unique();
+    let from_owner_key = Pubkey::new_unique();
+    let other_key = Pubkey::new_unique();
+
+    let (from_lamports, from_data) = (&mut 0, &mut vec![]);
+    let from_account_info = &get_initialized_token_account_info(
+      &from_key,
+      from_lamports,
+      from_data,
+      &other_key,
+      &from_owner_key
+    );
+
+    let (from_owner_lamports, from_owner_data) = (&mut 0, &mut vec![]);
+    let from_owner_account_info = &get_initialized_token_account_info(
+      &from_owner_key,
+      from_owner_lamports,
+      from_owner_data,
+      &other_key,
+      &other_key
+    );
+
+    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
+    let bad_account_info = &get_initialized_token_account_info(
+      &other_key,
+      bad_lamports,
+      bad_data,
+      &other_key,
+      &other_key
+    );
+
+    let bad_from_result = check_wormhole_token_accounts(
+      bad_account_info.clone(),
+      from_owner_account_info.clone(),
+    );
+    assert_error(bad_from_result, StakingBridgeErrorCode::WormholeTokenAccountNotOwnedByPDA);
+
+    let bad_from_owner_result = check_wormhole_token_accounts(
+      from_account_info.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_from_owner_result, StakingBridgeErrorCode::WormholeTokenAccountNotOwnedByPDA);
+
+    let result = check_wormhole_token_accounts(
+      from_account_info.clone(),
+      from_owner_account_info.clone(),
+    );
+    assert_eq!(result, Ok(()));
+}

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/wormhole_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/wormhole_tests.rs
@@ -3,10 +3,7 @@
 use anchor_lang::prelude::Pubkey;
 
 use staking_bridge::error::StakingBridgeErrorCode;
-use staking_bridge::wormhole::{
-    check_wormhole_programs,
-    check_wormhole_token_accounts,
-};
+use staking_bridge::wormhole::check_wormhole_programs;
 use staking_bridge::constant::{
   WORMHOLE_CORE_BRIDGE_ID,
   WORMHOLE_TOKEN_BRIDGE_ID
@@ -62,58 +59,6 @@ fn test_wormhole_programs() {
     let result = check_wormhole_programs(
       token_bridge_program.clone(),
       core_bridge_program.clone(),
-    );
-    assert_eq!(result, Ok(()));
-}
-
-#[test]
-fn test_wormhole_token_accounts() {
-    let from_key = Pubkey::new_unique();
-    let from_owner_key = Pubkey::new_unique();
-    let other_key = Pubkey::new_unique();
-
-    let (from_lamports, from_data) = (&mut 0, &mut vec![]);
-    let from_account_info = &get_initialized_token_account_info(
-      &from_key,
-      from_lamports,
-      from_data,
-      &other_key,
-      &from_owner_key
-    );
-
-    let (from_owner_lamports, from_owner_data) = (&mut 0, &mut vec![]);
-    let from_owner_account_info = &get_initialized_token_account_info(
-      &from_owner_key,
-      from_owner_lamports,
-      from_owner_data,
-      &other_key,
-      &other_key
-    );
-
-    let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
-    let bad_account_info = &get_initialized_token_account_info(
-      &other_key,
-      bad_lamports,
-      bad_data,
-      &other_key,
-      &other_key
-    );
-
-    let bad_from_result = check_wormhole_token_accounts(
-      bad_account_info.clone(),
-      from_owner_account_info.clone(),
-    );
-    assert_error(bad_from_result, StakingBridgeErrorCode::WormholeTokenAccountNotOwnedByPDA);
-
-    let bad_from_owner_result = check_wormhole_token_accounts(
-      from_account_info.clone(),
-      bad_account_info.clone(),
-    );
-    assert_error(bad_from_owner_result, StakingBridgeErrorCode::WormholeTokenAccountNotOwnedByPDA);
-
-    let result = check_wormhole_token_accounts(
-      from_account_info.clone(),
-      from_owner_account_info.clone(),
     );
     assert_eq!(result, Ok(()));
 }

--- a/solana-programs/staking-bridge/scripts/testCreateStakingBridgeBalanceAtas.sh
+++ b/solana-programs/staking-bridge/scripts/testCreateStakingBridgeBalanceAtas.sh
@@ -1,0 +1,9 @@
+solana_config=$(solana config get)
+keypair_path=$(echo "$solana_config" | grep "Keypair Path" | awk '{print $3}')
+
+if [ -z "$keypair_path" ]; then
+  echo "Error: fee payer keypair path not found"
+  exit 1
+fi
+
+feePayerSecret=$(cat $keypair_path) anchor run test-create-staking-bridge-balance-atas -- --skip-deploy

--- a/solana-programs/staking-bridge/tests/staking-bridge.ts
+++ b/solana-programs/staking-bridge/tests/staking-bridge.ts
@@ -202,6 +202,8 @@ describe('staking-bridge', () => {
       userSourceTokenAccount: usdcTokenAccount.address,
       userDestinationTokenAccount: audioTokenAccount.address,
       userSourceOwner: stakingBridgePda,
+      usdcMint: SOL_USDC_TOKEN_ADDRESS_KEY,
+      audioMint: SOL_AUDIO_TOKEN_ADDRESS_KEY,
       splTokenProgram: TOKEN_PROGRAM_ID,
     }
 
@@ -332,6 +334,7 @@ describe('staking-bridge', () => {
       message: messagePublicKey,
       from: pdaAtaKey,
       fromOwner: stakingBridgePda,
+      audioMint: SOL_AUDIO_TOKEN_ADDRESS_KEY,
 
       // bridge PDAs
       config,

--- a/solana-programs/staking-bridge/tests/staking-bridge.ts
+++ b/solana-programs/staking-bridge/tests/staking-bridge.ts
@@ -4,7 +4,9 @@ import { StakingBridge } from '../target/types/staking_bridge'
 import { CHAIN_ID_ETH } from '@certusone/wormhole-sdk'
 import {
   TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
   getOrCreateAssociatedTokenAccount,
+  getAssociatedTokenAddressSync,
 } from '@solana/spl-token'
 import {
   ETH_AUDIO_TOKEN_ADDRESS,
@@ -71,7 +73,7 @@ describe('staking-bridge', () => {
     program.programId
   )
 
-  it('creates the staking bridge pda', async () => {
+  it('creates the staking bridge balance pda', async () => {
     try {
       const tx = await program.methods
         .createStakingBridgeBalancePda()
@@ -97,6 +99,48 @@ describe('staking-bridge', () => {
     assert.ok(stakingBridgePdaAccount, 'Staking Bridge balance PDA account not found')
   })
 
+  it('creates the staking bridge balance usdc and audio associated token accounts', async () => {
+    const usdcTokenAccount = getAssociatedTokenAddressSync(
+      SOL_USDC_TOKEN_ADDRESS_KEY,
+      stakingBridgePda,
+      true // allowOwnerOffCurve: we need this since the owner is a program
+    )
+    const audioTokenAccount = getAssociatedTokenAddressSync(
+      SOL_AUDIO_TOKEN_ADDRESS_KEY,
+      stakingBridgePda,
+      true // allowOwnerOffCurve: we need this since the owner is a program
+    )
+
+    try {
+      const tx = await program.methods
+        .createStakingBridgeBalanceAtas(stakingBridgePdaBump)
+        .accounts({
+          stakingBridgePda,
+          usdcTokenAccount,
+          usdcMint: SOL_USDC_TOKEN_ADDRESS_KEY,
+          audioTokenAccount,
+          audioMint: SOL_AUDIO_TOKEN_ADDRESS_KEY,
+          payer: feePayerPublicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([feePayerKeypair])
+        .rpc()
+      console.log('Your transaction signature', tx)
+    } catch (e) {
+      const timeoutError = 'TransactionExpiredTimeoutError'
+      if (e.toString().includes(timeoutError)) {
+        assert.fail(`The transaction timed out, but the ATAs may have been created.\nError: ${e}`)
+      }
+    }
+
+    const usdcAtaAccount = await connection.getAccountInfo(usdcTokenAccount)
+    assert.ok(usdcAtaAccount, 'Staking Bridge USDC ATA account not found')
+    const audioAtaAccount = await connection.getAccountInfo(audioTokenAccount)
+    assert.ok(audioAtaAccount, 'Staking Bridge AUDIO ATA account not found')
+  })
+
   it('swaps SOL USDC to SOL AUDIO', async () => {
     const market = await getMarket(connection, serumMarketPublicKey.toString(), serumDexProgram.toString())
 
@@ -116,7 +160,6 @@ describe('staking-bridge', () => {
     )
 
     // Get associated token accounts for the staking bridge PDA.
-    // Create them if they don't exist.
     let usdcTokenAccount = await getOrCreateAssociatedTokenAccount(
       connection,
       feePayerKeypair,
@@ -216,7 +259,7 @@ describe('staking-bridge', () => {
     })
     const amountToTransfer = amount.toNumber()
 
-    // Associated token account owned by the PDA
+    // AUDIO associated token account owned by the PDA
     let audioTokenAccount = await getOrCreateAssociatedTokenAccount(
       connection,
       feePayerKeypair,


### PR DESCRIPTION
### Description

Update implementation to use anchor builtin macros for token accounts.
Add rust unit tests for both the payment router and staking bridge programs.

### How Has This Been Tested?

This PR itself has the tests. They all passed.

Note that integration tests already exist via our anchor tests and the scripts I wrote for running them.

To triple check, I redeployed the programs and sent transactions for a raydium swap, a wormhole tranfer, and payment routing. They all succeeded.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
