### PR TITLE
Do not repair if <20GB free on disk on a local storage CN

### DIFF
--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"mediorum/cidutil"
+	"strings"
 	"time"
 
 	"github.com/georgysavva/scany/v2/pgxscan"
@@ -24,15 +25,19 @@ func (ss *MediorumServer) startRepairer() {
 		}
 
 		logger := ss.logger.With("task", "repair", "run", i, "cleanupMode", cleanupMode)
-		repairStart := time.Now()
-
-		logger.Info("repair starting")
-		err := ss.runRepair(cleanupMode)
-		took := time.Since(repairStart)
-		if err != nil {
-			logger.Error("repair failed", "err", err, "took", took)
+		took := time.Duration(0)
+		if ss.shouldRunRepair() {
+			repairStart := time.Now()
+			logger.Info("repair starting")
+			err := ss.runRepair(cleanupMode)
+			took = time.Since(repairStart)
+			if err != nil {
+				logger.Error("repair failed", "err", err, "took", took)
+			} else {
+				logger.Info("repair OK", "took", took)
+			}
 		} else {
-			logger.Info("repair OK", "took", took)
+			logger.Info("disk has <20GB remaining. skipping repair")
 		}
 
 		// sleep for as long as the job took
@@ -44,6 +49,22 @@ func (ss *MediorumServer) startRepairer() {
 		time.Sleep(sleep)
 
 	}
+}
+
+// If the node is using local storage, do not run repair if there is <20GB remaining
+// on disk
+func (ss *MediorumServer) shouldRunRepair() bool {
+	if strings.HasPrefix(ss.Config.BlobStoreDSN, "file://") {
+		_, free, err := getDiskStatus(ss.Config.LegacyFSRoot)
+		if err == nil {
+			if free/uint64(1e9) < 20 {
+				return false
+			}
+		} else {
+			ss.logger.With("task", "repair").Error("getDiskStatus failed", "err", err)
+		}
+	}
+	return true
 }
 
 func (ss *MediorumServer) runRepair(cleanupMode bool) error {


### PR DESCRIPTION
### Description
If a node is a local storage node and has < 20GB free on disk, do not run repair.go.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
