### PR TITLE
Fix asyncio errors when attempting to fetch image cids in API

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -210,7 +210,13 @@ def get_image_cids(user, upload_id, variants):
                 urls = list(
                     map(lambda endpoint: f"{endpoint}/uploads/{upload_id}", endpoints)
                 )
-                resp = asyncio.run(race_requests(urls, 1))
+
+                # Race requests in a new event loop
+                new_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(new_loop)
+                resp = new_loop.run_until_complete(race_requests(urls, 1))
+                new_loop.close()
+
                 resp.raise_for_status()
                 image_cids = resp.json().get("results", {})
                 if not image_cids:


### PR DESCRIPTION
### Description
Seeing some `Exception fetching image cids for id: 01H53B3Z8ZBY5ZQ3JNYJRXG957: asyncio.run() cannot be called from a running event loop` in the logs on stage and prod. Not able to trigger this myself when clicking through the client or querying the API but manually creating a new event loop to run `race_requests` like this should fix this.

This exception doesn't impact users -- when this happens the client just falls back to using the old image url format, which redirects.

### How Has This Been Tested?
Deployed to stage, queried API and clicked around the client. No exceptions arose and cid fetching worked as expected.