### PR TITLE
Fix publish playlist notifs

### DIFF
--- a/discovery-provider/ddl/functions/handle_playlist.sql
+++ b/discovery-provider/ddl/functions/handle_playlist.sql
@@ -27,8 +27,6 @@ begin
       (playlist->>'playlist_id')::int = new.playlist_id
   limit 1;
 
-  raise log 'old_row %', old_row;
-
   delta := 0;
   if (new.is_delete = true and new.is_current = true) and (old_row.is_delete = false and old_row.is_private = false) then
     delta := -1;

--- a/discovery-provider/integration_tests/queries/test_populate_user_metadata.py
+++ b/discovery-provider/integration_tests/queries/test_populate_user_metadata.py
@@ -36,7 +36,6 @@ def test_populate_user_metadata(app):
                 "playlist_id": 5,
                 "is_delete": False,
                 "playlist_owner_id": 2,
-                "is_current": False,
             },
             {"playlist_id": 6, "is_album": True, "playlist_owner_id": 3},
             {"playlist_id": 6, "is_private": True, "playlist_owner_id": 3},
@@ -108,7 +107,7 @@ def test_populate_user_metadata(app):
 
         assert users[1]["user_id"] == 2
         assert users[1][response_name_constants.track_count] == 4
-        assert users[1][response_name_constants.playlist_count] == 1
+        assert users[1][response_name_constants.playlist_count] == 2
         assert users[1][response_name_constants.album_count] == 0
         assert users[1][response_name_constants.follower_count] == 1
         assert users[1][response_name_constants.followee_count] == 1

--- a/discovery-provider/src/queries/notifications.py
+++ b/discovery-provider/src/queries/notifications.py
@@ -795,7 +795,7 @@ def notifications():
             )
             # Previous private entry indicates transition to public, triggering a notification
             prev_entry = prev_entry_query.first()
-            if prev_entry.is_private == True:
+            if prev_entry and prev_entry.is_private == True:
                 publish_playlist_notif = {
                     const.notification_type: const.notification_type_create,
                     const.notification_blocknumber: entry.blocknumber,

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -402,7 +402,6 @@ def save_new_records(
 
     session.flush()
     for record_type, record_dict in new_records.items():
-        # This is actually a dict, but python has a hard time inferring.
         casted_record_dict = cast(dict, record_dict)
         for entity_id, records in casted_record_dict.items():
             if not records:

--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -388,11 +388,25 @@ def save_new_records(
                     original_records[record_type][entity_id].is_current = False
                 else:
                     session.delete(original_records[record_type][entity_id])
-                    session.flush()
                 # add the json record for revert blocks
                 prev_records[entity_type_table_mapping[record_type]].append(
                     existing_records_in_json[record_type][entity_id]
                 )
+
+    if prev_records:
+        revert_block = RevertBlock(blocknumber=block_number, prev_records=prev_records)
+        session.add(revert_block)
+
+    # flush so old records are deleted to prevent conflicts
+    # and revert block can be used in triggers below for historical state
+
+    session.flush()
+    for record_type, record_dict in new_records.items():
+        # This is actually a dict, but python has a hard time inferring.
+        casted_record_dict = cast(dict, record_dict)
+        for entity_id, records in casted_record_dict.items():
+            if not records:
+                continue
             # invalidate all new records except the last
             for record in records:
                 if "is_current" in get_record_columns(record):
@@ -406,10 +420,6 @@ def save_new_records(
                 session.add_all(records)
             else:
                 session.add(records[-1])
-
-    if prev_records:
-        revert_block = RevertBlock(blocknumber=block_number, prev_records=prev_records)
-        session.add(revert_block)
 
 
 def copy_original_records(existing_records):


### PR DESCRIPTION
### Description
Fixes two playlist notification flows impacted by removing historical is_current false records.
* Identity is currently still polling discovery /notifications for indexing to serve scheduled emails. This is deprecated on stage but not on prod yet. Checking for null here is a quick workaround to unblock indexing but some schedule email notifs may be missing. Schedule e-mails should be moved to discovery plugin asap then it'll work correctly. 
* The handle_playlist trigger used to insert into the notifications table is used for reads and push notifs. This also referenced a previous record. We can query the revert_blocks table to get the previous state but this does require modifying the session flush.



### How Has This Been Tested?
Tested on stage DN1. Confirmed playlist notif works.
<img width="430" alt="Screenshot 2023-08-23 at 2 47 08 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/ff059ae5-585d-421c-a742-0bba15333392">

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
