### PR TITLE
Fix sdk indexing

### DIFF
--- a/libs/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/libs/src/sdk/api/playlists/PlaylistsApi.ts
@@ -108,6 +108,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       entityId: playlistId,
       action: Action.CREATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,
@@ -514,6 +515,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           entityId: trackId,
           action: Action.CREATE,
           metadata: JSON.stringify({
+            cid: '',
             data: snakecaseKeys(updatedMetadata)
           }),
           auth: this.auth,
@@ -547,6 +549,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       entityId: playlistId,
       action: Action.CREATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,
@@ -617,6 +620,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       entityId: playlistId,
       action: Action.UPDATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,

--- a/libs/src/sdk/api/tracks/TracksApi.ts
+++ b/libs/src/sdk/api/tracks/TracksApi.ts
@@ -143,6 +143,7 @@ export class TracksApi extends GeneratedTracksApi {
       entityId: trackId,
       action: Action.CREATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,
@@ -234,6 +235,7 @@ export class TracksApi extends GeneratedTracksApi {
       entityId: trackId,
       action: Action.UPDATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,

--- a/libs/src/sdk/api/users/UsersApi.ts
+++ b/libs/src/sdk/api/users/UsersApi.ts
@@ -89,6 +89,7 @@ export class UsersApi extends GeneratedUsersApi {
       entityId: userId,
       action: Action.UPDATE,
       metadata: JSON.stringify({
+        cid: '',
         data: snakecaseKeys(updatedMetadata)
       }),
       auth: this.auth,


### PR DESCRIPTION
### Description

To support browser uploads, we removed cid generation from the sdk because the cid gets generated on discovery now and the cid utils were erroring in a browser env. However, this was causing an indexing validation exception because indexing still expects cid to be present on most types of metadata. The ideal fix is to update indexing to not expect cid to be present on any metadata (since the cid is generated serverside)

This pr is a temporary fix for sdk to include blank cids to appease the indexing validation. I'll make a couple follow up prs to clean up the logic in indexing and removing these blank cids from sdk

### How Has This Been Tested?

Tested that creating entities via sdk works and is indexed properly. Confirmed updating those entities also works
