### PR TITLE
Use BN.js instead of string for sla-auditor

### DIFF
--- a/discovery-provider/plugins/pedalboard/apps/sla-auditor/package.json
+++ b/discovery-provider/plugins/pedalboard/apps/sla-auditor/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@truffle/hdwallet-provider": "^1.7.0",
+    "bn.js": "^5.2.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/discovery-provider/plugins/pedalboard/apps/sla-auditor/src/audits/version.ts
+++ b/discovery-provider/plugins/pedalboard/apps/sla-auditor/src/audits/version.ts
@@ -3,9 +3,10 @@ import { SlashProposalParams } from "../proposal";
 import { Node } from "../audit";
 import * as knex from "knex";
 import { VERSION_DATA_TABLE_NAME, VersionData } from "../db";
+import BN from "bn.js";
 
 const SLASH_AMOUNT = 3000;
-const SLASH_AMOUNT_WEI = SLASH_AMOUNT * 1_000_000_000_000_000_000;
+const SLASH_AMOUNT_WEI = new BN("3000" + "0".repeat(18));
 const TIME_RANGE_MS = 24 * 60 * 60 * 1000;
 
 type AuditResponse = {

--- a/discovery-provider/plugins/pedalboard/apps/sla-auditor/src/proposal.ts
+++ b/discovery-provider/plugins/pedalboard/apps/sla-auditor/src/proposal.ts
@@ -1,8 +1,9 @@
 import App from "basekit/src/app";
 import { SharedData } from "./config";
+import BN from "bn.js";
 
 export type SlashProposalParams = {
-  amountWei: number;
+  amountWei: BN;
   title: string;
   description: string;
   owner: string;

--- a/discovery-provider/plugins/pedalboard/package-lock.json
+++ b/discovery-provider/plugins/pedalboard/package-lock.json
@@ -3962,6 +3962,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@truffle/hdwallet-provider": "^1.7.0",
+        "bn.js": "^5.2.1",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "express": "^4.17.1",


### PR DESCRIPTION
### Description

This was an err in the orig. implementation. Wei cannot be represented in JS. Use BN.js instead.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
