### PR TITLE
[CON-822] Expose peer reachability in health check

### DIFF
--- a/mediorum/server/peer_health.go
+++ b/mediorum/server/peer_health.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"io"
-	"mediorum/httputil"
+	"encoding/json"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 func (ss *MediorumServer) startHealthPoller() {
@@ -23,6 +24,9 @@ func (ss *MediorumServer) startHealthPoller() {
 			peer := peer
 			go func() {
 				defer wg.Done()
+				if peer.Host == ss.Config.Self.Host {
+					return
+				}
 				req, err := http.NewRequest("GET", peer.ApiPath("/health_check"), nil)
 				if err != nil {
 					return
@@ -34,24 +38,53 @@ func (ss *MediorumServer) startHealthPoller() {
 				}
 				defer resp.Body.Close()
 
-				// read body to enforce read deadline
-				_, err = io.Copy(io.Discard, resp.Body)
+				// read body
+				var response map[string]interface{}
+				decoder := json.NewDecoder(resp.Body)
+				err = decoder.Decode(&response)
 				if err != nil {
 					return
 				}
 
-				if resp.StatusCode == 200 {
-					// mark healthy
-					ss.peerHealthMutex.Lock()
-					ss.peerHealth[httputil.RemoveTrailingSlash(strings.ToLower(peer.Host))] = time.Now()
-					ss.peerHealthMutex.Unlock()
+				if data, ok := response["data"].(map[string]interface{}); ok {
+					if peerHealthsMap, ok := data["peerHealths"].(map[string]interface{}); ok {
+
+						// set node as reachable
+						ss.peerHealthsMutex.Lock()
+						defer ss.peerHealthsMutex.Unlock()
+						if _, ok := ss.peerHealths[peer.Host]; !ok {
+							ss.peerHealths[peer.Host] = &PeerHealth{}
+						}
+						ss.peerHealths[peer.Host].LastReachable = time.Now()
+
+						// set node's reachable peers
+						for host, hostPeerHealths := range peerHealthsMap {
+							if peerHealth, ok := hostPeerHealths.(map[string]interface{}); ok {
+								if lastReachable, ok := peerHealth["LastReachable"].(string); ok {
+									if t, err := time.Parse(time.RFC3339Nano, lastReachable); err == nil {
+										ss.peerHealths[peer.Host].ReachablePeers[host] = t
+									}
+								}
+							}
+						}
+
+						// set node as healthy
+						if resp.StatusCode == 200 {
+							// node isn't healthy if there's any other node that is reachable by >50% of other nodes but not by this node
+							unreachablePeers := ss.getReachableByMajorityButNotByHost(peer.Host)
+							if len(unreachablePeers) == 0 || true { // TODO: remove the || true after nodes upgrade to expose reachable peers
+								ss.peerHealths[peer.Host].LastHealthy = time.Now()
+							}
+						}
+
+					}
 				}
 
 			}()
 		}
 		wg.Wait()
 
-		if i < 2 {
+		if i < 5 {
 			time.Sleep(time.Second)
 		} else {
 			time.Sleep(time.Second * 30)
@@ -59,15 +92,69 @@ func (ss *MediorumServer) startHealthPoller() {
 	}
 }
 
+// @dev lock ss.peerHealthsMutex before calling this
+func (ss *MediorumServer) getReachableByMajorityButNotByHost(host string) []string {
+	if host == ss.Config.Self.Host {
+		return []string{} // not meant to be called on self
+	}
+
+	// for each peer, count how many other peers can reach it
+	twoMinAgo := time.Now().Add(-2 * time.Minute)
+	numReachableBy := map[string]int{}
+	totalReachableHosts := 0
+	for _, peer := range ss.Config.Peers {
+		if peer.Host == host || peer.Host == ss.Config.Self.Host {
+			continue
+		}
+		if !slices.Contains(maps.Keys(numReachableBy), peer.Host) {
+			numReachableBy[peer.Host] = 0
+		}
+
+		health, ok := ss.peerHealths[peer.Host]
+		if !ok {
+			continue
+		}
+		if !ok || health.LastReachable.Before(twoMinAgo) {
+			continue
+		}
+
+		totalReachableHosts++
+		numReachableBy[peer.Host]++ // record that this peer is reachable by us
+
+		for peersPeer, lastReachable := range health.ReachablePeers {
+			if lastReachable.After(twoMinAgo) {
+				numReachableBy[peersPeer]++ // record that this peer is reachable by its other peer
+			}
+		}
+	}
+
+	if totalReachableHosts < 5 {
+		return []string{} // not enough nodes to determine majority
+	}
+
+	var unreachableByHost []string
+	for peer, reachableBy := range numReachableBy {
+		if reachableBy > totalReachableHosts/2 {
+			// more than half of nodes can reach the peer
+			if lastReachable, ok := ss.peerHealths[peer].ReachablePeers[host]; !ok || lastReachable.Before(twoMinAgo) {
+				// but the host in question can't reach the peer
+				unreachableByHost = append(unreachableByHost, peer)
+			}
+		}
+	}
+
+	return unreachableByHost
+}
+
 func (ss *MediorumServer) findHealthyPeers(aliveInLast time.Duration) []string {
 	result := []string{}
-	ss.peerHealthMutex.RLock()
-	for host, ts := range ss.peerHealth {
-		if time.Since(ts) < aliveInLast {
+	ss.peerHealthsMutex.RLock()
+	defer ss.peerHealthsMutex.RUnlock()
+	for host, peerHealth := range ss.peerHealths {
+		if time.Since(peerHealth.LastHealthy) < aliveInLast {
 			result = append(result, host)
 		}
 	}
-	ss.peerHealthMutex.RUnlock()
 
 	return result
 }

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -55,7 +55,8 @@ type healthCheckResponseData struct {
 	ListenPort              string                     `json:"listenPort"`
 	TrustedNotifierID       int                        `json:"trustedNotifierId"`
 	CidCursors              []cidCursor                `json:"cidCursors"`
-	PeerHealths             map[string]time.Time       `json:"peerHealths"`
+	PeerHealths             map[string]*PeerHealth     `json:"peerHealths"`
+	UnreachablePeers        []string                   `json:"unreachablePeers"`
 	StoreAll                bool                       `json:"storeAll"`
 }
 
@@ -83,8 +84,8 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 
 	var err error
 	// since we're using peerHealth
-	ss.peerHealthMutex.RLock()
-	defer ss.peerHealthMutex.RUnlock()
+	ss.peerHealthsMutex.RLock()
+	defer ss.peerHealthsMutex.RUnlock()
 
 	data := healthCheckResponseData{
 		Healthy:                 healthy,
@@ -115,7 +116,8 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		WalletIsRegistered:      ss.Config.WalletIsRegistered,
 		TrustedNotifierID:       ss.Config.TrustedNotifierID,
 		CidCursors:              ss.cachedCidCursors,
-		PeerHealths:             ss.peerHealth,
+		PeerHealths:             ss.peerHealths,
+		UnreachablePeers:        ss.unreachablePeers,
 		Signers:                 ss.Config.Signers,
 		StoreAll:                ss.Config.StoreAll,
 	}

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -37,7 +37,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","cidCursors":null,"databaseSize":99999,"dbSizeErr":"","dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","cidCursors":null,"databaseSize":99999,"dbSizeErr":"","dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"listenPort":"1991","moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"unreachablePeers":null,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/monitoring/healthz/src/DiscoveryHealth.css
+++ b/monitoring/healthz/src/DiscoveryHealth.css
@@ -1,0 +1,37 @@
+/* Default / light mode */
+:root {
+  --unreachable-background-color: #ffffff;
+  --unreachable-border-color: #e0e0e0;
+  --unreachable-shadow-color: rgba(0, 0, 0, 0.1);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --unreachable-background-color: #1a1a1a;
+    --unreachable-border-color: #333333;
+    --unreachable-shadow-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.unreachable-peers {
+  position: relative;
+}
+
+.unreachable-peers div {
+  visibility: hidden;
+  position: absolute;
+  background-color: var(--unreachable-background-color);
+  border: 1px solid var(--unreachable-border-color);
+  padding: 8px;
+  box-shadow: 0px 2px 8px 0px var(--unreachable-shadow-color);
+  border-radius: 4px;
+  z-index: 10;
+  top: 30px;
+  left: 30px;
+  font-size: 0.9em;
+}
+
+.unreachable-peers:hover div {
+  visibility: visible;
+}

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -4,6 +4,7 @@ import {
 } from './components/EnvironmentSelector'
 import { SP, useServiceProviders } from './useServiceProviders'
 import { RelTime } from './misc'
+import './DiscoveryHealth.css'
 
 const bytesToGb = (bytes: number) => Math.floor(bytes / 10 ** 9)
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
@@ -85,12 +86,14 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   let healthyPeers2m = 0
   if (health?.peerHealths) {
     for (const endpoint of Object.keys(health.peerHealths)) {
-      const healthDate = new Date(health.peerHealths[endpoint])
+      const peerHealth = health.peerHealths[endpoint]
+      const healthDate = new Date(peerHealth?.lastHealthy)
       if (!isNaN(healthDate.getTime()) && healthDate > twoMinutesAgoDate) {
         healthyPeers2m++
       }
     }
   }
+  const unreachablePeers = health.unreachablePeers?.join(', ')
 
   const isCompose = health.infra_setup || health.audiusContentInfraSetup
   const composeSha =
@@ -177,7 +180,12 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
         <RelTime date={health?.startedAt} />
       </td>)}
       {isContent && <td>{metrics?.uploads}</td>}
-      {isContent && <td>{healthyPeers2m}</td>}
+      {isContent && (
+        <td className="unreachable-peers">
+          {healthyPeers2m}
+          {unreachablePeers && <div>{`Can't reach: ${unreachablePeers}`}</div>}
+        </td>
+      )}
       {isContent && (
         <td>
           <a href={sp.endpoint + '/internal/metrics'} target="_blank">

--- a/monitoring/healthz/src/index.css
+++ b/monitoring/healthz/src/index.css
@@ -1,56 +1,100 @@
 * {
   box-sizing: border-box;
+}
 
+/* Default / light mode */
+:root {
+  --background-color: #ffffff;
+  --body-background-color: #f5f5f5;
+  --border-color: #e0e0e0;
+  --table-border-color: #ccc;
+  --text-color: #000000;
+  --link-color: #007bff;
+  --hover-background-color: #f0f0f0;
+  --is-behind-color: #fff0f0;
+  --is-behind-hover-color: rgba(255, 200, 200, 0.4);
+  --matrix-hover-color: #fff5cc;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #1a1a1a;
+    --body-background-color: #121212;
+    --border-color: #333333;
+    --table-border-color: #666;
+    --text-color: #f5f5f5;
+    --link-color: #1e90ff;
+    --hover-background-color: #222222;
+    --is-behind-color: #440000;
+    --is-behind-hover-color: rgba(255, 50, 50, 0.4);
+    --matrix-hover-color: #333300;
+  }
 }
 
 body {
   margin: 0;
-  padding: 0;
-  font-family: sans-serif;
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  background: var(--body-background-color);
+  color: var(--text-color);
 }
 
 .table {
+  background: var(--background-color);
+  border: 1px solid var(--table-border-color);
+  border-radius: 5px;
   border-collapse: collapse;
   min-width: 100%;
 }
+
 .table td,
 .table th {
-  border: 1px solid #ccc;
+  border: 1px solid var(--table-border-color);
   padding: 4px;
 }
+
 .table tbody tr:hover td {
-  background: lightyellow;
+  background: var(--hover-background-color);
 }
 
 .is-behind {
-  background: #ffebe9;
-}
-table tr:hover td.is-behind {
-  background: rgba(255, 129, 130, 0.4);
+  background: var(--is-behind-color);
 }
 
-table .spun span {
-  -ms-writing-mode: tb-rl;
-  -webkit-writing-mode: vertical-rl;
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  white-space: nowrap;
+table tr:hover td.is-behind {
+  background: var(--is-behind-hover-color);
 }
-td.matrix-cell {
-  text-align: right;
-  font-family: monospace;
-}
+
 td.matrix-cell:hover {
-  background: yellow !important;
-  cursor: pointer;
+  background: var(--matrix-hover-color) !important;
+}
+
+.table tr:first-child th,
+.table tr:first-child td {
+  border-top: 1px solid var(--table-border-color);
+}
+
+.table th:last-child,
+.table td:last-child {
+  border-right: 1px solid var(--table-border-color);
+}
+
+.table tr:last-child th,
+.table tr:last-child td {
+  border-bottom: 1px solid var(--table-border-color);
+}
+
+.table th:first-child,
+.table td:first-child {
+  border-left: 1px solid var(--table-border-color);
 }
 
 a,
 a:visited {
-  color: blue;
-  text-decoration: none;
+  color: var(--link-color);
 }
+
 a:hover {
-  background: yellow;
-  text-decoration: underline;
+  background: var(--matrix-hover-color);
 }


### PR DESCRIPTION
### Description
- Nodes self-mark as unhealthy when there's any node that they can't reach but that a majority of peers report as reachable
- Nodes mark other nodes as unhealthy when there's any node that the other node can't reach but that a majority of peers report as reachable
- Displays peer reachability in healthz with slightly nicer styling and dark mode
<img width="2507" alt="healthz_reachability" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/934fb977-7861-4030-abdb-895db6e6ce30">


### How Has This Been Tested?
- Deployed to stage CN8 and CN10 while taking CN7 offline
- Will add some unit tests