### PR TITLE
Fix subscriptions api query

### DIFF
--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -256,7 +256,7 @@ def populate_user_metadata(
 
         # collect all outgoing subscription edges for current user
         current_user_subscribed_rows = (
-            session.query(Subscription.user_id)
+            session.query(Subscription)
             .filter(
                 Subscription.is_current == True,
                 Subscription.is_delete == False,
@@ -265,8 +265,8 @@ def populate_user_metadata(
             )
             .all()
         )
-        for user_id in current_user_subscribed_rows:
-            current_user_subscribed_user_ids[user_id] = True
+        for subscription in current_user_subscribed_rows:
+            current_user_subscribed_user_ids[subscription.user_id] = True
 
         # build dict of user id --> followee follow count
         current_user_followees = (


### PR DESCRIPTION
### Description
Querying 1 column (`Subscription.user_id`) directly with sqlalchemy seems to return an array of tuples, which was causing all `does_current_user_subscribe` fields to be false.

(No user impact. This field isn't used by the client yet.)

### How Has This Been Tested?
Tested on stage, verified field populated correctly via client debugger