### PR TITLE
[plat-1188] fix bug where delisted tracks cause internal server error

### DIFF
--- a/discovery-provider/src/queries/get_track_stream_info.py
+++ b/discovery-provider/src/queries/get_track_stream_info.py
@@ -27,6 +27,6 @@ def get_track_stream_info(track_id: int):
         )
 
         if not info:
-            return {"creator_nodes": None, "track": None}
+            return {"creator_nodes": None, "track": {}}
 
         return {"creator_nodes": info[0], "track": helpers.model_to_dictionary(info[1])}


### PR DESCRIPTION
### Description
streaming this delisted track currently causes an internal server error (https://discoveryprovider.audius.co/v1/tracks/jNkgo/stream) because we're trying to get a field from a none type object. we change that none type object to be an empty object 

### How Has This Been Tested?
tested on a sandbox by curling the same stream endpoint for this track and confirming a failed to find resource error message is returned instead of internal server error 

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
